### PR TITLE
[Gautam's Dev bot] feat(streaming-sample): per-conversation provider dropdown

### DIFF
--- a/samples/LmStreaming.Sample/Agents/MultiTurnAgentPool.cs
+++ b/samples/LmStreaming.Sample/Agents/MultiTurnAgentPool.cs
@@ -1,6 +1,9 @@
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
 using LmStreaming.Sample.Models;
+using LmStreaming.Sample.Services;
 
 namespace LmStreaming.Sample.Agents;
 
@@ -11,9 +14,18 @@ namespace LmStreaming.Sample.Agents;
 /// </summary>
 public sealed class MultiTurnAgentPool : IAsyncDisposable
 {
+    /// <summary>
+    /// Property key in <see cref="ThreadMetadata.Properties"/> that stores the provider
+    /// id chosen for a thread. Once set, the value is treated as immutable for the
+    /// lifetime of that thread (a thread is "locked" to a single provider).
+    /// </summary>
+    public const string ProviderPropertyKey = "provider";
+
     private readonly ConcurrentDictionary<string, AgentEntry> _agents = new();
     private readonly ConcurrentDictionary<string, object> _creationLocks = new();
-    private readonly Func<string, ChatMode, string?, AgentCreationResult> _agentFactory;
+    private readonly Func<string, ChatMode, string, string?, AgentCreationResult> _agentFactory;
+    private readonly ProviderRegistry? _providerRegistry;
+    private readonly IConversationStore? _conversationStore;
     private readonly ILogger<MultiTurnAgentPool> _logger;
     private readonly CancellationTokenSource _poolCts = new();
     private bool _disposed;
@@ -42,6 +54,7 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
         public required Task RunTask { get; init; }
         public required CancellationTokenSource Cts { get; init; }
         public required ChatMode Mode { get; init; }
+        public required string ProviderId { get; init; }
         public string? RequestResponseDumpFileName { get; init; }
         public IReadOnlyList<IAsyncDisposable>? OwnedResources { get; init; }
 
@@ -79,16 +92,57 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
     }
 
     /// <summary>
-    /// Creates a new MultiTurnAgentPool with mode-aware agent factory.
+    /// Creates a new MultiTurnAgentPool with a provider-aware, mode-aware agent factory.
     /// </summary>
-    /// <param name="agentFactory">Factory function that creates an AgentCreationResult for a given threadId and ChatMode</param>
-    /// <param name="logger">Logger for pool operations</param>
+    /// <param name="agentFactory">
+    /// Factory invoked once per (threadId, providerId) combination. Receives the resolved
+    /// provider id (after metadata lookup / default fallback) so the factory does not need
+    /// to know about the request hop or persistence rules.
+    /// </param>
+    /// <param name="providerRegistry">
+    /// Provider registry used to resolve the default provider and validate availability.
+    /// May be <c>null</c> in legacy/test scenarios — when null, the pool skips the
+    /// availability check and persists whatever provider id the caller supplied.
+    /// </param>
+    /// <param name="conversationStore">
+    /// Conversation store used to read/write the persisted provider id under
+    /// <see cref="ProviderPropertyKey"/>. Optional — when null, providers are not
+    /// persisted and the pool falls back to caller-supplied / default values only.
+    /// </param>
+    /// <param name="logger">Logger for pool operations.</param>
     public MultiTurnAgentPool(
-        Func<string, ChatMode, string?, AgentCreationResult> agentFactory,
+        Func<string, ChatMode, string, string?, AgentCreationResult> agentFactory,
+        ProviderRegistry? providerRegistry,
+        IConversationStore? conversationStore,
         ILogger<MultiTurnAgentPool> logger)
     {
         _agentFactory = agentFactory ?? throw new ArgumentNullException(nameof(agentFactory));
+        _providerRegistry = providerRegistry;
+        _conversationStore = conversationStore;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Back-compat overload that omits the provider-id parameter from the factory. The
+    /// pool injects a fixed provider id (<c>"legacy"</c>) when invoking the factory. Use
+    /// the provider-aware constructor for new code.
+    /// </summary>
+    public MultiTurnAgentPool(
+        Func<string, ChatMode, string?, AgentCreationResult> agentFactory,
+        ILogger<MultiTurnAgentPool> logger)
+        : this(
+            agentFactory: WrapLegacyFactory(agentFactory),
+            providerRegistry: null,
+            conversationStore: null,
+            logger: logger)
+    {
+    }
+
+    private static Func<string, ChatMode, string, string?, AgentCreationResult> WrapLegacyFactory(
+        Func<string, ChatMode, string?, AgentCreationResult> agentFactory)
+    {
+        ArgumentNullException.ThrowIfNull(agentFactory);
+        return (threadId, mode, _, dump) => agentFactory(threadId, mode, dump);
     }
 
     /// <summary>
@@ -105,33 +159,78 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
     /// <summary>
     /// Gets or creates an agent for the specified threadId using the specified mode.
     /// If the agent doesn't exist, it's created and its RunAsync() is started.
+    /// The provider id is resolved from persisted metadata (if any) or the registry default.
     /// </summary>
-    /// <param name="threadId">The thread identifier</param>
-    /// <param name="mode">The chat mode to use for the agent</param>
-    /// <param name="requestResponseDumpFileName">
-    /// Optional base file name for provider request/response recording.
-    /// Only applied when creating a new agent instance.
-    /// </param>
-    /// <returns>The agent for this thread</returns>
     public IMultiTurnAgent GetOrCreateAgent(
         string threadId,
         ChatMode mode,
         string? requestResponseDumpFileName = null)
     {
+        return GetOrCreateAgent(threadId, mode, requestedProviderId: null, requestResponseDumpFileName);
+    }
+
+    /// <summary>
+    /// Gets or creates an agent for the specified threadId using the specified mode and a
+    /// requested provider id (used only on first creation; persisted threads keep their
+    /// original provider).
+    /// </summary>
+    /// <param name="threadId">The thread identifier.</param>
+    /// <param name="mode">The chat mode.</param>
+    /// <param name="requestedProviderId">
+    /// Provider id requested by the caller (typically from the WS query string). Honored
+    /// only when the thread has no persisted provider yet; otherwise the persisted value
+    /// wins. May be <c>null</c> to fall back to the registry default.
+    /// </param>
+    /// <param name="requestResponseDumpFileName">
+    /// Optional base file name for provider request/response recording.
+    /// Only applied when creating a new agent instance.
+    /// </param>
+    /// <exception cref="ProviderUnavailableException">
+    /// Thrown when the resolved provider id (whether from persisted metadata or the
+    /// caller's request) is no longer available in the current process.
+    /// </exception>
+    public IMultiTurnAgent GetOrCreateAgent(
+        string threadId,
+        ChatMode mode,
+        string? requestedProviderId,
+        string? requestResponseDumpFileName)
+    {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentException.ThrowIfNullOrEmpty(threadId);
         ArgumentNullException.ThrowIfNull(mode);
+
+        // Resolve provider OUTSIDE the lock to avoid blocking other threadIds on file I/O.
+        // The lock below is acquired only after we know which provider to use, so concurrent
+        // first-creation calls for the same threadId still serialise on creation.
+        var resolvedProviderId = ResolveProviderId(threadId, requestedProviderId);
 
         // Use per-key lock to prevent concurrent factory invocations for the same threadId.
         // ConcurrentDictionary.GetOrAdd does not guarantee the factory runs at most once,
         // which would leak disposable resources (MCP clients) from the losing invocation.
         var lockObj = _creationLocks.GetOrAdd(threadId, _ => new object());
         AgentEntry entry;
+        bool created = false;
         lock (lockObj)
         {
-            entry = _agents.GetOrAdd(
-                threadId,
-                id => CreateAgentEntry(id, mode, requestResponseDumpFileName));
+            if (!_agents.TryGetValue(threadId, out var existing))
+            {
+                entry = CreateAgentEntry(threadId, mode, resolvedProviderId, requestResponseDumpFileName);
+                _agents[threadId] = entry;
+                created = true;
+            }
+            else
+            {
+                entry = existing;
+            }
+        }
+
+        if (created)
+        {
+            // Persist the provider on first creation. Fire-and-forget — the WS connect
+            // path runs in a request scope, and a transient failure here only means the
+            // next reconnect will re-resolve from the registry default. We log warnings
+            // so silent persistence drift is visible.
+            _ = PersistProviderIfNeededAsync(threadId, resolvedProviderId);
         }
 
         if (!string.IsNullOrWhiteSpace(requestResponseDumpFileName)
@@ -148,6 +247,148 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
         }
 
         return entry.Agent;
+    }
+
+    /// <summary>
+    /// Returns the provider id that <see cref="GetOrCreateAgent(string, ChatMode, string?, string?)"/>
+    /// would use for <paramref name="threadId"/>, without creating an agent. Useful when a
+    /// caller needs to surface "this thread is locked to provider X" to the UI.
+    /// </summary>
+    public string? GetEffectiveProviderId(string threadId, string? requestedProviderId)
+    {
+        if (string.IsNullOrEmpty(threadId))
+        {
+            return null;
+        }
+
+        try
+        {
+            return ResolveProviderId(threadId, requestedProviderId);
+        }
+        catch (ProviderUnavailableException)
+        {
+            // Surface the persisted id even when unavailable so the UI can show the badge.
+            var persisted = LoadPersistedProviderId(threadId);
+            return persisted ?? _providerRegistry?.DefaultProviderId;
+        }
+    }
+
+    private string ResolveProviderId(string threadId, string? requestedProviderId)
+    {
+        var persistedProviderId = LoadPersistedProviderId(threadId);
+        if (!string.IsNullOrWhiteSpace(persistedProviderId))
+        {
+            EnsureAvailableOrThrow(persistedProviderId, source: "persisted");
+            return persistedProviderId;
+        }
+
+        if (!string.IsNullOrWhiteSpace(requestedProviderId))
+        {
+            EnsureAvailableOrThrow(requestedProviderId, source: "requested");
+            return requestedProviderId;
+        }
+
+        var fallback = _providerRegistry?.DefaultProviderId;
+        if (string.IsNullOrWhiteSpace(fallback))
+        {
+            // No registry was wired up — surface a stable sentinel for the legacy back-compat path.
+            return "default";
+        }
+
+        EnsureAvailableOrThrow(fallback, source: "default");
+        return fallback;
+    }
+
+    private void EnsureAvailableOrThrow(string providerId, string source)
+    {
+        if (_providerRegistry == null)
+        {
+            return;
+        }
+
+        if (!_providerRegistry.IsAvailable(providerId))
+        {
+            var reason = _providerRegistry.IsKnown(providerId)
+                ? $"required configuration is missing (source: {source})"
+                : $"unknown provider id (source: {source})";
+            throw new ProviderUnavailableException(providerId, reason);
+        }
+    }
+
+    private string? LoadPersistedProviderId(string threadId)
+    {
+        if (_conversationStore == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            // Sync-over-async: provider lookup happens once per thread on first WS connect.
+            // The pool is already invoked from a request scope; making this whole code path
+            // async would cascade through GetOrCreateAgent and break existing call sites.
+            var metadata = _conversationStore.LoadMetadataAsync(threadId).GetAwaiter().GetResult();
+            if (metadata?.Properties != null
+                && metadata.Properties.TryGetValue(ProviderPropertyKey, out var raw)
+                && raw is string s
+                && !string.IsNullOrWhiteSpace(s))
+            {
+                return s.Trim().ToLowerInvariant();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to load persisted provider for thread {ThreadId}; falling back to default",
+                threadId);
+        }
+
+        return null;
+    }
+
+    private async Task PersistProviderIfNeededAsync(string threadId, string providerId)
+    {
+        if (_conversationStore == null)
+        {
+            return;
+        }
+
+        try
+        {
+            var existing = await _conversationStore.LoadMetadataAsync(threadId).ConfigureAwait(false);
+            var hasProvider = existing?.Properties?.ContainsKey(ProviderPropertyKey) == true;
+            if (hasProvider)
+            {
+                return;
+            }
+
+            var properties = existing?.Properties ?? ImmutableDictionary<string, object>.Empty;
+            properties = properties.SetItem(ProviderPropertyKey, providerId);
+
+            var updated = (existing ?? new ThreadMetadata
+            {
+                ThreadId = threadId,
+                LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            }) with
+            {
+                Properties = properties,
+                LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            };
+
+            await _conversationStore.SaveMetadataAsync(threadId, updated).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Persisted provider {ProviderId} for thread {ThreadId}",
+                providerId,
+                threadId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to persist provider {ProviderId} for thread {ThreadId}",
+                providerId,
+                threadId);
+        }
     }
 
     /// <summary>
@@ -239,6 +480,10 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
             mode.Id,
             mode.Name);
 
