### PR TITLE
[Gautam's Dev bot] docs(copilot): MockProviderHost redirect investigation + skipped E2E scaffold

### DIFF
--- a/samples/MockProviderHost/README.md
+++ b/samples/MockProviderHost/README.md
@@ -66,3 +66,158 @@ follow-ups:
 - Embeddings / rerank / `/v1/responses` / image / audio endpoints.
 - Admin API for hot-swapping scripts at runtime.
 - Docker image.
+
+## Copilot CLI integration (investigation, issue #14)
+
+Status: **investigation only — yellow light**. The information below was
+gathered from the public `@github/copilot` documentation, the in-repo
+`CopilotSdkProvider` source, and the Anthropic-side pattern landed in
+PR #12. The empirical probe described under "Probe matrix" below has **not**
+been executed on a CLI-equipped machine as part of this work item; that is
+the next person's job (or the follow-up E2E issue's job). This document
+captures the intended probe so the next session does not need to redo the
+research.
+
+### Two-layer architecture
+
+`CopilotSdkProvider` runs the Copilot CLI as a child process and speaks
+**ACP / JSON-RPC 2.0 over stdio** to it (see
+`src/CopilotSdkProvider/Transport/CopilotAcpTransport.cs`). The CLI in turn
+calls a model endpoint over HTTPS:
+
+```
++-------------------+     ACP/JSON-RPC      +-------------+    HTTPS    +--------------------------+
+|  CopilotSdk host  |  <----- stdio ----->  | copilot CLI |  -------->  |  api.githubcopilot.com   |
+| (this repo)       |                       | child proc  |             |  (or BYOK endpoint)      |
++-------------------+                       +-------------+             +--------------------------+
+```
+
+`MockProviderHost` can only intercept the **HTTPS layer**. Any redirect
+strategy therefore has to convince the CLI to point at the host's bound URL
+*from inside the child process*, via env vars set on `ProcessStartInfo`.
+
+### Documented BYOK env-var contract
+
+According to the public CLI docs (`copilot help environment`, plus the
+`@github/copilot` BYOK section), the CLI exposes the following overrides:
+
+| Env var                          | Purpose                                                 | Example                                  |
+|----------------------------------|---------------------------------------------------------|------------------------------------------|
+| `COPILOT_PROVIDER_BASE_URL`      | Endpoint base URL                                        | `http://127.0.0.1:51234/v1`              |
+| `COPILOT_PROVIDER_TYPE`          | `openai` (default) \| `azure` \| `anthropic`             | `openai`                                 |
+| `COPILOT_PROVIDER_API_KEY`       | API key the CLI presents to the endpoint                 | `sk-fake`                                |
+| `COPILOT_PROVIDER_BEARER_TOKEN`  | Pre-built bearer token (alternative to `_API_KEY`)       | `bearer-...`                             |
+| `COPILOT_PROVIDER_WIRE_API`      | `completions` (Chat Completions) \| `responses`          | `completions`                            |
+| `COPILOT_PROVIDER_MODEL_ID`      | Model id sent in the request body                        | `gpt-4o-mini`                            |
+| `COPILOT_PROVIDER_WIRE_MODEL`    | Wire-level model id override (when distinct from above)  | `gpt-4o-mini`                            |
+| `COPILOT_OFFLINE`                | Assert no egress to `api.githubcopilot.com`              | `1`                                      |
+
+Setting BYOK values is **documented to bypass GitHub OAuth** — i.e., a fake
+token against a local mock should work without a real GitHub login. The
+probe matrix below is what confirms (or refutes) this on the CLI version
+under test.
+
+### Existing-code reconciliation: `COPILOT_BASE_URL` vs `COPILOT_PROVIDER_BASE_URL`
+
+`CopilotAcpTransport.StartAsync` (lines 91-114) currently sets:
+
+- `COPILOT_API_KEY` and `GITHUB_TOKEN` from `CopilotSdkOptions.ApiKey`
+- `COPILOT_BASE_URL` (singular, no `_PROVIDER_`) from `CopilotSdkOptions.BaseUrl`
+
+The documented BYOK var is `COPILOT_PROVIDER_BASE_URL`. Two possibilities:
+
+1. The CLI honors **both** (legacy alias + new BYOK suite). In this case the
+   existing code path keeps working, but the BYOK suite is needed to also
+   force `_TYPE` / `_WIRE_API` / `_API_KEY`. The follow-up issue's
+   `CopilotSdkOptions` extension is then **purely additive** (new opt-in
+   knobs, existing `BaseUrl` keeps mapping to `COPILOT_BASE_URL`).
+2. Only the `_PROVIDER_` variants are honored on current CLI versions. In
+   that case, `BaseUrl` → `COPILOT_BASE_URL` is partially dead code today
+   and the follow-up issue should migrate to `COPILOT_PROVIDER_BASE_URL`
+   (with a deprecation note on the existing `BaseUrl` semantic).
+
+The probe matrix below disambiguates these. **Until the probe runs, do not
+remove the existing `COPILOT_BASE_URL` mapping.**
+
+### Wire-format compatibility
+
+| CLI setting                              | MockProviderHost endpoint            | Status                          |
+|------------------------------------------|--------------------------------------|---------------------------------|
+| `COPILOT_PROVIDER_TYPE=openai`,<br>`COPILOT_PROVIDER_WIRE_API=completions` | `POST /v1/chat/completions` | Already implemented today.      |
+| `COPILOT_PROVIDER_TYPE=anthropic`        | `POST /v1/messages`                  | Already implemented today.      |
+| `COPILOT_PROVIDER_WIRE_API=responses`    | (none)                               | Out of scope — follow-up issue. |
+
+Newer Copilot model paths (GPT-5 family) use `/v1/responses`. If the probe
+finds the CLI defaults to that route on the version under test, the
+follow-up E2E issue must add a `/v1/responses` route to
+`MockProviderHostBuilder` before E2E coverage is possible.
+
+### Probe matrix (the empirical step)
+
+Run on a developer machine with the Copilot CLI installed at
+≥ `0.0.410` (matches `CopilotSdkOptions.CopilotCliMinVersion`).
+
+1. `copilot --version` → record version.
+2. `copilot help environment` → snapshot env-var list. Confirm `COPILOT_PROVIDER_*`
+   names match the table above; flag any drift in this doc.
+3. Stand up `EphemeralHostFixture` with an OpenAI-shaped responder
+   (see `tests/MockProviderHost.E2E.Tests/Scenarios/CopilotSdkAgainstMockTests.cs`
+   for the scaffold).
+4. Spawn the CLI directly (not via `CopilotAcpTransport` — the transport
+   does not yet wire BYOK options) with the env matrix below, and record
+   whether `responder.RemainingTurns["parent"]` reaches `0` (the
+   ground-truth signal that the CLI hit `/v1/chat/completions`):
+
+   | Run | Env vars set                                                                                                                                         | Expected                                                                                                                                |
+   |-----|------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+   | A   | `COPILOT_PROVIDER_BASE_URL`, `COPILOT_PROVIDER_TYPE=openai`, `COPILOT_PROVIDER_API_KEY=fake`, `COPILOT_PROVIDER_WIRE_API=completions`, `COPILOT_OFFLINE=1` | CLI reaches mock without GitHub OAuth; `RemainingTurns["parent"] == 0`. Verdict: **GREEN** for follow-up E2E.                            |
+   | B   | `COPILOT_BASE_URL` only (legacy var the transport already sets), no BYOK suite                                                                       | If responder still drains, the legacy var is honored (case 1 above). If not, the existing code path is dead and case 2 applies.         |
+   | C   | No env overrides                                                                                                                                     | CLI prompts for OAuth or fails with a missing-token error — confirms BYOK is the bypass path.                                           |
+   | D   | BYOK suite **without** `COPILOT_OFFLINE=1`                                                                                                           | Same as A; `OFFLINE=1` is for asserting no egress, not for enabling the bypass.                                                          |
+
+5. If the CLI defaults to `/v1/responses` instead of `/v1/chat/completions`,
+   record the request the responder received and add a follow-up note for
+   the `/v1/responses` route work.
+
+### Verdict and follow-up shopping list
+
+Verdict will be one of:
+
+- **GREEN** — Run A succeeds. Follow-up E2E issue can land the
+  `CopilotSdkOptions` BYOK extension and a real (non-skipped) E2E test.
+- **YELLOW** — Run A succeeds with caveats (e.g., requires a specific
+  `WIRE_MODEL`, or only works for `WIRE_API=responses`). Follow-up E2E
+  issue must add the missing endpoint(s) first.
+- **RED** — BYOK does not bypass GitHub OAuth on the CLI version under
+  test. Follow-up E2E is blocked on either an upstream CLI fix or a
+  different redirect strategy (e.g., HTTPS proxy with a trusted root).
+
+Concrete next steps for the follow-up E2E issue (regardless of verdict
+shade, all are **additive**):
+
+- Extend `CopilotSdkOptions` with nullable BYOK knobs:
+  `ProviderBaseUrl`, `ProviderType`, `ProviderApiKey`, `ProviderBearerToken`,
+  `ProviderWireApi`, `ProviderModelId`, `ProviderWireModel`. All default
+  `null` (untouched today).
+- Mirror PR #12's `ApplyMockHostOverrides` shape on `CopilotAcpTransport.StartAsync`:
+  copy each non-null option onto `psi.Environment` under the matching
+  `COPILOT_PROVIDER_*` key.
+- Reconcile the existing `BaseUrl` → `COPILOT_BASE_URL` mapping based on
+  Run B: keep as alias (case 1) or migrate to `COPILOT_PROVIDER_BASE_URL`
+  with a deprecation note (case 2).
+- Decide whether `MockProviderHostBuilder` needs a `/v1/responses` route
+  (only if Run A or D recorded that path).
+- Replace the `[SkippableFact]` skip gate in `CopilotSdkAgainstMockTests`
+  with a CLI-presence-only gate (drop `LMDOTNET_RUN_COPILOT_E2E=1`) once
+  the contract is stable.
+
+### Scaffold test
+
+A skipped scaffold mirroring the Claude pattern lives at
+`tests/MockProviderHost.E2E.Tests/Scenarios/CopilotSdkAgainstMockTests.cs`,
+gated by `LMDOTNET_RUN_COPILOT_E2E=1` plus a CLI-presence probe in
+`tests/MockProviderHost.E2E.Tests/Infrastructure/CopilotCliPrerequisites.cs`.
+The test is intentionally not wired through `CopilotAcpTransport` — it
+spawns `copilot` directly and sets BYOK env vars on the child, so the
+scaffold can be turned on without first landing the transport-side
+options work.

