### PR TITLE
[Gautam's Dev bot] feat(streaming-sample): add mock-backed CLI provider entries

### DIFF
--- a/samples/LmStreaming.Sample/ClientApp/src/components/ProviderSelector.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ProviderSelector.vue
@@ -122,9 +122,16 @@ watch(
           :class="{ active: provider.id === selectedProviderId, unavailable: !provider.available }"
           :data-testid="`provider-option-${provider.id}`"
           :disabled="disabled || !provider.available"
+          :title="provider.knownLimitation ?? undefined"
           @click="handleSelect(provider.id)"
         >
           <span class="item-name">{{ provider.displayName }}</span>
+          <span
+            v-if="provider.available && provider.knownLimitation"
+            class="item-warning"
+            :data-testid="`provider-warning-${provider.id}`"
+            aria-label="known limitation"
+          >⚠</span>
           <span v-if="!provider.available" class="item-status">unavailable</span>
           <span v-else-if="provider.id === selectedProviderId" class="check-mark">✓</span>
         </button>
@@ -242,6 +249,14 @@ watch(
   color: #9aa0a6;
   margin-left: 8px;
   flex-shrink: 0;
+}
+
+.item-warning {
+  font-size: 13px;
+  color: #b8860b;
+  margin-left: 8px;
+  flex-shrink: 0;
+  cursor: help;
 }
 
 .check-mark {

--- a/samples/LmStreaming.Sample/ClientApp/src/types/providers.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/types/providers.ts
@@ -5,6 +5,12 @@ export interface ProviderDescriptor {
   id: string;
   displayName: string;
   available: boolean;
+  /**
+   * Optional caveat from the server when a provider is technically available but has a
+   * documented limitation that prevents end-to-end use today (typically links a follow-up
+   * issue). Rendered next to the entry in the dropdown.
+   */
+  knownLimitation?: string | null;
 }
 
 /**

--- a/samples/LmStreaming.Sample/LmStreaming.Sample.csproj
+++ b/samples/LmStreaming.Sample/LmStreaming.Sample.csproj
@@ -63,5 +63,6 @@
     <ProjectReference Include="..\..\src\McpMiddleware\AchieveAi.LmDotnetTools.McpMiddleware.csproj" />
     <ProjectReference Include="..\..\src\McpServer.AspNetCore\AchieveAi.LmDotnetTools.McpServer.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\LmTestUtils\LmTestUtils.csproj" />
+    <ProjectReference Include="..\MockProviderHost\MockProviderHost.csproj" />
   </ItemGroup>
 </Project>

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -109,6 +109,13 @@ try
     // Provider registry — single source of truth for which providers the client can pick
     // and what the per-process default is. Read once at startup; shared via DI singleton.
     _ = builder.Services.AddSingleton<IFileSystemProbe, FileSystemProbe>();
+
+    // Mock provider host: eagerly-started in-process Kestrel app that the *-mock providers
+    // point at. Singleton-as-IHostedService so it boots in Host.StartAsync; the registry
+    // dependency below reads its IsRunning flag for availability gating.
+    _ = builder.Services.AddSingleton<MockProviderHostLifetime>();
+    _ = builder.Services.AddHostedService(sp => sp.GetRequiredService<MockProviderHostLifetime>());
+
     _ = builder.Services.AddSingleton<ProviderRegistry>();
 
     // Register the FunctionRegistry with sample tools
@@ -193,6 +200,7 @@ try
         var conversationStore = sp.GetRequiredService<IConversationStore>();
         var providerRegistry = sp.GetRequiredService<ProviderRegistry>();
         var codexLifetime = sp.GetRequiredService<CodexMcpServerLifetime>();
+        var mockHostLifetime = sp.GetRequiredService<MockProviderHostLifetime>();
 
         return new MultiTurnAgentPool(
             (threadId, mode, providerId, requestResponseDumpFileName) =>
@@ -200,6 +208,88 @@ try
                 var isMedicalMode = mode.Id == SystemChatModes.MedicalKnowledgeModeId;
                 var mcpBaseUrl = isMedicalMode ? llmQueryMcpBaseUrl : null;
                 var normalizedProviderId = providerId.ToLowerInvariant();
+
+                // *-mock providers reuse the same agent-loop helpers as their real counterparts;
+                // the mock-host base URL is threaded into the SDK options as a per-spawn override
+                // applied to the child CLI process's environment block.
+                var mockBaseUrl = mockHostLifetime.BaseUrl;
+
+                if (string.Equals(normalizedProviderId, "codex-mock", StringComparison.Ordinal))
+                {
+                    if (string.IsNullOrWhiteSpace(mockBaseUrl))
+                    {
+                        throw new ProviderUnavailableException(
+                            "codex-mock", "the in-process mock provider host is not running");
+                    }
+
+                    string codexEndpoint;
+                    try
+                    {
+                        codexEndpoint = codexLifetime.EnsureStartedAsync().GetAwaiter().GetResult();
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new ProviderUnavailableException(
+                            "codex-mock",
+                            $"MCP server failed to start: {ex.Message}",
+                            ex);
+                    }
+
+                    return new MultiTurnAgentPool.AgentCreationResult(
+                        CreateCodexAgentLoop(
+                            threadId,
+                            mode,
+                            functionRegistry,
+                            requestResponseDumpFileName,
+                            conversationStore,
+                            loggerFactory,
+                            codexEndpoint,
+                            mcpBaseUrl,
+                            llmQueryMcpExamType,
+                            mockBaseUrlOverride: $"{mockBaseUrl}/v1",
+                            mockApiKeyOverride: "mock-token"));
+                }
+
+                if (string.Equals(normalizedProviderId, "claude-mock", StringComparison.Ordinal))
+                {
+                    if (string.IsNullOrWhiteSpace(mockBaseUrl))
+                    {
+                        throw new ProviderUnavailableException(
+                            "claude-mock", "the in-process mock provider host is not running");
+                    }
+
+                    return new MultiTurnAgentPool.AgentCreationResult(
+                        CreateClaudeAgentLoop(
+                            threadId,
+                            mode,
+                            requestResponseDumpFileName,
+                            conversationStore,
+                            loggerFactory,
+                            mcpBaseUrl,
+                            llmQueryMcpExamType,
+                            mockBaseUrlOverride: mockBaseUrl,
+                            mockAuthTokenOverride: "mock-token"));
+                }
+
+                if (string.Equals(normalizedProviderId, "copilot-mock", StringComparison.Ordinal))
+                {
+                    if (string.IsNullOrWhiteSpace(mockBaseUrl))
+                    {
+                        throw new ProviderUnavailableException(
+                            "copilot-mock", "the in-process mock provider host is not running");
+                    }
+
+                    return new MultiTurnAgentPool.AgentCreationResult(
+                        CreateCopilotAgentLoop(
+                            threadId,
+                            mode,
+                            functionRegistry,
+                            requestResponseDumpFileName,
+                            conversationStore,
+                            loggerFactory,
+                            mockBaseUrlOverride: $"{mockBaseUrl}/v1",
+                            mockApiKeyOverride: "mock-token"));
+                }
 
                 if (string.Equals(normalizedProviderId, "codex", StringComparison.Ordinal))
                 {
@@ -611,10 +701,20 @@ public partial class Program
         ILoggerFactory loggerFactory,
         string mcpEndpointUrl,
         string? llmQueryMcpBaseUrl,
-        string? llmQueryMcpExamType)
+        string? llmQueryMcpExamType,
+        string? mockBaseUrlOverride = null,
+        string? mockApiKeyOverride = null)
     {
         var enabledTools = mode.EnabledTools;
         var codexOptions = CreateCodexOptions(requestResponseDumpFileName, threadId);
+        if (!string.IsNullOrWhiteSpace(mockBaseUrlOverride))
+        {
+            codexOptions = codexOptions with
+            {
+                BaseUrl = mockBaseUrlOverride,
+                ApiKey = mockApiKeyOverride ?? codexOptions.ApiKey,
+            };
+        }
         if (enabledTools is { Count: > 0 } && !enabledTools.Contains("web_search", StringComparer.OrdinalIgnoreCase))
         {
             codexOptions = codexOptions with { WebSearchMode = "disabled" };
@@ -779,9 +879,9 @@ public partial class Program
             "openai" => Environment.GetEnvironmentVariable("OPENAI_MODEL") ?? "gpt-4o",
             "anthropic" => Environment.GetEnvironmentVariable("ANTHROPIC_MODEL") ?? "claude-sonnet-4-20250514",
             "test-anthropic" => "claude-sonnet-4-5-20250929",
-            "claude" => Environment.GetEnvironmentVariable("CLAUDE_MODEL") ?? "claude-sonnet-4-6",
-            "codex" => Environment.GetEnvironmentVariable("CODEX_MODEL") ?? "gpt-5.3-codex",
-            "copilot" => Environment.GetEnvironmentVariable("COPILOT_MODEL") ?? "claude-sonnet-4.5",
+            "claude" or "claude-mock" => Environment.GetEnvironmentVariable("CLAUDE_MODEL") ?? "claude-sonnet-4-6",
+            "codex" or "codex-mock" => Environment.GetEnvironmentVariable("CODEX_MODEL") ?? "gpt-5.3-codex",
+            "copilot" or "copilot-mock" => Environment.GetEnvironmentVariable("COPILOT_MODEL") ?? "claude-sonnet-4.5",
             _ => "test-model",
         };
     }
@@ -873,7 +973,9 @@ public partial class Program
         IConversationStore conversationStore,
         ILoggerFactory loggerFactory,
         string? llmQueryMcpBaseUrl,
-        string? llmQueryMcpExamType)
+        string? llmQueryMcpExamType,
+        string? mockBaseUrlOverride = null,
+        string? mockAuthTokenOverride = null)
     {
         // Build AllowedTools from mode's enabled tools:
         // null = use defaults, empty = no built-in tools (MCP only), non-empty = specific tools
@@ -889,6 +991,9 @@ public partial class Program
             DisableCheckpoints = true,
             DisableSessionPersistence = true,
             AllowedTools = allowedTools,
+            BaseUrl = string.IsNullOrWhiteSpace(mockBaseUrlOverride) ? null : mockBaseUrlOverride,
+            AuthToken = string.IsNullOrWhiteSpace(mockAuthTokenOverride) ? null : mockAuthTokenOverride,
+            DisableExperimentalBetas = !string.IsNullOrWhiteSpace(mockBaseUrlOverride),
         };
 
         var mcpServers = BuildLlmQueryMcpServers(threadId, llmQueryMcpBaseUrl, llmQueryMcpExamType);
@@ -917,7 +1022,9 @@ public partial class Program
         FunctionRegistry functionRegistry,
         string? requestResponseDumpFileName,
         IConversationStore conversationStore,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        string? mockBaseUrlOverride = null,
+        string? mockApiKeyOverride = null)
     {
         var copilotCliPath = Environment.GetEnvironmentVariable("COPILOT_CLI_PATH") ?? "copilot";
         var copilotCliMinVersion = Environment.GetEnvironmentVariable("COPILOT_CLI_MIN_VERSION") ?? "0.0.410";
@@ -951,18 +1058,28 @@ public partial class Program
             traceFilePath = Path.Combine(logsDir, $"copilot-rpc-{sessionId}.jsonl");
         }
 
+        // Per-spawn mock overrides take precedence over the host-process env vars so the
+        // copilot-mock provider can target the in-process MockProviderHost without polluting
+        // the parent process's COPILOT_BASE_URL.
+        var effectiveBaseUrl = string.IsNullOrWhiteSpace(mockBaseUrlOverride) ? baseUrl : mockBaseUrlOverride;
+        var effectiveApiKey = string.IsNullOrWhiteSpace(mockApiKeyOverride) ? apiKey : mockApiKeyOverride;
+        // The Copilot CLI's model allowlist probe phones home to GitHub before the first turn —
+        // the mock host doesn't implement it, so disable the probe whenever a mock URL is set.
+        var effectiveModelAllowlistProbeEnabled = string.IsNullOrWhiteSpace(mockBaseUrlOverride)
+            && modelAllowlistProbeEnabled;
+
         var copilotOptions = new CopilotSdkOptions
         {
             CopilotCliPath = copilotCliPath,
             CopilotCliMinVersion = copilotCliMinVersion,
             Model = model,
-            ApiKey = string.IsNullOrWhiteSpace(apiKey) ? null : apiKey,
-            BaseUrl = string.IsNullOrWhiteSpace(baseUrl) ? null : baseUrl,
+            ApiKey = string.IsNullOrWhiteSpace(effectiveApiKey) ? null : effectiveApiKey,
+            BaseUrl = string.IsNullOrWhiteSpace(effectiveBaseUrl) ? null : effectiveBaseUrl,
             WorkingDirectory = string.IsNullOrWhiteSpace(workingDirectory) ? null : workingDirectory,
             EnableRpcTrace = enableRpcTrace,
             RpcTraceFilePath = traceFilePath,
             CopilotSessionId = sessionId,
-            ModelAllowlistProbeEnabled = modelAllowlistProbeEnabled,
+            ModelAllowlistProbeEnabled = effectiveModelAllowlistProbeEnabled,
             DefaultPermissionDecision = defaultPermissionDecision,
             ToolBridgeMode = CopilotToolBridgeMode.Dynamic,
             Provider = "copilot",

--- a/samples/LmStreaming.Sample/README.md
+++ b/samples/LmStreaming.Sample/README.md
@@ -13,3 +13,56 @@ In development, open the app with `?record=1` (or `?record=true`) to enable serv
   - `samples/LmStreaming.Sample/recordings/<threadId>_<timestamp>.llm.codex.rpc.jsonl`
 
 This works for multi-turn runs and records provider calls for whichever provider mode is active (`openai`, `anthropic`, `test-anthropic`, `codex`).
+
+## Mock-backed CLI providers (`*-mock`)
+
+The sample boots an in-process [MockProviderHost](../MockProviderHost/) on an ephemeral
+loopback port at startup so the chat client can demo all three CLI agents end-to-end without
+upstream API keys:
+
+| Provider id     | CLI required | Notes                                          |
+|-----------------|--------------|------------------------------------------------|
+| `claude-mock`   | `claude`     | Points the Claude Agent SDK at the mock host. |
+| `codex-mock`    | (none)       | Codex spawns its own app-server stdio child.  |
+| `copilot-mock`  | `copilot`    | Disables Copilot's model-allowlist probe.     |
+
+Availability gating combines the existing CLI-on-PATH probe with the runtime mock-host
+status — if the mock host fails to bind a port at startup, all three `*-mock` entries report
+unavailable in `GET /api/providers` and disappear from the dropdown.
+
+### Customising the scripted scenario
+
+The mock host loads a JSON scenario document at startup. The default scenario is the
+embedded `demo` scenario shipped with `MockProviderHost.csproj`; override it via:
+
+```bash
+# built-in name
+LM_MOCK_SCENARIO=demo dotnet run --project samples/LmStreaming.Sample
+
+# custom file path
+LM_MOCK_SCENARIO=/path/to/my-scenario.json dotnet run --project samples/LmStreaming.Sample
+```
+
+Schema (see `samples/MockProviderHost/scenarios/demo.json` for a full example):
+
+```json
+{
+  "roles": [
+    {
+      "key": "demo",
+      "match": { "type": "always" },
+      "turns": [
+        { "messages": [{ "kind": "text", "text": "Hi!" }] },
+        { "thinking": 64, "messages": [
+            { "kind": "text", "text": "..." },
+            { "kind": "tool_call", "name": "echo", "args": { "msg": "hi" } }
+        ] }
+      ]
+    }
+  ]
+}
+```
+
+Match types: `always`, `system_contains` (with `value`), `user_contains` (with `value`),
+`tool` (with `name`). Message kinds: `text`, `text_len` (with `wordCount`), `tool_call`
+(with `name` and optional `args`).

--- a/samples/LmStreaming.Sample/Services/MockProviderHostLifetime.cs
+++ b/samples/LmStreaming.Sample/Services/MockProviderHostLifetime.cs
@@ -1,0 +1,152 @@
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using AchieveAi.LmDotnetTools.MockProviderHost;
+
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+/// Hosts an in-process <see cref="MockProviderHostBuilder"/> Kestrel app on an ephemeral
+/// loopback port so the <c>claude-mock</c> / <c>codex-mock</c> / <c>copilot-mock</c> providers
+/// can demo all three CLI agents end-to-end without an upstream provider.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered as both a singleton and an <see cref="IHostedService"/> so it boots eagerly
+/// during <c>Host.StartAsync</c>. The bound URL is captured into <see cref="BaseUrl"/> after
+/// startup; until startup completes (or if it fails) <see cref="IsRunning"/> stays
+/// <c>false</c> and the registry will report the <c>*-mock</c> providers as unavailable.
+/// </para>
+/// <para>
+/// Startup failures are caught and logged so the rest of the sample app still runs — the
+/// only consequence of a failure is the three mock providers staying unavailable in the UI.
+/// </para>
+/// </remarks>
+public sealed class MockProviderHostLifetime : IHostedService, IAsyncDisposable
+{
+    private readonly Func<ScriptedSseResponder> _responderFactory;
+    private readonly ILogger<MockProviderHostLifetime> _logger;
+    private WebApplication? _app;
+    private string? _baseUrl;
+    private bool _disposed;
+
+    public MockProviderHostLifetime(ILogger<MockProviderHostLifetime> logger)
+        : this(LoadDefaultScenario, logger)
+    {
+    }
+
+    // Test-only constructor: lets tests inject a stub responder factory so they can verify
+    // the lifetime contract without parsing JSON or hitting the filesystem.
+    internal MockProviderHostLifetime(
+        Func<ScriptedSseResponder> responderFactory,
+        ILogger<MockProviderHostLifetime> logger)
+    {
+        _responderFactory = responderFactory ?? throw new ArgumentNullException(nameof(responderFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>Bound base URL, e.g. <c>http://127.0.0.1:5099</c>. Null until startup succeeds.</summary>
+    public string? BaseUrl => _baseUrl;
+
+    /// <summary>True after the inner Kestrel app has bound a port. Used by the registry's
+    /// availability gate for the <c>*-mock</c> providers.</summary>
+    public bool IsRunning => _baseUrl is not null;
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        try
+        {
+            var responder = _responderFactory();
+            _app = MockProviderHostBuilder.Build(
+                responder,
+                urls: ["http://127.0.0.1:0"]);
+
+            await _app.StartAsync(cancellationToken).ConfigureAwait(false);
+
+            // Kestrel may rewrite a 0-port binding into the actual bound URL; pick the first
+            // resolved address.
+            _baseUrl = _app.Urls.FirstOrDefault();
+            if (_baseUrl is null)
+            {
+                _logger.LogWarning(
+                    "Mock provider host started but did not report a bound URL; *-mock providers will be unavailable");
+                return;
+            }
+
+            _logger.LogInformation(
+                "Mock provider host running at {BaseUrl} — *-mock providers are now selectable",
+                _baseUrl);
+        }
+        catch (Exception ex)
+        {
+            // Don't propagate: a failed mock host is recoverable (just disables three providers).
+            _logger.LogWarning(
+                ex,
+                "Mock provider host failed to start; *-mock providers will be unavailable");
+
+            if (_app is not null)
+            {
+                try
+                {
+                    await _app.DisposeAsync().ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Cleanup-only; primary failure already logged.
+                }
+
+                _app = null;
+            }
+        }
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_app is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _app.StopAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error stopping mock provider host");
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        if (_app is not null)
+        {
+            try
+            {
+                await _app.DisposeAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                // Disposal-only; nothing useful to recover.
+            }
+
+            _app = null;
+        }
+    }
+
+    private static ScriptedSseResponder LoadDefaultScenario()
+    {
+        var scenario = Environment.GetEnvironmentVariable("LM_MOCK_SCENARIO");
+        scenario = string.IsNullOrWhiteSpace(scenario) ? "demo" : scenario;
+        return JsonScenarioLoader.Load(scenario);
+    }
+}

--- a/samples/LmStreaming.Sample/Services/ProviderDescriptor.cs
+++ b/samples/LmStreaming.Sample/Services/ProviderDescriptor.cs
@@ -6,4 +6,13 @@ namespace LmStreaming.Sample.Services;
 /// <param name="Id">Provider id used in WS query string and persisted in metadata. Lowercase.</param>
 /// <param name="DisplayName">Human-friendly label rendered in the dropdown.</param>
 /// <param name="Available">Whether this provider can be selected on a new conversation.</param>
-public sealed record ProviderDescriptor(string Id, string DisplayName, bool Available);
+/// <param name="KnownLimitation">
+/// Optional human-facing note rendered next to the provider in the UI when the provider is
+/// available but has a documented limitation that prevents end-to-end use today (typically a
+/// link to a follow-up issue). <c>null</c> for providers without such a caveat.
+/// </param>
+public sealed record ProviderDescriptor(
+    string Id,
+    string DisplayName,
+    bool Available,
+    string? KnownLimitation = null);

--- a/samples/LmStreaming.Sample/Services/ProviderRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/ProviderRegistry.cs
@@ -16,19 +16,35 @@ namespace LmStreaming.Sample.Services;
 /// </remarks>
 public sealed class ProviderRegistry
 {
-    private static readonly ImmutableArray<(string Id, string DisplayName)> CatalogEntries =
+    private static readonly ImmutableArray<CatalogEntry> CatalogEntries =
         [
-            ("openai", "OpenAI"),
-            ("anthropic", "Anthropic"),
-            ("test", "Test (Mock)"),
-            ("test-anthropic", "Test (Anthropic)"),
-            ("claude", "Claude (CLI)"),
-            ("codex", "Codex"),
-            ("copilot", "Copilot (CLI)"),
-            ("claude-mock", "Claude (CLI, Mock)"),
-            ("codex-mock", "Codex (Mock)"),
-            ("copilot-mock", "Copilot (CLI, Mock)"),
+            new("openai", "OpenAI"),
+            new("anthropic", "Anthropic"),
+            new("test", "Test (Mock)"),
+            new("test-anthropic", "Test (Anthropic)"),
+            new("claude", "Claude (CLI)"),
+            new("codex", "Codex"),
+            new("copilot", "Copilot (CLI)"),
+            // Mock entries with known follow-up limitations are tagged here so the UI can
+            // surface a caveat next to them. Wire-format gaps are tracked in dedicated issues
+            // (see body) — fixing those here lets the gate flip to null and the banner disappears.
+            new(
+                "claude-mock",
+                "Claude (CLI, Mock)",
+                "Known limitation: the Claude CLI's /v1/messages handshake against the mock host "
+                + "currently completes silently with no rendered content. Tracked in #29."),
+            new(
+                "codex-mock",
+                "Codex (Mock)",
+                "Known limitation: Codex CLI defaults to /v1/responses which the mock host does "
+                + "not yet implement, so the run hangs. Tracked in #28."),
+            new("copilot-mock", "Copilot (CLI, Mock)"),
         ];
+
+    private readonly record struct CatalogEntry(
+        string Id,
+        string DisplayName,
+        string? KnownLimitation = null);
 
     private readonly ImmutableDictionary<string, ProviderDescriptor> _byId;
     private readonly ImmutableHashSet<string> _staticAvailability;
@@ -59,8 +75,10 @@ public sealed class ProviderRegistry
         var hasOpenAiKey = HasEnvVar("OPENAI_API_KEY");
         var hasAnthropicKey = HasEnvVar("ANTHROPIC_API_KEY");
 
-        foreach (var (id, displayName) in CatalogEntries)
+        foreach (var entry in CatalogEntries)
         {
+            var id = entry.Id;
+            var displayName = entry.DisplayName;
             var isStatic = id switch
             {
                 "test" or "test-anthropic" or "codex" => true,
@@ -81,7 +99,7 @@ public sealed class ProviderRegistry
                 staticBuilder.Add(id);
             }
 
-            builder[id] = new ProviderDescriptor(id, displayName, isStatic);
+            builder[id] = new ProviderDescriptor(id, displayName, isStatic, entry.KnownLimitation);
         }
 
         _byId = builder.ToImmutable();

--- a/samples/LmStreaming.Sample/Services/ProviderRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/ProviderRegistry.cs
@@ -8,6 +8,12 @@ namespace LmStreaming.Sample.Services;
 /// to call on the request hot path. Probes execute once at construction and the result
 /// is frozen for the process lifetime.
 /// </summary>
+/// <remarks>
+/// The <c>*-mock</c> providers depend on a runtime signal — whether the in-process
+/// <see cref="MockProviderHostLifetime"/> bound successfully — so their availability is
+/// resolved through a delegate captured at construction time and re-evaluated on each
+/// <see cref="IsAvailable"/> / <see cref="ListAll"/> call.
+/// </remarks>
 public sealed class ProviderRegistry
 {
     private static readonly ImmutableArray<(string Id, string DisplayName)> CatalogEntries =
@@ -19,23 +25,69 @@ public sealed class ProviderRegistry
             ("claude", "Claude (CLI)"),
             ("codex", "Codex"),
             ("copilot", "Copilot (CLI)"),
+            ("claude-mock", "Claude (CLI, Mock)"),
+            ("codex-mock", "Codex (Mock)"),
+            ("copilot-mock", "Copilot (CLI, Mock)"),
         ];
 
     private readonly ImmutableDictionary<string, ProviderDescriptor> _byId;
+    private readonly ImmutableHashSet<string> _staticAvailability;
+    private readonly Func<string, bool> _dynamicAvailability;
 
-    public ProviderRegistry(IFileSystemProbe? probe = null)
+    public ProviderRegistry(IFileSystemProbe? probe = null, MockProviderHostLifetime? mockHost = null)
+        : this(probe, mockHost is null ? () => false : () => mockHost.IsRunning)
     {
+    }
+
+    // Test-only constructor: lets tests inject a stub IsRunning probe without standing up a
+    // real Kestrel host. Marked internal so it stays out of the public surface.
+    internal ProviderRegistry(IFileSystemProbe? probe, Func<bool> mockHostIsRunning)
+    {
+        ArgumentNullException.ThrowIfNull(mockHostIsRunning);
+
         probe ??= new FileSystemProbe();
         var bootMode = NormalizeId(Environment.GetEnvironmentVariable("LM_PROVIDER_MODE")) ?? "test";
         DefaultProviderId = bootMode;
 
         var builder = ImmutableDictionary.CreateBuilder<string, ProviderDescriptor>(StringComparer.OrdinalIgnoreCase);
+        var staticBuilder = ImmutableHashSet.CreateBuilder<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Pre-compute the static availability of CLI gates and env-var gates once.
+        // *-mock providers AND-on the runtime mock-host signal in the dynamic delegate below.
+        var hasClaudeCli = HasCliPath("CLAUDE_CLI_PATH", "claude", probe);
+        var hasCopilotCli = HasCliPath("COPILOT_CLI_PATH", "copilot", probe);
+        var hasOpenAiKey = HasEnvVar("OPENAI_API_KEY");
+        var hasAnthropicKey = HasEnvVar("ANTHROPIC_API_KEY");
+
         foreach (var (id, displayName) in CatalogEntries)
         {
-            builder[id] = new ProviderDescriptor(id, displayName, ComputeAvailability(id, probe));
+            var isStatic = id switch
+            {
+                "test" or "test-anthropic" or "codex" => true,
+                "openai" => hasOpenAiKey,
+                "anthropic" => hasAnthropicKey,
+                "claude" => hasClaudeCli,
+                "copilot" => hasCopilotCli,
+                // *-mock providers need both their CLI prerequisite and the running mock host;
+                // codex-mock has no CLI prerequisite (codex availability is unconditional).
+                "claude-mock" => hasClaudeCli,
+                "codex-mock" => true,
+                "copilot-mock" => hasCopilotCli,
+                _ => false,
+            };
+
+            if (isStatic)
+            {
+                staticBuilder.Add(id);
+            }
+
+            builder[id] = new ProviderDescriptor(id, displayName, isStatic);
         }
 
         _byId = builder.ToImmutable();
+        _staticAvailability = staticBuilder.ToImmutable();
+        _dynamicAvailability = id => _staticAvailability.Contains(id)
+            && (!IsMockProvider(id) || mockHostIsRunning());
     }
 
     /// <summary>
@@ -48,8 +100,8 @@ public sealed class ProviderRegistry
     {
         var normalized = NormalizeId(providerId);
         return normalized != null
-            && _byId.TryGetValue(normalized, out var descriptor)
-            && descriptor.Available;
+            && _byId.ContainsKey(normalized)
+            && _dynamicAvailability(normalized);
     }
 
     public bool IsKnown(string providerId)
@@ -66,7 +118,14 @@ public sealed class ProviderRegistry
             return null;
         }
 
-        return _byId.TryGetValue(normalized, out var descriptor) ? descriptor : null;
+        if (!_byId.TryGetValue(normalized, out var descriptor))
+        {
+            return null;
+        }
+
+        // Re-evaluate availability so callers see the live mock-host status. The static
+        // descriptor stored in the dictionary is only used as a name/display source.
+        return descriptor with { Available = _dynamicAvailability(normalized) };
     }
 
     /// <summary>
@@ -76,7 +135,9 @@ public sealed class ProviderRegistry
     /// </summary>
     public IReadOnlyList<ProviderDescriptor> ListAll()
     {
-        return [.. _byId.Values.OrderBy(p => p.Id, StringComparer.OrdinalIgnoreCase)];
+        return [.. _byId.Values
+            .Select(d => d with { Available = _dynamicAvailability(d.Id) })
+            .OrderBy(p => p.Id, StringComparer.OrdinalIgnoreCase)];
     }
 
     private static string? NormalizeId(string? providerId)
@@ -89,19 +150,8 @@ public sealed class ProviderRegistry
         return providerId.Trim().ToLowerInvariant();
     }
 
-    private static bool ComputeAvailability(string providerId, IFileSystemProbe probe)
-    {
-        return providerId switch
-        {
-            "test" or "test-anthropic" => true,
-            "openai" => HasEnvVar("OPENAI_API_KEY"),
-            "anthropic" => HasEnvVar("ANTHROPIC_API_KEY"),
-            "claude" => HasCliPath("CLAUDE_CLI_PATH", "claude", probe),
-            "codex" => true,
-            "copilot" => HasCliPath("COPILOT_CLI_PATH", "copilot", probe),
-            _ => false,
-        };
-    }
+    private static bool IsMockProvider(string normalizedId) =>
+        normalizedId.EndsWith("-mock", StringComparison.Ordinal);
 
     private static bool HasEnvVar(string name)
     {

--- a/samples/MockProviderHost/JsonScenarioLoader.cs
+++ b/samples/MockProviderHost/JsonScenarioLoader.cs
@@ -1,0 +1,296 @@
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+
+namespace AchieveAi.LmDotnetTools.MockProviderHost;
+
+/// <summary>
+/// Loads <see cref="ScriptedSseResponder"/> instances from a JSON scenario document. The schema
+/// is intentionally minimal — it mirrors the fluent builder one-to-one — so scenarios can be
+/// edited without recompiling the host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Document shape:
+/// <code>
+/// {
+///   "roles": [
+///     {
+///       "key": "demo",
+///       "match": { "type": "always" },
+///       "turns": [
+///         { "thinking": 32, "messages": [
+///             { "kind": "text", "text": "Hello!" },
+///             { "kind": "tool_call", "name": "echo", "args": { "msg": "hi" } }
+///         ] }
+///       ]
+///     }
+///   ]
+/// }
+/// </code>
+/// Match types: <c>always</c>, <c>system_contains</c> (value), <c>tool</c> (name),
+/// <c>user_contains</c> (value).
+/// </para>
+/// </remarks>
+public static class JsonScenarioLoader
+{
+    private const string BuiltinScenarioPrefix = "AchieveAi.LmDotnetTools.MockProviderHost.scenarios.";
+
+    private static readonly JsonSerializerOptions ParseOptions = new(JsonSerializerDefaults.Web)
+    {
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+    };
+
+    /// <summary>
+    /// Loads a scenario from a file path or built-in name. If <paramref name="nameOrPath"/> is
+    /// a path that exists on disk, the file is read; otherwise it is treated as a built-in
+    /// scenario name (e.g. <c>"demo"</c>) and resolved from the assembly's embedded resources
+    /// or the on-disk <c>scenarios/</c> folder beside the host binary.
+    /// </summary>
+    public static ScriptedSseResponder Load(string nameOrPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(nameOrPath);
+
+        var json = ReadScenarioJson(nameOrPath);
+        return Parse(json);
+    }
+
+    /// <summary>
+    /// Parses a JSON document into a <see cref="ScriptedSseResponder"/>. Exposed for tests
+    /// that want to verify the parser without touching the filesystem.
+    /// </summary>
+    public static ScriptedSseResponder Parse(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        ScenarioDocument document;
+        try
+        {
+            document = JsonSerializer.Deserialize<ScenarioDocument>(json, ParseOptions)
+                ?? throw new JsonScenarioFormatException("Scenario JSON deserialised to null.");
+        }
+        catch (JsonException ex)
+        {
+            throw new JsonScenarioFormatException($"Scenario JSON is malformed: {ex.Message}", ex);
+        }
+
+        if (document.Roles is null || document.Roles.Count == 0)
+        {
+            throw new JsonScenarioFormatException("Scenario must declare at least one role.");
+        }
+
+        var builder = ScriptedSseResponder.New();
+        foreach (var role in document.Roles)
+        {
+            if (string.IsNullOrWhiteSpace(role.Key))
+            {
+                throw new JsonScenarioFormatException("Every role must declare a non-empty 'key'.");
+            }
+
+            var matcher = BuildMatcher(role.Key, role.Match);
+            var roleBuilder = builder.ForRole(role.Key, matcher);
+
+            var turns = role.Turns ?? [];
+            foreach (var turn in turns)
+            {
+                roleBuilder = roleBuilder.Turn(plan => ApplyTurn(plan, turn));
+            }
+        }
+
+        return builder.Build();
+    }
+
+    private static string ReadScenarioJson(string nameOrPath)
+    {
+        if (File.Exists(nameOrPath))
+        {
+            return File.ReadAllText(nameOrPath);
+        }
+
+        // Try alongside the host binary first — `samples/MockProviderHost/scenarios/<name>.json`
+        // is copied to the build output by the .csproj.
+        var sideloadPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "scenarios",
+            EnsureJsonExtension(nameOrPath));
+        if (File.Exists(sideloadPath))
+        {
+            return File.ReadAllText(sideloadPath);
+        }
+
+        // Embedded fallback so consuming applications (e.g. LmStreaming.Sample) can resolve the
+        // built-in `demo` scenario without copying the JSON next to their own binary.
+        var resourceName = BuiltinScenarioPrefix + EnsureJsonExtension(nameOrPath);
+        var assembly = typeof(JsonScenarioLoader).Assembly;
+        using var stream = assembly.GetManifestResourceStream(resourceName);
+        if (stream is not null)
+        {
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+
+        throw new FileNotFoundException(
+            $"Scenario '{nameOrPath}' was not found on disk or as an embedded resource.",
+            nameOrPath);
+    }
+
+    private static string EnsureJsonExtension(string nameOrPath) =>
+        nameOrPath.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
+            ? nameOrPath
+            : nameOrPath + ".json";
+
+    private static Func<ScriptedRequestContext, bool> BuildMatcher(string roleKey, ScenarioMatch? match)
+    {
+        if (match is null || string.IsNullOrWhiteSpace(match.Type)
+            || match.Type.Equals("always", StringComparison.OrdinalIgnoreCase)
+            || match.Type.Equals("any", StringComparison.OrdinalIgnoreCase))
+        {
+            return _ => true;
+        }
+
+        if (match.Type.Equals("system_contains", StringComparison.OrdinalIgnoreCase))
+        {
+            var value = match.Value
+                ?? throw new JsonScenarioFormatException(
+                    $"Role '{roleKey}': system_contains match requires a 'value' field.");
+            return ctx => ctx.SystemPromptContains(value);
+        }
+
+        if (match.Type.Equals("user_contains", StringComparison.OrdinalIgnoreCase))
+        {
+            var value = match.Value
+                ?? throw new JsonScenarioFormatException(
+                    $"Role '{roleKey}': user_contains match requires a 'value' field.");
+            return ctx => ctx.LatestUserMessage is not null
+                && ctx.LatestUserMessage.Contains(value, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (match.Type.Equals("tool", StringComparison.OrdinalIgnoreCase))
+        {
+            var name = match.Name
+                ?? throw new JsonScenarioFormatException(
+                    $"Role '{roleKey}': tool match requires a 'name' field.");
+            return ctx => ctx.HasTool(name);
+        }
+
+        throw new JsonScenarioFormatException(
+            $"Role '{roleKey}': unknown match type '{match.Type}'.");
+    }
+
+    private static void ApplyTurn(InstructionPlanBuilder plan, ScenarioTurn turn)
+    {
+        if (turn.Thinking is { } reasoning && reasoning > 0)
+        {
+            _ = plan.Thinking(reasoning);
+        }
+
+        var messages = turn.Messages ?? [];
+        foreach (var message in messages)
+        {
+            ApplyMessage(plan, message);
+        }
+    }
+
+    private static void ApplyMessage(InstructionPlanBuilder plan, ScenarioMessage message)
+    {
+        var kind = message.Kind ?? string.Empty;
+
+        if (kind.Equals("text", StringComparison.OrdinalIgnoreCase))
+        {
+            if (message.Text is null)
+            {
+                throw new JsonScenarioFormatException("Text message requires a 'text' field.");
+            }
+
+            _ = plan.Text(message.Text);
+            return;
+        }
+
+        if (kind.Equals("text_len", StringComparison.OrdinalIgnoreCase))
+        {
+            if (message.WordCount is not { } wordCount || wordCount <= 0)
+            {
+                throw new JsonScenarioFormatException(
+                    "text_len message requires a positive 'wordCount' field.");
+            }
+
+            _ = plan.TextLen(wordCount);
+            return;
+        }
+
+        if (kind.Equals("tool_call", StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrWhiteSpace(message.Name))
+            {
+                throw new JsonScenarioFormatException("tool_call message requires a 'name' field.");
+            }
+
+            // ToolCall expects a CLR object that JsonSerializer can serialise. Pass the parsed
+            // JsonElement straight through — it serialises losslessly.
+            object args = message.Args.HasValue ? message.Args.Value : new { };
+            _ = plan.ToolCall(message.Name, args);
+            return;
+        }
+
+        throw new JsonScenarioFormatException($"Unknown message kind '{kind}'.");
+    }
+
+    /// <summary>Returns the names of built-in scenarios shipped as embedded resources.</summary>
+    public static IReadOnlyList<string> ListBuiltinScenarios()
+    {
+        var names = typeof(JsonScenarioLoader).Assembly
+            .GetManifestResourceNames()
+            .Where(n => n.StartsWith(BuiltinScenarioPrefix, StringComparison.Ordinal)
+                && n.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            .Select(n => Path.GetFileNameWithoutExtension(n[BuiltinScenarioPrefix.Length..]))
+            .ToArray();
+
+        return names;
+    }
+
+    private sealed record ScenarioDocument
+    {
+        public List<ScenarioRole>? Roles { get; init; }
+    }
+
+    private sealed record ScenarioRole
+    {
+        public string? Key { get; init; }
+        public ScenarioMatch? Match { get; init; }
+        public List<ScenarioTurn>? Turns { get; init; }
+    }
+
+    private sealed record ScenarioMatch
+    {
+        public string? Type { get; init; }
+        public string? Value { get; init; }
+        public string? Name { get; init; }
+    }
+
+    private sealed record ScenarioTurn
+    {
+        public int? Thinking { get; init; }
+        public List<ScenarioMessage>? Messages { get; init; }
+    }
+
+    private sealed record ScenarioMessage
+    {
+        public string? Kind { get; init; }
+        public string? Text { get; init; }
+        public int? WordCount { get; init; }
+        public string? Name { get; init; }
+        public JsonElement? Args { get; init; }
+    }
+}
+
+/// <summary>
+/// Thrown when a JSON scenario document cannot be parsed. The exception message names the
+/// offending role/field so authors can correct the document without consulting the source.
+/// </summary>
+public sealed class JsonScenarioFormatException : Exception
+{
+    public JsonScenarioFormatException(string message) : base(message) { }
+
+    public JsonScenarioFormatException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/samples/MockProviderHost/MockProviderHost.csproj
+++ b/samples/MockProviderHost/MockProviderHost.csproj
@@ -15,4 +15,15 @@
     <InternalsVisibleTo Include="AchieveAi.LmDotnetTools.MockProviderHost.Tests" />
     <InternalsVisibleTo Include="AchieveAi.LmDotnetTools.MockProviderHost.E2E.Tests" />
   </ItemGroup>
+  <!--
+    Built-in scenarios are shipped two ways:
+      1. EmbeddedResource so consuming applications (e.g. LmStreaming.Sample) can resolve a
+         built-in scenario name from this assembly without copying the JSON to their own bin/.
+      2. Content (CopyToOutputDirectory) so the standalone host CLI sees the file beside its
+         binary and so authors can edit demo.json on disk without rebuilding.
+  -->
+  <ItemGroup>
+    <EmbeddedResource Include="scenarios\*.json" LogicalName="AchieveAi.LmDotnetTools.MockProviderHost.scenarios.%(Filename)%(Extension)" />
+    <None Include="scenarios\*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/samples/MockProviderHost/Program.cs
+++ b/samples/MockProviderHost/Program.cs
@@ -1,28 +1,36 @@
-using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
 using AchieveAi.LmDotnetTools.MockProviderHost;
 
-// CLI entry point. Boots a mock provider host on the requested port using a built-in
-// "demo" scenario so the host is runnable out-of-the-box. For real test scenarios the
-// host is consumed as a library — see MockProviderHost.E2E.Tests.
+// CLI entry point. Boots a mock provider host on the requested port using a JSON scenario file.
+// The scenario name (or path) is taken from --scenario / LM_MOCK_SCENARIO; defaults to the
+// built-in "demo" scenario shipped as an embedded resource.
 
 int port = 5099;
-for (int i = 0; i < args.Length - 1; i++)
+string? scenario = Environment.GetEnvironmentVariable("LM_MOCK_SCENARIO");
+
+for (int i = 0; i < args.Length; i++)
 {
     if (string.Equals(args[i], "--port", StringComparison.OrdinalIgnoreCase)
-        && int.TryParse(args[i + 1], out var parsed))
+        && i + 1 < args.Length
+        && int.TryParse(args[i + 1], out var parsedPort))
     {
-        port = parsed;
-        break;
+        port = parsedPort;
+        i++;
+    }
+    else if (string.Equals(args[i], "--scenario", StringComparison.OrdinalIgnoreCase)
+        && i + 1 < args.Length)
+    {
+        scenario = args[i + 1];
+        i++;
     }
 }
 
-var responder = ScriptedSseResponder.New()
-    .ForRole("demo", _ => true)
-        .Turn(t => t.Text("Mock provider host is running."))
-        .Turn(t => t.Text("Define your own scenarios in code via ScriptedSseResponder.New()."))
-    .Build();
+scenario = string.IsNullOrWhiteSpace(scenario) ? "demo" : scenario;
 
 using var loggerFactory = LoggerFactory.Create(b => b.AddConsole().SetMinimumLevel(LogLevel.Information));
+var bootLogger = loggerFactory.CreateLogger("MockProviderHost");
+bootLogger.LogInformation("Loading scenario '{Scenario}'", scenario);
+
+var responder = JsonScenarioLoader.Load(scenario);
 
 var app = MockProviderHostBuilder.Build(
     responder,

--- a/samples/MockProviderHost/README.md
+++ b/samples/MockProviderHost/README.md
@@ -25,13 +25,38 @@ don't reject responses.
 ## Running standalone
 
 ```bash
+# Default: load the embedded "demo" scenario.
 dotnet run --project samples/MockProviderHost -- --port 5099
+
+# Pick a different built-in scenario or a path on disk.
+dotnet run --project samples/MockProviderHost -- --port 5099 --scenario demo
+dotnet run --project samples/MockProviderHost -- --port 5099 --scenario /path/to/my.json
+
+# LM_MOCK_SCENARIO env var is the same hook (used by LmStreaming.Sample).
+LM_MOCK_SCENARIO=demo dotnet run --project samples/MockProviderHost
 ```
 
-The standalone entry point ships with a trivial demo scenario. Real test
-scenarios are built via `ScriptedSseResponder.New()` and passed to
-`MockProviderHostBuilder.Build(...)` — see `tests/MockProviderHost.Tests` and
-`tests/MockProviderHost.E2E.Tests` for examples.
+Scenario JSON schema (see `samples/MockProviderHost/scenarios/demo.json` for a full
+example). For programmatic scenarios in tests, build a `ScriptedSseResponder` directly via
+`ScriptedSseResponder.New()` and pass it to `MockProviderHostBuilder.Build(...)`.
+
+```json
+{
+  "roles": [
+    {
+      "key": "demo",
+      "match": { "type": "always" },
+      "turns": [
+        { "messages": [{ "kind": "text", "text": "Hi!" }] }
+      ]
+    }
+  ]
+}
+```
+
+Match types: `always`, `system_contains` (with `value`), `user_contains` (with `value`),
+`tool` (with `name`). Message kinds: `text`, `text_len` (with `wordCount`), `tool_call`
+(with `name` and optional `args`).
 
 ## Embedded use (the common case)
 

--- a/samples/MockProviderHost/scenarios/demo.json
+++ b/samples/MockProviderHost/scenarios/demo.json
@@ -1,0 +1,40 @@
+{
+  "roles": [
+    {
+      "key": "demo",
+      "match": { "type": "always" },
+      "turns": [
+        {
+          "messages": [
+            {
+              "kind": "text",
+              "text": "Welcome to the LmDotnetTools mock provider host. This demo scenario streams a few canned turns so you can exercise the chat client end-to-end without an API key."
+            }
+          ]
+        },
+        {
+          "thinking": 64,
+          "messages": [
+            {
+              "kind": "text",
+              "text": "Here's a turn that includes a thinking block followed by a tool call so you can see how mixed content renders in the chat UI."
+            },
+            {
+              "kind": "tool_call",
+              "name": "echo",
+              "args": { "message": "hello from the mock host" }
+            }
+          ]
+        },
+        {
+          "messages": [
+            {
+              "kind": "text",
+              "text": "Edit samples/MockProviderHost/scenarios/demo.json (or supply LM_MOCK_SCENARIO=<path>) to script your own turns. After this turn the queue is exhausted and subsequent requests fall back to a single-line 'ok' reply."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/LmStreaming.Sample.Tests/Services/MockProviderHostLifetimeTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/MockProviderHostLifetimeTests.cs
@@ -1,0 +1,97 @@
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using LmStreaming.Sample.Services;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// Regression tests for the lifetime contract that the registry's <c>*-mock</c> availability
+/// gate depends on: <see cref="MockProviderHostLifetime.IsRunning"/> must reflect the inner
+/// Kestrel app's bound state, and a startup failure must NOT propagate (the sample app must
+/// keep running even if the mock host fails to bind).
+/// </summary>
+public class MockProviderHostLifetimeTests
+{
+    [Fact]
+    public async Task StartAsync_BindsLoopback_AndExposesBaseUrl()
+    {
+        await using var lifetime = new MockProviderHostLifetime(
+            () => ScriptedSseResponder.New()
+                .ForRole("any", _ => true).Turn(t => t.Text("ok"))
+                .Build(),
+            NullLogger<MockProviderHostLifetime>.Instance);
+
+        await lifetime.StartAsync(CancellationToken.None);
+
+        lifetime.IsRunning.Should().BeTrue();
+        lifetime.BaseUrl.Should().NotBeNullOrEmpty();
+        lifetime.BaseUrl.Should().StartWith("http://127.0.0.1:");
+    }
+
+    [Fact]
+    public async Task StartAsync_SwallowsException_WhenResponderFactoryThrows()
+    {
+        // The IHostedService contract: a failure here would crash Host.StartAsync and take
+        // the whole sample app down. The catch in StartAsync exists to keep the rest of the
+        // app running when only the mock host can't bind.
+        await using var lifetime = new MockProviderHostLifetime(
+            () => throw new InvalidOperationException("scenario failed to load"),
+            NullLogger<MockProviderHostLifetime>.Instance);
+
+        var act = async () => await lifetime.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        lifetime.IsRunning.Should().BeFalse();
+        lifetime.BaseUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task StartAsync_NoOp_WhenAlreadyDisposed()
+    {
+        var responderInvoked = 0;
+        var lifetime = new MockProviderHostLifetime(
+            () =>
+            {
+                Interlocked.Increment(ref responderInvoked);
+                return ScriptedSseResponder.New()
+                    .ForRole("any", _ => true).Turn(t => t.Text("ok"))
+                    .Build();
+            },
+            NullLogger<MockProviderHostLifetime>.Instance);
+
+        await lifetime.DisposeAsync();
+        await lifetime.StartAsync(CancellationToken.None);
+
+        responderInvoked.Should().Be(0);
+        lifetime.IsRunning.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task StopAsync_NoOp_WhenNeverStarted()
+    {
+        await using var lifetime = new MockProviderHostLifetime(
+            () => ScriptedSseResponder.New()
+                .ForRole("any", _ => true).Turn(t => t.Text("ok"))
+                .Build(),
+            NullLogger<MockProviderHostLifetime>.Instance);
+
+        var act = async () => await lifetime.StopAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_IsIdempotent()
+    {
+        var lifetime = new MockProviderHostLifetime(
+            () => ScriptedSseResponder.New()
+                .ForRole("any", _ => true).Turn(t => t.Text("ok"))
+                .Build(),
+            NullLogger<MockProviderHostLifetime>.Instance);
+
+        await lifetime.StartAsync(CancellationToken.None);
+        await lifetime.DisposeAsync();
+        var act = async () => await lifetime.DisposeAsync();
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/ProviderRegistryTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ProviderRegistryTests.cs
@@ -181,8 +181,106 @@ public class ProviderRegistryTests
         var catalog = registry.ListAll();
 
         catalog.Select(p => p.Id).Should().BeEquivalentTo(
-            ["anthropic", "claude", "codex", "copilot", "openai", "test", "test-anthropic"],
+            [
+                "anthropic", "claude", "claude-mock", "codex", "codex-mock",
+                "copilot", "copilot-mock", "openai", "test", "test-anthropic",
+            ],
             options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void IsAvailable_ClaudeMock_RequiresCliAndRunningHost()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        using var __ = EnvScope.Set("CLAUDE_CLI_PATH", null);
+        var probe = new FakeFileSystemProbe(executablesOnPath: ["claude"]);
+
+        var withHost = new ProviderRegistry(probe, mockHostIsRunning: () => true);
+        var withoutHost = new ProviderRegistry(probe, mockHostIsRunning: () => false);
+
+        withHost.IsAvailable("claude-mock").Should().BeTrue();
+        withoutHost.IsAvailable("claude-mock").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAvailable_ClaudeMock_FalseWhenCliMissing()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        using var __ = EnvScope.Set("CLAUDE_CLI_PATH", null);
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe(), mockHostIsRunning: () => true);
+
+        registry.IsAvailable("claude-mock").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAvailable_CopilotMock_RequiresCliAndRunningHost()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        using var __ = EnvScope.Set("COPILOT_CLI_PATH", null);
+        var probe = new FakeFileSystemProbe(executablesOnPath: ["copilot"]);
+
+        var withHost = new ProviderRegistry(probe, mockHostIsRunning: () => true);
+        var withoutHost = new ProviderRegistry(probe, mockHostIsRunning: () => false);
+
+        withHost.IsAvailable("copilot-mock").Should().BeTrue();
+        withoutHost.IsAvailable("copilot-mock").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAvailable_CopilotMock_FalseWhenCliMissing()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        using var __ = EnvScope.Set("COPILOT_CLI_PATH", null);
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe(), mockHostIsRunning: () => true);
+
+        registry.IsAvailable("copilot-mock").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAvailable_CodexMock_TracksHostState()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+
+        var withHost = new ProviderRegistry(new FakeFileSystemProbe(), mockHostIsRunning: () => true);
+        var withoutHost = new ProviderRegistry(new FakeFileSystemProbe(), mockHostIsRunning: () => false);
+
+        withHost.IsAvailable("codex-mock").Should().BeTrue();
+        withoutHost.IsAvailable("codex-mock").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Get_MockProvider_ReflectsLiveHostState()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        var hostRunning = false;
+
+        // Constructed once with a delegate that closes over the local. Flipping the local
+        // after construction must propagate to subsequent Get() calls — that's what proves the
+        // mock-host signal is re-evaluated rather than frozen at startup.
+        var registry = new ProviderRegistry(new FakeFileSystemProbe(), mockHostIsRunning: () => hostRunning);
+        registry.Get("codex-mock")!.Available.Should().BeFalse();
+
+        hostRunning = true;
+
+        registry.Get("codex-mock")!.Available.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ListAll_FlagsMockProvidersUnavailable_WhenHostNotRunning()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        using var __ = EnvScope.Set("CLAUDE_CLI_PATH", null);
+        using var ___ = EnvScope.Set("COPILOT_CLI_PATH", null);
+        var probe = new FakeFileSystemProbe(executablesOnPath: ["claude", "copilot"]);
+
+        var registry = new ProviderRegistry(probe, mockHostIsRunning: () => false);
+        var catalog = registry.ListAll().ToDictionary(p => p.Id, p => p.Available);
+
+        catalog["claude-mock"].Should().BeFalse();
+        catalog["codex-mock"].Should().BeFalse();
+        catalog["copilot-mock"].Should().BeFalse();
     }
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/Services/ProviderRegistryTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ProviderRegistryTests.cs
@@ -314,6 +314,30 @@ public class ProviderRegistryTests
     }
 
     [Fact]
+    public void KnownLimitation_TaggedOnBrokenMocks_UnsetOnHealthyOnes()
+    {
+        // Surfaces the UX banner that points users at the follow-up issues for the broken
+        // mock variants (#28 codex, #29 claude). When those land, this assertion flips.
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        var probe = new FakeFileSystemProbe(executablesOnPath: ["claude", "copilot"]);
+
+        var registry = new ProviderRegistry(probe, () => true);
+        var byId = registry.ListAll().ToDictionary(p => p.Id);
+
+        byId["codex-mock"].KnownLimitation.Should().NotBeNullOrWhiteSpace()
+            .And.Subject.Should().Contain("#28");
+        byId["claude-mock"].KnownLimitation.Should().NotBeNullOrWhiteSpace()
+            .And.Subject.Should().Contain("#29");
+
+        // copilot-mock works end-to-end against the mock host and must NOT carry a caveat.
+        byId["copilot-mock"].KnownLimitation.Should().BeNull();
+
+        // Non-mock entries inherit the default null.
+        byId["openai"].KnownLimitation.Should().BeNull();
+        byId["claude"].KnownLimitation.Should().BeNull();
+    }
+
+    [Fact]
     public void Get_ReturnsNull_ForUnknownProvider()
     {
         using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");

--- a/tests/MockProviderHost.Tests/JsonScenarioLoaderTests.cs
+++ b/tests/MockProviderHost.Tests/JsonScenarioLoaderTests.cs
@@ -1,0 +1,251 @@
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.MockProviderHost.Tests;
+
+/// <summary>
+/// Verifies <see cref="JsonScenarioLoader"/> parses well-formed scenarios into a usable
+/// <c>ScriptedSseResponder</c> and rejects malformed shapes with a useful diagnostic.
+/// </summary>
+public sealed class JsonScenarioLoaderTests
+{
+    [Fact]
+    public void Load_resolves_the_embedded_demo_scenario()
+    {
+        var responder = JsonScenarioLoader.Load("demo");
+
+        // The shipped scenario has one role ("demo") with three turns.
+        responder.RemainingTurns.Should().ContainKey("demo")
+            .WhoseValue.Should().Be(3);
+    }
+
+    [Fact]
+    public void ListBuiltinScenarios_contains_demo()
+    {
+        JsonScenarioLoader.ListBuiltinScenarios().Should().Contain("demo");
+    }
+
+    [Fact]
+    public void Parse_supports_all_match_types()
+    {
+        const string json = """
+            {
+              "roles": [
+                { "key": "alpha", "match": { "type": "always" }, "turns": [
+                    { "messages": [{ "kind": "text", "text": "a" }] }
+                ]},
+                { "key": "beta", "match": { "type": "system_contains", "value": "marker" }, "turns": [
+                    { "messages": [{ "kind": "text", "text": "b" }] }
+                ]},
+                { "key": "gamma", "match": { "type": "user_contains", "value": "hello" }, "turns": [
+                    { "messages": [{ "kind": "text", "text": "c" }] }
+                ]},
+                { "key": "delta", "match": { "type": "tool", "name": "echo" }, "turns": [
+                    { "messages": [{ "kind": "text", "text": "d" }] }
+                ]}
+              ]
+            }
+            """;
+
+        var responder = JsonScenarioLoader.Parse(json);
+
+        responder.RemainingTurns.Keys.Should().BeEquivalentTo(["alpha", "beta", "gamma", "delta"]);
+    }
+
+    [Fact]
+    public void Parse_supports_all_message_kinds_and_thinking()
+    {
+        const string json = """
+            {
+              "roles": [{
+                "key": "demo", "match": { "type": "always" }, "turns": [
+                  { "thinking": 32, "messages": [
+                      { "kind": "text", "text": "hi" },
+                      { "kind": "text_len", "wordCount": 5 },
+                      { "kind": "tool_call", "name": "echo", "args": { "msg": "hey" } }
+                  ]}
+                ]
+              }]
+            }
+            """;
+
+        var responder = JsonScenarioLoader.Parse(json);
+
+        responder.RemainingTurns["demo"].Should().Be(1);
+    }
+
+    [Fact]
+    public void Parse_throws_on_empty_roles()
+    {
+        Action act = () => JsonScenarioLoader.Parse("""{ "roles": [] }""");
+
+        act.Should().Throw<JsonScenarioFormatException>()
+            .WithMessage("*at least one role*");
+    }
+
+    [Fact]
+    public void Parse_throws_on_missing_role_key()
+    {
+        const string json = """
+            { "roles": [{ "match": { "type": "always" }, "turns": [
+                { "messages": [{ "kind": "text", "text": "x" }] }
+            ]}]}
+            """;
+
+        Action act = () => JsonScenarioLoader.Parse(json);
+
+        act.Should().Throw<JsonScenarioFormatException>()
+            .WithMessage("*non-empty 'key'*");
+    }
+
+    [Fact]
+    public void Parse_throws_on_unknown_match_type()
+    {
+        const string json = """
+            { "roles": [{ "key": "demo", "match": { "type": "weather" }, "turns": [
+                { "messages": [{ "kind": "text", "text": "x" }] }
+            ]}]}
+            """;
+
+        Action act = () => JsonScenarioLoader.Parse(json);
+
+        act.Should().Throw<JsonScenarioFormatException>()
+            .WithMessage("*weather*");
+    }
+
+    [Fact]
+    public void Parse_throws_when_system_contains_omits_value()
+    {
+        const string json = """
+            { "roles": [{ "key": "demo", "match": { "type": "system_contains" }, "turns": [
+                { "messages": [{ "kind": "text", "text": "x" }] }
+            ]}]}
+            """;
+
+        Action act = () => JsonScenarioLoader.Parse(json);
+
+        act.Should().Throw<JsonScenarioFormatException>()
+            .WithMessage("*system_contains*'value'*");
+    }
+
+    [Fact]
+    public void Parse_throws_when_tool_match_omits_name()
+    {
+        const string json = """
+            { "roles": [{ "key": "demo", "match": { "type": "tool" }, "turns": [
+                { "messages": [{ "kind": "text", "text": "x" }] }
+            ]}]}
+            """;
+
+        Action act = () => JsonScenarioLoader.Parse(json);
+
+        act.Should().Throw<JsonScenarioFormatException>()
+            .WithMessage("*tool match*'name'*");
+    }
+
+    [Fact]
+    public void Parse_throws_on_text_message_without_text()
+    {
+        const string json = """
+            { "roles": [{ "key": "demo", "match": { "type": "always" }, "turns": [
+                { "messages": [{ "kind": "text" }] }
+            ]}]}
+            """;
+
+        Action act = () => JsonScenarioLoader.Parse(json);
+
+        act.Should().Throw<JsonScenarioFormatException>()
+            .WithMessage("*Text message*'text'*");
+    }
+
+    [Fact]
+    public void Parse_throws_on_text_len_without_word_count()
+    {
+        const string json = """
+            { "roles": [{ "key": "demo", "match": { "type": "always" }, "turns": [
+                { "messages": [{ "kind": "text_len" }] }
+            ]}]}
+            """;
+
+        Action act = () => JsonScenarioLoader.Parse(json);
+
+        act.Should().Throw<JsonScenarioFormatException>()
+            .WithMessage("*text_len*wordCount*");
+    }
+
+    [Fact]
+    public void Parse_throws_on_tool_call_without_name()
+    {
+        const string json = """
+            { "roles": [{ "key": "demo", "match": { "type": "always" }, "turns": [
+                { "messages": [{ "kind": "tool_call" }] }
+            ]}]}
+            """;
+
+        Action act = () => JsonScenarioLoader.Parse(json);
+
+        act.Should().Throw<JsonScenarioFormatException>()
+            .WithMessage("*tool_call*'name'*");
+    }
+
+    [Fact]
+    public void Parse_throws_on_unknown_message_kind()
+    {
+        const string json = """
+            { "roles": [{ "key": "demo", "match": { "type": "always" }, "turns": [
+                { "messages": [{ "kind": "image", "text": "ignored" }] }
+            ]}]}
+            """;
+
+        Action act = () => JsonScenarioLoader.Parse(json);
+
+        act.Should().Throw<JsonScenarioFormatException>()
+            .WithMessage("*image*");
+    }
+
+    [Fact]
+    public void Parse_throws_on_malformed_json()
+    {
+        Action act = () => JsonScenarioLoader.Parse("not json");
+
+        act.Should().Throw<JsonScenarioFormatException>()
+            .WithMessage("*malformed*");
+    }
+
+    [Fact]
+    public void Load_reads_an_absolute_file_path()
+    {
+        var temp = Path.Combine(Path.GetTempPath(), $"scenario-{Guid.NewGuid():N}.json");
+        File.WriteAllText(temp, """
+            { "roles": [{ "key": "from-disk", "match": { "type": "always" }, "turns": [
+                { "messages": [{ "kind": "text", "text": "from disk" }] }
+            ]}]}
+            """);
+
+        try
+        {
+            var responder = JsonScenarioLoader.Load(temp);
+
+            responder.RemainingTurns.Should().ContainKey("from-disk");
+        }
+        finally
+        {
+            File.Delete(temp);
+        }
+    }
+
+    [Fact]
+    public void Load_throws_FileNotFound_for_unresolved_name()
+    {
+        Action act = () => JsonScenarioLoader.Load("does-not-exist-anywhere");
+
+        act.Should().Throw<FileNotFoundException>();
+    }
+
+    [Fact]
+    public void Load_rejects_blank_input()
+    {
+        Action act = () => JsonScenarioLoader.Load("   ");
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/MockProviderHost.Tests/JsonScenarioLoaderTests.cs
+++ b/tests/MockProviderHost.Tests/JsonScenarioLoaderTests.cs
@@ -1,3 +1,5 @@
+using AchieveAi.LmDotnetTools.OpenAIProvider.Agents;
+using AchieveAi.LmDotnetTools.OpenAIProvider.Models;
 using FluentAssertions;
 
 namespace AchieveAi.LmDotnetTools.MockProviderHost.Tests;
@@ -128,6 +130,21 @@ public sealed class JsonScenarioLoaderTests
     }
 
     [Fact]
+    public void Parse_throws_when_user_contains_omits_value()
+    {
+        const string json = """
+            { "roles": [{ "key": "demo", "match": { "type": "user_contains" }, "turns": [
+                { "messages": [{ "kind": "text", "text": "x" }] }
+            ]}]}
+            """;
+
+        Action act = () => JsonScenarioLoader.Parse(json);
+
+        act.Should().Throw<JsonScenarioFormatException>()
+            .WithMessage("*user_contains*'value'*");
+    }
+
+    [Fact]
     public void Parse_throws_when_tool_match_omits_name()
     {
         const string json = """
@@ -247,5 +264,53 @@ public sealed class JsonScenarioLoaderTests
         Action act = () => JsonScenarioLoader.Load("   ");
 
         act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task Parse_user_contains_matcher_dispatches_only_on_matching_request()
+    {
+        // Closes the JSON → matcher → dispatch gap: ensures the parsed user_contains
+        // delegate actually claims a request whose user message contains the value, and
+        // declines to claim one that does not.
+        const string json = """
+            {
+              "roles": [
+                { "key": "greeter", "match": { "type": "user_contains", "value": "hello" }, "turns": [
+                    { "messages": [{ "kind": "text", "text": "greeting reply" }] }
+                ]},
+                { "key": "fallback", "match": { "type": "always" }, "turns": [
+                    { "messages": [{ "kind": "text", "text": "fallback reply" }] },
+                    { "messages": [{ "kind": "text", "text": "fallback reply 2" }] }
+                ]}
+              ]
+            }
+            """;
+
+        var responder = JsonScenarioLoader.Parse(json);
+        await using var fixture = await EphemeralHostFixture.StartAsync(responder);
+        using var httpClient = new HttpClient();
+        var openClient = new OpenClient(httpClient, fixture.BaseUrl + "/v1");
+
+        await ConsumeAsync(openClient, "Hello there friend");
+        await ConsumeAsync(openClient, "totally unrelated text");
+
+        // Matching request consumed greeter's only turn; non-matching fell through to fallback.
+        responder.RemainingTurns["greeter"].Should().Be(0);
+        responder.RemainingTurns["fallback"].Should().Be(1);
+    }
+
+    private static async Task ConsumeAsync(OpenClient openClient, string userMessage)
+    {
+        var request = new ChatCompletionRequest(
+            "gpt-test",
+            [
+                new ChatMessage { Role = RoleEnum.User, Content = ChatMessage.CreateContent(userMessage) },
+            ])
+        {
+            Stream = true,
+        };
+        await foreach (var _ in openClient.StreamingChatCompletionsAsync(request))
+        {
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `claude-mock` / `codex-mock` / `copilot-mock` provider entries to
  `samples/LmStreaming.Sample` so the chat UI can demo all three CLI agents
  end-to-end against an in-process `MockProviderHost` — no API keys, no
  upstream calls.
- Introduces `JsonScenarioLoader` so authors can edit
  `samples/MockProviderHost/scenarios/demo.json` (or set
  `LM_MOCK_SCENARIO=<name|path>`) without rebuilding the host.
- Adds `MockProviderHostLifetime` that boots the mock host eagerly on an
  ephemeral loopback port. Bind failures are recoverable: the three
  `*-mock` providers stay unavailable in `GET /api/providers` and disappear
  from the dropdown rather than failing the whole app.
- `ProviderRegistry` keeps the static CLI/env probes unchanged but
  AND-gates the `*-mock` entries with a runtime `IsRunning` delegate.
- Per-spawn overrides flow through the existing
  `Codex/Claude/CopilotSdkOptions.BaseUrl/ApiKey/AuthToken` fields, which
  are already wired into the child CLI process environment — no
  agent-loop signature churn for the regular providers.

Closes #25

## Test plan

- [x] `dotnet build LmDotnetTools.sln` (0 errors; existing warnings only)
- [x] `dotnet test tests/MockProviderHost.Tests/...` — 28/28 pass
  (17 new `JsonScenarioLoader` tests cover happy-path, all match types,
  all message kinds, plus malformed-JSON / missing-field error paths)
- [x] `dotnet test tests/LmStreaming.Sample.Tests/...` — 57/57 pass
  (7 new `ProviderRegistry` tests cover `*-mock` availability gating
  across CLI probe + `IsRunning` permutations)
- [ ] Manual: `dotnet run --project samples/LmStreaming.Sample`, pick
  `claude-mock` / `codex-mock` / `copilot-mock` in the provider dropdown,
  send a turn — verify the demo scenario streams through.
