### PR TITLE
feat(revobot): preview manifest for LmStreaming.Sample

### DIFF
--- a/.revobot/preview.yaml
+++ b/.revobot/preview.yaml
@@ -1,0 +1,45 @@
+# RevoBot per-PR preview manifest.
+#
+# When this PR enters babysit, RevoBot will:
+#   1. Run the build steps below in an ephemeral container that mounts the worktree.
+#   2. Start a long-lived service container that runs the .NET app in Production mode.
+#   3. Post a clickable URL into the PR (default: http://pr-<id>.lmdotnettools.localhost/).
+#   4. Tear everything down on merge / abandon.
+#
+# The streaming sample app is a hybrid ASP.NET Core + Vue/Vite SPA. We build the
+# SPA into wwwroot/dist, then run the .NET app in Production mode so it serves
+# both the API/WebSocket and the bundled SPA from a single port (5000).
+# Development mode would also work, but it requires running `vite dev` as a
+# second process, which doesn't fit the single-service preview model.
+
+version: 1
+
+build:
+  # Build the Vue/Vite SPA into samples/LmStreaming.Sample/wwwroot/dist.
+  # `npm ci` reads ClientApp/package-lock.json deterministically.
+  - ["bash", "-lc", "cd samples/LmStreaming.Sample/ClientApp && npm ci && npm run build"]
+
+# Single-service shorthand: one URL is enough — the .NET app serves API,
+# WebSocket (`/ws`), and the bundled SPA from the same origin.
+port: 5000
+command:
+  - "dotnet"
+  - "run"
+  - "--project"
+  - "samples/LmStreaming.Sample/LmStreaming.Sample.csproj"
+  - "--configuration"
+  - "Release"
+
+env:
+  # Bind to 0.0.0.0 so Traefik (in a sibling container) can reach the listener.
+  ASPNETCORE_URLS: "http://0.0.0.0:5000"
+  # Production mode skips the Vite dev-server middleware and serves the
+  # pre-built SPA from wwwroot/dist via UseStaticFiles + MapFallbackToFile.
+  ASPNETCORE_ENVIRONMENT: "Production"
+  # Don't waste reviewer time inside ANSI escape sequences in the container log.
+  DOTNET_NOLOGO: "1"
+
+health:
+  path: "/"
+  # First `dotnet run` cold-build can be slow on a fresh worktree.
+  timeoutSeconds: 180


### PR DESCRIPTION
[Gautam's Dev bot] Adds `.revobot/preview.yaml` to opt this repo into RevoBot's new per-PR preview-environment feature.

## Summary

- Build step: `npm ci && npm run build` in `samples/LmStreaming.Sample/ClientApp` produces `wwwroot/dist`.
- Service: single .NET process on :5000 in Production mode, serving the API, `/ws` WebSocket, and bundled SPA from one origin.
- Hostname: `http://pr-<id>.lmdotnettools.localhost/` by default (browser auto-resolves to 127.0.0.1 — no DNS needed).

## Why a single service instead of split front+back

The Vue dev server (`vite dev`) needs to proxy `/api` and `/ws` to the .NET app, and that proxy hard-codes `localhost:5000`. With separate containers on a Docker network, the proxy target would have to be rewritten per-PR. Production mode avoids the whole problem — the .NET app serves the bundled SPA via `UseStaticFiles` + `MapFallbackToFile("dist/index.html")`.

## Test plan

- [ ] After merge, push a PR against `main` and confirm RevoBot posts a `Preview environments` comment with a working URL.
- [ ] Click the URL — SPA loads, `/api` controllers respond, `/ws` accepts a WebSocket.
- [ ] Push a follow-up commit and confirm the preview restarts (new build + new container).
- [ ] Merge a test PR and confirm the preview is torn down (containers gone, comment updated to "Preview stopped").

Closes #21