--- a/tests/MockProviderHost.E2E.Tests/Infrastructure/CopilotCliPrerequisites.cs
+++ b/tests/MockProviderHost.E2E.Tests/Infrastructure/CopilotCliPrerequisites.cs
@@ -1,0 +1,97 @@
+using System.Diagnostics;
+
+namespace AchieveAi.LmDotnetTools.MockProviderHost.E2E.Tests.Infrastructure;
+
+/// <summary>
+/// Detects whether the GitHub Copilot CLI (<c>@github/copilot</c>) is present on the
+/// current machine. E2E tests skip rather than fail when this prerequisite is missing
+/// so CI without the CLI installed should not block the build.
+///
+/// Mirrors <see cref="ClaudeCliPrerequisites"/>: probes a small set of well-known
+/// install locations and PATH, returns <c>(false, reason)</c> when nothing is found.
+/// </summary>
+internal static class CopilotCliPrerequisites
+{
+    public static (bool Available, string? Reason) Detect()
+    {
+        if (!TryRun("node", "--version", out _))
+        {
+            return (false, "Node.js was not found on PATH.");
+        }
+
+        var cli = FindCopilotCli();
+        return cli is null
+            ? (false, "GitHub Copilot CLI was not found (looked for 'copilot' on PATH and standard install locations).")
+            : (true, null);
+    }
+
+    private static string? FindCopilotCli()
+    {
+        var candidates = new[]
+        {
+            "copilot",
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".npm-global",
+                "bin",
+                "copilot"),
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "npm",
+                "copilot.cmd"),
+        };
+
+        foreach (var candidate in candidates)
+        {
+            if (TryRun(candidate, "--version", out _))
+            {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static bool TryRun(string fileName, string args, out string output)
+    {
+        output = string.Empty;
+        try
+        {
+            using var p = Process.Start(new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = args,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            });
+            if (p is null)
+            {
+                return false;
+            }
+
+            // WaitForExit *before* ReadToEnd so a binary that never closes stdout cannot
+            // hang the probe — synchronous ReadToEnd blocks until stdout is closed by the
+            // child, which a hung CLI may never do.
+            if (!p.WaitForExit(5000))
+            {
+                try { p.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+                return false;
+            }
+            output = p.StandardOutput.ReadToEnd();
+            return p.ExitCode == 0;
+        }
+        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception
+                                       or InvalidOperationException
+                                       or PlatformNotSupportedException
+                                       or System.IO.IOException)
+        {
+            // Probe is best-effort (file not on PATH, permission denied, platform mismatch).
+            // Surface a Debug trace so a missing-tool diagnosis isn't silent on machines where
+            // the CLI is supposedly installed.
+            Debug.WriteLine(
+                $"CopilotCliPrerequisites probe failed for '{fileName}': {ex.GetType().Name}: {ex.Message}");
+            return false;
+        }
+    }
+}