+        // Resolve provider before re-entering the lock — the same persisted provider must
+        // continue to be used after a mode-switch (mode-switch is not a provider switch).
+        var resolvedProviderId = ResolveProviderId(threadId, requestedProviderId: null);
+
         // Acquire the per-key lock to prevent races with concurrent GetOrCreateAgent calls.
         var lockObj = _creationLocks.GetOrAdd(threadId, _ => new object());
         AgentEntry? oldEntry = null;
@@ -246,7 +491,7 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
         lock (lockObj)
         {
             _agents.TryRemove(threadId, out oldEntry);
-            entry = CreateAgentEntry(threadId, mode, requestResponseDumpFileName: null);
+            entry = CreateAgentEntry(threadId, mode, resolvedProviderId, requestResponseDumpFileName: null);
             _agents[threadId] = entry;
         }
 
@@ -260,16 +505,21 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
         return entry.Agent;
     }
 
-    private AgentEntry CreateAgentEntry(string threadId, ChatMode mode, string? requestResponseDumpFileName)
+    private AgentEntry CreateAgentEntry(
+        string threadId,
+        ChatMode mode,
+        string providerId,
+        string? requestResponseDumpFileName)
     {
         _logger.LogInformation(
-            "Creating new agent for thread {ThreadId} with mode {ModeId} ({ModeName}), dump recording enabled: {DumpEnabled}",
+            "Creating new agent for thread {ThreadId} with mode {ModeId} ({ModeName}) and provider {ProviderId}, dump recording enabled: {DumpEnabled}",
             threadId,
             mode.Id,
             mode.Name,
+            providerId,
             !string.IsNullOrWhiteSpace(requestResponseDumpFileName));
 
-        var result = _agentFactory(threadId, mode, requestResponseDumpFileName);
+        var result = _agentFactory(threadId, mode, providerId, requestResponseDumpFileName);
         var agent = result.Agent;
         var cts = CancellationTokenSource.CreateLinkedTokenSource(_poolCts.Token);
 
@@ -296,6 +546,7 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
             RunTask = runTask,
             Cts = cts,
             Mode = mode,
+            ProviderId = providerId,
             RequestResponseDumpFileName = requestResponseDumpFileName,
             OwnedResources = result.OwnedResources,
         };

--- a/samples/LmStreaming.Sample/ClientApp/src/api/index.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/api/index.ts
@@ -3,3 +3,4 @@ export * from './sseParser';
 export * from './wsClient';
 export * from './conversationsApi';
 export * from './chatModesApi';
+export * from './providersApi';

--- a/samples/LmStreaming.Sample/ClientApp/src/api/providersApi.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/api/providersApi.ts
@@ -1,0 +1,13 @@
+import type { ProvidersResponse } from '@/types/providers';
+
+/**
+ * Fetches the list of providers available in the current process and the default
+ * provider id. The default is used when the user does not explicitly pick one.
+ */
+export async function listProviders(): Promise<ProvidersResponse> {
+  const response = await fetch('/api/providers');
+  if (!response.ok) {
+    throw new Error(`Failed to fetch providers: ${response.statusText}`);
+  }
+  return response.json();
+}

--- a/samples/LmStreaming.Sample/ClientApp/src/api/wsClient.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/api/wsClient.ts
@@ -20,6 +20,11 @@ export interface WebSocketClientOptions extends WebSocketClientCallbacks {
   baseUrl?: string;
   threadId?: string;
   modeId?: string;
+  /**
+   * Provider id requested for this connection. Honored only when the thread has not
+   * yet locked in a provider; persisted threads keep their original provider regardless.
+   */
+  providerId?: string | null;
   record?: boolean;
 }
 
