### PR TITLE
build: integrate revobot credential-helper into workbench image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ node_modules/
 # WebSocket recordings
 **/recordings/
 .logs/
+
+# RevoBot cred-helper templates staged from b:/sources/revobot/templates
+# by docker-workbench-build.ps1 — never committed.
+.credhelper-staging/

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,15 @@ COPY .credhelper-staging/revobot-entrypoint /usr/local/bin/revobot-entrypoint
 RUN chmod +x /usr/local/bin/git-credential-revobot /usr/local/bin/revobot-entrypoint \
  && git config --system credential.helper revobot
 
+# Chain `revobot-entrypoint` to the workbench's original entrypoint so the
+# `sudo -E -H -u $WORKBENCH_USER --` privilege drop in
+# docker-workbench-entrypoint.ps1 still runs after credentials are seeded.
+# Without this, the docker `--entrypoint` override replaces the original
+# entrypoint and Claude CLI runs as root, which causes
+# `--dangerously-skip-permissions` to exit 1 ("cannot be used with root/sudo
+# privileges for security reasons"). See revobot/docs/bug-tracker.md B-009.
+ENV REVOBOT_INNER_ENTRYPOINT="pwsh -NoLogo -File /usr/local/bin/docker-workbench-entrypoint.ps1"
+
 WORKDIR /workspace
 ENTRYPOINT ["pwsh", "-NoLogo", "-File", "/usr/local/bin/docker-workbench-entrypoint.ps1"]
 CMD ["pwsh", "-NoLogo"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,16 @@ RUN dotnet --list-sdks \
 
 COPY scripts/docker-workbench-entrypoint.ps1 /usr/local/bin/docker-workbench-entrypoint.ps1
 
+# RevoBot credential helper — installs the in-container shim and entrypoint
+# wedge that fetch GH_TOKEN / AZURE_DEVOPS_EXT_PAT and back git's
+# credential.helper from the daemon's loopback proxy. Templates are staged
+# from b:/sources/revobot/templates by docker-workbench-build.ps1 into
+# .credhelper-staging/ before the build runs.
+COPY .credhelper-staging/git-credential-revobot /usr/local/bin/git-credential-revobot
+COPY .credhelper-staging/revobot-entrypoint /usr/local/bin/revobot-entrypoint
+RUN chmod +x /usr/local/bin/git-credential-revobot /usr/local/bin/revobot-entrypoint \
+ && git config --system credential.helper revobot
+
 WORKDIR /workspace
 ENTRYPOINT ["pwsh", "-NoLogo", "-File", "/usr/local/bin/docker-workbench-entrypoint.ps1"]
 CMD ["pwsh", "-NoLogo"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,8 +128,11 @@ COPY scripts/docker-workbench-entrypoint.ps1 /usr/local/bin/docker-workbench-ent
 # credential.helper from the daemon's loopback proxy. Templates are staged
 # from b:/sources/revobot/templates by docker-workbench-build.ps1 into
 # .credhelper-staging/ before the build runs.
-COPY .credhelper-staging/git-credential-revobot /usr/local/bin/git-credential-revobot
-COPY .credhelper-staging/revobot-entrypoint /usr/local/bin/revobot-entrypoint
+#
+# IMPORTANT: This image is NOT buildable via plain `docker build .`. The
+# `.credhelper-staging/` directory is git-ignored and must be populated by
+# scripts/docker-workbench-build.ps1, which is the supported entry point.
+COPY .credhelper-staging/git-credential-revobot .credhelper-staging/revobot-entrypoint /usr/local/bin/
 RUN chmod +x /usr/local/bin/git-credential-revobot /usr/local/bin/revobot-entrypoint \
  && git config --system credential.helper revobot
 
@@ -140,8 +143,13 @@ RUN chmod +x /usr/local/bin/git-credential-revobot /usr/local/bin/revobot-entryp
 # entrypoint and Claude CLI runs as root, which causes
 # `--dangerously-skip-permissions` to exit 1 ("cannot be used with root/sudo
 # privileges for security reasons"). See revobot/docs/bug-tracker.md B-009.
+#
+# NOTE: The command below MUST stay in lockstep with the ENTRYPOINT
+# instruction further down — if one is changed, update the other or the
+# revobot-entrypoint chain silently breaks.
 ENV REVOBOT_INNER_ENTRYPOINT="pwsh -NoLogo -File /usr/local/bin/docker-workbench-entrypoint.ps1"
 
 WORKDIR /workspace
+# Must match $REVOBOT_INNER_ENTRYPOINT above.
 ENTRYPOINT ["pwsh", "-NoLogo", "-File", "/usr/local/bin/docker-workbench-entrypoint.ps1"]
 CMD ["pwsh", "-NoLogo"]

--- a/scripts/docker-workbench-build.ps1
+++ b/scripts/docker-workbench-build.ps1
@@ -6,7 +6,11 @@ param(
     [int]$UserGid = 1001,
     [switch]$InstallOptionalCopilotSdk,
     [switch]$Pull,
-    [switch]$NoCache
+    [switch]$NoCache,
+    # RevoBot cred-helper templates source. The Dockerfile COPYs from
+    # .credhelper-staging/ (git-ignored), so we sync the canonical templates
+    # from revobot into that directory before each build.
+    [string]$RevobotTemplatesPath = "b:/sources/revobot/templates"
 )
 
 $ErrorActionPreference = "Stop"
@@ -17,6 +21,22 @@ $dockerfile = Join-Path $repoRoot $DockerfilePath
 if (-not (Test-Path $dockerfile)) {
     throw "Dockerfile '$dockerfile' was not found."
 }
+
+# Stage RevoBot cred-helper templates into the build context.
+$stagingDir = Join-Path $repoRoot ".credhelper-staging"
+$requiredTemplates = @("git-credential-revobot", "revobot-entrypoint")
+if (-not (Test-Path $RevobotTemplatesPath)) {
+    throw "RevobotTemplatesPath '$RevobotTemplatesPath' does not exist. Pass -RevobotTemplatesPath to point at the revobot/templates directory."
+}
+New-Item -ItemType Directory -Force -Path $stagingDir | Out-Null
+foreach ($name in $requiredTemplates) {
+    $src = Join-Path $RevobotTemplatesPath $name
+    if (-not (Test-Path $src)) {
+        throw "Required cred-helper template '$src' is missing."
+    }
+    Copy-Item -Force $src (Join-Path $stagingDir $name)
+}
+Write-Host "Staged cred-helper templates from $RevobotTemplatesPath -> $stagingDir"
 
 $dockerArgs = @(
     "build",

--- a/scripts/docker-workbench-build.ps1
+++ b/scripts/docker-workbench-build.ps1
@@ -28,6 +28,11 @@ $requiredTemplates = @("git-credential-revobot", "revobot-entrypoint")
 if (-not (Test-Path $RevobotTemplatesPath)) {
     throw "RevobotTemplatesPath '$RevobotTemplatesPath' does not exist. Pass -RevobotTemplatesPath to point at the revobot/templates directory."
 }
+# Clean any previous stage so renamed/removed upstream templates don't
+# linger in the build context and silently get baked into the image.
+if (Test-Path $stagingDir) {
+    Remove-Item -Recurse -Force $stagingDir -ErrorAction SilentlyContinue
+}
 New-Item -ItemType Directory -Force -Path $stagingDir | Out-Null
 foreach ($name in $requiredTemplates) {
     $src = Join-Path $RevobotTemplatesPath $name


### PR DESCRIPTION
## Summary

The revobot dev-daemon ships a credential-helper proxy ([revobot 65d71ca](https://github.com/) feat: credential helper proxy for in-container git push) that wedges `/usr/local/bin/revobot-entrypoint` ahead of the agent CLI in every docker spawn so the in-container agent can `git push` and `gh pr create` without baked-in tokens. The workbench image needs to ship the entrypoint binary and the git-credential shim, otherwise every docker-backed plan/babysit spawn fails at startup with `no such file or directory`.

## Changes

- **Dockerfile** — `COPY .credhelper-staging/{git-credential-revobot,revobot-entrypoint} /usr/local/bin/`, `chmod +x`, and `git config --system credential.helper revobot`. The image already includes `curl` and `jq` (deps for the entrypoint script), no extra apt installs needed.
- **scripts/docker-workbench-build.ps1** — stages the canonical templates from `b:/sources/revobot/templates` (override via `-RevobotTemplatesPath`) into `.credhelper-staging/` before each build, so the source-of-truth stays in the revobot repo rather than getting copied into this repo's history.
- **.gitignore** — excludes `.credhelper-staging/` (regenerated per build).

## Behaviour when cred-helper is disabled

If the daemon doesn't inject `REVOBOT_PLATFORM` / `REVOBOT_CREDHELPER_*` env vars (or `REVOBOT_DISABLE_CREDHELPER=1` is set), `revobot-entrypoint` is a transparent pass-through that just `exec`s the original CMD. So this change is backward compatible with any spawn path that hasn't switched to the proxy yet.

## Test plan

- [x] Built `lmdotnettools-workbench:latest` from the new Dockerfile — succeeds, layers `[ 9/12]` through `[11/12]` add the cred-helper binaries and config.
- [x] Built `nscript-workbench:latest` from the same Dockerfile (`docker-workbench-build.ps1 -ImageName nscript-workbench`) — succeeds.
- [x] `docker run --rm --entrypoint=/bin/sh lmdotnettools-workbench:latest -c "ls /usr/local/bin/git-credential-revobot /usr/local/bin/revobot-entrypoint && git config --system --get credential.helper"` returns the binaries and `revobot`.
- [ ] End-to-end: dev-daemon babysit cycle for an active PR (e.g. WI-13) issues a `git push` from inside the container against the credential proxy. (Will be exercised by the next babysit cycle.)


Closes #20 