--- a/tests/MockProviderHost.E2E.Tests/Scenarios/CopilotSdkAgainstMockTests.cs
+++ b/tests/MockProviderHost.E2E.Tests/Scenarios/CopilotSdkAgainstMockTests.cs
@@ -73,8 +73,11 @@ public sealed class CopilotSdkAgainstMockTests
         {
             FileName = "copilot",
             Arguments = "--print \"say hello\"", // PROBE TODO: confirm the CLI's non-interactive arg shape against `copilot help`.
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
+            // stdout/stderr are intentionally NOT redirected: this scaffold polls
+            // responder.RemainingTurns rather than CLI output, and an unread redirected
+            // pipe would block the child once the OS buffer fills (~4KB on Windows),
+            // hanging the test until the 30s CTS expires. If a follow-up needs CLI
+            // diagnostics, switch to BeginOutputReadLine/BeginErrorReadLine.
             UseShellExecute = false,
             CreateNoWindow = true,
         };

--- a/tests/MockProviderHost.E2E.Tests/Scenarios/CopilotSdkAgainstMockTests.cs
+++ b/tests/MockProviderHost.E2E.Tests/Scenarios/CopilotSdkAgainstMockTests.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using AchieveAi.LmDotnetTools.MockProviderHost.E2E.Tests.Infrastructure;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.MockProviderHost.E2E.Tests.Scenarios;
+
+/// <summary>
+/// Skipped scaffold for the Copilot CLI investigation tracked in issue #14. Exercises the
+/// BYOK env-var redirect contract (<c>COPILOT_PROVIDER_*</c>) by spawning <c>copilot</c>
+/// directly against an <see cref="EphemeralHostFixture"/>-bound <see cref="MockProviderHostBuilder"/>.
+///
+/// <para>
+/// Intentionally bypasses <c>CopilotAcpTransport</c> — that transport currently sets only
+/// <c>COPILOT_BASE_URL</c> / <c>COPILOT_API_KEY</c>, not the full BYOK suite
+/// (<c>COPILOT_PROVIDER_TYPE</c>, <c>COPILOT_PROVIDER_WIRE_API</c>, <c>COPILOT_PROVIDER_API_KEY</c>, ...).
+/// Wiring those into <c>CopilotSdkOptions</c> + transport is the follow-up E2E issue's job;
+/// this scaffold answers the empirical question of <em>whether</em> BYOK works at all on the
+/// CLI version under test.
+/// </para>
+///
+/// <para>
+/// See <c>samples/MockProviderHost/README.md#copilot-cli-integration-investigation-issue-14</c>
+/// for the full probe matrix this test instantiates.
+/// </para>
+/// </summary>
+public sealed class CopilotSdkAgainstMockTests
+{
+    [SkippableFact]
+    public async Task Copilot_cli_routes_through_mock_host_via_byok_env_overrides()
+    {
+        // Investigation-only: the CLI invocation shape (`--print` vs interactive vs `--acp`)
+        // and the BYOK bypass behavior are the subject of issue #14. Run with
+        // LMDOTNET_RUN_COPILOT_E2E=1 once a stable probe contract is recorded in the README.
+        Skip.If(
+            Environment.GetEnvironmentVariable("LMDOTNET_RUN_COPILOT_E2E") != "1",
+            "Set LMDOTNET_RUN_COPILOT_E2E=1 to run the Copilot CLI investigation probe.");
+
+        var (available, reason) = CopilotCliPrerequisites.Detect();
+        Skip.IfNot(available, reason ?? "Copilot CLI not available.");
+
+        // OpenAI-shaped responder: matches `COPILOT_PROVIDER_TYPE=openai` +
+        // `COPILOT_PROVIDER_WIRE_API=completions`. The responder draining its parent turn
+        // is the ground-truth signal that the CLI actually reached /v1/chat/completions
+        // (and therefore that BYOK bypassed GitHub OAuth).
+        var responder = ScriptedSseResponder.New()
+            .ForRole("parent", _ => true)
+                .Turn(t => t.Text("hello from the scripted parent"))
+            .Build();
+        await using var fixture = await EphemeralHostFixture.StartAsync(responder);
+
+        // BYOK env-var contract (see README probe matrix — Run A). All values are
+        // documented at https://docs.github.com/en/copilot/github-copilot-cli (env section).
+        var env = new Dictionary<string, string>
+        {
+            ["COPILOT_PROVIDER_BASE_URL"] = fixture.BaseUrl + "/v1",
+            ["COPILOT_PROVIDER_TYPE"] = "openai",
+            ["COPILOT_PROVIDER_API_KEY"] = "mock-token",
+            ["COPILOT_PROVIDER_WIRE_API"] = "completions",
+            ["COPILOT_PROVIDER_MODEL_ID"] = "gpt-4o-mini",
+            // Assert no egress to api.githubcopilot.com — if the CLI ignores BYOK and falls
+            // back to the public endpoint, OFFLINE=1 should make the call fail loudly rather
+            // than silently succeeding against the wrong host.
+            ["COPILOT_OFFLINE"] = "1",
+        };
+
+        // The non-interactive invocation shape is itself part of the investigation. The probe
+        // matrix in the README documents the candidate args; the first contributor to land on
+        // a CLI-equipped machine fills the actual invocation in here.
+        // Until then this scaffold sets up everything else (host, env, gating, assertion) so
+        // only the ProcessStartInfo.Arguments line below needs editing.
+        var psi = new ProcessStartInfo
+        {
+            FileName = "copilot",
+            Arguments = "--print \"say hello\"", // PROBE TODO: confirm the CLI's non-interactive arg shape against `copilot help`.
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var (k, v) in env)
+        {
+            psi.Environment[k] = v;
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        Process? proc = null;
+        try
+        {
+            proc = Process.Start(psi);
+            Skip.If(proc is null, "Failed to start copilot process — investigation cannot proceed on this machine.");
+
+            // Poll the responder; success is the parent turn draining (the CLI hit the mock
+            // and consumed the scripted turn). Time-out is the red-light verdict for the
+            // README probe matrix.
+            while (!cts.IsCancellationRequested)
+            {
+                if (responder.RemainingTurns["parent"] == 0)
+                {
+                    break;
+                }
+                if (proc.HasExited)
+                {
+                    break;
+                }
+                await Task.Delay(250, cts.Token).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            // Timeout is a real failure here — the test purpose is to verify BYOK reaches
+            // the mock. Surfacing it via the assertion below gives a clearer message than
+            // letting OCE propagate.
+        }
+        finally
+        {
+            if (proc is { HasExited: false })
+            {
+                try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            }
+            proc?.Dispose();
+        }
+
+        responder.RemainingTurns["parent"].Should().Be(0,
+            "the Copilot CLI under test should reach the mock host's /v1/chat/completions when "
+            + "BYOK env vars are set (COPILOT_PROVIDER_BASE_URL/_TYPE/_API_KEY/_WIRE_API). "
+            + "If this assertion fails, see the probe matrix in samples/MockProviderHost/README.md "
+            + "to determine whether to investigate the CLI invocation shape, the env-var contract, "
+            + "or to record a RED verdict for the follow-up E2E issue.");
+    }
+}


### PR DESCRIPTION
[Gautam's Dev bot]

Closes #14

## Summary

Investigation deliverable for routing the `@github/copilot` CLI at `MockProviderHost`. **Documentation + skipped scaffold only — no production code changes** in `CopilotSdkProvider`. The follow-up E2E issue lands the additive `CopilotSdkOptions` BYOK extension once the empirical probe records a green/yellow/red verdict.

- `samples/MockProviderHost/README.md` — new "Copilot CLI integration (investigation, issue #14)" subsection covering the two-layer ACP/HTTPS architecture, the documented BYOK env-var contract (`COPILOT_PROVIDER_*`), wire-format compatibility, the existing-code reconciliation between `COPILOT_BASE_URL` (what `CopilotAcpTransport` sets today) and `COPILOT_PROVIDER_BASE_URL` (the documented BYOK var), a 4-run probe matrix, verdict criteria, and a concrete shopping list for the follow-up E2E issue.
- `tests/MockProviderHost.E2E.Tests/Infrastructure/CopilotCliPrerequisites.cs` — CLI-presence probe mirroring `ClaudeCliPrerequisites`. Walks `copilot` on PATH plus standard npm install locations.
- `tests/MockProviderHost.E2E.Tests/Scenarios/CopilotSdkAgainstMockTests.cs` — `[SkippableFact]`, double-gated via `LMDOTNET_RUN_COPILOT_E2E=1` + `CopilotCliPrerequisites.Detect()`. Spawns `copilot` directly with the BYOK env matrix on `ProcessStartInfo.Environment` and asserts `responder.RemainingTurns["parent"] == 0`. Intentionally bypasses `CopilotAcpTransport` — that wire-up is the follow-up issue's job; this scaffold answers the empirical question of *whether* BYOK works at all.

The scaffold's CLI invocation `Arguments` line carries a `PROBE TODO` marker — the next contributor on a CLI-equipped machine confirms the non-interactive arg shape (`--print`, interactive REPL, etc.) and updates the README probe matrix. Everything else (host fixture, env injection, gating, polling, assertion, cleanup) is wired up.

## Decisions taken from the approved plan

The plan flagged three reviewer decisions; `/approve` was given without qualifications, so the defaults from the plan apply:
1. **Doc location**: extended `samples/MockProviderHost/README.md` (no new `docs/` page — section is ~150 lines, well under the split threshold).
2. **Scaffold test in scope**: yes, included.
3. **Worktree base**: rebased onto `origin/main` (PR #12 prereq, fast-forward merge).

## Test plan

- [x] `dotnet build tests/MockProviderHost.E2E.Tests/MockProviderHost.E2E.Tests.csproj` — succeeds with **0 warnings, 0 errors**.
- [x] `dotnet test tests/MockProviderHost.E2E.Tests/...` — both `ClaudeAgentSdkAgainstMockTests` and the new `CopilotSdkAgainstMockTests` correctly skip on CI (no CLI installed).
- [x] `dotnet test tests/MockProviderHost.Tests/...` — all 11 unit tests pass; no regressions to the existing host coverage.
- [ ] (Out of scope here) Run the probe matrix on a CLI-equipped machine — this is the follow-up issue's first step.

## Files explicitly NOT touched

Per the plan's "deferred to follow-up E2E issue" list:
- `src/CopilotSdkProvider/Configuration/CopilotSdkOptions.cs`
- `src/CopilotSdkProvider/Transport/CopilotAcpTransport.cs`
- `src/CopilotSdkProvider/Agents/CopilotSdkClient.cs`