@@ -74,7 +79,7 @@ function normalizeKeys(value: unknown): unknown {
 export function createWebSocketConnection(
   options: WebSocketClientOptions
 ): Promise<WebSocketConnection> {
-  const { baseUrl = '', threadId, modeId, record, onMessage, onDone, onError } = options;
+  const { baseUrl = '', threadId, modeId, providerId, record, onMessage, onDone, onError } = options;
 
   return new Promise((resolve, reject) => {
     const connectionId = generateConnectionId();
@@ -84,6 +89,9 @@ export function createWebSocketConnection(
     let wsUrl = `${wsProtocol}//${wsHost}/ws?threadId=${effectiveThreadId}&connectionId=${connectionId}`;
     if (modeId) {
       wsUrl += `&modeId=${encodeURIComponent(modeId)}`;
+    }
+    if (providerId) {
+      wsUrl += `&providerId=${encodeURIComponent(providerId)}`;
     }
     if (record) {
       wsUrl += '&record=1';

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
@@ -3,6 +3,7 @@ import { computed, ref, onMounted, provide } from 'vue';
 import { useConversations } from '@/composables/useConversations';
 import { useChat, getDisplayText } from '@/composables/useChat';
 import { useChatModes } from '@/composables/useChatModes';
+import { useProviders } from '@/composables/useProviders';
 import { updateConversationMetadata } from '@/api/conversationsApi';
 import type { ChatModeCreateUpdate } from '@/types/chatMode';
 import ConversationSidebar from './ConversationSidebar.vue';
@@ -10,6 +11,7 @@ import MessageList from './MessageList.vue';
 import PendingMessageQueue from './PendingMessageQueue.vue';
 import ChatInput from './ChatInput.vue';
 import ModeSelector from './ModeSelector.vue';
+import ProviderSelector from './ProviderSelector.vue';
 
 const {
   conversations,
@@ -38,7 +40,16 @@ const {
   copyMode,
 } = useChatModes();
 
-// Initialize chat with a getter for the current mode ID
+// Provider catalog + per-process selection for new conversations.
+const {
+  providers,
+  selectedProviderId,
+  isLoading: providersLoading,
+  loadProviders,
+  selectProvider,
+} = useProviders();
+
+// Initialize chat with getters for the current mode and provider ids.
 const {
   displayItems,
   isLoading: chatLoading,
@@ -53,7 +64,10 @@ const {
   setThreadId,
   loadMessagesFromBackend,
   getResultForToolCall,
-} = useChat({ getModeId: () => currentModeId.value });
+} = useChat({
+  getModeId: () => currentModeId.value,
+  getProviderId: () => selectedProviderId.value,
+});
 
 async function handleCancel(): Promise<void> {
   await cancelStream();
@@ -68,13 +82,38 @@ const modeSwitchDisabled = computed(
   () => modesLoading.value || chatLoading.value || isSending.value || isSwitchingMode.value
 );
 
+/**
+ * Provider id locked to the current thread, derived from the conversation summary
+ * (populated from <c>ThreadMetadata.Properties["provider"]</c>). A thread becomes
+ * "locked" the moment it appears in the sidebar — i.e. after its first message —
+ * and stays locked for the rest of its life. New conversations have no sidebar
+ * entry yet, so this resolves to <c>null</c> and the dropdown stays editable.
+ */
+const lockedProviderId = computed<string | null>(() => {
+  if (!currentThreadId.value) return null;
+  const conversation = conversations.value.find((c) => c.threadId === currentThreadId.value);
+  return conversation?.provider ?? null;
+});
+
+const providerSelectorDisabled = computed(
+  () => providersLoading.value || chatLoading.value || isSending.value || isSwitchingMode.value
+);
+
+function handleSelectProvider(providerId: string): void {
+  if (providerSelectorDisabled.value || lockedProviderId.value) {
+    return;
+  }
+  selectProvider(providerId);
+}
+
 // Load conversations and modes on mount
 onMounted(async () => {
-  // Load modes and tools in parallel with conversations
+  // Load modes, tools, and providers in parallel with conversations
   await Promise.all([
     loadConversations(),
     loadModes(),
     loadTools(),
+    loadProviders(),
   ]);
 
   // If there are existing conversations, select the most recent one
@@ -205,12 +244,14 @@ async function handleSend(text: string): Promise<void> {
     const title = displayText.substring(0, 50);
     const preview = displayText.substring(0, 100);
 
-    // Add to local sidebar immediately
+    // Add to local sidebar immediately. Reflect the provider that was used for the
+    // first connect so the dropdown locks to a badge without waiting for a refetch.
     addOrUpdateConversation({
       threadId: currentThreadId.value,
       title,
       preview,
       lastUpdated: Date.now(),
+      provider: selectedProviderId.value,
     });
 
     // Update backend metadata asynchronously
@@ -268,6 +309,14 @@ onMounted(() => {
           </button>
           <h1>LmStreaming Chat</h1>
           <div class="header-actions">
+            <ProviderSelector
+              :providers="providers"
+              :selected-provider-id="selectedProviderId"
+              :locked-provider-id="lockedProviderId"
+              :is-loading="providersLoading"
+              :disabled="providerSelectorDisabled"
+              @select-provider="handleSelectProvider"
+            />
             <ModeSelector
               :modes="modes"
               :current-mode-id="currentModeId"

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, onMounted, provide } from 'vue';
+import { computed, ref, onMounted, onBeforeUnmount, provide } from 'vue';
 import { useConversations } from '@/composables/useConversations';
 import { useChat, getDisplayText } from '@/composables/useChat';
 import { useChatModes } from '@/composables/useChatModes';
@@ -280,6 +280,10 @@ function checkMobile(): void {
 onMounted(() => {
   checkMobile();
   window.addEventListener('resize', checkMobile);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', checkMobile);
 });
 </script>
 

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ProviderSelector.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ProviderSelector.vue
@@ -1,0 +1,279 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
+import type { ProviderDescriptor } from '@/types/providers';
+
+const props = defineProps<{
+  providers: ProviderDescriptor[];
+  selectedProviderId: string | null;
+  /**
+   * Provider id locked to the current thread (set after the first message). When
+   * provided, the selector renders as a read-only badge instead of a dropdown.
+   */
+  lockedProviderId?: string | null;
+  isLoading?: boolean;
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{
+  'select-provider': [providerId: string];
+}>();
+
+const dropdownOpen = ref(false);
+const dropdownRef = ref<HTMLElement | null>(null);
+
+const isLocked = computed(() => !!props.lockedProviderId);
+
+const lockedProvider = computed<ProviderDescriptor | null>(() => {
+  if (!props.lockedProviderId) return null;
+  return (
+    props.providers.find((p) => p.id === props.lockedProviderId) ?? {
+      id: props.lockedProviderId,
+      displayName: props.lockedProviderId,
+      available: false,
+    }
+  );
+});
+
+const selectedProvider = computed<ProviderDescriptor | null>(() =>
+  props.providers.find((p) => p.id === props.selectedProviderId) ?? null
+);
+
+function toggleDropdown(): void {
+  if (props.disabled || props.isLoading || isLocked.value) {
+    return;
+  }
+  dropdownOpen.value = !dropdownOpen.value;
+}
+
+function closeDropdown(): void {
+  dropdownOpen.value = false;
+}
+
+function handleSelect(providerId: string): void {
+  if (props.disabled || isLocked.value) {
+    return;
+  }
+  emit('select-provider', providerId);
+  closeDropdown();
+}
+
+function handleClickOutside(event: MouseEvent): void {
+  if (dropdownRef.value && !dropdownRef.value.contains(event.target as Node)) {
+    closeDropdown();
+  }
+}
+
+function handleKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    closeDropdown();
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside);
+  document.addEventListener('keydown', handleKeydown);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside);
+  document.removeEventListener('keydown', handleKeydown);
+});
+
+watch(
+  () => [props.disabled, props.lockedProviderId] as const,
+  ([isDisabled, locked]) => {
+    if (isDisabled || locked) {
+      closeDropdown();
+    }
+  }
+);
+</script>
+
+<template>
+  <div class="provider-selector" ref="dropdownRef" data-testid="provider-selector">
+    <span
+      v-if="isLocked"
+      class="provider-badge"
+      data-testid="provider-locked-badge"
+      :title="`This conversation is locked to ${lockedProvider?.displayName ?? lockedProviderId}`"
+    >
+      <span class="badge-label">Provider:</span>
+      <span class="badge-name">{{ lockedProvider?.displayName ?? lockedProviderId }}</span>
+      <span class="badge-lock" aria-hidden="true">🔒</span>
+    </span>
+    <template v-else>
+      <button
+        class="selector-btn"
+        :class="{ open: dropdownOpen }"
+        data-testid="provider-selector-button"
+        @click="toggleDropdown"
+        :disabled="isLoading || disabled"
+      >
+        <span class="provider-label">Provider:</span>
+        <span class="provider-name">{{ selectedProvider?.displayName ?? 'Loading...' }}</span>
+        <span class="dropdown-arrow">{{ dropdownOpen ? '\u25B2' : '\u25BC' }}</span>
+      </button>
+
+      <div v-if="dropdownOpen" class="dropdown-menu">
+        <button
+          v-for="provider in providers"
+          :key="provider.id"
+          class="menu-item"
+          :class="{ active: provider.id === selectedProviderId, unavailable: !provider.available }"
+          :data-testid="`provider-option-${provider.id}`"
+          :disabled="disabled || !provider.available"
+          @click="handleSelect(provider.id)"
+        >
+          <span class="item-name">{{ provider.displayName }}</span>
+          <span v-if="!provider.available" class="item-status">unavailable</span>
+          <span v-else-if="provider.id === selectedProviderId" class="check-mark">✓</span>
+        </button>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.provider-selector {
+  position: relative;
+}
+
+.selector-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: #f8f9fa;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.selector-btn:hover:not(:disabled) {
+  background: #e9ecef;
+}
+
+.selector-btn.open {
+  border-color: #0d6efd;
+  box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.15);
+}
+
+.selector-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.provider-label {
+  color: #666;
+}
+
+.provider-name {
+  color: #333;
+  font-weight: 500;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dropdown-arrow {
+  color: #666;
+  font-size: 10px;
+  margin-left: 4px;
+}
+
+.dropdown-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  min-width: 200px;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 100;
+  overflow: hidden;
+  padding: 4px 0;
+}
+
+.menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.menu-item:hover:not(:disabled) {
+  background: #f8f9fa;
+}
+
+.menu-item:disabled,
+.menu-item.unavailable {
+  color: #9aa0a6;
+  cursor: not-allowed;
+}
+
+.menu-item.active {
+  background: #e7f1ff;
+  color: #0d6efd;
+}
+
+.item-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.item-status {
+  font-size: 11px;
+  font-style: italic;
+  color: #9aa0a6;
+  margin-left: 8px;
+  flex-shrink: 0;
+}
+
+.check-mark {
+  color: #0d6efd;
+  font-weight: bold;
+  flex-shrink: 0;
+  margin-left: 8px;
+}
+
+.provider-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: #eef1f5;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  font-size: 13px;
+  color: #444;
+}
+
+.badge-label {
+  color: #666;
+}
+
+.badge-name {
+  color: #333;
+  font-weight: 500;
+}
+
+.badge-lock {
+  font-size: 12px;
+  opacity: 0.8;
+}
+</style>

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/index.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/index.ts
@@ -2,3 +2,4 @@ export * from './useChat';
 export * from './useMessageMerger';
 export * from './useConversations';
 export * from './useChatModes';
+export * from './useProviders';

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -72,6 +72,12 @@ export interface ChatMessage {
 export interface UseChatOptions {
   transport?: TransportType;
   getModeId?: () => string | undefined;
+  /**
+   * Resolves the provider id to send on the WebSocket query string when the
+   * connection opens. Returning <c>null</c>/<c>undefined</c> lets the server
+   * fall back to its configured default.
+   */
+  getProviderId?: () => string | null | undefined;
 }
 
 /**
@@ -123,7 +129,7 @@ export function getDisplayText(text: string): string {
  * Composable for managing chat state and interactions
  */
 export function useChat(options: UseChatOptions = {}) {
-  const { transport: initialTransport = 'websocket', getModeId } = options;
+  const { transport: initialTransport = 'websocket', getModeId, getProviderId } = options;
   const recordEnabled = isRecordingEnabledFromPageQuery();
 
   // Core state
@@ -823,9 +829,11 @@ export function useChat(options: UseChatOptions = {}) {
       sendWebSocketMessage(wsConnection, text);
     } else {
       const currentModeId = getModeId?.();
+      const currentProviderId = getProviderId?.() ?? null;
       log.info('Creating new WebSocket connection', {
         threadId: effectiveThreadId,
         modeId: currentModeId,
+        providerId: currentProviderId,
         recordEnabled,
       });
 
@@ -842,6 +850,7 @@ export function useChat(options: UseChatOptions = {}) {
       wsConnection = await createWebSocketConnection({
         threadId: effectiveThreadId,
         modeId: currentModeId,
+        providerId: currentProviderId,
         record: recordEnabled,
         ...callbacks,
         onDone: () => {

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useProviders.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useProviders.ts
@@ -1,0 +1,89 @@
+import { ref, computed } from 'vue';
+import type { ProviderDescriptor } from '@/types/providers';
+import { listProviders } from '@/api/providersApi';
+
+/**
+ * Composable that loads the provider catalog from the backend and exposes the
+ * user's currently-selected provider for the next new conversation.
+ *
+ * The selection is intentionally process-local: the backend treats a thread's
+ * provider as immutable once the thread has its first message, so this state
+ * only matters until that point. After the first message we read the locked
+ * value from the conversation's metadata instead.
+ */
+export function useProviders() {
+  const providers = ref<ProviderDescriptor[]>([]);
+  const defaultProviderId = ref<string | null>(null);
+  const selectedProviderId = ref<string | null>(null);
+  const isLoading = ref(false);
+  const error = ref<string | null>(null);
+
+  /**
+   * Provider currently chosen for the next new conversation.
+   */
+  const selectedProvider = computed(() =>
+    providers.value.find((p) => p.id === selectedProviderId.value) ?? null
+  );
+
+  /**
+   * Loads the provider catalog. Selects the backend-supplied default if the
+   * user has not yet picked one, falling back to the first available provider.
+   */
+  async function loadProviders(): Promise<void> {
+    isLoading.value = true;
+    error.value = null;
+    try {
+      const response = await listProviders();
+      providers.value = response.providers ?? [];
+      defaultProviderId.value = response.default ?? null;
+
+      if (selectedProviderId.value === null) {
+        const initial =
+          providers.value.find((p) => p.id === defaultProviderId.value && p.available)?.id
+          ?? providers.value.find((p) => p.available)?.id
+          ?? defaultProviderId.value
+          ?? null;
+        selectedProviderId.value = initial;
+      }
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load providers';
+      console.error('Failed to load providers:', e);
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  /**
+   * Selects a provider for new conversations. No-op for unknown ids so the UI
+   * can defensively pass user input without leaving the dropdown in a stale
+   * state.
+   */
+  function selectProvider(providerId: string): void {
+    if (!providers.value.some((p) => p.id === providerId)) {
+      return;
+    }
+    selectedProviderId.value = providerId;
+  }
+
+  /**
+   * Look up a descriptor by id. Returns null if the id is unknown — useful for
+   * rendering a locked-thread badge when the persisted provider has since been
+   * removed from the registry.
+   */
+  function getProviderById(providerId: string | null | undefined): ProviderDescriptor | null {
+    if (!providerId) return null;
+    return providers.value.find((p) => p.id === providerId) ?? null;
+  }
+
+  return {
+    providers,
+    defaultProviderId,
+    selectedProviderId,
+    selectedProvider,
+    isLoading,
+    error,
+    loadProviders,
+    selectProvider,
+    getProviderById,
+  };
+}

--- a/samples/LmStreaming.Sample/ClientApp/src/types/conversations.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/types/conversations.ts
@@ -6,6 +6,11 @@ export interface ConversationSummary {
   title: string;
   preview?: string;
   lastUpdated: number;
+  /**
+   * Provider id this thread is locked to. Set on first agent creation; null for legacy
+   * threads predating the per-conversation provider feature.
+   */
+  provider?: string | null;
 }
 
 /**

--- a/samples/LmStreaming.Sample/ClientApp/src/types/index.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './messages';
 export * from './conversations';
 export * from './chatMode';
+export * from './providers';

--- a/samples/LmStreaming.Sample/ClientApp/src/types/providers.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/types/providers.ts
@@ -1,0 +1,16 @@
+/**
+ * Single provider entry returned by GET /api/providers.
+ */
+export interface ProviderDescriptor {
+  id: string;
+  displayName: string;
+  available: boolean;
+}
+
+/**
+ * Response body for GET /api/providers.
+ */
+export interface ProvidersResponse {
+  providers: ProviderDescriptor[];
+  default: string;
+}

--- a/samples/LmStreaming.Sample/Controllers/ConversationsController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ConversationsController.cs
@@ -35,6 +35,9 @@ public class ConversationsController(
                 ? previewObj?.ToString()
                 : null,
             LastUpdated = t.LastUpdated,
+            Provider = t.Properties?.TryGetValue(MultiTurnAgentPool.ProviderPropertyKey, out var providerObj) == true
+                ? providerObj?.ToString()
+                : null,
         });
         return Ok(result);
     }

--- a/samples/LmStreaming.Sample/Controllers/ProvidersController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ProvidersController.cs
@@ -1,0 +1,20 @@
+using LmStreaming.Sample.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LmStreaming.Sample.Controllers;
+
+[ApiController]
+[Route("api/providers")]
+public sealed class ProvidersController(ProviderRegistry registry) : ControllerBase
+{
+    [HttpGet]
+    public ActionResult<ProvidersResponse> List()
+    {
+        var providers = registry.ListAll();
+        return Ok(new ProvidersResponse(providers, registry.DefaultProviderId));
+    }
+}
+
+public sealed record ProvidersResponse(
+    IReadOnlyList<ProviderDescriptor> Providers,
+    string Default);

--- a/samples/LmStreaming.Sample/Models/ConversationDtos.cs
+++ b/samples/LmStreaming.Sample/Models/ConversationDtos.cs
@@ -9,6 +9,13 @@ public record ConversationSummary
     public required string Title { get; init; }
     public string? Preview { get; init; }
     public required long LastUpdated { get; init; }
+
+    /// <summary>
+    /// Provider id this thread is locked to. Set on first agent creation and persisted
+    /// in <c>ThreadMetadata.Properties["provider"]</c>. Null for legacy threads predating
+    /// the per-conversation provider feature.
+    /// </summary>
+    public string? Provider { get; init; }
 }
 
 /// <summary>

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -105,7 +105,11 @@ try
     var providerMode = Environment.GetEnvironmentVariable("LM_PROVIDER_MODE") ?? "test";
     var codexMcpPort = ResolveCodexMcpPort();
     Environment.SetEnvironmentVariable("CODEX_MCP_PORT_EFFECTIVE", codexMcpPort.ToString());
-    var codexMcpEndpointUrl = $"http://localhost:{codexMcpPort}/mcp";
+
+    // Provider registry — single source of truth for which providers the client can pick
+    // and what the per-process default is. Read once at startup; shared via DI singleton.
+    _ = builder.Services.AddSingleton<IFileSystemProbe, FileSystemProbe>();
+    _ = builder.Services.AddSingleton<ProviderRegistry>();
 
     // Register the FunctionRegistry with sample tools
     _ = builder.Services.AddSingleton(sp =>
@@ -115,16 +119,17 @@ try
         return registry;
     });
 
-    if (string.Equals(providerMode, "codex", StringComparison.OrdinalIgnoreCase))
+    // Codex MCP server: registered unconditionally but started lazily, so non-codex boots
+    // don't pay the startup cost and so the codex provider stays selectable from the
+    // dropdown regardless of LM_PROVIDER_MODE.
+    _ = builder.Services.AddSingleton<IFunctionProvider>(
+        new TypeFunctionProvider(typeof(SampleTools), providerName: "SampleTools"));
+    _ = builder.Services.AddMcpFunctionProviderServerLazy(options =>
     {
-        _ = builder.Services.AddSingleton<IFunctionProvider>(
-            new TypeFunctionProvider(typeof(SampleTools), providerName: "SampleTools"));
-        _ = builder.Services.AddMcpFunctionProviderServer(options =>
-        {
-            options.Port = codexMcpPort;
-            options.IncludeStatefulFunctions = true;
-        });
-    }
+        options.Port = codexMcpPort;
+        options.IncludeStatefulFunctions = true;
+    });
+    _ = builder.Services.AddSingleton<CodexMcpServerLifetime>();
 
     // Register the FileConversationStore for conversation persistence
     var conversationsPath = Path.Combine(AppContext.BaseDirectory, "conversations");
@@ -134,7 +139,9 @@ try
     var chatModesPath = Path.Combine(AppContext.BaseDirectory, "chat-modes");
     _ = builder.Services.AddSingleton<IChatModeStore>(new FileChatModeStore(chatModesPath));
 
-    // Register built-in (server-side) tool definitions for the tools API
+    // Register built-in (server-side) tool definitions for the tools API. The list is
+    // computed for the boot default so the global tools API stays stable; per-conversation
+    // built-in tools are derived from the resolved provider id at agent-creation time.
     var builtInTools = GetBuiltInToolsForProvider(providerMode);
     var builtInToolDefinitions = builtInTools?
         .OfType<AnthropicBuiltInTool>()
@@ -151,20 +158,25 @@ try
     // sub-agent templates without touching any real-provider code path.
     builder.Services.TryAddSingleton<ITestAgentBuilder, DefaultTestAgentBuilder>();
 
-    _ = builder.Services.AddSingleton<Func<IStreamingAgent>>(sp => () =>
+    // Provider id → IStreamingAgent. Receives the per-conversation provider id resolved
+    // by the pool (request → persisted → default), so this factory does not know about
+    // LM_PROVIDER_MODE — it just dispatches by id.
+    _ = builder.Services.AddSingleton<Func<string, IStreamingAgent>>(sp => providerId =>
         {
             var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
-
-            return providerMode.ToLowerInvariant() switch
+            return providerId.ToLowerInvariant() switch
             {
                 "openai" => CreateOpenAiAgent(loggerFactory),
                 "anthropic" => CreateAnthropicAgent(loggerFactory),
                 "test-anthropic" => CreateAnthropicTestAgent(
                     loggerFactory,
                     sp.GetRequiredService<ITestAgentBuilder>()),
-                _ => CreateTestAgent(
+                "test" => CreateTestAgent(
                     loggerFactory,
                     sp.GetRequiredService<ITestAgentBuilder>()),
+                _ => throw new ProviderUnavailableException(
+                    providerId,
+                    "no IStreamingAgent factory is registered for this provider"),
             };
         });
 
@@ -172,22 +184,41 @@ try
     var llmQueryMcpBaseUrl = builder.Configuration["LlmQueryMcp:BaseUrl"];
     var llmQueryMcpExamType = builder.Configuration["LlmQueryMcp:ExamType"] ?? "NeetPG";
 
-    // Register the MultiTurnAgentPool with mode-aware factory
+    // Register the MultiTurnAgentPool with provider- and mode-aware factory
     _ = builder.Services.AddSingleton(sp =>
     {
         var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
         var functionRegistry = sp.GetRequiredService<FunctionRegistry>();
-        var agentFactory = sp.GetRequiredService<Func<IStreamingAgent>>();
+        var agentFactory = sp.GetRequiredService<Func<string, IStreamingAgent>>();
         var conversationStore = sp.GetRequiredService<IConversationStore>();
+        var providerRegistry = sp.GetRequiredService<ProviderRegistry>();
+        var codexLifetime = sp.GetRequiredService<CodexMcpServerLifetime>();
 
         return new MultiTurnAgentPool(
-            (threadId, mode, requestResponseDumpFileName) =>
+            (threadId, mode, providerId, requestResponseDumpFileName) =>
             {
                 var isMedicalMode = mode.Id == SystemChatModes.MedicalKnowledgeModeId;
                 var mcpBaseUrl = isMedicalMode ? llmQueryMcpBaseUrl : null;
+                var normalizedProviderId = providerId.ToLowerInvariant();
 
-                if (string.Equals(providerMode, "codex", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(normalizedProviderId, "codex", StringComparison.Ordinal))
                 {
+                    string codexEndpoint;
+                    try
+                    {
+                        // Lazy MCP startup — fires on first codex agent creation regardless of
+                        // boot mode. Sync-over-async is acceptable: this happens at most once
+                        // per process from the pool's per-thread creation lock.
+                        codexEndpoint = codexLifetime.EnsureStartedAsync().GetAwaiter().GetResult();
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new ProviderUnavailableException(
+                            "codex",
+                            $"MCP server failed to start: {ex.Message}",
+                            ex);
+                    }
+
                     return new MultiTurnAgentPool.AgentCreationResult(
                         CreateCodexAgentLoop(
                             threadId,
@@ -196,12 +227,12 @@ try
                             requestResponseDumpFileName,
                             conversationStore,
                             loggerFactory,
-                            codexMcpEndpointUrl,
+                            codexEndpoint,
                             mcpBaseUrl,
                             llmQueryMcpExamType));
                 }
 
-                if (string.Equals(providerMode, "claude", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(normalizedProviderId, "claude", StringComparison.Ordinal))
                 {
                     return new MultiTurnAgentPool.AgentCreationResult(
                         CreateClaudeAgentLoop(
@@ -214,7 +245,7 @@ try
                             llmQueryMcpExamType));
                 }
 
-                if (string.Equals(providerMode, "copilot", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(normalizedProviderId, "copilot", StringComparison.Ordinal))
                 {
                     return new MultiTurnAgentPool.AgentCreationResult(
                         CreateCopilotAgentLoop(
@@ -226,7 +257,7 @@ try
                             loggerFactory));
                 }
 
-                var providerAgent = agentFactory();
+                var providerAgent = agentFactory(normalizedProviderId);
 
                 // Clone the shared registry per-agent to avoid mutation, filtering by mode
                 var (allContracts, allHandlers) = functionRegistry.Build();
@@ -257,16 +288,16 @@ try
 
                 try
                 {
-                    var modelId = GetModelIdForProvider(providerMode);
+                    var modelId = GetModelIdForProvider(normalizedProviderId);
 
                     // Filter built-in (server-side) tools based on mode's enabled tools
-                    var allBuiltInTools = GetBuiltInToolsForProvider(providerMode);
+                    var allBuiltInTools = GetBuiltInToolsForProvider(normalizedProviderId);
                     var filteredBuiltInTools = ModeToolFilter.FilterBuiltInTools(allBuiltInTools, mode.EnabledTools);
 
                     // Enable extended thinking for Anthropic-compatible providers
                     var extraProperties = ImmutableDictionary<string, object?>.Empty;
-                    if (providerMode.Equals("anthropic", StringComparison.OrdinalIgnoreCase)
-                        || providerMode.Equals("test-anthropic", StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(normalizedProviderId, "anthropic", StringComparison.Ordinal)
+                        || string.Equals(normalizedProviderId, "test-anthropic", StringComparison.Ordinal))
                     {
                         var budgetTokens = int.TryParse(
                             Environment.GetEnvironmentVariable("ANTHROPIC_THINKING_BUDGET"),
@@ -277,11 +308,11 @@ try
 
                     // Test-mode DI seam: opt-in sub-agent orchestration. Real-provider modes
                     // never resolve this service, so production wiring is unchanged.
-                    var isTestMode = string.Equals(providerMode, "test", StringComparison.OrdinalIgnoreCase)
-                        || string.Equals(providerMode, "test-anthropic", StringComparison.OrdinalIgnoreCase);
+                    var isTestMode = string.Equals(normalizedProviderId, "test", StringComparison.Ordinal)
+                        || string.Equals(normalizedProviderId, "test-anthropic", StringComparison.Ordinal);
                     var subAgentOptions = isTestMode
                         ? sp.GetRequiredService<ITestAgentBuilder>()
-                            .CreateSubAgentOptions(loggerFactory, agentFactory)
+                            .CreateSubAgentOptions(loggerFactory, () => agentFactory(normalizedProviderId))
                         : null;
 
                     var agent = new MultiTurnAgentLoop(
@@ -318,7 +349,9 @@ try
                     throw;
                 }
             },
-            loggerFactory.CreateLogger<MultiTurnAgentPool>());
+            providerRegistry: providerRegistry,
+            conversationStore: conversationStore,
+            logger: loggerFactory.CreateLogger<MultiTurnAgentPool>());
     });
 
     // Register the ChatWebSocketManager
@@ -378,6 +411,11 @@ try
             ? await modeStore.GetModeAsync(modeId, cancellationToken)
             : null;
 
+        // Optional per-conversation provider override. Honored only when the thread has
+        // not yet locked in a provider (first message). Persisted threads keep their
+        // original provider regardless of what the client sends.
+        var providerId = context.Request.Query["providerId"].FirstOrDefault();
+
         var recordEnabled = app.Environment.IsDevelopment()
             && IsRecordingEnabled(context.Request.Query["record"].FirstOrDefault());
 
@@ -418,6 +456,7 @@ try
                 webSocket,
                 threadId,
                 mode,
+                providerId,
                 requestResponseDumpFileName,
                 recordWriter,
                 cancellationToken);

--- a/samples/LmStreaming.Sample/Services/CodexMcpServerLifetime.cs
+++ b/samples/LmStreaming.Sample/Services/CodexMcpServerLifetime.cs
@@ -1,0 +1,86 @@
+using System.Runtime.CompilerServices;
+using AchieveAi.LmDotnetTools.McpServer.AspNetCore;
+
+[assembly: InternalsVisibleTo("LmStreaming.Sample.Tests")]
+
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+/// Lazy lifetime wrapper for the codex MCP server. The underlying
+/// <see cref="McpFunctionProviderServer"/> is registered as a singleton (without an
+/// <see cref="Microsoft.Extensions.Hosting.IHostedService"/> registration), and we only
+/// call <c>StartAsync</c> on it the first time a codex agent is created. Subsequent
+/// callers await the cached <see cref="Task{T}"/> from the same <see cref="Lazy{T}"/>.
+/// </summary>
+public sealed class CodexMcpServerLifetime : IAsyncDisposable
+{
+    private readonly McpFunctionProviderServer? _server;
+    private readonly Func<Task<string>> _startupDelegate;
+    private readonly ILogger<CodexMcpServerLifetime> _logger;
+    private readonly Lazy<Task<string>> _start;
+
+    public CodexMcpServerLifetime(
+        McpFunctionProviderServer server,
+        ILogger<CodexMcpServerLifetime> logger)
+    {
+        _server = server ?? throw new ArgumentNullException(nameof(server));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _startupDelegate = StartServerAsync;
+        _start = new Lazy<Task<string>>(_startupDelegate, LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    // Test-only constructor: supplies a custom startup delegate so tests can verify the
+    // lazy start-once / cached-failure semantics without spinning up a real MCP server.
+    internal CodexMcpServerLifetime(
+        Func<Task<string>> startupDelegate,
+        ILogger<CodexMcpServerLifetime> logger)
+    {
+        _server = null;
+        _startupDelegate = startupDelegate ?? throw new ArgumentNullException(nameof(startupDelegate));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _start = new Lazy<Task<string>>(_startupDelegate, LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    /// <summary>
+    /// Ensures the codex MCP server has started and returns its endpoint URL. The first
+    /// caller starts the server; subsequent callers await the cached task. If the start
+    /// fails, the failure is cached — every caller observes the same exception (recovery
+    /// requires an app restart, by design).
+    /// </summary>
+    public Task<string> EnsureStartedAsync(CancellationToken ct = default)
+    {
+        _ = ct;
+        return _start.Value;
+    }
+
+    private async Task<string> StartServerAsync()
+    {
+        _logger.LogInformation("Starting codex MCP server on demand");
+        await _server!.StartAsync().ConfigureAwait(false);
+        var endpoint = _server.McpEndpointUrl
+            ?? throw new InvalidOperationException("MCP server started without an endpoint URL.");
+        _logger.LogInformation("Codex MCP server started. Endpoint: {Endpoint}", endpoint);
+        return endpoint;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_start.IsValueCreated)
+        {
+            try
+            {
+                await _start.Value.ConfigureAwait(false);
+            }
+            catch
+            {
+                // Start failed — nothing to dispose beyond what the server already
+                // cleaned up internally. Don't propagate during disposal.
+            }
+        }
+
+        if (_server != null)
+        {
+            await _server.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/samples/LmStreaming.Sample/Services/IFileSystemProbe.cs
+++ b/samples/LmStreaming.Sample/Services/IFileSystemProbe.cs
@@ -1,0 +1,67 @@
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+/// Seam over the file system used by <see cref="ProviderRegistry"/> to detect CLI
+/// presence on PATH. Tests provide a fake to avoid touching the real environment.
+/// </summary>
+public interface IFileSystemProbe
+{
+    /// <summary>
+    /// Returns true when an executable named <paramref name="executableBaseName"/> exists
+    /// on the user's PATH. Probes platform-appropriate suffixes (.exe / .cmd on Windows).
+    /// </summary>
+    bool IsExecutableOnPath(string executableBaseName);
+
+    /// <summary>
+    /// Returns true when the file at <paramref name="path"/> exists on disk.
+    /// </summary>
+    bool FileExists(string path);
+}
+
+/// <summary>
+/// Default <see cref="IFileSystemProbe"/> implementation that walks PATH and checks the
+/// real file system. Probes are cached at <see cref="ProviderRegistry"/> construction so
+/// no I/O happens per request.
+/// </summary>
+public sealed class FileSystemProbe : IFileSystemProbe
+{
+    public bool IsExecutableOnPath(string executableBaseName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(executableBaseName);
+
+        var path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(path))
+        {
+            return false;
+        }
+
+        var isWindows = OperatingSystem.IsWindows();
+        var suffixes = isWindows
+            ? new[] { string.Empty, ".exe", ".cmd", ".bat", ".ps1" }
+            : new[] { string.Empty };
+
+        foreach (var dir in path.Split(Path.PathSeparator))
+        {
+            if (string.IsNullOrWhiteSpace(dir))
+            {
+                continue;
+            }
+
+            foreach (var suffix in suffixes)
+            {
+                var candidate = Path.Combine(dir, executableBaseName + suffix);
+                if (File.Exists(candidate))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public bool FileExists(string path)
+    {
+        return !string.IsNullOrWhiteSpace(path) && File.Exists(path);
+    }
+}

--- a/samples/LmStreaming.Sample/Services/ProviderDescriptor.cs
+++ b/samples/LmStreaming.Sample/Services/ProviderDescriptor.cs
@@ -1,0 +1,9 @@
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+/// Describes a single LLM provider exposed to the client provider-switcher dropdown.
+/// </summary>
+/// <param name="Id">Provider id used in WS query string and persisted in metadata. Lowercase.</param>
+/// <param name="DisplayName">Human-friendly label rendered in the dropdown.</param>
+/// <param name="Available">Whether this provider can be selected on a new conversation.</param>
+public sealed record ProviderDescriptor(string Id, string DisplayName, bool Available);

--- a/samples/LmStreaming.Sample/Services/ProviderRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/ProviderRegistry.cs
@@ -1,0 +1,121 @@
+using System.Collections.Immutable;
+
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+/// Centralises the set of LLM providers the sample app exposes to clients.
+/// Availability rules look only at env vars and (cached) PATH probes, so this is safe
+/// to call on the request hot path. Probes execute once at construction and the result
+/// is frozen for the process lifetime.
+/// </summary>
+public sealed class ProviderRegistry
+{
+    private static readonly ImmutableArray<(string Id, string DisplayName)> CatalogEntries =
+        [
+            ("openai", "OpenAI"),
+            ("anthropic", "Anthropic"),
+            ("test", "Test (Mock)"),
+            ("test-anthropic", "Test (Anthropic)"),
+            ("claude", "Claude (CLI)"),
+            ("codex", "Codex"),
+            ("copilot", "Copilot (CLI)"),
+        ];
+
+    private readonly ImmutableDictionary<string, ProviderDescriptor> _byId;
+
+    public ProviderRegistry(IFileSystemProbe? probe = null)
+    {
+        probe ??= new FileSystemProbe();
+        var bootMode = NormalizeId(Environment.GetEnvironmentVariable("LM_PROVIDER_MODE")) ?? "test";
+        DefaultProviderId = bootMode;
+
+        var builder = ImmutableDictionary.CreateBuilder<string, ProviderDescriptor>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (id, displayName) in CatalogEntries)
+        {
+            builder[id] = new ProviderDescriptor(id, displayName, ComputeAvailability(id, probe));
+        }
+
+        _byId = builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// The provider id resolved from <c>LM_PROVIDER_MODE</c> at construction time.
+    /// Used as the fallback for legacy threads with no persisted provider.
+    /// </summary>
+    public string DefaultProviderId { get; }
+
+    public bool IsAvailable(string providerId)
+    {
+        var normalized = NormalizeId(providerId);
+        return normalized != null
+            && _byId.TryGetValue(normalized, out var descriptor)
+            && descriptor.Available;
+    }
+
+    public bool IsKnown(string providerId)
+    {
+        var normalized = NormalizeId(providerId);
+        return normalized != null && _byId.ContainsKey(normalized);
+    }
+
+    public ProviderDescriptor? Get(string providerId)
+    {
+        var normalized = NormalizeId(providerId);
+        if (normalized == null)
+        {
+            return null;
+        }
+
+        return _byId.TryGetValue(normalized, out var descriptor) ? descriptor : null;
+    }
+
+    /// <summary>
+    /// Returns the full provider catalog (each entry tagged with its availability flag).
+    /// Used by <c>GET /api/providers</c>; the client is responsible for hiding entries
+    /// it doesn't want to render.
+    /// </summary>
+    public IReadOnlyList<ProviderDescriptor> ListAll()
+    {
+        return [.. _byId.Values.OrderBy(p => p.Id, StringComparer.OrdinalIgnoreCase)];
+    }
+
+    private static string? NormalizeId(string? providerId)
+    {
+        if (string.IsNullOrWhiteSpace(providerId))
+        {
+            return null;
+        }
+
+        return providerId.Trim().ToLowerInvariant();
+    }
+
+    private static bool ComputeAvailability(string providerId, IFileSystemProbe probe)
+    {
+        return providerId switch
+        {
+            "test" or "test-anthropic" => true,
+            "openai" => HasEnvVar("OPENAI_API_KEY"),
+            "anthropic" => HasEnvVar("ANTHROPIC_API_KEY"),
+            "claude" => HasCliPath("CLAUDE_CLI_PATH", "claude", probe),
+            "codex" => true,
+            "copilot" => HasCliPath("COPILOT_CLI_PATH", "copilot", probe),
+            _ => false,
+        };
+    }
+
+    private static bool HasEnvVar(string name)
+    {
+        return !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(name));
+    }
+
+    private static bool HasCliPath(string envVar, string cliName, IFileSystemProbe probe)
+    {
+        var explicitPath = Environment.GetEnvironmentVariable(envVar);
+        if (!string.IsNullOrWhiteSpace(explicitPath))
+        {
+            return probe.FileExists(explicitPath);
+        }
+
+        return probe.IsExecutableOnPath(cliName);
+    }
+}

--- a/samples/LmStreaming.Sample/Services/ProviderUnavailableException.cs
+++ b/samples/LmStreaming.Sample/Services/ProviderUnavailableException.cs
@@ -1,0 +1,26 @@
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+/// Thrown when an agent factory is asked to create an agent for a provider that
+/// is not currently available (missing API key, MCP server failed to start, etc.).
+/// </summary>
+public sealed class ProviderUnavailableException : Exception
+{
+    public ProviderUnavailableException(string providerId, string reason)
+        : base($"Provider '{providerId}' is unavailable: {reason}")
+    {
+        ProviderId = providerId;
+        Reason = reason;
+    }
+
+    public ProviderUnavailableException(string providerId, string reason, Exception inner)
+        : base($"Provider '{providerId}' is unavailable: {reason}", inner)
+    {
+        ProviderId = providerId;
+        Reason = reason;
+    }
+
+    public string ProviderId { get; }
+
+    public string Reason { get; }
+}

--- a/samples/LmStreaming.Sample/WebSocket/ChatWebSocketManager.cs
+++ b/samples/LmStreaming.Sample/WebSocket/ChatWebSocketManager.cs
@@ -8,6 +8,7 @@ using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
 using LmStreaming.Sample.Agents;
 using LmStreaming.Sample.Models;
 using LmStreaming.Sample.Persistence;
+using LmStreaming.Sample.Services;
 using Serilog.Context;
 
 namespace LmStreaming.Sample.WebSocket;
@@ -37,6 +38,10 @@ public sealed class ChatWebSocketManager
     /// <param name="webSocket">The WebSocket connection</param>
     /// <param name="threadId">The thread ID for routing to the correct agent</param>
     /// <param name="mode">Optional chat mode for agent configuration</param>
+    /// <param name="providerId">
+    /// Optional provider id requested by the client for this connection. Honored only when
+    /// the thread has no persisted provider yet; otherwise the persisted value wins.
+    /// </param>
     /// <param name="requestResponseDumpFileName">
     /// Optional base file name for provider request/response recording.
     /// </param>
@@ -46,6 +51,7 @@ public sealed class ChatWebSocketManager
         System.Net.WebSockets.WebSocket webSocket,
         string threadId,
         ChatMode? mode,
+        string? providerId,
         string? requestResponseDumpFileName,
         StreamWriter? recordWriter,
         CancellationToken cancellationToken)
@@ -57,18 +63,39 @@ public sealed class ChatWebSocketManager
         using var logScope = LogContext.PushProperty("codex_session_id", codexSessionId);
 
         _logger.LogInformation(
-            "WebSocket connection started for thread {ThreadId} with mode {ModeId} and session {CodexSessionId}",
+            "WebSocket connection started for thread {ThreadId} with mode {ModeId} provider {ProviderId} and session {CodexSessionId}",
             threadId,
             mode?.Id ?? "default",
+            providerId ?? "(default)",
             codexSessionId);
 
-        // Get or create agent for this thread with the specified mode
-        var agent = mode != null
-            ? _agentPool.GetOrCreateAgent(threadId, mode, requestResponseDumpFileName)
-            : _agentPool.GetOrCreateAgent(
+        var resolvedMode = mode ?? SystemChatModes.All[0];
+
+        // Get or create agent for this thread with the specified mode and requested provider.
+        // ProviderUnavailableException is surfaced to the client as a structured error event
+        // before the connection is closed, so the UI can show "this provider is unavailable"
+        // rather than a generic disconnect.
+        IMultiTurnAgent agent;
+        try
+        {
+            agent = _agentPool.GetOrCreateAgent(
                 threadId,
-                SystemChatModes.All[0],
+                resolvedMode,
+                providerId,
                 requestResponseDumpFileName);
+        }
+        catch (ProviderUnavailableException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Provider {ProviderId} unavailable for thread {ThreadId}: {Reason}",
+                ex.ProviderId,
+                threadId,
+                ex.Reason);
+
+            await SendProviderUnavailableErrorAsync(webSocket, ex, recordWriter, cancellationToken);
+            return;
+        }
 
         // Create linked cancellation for connection lifetime
         using var connectionCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -288,6 +315,57 @@ public sealed class ChatWebSocketManager
         catch (JsonException ex)
         {
             _logger.LogWarning(ex, "Invalid JSON from thread {ThreadId}: {Json}", threadId, json);
+        }
+    }
+
+    private async Task SendProviderUnavailableErrorAsync(
+        System.Net.WebSockets.WebSocket webSocket,
+        ProviderUnavailableException ex,
+        StreamWriter? recordWriter,
+        CancellationToken ct)
+    {
+        if (webSocket.State != WebSocketState.Open)
+        {
+            return;
+        }
+
+        var payload = new Dictionary<string, object?>
+        {
+            ["$type"] = "error",
+            ["code"] = "provider_unavailable",
+            ["providerId"] = ex.ProviderId,
+            ["reason"] = ex.Reason,
+            ["message"] = ex.Message,
+        };
+        var json = JsonSerializer.Serialize(payload, _jsonOptions);
+        var bytes = Encoding.UTF8.GetBytes(json);
+
+        try
+        {
+            await webSocket.SendAsync(
+                new ArraySegment<byte>(bytes),
+                WebSocketMessageType.Text,
+                endOfMessage: true,
+                ct);
+
+            if (recordWriter != null)
+            {
+                await recordWriter.WriteLineAsync(json);
+                await recordWriter.FlushAsync();
+            }
+
+            await webSocket.CloseAsync(
+                WebSocketCloseStatus.NormalClosure,
+                "Provider unavailable",
+                CancellationToken.None);
+        }
+        catch (WebSocketException wsEx)
+        {
+            _logger.LogDebug(wsEx, "Failed to send provider_unavailable error frame");
+        }
+        catch (OperationCanceledException)
+        {
+            // Connection cancelled before we could write — nothing to do.
         }
     }
 }

--- a/src/McpServer.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/McpServer.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -79,6 +79,34 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         Action<McpFunctionProviderServerOptions>? configure = null)
     {
+        AddMcpFunctionProviderServerCore(services, configure);
+
+        // Register as hosted service (reuses the singleton instance)
+        _ = services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<McpFunctionProviderServer>());
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers <see cref="McpFunctionProviderServer"/> as a singleton WITHOUT wiring it
+    /// up as an <see cref="IHostedService"/>. The caller is responsible for invoking
+    /// <c>StartAsync</c> on the singleton on demand (typically through a lazy-lifetime
+    /// wrapper). Use this when the MCP server should only spin up when actually needed
+    /// (e.g. when the user picks a provider that depends on it from a per-conversation
+    /// dropdown), so non-MCP boots pay no startup cost.
+    /// </summary>
+    public static IServiceCollection AddMcpFunctionProviderServerLazy(
+        this IServiceCollection services,
+        Action<McpFunctionProviderServerOptions>? configure = null)
+    {
+        AddMcpFunctionProviderServerCore(services, configure);
+        return services;
+    }
+
+    private static void AddMcpFunctionProviderServerCore(
+        IServiceCollection services,
+        Action<McpFunctionProviderServerOptions>? configure)
+    {
         // Register options
         _ = services.Configure(configure ?? (_ => { }));
 
@@ -114,10 +142,5 @@ public static class ServiceCollectionExtensions
 
             return new McpFunctionProviderServer(app);
         });
-
-        // Register as hosted service (reuses the singleton instance)
-        _ = services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<McpFunctionProviderServer>());
-
-        return services;
     }
 }

--- a/tests/LmStreaming.Sample.Tests/Agents/MultiTurnAgentPoolTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Agents/MultiTurnAgentPoolTests.cs
@@ -1,7 +1,10 @@
+using System.Collections.Immutable;
+using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Tests.TestDoubles;
 
 namespace LmStreaming.Sample.Tests.Agents;
 
+[Collection("EnvironmentVariables")]
 public class MultiTurnAgentPoolTests
 {
     [Fact]
@@ -50,10 +53,282 @@ public class MultiTurnAgentPoolTests
         state.CurrentRunId.Should().Be("run_stale");
     }
 
+    [Fact]
+    public async Task GetOrCreateAgent_PersistsRequestedProvider_OnFirstCreation()
+    {
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test", "openai", "anthropic"]);
+        var store = new InMemoryConversationStore();
+        var providerSeen = new List<string>();
+
+        await using var pool = new MultiTurnAgentPool(
+            (threadId, _, providerId, _) =>
+            {
+                providerSeen.Add(providerId);
+                return new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId));
+            },
+            registry.ToReal(),
+            store,
+            NullLogger<MultiTurnAgentPool>.Instance);
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        _ = pool.GetOrCreateAgent("thread-x", mode, requestedProviderId: "openai", requestResponseDumpFileName: null);
+
+        providerSeen.Should().ContainSingle().Which.Should().Be("openai");
+
+        // Persistence is fire-and-forget; allow it to complete before asserting.
+        var persisted = await WaitForPersistedProviderAsync(store, "thread-x");
+        persisted.Should().Be("openai");
+    }
+
+    [Fact]
+    public async Task GetOrCreateAgent_PersistedProviderWins_OverRequested()
+    {
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test", "openai", "anthropic"]);
+        var store = new InMemoryConversationStore();
+        await store.SaveMetadataAsync("thread-y", new ThreadMetadata
+        {
+            ThreadId = "thread-y",
+            LastUpdated = 1,
+            Properties = ImmutableDictionary<string, object>.Empty.SetItem(
+                MultiTurnAgentPool.ProviderPropertyKey,
+                "anthropic"),
+        });
+
+        var providerSeen = new List<string>();
+        await using var pool = new MultiTurnAgentPool(
+            (threadId, _, providerId, _) =>
+            {
+                providerSeen.Add(providerId);
+                return new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId));
+            },
+            registry.ToReal(),
+            store,
+            NullLogger<MultiTurnAgentPool>.Instance);
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        _ = pool.GetOrCreateAgent("thread-y", mode, requestedProviderId: "openai", requestResponseDumpFileName: null);
+
+        providerSeen.Should().ContainSingle().Which.Should().Be("anthropic");
+    }
+
+    [Fact]
+    public async Task GetOrCreateAgent_Throws_WhenPersistedProviderUnavailable()
+    {
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test"]);
+        var store = new InMemoryConversationStore();
+        await store.SaveMetadataAsync("thread-z", new ThreadMetadata
+        {
+            ThreadId = "thread-z",
+            LastUpdated = 1,
+            Properties = ImmutableDictionary<string, object>.Empty.SetItem(
+                MultiTurnAgentPool.ProviderPropertyKey,
+                "openai"),
+        });
+
+        await using var pool = new MultiTurnAgentPool(
+            (threadId, _, _, _) => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId)),
+            registry.ToReal(),
+            store,
+            NullLogger<MultiTurnAgentPool>.Instance);
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        var act = () => pool.GetOrCreateAgent("thread-z", mode, requestedProviderId: null, requestResponseDumpFileName: null);
+
+        act.Should().Throw<ProviderUnavailableException>()
+            .Which.ProviderId.Should().Be("openai");
+    }
+
+    [Fact]
+    public async Task GetOrCreateAgent_Throws_WhenRequestedProviderUnavailable()
+    {
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test"]);
+        var store = new InMemoryConversationStore();
+
+        await using var pool = new MultiTurnAgentPool(
+            (threadId, _, _, _) => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId)),
+            registry.ToReal(),
+            store,
+            NullLogger<MultiTurnAgentPool>.Instance);
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        var act = () => pool.GetOrCreateAgent("thread-q", mode, requestedProviderId: "openai", requestResponseDumpFileName: null);
+
+        act.Should().Throw<ProviderUnavailableException>()
+            .Which.ProviderId.Should().Be("openai");
+    }
+
+    [Fact]
+    public async Task GetOrCreateAgent_FallsBackToDefault_WhenNoRequestedAndNoPersisted()
+    {
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test"]);
+        var store = new InMemoryConversationStore();
+        var providerSeen = new List<string>();
+
+        await using var pool = new MultiTurnAgentPool(
+            (threadId, _, providerId, _) =>
+            {
+                providerSeen.Add(providerId);
+                return new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId));
+            },
+            registry.ToReal(),
+            store,
+            NullLogger<MultiTurnAgentPool>.Instance);
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        _ = pool.GetOrCreateAgent("thread-d", mode, requestedProviderId: null, requestResponseDumpFileName: null);
+
+        providerSeen.Should().ContainSingle().Which.Should().Be("test");
+
+        var persisted = await WaitForPersistedProviderAsync(store, "thread-d");
+        persisted.Should().Be("test");
+    }
+
+    [Fact]
+    public async Task GetOrCreateAgent_LegacyConstructor_PassesSentinelToFactory()
+    {
+        var providerSeen = new List<string>();
+        await using var pool = new MultiTurnAgentPool(
+            (threadId, _, _) =>
+            {
+                providerSeen.Add("default-sentinel-observed");
+                return new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId));
+            },
+            NullLogger<MultiTurnAgentPool>.Instance);
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        _ = pool.GetOrCreateAgent("thread-legacy", mode);
+
+        providerSeen.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task GetEffectiveProviderId_ReturnsPersisted_EvenWhenUnavailable()
+    {
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test"]);
+        var store = new InMemoryConversationStore();
+        await store.SaveMetadataAsync("thread-eff", new ThreadMetadata
+        {
+            ThreadId = "thread-eff",
+            LastUpdated = 1,
+            Properties = ImmutableDictionary<string, object>.Empty.SetItem(
+                MultiTurnAgentPool.ProviderPropertyKey,
+                "openai"),
+        });
+
+        await using var pool = new MultiTurnAgentPool(
+            (threadId, _, _, _) => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId)),
+            registry.ToReal(),
+            store,
+            NullLogger<MultiTurnAgentPool>.Instance);
+
+        pool.GetEffectiveProviderId("thread-eff", null).Should().Be("openai");
+    }
+
+    [Fact]
+    public async Task GetEffectiveProviderId_ReturnsDefault_WhenNoPersistedProvider()
+    {
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test"]);
+        var store = new InMemoryConversationStore();
+
+        await using var pool = new MultiTurnAgentPool(
+            (threadId, _, _, _) => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId)),
+            registry.ToReal(),
+            store,
+            NullLogger<MultiTurnAgentPool>.Instance);
+
+        pool.GetEffectiveProviderId("thread-fresh", null).Should().Be("test");
+    }
+
     private static MultiTurnAgentPool CreatePool()
     {
         return new MultiTurnAgentPool(
             (threadId, _, _) => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId)),
             NullLogger<MultiTurnAgentPool>.Instance);
+    }
+
+    private static async Task<string?> WaitForPersistedProviderAsync(
+        IConversationStore store,
+        string threadId,
+        int timeoutMs = 1000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            var metadata = await store.LoadMetadataAsync(threadId);
+            if (metadata?.Properties != null
+                && metadata.Properties.TryGetValue(MultiTurnAgentPool.ProviderPropertyKey, out var raw)
+                && raw is string s
+                && !string.IsNullOrWhiteSpace(s))
+            {
+                return s;
+            }
+
+            await Task.Delay(20);
+        }
+
+        return null;
+    }
+}
+
+/// <summary>
+/// Builds a <see cref="ProviderRegistry"/> that reports a controlled availability set.
+/// We construct it via env vars so we exercise the same code path as production —
+/// availability is determined at construction time and cached.
+/// </summary>
+internal sealed class FakeProviderRegistry
+{
+    private readonly string _defaultProviderId;
+    private readonly HashSet<string> _available;
+
+    public FakeProviderRegistry(string defaultProviderId, IEnumerable<string> available)
+    {
+        _defaultProviderId = defaultProviderId;
+        _available = new HashSet<string>(available, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public ProviderRegistry ToReal()
+    {
+        // Snapshot env vars, set them per the requested availability set, build registry,
+        // then restore. The registry caches availability at construction.
+        var snapshot = new Dictionary<string, string?>
+        {
+            ["LM_PROVIDER_MODE"] = Environment.GetEnvironmentVariable("LM_PROVIDER_MODE"),
+            ["OPENAI_API_KEY"] = Environment.GetEnvironmentVariable("OPENAI_API_KEY"),
+            ["ANTHROPIC_API_KEY"] = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY"),
+            ["CLAUDE_CLI_PATH"] = Environment.GetEnvironmentVariable("CLAUDE_CLI_PATH"),
+            ["COPILOT_CLI_PATH"] = Environment.GetEnvironmentVariable("COPILOT_CLI_PATH"),
+        };
+
+        try
+        {
+            Environment.SetEnvironmentVariable("LM_PROVIDER_MODE", _defaultProviderId);
+            Environment.SetEnvironmentVariable("OPENAI_API_KEY", _available.Contains("openai") ? "sk-fake" : null);
+            Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", _available.Contains("anthropic") ? "sk-fake" : null);
+            Environment.SetEnvironmentVariable("CLAUDE_CLI_PATH", null);
+            Environment.SetEnvironmentVariable("COPILOT_CLI_PATH", null);
+
+            var probe = new FakeFileSystemProbe(
+                executablesOnPath: BuildCliList());
+            return new ProviderRegistry(probe);
+        }
+        finally
+        {
+            foreach (var (k, v) in snapshot)
+            {
+                Environment.SetEnvironmentVariable(k, v);
+            }
+        }
+    }
+
+    private IEnumerable<string> BuildCliList()
+    {
+        if (_available.Contains("claude"))
+        {
+            yield return "claude";
+        }
+        if (_available.Contains("copilot"))
+        {
+            yield return "copilot";
+        }
     }
 }

--- a/tests/LmStreaming.Sample.Tests/Controllers/ProvidersControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ProvidersControllerTests.cs
@@ -1,0 +1,84 @@
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Tests.TestDoubles;
+
+namespace LmStreaming.Sample.Tests.Controllers;
+
+[Collection("EnvironmentVariables")]
+public class ProvidersControllerTests
+{
+    [Fact]
+    public void List_ReturnsCatalog_AndDefault()
+    {
+        var snapshot = SnapshotEnv();
+        try
+        {
+            Environment.SetEnvironmentVariable("LM_PROVIDER_MODE", "openai");
+            Environment.SetEnvironmentVariable("OPENAI_API_KEY", "sk-test");
+            Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", null);
+            Environment.SetEnvironmentVariable("CLAUDE_CLI_PATH", null);
+            Environment.SetEnvironmentVariable("COPILOT_CLI_PATH", null);
+
+            var registry = new ProviderRegistry(new FakeFileSystemProbe());
+            var controller = new ProvidersController(registry);
+
+            var result = controller.List();
+            var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+            var response = ok.Value.Should().BeOfType<ProvidersResponse>().Subject;
+
+            response.Default.Should().Be("openai");
+            response.Providers.Select(p => p.Id).Should().Contain(
+                ["openai", "anthropic", "claude", "codex", "copilot", "test", "test-anthropic"]);
+
+            var openai = response.Providers.Single(p => p.Id == "openai");
+            openai.Available.Should().BeTrue();
+            openai.DisplayName.Should().Be("OpenAI");
+
+            var anthropic = response.Providers.Single(p => p.Id == "anthropic");
+            anthropic.Available.Should().BeFalse();
+        }
+        finally
+        {
+            RestoreEnv(snapshot);
+        }
+    }
+
+    [Fact]
+    public void List_DefaultsToTestMode_WhenEnvVarUnset()
+    {
+        var snapshot = SnapshotEnv();
+        try
+        {
+            Environment.SetEnvironmentVariable("LM_PROVIDER_MODE", null);
+
+            var registry = new ProviderRegistry(new FakeFileSystemProbe());
+            var controller = new ProvidersController(registry);
+
+            var result = controller.List();
+            var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+            var response = ok.Value.Should().BeOfType<ProvidersResponse>().Subject;
+
+            response.Default.Should().Be("test");
+        }
+        finally
+        {
+            RestoreEnv(snapshot);
+        }
+    }
+
+    private static Dictionary<string, string?> SnapshotEnv() => new()
+    {
+        ["LM_PROVIDER_MODE"] = Environment.GetEnvironmentVariable("LM_PROVIDER_MODE"),
+        ["OPENAI_API_KEY"] = Environment.GetEnvironmentVariable("OPENAI_API_KEY"),
+        ["ANTHROPIC_API_KEY"] = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY"),
+        ["CLAUDE_CLI_PATH"] = Environment.GetEnvironmentVariable("CLAUDE_CLI_PATH"),
+        ["COPILOT_CLI_PATH"] = Environment.GetEnvironmentVariable("COPILOT_CLI_PATH"),
+    };
+
+    private static void RestoreEnv(Dictionary<string, string?> snapshot)
+    {
+        foreach (var (k, v) in snapshot)
+        {
+            Environment.SetEnvironmentVariable(k, v);
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/CodexMcpServerLifetimeTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/CodexMcpServerLifetimeTests.cs
@@ -1,0 +1,97 @@
+using LmStreaming.Sample.Services;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+public class CodexMcpServerLifetimeTests
+{
+    [Fact]
+    public async Task EnsureStartedAsync_StartsOnce_UnderConcurrency()
+    {
+        var startCount = 0;
+        var startGate = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var lifetime = new CodexMcpServerLifetime(
+            async () =>
+            {
+                Interlocked.Increment(ref startCount);
+                return await startGate.Task;
+            },
+            NullLogger<CodexMcpServerLifetime>.Instance);
+
+        var tasks = Enumerable.Range(0, 16)
+            .Select(_ => lifetime.EnsureStartedAsync())
+            .ToArray();
+
+        startGate.SetResult("http://localhost:1234/mcp");
+
+        var results = await Task.WhenAll(tasks);
+
+        startCount.Should().Be(1);
+        results.Should().AllBe("http://localhost:1234/mcp");
+    }
+
+    [Fact]
+    public async Task EnsureStartedAsync_CachesFailure()
+    {
+        var startCount = 0;
+        await using var lifetime = new CodexMcpServerLifetime(
+            () =>
+            {
+                Interlocked.Increment(ref startCount);
+                return Task.FromException<string>(new InvalidOperationException("boom"));
+            },
+            NullLogger<CodexMcpServerLifetime>.Instance);
+
+        var first = await Record.ExceptionAsync(() => lifetime.EnsureStartedAsync());
+        var second = await Record.ExceptionAsync(() => lifetime.EnsureStartedAsync());
+
+        first.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("boom");
+        second.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("boom");
+        startCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task EnsureStartedAsync_ReturnsSameEndpointAcrossCalls()
+    {
+        const string endpoint = "http://localhost:9999/mcp";
+        await using var lifetime = new CodexMcpServerLifetime(
+            () => Task.FromResult(endpoint),
+            NullLogger<CodexMcpServerLifetime>.Instance);
+
+        var a = await lifetime.EnsureStartedAsync();
+        var b = await lifetime.EnsureStartedAsync();
+
+        a.Should().Be(endpoint);
+        b.Should().Be(endpoint);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DoesNotThrow_WhenStartFailed()
+    {
+        var lifetime = new CodexMcpServerLifetime(
+            () => Task.FromException<string>(new InvalidOperationException("boom")),
+            NullLogger<CodexMcpServerLifetime>.Instance);
+
+        _ = await Record.ExceptionAsync(() => lifetime.EnsureStartedAsync());
+
+        var dispose = async () => await lifetime.DisposeAsync();
+        await dispose.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DoesNotInvokeStartup_WhenNeverStarted()
+    {
+        var startCount = 0;
+        var lifetime = new CodexMcpServerLifetime(
+            () =>
+            {
+                Interlocked.Increment(ref startCount);
+                return Task.FromResult("http://localhost:1234/mcp");
+            },
+            NullLogger<CodexMcpServerLifetime>.Instance);
+
+        await lifetime.DisposeAsync();
+
+        startCount.Should().Be(0);
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/ProviderRegistryTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ProviderRegistryTests.cs
@@ -1,0 +1,263 @@
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Tests.TestDoubles;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+[Collection("EnvironmentVariables")]
+public class ProviderRegistryTests
+{
+    [Fact]
+    public void DefaultProviderId_FallsBackToTest_WhenEnvVarUnset()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", null);
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe());
+
+        registry.DefaultProviderId.Should().Be("test");
+    }
+
+    [Fact]
+    public void DefaultProviderId_NormalizesEnvVar()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "  OpenAI  ");
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe());
+
+        registry.DefaultProviderId.Should().Be("openai");
+    }
+
+    [Fact]
+    public void IsAvailable_OpenAi_RequiresApiKey()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        using var __ = EnvScope.Set("OPENAI_API_KEY", null);
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe());
+
+        registry.IsAvailable("openai").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAvailable_OpenAi_TrueWhenApiKeyPresent()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        using var __ = EnvScope.Set("OPENAI_API_KEY", "sk-test");
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe());
+
+        registry.IsAvailable("openai").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAvailable_Anthropic_RequiresApiKey()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        using var __ = EnvScope.Set("ANTHROPIC_API_KEY", null);
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe());
+
+        registry.IsAvailable("anthropic").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAvailable_Claude_TrueWhenCliOnPath()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        using var __ = EnvScope.Set("CLAUDE_CLI_PATH", null);
+        var probe = new FakeFileSystemProbe(executablesOnPath: ["claude"]);
+
+        var registry = new ProviderRegistry(probe);
+
+        registry.IsAvailable("claude").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAvailable_Claude_FalseWhenCliMissing()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        using var __ = EnvScope.Set("CLAUDE_CLI_PATH", null);
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe());
+
+        registry.IsAvailable("claude").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAvailable_Claude_TrueWhenExplicitPathExists()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        using var __ = EnvScope.Set("CLAUDE_CLI_PATH", "/usr/local/bin/claude");
+        var probe = new FakeFileSystemProbe(existingFiles: ["/usr/local/bin/claude"]);
+
+        var registry = new ProviderRegistry(probe);
+
+        registry.IsAvailable("claude").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAvailable_Claude_FalseWhenExplicitPathMissing()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        using var __ = EnvScope.Set("CLAUDE_CLI_PATH", "/nope/claude");
+        var probe = new FakeFileSystemProbe(executablesOnPath: ["claude"]);
+
+        var registry = new ProviderRegistry(probe);
+
+        registry.IsAvailable("claude").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAvailable_Copilot_TrueWhenCliOnPath()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        using var __ = EnvScope.Set("COPILOT_CLI_PATH", null);
+        var probe = new FakeFileSystemProbe(executablesOnPath: ["copilot"]);
+
+        var registry = new ProviderRegistry(probe);
+
+        registry.IsAvailable("copilot").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAvailable_TestProviders_AlwaysAvailable()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe());
+
+        registry.IsAvailable("test").Should().BeTrue();
+        registry.IsAvailable("test-anthropic").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAvailable_Codex_AlwaysAvailable()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe());
+
+        registry.IsAvailable("codex").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAvailable_NormalizesIdCasing()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe());
+
+        registry.IsAvailable("  CODEX  ").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAvailable_FalseForUnknownProvider()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe());
+
+        registry.IsAvailable("does-not-exist").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsKnown_TrueForCatalogEntry_FalseForUnknown()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe());
+
+        registry.IsKnown("openai").Should().BeTrue();
+        registry.IsKnown("does-not-exist").Should().BeFalse();
+        registry.IsKnown("").Should().BeFalse();
+        registry.IsKnown(null!).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ListAll_ReturnsCompleteCatalogSortedById()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe());
+        var catalog = registry.ListAll();
+
+        catalog.Select(p => p.Id).Should().BeEquivalentTo(
+            ["anthropic", "claude", "codex", "copilot", "openai", "test", "test-anthropic"],
+            options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void ListAll_FlagsUnavailableProviders()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        using var __ = EnvScope.Set("OPENAI_API_KEY", null);
+        using var ___ = EnvScope.Set("ANTHROPIC_API_KEY", null);
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe());
+        var catalog = registry.ListAll().ToDictionary(p => p.Id, p => p.Available);
+
+        catalog["openai"].Should().BeFalse();
+        catalog["anthropic"].Should().BeFalse();
+        catalog["test"].Should().BeTrue();
+    }
+
+    [Fact]
+    public void Get_ReturnsDescriptor_WithAvailability()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        using var __ = EnvScope.Set("OPENAI_API_KEY", "sk-test");
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe());
+        var descriptor = registry.Get("openai");
+
+        descriptor.Should().NotBeNull();
+        descriptor!.Id.Should().Be("openai");
+        descriptor.DisplayName.Should().Be("OpenAI");
+        descriptor.Available.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Get_ReturnsNull_ForUnknownProvider()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe());
+
+        registry.Get("does-not-exist").Should().BeNull();
+        registry.Get(null!).Should().BeNull();
+        registry.Get("").Should().BeNull();
+    }
+
+    /// <summary>
+    /// Snapshots the current value of an environment variable and restores it on dispose.
+    /// Tests that mutate env vars must use this scope to avoid polluting other tests.
+    /// </summary>
+    private sealed class EnvScope : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _previous;
+
+        private EnvScope(string name, string? previous)
+        {
+            _name = name;
+            _previous = previous;
+        }
+
+        public static EnvScope Set(string name, string? value)
+        {
+            var previous = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+            return new EnvScope(name, previous);
+        }
+
+        public void Dispose() => Environment.SetEnvironmentVariable(_name, _previous);
+    }
+}
+
+/// <summary>
+/// All tests that mutate process-wide environment variables must opt into this collection
+/// so xUnit serialises them — env vars are global state and concurrent mutation flakes.
+/// </summary>
+[CollectionDefinition("EnvironmentVariables", DisableParallelization = true)]
+public class EnvironmentVariablesCollection
+{
+}

--- a/tests/LmStreaming.Sample.Tests/TestDoubles/FakeFileSystemProbe.cs
+++ b/tests/LmStreaming.Sample.Tests/TestDoubles/FakeFileSystemProbe.cs
@@ -1,0 +1,31 @@
+using LmStreaming.Sample.Services;
+
+namespace LmStreaming.Sample.Tests.TestDoubles;
+
+internal sealed class FakeFileSystemProbe : IFileSystemProbe
+{
+    private readonly HashSet<string> _executablesOnPath;
+    private readonly HashSet<string> _existingFiles;
+
+    public FakeFileSystemProbe(
+        IEnumerable<string>? executablesOnPath = null,
+        IEnumerable<string>? existingFiles = null)
+    {
+        _executablesOnPath = new HashSet<string>(
+            executablesOnPath ?? [],
+            StringComparer.OrdinalIgnoreCase);
+        _existingFiles = new HashSet<string>(
+            existingFiles ?? [],
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    public bool IsExecutableOnPath(string executableBaseName)
+    {
+        return _executablesOnPath.Contains(executableBaseName);
+    }
+
+    public bool FileExists(string path)
+    {
+        return !string.IsNullOrWhiteSpace(path) && _existingFiles.Contains(path);
+    }
+}


### PR DESCRIPTION
[Gautam's Dev bot]

Closes #23.

## Summary
- Header dropdown lets the user pick an LLM provider for each new chat. After the first message lands, the selection is persisted in `ThreadMetadata.Properties["provider"]` and the control becomes a read-only "Provider: X" badge for the rest of the thread's life.
- Server-side `ProviderRegistry` is the single source of truth for the catalog and the per-process default; it caches availability at startup so the request path never touches PATH or env vars again.
- `MultiTurnAgentPool` resolves provider per thread under its existing per-key lock (request -> persisted -> default), persists on first creation, and throws `ProviderUnavailableException` when a persisted/requested provider is no longer available. The WS manager surfaces that exception as a structured `{"$type":"error","code":"provider_unavailable"}` frame before closing the socket.
- The codex MCP server is now started lazily on first codex use (`AddMcpFunctionProviderServerLazy` + `CodexMcpServerLifetime`), so non-codex boots pay no startup cost and codex stays selectable from the dropdown regardless of `LM_PROVIDER_MODE`.

## Files of note
- `samples/LmStreaming.Sample/Services/ProviderRegistry.cs`, `ProviderUnavailableException.cs`, `IFileSystemProbe.cs`, `CodexMcpServerLifetime.cs`
- `samples/LmStreaming.Sample/Agents/MultiTurnAgentPool.cs` — provider-aware factory + persistence
- `samples/LmStreaming.Sample/Controllers/ProvidersController.cs`, `ConversationsController.cs`, `Models/ConversationDtos.cs`
- `samples/LmStreaming.Sample/WebSocket/ChatWebSocketManager.cs`, `Program.cs` — query-string plumbing + DI wiring
- `src/McpServer.AspNetCore/Extensions/ServiceCollectionExtensions.cs` — opt-in `AddMcpFunctionProviderServerLazy`
- `samples/LmStreaming.Sample/ClientApp/src/components/ProviderSelector.vue`, `composables/useProviders.ts`, plus `ChatLayout.vue` / `useChat.ts` / `wsClient.ts` integration

## Test plan
- [x] `dotnet build LmDotnetTools.sln` — 0 errors
- [x] `dotnet test tests/LmStreaming.Sample.Tests/LmStreaming.Sample.Tests.csproj` — 50/50 passing (includes new `ProviderRegistryTests`, `MultiTurnAgentPoolTests` extensions, `ProvidersControllerTests`, `CodexMcpServerLifetimeTests`)
- [ ] Manual smoke (post-merge / in preview):
  - new chat: pick a provider, send a message; reload — badge appears with the same provider
  - pick an unavailable provider → WS frame surfaces a `provider_unavailable` error and the UI shows the message
  - select codex on first new chat → MCP server starts on demand