### PR TITLE
Feat/deferred tool execution

### DIFF
--- a/docs/features/deferred-tool-execution/motivation.md
+++ b/docs/features/deferred-tool-execution/motivation.md
@@ -1,0 +1,60 @@
+# Deferred Tool Execution — Motivation
+
+## Problem
+
+`MultiTurnAgentLoop` executes tool calls synchronously: the run loop awaits every handler via `Task.WhenAll(pendingToolCalls.Values)` before starting the next turn. This works for fast tools (filesystem reads, in-process computation, quick HTTP calls) but breaks down whenever a tool's result depends on something the loop can't drive forward on its own.
+
+Concrete scenarios that don't fit the current model:
+
+- **Human-in-the-loop approval.** LLM asks to read a directory; a human must approve before it proceeds. Approval may take minutes to hours.
+- **External async APIs with callbacks.** A bank verification API accepts a request and fires a webhook 10 minutes later. Nothing useful to await locally.
+- **Long-running batch jobs.** Submit work to a queue or scheduler; result comes back via a separate channel.
+- **Sub-agents with their own tool loops.** Already long-lived; modeling them as deferred calls is a natural fit.
+
+In all of these the handler can't reasonably block. Today, doing so would:
+
+- Pin a turn (and the entire run loop) for the full duration.
+- Prevent the loop from draining new inputs from `SendAsync` until the slow tool returns (`TryDrainInputs` runs at turn boundaries).
+- Provide no cooperative cancellation — handler signatures are `Func<string, Task<string>>` with no `CancellationToken`.
+- Hide partial progress from the UI and the LLM.
+
+## The generalizing insight
+
+Approval is not a special case. The unifying primitive is **deferred tool execution**: a handler that returns a placeholder synchronously and is resolved later by *something* outside the loop. The loop should not care whether that "something" is a human, a webhook, a worker, or a timer.
+
+Specializations collapse into thin integration layers:
+
+| Use case | What "resolves" the call |
+|---|---|
+| HITL approval | UI calls `ResolveToolCallAsync` when the human acts |
+| Bank webhook | Webhook receiver calls `ResolveToolCallAsync` |
+| Long batch job | Worker calls `ResolveToolCallAsync` on completion |
+| Timeout/cancellation | Host timer calls `ResolveToolCallAsync` with an error |
+
+## Why a placeholder is required, not optional
+
+Both Anthropic and OpenAI enforce that every `tool_use` (or `tool_call`) ID in an assistant message must have a matching `tool_result` before the next assistant inference. There is no "partially answered tool calls" state in either contract.
+
+So while the loop is waiting on a deferred resolution, it must still place *some* `tool_result` in history for protocol validity. A placeholder string (`"PENDING ..."`) plus a flag like `IsDeferred = true` on the message satisfies both the contract and the loop's own state-tracking needs.
+
+When resolution arrives, the placeholder is replaced in-place by the real result (mutating history by `ToolCallId`). Appending a second `tool_result` for the same ID is not a defined operation and would produce an invalid request payload.
+
+## Design implications worth noting
+
+These are flagged here as motivation context; the actual design lives in `design.md` (TBD).
+
+- **History as the single source of truth.** Pending state lives on `ToolCallResultMessage` (e.g., `IsDeferred`), not in a parallel registry. Persistence via `IConversationStore` is then automatic.
+- **Resolution is one API.** `ResolveToolCallAsync(toolCallId, result, isError)` — used identically by every integrator. Approvals, webhooks, and timeouts all funnel through it.
+- **Idempotency matters once async is in scope.** Webhooks retry; resolution must be safe against double-delivery in a way approvals never required.
+- **Restart durability is the hardest open question.** When the process dies mid-deferral, the in-flight outbound work the handler initiated (HTTP request, queue publish) is *not* persisted. Handlers must be responsible for their own outbound idempotency / recovery; the loop should expose enough metadata (deferred call inspection on startup) to support that, but cannot solve it generically.
+- **Progress updates use the existing subscriber stream.** Tool results are write-once; partial progress flows as separate published events to UI subscribers without resolving the placeholder.
+
+## Out of scope (for now)
+
+- Cross-process resolution and durable workflow integration (Temporal, Durable Functions). The first cut targets in-process async; durable hand-off is an explicit future concern.
+- Built-in timeout policy. Timeouts are host-driven (host calls `ResolveToolCallAsync` with an error after its own deadline) rather than enforced by the loop. Helpers may follow.
+- Streaming partial tool results into LLM context. The LLM only sees a deferred call's result on final resolution.
+
+## Recommendation
+
+Build the primitive at the level of **deferred tool result**, not "approval." Approvals, webhooks, and long-running jobs all become thin convenience layers over the same `ResolveToolCallAsync` API and the same `IsDeferred` placeholder shape. The loop stays focused on driving turns; everything domain-specific lives outside it.

--- a/example/ExamplePythonMCPClient/Program.cs
+++ b/example/ExamplePythonMCPClient/Program.cs
@@ -62,7 +62,7 @@ public class CustomFunctionProvider : IFunctionProvider
             ],
         };
 
-        static async Task<ToolHandlerResult> askUserHandler(string json, ToolCallContext context)
+        static async Task<ToolHandlerResult> askUserHandler(string json, ToolCallContext context, CancellationToken cancellationToken)
         {
             var jsonObject = JsonNode.Parse(json)!;
             var question = jsonObject["question"]?.ToString() ?? "";

--- a/example/ExamplePythonMCPClient/Program.cs
+++ b/example/ExamplePythonMCPClient/Program.cs
@@ -62,7 +62,7 @@ public class CustomFunctionProvider : IFunctionProvider
             ],
         };
 
-        static async Task<ToolHandlerResult> askUserHandler(string json)
+        static async Task<ToolHandlerResult> askUserHandler(string json, ToolCallContext context)
         {
             var jsonObject = JsonNode.Parse(json)!;
             var question = jsonObject["question"]?.ToString() ?? "";

--- a/example/ExamplePythonMCPClient/Program.cs
+++ b/example/ExamplePythonMCPClient/Program.cs
@@ -62,12 +62,12 @@ public class CustomFunctionProvider : IFunctionProvider
             ],
         };
 
-        static async Task<string> askUserHandler(string json)
+        static async Task<ToolHandlerResult> askUserHandler(string json)
         {
             var jsonObject = JsonNode.Parse(json)!;
             var question = jsonObject["question"]?.ToString() ?? "";
             var options = jsonObject["options"]?.AsArray().Select(x => x!.ToString()).ToArray() ?? [];
-            return await Program.AskUser(question, options);
+            return new ToolHandlerResult.Resolved(new ToolCallResult(null, await Program.AskUser(question, options)));
         }
 
         yield return new FunctionDescriptor

--- a/example/ExamplePythonMCPClient/Program.cs
+++ b/example/ExamplePythonMCPClient/Program.cs
@@ -67,7 +67,7 @@ public class CustomFunctionProvider : IFunctionProvider
             var jsonObject = JsonNode.Parse(json)!;
             var question = jsonObject["question"]?.ToString() ?? "";
             var options = jsonObject["options"]?.AsArray().Select(x => x!.ToString()).ToArray() ?? [];
-            return new ToolHandlerResult.Resolved(new ToolCallResult(null, await Program.AskUser(question, options)));
+            return ToolHandlerResult.FromText(await Program.AskUser(question, options));
         }
 
         yield return new FunctionDescriptor

--- a/example/LmConfigUsageExample/OpenAiGrokAgenticExample.cs
+++ b/example/LmConfigUsageExample/OpenAiGrokAgenticExample.cs
@@ -97,7 +97,7 @@ public class OpenAiGrokAgenticExample
                     },
                 ],
             },
-            async (args, _) =>
+            async (args, _, _) =>
             {
                 var weatherArgs = JsonSerializer.Deserialize<WeatherArgs>(args);
                 _logger.LogInformation("[TOOL] Getting weather for {Location}", weatherArgs?.Location);
@@ -134,7 +134,7 @@ public class OpenAiGrokAgenticExample
                     },
                 ],
             },
-            async (args, _) =>
+            async (args, _, _) =>
             {
                 var timeArgs = JsonSerializer.Deserialize<TimeArgs>(args);
                 _logger.LogInformation("[TOOL] Getting time for {Timezone}", timeArgs?.Timezone);
@@ -170,7 +170,7 @@ public class OpenAiGrokAgenticExample
                     },
                 ],
             },
-            async (args, _) =>
+            async (args, _, _) =>
             {
                 var calcArgs = JsonSerializer.Deserialize<CalculateArgs>(args);
                 _logger.LogInformation("[TOOL] Calculating: {Expression}", calcArgs?.Expression);
@@ -364,7 +364,7 @@ public class OpenAiGrokAgenticExample
             if (handlers.TryGetValue(functionName, out var handler))
             {
                 var ctx = new ToolCallContext { ToolCallId = toolCall.ToolCallId };
-                var result = await handler(functionArgs, ctx);
+                var result = await handler(functionArgs, ctx, CancellationToken.None);
                 return new ToolCallResultMessage
                 {
                     ToolCallId = toolCallId,

--- a/example/LmConfigUsageExample/OpenAiGrokAgenticExample.cs
+++ b/example/LmConfigUsageExample/OpenAiGrokAgenticExample.cs
@@ -192,7 +192,7 @@ public class OpenAiGrokAgenticExample
         );
 
         // Build middleware and handlers from registry
-        var (toolCallMiddleware, functionHandlers, _) = registry.BuildToolCallComponents(name: "ToolCallInjection");
+        var (toolCallMiddleware, functionHandlers) = registry.BuildToolCallComponents(name: "ToolCallInjection");
 
         // ===== Step 4: Create Provider Agent =====
         var providerAgent = _agentFactory.CreateStreamingAgent(resolution)
@@ -352,7 +352,7 @@ public class OpenAiGrokAgenticExample
     /// </summary>
     private async Task<ToolCallResultMessage> ExecuteToolCallAsync(
         ToolCallMessage toolCall,
-        IDictionary<string, Func<string, Task<string>>> handlers
+        IDictionary<string, Func<string, Task<ToolHandlerResult>>> handlers
     )
     {
         var toolCallId = toolCall.ToolCallId ?? $"call_{toolCall.Index}";
@@ -367,7 +367,7 @@ public class OpenAiGrokAgenticExample
                 return new ToolCallResultMessage
                 {
                     ToolCallId = toolCallId,
-                    Result = result,
+                    Result = result.ResultText,
                     Role = Role.User,
                     FromAgent = toolCall.FromAgent,
                     GenerationId = toolCall.GenerationId,

--- a/example/LmConfigUsageExample/OpenAiGrokAgenticExample.cs
+++ b/example/LmConfigUsageExample/OpenAiGrokAgenticExample.cs
@@ -97,7 +97,7 @@ public class OpenAiGrokAgenticExample
                     },
                 ],
             },
-            async (args) =>
+            async (args, _) =>
             {
                 var weatherArgs = JsonSerializer.Deserialize<WeatherArgs>(args);
                 _logger.LogInformation("[TOOL] Getting weather for {Location}", weatherArgs?.Location);
@@ -134,7 +134,7 @@ public class OpenAiGrokAgenticExample
                     },
                 ],
             },
-            async (args) =>
+            async (args, _) =>
             {
                 var timeArgs = JsonSerializer.Deserialize<TimeArgs>(args);
                 _logger.LogInformation("[TOOL] Getting time for {Timezone}", timeArgs?.Timezone);
@@ -170,7 +170,7 @@ public class OpenAiGrokAgenticExample
                     },
                 ],
             },
-            async (args) =>
+            async (args, _) =>
             {
                 var calcArgs = JsonSerializer.Deserialize<CalculateArgs>(args);
                 _logger.LogInformation("[TOOL] Calculating: {Expression}", calcArgs?.Expression);
@@ -352,7 +352,7 @@ public class OpenAiGrokAgenticExample
     /// </summary>
     private async Task<ToolCallResultMessage> ExecuteToolCallAsync(
         ToolCallMessage toolCall,
-        IDictionary<string, Func<string, Task<ToolHandlerResult>>> handlers
+        IDictionary<string, ToolHandler> handlers
     )
     {
         var toolCallId = toolCall.ToolCallId ?? $"call_{toolCall.Index}";
@@ -363,7 +363,8 @@ public class OpenAiGrokAgenticExample
         {
             if (handlers.TryGetValue(functionName, out var handler))
             {
-                var result = await handler(functionArgs);
+                var ctx = new ToolCallContext { ToolCallId = toolCall.ToolCallId };
+                var result = await handler(functionArgs, ctx);
                 return new ToolCallResultMessage
                 {
                     ToolCallId = toolCallId,

--- a/example/LmConfigUsageExample/OpenAiGrokAgenticExample.cs
+++ b/example/LmConfigUsageExample/OpenAiGrokAgenticExample.cs
@@ -112,7 +112,7 @@ public class OpenAiGrokAgenticExample
                     condition = stringArray[Random.Shared.Next(4)],
                 };
 
-                return JsonSerializer.Serialize(weather);
+                return ToolHandlerResult.FromText(JsonSerializer.Serialize(weather));
             },
             providerName: "Example"
         );
@@ -148,7 +148,7 @@ public class OpenAiGrokAgenticExample
                     date = DateTime.UtcNow.ToString("yyyy-MM-dd"),
                 };
 
-                return JsonSerializer.Serialize(time);
+                return ToolHandlerResult.FromText(JsonSerializer.Serialize(time));
             },
             providerName: "Example"
         );
@@ -181,11 +181,11 @@ public class OpenAiGrokAgenticExample
                 try
                 {
                     var result = EvaluateSimpleExpression(calcArgs?.Expression ?? "0");
-                    return JsonSerializer.Serialize(new { result, expression = calcArgs?.Expression });
+                    return ToolHandlerResult.FromText(JsonSerializer.Serialize(new { result, expression = calcArgs?.Expression }));
                 }
                 catch (Exception ex)
                 {
-                    return JsonSerializer.Serialize(new { error = ex.Message });
+                    return ToolHandlerResult.FromError(JsonSerializer.Serialize(new { error = ex.Message }));
                 }
             },
             providerName: "Example"

--- a/example/LmConfigUsageExample/Program.cs
+++ b/example/LmConfigUsageExample/Program.cs
@@ -1424,7 +1424,7 @@ internal sealed class WeatherTool : IFunctionProvider
         yield return new FunctionDescriptor
         {
             Contract = contract,
-            Handler = GetWeatherAsync,
+            Handler = async args => new ToolHandlerResult.Resolved(new ToolCallResult(null, await GetWeatherAsync(args))),
             ProviderName = ProviderName,
         };
     }

--- a/example/LmConfigUsageExample/Program.cs
+++ b/example/LmConfigUsageExample/Program.cs
@@ -1424,7 +1424,7 @@ internal sealed class WeatherTool : IFunctionProvider
         yield return new FunctionDescriptor
         {
             Contract = contract,
-            Handler = async args => new ToolHandlerResult.Resolved(new ToolCallResult(null, await GetWeatherAsync(args))),
+            Handler = async (args, _) => new ToolHandlerResult.Resolved(new ToolCallResult(null, await GetWeatherAsync(args))),
             ProviderName = ProviderName,
         };
     }

--- a/example/LmConfigUsageExample/Program.cs
+++ b/example/LmConfigUsageExample/Program.cs
@@ -1424,7 +1424,7 @@ internal sealed class WeatherTool : IFunctionProvider
         yield return new FunctionDescriptor
         {
             Contract = contract,
-            Handler = async (args, _) => new ToolHandlerResult.Resolved(new ToolCallResult(null, await GetWeatherAsync(args))),
+            Handler = async (args, _, _) => new ToolHandlerResult.Resolved(new ToolCallResult(null, await GetWeatherAsync(args))),
             ProviderName = ProviderName,
         };
     }

--- a/example/LmConfigUsageExample/Program.cs
+++ b/example/LmConfigUsageExample/Program.cs
@@ -1424,7 +1424,7 @@ internal sealed class WeatherTool : IFunctionProvider
         yield return new FunctionDescriptor
         {
             Contract = contract,
-            Handler = async (args, _, _) => new ToolHandlerResult.Resolved(new ToolCallResult(null, await GetWeatherAsync(args))),
+            Handler = async (args, _, _) => ToolHandlerResult.FromText(await GetWeatherAsync(args)),
             ProviderName = ProviderName,
         };
     }

--- a/src/LmCore/Messages/ToolCall.cs
+++ b/src/LmCore/Messages/ToolCall.cs
@@ -193,6 +193,42 @@ public record ToolCallResultMessage : IMessage
     public IList<ToolResultContentBlock>? ContentBlocks { get; init; }
 
     /// <summary>
+    /// Marker for deferred tool execution. When true, <see cref="Result"/> holds an
+    /// interim placeholder text and a final result will be supplied later via
+    /// <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>. The loop ends the current run
+    /// once the deferred placeholder is recorded.
+    /// </summary>
+    [JsonPropertyName("is_deferred")]
+    public bool IsDeferred { get; init; }
+
+    /// <summary>
+    /// Opaque host-supplied metadata captured when the tool handler signaled deferral.
+    /// Surfaced via <c>MultiTurnAgentLoop.GetDeferredToolCallsAsync</c> so external
+    /// integrators (UIs, webhook services) can correlate the placeholder with their
+    /// own state.
+    /// </summary>
+    [JsonPropertyName("deferral_metadata")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public System.Collections.Immutable.ImmutableDictionary<string, string>? DeferralMetadata { get; init; }
+
+    /// <summary>
+    /// Unix-ms timestamp recorded when the tool handler signaled deferral. Null on
+    /// non-deferred results.
+    /// </summary>
+    [JsonPropertyName("deferred_at")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? DeferredAt { get; init; }
+
+    /// <summary>
+    /// Unix-ms timestamp recorded when the deferred placeholder was replaced with a
+    /// real result via <c>ResolveToolCallAsync</c>. Null while still deferred or for
+    /// results that were never deferred.
+    /// </summary>
+    [JsonPropertyName("resolved_at")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? ResolvedAt { get; init; }
+
+    /// <summary>
     /// Converts this message to a ToolCallResult struct.
     /// </summary>
     public ToolCallResult ToToolCallResult()

--- a/src/LmCore/Messages/ToolCall.cs
+++ b/src/LmCore/Messages/ToolCall.cs
@@ -123,6 +123,36 @@ public readonly record struct ToolCallResult
     /// </summary>
     [JsonPropertyName("execution_target")]
     public ExecutionTarget ExecutionTarget { get; init; } = ExecutionTarget.LocalFunction;
+
+    /// <summary>
+    /// Marker for deferred tool execution. When true, <see cref="Result"/> holds an interim
+    /// placeholder text and a final result is expected to be supplied later by the caller's
+    /// loop (or via <c>MultiTurnAgentLoop.ResolveToolCallAsync</c> when running under that loop).
+    /// </summary>
+    [JsonPropertyName("is_deferred")]
+    public bool IsDeferred { get; init; }
+
+    /// <summary>
+    /// Opaque host-supplied metadata captured when the handler signaled deferral.
+    /// </summary>
+    [JsonPropertyName("deferral_metadata")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public System.Collections.Immutable.ImmutableDictionary<string, string>? DeferralMetadata { get; init; }
+
+    /// <summary>
+    /// Unix-ms timestamp recorded when the handler signaled deferral. Null on non-deferred results.
+    /// </summary>
+    [JsonPropertyName("deferred_at")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? DeferredAt { get; init; }
+
+    /// <summary>
+    /// Unix-ms timestamp recorded when a previously-deferred placeholder was replaced with a real
+    /// result. Null while still deferred or for results that were never deferred.
+    /// </summary>
+    [JsonPropertyName("resolved_at")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? ResolvedAt { get; init; }
 }
 
 /// <summary>
@@ -239,6 +269,10 @@ public record ToolCallResultMessage : IMessage
             IsError = IsError,
             ErrorCode = ErrorCode,
             ExecutionTarget = ExecutionTarget,
+            IsDeferred = IsDeferred,
+            DeferralMetadata = DeferralMetadata,
+            DeferredAt = DeferredAt,
+            ResolvedAt = ResolvedAt,
         };
     }
 
@@ -266,6 +300,10 @@ public record ToolCallResultMessage : IMessage
             IsError = result.IsError,
             ErrorCode = result.ErrorCode,
             ExecutionTarget = result.ExecutionTarget,
+            IsDeferred = result.IsDeferred,
+            DeferralMetadata = result.DeferralMetadata,
+            DeferredAt = result.DeferredAt,
+            ResolvedAt = result.ResolvedAt,
             Role = role,
             FromAgent = fromAgent,
             GenerationId = generationId,

--- a/src/LmCore/Messages/ToolCall.cs
+++ b/src/LmCore/Messages/ToolCall.cs
@@ -125,19 +125,13 @@ public readonly record struct ToolCallResult
     public ExecutionTarget ExecutionTarget { get; init; } = ExecutionTarget.LocalFunction;
 
     /// <summary>
-    /// Marker for deferred tool execution. When true, <see cref="Result"/> holds an interim
-    /// placeholder text and a final result is expected to be supplied later by the caller's
-    /// loop (or via <c>MultiTurnAgentLoop.ResolveToolCallAsync</c> when running under that loop).
+    /// Marker for deferred tool execution. When true, <see cref="Result"/> is empty and a
+    /// final result is expected to be supplied later via <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>.
+    /// The agent loop refuses to send any provider request while a deferred entry remains
+    /// unresolved in history.
     /// </summary>
     [JsonPropertyName("is_deferred")]
     public bool IsDeferred { get; init; }
-
-    /// <summary>
-    /// Opaque host-supplied metadata captured when the handler signaled deferral.
-    /// </summary>
-    [JsonPropertyName("deferral_metadata")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public System.Collections.Immutable.ImmutableDictionary<string, string>? DeferralMetadata { get; init; }
 
     /// <summary>
     /// Unix-ms timestamp recorded when the handler signaled deferral. Null on non-deferred results.
@@ -223,23 +217,13 @@ public record ToolCallResultMessage : IMessage
     public IList<ToolResultContentBlock>? ContentBlocks { get; init; }
 
     /// <summary>
-    /// Marker for deferred tool execution. When true, <see cref="Result"/> holds an
-    /// interim placeholder text and a final result will be supplied later via
-    /// <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>. The loop ends the current run
-    /// once the deferred placeholder is recorded.
+    /// Marker for deferred tool execution. When true, <see cref="Result"/> is empty and a
+    /// final result will be supplied later via <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>.
+    /// The agent loop refuses to send any provider request while a deferred entry remains
+    /// unresolved in history.
     /// </summary>
     [JsonPropertyName("is_deferred")]
     public bool IsDeferred { get; init; }
-
-    /// <summary>
-    /// Opaque host-supplied metadata captured when the tool handler signaled deferral.
-    /// Surfaced via <c>MultiTurnAgentLoop.GetDeferredToolCallsAsync</c> so external
-    /// integrators (UIs, webhook services) can correlate the placeholder with their
-    /// own state.
-    /// </summary>
-    [JsonPropertyName("deferral_metadata")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public System.Collections.Immutable.ImmutableDictionary<string, string>? DeferralMetadata { get; init; }
 
     /// <summary>
     /// Unix-ms timestamp recorded when the tool handler signaled deferral. Null on
@@ -270,7 +254,6 @@ public record ToolCallResultMessage : IMessage
             ErrorCode = ErrorCode,
             ExecutionTarget = ExecutionTarget,
             IsDeferred = IsDeferred,
-            DeferralMetadata = DeferralMetadata,
             DeferredAt = DeferredAt,
             ResolvedAt = ResolvedAt,
         };
@@ -301,7 +284,6 @@ public record ToolCallResultMessage : IMessage
             ErrorCode = result.ErrorCode,
             ExecutionTarget = result.ExecutionTarget,
             IsDeferred = result.IsDeferred,
-            DeferralMetadata = result.DeferralMetadata,
             DeferredAt = result.DeferredAt,
             ResolvedAt = result.ResolvedAt,
             Role = role,

--- a/src/LmCore/Messages/ToolCallResultBuilder.cs
+++ b/src/LmCore/Messages/ToolCallResultBuilder.cs
@@ -1,0 +1,60 @@
+namespace AchieveAi.LmDotnetTools.LmCore.Messages;
+
+/// <summary>
+/// Single mapping point from a handler-side <see cref="ToolHandlerResult"/> to the wire-shape
+/// <see cref="ToolCallResult"/>. Stamps in framework-controlled fields (tool call id, tool
+/// name, deferral marker, timestamps) that handlers should not — and now cannot — set
+/// themselves.
+/// </summary>
+/// <remarks>
+/// Both <c>FunctionCallMiddleware</c> and <c>MultiTurnAgentLoop</c> route through here so
+/// the two paths can't drift. Handlers signal "deferred" with an empty
+/// <see cref="ToolHandlerResult.Deferred"/> record; the builder produces a
+/// <see cref="ToolCallResult"/> with empty <c>Result</c> text and <c>IsDeferred=true</c> —
+/// host loops are responsible for refusing to send any provider request while such a
+/// result is unresolved in history (see <c>MultiTurnAgentLoop.ExecuteTurnAsync</c>).
+/// </remarks>
+public static class ToolCallResultBuilder
+{
+    /// <summary>
+    /// Maps a handler return into a wire-shape <see cref="ToolCallResult"/>.
+    /// </summary>
+    /// <param name="result">The handler's return value.</param>
+    /// <param name="toolCallId">Tool call id from <c>ToolCallContext.ToolCallId</c> (or the
+    /// originating <c>ToolCallMessage</c>). May be null on call paths that don't carry one.</param>
+    /// <param name="toolName">Function name. Optional but recommended — used by providers
+    /// that surface <c>tool_name</c> separately from <c>tool_call_id</c>.</param>
+    /// <param name="executionTarget">Distinguishes local function tools from provider-executed
+    /// server tools. Defaults to <see cref="ExecutionTarget.LocalFunction"/>.</param>
+    public static ToolCallResult FromHandlerResult(
+        ToolHandlerResult result,
+        string? toolCallId,
+        string? toolName = null,
+        ExecutionTarget executionTarget = ExecutionTarget.LocalFunction)
+    {
+        return result switch
+        {
+            ToolHandlerResult.Resolved r => new ToolCallResult(
+                toolCallId,
+                r.Payload.Text,
+                r.Payload.ContentBlocks,
+                executionTarget)
+            {
+                ToolName = toolName,
+                IsError = r.Payload.IsError,
+                ErrorCode = r.Payload.ErrorCode,
+            },
+            ToolHandlerResult.Deferred => new ToolCallResult(
+                toolCallId,
+                string.Empty,
+                executionTarget)
+            {
+                ToolName = toolName,
+                IsDeferred = true,
+                DeferredAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            },
+            _ => throw new InvalidOperationException(
+                $"Unknown ToolHandlerResult variant '{result.GetType().Name}'."),
+        };
+    }
+}

--- a/src/LmCore/Messages/ToolHandlerResult.cs
+++ b/src/LmCore/Messages/ToolHandlerResult.cs
@@ -1,0 +1,91 @@
+using System.Collections.Immutable;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Messages;
+
+/// <summary>
+/// Result of a tool handler invocation. Either a synchronous (resolved) <see cref="ToolCallResult"/>
+/// whose value is fed back to the LLM on the next turn, or a deferred placeholder that the loop
+/// records as <see cref="ToolCallResultMessage.IsDeferred"/> and resolves later via
+/// <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>.
+/// </summary>
+/// <remarks>
+/// Deferred tool execution is only supported when handlers are dispatched by
+/// <c>MultiTurnAgentLoop</c>. <c>FunctionCallMiddleware</c>-driven flows have no
+/// resolution channel and treat <see cref="Deferred"/> as an error.
+/// </remarks>
+public abstract record ToolHandlerResult
+{
+    private ToolHandlerResult() { }
+
+    /// <summary>
+    /// Tool finished synchronously. The wrapped <see cref="ToolCallResult"/> carries the text
+    /// payload, optional <see cref="ToolCallResult.ContentBlocks"/> (images / multi-modal),
+    /// and any error flags. The loop reads through to those fields when populating
+    /// <see cref="ToolCallResultMessage"/>.
+    /// </summary>
+    public sealed record Resolved(ToolCallResult Result) : ToolHandlerResult;
+
+    /// <summary>
+    /// Tool execution is deferred. The handler has initiated some out-of-process
+    /// work; the loop will write <paramref name="Placeholder"/> into history with
+    /// <see cref="ToolCallResultMessage.IsDeferred"/> set, end the run after the
+    /// current turn, and wait for an external caller to invoke
+    /// <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>.
+    /// </summary>
+    /// <param name="Placeholder">Text recorded as the (interim) tool_result. Required
+    /// because the LLM protocol mandates a tool_result for every tool_use ID.</param>
+    /// <param name="Metadata">Opaque host-supplied metadata round-tripped to
+    /// <c>DeferredToolCallInfo</c> (e.g., correlation IDs, expected wait time).</param>
+    public sealed record Deferred(
+        string Placeholder,
+        ImmutableDictionary<string, string>? Metadata = null) : ToolHandlerResult;
+
+    /// <summary>
+    /// Convenience wrapper so call sites can write
+    /// <c>Task.FromResult(ToolHandlerResult.FromString("..."))</c> without spelling out
+    /// the <see cref="ToolCallResult"/> ctor.
+    /// </summary>
+    public static Resolved FromString(string result)
+    {
+        return new Resolved(new ToolCallResult(null, result));
+    }
+
+    /// <summary>
+    /// Extracts the resolved result text. Throws <see cref="InvalidOperationException"/>
+    /// if this is a <see cref="Deferred"/> case. Useful in tests and in code paths that
+    /// have already gated out the deferred branch.
+    /// </summary>
+    public string ResultText
+    {
+        get
+        {
+            return this switch
+            {
+                Resolved r => r.Result.Result,
+                Deferred => throw new InvalidOperationException(
+                    "Cannot extract result text from a deferred ToolHandlerResult — it has not been resolved yet."),
+                _ => throw new InvalidOperationException(
+                    $"Unknown ToolHandlerResult variant '{GetType().Name}'."),
+            };
+        }
+    }
+
+    /// <summary>
+    /// Implicit conversion lets handlers return a bare string and have it auto-wrapped
+    /// as <see cref="Resolved"/> with a text-only <see cref="ToolCallResult"/>.
+    /// </summary>
+    public static implicit operator ToolHandlerResult(string result)
+    {
+        return new Resolved(new ToolCallResult(null, result));
+    }
+
+    /// <summary>
+    /// Implicit conversion lets handlers return a <see cref="ToolCallResult"/> directly
+    /// — useful when the handler has populated <see cref="ToolCallResult.ContentBlocks"/>
+    /// or other fields and wants the loop to forward them verbatim.
+    /// </summary>
+    public static implicit operator ToolHandlerResult(ToolCallResult result)
+    {
+        return new Resolved(result);
+    }
+}

--- a/src/LmCore/Messages/ToolHandlerResult.cs
+++ b/src/LmCore/Messages/ToolHandlerResult.cs
@@ -1,91 +1,81 @@
-using System.Collections.Immutable;
-
 namespace AchieveAi.LmDotnetTools.LmCore.Messages;
 
 /// <summary>
-/// Result of a tool handler invocation. Either a synchronous (resolved) <see cref="ToolCallResult"/>
-/// whose value is fed back to the LLM on the next turn, or a deferred placeholder that the loop
-/// records as <see cref="ToolCallResultMessage.IsDeferred"/> and resolves later via
+/// Payload carried by <see cref="ToolHandlerResult.Resolved"/>. Holds the data a tool
+/// handler produced — text, optional multi-modal blocks, error flags. Framework-controlled
+/// fields (<c>ToolCallId</c>, <c>IsDeferred</c>, timestamps) are stamped in by the loop
+/// via <see cref="ToolCallResultBuilder.FromHandlerResult"/>, not by handlers.
+/// </summary>
+public readonly record struct ToolHandlerResultPayload(
+    string Text,
+    IList<ToolResultContentBlock>? ContentBlocks = null,
+    bool IsError = false,
+    string? ErrorCode = null);
+
+/// <summary>
+/// Result of a tool handler invocation. Either a synchronous <see cref="Resolved"/>
+/// payload whose value is fed back to the LLM on the next turn, or a <see cref="Deferred"/>
+/// signal indicating the loop should pause and wait for an external caller to invoke
 /// <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>.
 /// </summary>
 /// <remarks>
 /// Deferred tool execution is only supported when handlers are dispatched by
 /// <c>MultiTurnAgentLoop</c>. <c>FunctionCallMiddleware</c>-driven flows have no
-/// resolution channel and treat <see cref="Deferred"/> as an error.
+/// resolution channel; a <see cref="Deferred"/> in that context yields a placeholder
+/// tool result with <c>IsDeferred=true</c> in the wire <c>ToolCallResult</c>, but
+/// nothing will ever resolve it.
 /// </remarks>
 public abstract record ToolHandlerResult
 {
     private ToolHandlerResult() { }
 
     /// <summary>
-    /// Tool finished synchronously. The wrapped <see cref="ToolCallResult"/> carries the text
-    /// payload, optional <see cref="ToolCallResult.ContentBlocks"/> (images / multi-modal),
-    /// and any error flags. The loop reads through to those fields when populating
-    /// <see cref="ToolCallResultMessage"/>.
+    /// Tool finished synchronously. The wrapped <see cref="ToolHandlerResultPayload"/>
+    /// carries the text, optional multi-modal content blocks, and error flags.
     /// </summary>
-    public sealed record Resolved(ToolCallResult Result) : ToolHandlerResult;
+    public sealed record Resolved(ToolHandlerResultPayload Payload) : ToolHandlerResult;
 
     /// <summary>
-    /// Tool execution is deferred. The handler has initiated some out-of-process
-    /// work; the loop will write <paramref name="Placeholder"/> into history with
-    /// <see cref="ToolCallResultMessage.IsDeferred"/> set, end the run after the
-    /// current turn, and wait for an external caller to invoke
-    /// <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>.
+    /// Tool execution is deferred. The handler has initiated some out-of-process work;
+    /// the loop will record the deferral, end the run after the current turn, and wait
+    /// for an external caller to invoke <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>.
+    /// Carries no fields — host-side correlation should key on the tool call id available
+    /// on <c>ToolCallContext</c> at the time the handler ran.
     /// </summary>
-    /// <param name="Placeholder">Text recorded as the (interim) tool_result. Required
-    /// because the LLM protocol mandates a tool_result for every tool_use ID.</param>
-    /// <param name="Metadata">Opaque host-supplied metadata round-tripped to
-    /// <c>DeferredToolCallInfo</c> (e.g., correlation IDs, expected wait time).</param>
-    public sealed record Deferred(
-        string Placeholder,
-        ImmutableDictionary<string, string>? Metadata = null) : ToolHandlerResult;
+    public sealed record Deferred() : ToolHandlerResult;
 
     /// <summary>
-    /// Convenience wrapper so call sites can write
-    /// <c>Task.FromResult(ToolHandlerResult.FromString("..."))</c> without spelling out
-    /// the <see cref="ToolCallResult"/> ctor.
+    /// Builds a <see cref="Resolved"/> with a text-only payload. Most common case.
     /// </summary>
-    public static Resolved FromString(string result)
+    public static Resolved FromText(string text)
+        => new(new ToolHandlerResultPayload(text));
+
+    /// <summary>
+    /// Builds a <see cref="Resolved"/> with <see cref="ToolHandlerResultPayload.IsError"/>
+    /// set and an optional provider-defined error code. Use for tool-side error returns
+    /// (e.g., validation failures, expected API errors) so the LLM sees the error flag.
+    /// </summary>
+    public static Resolved FromError(string text, string? errorCode = null)
+        => new(new ToolHandlerResultPayload(text, IsError: true, ErrorCode: errorCode));
+
+    /// <summary>
+    /// Builds a <see cref="Resolved"/> carrying multi-modal content blocks (e.g., MCP
+    /// image returns). The text is still required — providers without multi-modal
+    /// support fall back to it.
+    /// </summary>
+    public static Resolved FromMultiModal(string text, IList<ToolResultContentBlock> blocks)
+        => new(new ToolHandlerResultPayload(text, ContentBlocks: blocks));
+
+    /// <summary>
+    /// Convenience accessor for the resolved text. Throws on <see cref="Deferred"/> —
+    /// callers that may receive a deferral should pattern-match instead.
+    /// </summary>
+    public string ResultText => this switch
     {
-        return new Resolved(new ToolCallResult(null, result));
-    }
-
-    /// <summary>
-    /// Extracts the resolved result text. Throws <see cref="InvalidOperationException"/>
-    /// if this is a <see cref="Deferred"/> case. Useful in tests and in code paths that
-    /// have already gated out the deferred branch.
-    /// </summary>
-    public string ResultText
-    {
-        get
-        {
-            return this switch
-            {
-                Resolved r => r.Result.Result,
-                Deferred => throw new InvalidOperationException(
-                    "Cannot extract result text from a deferred ToolHandlerResult — it has not been resolved yet."),
-                _ => throw new InvalidOperationException(
-                    $"Unknown ToolHandlerResult variant '{GetType().Name}'."),
-            };
-        }
-    }
-
-    /// <summary>
-    /// Implicit conversion lets handlers return a bare string and have it auto-wrapped
-    /// as <see cref="Resolved"/> with a text-only <see cref="ToolCallResult"/>.
-    /// </summary>
-    public static implicit operator ToolHandlerResult(string result)
-    {
-        return new Resolved(new ToolCallResult(null, result));
-    }
-
-    /// <summary>
-    /// Implicit conversion lets handlers return a <see cref="ToolCallResult"/> directly
-    /// — useful when the handler has populated <see cref="ToolCallResult.ContentBlocks"/>
-    /// or other fields and wants the loop to forward them verbatim.
-    /// </summary>
-    public static implicit operator ToolHandlerResult(ToolCallResult result)
-    {
-        return new Resolved(result);
-    }
+        Resolved r => r.Payload.Text,
+        Deferred => throw new InvalidOperationException(
+            "Cannot read ResultText from a deferred ToolHandlerResult — it has not been resolved yet."),
+        _ => throw new InvalidOperationException(
+            $"Unknown ToolHandlerResult variant '{GetType().Name}'."),
+    };
 }

--- a/src/LmCore/Middleware/FunctionCallMiddleware.cs
+++ b/src/LmCore/Middleware/FunctionCallMiddleware.cs
@@ -97,9 +97,9 @@ public class FunctionCallMiddleware : IStreamingMiddleware
         {
             var key = kvp.Key;
             var handler = kvp.Value;
-            wrapped[key] = async (args, ctx) =>
+            wrapped[key] = async (args, ctx, ct) =>
             {
-                var result = await handler(args, ctx);
+                var result = await handler(args, ctx, ct);
                 return result switch
                 {
                     ToolHandlerResult.Resolved r => r.Result,

--- a/src/LmCore/Middleware/FunctionCallMiddleware.cs
+++ b/src/LmCore/Middleware/FunctionCallMiddleware.cs
@@ -14,7 +14,7 @@ namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
 /// </summary>
 public class FunctionCallMiddleware : IStreamingMiddleware
 {
-    private readonly IDictionary<string, Func<string, Task<ToolCallResult>>> _functionMap;
+    private readonly IDictionary<string, ToolCallResultHandler> _functionMap;
     private readonly IEnumerable<FunctionContract> _functions;
 
     private readonly ILogger<FunctionCallMiddleware> _logger;
@@ -42,7 +42,7 @@ public class FunctionCallMiddleware : IStreamingMiddleware
     /// </remarks>
     public FunctionCallMiddleware(
         IEnumerable<FunctionContract> functions,
-        IDictionary<string, Func<string, Task<ToolHandlerResult>>> functionMap,
+        IDictionary<string, ToolHandler> functionMap,
         string? name = null,
         ILogger<FunctionCallMiddleware>? logger = null,
         IToolResultCallback? resultCallback = null
@@ -88,18 +88,18 @@ public class FunctionCallMiddleware : IStreamingMiddleware
         _resultCallback = resultCallback;
     }
 
-    private static IDictionary<string, Func<string, Task<ToolCallResult>>> AdaptToToolCallResultHandlers(
-        IDictionary<string, Func<string, Task<ToolHandlerResult>>> source
+    private static IDictionary<string, ToolCallResultHandler> AdaptToToolCallResultHandlers(
+        IDictionary<string, ToolHandler> source
     )
     {
-        var wrapped = new Dictionary<string, Func<string, Task<ToolCallResult>>>(source.Count);
+        var wrapped = new Dictionary<string, ToolCallResultHandler>(source.Count);
         foreach (var kvp in source)
         {
             var key = kvp.Key;
             var handler = kvp.Value;
-            wrapped[key] = async args =>
+            wrapped[key] = async (args, ctx) =>
             {
-                var result = await handler(args);
+                var result = await handler(args, ctx);
                 return result switch
                 {
                     ToolHandlerResult.Resolved r => r.Result,

--- a/src/LmCore/Middleware/FunctionCallMiddleware.cs
+++ b/src/LmCore/Middleware/FunctionCallMiddleware.cs
@@ -14,9 +14,7 @@ namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
 /// </summary>
 public class FunctionCallMiddleware : IStreamingMiddleware
 {
-    private readonly IDictionary<string, Func<string, Task<string>>> _functionMap;
-    private readonly IDictionary<string, Func<string, Task<ToolCallResult>>>? _multiModalFunctionMap;
-    private readonly IDictionary<string, Func<string, Task<ToolCallResult>>>? _mergedMultiModalMap;
+    private readonly IDictionary<string, Func<string, Task<ToolCallResult>>> _functionMap;
     private readonly IEnumerable<FunctionContract> _functions;
 
     private readonly ILogger<FunctionCallMiddleware> _logger;
@@ -26,10 +24,20 @@ public class FunctionCallMiddleware : IStreamingMiddleware
 
     private IToolResultCallback? _resultCallback;
 
+    /// <summary>
+    /// Constructs a FunctionCallMiddleware. Handler dictionary uses the unified
+    /// <see cref="ToolHandlerResult"/> shape; multi-modal payloads are carried by the wrapped
+    /// <see cref="ToolCallResult.ContentBlocks"/>.
+    /// </summary>
+    /// <remarks>
+    /// FunctionCallMiddleware does not support deferred tool execution — it has no
+    /// resolution channel. If a handler returns <see cref="ToolHandlerResult.Deferred"/>,
+    /// invocation throws <see cref="NotSupportedException"/>. Deferred semantics are
+    /// only available when handlers are dispatched by <c>MultiTurnAgentLoop</c>.
+    /// </remarks>
     public FunctionCallMiddleware(
         IEnumerable<FunctionContract> functions,
-        IDictionary<string, Func<string, Task<string>>> functionMap,
-        IDictionary<string, Func<string, Task<ToolCallResult>>>? multiModalFunctionMap = null,
+        IDictionary<string, Func<string, Task<ToolHandlerResult>>> functionMap,
         string? name = null,
         ILogger<FunctionCallMiddleware>? logger = null,
         IToolResultCallback? resultCallback = null
@@ -43,12 +51,12 @@ public class FunctionCallMiddleware : IStreamingMiddleware
         {
             if (functionMap != null)
             {
+                var availableKeys = new HashSet<string>(functionMap.Keys);
                 var missingFunctions = functions
-                    .Where(f => !HasFunctionHandler(functionMap, f))
+                    .Where(f => !HasFunctionHandler(availableKeys, f))
                     .Select(GetFunctionMapKey)
                     .ToList();
 
-                // Removing following check ` || functionMap.Count != functions.Count()`
                 if (missingFunctions.Count != 0)
                 {
                     throw new ArgumentException(
@@ -67,41 +75,47 @@ public class FunctionCallMiddleware : IStreamingMiddleware
         }
 
         Name = name ?? nameof(FunctionCallMiddleware);
-        _functionMap = functionMap;
-        _multiModalFunctionMap = multiModalFunctionMap;
+
+        // Adapt unified handlers into ToolCallResult-returning handlers for the executor.
+        // Deferred returns surface as NotSupportedException at invocation time — this
+        // middleware has no resolution channel.
+        _functionMap = AdaptToToolCallResultHandlers(functionMap);
         _resultCallback = resultCallback;
-
-        // Pre-build merged multimodal map once (maps never change after construction)
-        if (multiModalFunctionMap is { Count: > 0 })
-        {
-            var merged = new Dictionary<string, Func<string, Task<ToolCallResult>>>();
-            foreach (var kvp in functionMap)
-            {
-                var textHandler = kvp.Value;
-                merged[kvp.Key] = async args =>
-                {
-                    var textResult = await textHandler(args);
-                    return new ToolCallResult(null, textResult);
-                };
-            }
-
-            foreach (var kvp in multiModalFunctionMap)
-            {
-                merged[kvp.Key] = kvp.Value;
-            }
-
-            _mergedMultiModalMap = merged;
-        }
     }
 
-    private static bool HasFunctionHandler(
-        IDictionary<string, Func<string, Task<string>>> functionMap,
-        FunctionContract function
+    private static IDictionary<string, Func<string, Task<ToolCallResult>>> AdaptToToolCallResultHandlers(
+        IDictionary<string, Func<string, Task<ToolHandlerResult>>> source
     )
     {
-        return functionMap.ContainsKey(function.Name)
-            || (!string.IsNullOrEmpty(function.ClassName)
-                && functionMap.ContainsKey(GetFunctionMapKey(function)));
+        var wrapped = new Dictionary<string, Func<string, Task<ToolCallResult>>>(source.Count);
+        foreach (var kvp in source)
+        {
+            var key = kvp.Key;
+            var handler = kvp.Value;
+            wrapped[key] = async args =>
+            {
+                var result = await handler(args);
+                return result switch
+                {
+                    ToolHandlerResult.Resolved r => r.Result,
+                    ToolHandlerResult.Deferred => throw new NotSupportedException(
+                        $"Tool '{key}' returned a deferred result. Deferred tool execution is only "
+                        + "supported when handlers are dispatched by MultiTurnAgentLoop, not by FunctionCallMiddleware."
+                    ),
+                    _ => throw new InvalidOperationException(
+                        $"Unknown ToolHandlerResult variant '{result.GetType().Name}' for tool '{key}'."
+                    ),
+                };
+            };
+        }
+
+        return wrapped;
+    }
+
+    private static bool HasFunctionHandler(ISet<string> availableKeys, FunctionContract function)
+    {
+        return availableKeys.Contains(function.Name)
+            || (!string.IsNullOrEmpty(function.ClassName) && availableKeys.Contains(GetFunctionMapKey(function)));
     }
 
     private static string GetFunctionMapKey(FunctionContract function)
@@ -398,8 +412,9 @@ public class FunctionCallMiddleware : IStreamingMiddleware
     }
 
     /// <summary>
-    ///     Execute multiple tool calls and return a message with results.
-    ///     Prefers multimodal handlers when available, falls back to text-only.
+    ///     Execute multiple tool calls and return a message with results. Single execution
+    ///     path — multi-modal payloads ride on the <see cref="ToolCallResult"/> returned by
+    ///     each handler.
     /// </summary>
     private async Task<ToolsCallResultMessage> ExecuteToolCallsAsync(
         IEnumerable<ToolCall> toolCalls,
@@ -414,20 +429,6 @@ public class FunctionCallMiddleware : IStreamingMiddleware
             FromAgent = string.Empty,
         };
 
-        // Use multimodal executor if any tool calls have multimodal handlers
-        if (_mergedMultiModalMap != null &&
-            toolsCallMessage.ToolCalls.Any(tc =>
-                tc.FunctionName != null && _multiModalFunctionMap!.ContainsKey(tc.FunctionName)))
-        {
-            return await ToolCallExecutor.ExecuteMultiModalAsync(
-                toolsCallMessage,
-                _mergedMultiModalMap,
-                _resultCallback,
-                _logger,
-                cancellationToken
-            );
-        }
-
         return await ToolCallExecutor.ExecuteAsync(
             toolsCallMessage,
             _functionMap,
@@ -439,53 +440,28 @@ public class FunctionCallMiddleware : IStreamingMiddleware
 
     /// <summary>
     ///     Execute a single tool call and return the result.
-    ///     Prefers multimodal handler when available, falls back to text-only.
     /// </summary>
     private async Task<ToolCallResult> ExecuteToolCallAsync(
         ToolCall toolCall,
         CancellationToken cancellationToken = default
     )
     {
-        // Prefer multimodal handler if available
-        if (_multiModalFunctionMap is { Count: > 0 } &&
-            toolCall.FunctionName != null &&
-            _multiModalFunctionMap.TryGetValue(toolCall.FunctionName, out var mmHandler))
-        {
-            var toolsCallMessage = new ToolsCallMessage
-            {
-                ToolCalls = [toolCall],
-                Role = Role.Assistant,
-                FromAgent = string.Empty,
-            };
-
-            var result = await ToolCallExecutor.ExecuteMultiModalAsync(
-                toolsCallMessage,
-                new Dictionary<string, Func<string, Task<ToolCallResult>>> { [toolCall.FunctionName] = mmHandler },
-                _resultCallback,
-                _logger,
-                cancellationToken
-            );
-
-            return result.ToolCallResults.First();
-        }
-
-        // Fall back to text-only
-        var textToolsCallMessage = new ToolsCallMessage
+        var toolsCallMessage = new ToolsCallMessage
         {
             ToolCalls = [toolCall],
             Role = Role.Assistant,
             FromAgent = string.Empty,
         };
 
-        var textResult = await ToolCallExecutor.ExecuteAsync(
-            textToolsCallMessage,
+        var result = await ToolCallExecutor.ExecuteAsync(
+            toolsCallMessage,
             _functionMap,
             _resultCallback,
             _logger,
             cancellationToken
         );
 
-        return textResult.ToolCallResults.First();
+        return result.ToolCallResults.First();
     }
 
     /// <summary>

--- a/src/LmCore/Middleware/FunctionCallMiddleware.cs
+++ b/src/LmCore/Middleware/FunctionCallMiddleware.cs
@@ -30,10 +30,15 @@ public class FunctionCallMiddleware : IStreamingMiddleware
     /// <see cref="ToolCallResult.ContentBlocks"/>.
     /// </summary>
     /// <remarks>
-    /// FunctionCallMiddleware does not support deferred tool execution — it has no
-    /// resolution channel. If a handler returns <see cref="ToolHandlerResult.Deferred"/>,
-    /// invocation throws <see cref="NotSupportedException"/>. Deferred semantics are
-    /// only available when handlers are dispatched by <c>MultiTurnAgentLoop</c>.
+    /// Deferred handlers (<see cref="ToolHandlerResult.Deferred"/>) surface as
+    /// <see cref="ToolCallResult.IsDeferred"/> = true entries inside the emitted
+    /// <see cref="ToolsCallAggregateMessage"/>. The placeholder text is carried as
+    /// <see cref="ToolCallResult.Result"/>; metadata and the deferral timestamp are populated.
+    /// This middleware does NOT loop or wait for resolution — callers must inspect the aggregate
+    /// for deferred entries and implement their own resolution policy (typically: stash the
+    /// tool_call_id, wait for an external signal, splice the resolved result into history,
+    /// and re-call <c>GenerateReplyAsync</c>). Use <c>MultiTurnAgentLoop</c> for built-in
+    /// deferred bookkeeping with persistence and webhook-friendly idempotent resolution.
     /// </remarks>
     public FunctionCallMiddleware(
         IEnumerable<FunctionContract> functions,
@@ -77,8 +82,8 @@ public class FunctionCallMiddleware : IStreamingMiddleware
         Name = name ?? nameof(FunctionCallMiddleware);
 
         // Adapt unified handlers into ToolCallResult-returning handlers for the executor.
-        // Deferred returns surface as NotSupportedException at invocation time — this
-        // middleware has no resolution channel.
+        // Deferred returns surface as ToolCallResult.IsDeferred=true so callers can detect
+        // and resolve them via their own loop. This middleware does not wait for resolution.
         _functionMap = AdaptToToolCallResultHandlers(functionMap);
         _resultCallback = resultCallback;
     }
@@ -98,10 +103,12 @@ public class FunctionCallMiddleware : IStreamingMiddleware
                 return result switch
                 {
                     ToolHandlerResult.Resolved r => r.Result,
-                    ToolHandlerResult.Deferred => throw new NotSupportedException(
-                        $"Tool '{key}' returned a deferred result. Deferred tool execution is only "
-                        + "supported when handlers are dispatched by MultiTurnAgentLoop, not by FunctionCallMiddleware."
-                    ),
+                    ToolHandlerResult.Deferred d => new ToolCallResult(toolCallId: null, result: d.Placeholder)
+                    {
+                        IsDeferred = true,
+                        DeferralMetadata = d.Metadata,
+                        DeferredAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    },
                     _ => throw new InvalidOperationException(
                         $"Unknown ToolHandlerResult variant '{result.GetType().Name}' for tool '{key}'."
                     ),

--- a/src/LmCore/Middleware/FunctionCallMiddleware.cs
+++ b/src/LmCore/Middleware/FunctionCallMiddleware.cs
@@ -32,13 +32,13 @@ public class FunctionCallMiddleware : IStreamingMiddleware
     /// <remarks>
     /// Deferred handlers (<see cref="ToolHandlerResult.Deferred"/>) surface as
     /// <see cref="ToolCallResult.IsDeferred"/> = true entries inside the emitted
-    /// <see cref="ToolsCallAggregateMessage"/>. The placeholder text is carried as
-    /// <see cref="ToolCallResult.Result"/>; metadata and the deferral timestamp are populated.
-    /// This middleware does NOT loop or wait for resolution — callers must inspect the aggregate
-    /// for deferred entries and implement their own resolution policy (typically: stash the
-    /// tool_call_id, wait for an external signal, splice the resolved result into history,
-    /// and re-call <c>GenerateReplyAsync</c>). Use <c>MultiTurnAgentLoop</c> for built-in
-    /// deferred bookkeeping with persistence and webhook-friendly idempotent resolution.
+    /// <see cref="ToolsCallAggregateMessage"/>, with empty <see cref="ToolCallResult.Result"/>
+    /// text and a populated <see cref="ToolCallResult.DeferredAt"/> timestamp. This middleware
+    /// does NOT loop or wait for resolution — callers must inspect the aggregate for deferred
+    /// entries and implement their own resolution policy (typically: stash the tool_call_id,
+    /// wait for an external signal, splice the resolved result into history, and re-call
+    /// <c>GenerateReplyAsync</c>). Use <c>MultiTurnAgentLoop</c> for built-in deferred
+    /// bookkeeping with persistence and webhook-friendly idempotent resolution.
     /// </remarks>
     public FunctionCallMiddleware(
         IEnumerable<FunctionContract> functions,
@@ -100,19 +100,7 @@ public class FunctionCallMiddleware : IStreamingMiddleware
             wrapped[key] = async (args, ctx, ct) =>
             {
                 var result = await handler(args, ctx, ct);
-                return result switch
-                {
-                    ToolHandlerResult.Resolved r => r.Result,
-                    ToolHandlerResult.Deferred d => new ToolCallResult(toolCallId: null, result: d.Placeholder)
-                    {
-                        IsDeferred = true,
-                        DeferralMetadata = d.Metadata,
-                        DeferredAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                    },
-                    _ => throw new InvalidOperationException(
-                        $"Unknown ToolHandlerResult variant '{result.GetType().Name}' for tool '{key}'."
-                    ),
-                };
+                return ToolCallResultBuilder.FromHandlerResult(result, ctx.ToolCallId, key);
             };
         }
 

--- a/src/LmCore/Middleware/FunctionDescriptor.cs
+++ b/src/LmCore/Middleware/FunctionDescriptor.cs
@@ -14,20 +14,16 @@ public record FunctionDescriptor
     public required FunctionContract Contract { get; init; }
 
     /// <summary>
-    ///     The function handler that executes the actual function logic
+    ///     The function handler that executes the actual function logic.
+    ///     Returns a <see cref="ToolHandlerResult"/> — either <see cref="ToolHandlerResult.Resolved"/>
+    ///     wrapping a <see cref="ToolCallResult"/> (which may carry text and/or multi-modal
+    ///     <see cref="ToolResultContentBlock"/>s), or <see cref="ToolHandlerResult.Deferred"/> to
+    ///     signal that the result will be supplied later via
+    ///     <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>.
+    ///     Strings and <see cref="ToolCallResult"/>s can be returned directly via implicit
+    ///     conversion to <see cref="ToolHandlerResult.Resolved"/>.
     /// </summary>
-    public required Func<string, Task<string>> Handler { get; init; }
-
-    /// <summary>
-    ///     Optional multimodal handler returning ToolCallResult with ContentBlocks.
-    ///     When set, FunctionCallMiddleware prefers this over the text-only Handler.
-    /// </summary>
-    public Func<string, Task<ToolCallResult>>? MultiModalHandler { get; init; }
-
-    /// <summary>
-    ///     Whether this descriptor has a multimodal handler available.
-    /// </summary>
-    public bool HasMultiModalHandler => MultiModalHandler != null;
+    public required Func<string, Task<ToolHandlerResult>> Handler { get; init; }
 
     /// <summary>
     ///     Unique key for this function (handles class name prefixing for MCP functions)

--- a/src/LmCore/Middleware/FunctionDescriptor.cs
+++ b/src/LmCore/Middleware/FunctionDescriptor.cs
@@ -15,6 +15,8 @@ public record FunctionDescriptor
 
     /// <summary>
     ///     The function handler that executes the actual function logic.
+    ///     Receives raw JSON args and a <see cref="ToolCallContext"/> carrying the call's
+    ///     <c>tool_call_id</c> and the host's <see cref="CancellationToken"/>.
     ///     Returns a <see cref="ToolHandlerResult"/> — either <see cref="ToolHandlerResult.Resolved"/>
     ///     wrapping a <see cref="ToolCallResult"/> (which may carry text and/or multi-modal
     ///     <see cref="ToolResultContentBlock"/>s), or <see cref="ToolHandlerResult.Deferred"/> to
@@ -23,7 +25,7 @@ public record FunctionDescriptor
     ///     Strings and <see cref="ToolCallResult"/>s can be returned directly via implicit
     ///     conversion to <see cref="ToolHandlerResult.Resolved"/>.
     /// </summary>
-    public required Func<string, Task<ToolHandlerResult>> Handler { get; init; }
+    public required ToolHandler Handler { get; init; }
 
     /// <summary>
     ///     Unique key for this function (handles class name prefixing for MCP functions)

--- a/src/LmCore/Middleware/FunctionDescriptor.cs
+++ b/src/LmCore/Middleware/FunctionDescriptor.cs
@@ -17,13 +17,12 @@ public record FunctionDescriptor
     ///     The function handler that executes the actual function logic.
     ///     Receives raw JSON args and a <see cref="ToolCallContext"/> carrying the call's
     ///     <c>tool_call_id</c> and the host's <see cref="CancellationToken"/>.
-    ///     Returns a <see cref="ToolHandlerResult"/> — either <see cref="ToolHandlerResult.Resolved"/>
-    ///     wrapping a <see cref="ToolCallResult"/> (which may carry text and/or multi-modal
-    ///     <see cref="ToolResultContentBlock"/>s), or <see cref="ToolHandlerResult.Deferred"/> to
-    ///     signal that the result will be supplied later via
-    ///     <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>.
-    ///     Strings and <see cref="ToolCallResult"/>s can be returned directly via implicit
-    ///     conversion to <see cref="ToolHandlerResult.Resolved"/>.
+    ///     Returns a <see cref="ToolHandlerResult"/> — build one with
+    ///     <see cref="ToolHandlerResult.FromText(string)"/>,
+    ///     <see cref="ToolHandlerResult.FromError(string, string?)"/>, or
+    ///     <see cref="ToolHandlerResult.FromMultiModal(string, IList{ToolResultContentBlock})"/>;
+    ///     or return <see cref="ToolHandlerResult.Deferred"/> to signal that the result will
+    ///     be supplied later via <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>.
     /// </summary>
     public required ToolHandler Handler { get; init; }
 

--- a/src/LmCore/Middleware/FunctionRegistry.cs
+++ b/src/LmCore/Middleware/FunctionRegistry.cs
@@ -89,27 +89,14 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
     }
 
     /// <summary>
-    ///     Build the final function collections for FunctionCallMiddleware
+    ///     Build the final function collections for <see cref="FunctionCallMiddleware"/>.
+    ///     Multi-modal payloads are carried by individual <see cref="ToolCallResult"/>s
+    ///     wrapped in <see cref="ToolHandlerResult.Resolved"/> — there's no separate handler track.
     /// </summary>
-    public (IEnumerable<FunctionContract>, IDictionary<string, Func<string, Task<string>>>) Build()
-    {
-        var (contracts, textHandlers, _) = BuildWithMultiModal();
-        return (contracts, textHandlers);
-    }
-
-    /// <summary>
-    ///     Build the final function collections including multimodal handlers.
-    ///     Returns both text-only and multimodal function maps.
-    ///     The multimodal map is a subset — only functions with MultiModalHandler set appear in it.
-    /// </summary>
-    public (
-        IEnumerable<FunctionContract> Contracts,
-        IDictionary<string, Func<string, Task<string>>> TextHandlers,
-        IDictionary<string, Func<string, Task<ToolCallResult>>> MultiModalHandlers
-    ) BuildWithMultiModal()
+    public (IEnumerable<FunctionContract>, IDictionary<string, Func<string, Task<ToolHandlerResult>>>) Build()
     {
         var logger = _logger ?? NullLogger.Instance;
-        logger.LogDebug("Building function registry (with multimodal) with {ProviderCount} providers", _providers.Count);
+        logger.LogDebug("Building function registry with {ProviderCount} providers", _providers.Count);
 
         // Step 1: Collect all functions from providers
         var allDescriptors = new List<FunctionDescriptor>();
@@ -161,10 +148,9 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
         var collisionDetector = new FunctionCollisionDetector(logger);
         var namingMap = collisionDetector.DetectAndResolveCollisions(resolvedFunctions, _filterConfig);
 
-        // Step 6: Build final collections (both text-only and multimodal)
+        // Step 6: Build final collections (single unified handler per name)
         var finalContracts = new List<FunctionContract>();
-        var finalTextHandlers = new Dictionary<string, Func<string, Task<string>>>();
-        var finalMultiModalHandlers = new Dictionary<string, Func<string, Task<ToolCallResult>>>();
+        var finalHandlers = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>();
 
         foreach (var resolved in resolvedFunctions)
         {
@@ -189,22 +175,15 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
                 finalContracts.Add(resolved.Contract);
             }
 
-            finalTextHandlers[registeredName] = resolved.Handler;
-
-            if (resolved.MultiModalHandler != null)
-            {
-                finalMultiModalHandlers[registeredName] = resolved.MultiModalHandler;
-            }
+            finalHandlers[registeredName] = resolved.Handler;
         }
 
-        var multiModalCount = finalMultiModalHandlers.Count;
         logger.LogInformation(
-            "Function registry built (with multimodal): {ContractCount} functions registered, {MultiModalCount} with multimodal handlers",
-            finalContracts.Count,
-            multiModalCount
+            "Function registry built: {ContractCount} functions registered",
+            finalContracts.Count
         );
 
-        return (finalContracts, finalTextHandlers, finalMultiModalHandlers);
+        return (finalContracts, finalHandlers);
     }
 
     /// <summary>
@@ -216,35 +195,34 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
         IToolResultCallback? resultCallback = null
     )
     {
-        var (contracts, textHandlers, multiModalHandlers) = BuildWithMultiModal();
+        var (contracts, handlers) = Build();
         return new FunctionCallMiddleware(
             contracts,
-            textHandlers,
-            multiModalHandlers.Count > 0 ? multiModalHandlers : null,
+            handlers,
             name,
             logger: logger,
             resultCallback: resultCallback);
     }
 
     /// <summary>
-    /// Build ToolCallInjectionMiddleware and handler dictionaries for explicit tool execution.
-    /// Use this pattern when you want manual control over tool execution via ToolCallExecutor.
+    /// Build <see cref="ToolCallInjectionMiddleware"/> and the handler dictionary for explicit
+    /// tool execution. Use this pattern when you want manual control over tool execution via
+    /// <see cref="ToolCallExecutor"/>.
     /// </summary>
     /// <param name="name">Optional name for the middleware instance</param>
     /// <param name="logger">Optional logger for the middleware</param>
-    /// <returns>A tuple containing the middleware, the text handler dictionary, and the multimodal handler dictionary</returns>
+    /// <returns>A tuple containing the middleware and the handler dictionary</returns>
     public (
         ToolCallInjectionMiddleware Middleware,
-        IDictionary<string, Func<string, Task<string>>> Handlers,
-        IDictionary<string, Func<string, Task<ToolCallResult>>> MultiModalHandlers
+        IDictionary<string, Func<string, Task<ToolHandlerResult>>> Handlers
     ) BuildToolCallComponents(
         string? name = null,
         ILogger<ToolCallInjectionMiddleware>? logger = null
     )
     {
-        var (contracts, textHandlers, multiModalHandlers) = BuildWithMultiModal();
+        var (contracts, handlers) = Build();
         var middleware = new ToolCallInjectionMiddleware(contracts, name, logger);
-        return (middleware, textHandlers, multiModalHandlers);
+        return (middleware, handlers);
     }
 
     /// <summary>
@@ -315,7 +293,7 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
     /// </summary>
     IFunctionRegistryBuilder IFunctionRegistryBuilder.AddFunction(
         FunctionContract contract,
-        Func<string, Task<string>> handler,
+        Func<string, Task<ToolHandlerResult>> handler,
         string? providerName
     )
     {
@@ -374,11 +352,13 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
     }
 
     /// <summary>
-    ///     Add a single function explicitly
+    ///     Add a single function explicitly. The handler returns a unified
+    ///     <see cref="ToolHandlerResult"/>; multi-modal payloads are carried by the wrapped
+    ///     <see cref="ToolCallResult.ContentBlocks"/>.
     /// </summary>
     public FunctionRegistry AddFunction(
         FunctionContract contract,
-        Func<string, Task<string>> handler,
+        Func<string, Task<ToolHandlerResult>> handler,
         string? providerName = null
     )
     {
@@ -386,27 +366,6 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
         {
             Contract = contract,
             Handler = handler,
-            ProviderName = providerName ?? "Explicit",
-        };
-        _explicitFunctions[descriptor.Key] = descriptor;
-        return this;
-    }
-
-    /// <summary>
-    ///     Add a single function explicitly with an optional multimodal handler.
-    /// </summary>
-    public FunctionRegistry AddFunction(
-        FunctionContract contract,
-        Func<string, Task<string>> handler,
-        Func<string, Task<ToolCallResult>>? multiModalHandler,
-        string? providerName = null
-    )
-    {
-        var descriptor = new FunctionDescriptor
-        {
-            Contract = contract,
-            Handler = handler,
-            MultiModalHandler = multiModalHandler,
             ProviderName = providerName ?? "Explicit",
         };
         _explicitFunctions[descriptor.Key] = descriptor;

--- a/src/LmCore/Middleware/FunctionRegistry.cs
+++ b/src/LmCore/Middleware/FunctionRegistry.cs
@@ -93,7 +93,7 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
     ///     Multi-modal payloads are carried by individual <see cref="ToolCallResult"/>s
     ///     wrapped in <see cref="ToolHandlerResult.Resolved"/> — there's no separate handler track.
     /// </summary>
-    public (IEnumerable<FunctionContract>, IDictionary<string, Func<string, Task<ToolHandlerResult>>>) Build()
+    public (IEnumerable<FunctionContract>, IDictionary<string, ToolHandler>) Build()
     {
         var logger = _logger ?? NullLogger.Instance;
         logger.LogDebug("Building function registry with {ProviderCount} providers", _providers.Count);
@@ -150,7 +150,7 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
 
         // Step 6: Build final collections (single unified handler per name)
         var finalContracts = new List<FunctionContract>();
-        var finalHandlers = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>();
+        var finalHandlers = new Dictionary<string, ToolHandler>();
 
         foreach (var resolved in resolvedFunctions)
         {
@@ -214,7 +214,7 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
     /// <returns>A tuple containing the middleware and the handler dictionary</returns>
     public (
         ToolCallInjectionMiddleware Middleware,
-        IDictionary<string, Func<string, Task<ToolHandlerResult>>> Handlers
+        IDictionary<string, ToolHandler> Handlers
     ) BuildToolCallComponents(
         string? name = null,
         ILogger<ToolCallInjectionMiddleware>? logger = null
@@ -293,7 +293,7 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
     /// </summary>
     IFunctionRegistryBuilder IFunctionRegistryBuilder.AddFunction(
         FunctionContract contract,
-        Func<string, Task<ToolHandlerResult>> handler,
+        ToolHandler handler,
         string? providerName
     )
     {
@@ -358,7 +358,7 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
     /// </summary>
     public FunctionRegistry AddFunction(
         FunctionContract contract,
-        Func<string, Task<ToolHandlerResult>> handler,
+        ToolHandler handler,
         string? providerName = null
     )
     {

--- a/src/LmCore/Middleware/FunctionRegistry.cs
+++ b/src/LmCore/Middleware/FunctionRegistry.cs
@@ -90,8 +90,9 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
 
     /// <summary>
     ///     Build the final function collections for <see cref="FunctionCallMiddleware"/>.
-    ///     Multi-modal payloads are carried by individual <see cref="ToolCallResult"/>s
-    ///     wrapped in <see cref="ToolHandlerResult.Resolved"/> — there's no separate handler track.
+    ///     Multi-modal payloads are carried by handlers returning
+    ///     <see cref="ToolHandlerResult.FromMultiModal(string, IList{ToolResultContentBlock})"/>;
+    ///     there's no separate handler track.
     /// </summary>
     public (IEnumerable<FunctionContract>, IDictionary<string, ToolHandler>) Build()
     {
@@ -353,8 +354,8 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
 
     /// <summary>
     ///     Add a single function explicitly. The handler returns a unified
-    ///     <see cref="ToolHandlerResult"/>; multi-modal payloads are carried by the wrapped
-    ///     <see cref="ToolCallResult.ContentBlocks"/>.
+    ///     <see cref="ToolHandlerResult"/>; multi-modal payloads are carried by
+    ///     <see cref="ToolHandlerResult.FromMultiModal(string, IList{ToolResultContentBlock})"/>.
     /// </summary>
     public FunctionRegistry AddFunction(
         FunctionContract contract,

--- a/src/LmCore/Middleware/IFunctionRegistryBuilder.cs
+++ b/src/LmCore/Middleware/IFunctionRegistryBuilder.cs
@@ -22,8 +22,10 @@ public interface IFunctionRegistryBuilder
     ///     Adds a single function explicitly to the registry.
     /// </summary>
     /// <param name="contract">The function contract</param>
-    /// <param name="handler">The function handler. Returns <see cref="ToolHandlerResult"/> —
-    /// either <see cref="ToolHandlerResult.Resolved"/> wrapping a <see cref="ToolCallResult"/>
+    /// <param name="handler">The function handler. Receives raw JSON args and a
+    /// <see cref="ToolCallContext"/> carrying the call's <c>tool_call_id</c> and the host's
+    /// <see cref="CancellationToken"/>. Returns <see cref="ToolHandlerResult"/> — either
+    /// <see cref="ToolHandlerResult.Resolved"/> wrapping a <see cref="ToolCallResult"/>
     /// (a bare string or <see cref="ToolCallResult"/> is implicitly convertible) or
     /// <see cref="ToolHandlerResult.Deferred"/> for long-running operations resolved later
     /// via <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>.</param>
@@ -31,7 +33,7 @@ public interface IFunctionRegistryBuilder
     /// <returns>The builder for method chaining</returns>
     IFunctionRegistryBuilder AddFunction(
         FunctionContract contract,
-        Func<string, Task<ToolHandlerResult>> handler,
+        ToolHandler handler,
         string? providerName = null
     );
 
@@ -91,7 +93,7 @@ public interface IConfiguredFunctionRegistry
     ///     <see cref="ToolHandlerResult.Resolved"/>; there is no separate handler track.
     /// </summary>
     /// <returns>A tuple containing the function contracts and their handlers</returns>
-    (IEnumerable<FunctionContract>, IDictionary<string, Func<string, Task<ToolHandlerResult>>>) Build();
+    (IEnumerable<FunctionContract>, IDictionary<string, ToolHandler>) Build();
 
     /// <summary>
     ///     Builds and creates a FunctionCallMiddleware instance directly.

--- a/src/LmCore/Middleware/IFunctionRegistryBuilder.cs
+++ b/src/LmCore/Middleware/IFunctionRegistryBuilder.cs
@@ -22,12 +22,16 @@ public interface IFunctionRegistryBuilder
     ///     Adds a single function explicitly to the registry.
     /// </summary>
     /// <param name="contract">The function contract</param>
-    /// <param name="handler">The function handler</param>
+    /// <param name="handler">The function handler. Returns <see cref="ToolHandlerResult"/> —
+    /// either <see cref="ToolHandlerResult.Resolved"/> wrapping a <see cref="ToolCallResult"/>
+    /// (a bare string or <see cref="ToolCallResult"/> is implicitly convertible) or
+    /// <see cref="ToolHandlerResult.Deferred"/> for long-running operations resolved later
+    /// via <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>.</param>
     /// <param name="providerName">Optional provider name for the function</param>
     /// <returns>The builder for method chaining</returns>
     IFunctionRegistryBuilder AddFunction(
         FunctionContract contract,
-        Func<string, Task<string>> handler,
+        Func<string, Task<ToolHandlerResult>> handler,
         string? providerName = null
     );
 
@@ -82,21 +86,12 @@ public interface IFunctionRegistryWithProviders : IFunctionRegistryBuilder
 public interface IConfiguredFunctionRegistry
 {
     /// <summary>
-    ///     Builds the final function collections from the configured registry.
+    ///     Builds the final function collections from the configured registry. Multi-modal
+    ///     payloads are carried by individual <see cref="ToolCallResult"/>s wrapped in
+    ///     <see cref="ToolHandlerResult.Resolved"/>; there is no separate handler track.
     /// </summary>
     /// <returns>A tuple containing the function contracts and their handlers</returns>
-    (IEnumerable<FunctionContract>, IDictionary<string, Func<string, Task<string>>>) Build();
-
-    /// <summary>
-    ///     Builds the final function collections including multimodal handlers.
-    ///     The multimodal handler map is a subset — only functions with multimodal handlers appear in it.
-    /// </summary>
-    /// <returns>A tuple containing function contracts, text-only handlers, and multimodal handlers</returns>
-    (
-        IEnumerable<FunctionContract> Contracts,
-        IDictionary<string, Func<string, Task<string>>> TextHandlers,
-        IDictionary<string, Func<string, Task<ToolCallResult>>> MultiModalHandlers
-    ) BuildWithMultiModal();
+    (IEnumerable<FunctionContract>, IDictionary<string, Func<string, Task<ToolHandlerResult>>>) Build();
 
     /// <summary>
     ///     Builds and creates a FunctionCallMiddleware instance directly.

--- a/src/LmCore/Middleware/IFunctionRegistryBuilder.cs
+++ b/src/LmCore/Middleware/IFunctionRegistryBuilder.cs
@@ -24,11 +24,12 @@ public interface IFunctionRegistryBuilder
     /// <param name="contract">The function contract</param>
     /// <param name="handler">The function handler. Receives raw JSON args and a
     /// <see cref="ToolCallContext"/> carrying the call's <c>tool_call_id</c> and the host's
-    /// <see cref="CancellationToken"/>. Returns <see cref="ToolHandlerResult"/> — either
-    /// <see cref="ToolHandlerResult.Resolved"/> wrapping a <see cref="ToolCallResult"/>
-    /// (a bare string or <see cref="ToolCallResult"/> is implicitly convertible) or
-    /// <see cref="ToolHandlerResult.Deferred"/> for long-running operations resolved later
-    /// via <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>.</param>
+    /// <see cref="CancellationToken"/>. Returns <see cref="ToolHandlerResult"/> — build with
+    /// <see cref="ToolHandlerResult.FromText(string)"/>,
+    /// <see cref="ToolHandlerResult.FromError(string, string?)"/>, or
+    /// <see cref="ToolHandlerResult.FromMultiModal(string, IList{ToolResultContentBlock})"/>;
+    /// or return <see cref="ToolHandlerResult.Deferred"/> for long-running operations
+    /// resolved later via <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>.</param>
     /// <param name="providerName">Optional provider name for the function</param>
     /// <returns>The builder for method chaining</returns>
     IFunctionRegistryBuilder AddFunction(
@@ -89,8 +90,9 @@ public interface IConfiguredFunctionRegistry
 {
     /// <summary>
     ///     Builds the final function collections from the configured registry. Multi-modal
-    ///     payloads are carried by individual <see cref="ToolCallResult"/>s wrapped in
-    ///     <see cref="ToolHandlerResult.Resolved"/>; there is no separate handler track.
+    ///     payloads are produced by handlers returning
+    ///     <see cref="ToolHandlerResult.FromMultiModal(string, IList{ToolResultContentBlock})"/>;
+    ///     there is no separate handler track.
     /// </summary>
     /// <returns>A tuple containing the function contracts and their handlers</returns>
     (IEnumerable<FunctionContract>, IDictionary<string, ToolHandler>) Build();

--- a/src/LmCore/Middleware/LegacyHandlerAdapter.cs
+++ b/src/LmCore/Middleware/LegacyHandlerAdapter.cs
@@ -1,0 +1,118 @@
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
+
+/// <summary>
+/// Adapters that bridge the new <see cref="ToolHandlerResult"/> handler shape to/from the
+/// legacy <c>Func&lt;string, Task&lt;string&gt;&gt;</c> and
+/// <c>Func&lt;string, Task&lt;ToolCallResult&gt;&gt;</c> shapes used by external integrations
+/// (MCP server adapters, external SDK tool bridges) that cannot support deferred tool execution.
+/// </summary>
+/// <remarks>
+/// Deferred tool execution requires an out-of-band resolution channel (see
+/// <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>). Components that lack one — external SDK
+/// bridges, <c>FunctionCallMiddleware</c>-driven flows — should adapt new-shape handlers via
+/// these helpers. Deferred returns surface as <see cref="NotSupportedException"/> at invocation
+/// time.
+/// </remarks>
+public static class LegacyHandlerAdapter
+{
+    /// <summary>
+    /// Wraps a single new-shape <see cref="ToolHandlerResult"/> handler into the legacy
+    /// <c>Func&lt;string, Task&lt;string&gt;&gt;</c> shape. Throws
+    /// <see cref="NotSupportedException"/> at invocation time on
+    /// <see cref="ToolHandlerResult.Deferred"/>.
+    /// </summary>
+    public static Func<string, Task<string>> ToLegacyHandler(
+        Func<string, Task<ToolHandlerResult>> handler,
+        string toolKey = "<unknown>")
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        return async args =>
+        {
+            var result = await handler(args);
+            return result switch
+            {
+                ToolHandlerResult.Resolved r => r.Result.Result,
+                ToolHandlerResult.Deferred => throw new NotSupportedException(
+                    $"Tool '{toolKey}' returned a deferred result. Deferred tool execution is "
+                    + "only supported when handlers are dispatched by MultiTurnAgentLoop."
+                ),
+                _ => throw new InvalidOperationException(
+                    $"Unknown ToolHandlerResult variant '{result.GetType().Name}' for tool '{toolKey}'."
+                ),
+            };
+        };
+    }
+
+    /// <summary>
+    /// Wraps a handler dictionary of the new <see cref="ToolHandlerResult"/> shape into the
+    /// legacy <c>Func&lt;string, Task&lt;string&gt;&gt;</c> shape. Each wrapped handler unwraps
+    /// <see cref="ToolHandlerResult.Resolved"/> and throws <see cref="NotSupportedException"/>
+    /// on <see cref="ToolHandlerResult.Deferred"/>.
+    /// </summary>
+    public static IDictionary<string, Func<string, Task<string>>> WrapToLegacyHandlers(
+        IDictionary<string, Func<string, Task<ToolHandlerResult>>> source,
+        IEqualityComparer<string>? keyComparer = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        var wrapped = new Dictionary<string, Func<string, Task<string>>>(
+            source.Count,
+            keyComparer ?? StringComparer.Ordinal);
+
+        foreach (var kvp in source)
+        {
+            wrapped[kvp.Key] = ToLegacyHandler(kvp.Value, kvp.Key);
+        }
+
+        return wrapped;
+    }
+
+    /// <summary>
+    /// Wraps a single legacy <c>Func&lt;string, Task&lt;string&gt;&gt;</c> handler into the new
+    /// <see cref="ToolHandlerResult"/> shape. The wrapped handler always returns
+    /// <see cref="ToolHandlerResult.Resolved"/> with a text-only <see cref="ToolCallResult"/>;
+    /// legacy handlers cannot signal deferral.
+    /// </summary>
+    public static Func<string, Task<ToolHandlerResult>> ToNewHandler(
+        Func<string, Task<string>> legacy)
+    {
+        ArgumentNullException.ThrowIfNull(legacy);
+        return async args => new ToolHandlerResult.Resolved(new ToolCallResult(null, await legacy(args)));
+    }
+
+    /// <summary>
+    /// Wraps a single legacy <c>Func&lt;string, Task&lt;ToolCallResult&gt;&gt;</c> handler into
+    /// the new <see cref="ToolHandlerResult"/> shape. Useful for multi-modal handlers where the
+    /// legacy callsite produces a <see cref="ToolCallResult"/> with content blocks; the wrapped
+    /// handler forwards the entire <see cref="ToolCallResult"/> verbatim.
+    /// </summary>
+    public static Func<string, Task<ToolHandlerResult>> ToNewHandler(
+        Func<string, Task<ToolCallResult>> legacy)
+    {
+        ArgumentNullException.ThrowIfNull(legacy);
+        return async args => new ToolHandlerResult.Resolved(await legacy(args));
+    }
+
+    /// <summary>
+    /// Wraps a handler dictionary of the legacy <c>Func&lt;string, Task&lt;string&gt;&gt;</c>
+    /// shape into the new <see cref="ToolHandlerResult"/> shape. Each wrapped handler always
+    /// resolves synchronously with a text-only <see cref="ToolCallResult"/>.
+    /// </summary>
+    public static IDictionary<string, Func<string, Task<ToolHandlerResult>>> WrapToNewHandlers(
+        IDictionary<string, Func<string, Task<string>>> source,
+        IEqualityComparer<string>? keyComparer = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        var wrapped = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>(
+            source.Count,
+            keyComparer ?? StringComparer.Ordinal);
+
+        foreach (var kvp in source)
+        {
+            wrapped[kvp.Key] = ToNewHandler(kvp.Value);
+        }
+
+        return wrapped;
+    }
+}

--- a/src/LmCore/Middleware/LegacyHandlerAdapter.cs
+++ b/src/LmCore/Middleware/LegacyHandlerAdapter.cs
@@ -18,19 +18,20 @@ namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
 public static class LegacyHandlerAdapter
 {
     /// <summary>
-    /// Wraps a single new-shape <see cref="ToolHandlerResult"/> handler into the legacy
-    /// <c>Func&lt;string, Task&lt;string&gt;&gt;</c> shape. Throws
-    /// <see cref="NotSupportedException"/> at invocation time on
-    /// <see cref="ToolHandlerResult.Deferred"/>.
+    /// Wraps a single new-shape <see cref="ToolHandler"/> into the legacy
+    /// <c>Func&lt;string, Task&lt;string&gt;&gt;</c> shape used by external SDKs that
+    /// can't supply a <see cref="ToolCallContext"/>. The wrapper invokes the handler with
+    /// a default <see cref="ToolCallContext"/>. Throws <see cref="NotSupportedException"/>
+    /// at invocation time on <see cref="ToolHandlerResult.Deferred"/>.
     /// </summary>
     public static Func<string, Task<string>> ToLegacyHandler(
-        Func<string, Task<ToolHandlerResult>> handler,
+        ToolHandler handler,
         string toolKey = "<unknown>")
     {
         ArgumentNullException.ThrowIfNull(handler);
         return async args =>
         {
-            var result = await handler(args);
+            var result = await handler(args, new ToolCallContext());
             return result switch
             {
                 ToolHandlerResult.Resolved r => r.Result.Result,
@@ -52,7 +53,7 @@ public static class LegacyHandlerAdapter
     /// on <see cref="ToolHandlerResult.Deferred"/>.
     /// </summary>
     public static IDictionary<string, Func<string, Task<string>>> WrapToLegacyHandlers(
-        IDictionary<string, Func<string, Task<ToolHandlerResult>>> source,
+        IDictionary<string, ToolHandler> source,
         IEqualityComparer<string>? keyComparer = null)
     {
         ArgumentNullException.ThrowIfNull(source);
@@ -74,11 +75,11 @@ public static class LegacyHandlerAdapter
     /// <see cref="ToolHandlerResult.Resolved"/> with a text-only <see cref="ToolCallResult"/>;
     /// legacy handlers cannot signal deferral.
     /// </summary>
-    public static Func<string, Task<ToolHandlerResult>> ToNewHandler(
+    public static ToolHandler ToNewHandler(
         Func<string, Task<string>> legacy)
     {
         ArgumentNullException.ThrowIfNull(legacy);
-        return async args => new ToolHandlerResult.Resolved(new ToolCallResult(null, await legacy(args)));
+        return async (args, _) => new ToolHandlerResult.Resolved(new ToolCallResult(null, await legacy(args)));
     }
 
     /// <summary>
@@ -87,11 +88,11 @@ public static class LegacyHandlerAdapter
     /// legacy callsite produces a <see cref="ToolCallResult"/> with content blocks; the wrapped
     /// handler forwards the entire <see cref="ToolCallResult"/> verbatim.
     /// </summary>
-    public static Func<string, Task<ToolHandlerResult>> ToNewHandler(
+    public static ToolHandler ToNewHandler(
         Func<string, Task<ToolCallResult>> legacy)
     {
         ArgumentNullException.ThrowIfNull(legacy);
-        return async args => new ToolHandlerResult.Resolved(await legacy(args));
+        return async (args, _) => new ToolHandlerResult.Resolved(await legacy(args));
     }
 
     /// <summary>
@@ -99,12 +100,12 @@ public static class LegacyHandlerAdapter
     /// shape into the new <see cref="ToolHandlerResult"/> shape. Each wrapped handler always
     /// resolves synchronously with a text-only <see cref="ToolCallResult"/>.
     /// </summary>
-    public static IDictionary<string, Func<string, Task<ToolHandlerResult>>> WrapToNewHandlers(
+    public static IDictionary<string, ToolHandler> WrapToNewHandlers(
         IDictionary<string, Func<string, Task<string>>> source,
         IEqualityComparer<string>? keyComparer = null)
     {
         ArgumentNullException.ThrowIfNull(source);
-        var wrapped = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>(
+        var wrapped = new Dictionary<string, ToolHandler>(
             source.Count,
             keyComparer ?? StringComparer.Ordinal);
 

--- a/src/LmCore/Middleware/LegacyHandlerAdapter.cs
+++ b/src/LmCore/Middleware/LegacyHandlerAdapter.cs
@@ -31,7 +31,7 @@ public static class LegacyHandlerAdapter
         ArgumentNullException.ThrowIfNull(handler);
         return async args =>
         {
-            var result = await handler(args, new ToolCallContext());
+            var result = await handler(args, new ToolCallContext(), CancellationToken.None);
             return result switch
             {
                 ToolHandlerResult.Resolved r => r.Result.Result,
@@ -79,7 +79,7 @@ public static class LegacyHandlerAdapter
         Func<string, Task<string>> legacy)
     {
         ArgumentNullException.ThrowIfNull(legacy);
-        return async (args, _) => new ToolHandlerResult.Resolved(new ToolCallResult(null, await legacy(args)));
+        return async (args, _, _) => new ToolHandlerResult.Resolved(new ToolCallResult(null, await legacy(args)));
     }
 
     /// <summary>
@@ -92,7 +92,7 @@ public static class LegacyHandlerAdapter
         Func<string, Task<ToolCallResult>> legacy)
     {
         ArgumentNullException.ThrowIfNull(legacy);
-        return async (args, _) => new ToolHandlerResult.Resolved(await legacy(args));
+        return async (args, _, _) => new ToolHandlerResult.Resolved(await legacy(args));
     }
 
     /// <summary>

--- a/src/LmCore/Middleware/LegacyHandlerAdapter.cs
+++ b/src/LmCore/Middleware/LegacyHandlerAdapter.cs
@@ -34,7 +34,7 @@ public static class LegacyHandlerAdapter
             var result = await handler(args, new ToolCallContext(), CancellationToken.None);
             return result switch
             {
-                ToolHandlerResult.Resolved r => r.Result.Result,
+                ToolHandlerResult.Resolved r => r.Payload.Text,
                 ToolHandlerResult.Deferred => throw new NotSupportedException(
                     $"Tool '{toolKey}' returned a deferred result. Deferred tool execution is "
                     + "only supported when handlers are dispatched by MultiTurnAgentLoop."
@@ -71,28 +71,36 @@ public static class LegacyHandlerAdapter
 
     /// <summary>
     /// Wraps a single legacy <c>Func&lt;string, Task&lt;string&gt;&gt;</c> handler into the new
-    /// <see cref="ToolHandlerResult"/> shape. The wrapped handler always returns
-    /// <see cref="ToolHandlerResult.Resolved"/> with a text-only <see cref="ToolCallResult"/>;
-    /// legacy handlers cannot signal deferral.
+    /// <see cref="ToolHandlerResult"/> shape. Always returns
+    /// <see cref="ToolHandlerResult.FromText(string)"/>; legacy handlers cannot signal deferral.
     /// </summary>
     public static ToolHandler ToNewHandler(
         Func<string, Task<string>> legacy)
     {
         ArgumentNullException.ThrowIfNull(legacy);
-        return async (args, _, _) => new ToolHandlerResult.Resolved(new ToolCallResult(null, await legacy(args)));
+        return async (args, _, _) => ToolHandlerResult.FromText(await legacy(args));
     }
 
     /// <summary>
     /// Wraps a single legacy <c>Func&lt;string, Task&lt;ToolCallResult&gt;&gt;</c> handler into
-    /// the new <see cref="ToolHandlerResult"/> shape. Useful for multi-modal handlers where the
-    /// legacy callsite produces a <see cref="ToolCallResult"/> with content blocks; the wrapped
-    /// handler forwards the entire <see cref="ToolCallResult"/> verbatim.
+    /// the new <see cref="ToolHandlerResult"/> shape. Projects the legacy result's text,
+    /// content blocks, and error fields into a <see cref="ToolHandlerResultPayload"/>;
+    /// framework-controlled fields on the legacy result (tool call id, deferral flags) are
+    /// dropped — those are stamped in by <see cref="ToolCallResultBuilder"/> downstream.
     /// </summary>
     public static ToolHandler ToNewHandler(
         Func<string, Task<ToolCallResult>> legacy)
     {
         ArgumentNullException.ThrowIfNull(legacy);
-        return async (args, _, _) => new ToolHandlerResult.Resolved(await legacy(args));
+        return async (args, _, _) =>
+        {
+            var tcr = await legacy(args);
+            return new ToolHandlerResult.Resolved(new ToolHandlerResultPayload(
+                Text: tcr.Result,
+                ContentBlocks: tcr.ContentBlocks,
+                IsError: tcr.IsError,
+                ErrorCode: tcr.ErrorCode));
+        };
     }
 
     /// <summary>

--- a/src/LmCore/Middleware/NaturalToolUseMiddleware.cs
+++ b/src/LmCore/Middleware/NaturalToolUseMiddleware.cs
@@ -26,7 +26,7 @@ public class NaturalToolUseMiddleware : IStreamingMiddleware
     /// <param name="schemaValidator">Optional schema validator for validating tool call arguments.</param>
     public NaturalToolUseMiddleware(
         IEnumerable<FunctionContract> functions,
-        IDictionary<string, Func<string, Task<ToolHandlerResult>>> functionMap,
+        IDictionary<string, ToolHandler> functionMap,
         IAgent? fallbackParser = null,
         string? name = null,
         IJsonSchemaValidator? schemaValidator = null

--- a/src/LmCore/Middleware/NaturalToolUseMiddleware.cs
+++ b/src/LmCore/Middleware/NaturalToolUseMiddleware.cs
@@ -18,13 +18,15 @@ public class NaturalToolUseMiddleware : IStreamingMiddleware
     ///     Creates a new instance of NaturalToolUseMiddleware.
     /// </summary>
     /// <param name="functions">The function contracts to be used for tool calls.</param>
-    /// <param name="functionMap">A dictionary mapping function names to their implementations.</param>
+    /// <param name="functionMap">A dictionary mapping function names to their implementations.
+    /// Handlers return <see cref="ToolHandlerResult"/>; deferred results are not supported in
+    /// this middleware path and will throw at invocation time.</param>
     /// <param name="fallbackParser">Optional agent to use for parsing invalid tool calls.</param>
     /// <param name="name">Optional name for the middleware.</param>
     /// <param name="schemaValidator">Optional schema validator for validating tool call arguments.</param>
     public NaturalToolUseMiddleware(
         IEnumerable<FunctionContract> functions,
-        IDictionary<string, Func<string, Task<string>>> functionMap,
+        IDictionary<string, Func<string, Task<ToolHandlerResult>>> functionMap,
         IAgent? fallbackParser = null,
         string? name = null,
         IJsonSchemaValidator? schemaValidator = null
@@ -48,7 +50,6 @@ public class NaturalToolUseMiddleware : IStreamingMiddleware
         _functionCallMiddleware = new FunctionCallMiddleware(
             functions,
             functionMap,
-            multiModalFunctionMap: null,
             name: $"{Name}.FunctionCall");
     }
 

--- a/src/LmCore/Middleware/ToolCallContext.cs
+++ b/src/LmCore/Middleware/ToolCallContext.cs
@@ -1,10 +1,8 @@
 namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
 
 /// <summary>
-/// Per-invocation context handed to a tool handler. Carries the call's identity and the
-/// host's cancellation signal so handlers can correlate deferred work without inventing
-/// synthetic IDs and can react to cancellation without closing over an outer
-/// <see cref="System.Threading.CancellationToken"/>.
+/// Per-invocation metadata handed to a tool handler. Carries the call's identity so
+/// handlers can correlate deferred work without inventing synthetic IDs.
 /// </summary>
 public sealed record ToolCallContext
 {
@@ -13,7 +11,4 @@ public sealed record ToolCallContext
     /// path doesn't carry one (e.g. natural tool use without an explicit ID).
     /// </summary>
     public string? ToolCallId { get; init; }
-
-    /// <summary>Host cancellation signal threaded by the middleware.</summary>
-    public CancellationToken CancellationToken { get; init; }
 }

--- a/src/LmCore/Middleware/ToolCallContext.cs
+++ b/src/LmCore/Middleware/ToolCallContext.cs
@@ -1,0 +1,19 @@
+namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
+
+/// <summary>
+/// Per-invocation context handed to a tool handler. Carries the call's identity and the
+/// host's cancellation signal so handlers can correlate deferred work without inventing
+/// synthetic IDs and can react to cancellation without closing over an outer
+/// <see cref="System.Threading.CancellationToken"/>.
+/// </summary>
+public sealed record ToolCallContext
+{
+    /// <summary>
+    /// The tool_call_id assigned by the model for this invocation. Null when the call
+    /// path doesn't carry one (e.g. natural tool use without an explicit ID).
+    /// </summary>
+    public string? ToolCallId { get; init; }
+
+    /// <summary>Host cancellation signal threaded by the middleware.</summary>
+    public CancellationToken CancellationToken { get; init; }
+}

--- a/src/LmCore/Middleware/ToolCallExecutor.cs
+++ b/src/LmCore/Middleware/ToolCallExecutor.cs
@@ -131,9 +131,8 @@ public class ToolCallExecutor
                 var ctx = new ToolCallContext
                 {
                     ToolCallId = toolCall.ToolCallId,
-                    CancellationToken = cancellationToken,
                 };
-                var result = await func(functionArgs ?? "{}", ctx);
+                var result = await func(functionArgs ?? "{}", ctx, cancellationToken);
                 var duration = (DateTime.UtcNow - startTime).TotalMilliseconds;
 
                 var imageBlockCount = result.ContentBlocks?.OfType<ImageToolResultBlock>().Count() ?? 0;

--- a/src/LmCore/Middleware/ToolCallExecutor.cs
+++ b/src/LmCore/Middleware/ToolCallExecutor.cs
@@ -5,31 +5,32 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
 
 /// <summary>
-///     Stateless executor for tool calls. Takes a ToolCallMessage and executes the tools,
-///     returning a ToolsCallResultMessage. Designed for explicit tool execution in application code
-///     for the new simplified message flow where applications control the agentic loop.
+///     Stateless executor for tool calls. Takes a <see cref="ToolsCallMessage"/> and executes
+///     the tools, returning a <see cref="ToolsCallResultMessage"/>. Single execution path:
+///     handlers return <see cref="ToolCallResult"/> directly (with optional
+///     <see cref="ToolCallResult.ContentBlocks"/> for multi-modal payloads); the executor
+///     stamps each result with its originating <see cref="ToolCall.ToolCallId"/>.
 /// </summary>
+/// <remarks>
+///     Deferred tool execution is not supported here — this executor has no resolution
+///     channel. <see cref="FunctionCallMiddleware"/> adapts unified <see cref="ToolHandlerResult"/>
+///     handlers down to <see cref="ToolCallResult"/>-returning handlers (throwing on
+///     <see cref="ToolHandlerResult.Deferred"/>) before invoking this executor.
+/// </remarks>
 public class ToolCallExecutor
 {
     /// <summary>
-    ///     Executes all tool calls in the provided message using the given function map
+    ///     Executes all tool calls in the provided message using the given function map.
     /// </summary>
-    /// <param name="toolCallMessage">The message containing tool calls to execute</param>
-    /// <param name="functionMap">Map of function names to their implementations</param>
-    /// <param name="resultCallback">Optional callback for tool execution events</param>
-    /// <param name="logger">Optional logger</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>A ToolsCallResultMessage containing all execution results</returns>
     public static async Task<ToolsCallResultMessage> ExecuteAsync(
         ToolsCallMessage toolCallMessage,
-        IDictionary<string, Func<string, Task<string>>> functionMap,
+        IDictionary<string, Func<string, Task<ToolCallResult>>> functionMap,
         IToolResultCallback? resultCallback = null,
         ILogger? logger = null,
         CancellationToken cancellationToken = default
     )
     {
         ArgumentNullException.ThrowIfNull(toolCallMessage);
-
         ArgumentNullException.ThrowIfNull(functionMap);
 
         var effectiveLogger = logger ?? NullLogger.Instance;
@@ -62,7 +63,6 @@ public class ToolCallExecutor
                     toolCall.FunctionName
                 );
 
-                // Add an error result for this tool call
                 toolCallResults.Add(
                     new ToolCallResult(toolCall.ToolCallId, $"Tool call execution error: {ex.Message}")
                     {
@@ -84,8 +84,6 @@ public class ToolCallExecutor
             duration
         );
 
-        // Return a ToolsCallResultMessage with all results
-        // Preserve GenerationId from the original tool call message
         return new ToolsCallResultMessage
         {
             ToolCallResults = [.. toolCallResults],
@@ -97,98 +95,9 @@ public class ToolCallExecutor
         };
     }
 
-    /// <summary>
-    ///     Executes all tool calls using a multi-modal function map that returns ToolCallResult directly.
-    ///     This overload supports functions that return both text and image content blocks.
-    /// </summary>
-    /// <param name="toolCallMessage">The message containing tool calls to execute</param>
-    /// <param name="multiModalFunctionMap">Map of function names to multi-modal implementations</param>
-    /// <param name="resultCallback">Optional callback for tool execution events</param>
-    /// <param name="logger">Optional logger</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>A ToolsCallResultMessage containing all execution results with content blocks</returns>
-    public static async Task<ToolsCallResultMessage> ExecuteMultiModalAsync(
-        ToolsCallMessage toolCallMessage,
-        IDictionary<string, Func<string, Task<ToolCallResult>>> multiModalFunctionMap,
-        IToolResultCallback? resultCallback = null,
-        ILogger? logger = null,
-        CancellationToken cancellationToken = default
-    )
-    {
-        ArgumentNullException.ThrowIfNull(toolCallMessage);
-        ArgumentNullException.ThrowIfNull(multiModalFunctionMap);
-
-        var effectiveLogger = logger ?? NullLogger.Instance;
-        var toolCalls = toolCallMessage.ToolCalls;
-        var toolCallResults = new List<ToolCallResult>();
-        var toolCallCount = toolCalls.Count;
-        var startTime = DateTime.UtcNow;
-
-        effectiveLogger.LogInformation(
-            "Multi-modal tool call execution started: ToolCallCount={ToolCallCount}",
-            toolCallCount
-        );
-
-        foreach (var toolCall in toolCalls)
-        {
-            try
-            {
-                var result = await ExecuteMultiModalToolCallAsync(
-                    toolCall,
-                    multiModalFunctionMap,
-                    resultCallback,
-                    effectiveLogger,
-                    cancellationToken
-                );
-                toolCallResults.Add(result);
-            }
-            catch (Exception ex)
-            {
-                effectiveLogger.LogError(
-                    ex,
-                    "Multi-modal tool call execution error: ToolCallId={ToolCallId}, FunctionName={FunctionName}",
-                    toolCall.ToolCallId,
-                    toolCall.FunctionName
-                );
-
-                toolCallResults.Add(
-                    new ToolCallResult(toolCall.ToolCallId, $"Tool call execution error: {ex.Message}")
-                    {
-                        ToolName = toolCall.FunctionName,
-                        ExecutionTarget = toolCall.ExecutionTarget,
-                        IsError = true,
-                    }
-                );
-            }
-        }
-
-        var duration = (DateTime.UtcNow - startTime).TotalMilliseconds;
-        var successCount = toolCallResults.Count(r => !r.IsError);
-
-        effectiveLogger.LogInformation(
-            "Multi-modal tool call execution completed: ToolCallCount={ToolCallCount}, SuccessCount={SuccessCount}, Duration={Duration}ms",
-            toolCallCount,
-            successCount,
-            duration
-        );
-
-        return new ToolsCallResultMessage
-        {
-            ToolCallResults = [.. toolCallResults],
-            Role = Role.Tool,
-            FromAgent = string.Empty,
-            GenerationId = toolCallMessage.GenerationId,
-            ThreadId = toolCallMessage.ThreadId,
-            RunId = toolCallMessage.RunId,
-        };
-    }
-
-    /// <summary>
-    ///     Executes a single tool call and returns the result
-    /// </summary>
     private static async Task<ToolCallResult> ExecuteToolCallAsync(
         ToolCall toolCall,
-        IDictionary<string, Func<string, Task<string>>> functionMap,
+        IDictionary<string, Func<string, Task<ToolCallResult>>> functionMap,
         IToolResultCallback? resultCallback,
         ILogger logger,
         CancellationToken cancellationToken
@@ -198,13 +107,18 @@ public class ToolCallExecutor
         var functionArgs = toolCall.FunctionArgs!;
         var startTime = DateTime.UtcNow;
 
-        // Notify callback that tool call is starting
+        logger.LogTrace(
+            "ExecuteToolCallAsync entry: FunctionName={FunctionName}, ToolCallId={ToolCallId}, ArgsLength={ArgsLength}",
+            functionName,
+            toolCall.ToolCallId,
+            functionArgs?.Length ?? 0);
+
         if (resultCallback != null && !string.IsNullOrEmpty(toolCall.ToolCallId))
         {
             await resultCallback.OnToolCallStartedAsync(
                 toolCall.ToolCallId,
                 functionName,
-                functionArgs,
+                functionArgs ?? string.Empty,
                 cancellationToken
             );
         }
@@ -213,33 +127,40 @@ public class ToolCallExecutor
         {
             try
             {
-                var result = await func(functionArgs);
+                var result = await func(functionArgs ?? "{}");
                 var duration = (DateTime.UtcNow - startTime).TotalMilliseconds;
 
+                var imageBlockCount = result.ContentBlocks?.OfType<ImageToolResultBlock>().Count() ?? 0;
+                var totalBlockCount = result.ContentBlocks?.Count ?? 0;
+
                 logger.LogInformation(
-                    "Function executed: Name={FunctionName}, Duration={Duration}ms, Success={Success}",
+                    "Function executed: Name={FunctionName}, Duration={Duration}ms, Success={Success}, ContentBlocks={ContentBlockCount} (Images={ImageBlocks}), ResultLength={ResultLength}",
                     functionName,
                     duration,
-                    true
+                    !result.IsError,
+                    totalBlockCount,
+                    imageBlockCount,
+                    result.Result?.Length ?? 0
                 );
 
-                var toolCallResult = new ToolCallResult(toolCall.ToolCallId, result)
+                // Ensure tool call ID is set (handlers typically leave it null).
+                var stamped = result with
                 {
-                    ToolName = functionName,
+                    ToolCallId = toolCall.ToolCallId,
+                    ToolName = string.IsNullOrEmpty(result.ToolName) ? functionName : result.ToolName,
                     ExecutionTarget = toolCall.ExecutionTarget,
                 };
 
-                // Notify callback that result is available
                 if (resultCallback != null && !string.IsNullOrEmpty(toolCall.ToolCallId))
                 {
                     await resultCallback.OnToolResultAvailableAsync(
                         toolCall.ToolCallId,
-                        toolCallResult,
+                        stamped,
                         cancellationToken
                     );
                 }
 
-                return toolCallResult;
+                return stamped;
             }
             catch (Exception ex)
             {
@@ -254,194 +175,8 @@ public class ToolCallExecutor
                     toolCall.ToolCallId
                 );
 
-                logger.LogInformation(
-                    "Function executed: Name={FunctionName}, Duration={Duration}ms, Success={Success}",
-                    functionName,
-                    duration,
-                    false
-                );
-
                 var errorMessage = $"Error executing function: {ex.Message}";
 
-                // Notify callback about the error
-                if (resultCallback != null && !string.IsNullOrEmpty(toolCall.ToolCallId))
-                {
-                    await resultCallback.OnToolCallErrorAsync(
-                        toolCall.ToolCallId,
-                        functionName,
-                        errorMessage,
-                        cancellationToken
-                    );
-                }
-
-                // Handle exceptions during function execution
-                var errorResult = new ToolCallResult(toolCall.ToolCallId, errorMessage)
-                {
-                    ToolName = functionName,
-                    ExecutionTarget = toolCall.ExecutionTarget,
-                    IsError = true,
-                };
-
-                // Still notify with result (containing error)
-                if (resultCallback != null && !string.IsNullOrEmpty(toolCall.ToolCallId))
-                {
-                    await resultCallback.OnToolResultAvailableAsync(
-                        toolCall.ToolCallId,
-                        errorResult,
-                        cancellationToken
-                    );
-                }
-
-                return errorResult;
-            }
-        }
-
-        {
-            // Return error for unavailable function
-            var availableFunctions = string.Join(", ", functionMap.Keys);
-            var errorMessage = $"Function '{functionName}' is not available. Available functions: {availableFunctions}";
-
-            logger.LogError(
-                "Function mapping error: Unavailable function '{FunctionName}' requested, ToolCallId={ToolCallId}, AvailableFunctions=[{AvailableFunctions}]",
-                functionName,
-                toolCall.ToolCallId,
-                availableFunctions
-            );
-
-            logger.LogInformation(
-                "Function executed: Name={FunctionName}, Duration={Duration}ms, Success={Success}",
-                functionName,
-                0,
-                false
-            );
-
-            // Notify callback about the error
-            if (resultCallback != null && !string.IsNullOrEmpty(toolCall.ToolCallId))
-            {
-                await resultCallback.OnToolCallErrorAsync(
-                    toolCall.ToolCallId,
-                    functionName,
-                    errorMessage,
-                    cancellationToken
-                );
-            }
-
-            var errorResult = new ToolCallResult(toolCall.ToolCallId, errorMessage)
-            {
-                ToolName = functionName,
-                ExecutionTarget = toolCall.ExecutionTarget,
-                IsError = true,
-            };
-
-            // Still notify with result (containing error)
-            if (resultCallback != null && !string.IsNullOrEmpty(toolCall.ToolCallId))
-            {
-                await resultCallback.OnToolResultAvailableAsync(toolCall.ToolCallId, errorResult, cancellationToken);
-            }
-
-            return errorResult;
-        }
-    }
-
-    /// <summary>
-    ///     Executes a single tool call using a multi-modal function map
-    /// </summary>
-    private static async Task<ToolCallResult> ExecuteMultiModalToolCallAsync(
-        ToolCall toolCall,
-        IDictionary<string, Func<string, Task<ToolCallResult>>> multiModalFunctionMap,
-        IToolResultCallback? resultCallback,
-        ILogger logger,
-        CancellationToken cancellationToken
-    )
-    {
-        var functionName = toolCall.FunctionName!;
-        var functionArgs = toolCall.FunctionArgs!;
-        var startTime = DateTime.UtcNow;
-
-        logger.LogTrace(
-            "ExecuteMultiModalToolCallAsync entry: FunctionName={FunctionName}, ToolCallId={ToolCallId}, ArgsLength={ArgsLength}",
-            functionName,
-            toolCall.ToolCallId,
-            functionArgs.Length);
-
-        // Notify callback that tool call is starting
-        if (resultCallback != null && !string.IsNullOrEmpty(toolCall.ToolCallId))
-        {
-            await resultCallback.OnToolCallStartedAsync(
-                toolCall.ToolCallId,
-                functionName,
-                functionArgs,
-                cancellationToken
-            );
-        }
-
-        if (multiModalFunctionMap.TryGetValue(functionName, out var func))
-        {
-            try
-            {
-                // Function returns ToolCallResult directly with content blocks
-                var result = await func(functionArgs);
-                var duration = (DateTime.UtcNow - startTime).TotalMilliseconds;
-
-                // Count content block types for detailed logging
-                var imageBlockCount = result.ContentBlocks?.OfType<ImageToolResultBlock>().Count() ?? 0;
-                var textBlockCount = result.ContentBlocks?.OfType<TextToolResultBlock>().Count() ?? 0;
-                var totalBlockCount = result.ContentBlocks?.Count ?? 0;
-
-                logger.LogInformation(
-                    "Multi-modal function executed: Name={FunctionName}, Duration={Duration}ms, Success={Success}, ContentBlocks={ContentBlockCount} (Images={ImageBlocks}, Text={TextBlocks}), ResultLength={ResultLength}",
-                    functionName,
-                    duration,
-                    true,
-                    totalBlockCount,
-                    imageBlockCount,
-                    textBlockCount,
-                    result.Result?.Length ?? 0
-                );
-
-                if (imageBlockCount > 0)
-                {
-                    // Log image details at debug level
-                    var imageDetails = result.ContentBlocks?
-                        .OfType<ImageToolResultBlock>()
-                        .Select((img, idx) => $"[{idx}:{img.MimeType}:{img.Data?.Length ?? 0}b]");
-                    logger.LogDebug(
-                        "Multi-modal result image details: FunctionName={FunctionName}, Images={ImageDetails}",
-                        functionName,
-                        string.Join(", ", imageDetails ?? []));
-                }
-
-                // Ensure tool call ID is set
-                var toolCallResult = result with { ToolCallId = toolCall.ToolCallId };
-
-                // Notify callback that result is available
-                if (resultCallback != null && !string.IsNullOrEmpty(toolCall.ToolCallId))
-                {
-                    await resultCallback.OnToolResultAvailableAsync(
-                        toolCall.ToolCallId,
-                        toolCallResult,
-                        cancellationToken
-                    );
-                }
-
-                return toolCallResult;
-            }
-            catch (Exception ex)
-            {
-                var duration = (DateTime.UtcNow - startTime).TotalMilliseconds;
-
-                logger.LogError(
-                    ex,
-                    "Multi-modal function execution failed: Name={FunctionName}, Args={Args}, Duration={Duration}ms, ToolCallId={ToolCallId}",
-                    functionName,
-                    functionArgs,
-                    duration,
-                    toolCall.ToolCallId
-                );
-
-                var errorMessage = $"Error executing function: {ex.Message}";
-
-                // Notify callback about the error
                 if (resultCallback != null && !string.IsNullOrEmpty(toolCall.ToolCallId))
                 {
                     await resultCallback.OnToolCallErrorAsync(
@@ -472,14 +207,15 @@ public class ToolCallExecutor
             }
         }
 
-        // Return error for unavailable function
-        var availableFunctions = string.Join(", ", multiModalFunctionMap.Keys);
-        var unavailableErrorMessage = $"Function '{functionName}' is not available. Available functions: {availableFunctions}";
+        // Unavailable function — return error so the LLM can self-correct.
+        var availableFunctions = string.Join(", ", functionMap.Keys);
+        var unavailableMessage = $"Function '{functionName}' is not available. Available functions: {availableFunctions}";
 
         logger.LogError(
-            "Multi-modal function mapping error: Unavailable function '{FunctionName}' requested, ToolCallId={ToolCallId}",
+            "Function mapping error: Unavailable function '{FunctionName}' requested, ToolCallId={ToolCallId}, AvailableFunctions=[{AvailableFunctions}]",
             functionName,
-            toolCall.ToolCallId
+            toolCall.ToolCallId,
+            availableFunctions
         );
 
         if (resultCallback != null && !string.IsNullOrEmpty(toolCall.ToolCallId))
@@ -487,12 +223,12 @@ public class ToolCallExecutor
             await resultCallback.OnToolCallErrorAsync(
                 toolCall.ToolCallId,
                 functionName,
-                unavailableErrorMessage,
+                unavailableMessage,
                 cancellationToken
             );
         }
 
-        var unavailableErrorResult = new ToolCallResult(toolCall.ToolCallId, unavailableErrorMessage)
+        var unavailableResult = new ToolCallResult(toolCall.ToolCallId, unavailableMessage)
         {
             ToolName = functionName,
             ExecutionTarget = toolCall.ExecutionTarget,
@@ -501,9 +237,9 @@ public class ToolCallExecutor
 
         if (resultCallback != null && !string.IsNullOrEmpty(toolCall.ToolCallId))
         {
-            await resultCallback.OnToolResultAvailableAsync(toolCall.ToolCallId, unavailableErrorResult, cancellationToken);
+            await resultCallback.OnToolResultAvailableAsync(toolCall.ToolCallId, unavailableResult, cancellationToken);
         }
 
-        return unavailableErrorResult;
+        return unavailableResult;
     }
 }

--- a/src/LmCore/Middleware/ToolCallExecutor.cs
+++ b/src/LmCore/Middleware/ToolCallExecutor.cs
@@ -12,10 +12,11 @@ namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
 ///     stamps each result with its originating <see cref="ToolCall.ToolCallId"/>.
 /// </summary>
 /// <remarks>
-///     Deferred tool execution is not supported here — this executor has no resolution
-///     channel. <see cref="FunctionCallMiddleware"/> adapts unified <see cref="ToolHandlerResult"/>
-///     handlers down to <see cref="ToolCallResult"/>-returning handlers (throwing on
-///     <see cref="ToolHandlerResult.Deferred"/>) before invoking this executor.
+///     Deferred tool execution is surfaced — handlers signaling
+///     <see cref="ToolHandlerResult.Deferred"/> are adapted by
+///     <see cref="FunctionCallMiddleware"/> into <see cref="ToolCallResult"/>s with
+///     <see cref="ToolCallResult.IsDeferred"/> = true; the executor passes them through
+///     unchanged. Resolution is the caller's responsibility.
 /// </remarks>
 public class ToolCallExecutor
 {
@@ -24,7 +25,7 @@ public class ToolCallExecutor
     /// </summary>
     public static async Task<ToolsCallResultMessage> ExecuteAsync(
         ToolsCallMessage toolCallMessage,
-        IDictionary<string, Func<string, Task<ToolCallResult>>> functionMap,
+        IDictionary<string, ToolCallResultHandler> functionMap,
         IToolResultCallback? resultCallback = null,
         ILogger? logger = null,
         CancellationToken cancellationToken = default
@@ -97,7 +98,7 @@ public class ToolCallExecutor
 
     private static async Task<ToolCallResult> ExecuteToolCallAsync(
         ToolCall toolCall,
-        IDictionary<string, Func<string, Task<ToolCallResult>>> functionMap,
+        IDictionary<string, ToolCallResultHandler> functionMap,
         IToolResultCallback? resultCallback,
         ILogger logger,
         CancellationToken cancellationToken
@@ -127,7 +128,12 @@ public class ToolCallExecutor
         {
             try
             {
-                var result = await func(functionArgs ?? "{}");
+                var ctx = new ToolCallContext
+                {
+                    ToolCallId = toolCall.ToolCallId,
+                    CancellationToken = cancellationToken,
+                };
+                var result = await func(functionArgs ?? "{}", ctx);
                 var duration = (DateTime.UtcNow - startTime).TotalMilliseconds;
 
                 var imageBlockCount = result.ContentBlocks?.OfType<ImageToolResultBlock>().Count() ?? 0;

--- a/src/LmCore/Middleware/ToolHandler.cs
+++ b/src/LmCore/Middleware/ToolHandler.cs
@@ -4,12 +4,15 @@ namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
 
 /// <summary>
 /// Tool handler signature used by <see cref="FunctionRegistry"/> and
-/// <see cref="FunctionCallMiddleware"/>. Handlers receive raw JSON args and a
-/// <see cref="ToolCallContext"/>, and return a <see cref="ToolHandlerResult"/>
-/// (either <see cref="ToolHandlerResult.Resolved"/> or
-/// <see cref="ToolHandlerResult.Deferred"/>).
+/// <see cref="FunctionCallMiddleware"/>. Handlers receive raw JSON args, a
+/// <see cref="ToolCallContext"/>, and a <see cref="CancellationToken"/>, and return
+/// a <see cref="ToolHandlerResult"/> (either <see cref="ToolHandlerResult.Resolved"/>
+/// or <see cref="ToolHandlerResult.Deferred"/>).
 /// </summary>
-public delegate Task<ToolHandlerResult> ToolHandler(string argsJson, ToolCallContext context);
+public delegate Task<ToolHandlerResult> ToolHandler(
+    string argsJson,
+    ToolCallContext context,
+    CancellationToken cancellationToken);
 
 /// <summary>
 /// Post-adapter shape produced by <see cref="FunctionCallMiddleware"/> and consumed by
@@ -19,4 +22,7 @@ public delegate Task<ToolHandlerResult> ToolHandler(string argsJson, ToolCallCon
 /// shape; most users register <see cref="ToolHandler"/>-shaped handlers via
 /// <see cref="FunctionRegistry"/> and let the middleware perform the adaptation.
 /// </summary>
-public delegate Task<ToolCallResult> ToolCallResultHandler(string argsJson, ToolCallContext context);
+public delegate Task<ToolCallResult> ToolCallResultHandler(
+    string argsJson,
+    ToolCallContext context,
+    CancellationToken cancellationToken);

--- a/src/LmCore/Middleware/ToolHandler.cs
+++ b/src/LmCore/Middleware/ToolHandler.cs
@@ -1,0 +1,22 @@
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
+
+/// <summary>
+/// Tool handler signature used by <see cref="FunctionRegistry"/> and
+/// <see cref="FunctionCallMiddleware"/>. Handlers receive raw JSON args and a
+/// <see cref="ToolCallContext"/>, and return a <see cref="ToolHandlerResult"/>
+/// (either <see cref="ToolHandlerResult.Resolved"/> or
+/// <see cref="ToolHandlerResult.Deferred"/>).
+/// </summary>
+public delegate Task<ToolHandlerResult> ToolHandler(string argsJson, ToolCallContext context);
+
+/// <summary>
+/// Post-adapter shape produced by <see cref="FunctionCallMiddleware"/> and consumed by
+/// <see cref="ToolCallExecutor"/>. Resolved/Deferred have already been reconciled into a
+/// single <see cref="ToolCallResult"/> with deferral fields populated. External callers
+/// invoking <see cref="ToolCallExecutor.ExecuteAsync"/> directly author handlers in this
+/// shape; most users register <see cref="ToolHandler"/>-shaped handlers via
+/// <see cref="FunctionRegistry"/> and let the middleware perform the adaptation.
+/// </summary>
+public delegate Task<ToolCallResult> ToolCallResultHandler(string argsJson, ToolCallContext context);

--- a/src/LmCore/Middleware/TypeFunctionProvider.cs
+++ b/src/LmCore/Middleware/TypeFunctionProvider.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Utils;
 
 namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
@@ -207,7 +208,7 @@ public class TypeFunctionProvider : IFunctionProvider
         return false;
     }
 
-    private Func<string, Task<string>> CreateHandler(MethodInfo method)
+    private Func<string, Task<ToolHandlerResult>> CreateHandler(MethodInfo method)
     {
         return async argsJson =>
         {
@@ -290,8 +291,9 @@ public class TypeFunctionProvider : IFunctionProvider
                     result = method.Invoke(target, paramValues);
                 }
 
-                // Serialize the result
-                return result != null && method.ReturnType != typeof(void)
+                // Reflective handlers always resolve synchronously — they don't have access to a
+                // ToolCallId or DeferralContext. Wrap the serialized result as Resolved.
+                var serialized = result != null && method.ReturnType != typeof(void)
                     ? JsonSerializer.Serialize(
                         result,
                         new JsonSerializerOptions
@@ -301,18 +303,21 @@ public class TypeFunctionProvider : IFunctionProvider
                         }
                     )
                     : "{}";
+                return new ToolHandlerResult.Resolved(new ToolCallResult(null, serialized));
             }
             catch (TargetInvocationException tie)
             {
                 // Unwrap the real exception
                 var innerException = tie.InnerException ?? tie;
-                return JsonSerializer.Serialize(
+                var errorJson = JsonSerializer.Serialize(
                     new { error = innerException.Message, type = innerException.GetType().Name }
                 );
+                return new ToolHandlerResult.Resolved(new ToolCallResult(null, errorJson) { IsError = true });
             }
             catch (Exception ex)
             {
-                return JsonSerializer.Serialize(new { error = ex.Message, type = ex.GetType().Name });
+                var errorJson = JsonSerializer.Serialize(new { error = ex.Message, type = ex.GetType().Name });
+                return new ToolHandlerResult.Resolved(new ToolCallResult(null, errorJson) { IsError = true });
             }
         };
     }

--- a/src/LmCore/Middleware/TypeFunctionProvider.cs
+++ b/src/LmCore/Middleware/TypeFunctionProvider.cs
@@ -208,9 +208,9 @@ public class TypeFunctionProvider : IFunctionProvider
         return false;
     }
 
-    private Func<string, Task<ToolHandlerResult>> CreateHandler(MethodInfo method)
+    private ToolHandler CreateHandler(MethodInfo method)
     {
-        return async argsJson =>
+        return async (argsJson, _) =>
         {
             try
             {

--- a/src/LmCore/Middleware/TypeFunctionProvider.cs
+++ b/src/LmCore/Middleware/TypeFunctionProvider.cs
@@ -210,7 +210,7 @@ public class TypeFunctionProvider : IFunctionProvider
 
     private ToolHandler CreateHandler(MethodInfo method)
     {
-        return async (argsJson, _) =>
+        return async (argsJson, _, _) =>
         {
             try
             {

--- a/src/LmCore/Middleware/TypeFunctionProvider.cs
+++ b/src/LmCore/Middleware/TypeFunctionProvider.cs
@@ -303,7 +303,7 @@ public class TypeFunctionProvider : IFunctionProvider
                         }
                     )
                     : "{}";
-                return new ToolHandlerResult.Resolved(new ToolCallResult(null, serialized));
+                return ToolHandlerResult.FromText(serialized);
             }
             catch (TargetInvocationException tie)
             {
@@ -312,12 +312,12 @@ public class TypeFunctionProvider : IFunctionProvider
                 var errorJson = JsonSerializer.Serialize(
                     new { error = innerException.Message, type = innerException.GetType().Name }
                 );
-                return new ToolHandlerResult.Resolved(new ToolCallResult(null, errorJson) { IsError = true });
+                return ToolHandlerResult.FromError(errorJson);
             }
             catch (Exception ex)
             {
                 var errorJson = JsonSerializer.Serialize(new { error = ex.Message, type = ex.GetType().Name });
-                return new ToolHandlerResult.Resolved(new ToolCallResult(null, errorJson) { IsError = true });
+                return ToolHandlerResult.FromError(errorJson);
             }
         };
     }

--- a/src/LmMultiTurn/CodexAgentLoop.cs
+++ b/src/LmMultiTurn/CodexAgentLoop.cs
@@ -92,7 +92,10 @@ public sealed class CodexAgentLoop : MultiTurnAgentBase
         {
             var (contracts, handlers) = functionRegistry.Build();
             dynamicContracts = [.. contracts.Where(static c => !string.IsNullOrWhiteSpace(c.Name))];
-            dynamicHandlers = new Dictionary<string, Func<string, Task<string>>>(handlers, StringComparer.OrdinalIgnoreCase);
+            // Codex SDK consumes legacy string-returning handlers. Deferred tool execution is
+            // a MultiTurnAgentLoop-only feature, so we unwrap ToolHandlerResult.Resolved here
+            // and surface a NotSupportedException if a handler ever returns Deferred.
+            dynamicHandlers = LegacyHandlerAdapter.WrapToLegacyHandlers(handlers, StringComparer.OrdinalIgnoreCase);
         }
 
         _toolPolicy = new CodexToolPolicyEngine(

--- a/src/LmMultiTurn/CopilotAgentLoop.cs
+++ b/src/LmMultiTurn/CopilotAgentLoop.cs
@@ -91,7 +91,10 @@ public sealed class CopilotAgentLoop : MultiTurnAgentBase
         {
             var (contracts, handlers) = functionRegistry.Build();
             dynamicContracts = [.. contracts.Where(static c => !string.IsNullOrWhiteSpace(c.Name))];
-            dynamicHandlers = new Dictionary<string, Func<string, Task<string>>>(handlers, StringComparer.OrdinalIgnoreCase);
+            // Copilot SDK consumes legacy string-returning handlers. Deferred tool execution
+            // is a MultiTurnAgentLoop-only feature; unwrap Resolved here and surface
+            // NotSupportedException if a handler ever returns Deferred.
+            dynamicHandlers = LegacyHandlerAdapter.WrapToLegacyHandlers(handlers, StringComparer.OrdinalIgnoreCase);
         }
 
         _toolPolicy = new CopilotToolPolicyEngine(

--- a/src/LmMultiTurn/DeferredToolCallInfo.cs
+++ b/src/LmMultiTurn/DeferredToolCallInfo.cs
@@ -1,0 +1,55 @@
+using System.Collections.Immutable;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn;
+
+/// <summary>
+/// Snapshot of a deferred tool call that is awaiting external resolution.
+/// Returned by <c>MultiTurnAgentLoop.GetDeferredToolCallsAsync</c> so hosts (UIs, webhook
+/// receivers, restart-recovery code) can correlate the placeholder in conversation history
+/// with their own state and call <c>ResolveToolCallAsync</c> when the answer is known.
+/// </summary>
+public sealed record DeferredToolCallInfo
+{
+    /// <summary>
+    /// Identifier of the tool call. Use this when calling <c>ResolveToolCallAsync</c>.
+    /// </summary>
+    public required string ToolCallId { get; init; }
+
+    /// <summary>
+    /// Name of the tool function that was invoked.
+    /// </summary>
+    public required string FunctionName { get; init; }
+
+    /// <summary>
+    /// JSON-serialized arguments the LLM passed to the function.
+    /// </summary>
+    public required string FunctionArgs { get; init; }
+
+    /// <summary>
+    /// Placeholder text the handler returned in lieu of a real result. Currently sitting in
+    /// conversation history as the (interim) <c>tool_result</c> for this call.
+    /// </summary>
+    public required string Placeholder { get; init; }
+
+    /// <summary>
+    /// Unix-ms timestamp recorded when the handler signaled deferral.
+    /// </summary>
+    public required long DeferredAtUnixMs { get; init; }
+
+    /// <summary>
+    /// Opaque host-supplied metadata captured at deferral time (correlation IDs, ticket numbers,
+    /// expected wait time, etc.).
+    /// </summary>
+    public ImmutableDictionary<string, string>? Metadata { get; init; }
+
+    /// <summary>
+    /// Identifier of the run during which the tool call was emitted. The run has since ended;
+    /// resolving the call will start a new run.
+    /// </summary>
+    public string? RunId { get; init; }
+
+    /// <summary>
+    /// Identifier of the assistant generation (turn) that emitted this tool call.
+    /// </summary>
+    public string? GenerationId { get; init; }
+}

--- a/src/LmMultiTurn/DeferredToolCallInfo.cs
+++ b/src/LmMultiTurn/DeferredToolCallInfo.cs
@@ -1,12 +1,11 @@
-using System.Collections.Immutable;
-
 namespace AchieveAi.LmDotnetTools.LmMultiTurn;
 
 /// <summary>
 /// Snapshot of a deferred tool call that is awaiting external resolution.
 /// Returned by <c>MultiTurnAgentLoop.GetDeferredToolCallsAsync</c> so hosts (UIs, webhook
-/// receivers, restart-recovery code) can correlate the placeholder in conversation history
-/// with their own state and call <c>ResolveToolCallAsync</c> when the answer is known.
+/// receivers, restart-recovery code) can correlate the deferred entry in conversation history
+/// with their own state — keyed on <see cref="ToolCallId"/> — and call
+/// <c>ResolveToolCallAsync</c> when the answer is known.
 /// </summary>
 public sealed record DeferredToolCallInfo
 {
@@ -26,21 +25,9 @@ public sealed record DeferredToolCallInfo
     public required string FunctionArgs { get; init; }
 
     /// <summary>
-    /// Placeholder text the handler returned in lieu of a real result. Currently sitting in
-    /// conversation history as the (interim) <c>tool_result</c> for this call.
-    /// </summary>
-    public required string Placeholder { get; init; }
-
-    /// <summary>
     /// Unix-ms timestamp recorded when the handler signaled deferral.
     /// </summary>
     public required long DeferredAtUnixMs { get; init; }
-
-    /// <summary>
-    /// Opaque host-supplied metadata captured at deferral time (correlation IDs, ticket numbers,
-    /// expected wait time, etc.).
-    /// </summary>
-    public ImmutableDictionary<string, string>? Metadata { get; init; }
 
     /// <summary>
     /// Identifier of the run during which the tool call was emitted. The run has since ended;

--- a/src/LmMultiTurn/Messages/QueuedInput.cs
+++ b/src/LmMultiTurn/Messages/QueuedInput.cs
@@ -7,7 +7,12 @@ namespace AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
 /// <param name="Input">The original user input</param>
 /// <param name="ReceiptId">Unique ID for this queued item (matches SendReceipt.ReceiptId)</param>
 /// <param name="QueuedAt">Timestamp when the input was queued</param>
+/// <param name="Resume">When non-null, this entry is an internal resume sentinel posted by the
+/// loop after the last deferred tool call from a previous turn was resolved. The loop drains
+/// it and starts a new run with no fresh user messages — the resolved tool_results already in
+/// history feed the LLM. Real user inputs always have <c>Resume == null</c>.</param>
 public record QueuedInput(
     UserInput Input,
     string ReceiptId,
-    DateTimeOffset QueuedAt);
+    DateTimeOffset QueuedAt,
+    ResumeSentinel? Resume = null);

--- a/src/LmMultiTurn/Messages/ResumeSentinel.cs
+++ b/src/LmMultiTurn/Messages/ResumeSentinel.cs
@@ -1,0 +1,11 @@
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+
+/// <summary>
+/// Internal sentinel placed onto the input channel by <c>MultiTurnAgentLoop</c> when all
+/// deferred tool calls from a previous assistant turn have been resolved. Triggers the
+/// loop to start a new run with no fresh user input — the resolved tool_results already
+/// in history feed the LLM the data it was waiting for.
+/// </summary>
+/// <param name="ResumeForRunId">The run that ended with deferred tool calls; recorded for telemetry only.</param>
+/// <param name="ResumeForGenerationId">The assistant generation whose deferrals have all been resolved.</param>
+public sealed record ResumeSentinel(string ResumeForRunId, string ResumeForGenerationId);

--- a/src/LmMultiTurn/MultiTurnAgentBase.cs
+++ b/src/LmMultiTurn/MultiTurnAgentBase.cs
@@ -247,6 +247,142 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
         }
     }
 
+    /// <summary>
+    /// Adds a message that represents a deferred tool-call placeholder, waiting on persistence
+    /// to complete before returning. Used by <c>MultiTurnAgentLoop</c> when a tool handler
+    /// returns <see cref="LmCore.Messages.ToolHandlerResult.Deferred"/>: the placeholder must
+    /// be durable in the store before any subscriber sees it, so a webhook-triggered
+    /// <c>ResolveToolCallAsync</c> can safely call <see cref="IConversationStore.ReplaceMessageAsync"/>
+    /// without racing the placeholder's persistence.
+    /// </summary>
+    /// <remarks>
+    /// In-memory append happens first, then persistence is awaited inline. The non-deferred
+    /// <see cref="AddToHistory"/> path remains fire-and-forget — synchronous persistence is
+    /// only required where in-place replacement is on the table.
+    /// </remarks>
+    protected async Task AddDeferredToHistoryAsync(IMessage message, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        lock (_historyLock)
+        {
+            ConversationHistory.Add(message);
+        }
+
+        if (Store == null)
+        {
+            return;
+        }
+
+        string? runId;
+        lock (_stateLock)
+        {
+            runId = _currentRunId;
+        }
+
+        if (runId == null)
+        {
+            return;
+        }
+
+        try
+        {
+            var persisted = MessagePersistenceConverter.ToPersistedMessage(message, ThreadId, runId);
+            await Store.AppendMessagesAsync(ThreadId, [persisted], ct);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to persist deferred-tool placeholder");
+        }
+    }
+
+    /// <summary>
+    /// Replaces the most recent <see cref="ToolCallResultMessage"/> in history that has the
+    /// given <c>ToolCallId</c>, applying <paramref name="updater"/> to compute the new value.
+    /// Returns the (old, new) pair so the caller can publish the updated message and persist
+    /// the change via <see cref="ReplacePersistedAsync"/>.
+    /// </summary>
+    /// <remarks>
+    /// Idempotency is the updater's responsibility — typically the updater short-circuits and
+    /// returns <c>existing</c> unchanged when the resolution has already been applied with the
+    /// same content. The base method only enforces "must exist".
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when no <see cref="ToolCallResultMessage"/> with the given ToolCallId is in history.
+    /// </exception>
+    protected (ToolCallResultMessage Old, ToolCallResultMessage New) UpdateToolResultByCallId(
+        string toolCallId,
+        Func<ToolCallResultMessage, ToolCallResultMessage> updater)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(toolCallId);
+        ArgumentNullException.ThrowIfNull(updater);
+
+        lock (_historyLock)
+        {
+            var index = ConversationHistory.FindLastIndex(m =>
+                m is ToolCallResultMessage tcr && tcr.ToolCallId == toolCallId);
+            if (index < 0)
+            {
+                throw new InvalidOperationException(
+                    $"No ToolCallResultMessage with ToolCallId '{toolCallId}' found in history.");
+            }
+
+            var old = (ToolCallResultMessage)ConversationHistory[index];
+            var updated = updater(old);
+            ConversationHistory[index] = updated;
+            return (old, updated);
+        }
+    }
+
+    /// <summary>
+    /// Persists the replacement of a previously-appended <see cref="ToolCallResultMessage"/>
+    /// in the store, addressing it by its deterministic Id (<c>tcr:{threadId}:{toolCallId}</c>).
+    /// Failures are logged and swallowed — in-memory mutation is the source of truth for the
+    /// running loop; persistence becomes eventually consistent.
+    /// </summary>
+    protected async Task ReplacePersistedAsync(
+        ToolCallResultMessage old,
+        ToolCallResultMessage updated,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(old);
+        ArgumentNullException.ThrowIfNull(updated);
+
+        if (Store == null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(updated.ToolCallId))
+        {
+            // Without a ToolCallId we can't construct the deterministic Id. Should not happen
+            // for valid tool-call results.
+            Logger.LogWarning("Cannot persist replacement: ToolCallId is null/empty");
+            return;
+        }
+
+        string? runId;
+        lock (_stateLock)
+        {
+            runId = _currentRunId ?? _latestRunId;
+        }
+
+        runId ??= old.RunId ?? updated.RunId ?? string.Empty;
+
+        try
+        {
+            var persisted = MessagePersistenceConverter.ToPersistedMessage(updated, ThreadId, runId);
+            await Store.ReplaceMessageAsync(ThreadId, persisted, ct);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(
+                ex,
+                "Failed to persist deferred-tool resolution for ToolCallId={ToolCallId}",
+                updated.ToolCallId);
+        }
+    }
+
     #endregion
 
     #region Persistence
@@ -358,6 +494,10 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
             _latestRunId = metadata.LatestRunId;
         }
 
+        // Give implementations a chance to seed in-memory state from the restored history
+        // (e.g., MultiTurnAgentLoop rebuilds its deferred-tool registry here).
+        await OnHistoryRestoredAsync(messages, ct);
+
         Logger.LogInformation(
             "Recovered {MessageCount} messages for thread {ThreadId}. LatestRunId: {LatestRunId}",
             messages.Count,
@@ -365,6 +505,18 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
             metadata.LatestRunId);
 
         return true;
+    }
+
+    /// <summary>
+    /// Called from <see cref="RecoverAsync"/> after history has been restored from the store.
+    /// Override to rebuild any in-memory state derived from history (e.g., a deferred-tool
+    /// registry on the loop).
+    /// </summary>
+    /// <param name="messages">The full restored conversation history, in load order.</param>
+    /// <param name="ct">Cancellation token.</param>
+    protected virtual Task OnHistoryRestoredAsync(IReadOnlyList<IMessage> messages, CancellationToken ct)
+    {
+        return Task.CompletedTask;
     }
 
     #endregion
@@ -375,6 +527,25 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     /// Direct access to the input channel reader for implementations that need push-based notification.
     /// </summary>
     protected ChannelReader<QueuedInput> InputReader => _inputChannel.Reader;
+
+    /// <summary>
+    /// Posts a pre-built <see cref="QueuedInput"/> directly to the input channel, preserving
+    /// any non-default fields (including <see cref="QueuedInput.Resume"/>). Used by
+    /// <c>MultiTurnAgentLoop</c> to enqueue internal resume sentinels for deferred-tool
+    /// auto-resume; not for general user input — use <see cref="SendAsync"/> for that.
+    /// </summary>
+    protected ValueTask EnqueueRawAsync(QueuedInput queuedInput, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(queuedInput);
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
+
+        if (_inputChannel.Writer.TryWrite(queuedInput))
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        return _inputChannel.Writer.WriteAsync(queuedInput, ct);
+    }
 
     /// <summary>
     /// Convenience method to drain all currently available inputs from the queue.

--- a/src/LmMultiTurn/MultiTurnAgentBase.cs
+++ b/src/LmMultiTurn/MultiTurnAgentBase.cs
@@ -256,43 +256,38 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     /// without racing the placeholder's persistence.
     /// </summary>
     /// <remarks>
-    /// In-memory append happens first, then persistence is awaited inline. The non-deferred
-    /// <see cref="AddToHistory"/> path remains fire-and-forget — synchronous persistence is
-    /// only required where in-place replacement is on the table.
+    /// Persistence runs first; the in-memory append happens only after the store has accepted
+    /// the message. If persistence fails, the exception propagates and no in-memory state is
+    /// mutated — callers (e.g., <c>MultiTurnAgentLoop.ExecuteAndPublishToolCallAsync</c>) are
+    /// responsible for unwinding any pre-registered deferred entries on failure. The
+    /// non-deferred <see cref="AddToHistory"/> path remains fire-and-forget; synchronous
+    /// persistence is only required where in-place replacement is on the table.
     /// </remarks>
     protected async Task AddDeferredToHistoryAsync(IMessage message, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(message);
 
+        if (Store != null)
+        {
+            string? runId;
+            lock (_stateLock)
+            {
+                runId = _currentRunId;
+            }
+
+            if (runId != null)
+            {
+                // Persist BEFORE the in-memory append so a failure leaves no orphaned entry
+                // in ConversationHistory. Letting the exception propagate is intentional —
+                // the deferred-tool guarantee is load-bearing for webhook resolution.
+                var persisted = MessagePersistenceConverter.ToPersistedMessage(message, ThreadId, runId);
+                await Store.AppendMessagesAsync(ThreadId, [persisted], ct);
+            }
+        }
+
         lock (_historyLock)
         {
             ConversationHistory.Add(message);
-        }
-
-        if (Store == null)
-        {
-            return;
-        }
-
-        string? runId;
-        lock (_stateLock)
-        {
-            runId = _currentRunId;
-        }
-
-        if (runId == null)
-        {
-            return;
-        }
-
-        try
-        {
-            var persisted = MessagePersistenceConverter.ToPersistedMessage(message, ThreadId, runId);
-            await Store.AppendMessagesAsync(ThreadId, [persisted], ct);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex, "Failed to persist deferred-tool placeholder");
         }
     }
 
@@ -546,6 +541,13 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
 
         return _inputChannel.Writer.WriteAsync(queuedInput, ct);
     }
+
+    /// <summary>
+    /// Throws <see cref="ObjectDisposedException"/> if the agent has been disposed. Public API
+    /// methods on subclasses (e.g., <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>) call this
+    /// to fail fast instead of mutating disposed state.
+    /// </summary>
+    protected void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_isDisposed, this);
 
     /// <summary>
     /// Convenience method to drain all currently available inputs from the queue.

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -35,7 +35,7 @@ namespace AchieveAi.LmDotnetTools.LmMultiTurn;
 public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
 {
     private readonly IStreamingAgent _agent;
-    private readonly IDictionary<string, Func<string, Task<ToolHandlerResult>>> _toolHandlers;
+    private readonly IDictionary<string, ToolHandler> _toolHandlers;
     private readonly SubAgentManager? _subAgentManager;
 
     // Deferred tool tracking. Keyed by ToolCallId. Concurrent because resolutions arrive on
@@ -541,7 +541,12 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                 };
             }
 
-            var result = await handler(functionArgs);
+            var ctx = new ToolCallContext
+            {
+                ToolCallId = toolCall.ToolCallId,
+                CancellationToken = ct,
+            };
+            var result = await handler(functionArgs, ctx);
             return BuildResultMessage(toolCall, result);
         }
         catch (Exception ex)

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -544,9 +544,8 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
             var ctx = new ToolCallContext
             {
                 ToolCallId = toolCall.ToolCallId,
-                CancellationToken = ct,
             };
-            var result = await handler(functionArgs, ctx);
+            var result = await handler(functionArgs, ctx, ct);
             return BuildResultMessage(toolCall, result);
         }
         catch (Exception ex)

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Text.Json;
 using System.Threading.Channels;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
@@ -16,6 +18,11 @@ namespace AchieveAi.LmDotnetTools.LmMultiTurn;
 /// Multi-turn agent implementation using raw LLM APIs with middleware pipeline.
 /// Thread-safe for concurrent input via SendAsync.
 /// Supports multiple independent output subscribers via SubscribeAsync.
+/// Supports deferred tool execution: a tool handler may return
+/// <see cref="ToolHandlerResult.Deferred"/>, in which case the loop records a placeholder
+/// in history, ends the run, and waits for an external caller to invoke
+/// <see cref="ResolveToolCallAsync"/>. When all deferrals from the latest turn resolve,
+/// a new run starts automatically.
 /// </summary>
 /// <remarks>
 /// This implementation uses a middleware stack for message processing:
@@ -28,9 +35,21 @@ namespace AchieveAi.LmDotnetTools.LmMultiTurn;
 public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
 {
     private readonly IStreamingAgent _agent;
-    private readonly IDictionary<string, Func<string, Task<string>>> _toolHandlers;
-    private readonly IDictionary<string, Func<string, Task<ToolCallResult>>>? _multiModalHandlers;
+    private readonly IDictionary<string, Func<string, Task<ToolHandlerResult>>> _toolHandlers;
     private readonly SubAgentManager? _subAgentManager;
+
+    // Deferred tool tracking. Keyed by ToolCallId. Concurrent because resolutions arrive on
+    // arbitrary threads (UI callbacks, webhook handlers).
+    private readonly ConcurrentDictionary<string, DeferredEntry> _deferred = new();
+
+    // Auto-resume gating. _resumeLock guards _resumeScheduled, _runActive, and the
+    // _lastDeferring* pair so we never schedule two sentinels for the same wave nor
+    // schedule one while the loop is still mid-run.
+    private readonly object _resumeLock = new();
+    private bool _resumeScheduled;
+    private bool _runActive;
+    private string? _lastDeferringRunId;
+    private string? _lastDeferringGenerationId;
 
     /// <summary>
     /// Creates a new MultiTurnAgentLoop with FunctionRegistry for tool management.
@@ -71,15 +90,12 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
             // IMPORTANT: Snapshot parent tools BEFORE registering sub-agent tools.
             // This ensures sub-agents inherit the parent's domain tools but NOT the
             // Agent/CheckAgent tools, preventing unbounded recursive delegation.
-            var (contracts, handlers, mmHandlers) =
-                functionRegistry.BuildWithMultiModal();
+            var (contracts, handlers) = functionRegistry.Build();
 
             _subAgentManager = new SubAgentManager(
                 parentAgent: this,
                 parentContracts: contracts.ToList(),
                 parentHandlers: handlers,
-                parentMultiModalHandlers:
-                    mmHandlers.Count > 0 ? mmHandlers : null,
                 options: subAgentOptions,
                 logger: logger);
 
@@ -91,9 +107,8 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         }
 
         // Build tool call components from registry
-        var (toolCallMiddleware, finalHandlers, multiModalHandlers) = functionRegistry.BuildToolCallComponents(name: "MultiTurnAgentTools");
+        var (toolCallMiddleware, finalHandlers) = functionRegistry.BuildToolCallComponents(name: "MultiTurnAgentTools");
         _toolHandlers = finalHandlers;
-        _multiModalHandlers = multiModalHandlers.Count > 0 ? multiModalHandlers : null;
 
         // Create publishing middleware that publishes to subscribers
         // Positioned BEFORE MessageUpdateJoinerMiddleware to capture streaming updates
@@ -140,21 +155,51 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                     continue;
                 }
 
-                // Start run with initial batch
-                var assignment = StartRun(batch);
+                // Split into real user inputs vs internal resume sentinels. A batch can mix
+                // both if a real input lands while a resume is already queued; both feed into
+                // the same run.
+                var realInputs = batch.Where(b => b.Resume == null).ToList();
+                var resumeSentinels = batch.Where(b => b.Resume != null).ToList();
+
+                if (realInputs.Count == 0 && resumeSentinels.Count == 0)
+                {
+                    continue;
+                }
+
+                if (resumeSentinels.Count > 0)
+                {
+                    // Clear the scheduled flag now that we're consuming the sentinel; future
+                    // resolution waves can schedule again.
+                    lock (_resumeLock)
+                    {
+                        _resumeScheduled = false;
+                    }
+                }
+
+                // Start run with the available inputs (use real if any, otherwise sentinels
+                // — StartRun records receipt IDs for telemetry but doesn't otherwise care).
+                var inputsForAssignment = realInputs.Count > 0 ? realInputs : resumeSentinels;
+                var assignment = StartRun(inputsForAssignment);
                 await PublishToAllAsync(new RunAssignmentMessage
                 {
                     Assignment = assignment,
                     ThreadId = ThreadId,
                 }, ct);
 
-                // Add initial messages to history
-                foreach (var input in batch)
+                // Add real-input messages to history. Resume sentinels contribute no new
+                // messages — the loop continues from history that already has the resolved
+                // tool_results in place of the prior placeholders.
+                foreach (var input in realInputs)
                 {
                     foreach (var msg in input.Input.Messages)
                     {
                         AddToHistory(msg);
                     }
+                }
+
+                lock (_resumeLock)
+                {
+                    _runActive = true;
                 }
 
                 try
@@ -182,6 +227,19 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                         errorMessage: ex.Message,
                         ct: ct);
                 }
+                finally
+                {
+                    lock (_resumeLock)
+                    {
+                        _runActive = false;
+                    }
+
+                    // The run is over. If resolutions arrived during the run such that all
+                    // deferreds for the deferring generation are already resolved, schedule
+                    // an auto-resume now (the in-run resolutions deliberately deferred this
+                    // until _runActive flipped false).
+                    TryScheduleAutoResume(ct);
+                }
             }
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -205,6 +263,8 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
 
     /// <summary>
     /// Execute the agentic turns for a run, polling for new input between turns.
+    /// Ends the run early if any tool call deferrals from the current generation remain
+    /// unresolved at the end of a turn — see <see cref="ResolveToolCallAsync"/>.
     /// </summary>
     private async Task ExecuteRunTurnsAsync(string runId, string generationId, CancellationToken ct)
     {
@@ -214,44 +274,65 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         {
             ct.ThrowIfCancellationRequested();
 
-            // POLL: Check for new inputs before each turn
+            // POLL: Check for new inputs before each turn (skip resume sentinels — they're
+            // not real injected messages, they only exist to wake the channel).
             if (TryDrainInputs(out var newInputs) && newInputs.Count > 0)
             {
-                // Send RunAssignment for the newly injected inputs
-                // Note: These are added to the CURRENT run, not a new run
-                var injectionAssignment = new RunAssignment(
-                    RunId: runId,
-                    GenerationId: generationId,
-                    InputIds: [.. newInputs.Select(i => i.ReceiptId)],
-                    ParentRunId: null, // Injected into current run
-                    WasInjected: true  // Mark as injected to differentiate from initial assignment
-                );
-
-                await PublishToAllAsync(new RunAssignmentMessage
+                var realNewInputs = newInputs.Where(b => b.Resume == null).ToList();
+                if (realNewInputs.Count > 0)
                 {
-                    Assignment = injectionAssignment,
-                    ThreadId = ThreadId,
-                }, ct);
+                    var injectionAssignment = new RunAssignment(
+                        RunId: runId,
+                        GenerationId: generationId,
+                        InputIds: [.. realNewInputs.Select(i => i.ReceiptId)],
+                        ParentRunId: null,
+                        WasInjected: true
+                    );
 
-                // Add new messages to current run (injection)
-                foreach (var input in newInputs)
-                {
-                    foreach (var msg in input.Input.Messages)
+                    await PublishToAllAsync(new RunAssignmentMessage
                     {
-                        AddToHistory(msg);
-                    }
-                }
+                        Assignment = injectionAssignment,
+                        ThreadId = ThreadId,
+                    }, ct);
 
-                Logger.LogInformation(
-                    "Injected {Count} new inputs into run {RunId}, sent RunAssignment",
-                    newInputs.Count,
-                    runId);
+                    foreach (var input in realNewInputs)
+                    {
+                        foreach (var msg in input.Input.Messages)
+                        {
+                            AddToHistory(msg);
+                        }
+                    }
+
+                    Logger.LogInformation(
+                        "Injected {Count} new inputs into run {RunId}, sent RunAssignment",
+                        realNewInputs.Count,
+                        runId);
+                }
             }
 
             turnCount++;
             Logger.LogDebug("Executing turn {Turn} of run {RunId}", turnCount, runId);
 
             var hasToolCalls = await ExecuteTurnAsync(runId, generationId, turnCount, ct);
+
+            // If any tool call from this generation deferred and is still unresolved, end
+            // the run cleanly. Resolution of the last deferred entry will auto-trigger a
+            // new run via the resume sentinel.
+            if (HasUnresolvedDeferralsForGeneration(generationId))
+            {
+                lock (_resumeLock)
+                {
+                    _lastDeferringRunId = runId;
+                    _lastDeferringGenerationId = generationId;
+                    _resumeScheduled = false;
+                }
+
+                Logger.LogInformation(
+                    "Run {RunId} pausing on {Count} deferred tool call(s); awaiting external resolution",
+                    runId,
+                    _deferred.Values.Count(d => d.GenerationId == generationId));
+                break;
+            }
 
             if (!hasToolCalls)
             {
@@ -324,14 +405,17 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                     toolCall.ToolCallId);
 
                 // Start execution and publish result immediately when complete
-                // This runs in parallel with LLM streaming and other tool executions
-                var executionTask = ExecuteAndPublishToolCallAsync(toolCall, ct);
+                // This runs in parallel with LLM streaming and other tool executions.
+                // Pass the run's generationId so deferred entries are tagged consistently —
+                // toolCall.GenerationId is set by the provider/middleware and may be missing.
+                var executionTask = ExecuteAndPublishToolCallAsync(toolCall, runId, generationId, ct);
                 pendingToolCalls[toolCall.ToolCallId] = executionTask;
             }
         }
 
         // Wait for all tool executions to complete before next turn
-        // Results are already published as each tool completes
+        // Results are already published as each tool completes. Deferred handlers complete
+        // synchronously with a placeholder, so this never blocks on external resolution.
         if (pendingToolCalls.Count > 0)
         {
             Logger.LogDebug("Awaiting {Count} tool call results", pendingToolCalls.Count);
@@ -345,15 +429,51 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
     /// Executes a tool call and immediately publishes the result to all subscribers.
     /// This enables parallel execution with LLM streaming - results are sent to clients
     /// as each tool completes, rather than waiting for all tools to finish.
+    /// For deferred handlers, the placeholder is registered in <see cref="_deferred"/>
+    /// before publishing so a racing <see cref="ResolveToolCallAsync"/> always finds it.
     /// </summary>
     private async Task<ToolCallResultMessage> ExecuteAndPublishToolCallAsync(
         ToolCallMessage toolCall,
+        string runId,
+        string generationId,
         CancellationToken ct)
     {
         var result = await ExecuteToolCallAsync(toolCall, ct);
 
-        // Add text-only version to LLM history (captions are in the text for id:// referencing)
-        // Publish full version with ContentBlocks to subscribers (for image data resolution)
+        if (result.IsDeferred)
+        {
+            // Register the deferred entry BEFORE making the placeholder visible to history
+            // or subscribers. Any incoming ResolveToolCallAsync needs to find the entry to
+            // succeed. Stamp with the run's runId/generationId — toolCall.RunId/GenerationId
+            // are set by the provider/middleware and may be unset in some agents/tests.
+            var deferredEntry = new DeferredEntry(
+                ToolCallId: result.ToolCallId!,
+                FunctionName: toolCall.FunctionName ?? string.Empty,
+                FunctionArgs: toolCall.FunctionArgs ?? "{}",
+                Placeholder: result.Result,
+                DeferredAtUnixMs: result.DeferredAt ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                RunId: toolCall.RunId ?? runId,
+                GenerationId: toolCall.GenerationId ?? generationId,
+                Metadata: result.DeferralMetadata);
+            _deferred[result.ToolCallId!] = deferredEntry;
+
+            // Persist synchronously so a webhook-triggered ReplaceMessageAsync cannot race
+            // the placeholder's append.
+            await AddDeferredToHistoryAsync(result, ct);
+            await PublishToAllAsync(result, ct);
+
+            Logger.LogInformation(
+                "Tool call {ToolCallId} ({FunctionName}) deferred with placeholder length {Length}",
+                toolCall.ToolCallId,
+                toolCall.FunctionName,
+                result.Result.Length);
+
+            return result;
+        }
+
+        // Non-deferred result. Add text-only version to LLM history (captions are in the
+        // text for id:// referencing); publish full version with ContentBlocks to
+        // subscribers (for image data resolution).
         var historyResult = result.ContentBlocks != null
             ? result with { ContentBlocks = null }
             : result;
@@ -421,45 +541,8 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                 };
             }
 
-            // Prefer multimodal handler when available — preserves images in tool results
-            if (_multiModalHandlers != null &&
-                _multiModalHandlers.TryGetValue(toolCall.FunctionName, out var multiModalHandler))
-            {
-                Logger.LogInformation(
-                    "Using multimodal handler for tool '{FunctionName}' (ToolCallId: {ToolCallId})",
-                    toolCall.FunctionName, toolCall.ToolCallId);
-
-                var mmResult = await multiModalHandler(functionArgs);
-
-                var imageCount = mmResult.ContentBlocks?.Count(b => b is ImageToolResultBlock) ?? 0;
-                Logger.LogInformation(
-                    "Multimodal tool result for '{FunctionName}': {ImageCount} images, result length={ResultLength}",
-                    toolCall.FunctionName, imageCount, mmResult.Result?.Length ?? 0);
-
-                return new ToolCallResultMessage
-                {
-                    ToolCallId = toolCall.ToolCallId,
-                    ToolName = toolCall.FunctionName,
-                    Result = mmResult.Result ?? "",
-                    ContentBlocks = mmResult.ContentBlocks,
-                    ExecutionTarget = ExecutionTarget.LocalFunction,
-                    Role = Role.User,
-                    FromAgent = toolCall.FromAgent,
-                    GenerationId = toolCall.GenerationId,
-                };
-            }
-
             var result = await handler(functionArgs);
-            return new ToolCallResultMessage
-            {
-                ToolCallId = toolCall.ToolCallId,
-                ToolName = toolCall.FunctionName,
-                Result = result,
-                ExecutionTarget = ExecutionTarget.LocalFunction,
-                Role = Role.User,
-                FromAgent = toolCall.FromAgent,
-                GenerationId = toolCall.GenerationId,
-            };
+            return BuildResultMessage(toolCall, result);
         }
         catch (Exception ex)
         {
@@ -478,4 +561,341 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
             };
         }
     }
+
+    private static ToolCallResultMessage BuildResultMessage(
+        ToolCallMessage toolCall,
+        ToolHandlerResult result)
+    {
+        return result switch
+        {
+            ToolHandlerResult.Resolved r => new ToolCallResultMessage
+            {
+                ToolCallId = toolCall.ToolCallId,
+                ToolName = toolCall.FunctionName,
+                Result = r.Result.Result ?? string.Empty,
+                ContentBlocks = r.Result.ContentBlocks,
+                IsError = r.Result.IsError,
+                ErrorCode = r.Result.ErrorCode,
+                ExecutionTarget = ExecutionTarget.LocalFunction,
+                Role = Role.User,
+                FromAgent = toolCall.FromAgent,
+                GenerationId = toolCall.GenerationId,
+            },
+            ToolHandlerResult.Deferred d => new ToolCallResultMessage
+            {
+                ToolCallId = toolCall.ToolCallId,
+                ToolName = toolCall.FunctionName,
+                Result = d.Placeholder,
+                IsDeferred = true,
+                DeferralMetadata = d.Metadata,
+                DeferredAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ExecutionTarget = ExecutionTarget.LocalFunction,
+                Role = Role.User,
+                FromAgent = toolCall.FromAgent,
+                GenerationId = toolCall.GenerationId,
+            },
+            _ => throw new InvalidOperationException(
+                $"Unknown ToolHandlerResult variant '{result.GetType().Name}'"),
+        };
+    }
+
+    /// <summary>
+    /// Resolves a previously-deferred tool call. Mutates the placeholder in history and
+    /// persisted store, publishes the resolved <see cref="ToolCallResultMessage"/> to
+    /// subscribers, and — when this resolution completes the most recent turn's deferred
+    /// set — auto-triggers a new run.
+    /// </summary>
+    /// <remarks>
+    /// Idempotent for byte-equal duplicate deliveries (webhook retries are common).
+    /// Throws <see cref="InvalidOperationException"/> if no matching deferred call exists,
+    /// or if the call has already been resolved with different content.
+    /// </remarks>
+    public Task ResolveToolCallAsync(
+        string toolCallId,
+        string result,
+        bool isError = false,
+        IList<ToolResultContentBlock>? contentBlocks = null,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(toolCallId);
+        ArgumentNullException.ThrowIfNull(result);
+
+        return ResolveToolCallInternalAsync(toolCallId, result, isError, contentBlocks, ct);
+    }
+
+    private async Task ResolveToolCallInternalAsync(
+        string toolCallId,
+        string result,
+        bool isError,
+        IList<ToolResultContentBlock>? contentBlocks,
+        CancellationToken ct)
+    {
+        // Capture deferred entry first to fail-fast on unknown ids without locking history.
+        if (!_deferred.TryGetValue(toolCallId, out var deferredEntry))
+        {
+            // It might have been resolved already — UpdateToolResultByCallId will surface a
+            // proper conflict error. If history doesn't have the id either, that throws
+            // InvalidOperationException with a clear message.
+        }
+
+        var noOp = false;
+
+        var (oldMessage, newMessage) = UpdateToolResultByCallId(toolCallId, existing =>
+        {
+            // Case 1: still deferred — apply the resolution.
+            if (existing.IsDeferred)
+            {
+                return existing with
+                {
+                    Result = result,
+                    ContentBlocks = null, // history-side is text-only; subscribers get full
+                    IsError = isError,
+                    ErrorCode = isError ? "deferred_resolution_error" : null,
+                    IsDeferred = false,
+                    DeferralMetadata = null,
+                    ResolvedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                };
+            }
+
+            // Case 2: already resolved with the same content — idempotent no-op.
+            if (existing.Result == result && existing.IsError == isError)
+            {
+                noOp = true;
+                return existing;
+            }
+
+            // Case 3: already resolved with different content — conflict.
+            throw new InvalidOperationException(
+                $"Tool call '{toolCallId}' has already been resolved with different content. " +
+                "Cannot resolve again with a different value.");
+        });
+
+        if (noOp)
+        {
+            Logger.LogDebug(
+                "ResolveToolCallAsync no-op: '{ToolCallId}' was already resolved with identical content",
+                toolCallId);
+            // Make sure the deferred entry is cleaned up in case it lingered.
+            _ = _deferred.TryRemove(toolCallId, out _);
+            return;
+        }
+
+        // Persist the replacement (best-effort; failures are logged inside).
+        await ReplacePersistedAsync(oldMessage, newMessage, ct);
+
+        // Publish the full message (including ContentBlocks) to subscribers so UIs can
+        // render images. The history entry stays text-only.
+        var publishMessage = contentBlocks != null && contentBlocks.Count > 0
+            ? newMessage with { ContentBlocks = contentBlocks }
+            : newMessage;
+        await PublishToAllAsync(publishMessage, ct);
+
+        _ = _deferred.TryRemove(toolCallId, out _);
+
+        Logger.LogInformation(
+            "Tool call {ToolCallId} resolved (was deferred for {ElapsedMs}ms)",
+            toolCallId,
+            deferredEntry != null
+                ? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - deferredEntry.DeferredAtUnixMs
+                : 0);
+
+        TryScheduleAutoResume(ct);
+    }
+
+    /// <summary>
+    /// Returns the set of tool calls currently deferred (awaiting external resolution).
+    /// Hosts use this to inspect state, render pending UI, or — on process restart —
+    /// reconnect external workflows to the calls they're supposed to complete.
+    /// </summary>
+    public Task<IReadOnlyList<DeferredToolCallInfo>> GetDeferredToolCallsAsync(CancellationToken ct = default)
+    {
+        var snapshot = _deferred.Values
+            .Select(e => new DeferredToolCallInfo
+            {
+                ToolCallId = e.ToolCallId,
+                FunctionName = e.FunctionName,
+                FunctionArgs = e.FunctionArgs,
+                Placeholder = e.Placeholder,
+                DeferredAtUnixMs = e.DeferredAtUnixMs,
+                Metadata = e.Metadata,
+                RunId = e.RunId,
+                GenerationId = e.GenerationId,
+            })
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<DeferredToolCallInfo>>(snapshot);
+    }
+
+    /// <inheritdoc />
+    protected override Task OnHistoryRestoredAsync(IReadOnlyList<IMessage> messages, CancellationToken ct)
+    {
+        // Rebuild the deferred registry from persisted history. Each ToolCallResultMessage
+        // with IsDeferred=true gets re-registered so GetDeferredToolCallsAsync surfaces it
+        // and ResolveToolCallAsync can complete it after restart.
+        if (messages == null || messages.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        // Index ToolCallMessages by ToolCallId so we can recover function name/args for
+        // each deferred result.
+        var toolCallsById = new Dictionary<string, ToolCallMessage>(StringComparer.Ordinal);
+        foreach (var msg in messages)
+        {
+            if (msg is ToolCallMessage tc && !string.IsNullOrEmpty(tc.ToolCallId))
+            {
+                toolCallsById[tc.ToolCallId] = tc;
+            }
+        }
+
+        string? mostRecentDeferringRun = null;
+        string? mostRecentDeferringGen = null;
+
+        foreach (var msg in messages)
+        {
+            if (msg is not ToolCallResultMessage tcr || !tcr.IsDeferred || string.IsNullOrEmpty(tcr.ToolCallId))
+            {
+                continue;
+            }
+
+            toolCallsById.TryGetValue(tcr.ToolCallId, out var sourceCall);
+
+            var entry = new DeferredEntry(
+                ToolCallId: tcr.ToolCallId,
+                FunctionName: sourceCall?.FunctionName ?? tcr.ToolName ?? string.Empty,
+                FunctionArgs: sourceCall?.FunctionArgs ?? "{}",
+                Placeholder: tcr.Result,
+                DeferredAtUnixMs: tcr.DeferredAt ?? 0,
+                RunId: tcr.RunId,
+                GenerationId: tcr.GenerationId,
+                Metadata: tcr.DeferralMetadata);
+            _deferred[tcr.ToolCallId] = entry;
+
+            // Track the most recent (last in load order) deferring run/generation so a
+            // resolution after restart will trigger an auto-resume into the right context.
+            mostRecentDeferringRun = tcr.RunId ?? mostRecentDeferringRun;
+            mostRecentDeferringGen = tcr.GenerationId ?? mostRecentDeferringGen;
+        }
+
+        if (_deferred.Count > 0)
+        {
+            lock (_resumeLock)
+            {
+                _lastDeferringRunId = mostRecentDeferringRun;
+                _lastDeferringGenerationId = mostRecentDeferringGen;
+                _resumeScheduled = false;
+            }
+
+            Logger.LogInformation(
+                "Restored {Count} deferred tool call(s) from persisted history",
+                _deferred.Count);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private bool HasUnresolvedDeferralsForGeneration(string generationId)
+    {
+        foreach (var entry in _deferred.Values)
+        {
+            if (entry.GenerationId == generationId)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Schedule an auto-resume sentinel onto the input channel when:
+    /// (1) we have recorded a deferring generation,
+    /// (2) all deferred entries for that generation have been resolved,
+    /// (3) the loop is not currently inside a run, and
+    /// (4) a sentinel hasn't already been scheduled for this wave.
+    /// All four conditions are checked under <see cref="_resumeLock"/> to avoid scheduling
+    /// duplicate sentinels when many resolutions land at once.
+    /// </summary>
+    private void TryScheduleAutoResume(CancellationToken ct)
+    {
+        string runId;
+        string genId;
+
+        lock (_resumeLock)
+        {
+            if (_lastDeferringRunId == null || _lastDeferringGenerationId == null)
+            {
+                return;
+            }
+
+            if (_runActive || _resumeScheduled)
+            {
+                return;
+            }
+
+            if (HasUnresolvedDeferralsForGeneration(_lastDeferringGenerationId))
+            {
+                return;
+            }
+
+            runId = _lastDeferringRunId;
+            genId = _lastDeferringGenerationId;
+            _resumeScheduled = true;
+
+            // Clear the deferring marker now — once we've scheduled a resume for this wave,
+            // future no-op resolutions or post-run TryScheduleAutoResume calls must not
+            // re-schedule. The marker is set again only when a new turn defers.
+            _lastDeferringRunId = null;
+            _lastDeferringGenerationId = null;
+        }
+
+        EnqueueResumeSentinel(runId, genId, ct);
+    }
+
+    private void EnqueueResumeSentinel(string runId, string generationId, CancellationToken ct)
+    {
+        // Build a QueuedInput marked with a ResumeSentinel. The Input.Messages list is
+        // empty by design — resumes contribute no new messages, only a wake-up.
+        var sentinel = new ResumeSentinel(runId, generationId);
+        var emptyInput = new UserInput([], InputId: null, ParentRunId: runId);
+        var queuedInput = new QueuedInput(
+            emptyInput,
+            ReceiptId: $"resume:{Guid.NewGuid():N}",
+            QueuedAt: DateTimeOffset.UtcNow,
+            Resume: sentinel);
+
+        _ = WriteResumeSentinelAsync(queuedInput, ct);
+    }
+
+    private async Task WriteResumeSentinelAsync(QueuedInput sentinelInput, CancellationToken ct)
+    {
+        try
+        {
+            await EnqueueRawAsync(sentinelInput, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Expected on shutdown
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(
+                ex,
+                "Failed to enqueue resume sentinel for run {RunId}",
+                sentinelInput.Resume?.ResumeForRunId);
+        }
+    }
+
+    /// <summary>
+    /// Internal record describing a single deferred tool call awaiting external resolution.
+    /// Public surface is <see cref="DeferredToolCallInfo"/>.
+    /// </summary>
+    private sealed record DeferredEntry(
+        string ToolCallId,
+        string FunctionName,
+        string FunctionArgs,
+        string Placeholder,
+        long DeferredAtUnixMs,
+        string? RunId,
+        string? GenerationId,
+        ImmutableDictionary<string, string>? Metadata);
 }

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -363,6 +363,32 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         // Build messages list with system prompt prepended (if configured)
         var messagesToSend = GetMessagesWithSystemPrompt();
 
+        // Precondition: never send a request while any deferred tool result is unresolved.
+        // The provider would reject an empty tool_result.content, but the real bug is sending
+        // at all — host code must call ResolveToolCallAsync before resuming.
+        foreach (var m in messagesToSend)
+        {
+            if (m is ToolCallResultMessage tcr && tcr.IsDeferred)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot send request: tool call '{tcr.ToolCallId}' is still deferred. " +
+                    "Resolve all deferred tool calls via ResolveToolCallAsync before resuming.");
+            }
+
+            if (m is ToolsCallResultMessage agg)
+            {
+                foreach (var r in agg.ToolCallResults)
+                {
+                    if (r.IsDeferred)
+                    {
+                        throw new InvalidOperationException(
+                            $"Cannot send request: tool call '{r.ToolCallId}' is still deferred. " +
+                            "Resolve all deferred tool calls via ResolveToolCallAsync before resuming.");
+                    }
+                }
+            }
+        }
+
         var stream = await _agent.GenerateReplyStreamingAsync(messagesToSend, options, ct);
 
         var hasToolCalls = false;
@@ -450,11 +476,9 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                 ToolCallId: result.ToolCallId!,
                 FunctionName: toolCall.FunctionName ?? string.Empty,
                 FunctionArgs: toolCall.FunctionArgs ?? "{}",
-                Placeholder: result.Result,
                 DeferredAtUnixMs: result.DeferredAt ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                 RunId: toolCall.RunId ?? runId,
-                GenerationId: toolCall.GenerationId ?? generationId,
-                Metadata: result.DeferralMetadata);
+                GenerationId: toolCall.GenerationId ?? generationId);
             _deferred[result.ToolCallId!] = deferredEntry;
 
             // Persist synchronously so a webhook-triggered ReplaceMessageAsync cannot race
@@ -570,37 +594,12 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         ToolCallMessage toolCall,
         ToolHandlerResult result)
     {
-        return result switch
-        {
-            ToolHandlerResult.Resolved r => new ToolCallResultMessage
-            {
-                ToolCallId = toolCall.ToolCallId,
-                ToolName = toolCall.FunctionName,
-                Result = r.Result.Result ?? string.Empty,
-                ContentBlocks = r.Result.ContentBlocks,
-                IsError = r.Result.IsError,
-                ErrorCode = r.Result.ErrorCode,
-                ExecutionTarget = ExecutionTarget.LocalFunction,
-                Role = Role.User,
-                FromAgent = toolCall.FromAgent,
-                GenerationId = toolCall.GenerationId,
-            },
-            ToolHandlerResult.Deferred d => new ToolCallResultMessage
-            {
-                ToolCallId = toolCall.ToolCallId,
-                ToolName = toolCall.FunctionName,
-                Result = d.Placeholder,
-                IsDeferred = true,
-                DeferralMetadata = d.Metadata,
-                DeferredAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                ExecutionTarget = ExecutionTarget.LocalFunction,
-                Role = Role.User,
-                FromAgent = toolCall.FromAgent,
-                GenerationId = toolCall.GenerationId,
-            },
-            _ => throw new InvalidOperationException(
-                $"Unknown ToolHandlerResult variant '{result.GetType().Name}'"),
-        };
+        var tcr = ToolCallResultBuilder.FromHandlerResult(result, toolCall.ToolCallId, toolCall.FunctionName);
+        return ToolCallResultMessage.FromToolCallResult(
+            tcr,
+            role: Role.User,
+            fromAgent: toolCall.FromAgent,
+            generationId: toolCall.GenerationId);
     }
 
     /// <summary>
@@ -656,7 +655,6 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                     IsError = isError,
                     ErrorCode = isError ? "deferred_resolution_error" : null,
                     IsDeferred = false,
-                    DeferralMetadata = null,
                     ResolvedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                 };
             }
@@ -719,9 +717,7 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                 ToolCallId = e.ToolCallId,
                 FunctionName = e.FunctionName,
                 FunctionArgs = e.FunctionArgs,
-                Placeholder = e.Placeholder,
                 DeferredAtUnixMs = e.DeferredAtUnixMs,
-                Metadata = e.Metadata,
                 RunId = e.RunId,
                 GenerationId = e.GenerationId,
             })
@@ -768,11 +764,9 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                 ToolCallId: tcr.ToolCallId,
                 FunctionName: sourceCall?.FunctionName ?? tcr.ToolName ?? string.Empty,
                 FunctionArgs: sourceCall?.FunctionArgs ?? "{}",
-                Placeholder: tcr.Result,
                 DeferredAtUnixMs: tcr.DeferredAt ?? 0,
                 RunId: tcr.RunId,
-                GenerationId: tcr.GenerationId,
-                Metadata: tcr.DeferralMetadata);
+                GenerationId: tcr.GenerationId);
             _deferred[tcr.ToolCallId] = entry;
 
             // Track the most recent (last in load order) deferring run/generation so a
@@ -897,9 +891,7 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         string ToolCallId,
         string FunctionName,
         string FunctionArgs,
-        string Placeholder,
         long DeferredAtUnixMs,
         string? RunId,
-        string? GenerationId,
-        ImmutableDictionary<string, string>? Metadata);
+        string? GenerationId);
 }

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -366,24 +366,31 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         // Precondition: never send a request while any deferred tool result is unresolved.
         // The provider would reject an empty tool_result.content, but the real bug is sending
         // at all — host code must call ResolveToolCallAsync before resuming.
-        foreach (var m in messagesToSend)
+        // Fast path: if no known deferrals exist, skip the O(n) history scan. The scan is
+        // belt-and-suspenders against history rebuilt from a store that wasn't routed
+        // through _deferred (e.g., a partially-applied OnHistoryRestoredAsync); when
+        // _deferred IS empty, the in-memory index is the authoritative answer.
+        if (!_deferred.IsEmpty)
         {
-            if (m is ToolCallResultMessage tcr && tcr.IsDeferred)
+            foreach (var m in messagesToSend)
             {
-                throw new InvalidOperationException(
-                    $"Cannot send request: tool call '{tcr.ToolCallId}' is still deferred. " +
-                    "Resolve all deferred tool calls via ResolveToolCallAsync before resuming.");
-            }
-
-            if (m is ToolsCallResultMessage agg)
-            {
-                foreach (var r in agg.ToolCallResults)
+                if (m is ToolCallResultMessage tcr && tcr.IsDeferred)
                 {
-                    if (r.IsDeferred)
+                    throw new InvalidOperationException(
+                        $"Cannot send request: tool call '{tcr.ToolCallId}' is still deferred. " +
+                        "Resolve all deferred tool calls via ResolveToolCallAsync before resuming.");
+                }
+
+                if (m is ToolsCallResultMessage agg)
+                {
+                    foreach (var r in agg.ToolCallResults)
                     {
-                        throw new InvalidOperationException(
-                            $"Cannot send request: tool call '{r.ToolCallId}' is still deferred. " +
-                            "Resolve all deferred tool calls via ResolveToolCallAsync before resuming.");
+                        if (r.IsDeferred)
+                        {
+                            throw new InvalidOperationException(
+                                $"Cannot send request: tool call '{r.ToolCallId}' is still deferred. " +
+                                "Resolve all deferred tool calls via ResolveToolCallAsync before resuming.");
+                        }
                     }
                 }
             }
@@ -482,8 +489,18 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
             _deferred[result.ToolCallId!] = deferredEntry;
 
             // Persist synchronously so a webhook-triggered ReplaceMessageAsync cannot race
-            // the placeholder's append.
-            await AddDeferredToHistoryAsync(result, ct);
+            // the placeholder's append. If persistence fails, unwind the deferred-entry
+            // registration so a future resolution doesn't find a half-applied state — the
+            // exception propagates up to the run loop and surfaces as a RunFailed.
+            try
+            {
+                await AddDeferredToHistoryAsync(result, ct);
+            }
+            catch
+            {
+                _ = _deferred.TryRemove(result.ToolCallId!, out _);
+                throw;
+            }
             await PublishToAllAsync(result, ct);
 
             Logger.LogInformation(
@@ -572,6 +589,13 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
             var result = await handler(functionArgs, ctx, ct);
             return BuildResultMessage(toolCall, result);
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Caller-initiated cancellation (shutdown, run abort) must propagate — converting
+            // it into an LLM-visible error message would silently swallow the abort and let
+            // the loop continue.
+            throw;
+        }
         catch (Exception ex)
         {
             // Tool execution errors are returned to the LLM for retry/correction
@@ -620,6 +644,7 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         IList<ToolResultContentBlock>? contentBlocks = null,
         CancellationToken ct = default)
     {
+        ThrowIfDisposed();
         ArgumentException.ThrowIfNullOrEmpty(toolCallId);
         ArgumentNullException.ThrowIfNull(result);
 
@@ -711,6 +736,7 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
     /// </summary>
     public Task<IReadOnlyList<DeferredToolCallInfo>> GetDeferredToolCallsAsync(CancellationToken ct = default)
     {
+        ThrowIfDisposed();
         var snapshot = _deferred.Values
             .Select(e => new DeferredToolCallInfo
             {
@@ -880,6 +906,29 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                 ex,
                 "Failed to enqueue resume sentinel for run {RunId}",
                 sentinelInput.Resume?.ResumeForRunId);
+
+            // Restore scheduling state so a future ResolveToolCallAsync (or per-run finally)
+            // can retry the sentinel. Without this, _resumeScheduled stays true and the
+            // deferring markers stay null — TryScheduleAutoResume short-circuits on its
+            // first guard and the loop is permanently stuck.
+            // Only restore if no concurrent state change happened; if a new turn has
+            // already deferred and set fresh markers, we must not clobber them.
+            var sentinelRunId = sentinelInput.Resume?.ResumeForRunId;
+            var sentinelGenId = sentinelInput.Resume?.ResumeForGenerationId;
+            if (sentinelRunId != null && sentinelGenId != null)
+            {
+                lock (_resumeLock)
+                {
+                    if (_resumeScheduled
+                        && _lastDeferringRunId == null
+                        && _lastDeferringGenerationId == null)
+                    {
+                        _lastDeferringRunId = sentinelRunId;
+                        _lastDeferringGenerationId = sentinelGenId;
+                        _resumeScheduled = false;
+                    }
+                }
+            }
         }
     }
 

--- a/src/LmMultiTurn/Persistence/FileConversationStore.cs
+++ b/src/LmMultiTurn/Persistence/FileConversationStore.cs
@@ -63,6 +63,37 @@ public sealed class FileConversationStore : IConversationStore
     }
 
     /// <inheritdoc />
+    public async Task ReplaceMessageAsync(
+        string threadId,
+        PersistedMessage replacement,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(threadId);
+        ArgumentNullException.ThrowIfNull(replacement);
+
+        await _lock.WaitAsync(ct);
+        try
+        {
+            var messagesFile = Path.Combine(GetThreadDirectory(threadId), MessagesFileName);
+            var existing = await LoadMessagesFromFileAsync(messagesFile, ct);
+            var idx = existing.FindIndex(m => m.Id == replacement.Id);
+            if (idx < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Message '{replacement.Id}' not found in thread '{threadId}'.");
+            }
+
+            // Preserve original timestamp so load ordering remains stable across replacement.
+            existing[idx] = replacement with { Timestamp = existing[idx].Timestamp };
+            await WriteJsonFileAsync(messagesFile, existing, ct);
+        }
+        finally
+        {
+            _ = _lock.Release();
+        }
+    }
+
+    /// <inheritdoc />
     public async Task<IReadOnlyList<PersistedMessage>> LoadMessagesAsync(
         string threadId,
         CancellationToken ct = default)

--- a/src/LmMultiTurn/Persistence/IConversationStore.cs
+++ b/src/LmMultiTurn/Persistence/IConversationStore.cs
@@ -29,6 +29,26 @@ public interface IConversationStore
         string threadId,
         CancellationToken ct = default);
 
+    /// <summary>
+    /// Replaces a single previously-appended message identified by its persisted Id.
+    /// Used to mutate <see cref="LmCore.Messages.ToolCallResultMessage"/> placeholders to their
+    /// final form when a deferred tool call is resolved via
+    /// <c>MultiTurnAgentLoop.ResolveToolCallAsync</c>.
+    /// </summary>
+    /// <remarks>
+    /// Implementations MUST preserve the message's original timestamp so that load ordering
+    /// remains stable across replacement. Throws <see cref="InvalidOperationException"/> if
+    /// no message with the given Id exists for the thread.
+    /// </remarks>
+    /// <param name="threadId">The thread identifier.</param>
+    /// <param name="replacement">The replacement message. Its <see cref="PersistedMessage.Id"/>
+    /// is the lookup key.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task ReplaceMessageAsync(
+        string threadId,
+        PersistedMessage replacement,
+        CancellationToken ct = default);
+
     // === Metadata (property bag for state, session mappings, etc.) ===
 
     /// <summary>

--- a/src/LmMultiTurn/Persistence/InMemoryConversationStore.cs
+++ b/src/LmMultiTurn/Persistence/InMemoryConversationStore.cs
@@ -36,6 +36,37 @@ public sealed class InMemoryConversationStore : IConversationStore
     }
 
     /// <inheritdoc />
+    public Task ReplaceMessageAsync(
+        string threadId,
+        PersistedMessage replacement,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(threadId);
+        ArgumentNullException.ThrowIfNull(replacement);
+
+        lock (_messagesLock)
+        {
+            if (!_messages.TryGetValue(threadId, out var threadMessages))
+            {
+                throw new InvalidOperationException(
+                    $"Thread '{threadId}' not found; cannot replace message '{replacement.Id}'.");
+            }
+
+            var idx = threadMessages.FindIndex(m => m.Id == replacement.Id);
+            if (idx < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Message '{replacement.Id}' not found in thread '{threadId}'.");
+            }
+
+            // Preserve the original timestamp so load ordering remains stable across replacement.
+            threadMessages[idx] = replacement with { Timestamp = threadMessages[idx].Timestamp };
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
     public Task<IReadOnlyList<PersistedMessage>> LoadMessagesAsync(
         string threadId,
         CancellationToken ct = default)

--- a/src/LmMultiTurn/Persistence/MessagePersistenceConverter.cs
+++ b/src/LmMultiTurn/Persistence/MessagePersistenceConverter.cs
@@ -34,11 +34,15 @@ public static class MessagePersistenceConverter
 
         var options = jsonOptions ?? DefaultOptions;
         var messageJson = JsonSerializer.Serialize(message, message.GetType(), options);
+        var effectiveThreadId = message.ThreadId ?? threadId;
 
         return new PersistedMessage
         {
-            Id = Guid.NewGuid().ToString("N"),
-            ThreadId = message.ThreadId ?? threadId,
+            // Deterministic Id for ToolCallResultMessage with a non-empty ToolCallId so that
+            // ReplaceMessageAsync can address the row without an in-memory index. Other message
+            // types keep a random Id since they're append-only.
+            Id = BuildPersistedId(message, effectiveThreadId),
+            ThreadId = effectiveThreadId,
             RunId = message.RunId ?? runId,
             ParentRunId = message.ParentRunId,
             GenerationId = message.GenerationId,
@@ -49,6 +53,28 @@ public static class MessagePersistenceConverter
             FromAgent = message.FromAgent,
             MessageJson = messageJson,
         };
+    }
+
+    /// <summary>
+    /// Constructs the deterministic persisted-Id for a <see cref="ToolCallResultMessage"/> with
+    /// a non-empty ToolCallId. Used by <c>MultiTurnAgentBase</c> when calling
+    /// <see cref="IConversationStore.ReplaceMessageAsync"/> on deferred-tool resolution.
+    /// </summary>
+    public static string BuildToolResultPersistedId(string threadId, string toolCallId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(threadId);
+        ArgumentException.ThrowIfNullOrEmpty(toolCallId);
+        return $"tcr:{threadId}:{toolCallId}";
+    }
+
+    private static string BuildPersistedId(IMessage message, string threadId)
+    {
+        if (message is ToolCallResultMessage tcr && !string.IsNullOrEmpty(tcr.ToolCallId))
+        {
+            return BuildToolResultPersistedId(threadId, tcr.ToolCallId);
+        }
+
+        return Guid.NewGuid().ToString("N");
     }
 
     /// <summary>

--- a/src/LmMultiTurn/Persistence/Sqlite/SqliteConversationStore.cs
+++ b/src/LmMultiTurn/Persistence/Sqlite/SqliteConversationStore.cs
@@ -106,6 +106,55 @@ public sealed class SqliteConversationStore : IConversationStore, IAsyncDisposab
     }
 
     /// <inheritdoc />
+    public async Task ReplaceMessageAsync(
+        string threadId,
+        PersistedMessage replacement,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(threadId);
+        ArgumentNullException.ThrowIfNull(replacement);
+
+        await EnsureSchemaAsync(ct).ConfigureAwait(false);
+
+        await using var connection = await _connectionFactory.GetConnectionAsync(ct)
+            .ConfigureAwait(false);
+
+        // Preserve the existing timestamp (don't update it on replace) so load ordering stays
+        // stable when a deferred placeholder is later resolved.
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            UPDATE messages SET
+                run_id = $run_id,
+                parent_run_id = $parent_run_id,
+                generation_id = $generation_id,
+                message_order_idx = $message_order_idx,
+                message_type = $message_type,
+                role = $role,
+                from_agent = $from_agent,
+                message_json = $message_json
+            WHERE id = $id AND thread_id = $thread_id;
+            """;
+
+        _ = command.Parameters.AddWithValue("$id", replacement.Id);
+        _ = command.Parameters.AddWithValue("$thread_id", threadId);
+        _ = command.Parameters.AddWithValue("$run_id", replacement.RunId);
+        _ = command.Parameters.AddWithValue("$parent_run_id", (object?)replacement.ParentRunId ?? DBNull.Value);
+        _ = command.Parameters.AddWithValue("$generation_id", (object?)replacement.GenerationId ?? DBNull.Value);
+        _ = command.Parameters.AddWithValue("$message_order_idx", (object?)replacement.MessageOrderIdx ?? DBNull.Value);
+        _ = command.Parameters.AddWithValue("$message_type", replacement.MessageType);
+        _ = command.Parameters.AddWithValue("$role", replacement.Role);
+        _ = command.Parameters.AddWithValue("$from_agent", (object?)replacement.FromAgent ?? DBNull.Value);
+        _ = command.Parameters.AddWithValue("$message_json", replacement.MessageJson);
+
+        var rows = await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        if (rows == 0)
+        {
+            throw new InvalidOperationException(
+                $"Message '{replacement.Id}' not found in thread '{threadId}'.");
+        }
+    }
+
+    /// <inheritdoc />
     public async Task<IReadOnlyList<PersistedMessage>> LoadMessagesAsync(
         string threadId,
         CancellationToken ct = default)

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -19,7 +19,7 @@ public sealed class SubAgentManager : IAsyncDisposable
 {
     private readonly IMultiTurnAgent _parentAgent;
     private readonly IReadOnlyList<FunctionContract> _parentContracts;
-    private readonly IDictionary<string, Func<string, Task<ToolHandlerResult>>> _parentHandlers;
+    private readonly IDictionary<string, ToolHandler> _parentHandlers;
     private readonly SubAgentOptions _options;
     private readonly ILogger _logger;
 
@@ -29,7 +29,7 @@ public sealed class SubAgentManager : IAsyncDisposable
     public SubAgentManager(
         IMultiTurnAgent parentAgent,
         IReadOnlyList<FunctionContract> parentContracts,
-        IDictionary<string, Func<string, Task<ToolHandlerResult>>> parentHandlers,
+        IDictionary<string, ToolHandler> parentHandlers,
         SubAgentOptions options,
         ILogger? logger = null)
     {

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -19,8 +19,7 @@ public sealed class SubAgentManager : IAsyncDisposable
 {
     private readonly IMultiTurnAgent _parentAgent;
     private readonly IReadOnlyList<FunctionContract> _parentContracts;
-    private readonly IDictionary<string, Func<string, Task<string>>> _parentHandlers;
-    private readonly IDictionary<string, Func<string, Task<ToolCallResult>>>? _parentMultiModalHandlers;
+    private readonly IDictionary<string, Func<string, Task<ToolHandlerResult>>> _parentHandlers;
     private readonly SubAgentOptions _options;
     private readonly ILogger _logger;
 
@@ -30,8 +29,7 @@ public sealed class SubAgentManager : IAsyncDisposable
     public SubAgentManager(
         IMultiTurnAgent parentAgent,
         IReadOnlyList<FunctionContract> parentContracts,
-        IDictionary<string, Func<string, Task<string>>> parentHandlers,
-        IDictionary<string, Func<string, Task<ToolCallResult>>>? parentMultiModalHandlers,
+        IDictionary<string, Func<string, Task<ToolHandlerResult>>> parentHandlers,
         SubAgentOptions options,
         ILogger? logger = null)
     {
@@ -43,7 +41,6 @@ public sealed class SubAgentManager : IAsyncDisposable
         _parentAgent = parentAgent;
         _parentContracts = parentContracts;
         _parentHandlers = parentHandlers;
-        _parentMultiModalHandlers = parentMultiModalHandlers;
         _options = options;
         _logger = logger ?? NullLogger.Instance;
         _concurrencyGate = new SemaphoreSlim(
@@ -373,10 +370,7 @@ public sealed class SubAgentManager : IAsyncDisposable
                 continue;
             }
 
-            Func<string, Task<ToolCallResult>>? mmHandler = null;
-            _parentMultiModalHandlers?.TryGetValue(contract.Name, out mmHandler);
-
-            registry.AddFunction(contract, handler, mmHandler, "ParentTools");
+            registry.AddFunction(contract, handler, "ParentTools");
         }
 
         return new MultiTurnAgentLoop(

--- a/src/LmMultiTurn/SubAgents/SubAgentToolProvider.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentToolProvider.cs
@@ -152,7 +152,10 @@ public class SubAgentToolProvider : IFunctionProvider
         };
     }
 
-    private async Task<ToolHandlerResult> HandleAgentToolAsync(string argsJson, ToolCallContext context)
+    private async Task<ToolHandlerResult> HandleAgentToolAsync(
+        string argsJson,
+        ToolCallContext context,
+        CancellationToken cancellationToken)
     {
         using var doc = JsonDocument.Parse(argsJson);
         var root = doc.RootElement;
@@ -183,7 +186,10 @@ public class SubAgentToolProvider : IFunctionProvider
             new ToolCallResult(null, await _manager.SpawnAsync(templateName, task, addTools, removeTools)));
     }
 
-    private Task<ToolHandlerResult> HandleCheckAgentToolAsync(string argsJson, ToolCallContext context)
+    private Task<ToolHandlerResult> HandleCheckAgentToolAsync(
+        string argsJson,
+        ToolCallContext context,
+        CancellationToken cancellationToken)
     {
         using var doc = JsonDocument.Parse(argsJson);
         var root = doc.RootElement;

--- a/src/LmMultiTurn/SubAgents/SubAgentToolProvider.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentToolProvider.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmCore.Models;
 
@@ -151,7 +152,7 @@ public class SubAgentToolProvider : IFunctionProvider
         };
     }
 
-    private async Task<string> HandleAgentToolAsync(string argsJson)
+    private async Task<ToolHandlerResult> HandleAgentToolAsync(string argsJson)
     {
         using var doc = JsonDocument.Parse(argsJson);
         var root = doc.RootElement;
@@ -164,7 +165,7 @@ public class SubAgentToolProvider : IFunctionProvider
         if (agentId != null)
         {
             // Resume or send to existing agent
-            return await _manager.ResumeAsync(agentId, task);
+            return new ToolHandlerResult.Resolved(new ToolCallResult(null, await _manager.ResumeAsync(agentId, task)));
         }
 
         // Spawn new agent
@@ -178,11 +179,11 @@ public class SubAgentToolProvider : IFunctionProvider
         var removeTools = ParseCommaSeparated(
             GetOptionalString(root, "remove_tools"));
 
-        return await _manager.SpawnAsync(
-            templateName, task, addTools, removeTools);
+        return new ToolHandlerResult.Resolved(
+            new ToolCallResult(null, await _manager.SpawnAsync(templateName, task, addTools, removeTools)));
     }
 
-    private Task<string> HandleCheckAgentToolAsync(string argsJson)
+    private Task<ToolHandlerResult> HandleCheckAgentToolAsync(string argsJson)
     {
         using var doc = JsonDocument.Parse(argsJson);
         var root = doc.RootElement;
@@ -191,7 +192,8 @@ public class SubAgentToolProvider : IFunctionProvider
             ?? throw new ArgumentException(
                 "The 'agent_id' parameter is required.");
 
-        return Task.FromResult(_manager.Peek(agentId));
+        return Task.FromResult<ToolHandlerResult>(
+            new ToolHandlerResult.Resolved(new ToolCallResult(null, _manager.Peek(agentId))));
     }
 
     private static string? GetOptionalString(

--- a/src/LmMultiTurn/SubAgents/SubAgentToolProvider.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentToolProvider.cs
@@ -152,7 +152,7 @@ public class SubAgentToolProvider : IFunctionProvider
         };
     }
 
-    private async Task<ToolHandlerResult> HandleAgentToolAsync(string argsJson)
+    private async Task<ToolHandlerResult> HandleAgentToolAsync(string argsJson, ToolCallContext context)
     {
         using var doc = JsonDocument.Parse(argsJson);
         var root = doc.RootElement;
@@ -183,7 +183,7 @@ public class SubAgentToolProvider : IFunctionProvider
             new ToolCallResult(null, await _manager.SpawnAsync(templateName, task, addTools, removeTools)));
     }
 
-    private Task<ToolHandlerResult> HandleCheckAgentToolAsync(string argsJson)
+    private Task<ToolHandlerResult> HandleCheckAgentToolAsync(string argsJson, ToolCallContext context)
     {
         using var doc = JsonDocument.Parse(argsJson);
         var root = doc.RootElement;

--- a/src/LmMultiTurn/SubAgents/SubAgentToolProvider.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentToolProvider.cs
@@ -168,7 +168,7 @@ public class SubAgentToolProvider : IFunctionProvider
         if (agentId != null)
         {
             // Resume or send to existing agent
-            return new ToolHandlerResult.Resolved(new ToolCallResult(null, await _manager.ResumeAsync(agentId, task)));
+            return ToolHandlerResult.FromText(await _manager.ResumeAsync(agentId, task));
         }
 
         // Spawn new agent
@@ -182,8 +182,8 @@ public class SubAgentToolProvider : IFunctionProvider
         var removeTools = ParseCommaSeparated(
             GetOptionalString(root, "remove_tools"));
 
-        return new ToolHandlerResult.Resolved(
-            new ToolCallResult(null, await _manager.SpawnAsync(templateName, task, addTools, removeTools)));
+        return ToolHandlerResult.FromText(
+            await _manager.SpawnAsync(templateName, task, addTools, removeTools));
     }
 
     private Task<ToolHandlerResult> HandleCheckAgentToolAsync(
@@ -199,7 +199,7 @@ public class SubAgentToolProvider : IFunctionProvider
                 "The 'agent_id' parameter is required.");
 
         return Task.FromResult<ToolHandlerResult>(
-            new ToolHandlerResult.Resolved(new ToolCallResult(null, _manager.Peek(agentId))));
+            ToolHandlerResult.FromText(_manager.Peek(agentId)));
     }
 
     private static string? GetOptionalString(

--- a/src/McpMiddleware/McpClientFunctionProvider.cs
+++ b/src/McpMiddleware/McpClientFunctionProvider.cs
@@ -201,7 +201,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                         Name = tool.Name,
                         Description = tool.Description ?? string.Empty,
                     },
-                    Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
+                    Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
                     ProviderName = serverId,
                 };
 
@@ -472,7 +472,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                     var descriptor = new FunctionDescriptor
                     {
                         Contract = new FunctionContract { Name = tool.Name },
-                        Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))),
+                        Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))),
                         ProviderName = serverId,
                     };
 
@@ -1050,7 +1050,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                         var descriptor = new FunctionDescriptor
                         {
                             Contract = new FunctionContract { Name = tool.Name },
-                            Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
+                            Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
                             ProviderName = serverId,
                         };
 
@@ -1137,7 +1137,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                     var descriptor = new FunctionDescriptor
                     {
                         Contract = new FunctionContract { Name = tool.Name },
-                        Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
+                        Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
                         ProviderName = serverId,
                     };
 

--- a/src/McpMiddleware/McpClientFunctionProvider.cs
+++ b/src/McpMiddleware/McpClientFunctionProvider.cs
@@ -201,7 +201,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                         Name = tool.Name,
                         Description = tool.Description ?? string.Empty,
                     },
-                    Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
+                    Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
                     ProviderName = serverId,
                 };
 
@@ -472,7 +472,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                     var descriptor = new FunctionDescriptor
                     {
                         Contract = new FunctionContract { Name = tool.Name },
-                        Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))),
+                        Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))),
                         ProviderName = serverId,
                     };
 
@@ -1050,7 +1050,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                         var descriptor = new FunctionDescriptor
                         {
                             Contract = new FunctionContract { Name = tool.Name },
-                            Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
+                            Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
                             ProviderName = serverId,
                         };
 
@@ -1137,7 +1137,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                     var descriptor = new FunctionDescriptor
                     {
                         Contract = new FunctionContract { Name = tool.Name },
-                        Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
+                        Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
                         ProviderName = serverId,
                     };
 

--- a/src/McpMiddleware/McpClientFunctionProvider.cs
+++ b/src/McpMiddleware/McpClientFunctionProvider.cs
@@ -91,12 +91,17 @@ public partial class McpClientFunctionProvider : IFunctionProvider
             if (functionMap.TryGetValue(key, out var handler))
             {
                 multiModalMap.TryGetValue(key, out var multiModalHandler);
+                // The multi-modal handler (returning ToolCallResult with optional ContentBlocks)
+                // is the canonical handler shape; the text-only handler is no longer used.
+                // Wrap the multi-modal flavor when available, otherwise wrap the text handler.
+                var unifiedHandler = multiModalHandler != null
+                    ? LegacyHandlerAdapter.ToNewHandler(multiModalHandler)
+                    : LegacyHandlerAdapter.ToNewHandler(handler);
                 functions.Add(
                     new FunctionDescriptor
                     {
                         Contract = contract,
-                        Handler = handler,
-                        MultiModalHandler = multiModalHandler,
+                        Handler = unifiedHandler,
                         ProviderName = providerName ?? "McpClient",
                     }
                 );
@@ -196,7 +201,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                         Name = tool.Name,
                         Description = tool.Description ?? string.Empty,
                     },
-                    Handler = _ => Task.FromResult(string.Empty), // Dummy handler
+                    Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
                     ProviderName = serverId,
                 };
 
@@ -270,12 +275,17 @@ public partial class McpClientFunctionProvider : IFunctionProvider
             if (functionMap.TryGetValue(key, out var handler))
             {
                 multiModalMap.TryGetValue(key, out var multiModalHandler);
+                // The multi-modal handler (returning ToolCallResult with optional ContentBlocks)
+                // is the canonical handler shape; the text-only handler is no longer used.
+                // Wrap the multi-modal flavor when available, otherwise wrap the text handler.
+                var unifiedHandler = multiModalHandler != null
+                    ? LegacyHandlerAdapter.ToNewHandler(multiModalHandler)
+                    : LegacyHandlerAdapter.ToNewHandler(handler);
                 functions.Add(
                     new FunctionDescriptor
                     {
                         Contract = contract,
-                        Handler = handler,
-                        MultiModalHandler = multiModalHandler,
+                        Handler = unifiedHandler,
                         ProviderName = providerName ?? "McpClient",
                     }
                 );
@@ -462,7 +472,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                     var descriptor = new FunctionDescriptor
                     {
                         Contract = new FunctionContract { Name = tool.Name },
-                        Handler = _ => Task.FromResult(string.Empty),
+                        Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))),
                         ProviderName = serverId,
                     };
 
@@ -1040,7 +1050,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                         var descriptor = new FunctionDescriptor
                         {
                             Contract = new FunctionContract { Name = tool.Name },
-                            Handler = _ => Task.FromResult(string.Empty), // Dummy handler
+                            Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
                             ProviderName = serverId,
                         };
 
@@ -1127,7 +1137,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                     var descriptor = new FunctionDescriptor
                     {
                         Contract = new FunctionContract { Name = tool.Name },
-                        Handler = _ => Task.FromResult(string.Empty), // Dummy handler
+                        Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
                         ProviderName = serverId,
                     };
 

--- a/src/McpMiddleware/McpClientFunctionProvider.cs
+++ b/src/McpMiddleware/McpClientFunctionProvider.cs
@@ -201,7 +201,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                         Name = tool.Name,
                         Description = tool.Description ?? string.Empty,
                     },
-                    Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
+                    Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText(string.Empty)), // Dummy handler
                     ProviderName = serverId,
                 };
 
@@ -472,7 +472,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                     var descriptor = new FunctionDescriptor
                     {
                         Contract = new FunctionContract { Name = tool.Name },
-                        Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))),
+                        Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText(string.Empty)),
                         ProviderName = serverId,
                     };
 
@@ -1050,7 +1050,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                         var descriptor = new FunctionDescriptor
                         {
                             Contract = new FunctionContract { Name = tool.Name },
-                            Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
+                            Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText(string.Empty)), // Dummy handler
                             ProviderName = serverId,
                         };
 
@@ -1137,7 +1137,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                     var descriptor = new FunctionDescriptor
                     {
                         Contract = new FunctionContract { Name = tool.Name },
-                        Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
+                        Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText(string.Empty)), // Dummy handler
                         ProviderName = serverId,
                     };
 

--- a/src/McpMiddleware/McpFunctionCallExtensions.cs
+++ b/src/McpMiddleware/McpFunctionCallExtensions.cs
@@ -223,6 +223,9 @@ public static class McpFunctionCallExtensions
     )
     {
         var (functions, functionMap) = CreateFunctionCallComponentsFromAssembly(toolAssembly);
-        return new FunctionCallMiddleware(functions, functionMap, multiModalFunctionMap: null, name: name);
+        return new FunctionCallMiddleware(
+            functions,
+            LegacyHandlerAdapter.WrapToNewHandlers(functionMap),
+            name: name);
     }
 }

--- a/src/McpMiddleware/McpFunctionProvider.cs
+++ b/src/McpMiddleware/McpFunctionProvider.cs
@@ -30,7 +30,8 @@ public class McpFunctionProvider : IFunctionProvider
         return contracts.Select(contract => new FunctionDescriptor
         {
             Contract = contract,
-            Handler = handlers[contract.ClassName != null ? $"{contract.ClassName}-{contract.Name}" : contract.Name],
+            Handler = LegacyHandlerAdapter.ToNewHandler(
+                handlers[contract.ClassName != null ? $"{contract.ClassName}-{contract.Name}" : contract.Name]),
             ProviderName = ProviderName,
         });
     }

--- a/src/McpMiddleware/McpMiddleware.cs
+++ b/src/McpMiddleware/McpMiddleware.cs
@@ -46,11 +46,12 @@ public partial class McpMiddleware : IStreamingMiddleware
         Name = name;
         _logger = logger;
 
-        // Initialize the FunctionCallMiddleware with our function map and logger
+        // Initialize the FunctionCallMiddleware with our function map and logger.
+        // McpMiddleware tools always resolve synchronously via the underlying MCP client;
+        // wrap legacy-shape handlers into the new ToolHandlerResult shape for FunctionCallMiddleware.
         _functionCallMiddleware = new FunctionCallMiddleware(
             functions,
-            functionMap,
-            multiModalFunctionMap: null,
+            LegacyHandlerAdapter.WrapToNewHandlers(functionMap),
             name: Name,
             logger: functionCallLogger);
     }

--- a/src/McpMiddleware/McpToolCollisionDetector.cs
+++ b/src/McpMiddleware/McpToolCollisionDetector.cs
@@ -1,5 +1,6 @@
 using AchieveAi.LmDotnetTools.LmCore.Configuration;
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -58,7 +59,7 @@ public class McpToolCollisionDetector
                         Name = tool.Name,
                         Description = tool.Description ?? string.Empty,
                     },
-                    Handler = _ => Task.FromResult(string.Empty), // Dummy handler
+                    Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
                     ProviderName = serverId,
                 };
 

--- a/src/McpMiddleware/McpToolCollisionDetector.cs
+++ b/src/McpMiddleware/McpToolCollisionDetector.cs
@@ -59,7 +59,7 @@ public class McpToolCollisionDetector
                         Name = tool.Name,
                         Description = tool.Description ?? string.Empty,
                     },
-                    Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
+                    Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
                     ProviderName = serverId,
                 };
 

--- a/src/McpMiddleware/McpToolCollisionDetector.cs
+++ b/src/McpMiddleware/McpToolCollisionDetector.cs
@@ -59,7 +59,7 @@ public class McpToolCollisionDetector
                         Name = tool.Name,
                         Description = tool.Description ?? string.Empty,
                     },
-                    Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
+                    Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
                     ProviderName = serverId,
                 };
 

--- a/src/McpMiddleware/McpToolCollisionDetector.cs
+++ b/src/McpMiddleware/McpToolCollisionDetector.cs
@@ -59,7 +59,7 @@ public class McpToolCollisionDetector
                         Name = tool.Name,
                         Description = tool.Description ?? string.Empty,
                     },
-                    Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
+                    Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText(string.Empty)), // Dummy handler
                     ProviderName = serverId,
                 };
 

--- a/src/McpMiddleware/McpToolFilter.cs
+++ b/src/McpMiddleware/McpToolFilter.cs
@@ -1,5 +1,6 @@
 using AchieveAi.LmDotnetTools.LmCore.Configuration;
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using Microsoft.Extensions.Logging;
 
@@ -74,7 +75,7 @@ public class McpToolFilter
         var descriptor = new FunctionDescriptor
         {
             Contract = new FunctionContract { Name = originalToolName },
-            Handler = _ => Task.FromResult(string.Empty), // Dummy handler
+            Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
             ProviderName = serverId,
         };
 

--- a/src/McpMiddleware/McpToolFilter.cs
+++ b/src/McpMiddleware/McpToolFilter.cs
@@ -75,7 +75,7 @@ public class McpToolFilter
         var descriptor = new FunctionDescriptor
         {
             Contract = new FunctionContract { Name = originalToolName },
-            Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
+            Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
             ProviderName = serverId,
         };
 

--- a/src/McpMiddleware/McpToolFilter.cs
+++ b/src/McpMiddleware/McpToolFilter.cs
@@ -75,7 +75,7 @@ public class McpToolFilter
         var descriptor = new FunctionDescriptor
         {
             Contract = new FunctionContract { Name = originalToolName },
-            Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
+            Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
             ProviderName = serverId,
         };
 

--- a/src/McpMiddleware/McpToolFilter.cs
+++ b/src/McpMiddleware/McpToolFilter.cs
@@ -75,7 +75,7 @@ public class McpToolFilter
         var descriptor = new FunctionDescriptor
         {
             Contract = new FunctionContract { Name = originalToolName },
-            Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, string.Empty))), // Dummy handler
+            Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText(string.Empty)), // Dummy handler
             ProviderName = serverId,
         };
 

--- a/src/McpServer.AspNetCore/FunctionProviderMcpAdapter.cs
+++ b/src/McpServer.AspNetCore/FunctionProviderMcpAdapter.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmCore.Models;
 using Microsoft.Extensions.DependencyInjection;
@@ -36,7 +37,11 @@ public static class FunctionProviderMcpAdapter
                     .SelectMany(p => p.GetFunctions())
                     .ToList();
 
-                // Build a lookup dictionary: toolName -> (contract, handler)
+                // Build a lookup dictionary: toolName -> (contract, handler).
+                // FunctionDescriptor.Handler is now Func<string, Task<ToolHandlerResult>>; this MCP
+                // server adapter doesn't support deferred tool execution (it has no resolution
+                // channel), so we adapt to the legacy string-returning shape and a Deferred return
+                // surfaces as NotSupportedException at call time.
                 var toolLookup = new Dictionary<string, (FunctionContract Contract, Func<string, Task<string>> Handler)>();
 
                 foreach (var functionDescriptor in allFunctions)
@@ -52,7 +57,8 @@ public static class FunctionProviderMcpAdapter
                         continue;
                     }
 
-                    toolLookup[toolName] = (functionDescriptor.Contract, functionDescriptor.Handler);
+                    var legacyHandler = LegacyHandlerAdapter.ToLegacyHandler(functionDescriptor.Handler, toolName);
+                    toolLookup[toolName] = (functionDescriptor.Contract, legacyHandler);
 
                     logger?.LogDebug(
                         "Registered MCP tool '{ToolName}' from provider '{Provider}'",

--- a/tests/AnthropicProvider.Tests/Agents/MultiModalToolResultEndToEndTests.cs
+++ b/tests/AnthropicProvider.Tests/Agents/MultiModalToolResultEndToEndTests.cs
@@ -52,7 +52,7 @@ public class MultiModalToolResultEndToEndTests : LoggingTestBase
         // ToolCallResult, no separate map.
         var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["search_tool"] = (_, _) => Task.FromResult<ToolHandlerResult>(
+            ["search_tool"] = (_, _, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Resolved(new ToolCallResult(
                     null,
                     "Here is a medical diagram:",

--- a/tests/AnthropicProvider.Tests/Agents/MultiModalToolResultEndToEndTests.cs
+++ b/tests/AnthropicProvider.Tests/Agents/MultiModalToolResultEndToEndTests.cs
@@ -47,31 +47,27 @@ public class MultiModalToolResultEndToEndTests : LoggingTestBase
             ],
         };
 
-        // Text-only function map (required by FunctionCallMiddleware validation)
-        var functionMap = new Dictionary<string, Func<string, Task<string>>>
+        // Unified function map: handler returns ToolHandlerResult.Resolved wrapping a
+        // ToolCallResult — multi-modal payload is carried via ContentBlocks on the
+        // ToolCallResult, no separate map.
+        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
         {
-            ["search_tool"] = _ => Task.FromResult("Search result text"),
-        };
-
-        // Multimodal function map: simulates an MCP tool returning text + image
-        var mmFunctionMap = new Dictionary<string, Func<string, Task<ToolCallResult>>>
-        {
-            ["search_tool"] = _ => Task.FromResult(new ToolCallResult(
-                null,
-                "Here is a medical diagram:",
-                [
-                    new TextToolResultBlock { Text = "Here is a medical diagram:" },
-                    new ImageToolResultBlock
-                    {
-                        Data = CreateMinimalPngBase64(),
-                        MimeType = "image/png",
-                    },
-                ])),
+            ["search_tool"] = _ => Task.FromResult<ToolHandlerResult>(
+                new ToolHandlerResult.Resolved(new ToolCallResult(
+                    null,
+                    "Here is a medical diagram:",
+                    [
+                        new TextToolResultBlock { Text = "Here is a medical diagram:" },
+                        new ImageToolResultBlock
+                        {
+                            Data = CreateMinimalPngBase64(),
+                            MimeType = "image/png",
+                        },
+                    ]))),
         };
 
         // Build middleware and wrap agent for the full pipeline
-        var middleware = new FunctionCallMiddleware(
-            [toolContract], functionMap, mmFunctionMap);
+        var middleware = new FunctionCallMiddleware([toolContract], functionMap);
         var agentWithMiddleware = agent.WithMiddleware(middleware);
         Logger.LogDebug("Agent wrapped with FunctionCallMiddleware (multimodal enabled)");
 

--- a/tests/AnthropicProvider.Tests/Agents/MultiModalToolResultEndToEndTests.cs
+++ b/tests/AnthropicProvider.Tests/Agents/MultiModalToolResultEndToEndTests.cs
@@ -50,9 +50,9 @@ public class MultiModalToolResultEndToEndTests : LoggingTestBase
         // Unified function map: handler returns ToolHandlerResult.Resolved wrapping a
         // ToolCallResult — multi-modal payload is carried via ContentBlocks on the
         // ToolCallResult, no separate map.
-        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
+        var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["search_tool"] = _ => Task.FromResult<ToolHandlerResult>(
+            ["search_tool"] = (_, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Resolved(new ToolCallResult(
                     null,
                     "Here is a medical diagram:",

--- a/tests/AnthropicProvider.Tests/Agents/MultiModalToolResultEndToEndTests.cs
+++ b/tests/AnthropicProvider.Tests/Agents/MultiModalToolResultEndToEndTests.cs
@@ -47,14 +47,12 @@ public class MultiModalToolResultEndToEndTests : LoggingTestBase
             ],
         };
 
-        // Unified function map: handler returns ToolHandlerResult.Resolved wrapping a
-        // ToolCallResult — multi-modal payload is carried via ContentBlocks on the
-        // ToolCallResult, no separate map.
+        // Unified function map: handler returns ToolHandlerResult.FromMultiModal — the text and
+        // content blocks travel through the payload struct.
         var functionMap = new Dictionary<string, ToolHandler>
         {
             ["search_tool"] = (_, _, _) => Task.FromResult<ToolHandlerResult>(
-                new ToolHandlerResult.Resolved(new ToolCallResult(
-                    null,
+                ToolHandlerResult.FromMultiModal(
                     "Here is a medical diagram:",
                     [
                         new TextToolResultBlock { Text = "Here is a medical diagram:" },
@@ -63,7 +61,7 @@ public class MultiModalToolResultEndToEndTests : LoggingTestBase
                             Data = CreateMinimalPngBase64(),
                             MimeType = "image/png",
                         },
-                    ]))),
+                    ])),
         };
 
         // Build middleware and wrap agent for the full pipeline

--- a/tests/LmCore.Tests/Integration/AgenticLoopIntegrationTests.cs
+++ b/tests/LmCore.Tests/Integration/AgenticLoopIntegrationTests.cs
@@ -48,9 +48,9 @@ public class AgenticLoopIntegrationTests
         var middleware = new MessageTransformationMiddleware();
         var agent = new MiddlewareWrappingAgent(mockProvider, middleware);
         // Define tool function
-        var functionMap = new Dictionary<string, Func<string, Task<ToolCallResult>>>
+        var functionMap = new Dictionary<string, ToolCallResultHandler>
         {
-            ["get_weather"] = args => Task.FromResult(new ToolCallResult(null, "{\"temperature\": 72, \"condition\": \"sunny\"}")),
+            ["get_weather"] = (args, _) => Task.FromResult(new ToolCallResult(null, "{\"temperature\": 72, \"condition\": \"sunny\"}")),
         };
         // Act
         // Step 1: Initial call to LLM
@@ -174,9 +174,9 @@ public class AgenticLoopIntegrationTests
         );
         var middleware = new MessageTransformationMiddleware();
         var agent = new MiddlewareWrappingAgent(mockProvider, middleware);
-        var functionMap = new Dictionary<string, Func<string, Task<ToolCallResult>>>
+        var functionMap = new Dictionary<string, ToolCallResultHandler>
         {
-            ["get_weather"] = args =>
+            ["get_weather"] = (args, _) =>
             {
                 var location = args.Contains("SF") ? "SF" : "NYC";
                 var temp = location == "SF" ? "72" : "65";

--- a/tests/LmCore.Tests/Integration/AgenticLoopIntegrationTests.cs
+++ b/tests/LmCore.Tests/Integration/AgenticLoopIntegrationTests.cs
@@ -1,4 +1,6 @@
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmCore.Models;
 
 namespace AchieveAi.LmDotnetTools.LmCore.Tests.Integration;
@@ -46,9 +48,9 @@ public class AgenticLoopIntegrationTests
         var middleware = new MessageTransformationMiddleware();
         var agent = new MiddlewareWrappingAgent(mockProvider, middleware);
         // Define tool function
-        var functionMap = new Dictionary<string, Func<string, Task<string>>>
+        var functionMap = new Dictionary<string, Func<string, Task<ToolCallResult>>>
         {
-            ["get_weather"] = args => Task.FromResult("{\"temperature\": 72, \"condition\": \"sunny\"}"),
+            ["get_weather"] = args => Task.FromResult(new ToolCallResult(null, "{\"temperature\": 72, \"condition\": \"sunny\"}")),
         };
         // Act
         // Step 1: Initial call to LLM
@@ -172,13 +174,13 @@ public class AgenticLoopIntegrationTests
         );
         var middleware = new MessageTransformationMiddleware();
         var agent = new MiddlewareWrappingAgent(mockProvider, middleware);
-        var functionMap = new Dictionary<string, Func<string, Task<string>>>
+        var functionMap = new Dictionary<string, Func<string, Task<ToolCallResult>>>
         {
             ["get_weather"] = args =>
             {
                 var location = args.Contains("SF") ? "SF" : "NYC";
                 var temp = location == "SF" ? "72" : "65";
-                return Task.FromResult($"{{\"temperature\": {temp}}}");
+                return Task.FromResult(new ToolCallResult(null, $"{{\"temperature\": {temp}}}"));
             },
         };
         // Act

--- a/tests/LmCore.Tests/Integration/AgenticLoopIntegrationTests.cs
+++ b/tests/LmCore.Tests/Integration/AgenticLoopIntegrationTests.cs
@@ -50,7 +50,7 @@ public class AgenticLoopIntegrationTests
         // Define tool function
         var functionMap = new Dictionary<string, ToolCallResultHandler>
         {
-            ["get_weather"] = (args, _) => Task.FromResult(new ToolCallResult(null, "{\"temperature\": 72, \"condition\": \"sunny\"}")),
+            ["get_weather"] = (args, _, _) => Task.FromResult(new ToolCallResult(null, "{\"temperature\": 72, \"condition\": \"sunny\"}")),
         };
         // Act
         // Step 1: Initial call to LLM
@@ -176,7 +176,7 @@ public class AgenticLoopIntegrationTests
         var agent = new MiddlewareWrappingAgent(mockProvider, middleware);
         var functionMap = new Dictionary<string, ToolCallResultHandler>
         {
-            ["get_weather"] = (args, _) =>
+            ["get_weather"] = (args, _, _) =>
             {
                 var location = args.Contains("SF") ? "SF" : "NYC";
                 var temp = location == "SF" ? "72" : "65";

--- a/tests/LmCore.Tests/Integration/LoggingIntegrationTests.cs
+++ b/tests/LmCore.Tests/Integration/LoggingIntegrationTests.cs
@@ -1,6 +1,7 @@
 using AchieveAi.LmDotnetTools.LmConfig.Agents;
 using AchieveAi.LmDotnetTools.LmConfig.Models;
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmCore.Models;
 using AchieveAi.LmDotnetTools.OpenAIProvider.Agents;
 using Microsoft.Extensions.DependencyInjection;
@@ -145,7 +146,7 @@ public class LoggingIntegrationTests : IDisposable
             },
         };
 
-        var middleware = new FunctionCallMiddleware([testFunction], functionMap, name: "TestMiddleware", logger: _middlewareLogger);
+        var middleware = new FunctionCallMiddleware([testFunction], LegacyHandlerAdapter.WrapToNewHandlers(functionMap), name: "TestMiddleware", logger: _middlewareLogger);
 
         var mockAgent = new Mock<IAgent>();
         var toolCall = new ToolCall { FunctionName = "TestFunction", FunctionArgs = "{\"input\":\"test\"}" };

--- a/tests/LmCore.Tests/Logging/LoggingSystemIntegrationTests.cs
+++ b/tests/LmCore.Tests/Logging/LoggingSystemIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 namespace AchieveAi.LmDotnetTools.LmCore.Tests.Logging;
@@ -50,7 +51,7 @@ public class LoggingSystemIntegrationTests
             )
             .ReturnsAsync([new TextMessage { Text = "Response", Role = Role.Assistant }]);
 
-        var middleware = new FunctionCallMiddleware(functions, functionMap, name: "perf-test", logger: mockLogger.Object);
+        var middleware = new FunctionCallMiddleware(functions, LegacyHandlerAdapter.WrapToNewHandlers(functionMap), name: "perf-test", logger: mockLogger.Object);
 
         // Act - Measure performance
         const int iterations = 100;
@@ -116,7 +117,7 @@ public class LoggingSystemIntegrationTests
         var messages = new List<IMessage> { toolCallMessage };
         var context = new MiddlewareContext(messages);
 
-        var middleware = new FunctionCallMiddleware(functions, functionMap, name: "error-test-middleware", logger: mockLogger.Object);
+        var middleware = new FunctionCallMiddleware(functions, LegacyHandlerAdapter.WrapToNewHandlers(functionMap), name: "error-test-middleware", logger: mockLogger.Object);
 
         // Act
         _ = await middleware.InvokeAsync(context, new Mock<IAgent>().Object);
@@ -162,7 +163,7 @@ public class LoggingSystemIntegrationTests
         };
 
         // Act & Assert - Should not throw with null logger
-        var middleware = new FunctionCallMiddleware(functions, functionMap, name: "test-middleware");
+        var middleware = new FunctionCallMiddleware(functions, LegacyHandlerAdapter.WrapToNewHandlers(functionMap), name: "test-middleware");
         Assert.NotNull(middleware);
         Assert.Equal("test-middleware", middleware.Name);
     }
@@ -203,7 +204,7 @@ public class LoggingSystemIntegrationTests
             )
             .ReturnsAsync([new TextMessage { Text = "Response", Role = Role.Assistant }]);
 
-        var middleware = new FunctionCallMiddleware(functions, functionMap, name: "test-middleware", logger: mockLogger.Object);
+        var middleware = new FunctionCallMiddleware(functions, LegacyHandlerAdapter.WrapToNewHandlers(functionMap), name: "test-middleware", logger: mockLogger.Object);
 
         // Act
         _ = await middleware.InvokeAsync(context, mockAgent.Object);
@@ -260,7 +261,7 @@ public class LoggingSystemIntegrationTests
 
         var middleware = new FunctionCallMiddleware(
             functions,
-            functionMap,
+            LegacyHandlerAdapter.WrapToNewHandlers(functionMap),
             name: "logging-test-middleware",
             logger: mockLogger.Object
         );
@@ -403,7 +404,7 @@ public class LoggingSystemIntegrationTests
         };
 
         // Should not throw with null logger
-        var middleware = new FunctionCallMiddleware(functions, functionMap, name: "null-safe-test");
+        var middleware = new FunctionCallMiddleware(functions, LegacyHandlerAdapter.WrapToNewHandlers(functionMap), name: "null-safe-test");
         Assert.NotNull(middleware);
         Assert.Equal("null-safe-test", middleware.Name);
     }

--- a/tests/LmCore.Tests/Messages/ToolHandlerResultTests.cs
+++ b/tests/LmCore.Tests/Messages/ToolHandlerResultTests.cs
@@ -1,0 +1,135 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using FluentAssertions;
+using Xunit;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.Messages;
+
+public class ToolHandlerResultTests
+{
+    [Fact]
+    public void ImplicitConversion_FromString_ProducesResolved()
+    {
+        ToolHandlerResult result = "hello";
+
+        result.Should().BeOfType<ToolHandlerResult.Resolved>();
+        ((ToolHandlerResult.Resolved)result).Result.Result.Should().Be("hello");
+    }
+
+    [Fact]
+    public void FromString_FactoryHelper_ProducesResolved()
+    {
+        var result = ToolHandlerResult.FromString("payload");
+
+        result.Should().BeOfType<ToolHandlerResult.Resolved>();
+        result.Result.Result.Should().Be("payload");
+    }
+
+    [Fact]
+    public void ImplicitConversion_FromToolCallResult_ProducesResolved()
+    {
+        var inner = new ToolCallResult(null, "complex", new List<ToolResultContentBlock>
+        {
+            new TextToolResultBlock { Text = "rich" },
+        });
+        ToolHandlerResult result = inner;
+
+        result.Should().BeOfType<ToolHandlerResult.Resolved>();
+        var resolved = (ToolHandlerResult.Resolved)result;
+        resolved.Result.Result.Should().Be("complex");
+        resolved.Result.ContentBlocks.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Deferred_CarriesPlaceholderAndMetadata()
+    {
+        var metadata = ImmutableDictionary.CreateRange(new Dictionary<string, string>
+        {
+            ["correlation_id"] = "abc-123",
+            ["expected_wait_seconds"] = "60",
+        });
+
+        var deferred = new ToolHandlerResult.Deferred("PENDING approval", metadata);
+
+        deferred.Placeholder.Should().Be("PENDING approval");
+        deferred.Metadata.Should().NotBeNull();
+        deferred.Metadata!["correlation_id"].Should().Be("abc-123");
+    }
+
+    [Fact]
+    public void ResultText_OnResolved_ReturnsValue()
+    {
+        ToolHandlerResult resolved = new ToolHandlerResult.Resolved(new ToolCallResult(null, "payload"));
+        resolved.ResultText.Should().Be("payload");
+    }
+
+    [Fact]
+    public void ResultText_OnDeferred_Throws()
+    {
+        ToolHandlerResult deferred = new ToolHandlerResult.Deferred("pending");
+
+        var act = () => _ = deferred.ResultText;
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*deferred*");
+    }
+
+    [Fact]
+    public void PatternMatch_DistinguishesVariantsExhaustively()
+    {
+        ToolHandlerResult resolved = new ToolHandlerResult.Resolved(new ToolCallResult(null, "ok"));
+        ToolHandlerResult deferred = new ToolHandlerResult.Deferred("pending");
+
+        string Match(ToolHandlerResult r) => r switch
+        {
+            ToolHandlerResult.Resolved x => $"resolved:{x.Result.Result}",
+            ToolHandlerResult.Deferred x => $"deferred:{x.Placeholder}",
+            _ => throw new InvalidOperationException("unreachable"),
+        };
+
+        Match(resolved).Should().Be("resolved:ok");
+        Match(deferred).Should().Be("deferred:pending");
+    }
+
+    [Fact]
+    public void ToolCallResultMessage_RoundTrips_DeferredFields()
+    {
+        var original = new ToolCallResultMessage
+        {
+            ToolCallId = "tc_1",
+            Result = "PENDING",
+            ToolName = "approval_tool",
+            IsDeferred = true,
+            DeferredAt = 1_700_000_000_000,
+            DeferralMetadata = ImmutableDictionary.CreateRange(new Dictionary<string, string>
+            {
+                ["correlation"] = "abc",
+            }),
+        };
+
+        var json = JsonSerializer.Serialize(original);
+        var roundTripped = JsonSerializer.Deserialize<ToolCallResultMessage>(json);
+
+        roundTripped.Should().NotBeNull();
+        roundTripped!.ToolCallId.Should().Be("tc_1");
+        roundTripped.IsDeferred.Should().BeTrue();
+        roundTripped.DeferredAt.Should().Be(1_700_000_000_000);
+        roundTripped.DeferralMetadata.Should().NotBeNull();
+        roundTripped.DeferralMetadata!["correlation"].Should().Be("abc");
+    }
+
+    [Fact]
+    public void ToolCallResultMessage_Resolved_Has_ResolvedAt_And_ClearedDeferredFlag()
+    {
+        var resolved = new ToolCallResultMessage
+        {
+            ToolCallId = "tc_1",
+            Result = "real",
+            IsDeferred = false,
+            ResolvedAt = 1_700_000_001_000,
+        };
+
+        resolved.IsDeferred.Should().BeFalse();
+        resolved.ResolvedAt.Should().Be(1_700_000_001_000);
+    }
+}

--- a/tests/LmCore.Tests/Messages/ToolHandlerResultTests.cs
+++ b/tests/LmCore.Tests/Messages/ToolHandlerResultTests.cs
@@ -132,4 +132,167 @@ public class ToolHandlerResultTests
         resolved.IsDeferred.Should().BeFalse();
         resolved.ResolvedAt.Should().Be(1_700_000_001_000);
     }
+
+    [Fact]
+    public void ToolCallResult_Struct_DeferredFields_AreSettableViaWith()
+    {
+        var initial = new ToolCallResult("tc_1", "PENDING");
+        var metadata = ImmutableDictionary.CreateRange(new Dictionary<string, string>
+        {
+            ["correlation"] = "xyz",
+        });
+
+        var deferred = initial with
+        {
+            IsDeferred = true,
+            DeferralMetadata = metadata,
+            DeferredAt = 1_700_000_000_000,
+        };
+
+        deferred.IsDeferred.Should().BeTrue();
+        deferred.DeferralMetadata.Should().NotBeNull();
+        deferred.DeferralMetadata!["correlation"].Should().Be("xyz");
+        deferred.DeferredAt.Should().Be(1_700_000_000_000);
+        deferred.ResolvedAt.Should().BeNull();
+        // Existing fields preserved.
+        deferred.ToolCallId.Should().Be("tc_1");
+        deferred.Result.Should().Be("PENDING");
+    }
+
+    [Fact]
+    public void ToolCallResult_Struct_DefaultValues_AreNotDeferred()
+    {
+        var plain = new ToolCallResult("tc_2", "ok");
+
+        plain.IsDeferred.Should().BeFalse();
+        plain.DeferralMetadata.Should().BeNull();
+        plain.DeferredAt.Should().BeNull();
+        plain.ResolvedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToolCallResult_Struct_JsonRoundTrip_PreservesDeferredFields()
+    {
+        var original = new ToolCallResult("tc_3", "PENDING")
+        {
+            IsDeferred = true,
+            DeferralMetadata = ImmutableDictionary.CreateRange(new Dictionary<string, string>
+            {
+                ["wait_ms"] = "60000",
+            }),
+            DeferredAt = 1_700_000_000_000,
+        };
+
+        var json = JsonSerializer.Serialize(original);
+        json.Should().Contain("\"is_deferred\":true");
+        json.Should().Contain("\"deferral_metadata\"");
+        json.Should().Contain("\"deferred_at\":1700000000000");
+        // Resolved_at omitted on null.
+        json.Should().NotContain("resolved_at");
+
+        var roundTripped = JsonSerializer.Deserialize<ToolCallResult>(json);
+        roundTripped.IsDeferred.Should().BeTrue();
+        roundTripped.DeferralMetadata.Should().NotBeNull();
+        roundTripped.DeferralMetadata!["wait_ms"].Should().Be("60000");
+        roundTripped.DeferredAt.Should().Be(1_700_000_000_000);
+        roundTripped.ResolvedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToolCallResult_Struct_JsonRoundTrip_OmitsNullableDeferredFieldsWhenDefault()
+    {
+        var plain = new ToolCallResult("tc_4", "result");
+
+        var json = JsonSerializer.Serialize(plain);
+
+        // Nullable deferral fields are omitted via [JsonIgnore(WhenWritingNull)].
+        json.Should().NotContain("deferral_metadata");
+        json.Should().NotContain("deferred_at");
+        json.Should().NotContain("resolved_at");
+        // `is_deferred` is a non-nullable bool and always serializes (mirrors `is_error`),
+        // matching the singular ToolCallResultMessage record's behavior. Default is false.
+        json.Should().Contain("\"is_deferred\":false");
+    }
+
+    [Fact]
+    public void ToToolCallResult_PreservesDeferralFields()
+    {
+        var metadata = ImmutableDictionary.CreateRange(new Dictionary<string, string>
+        {
+            ["ticket"] = "T-99",
+        });
+        var record = new ToolCallResultMessage
+        {
+            ToolCallId = "tc_5",
+            Result = "PENDING",
+            ToolName = "send_email",
+            IsDeferred = true,
+            DeferralMetadata = metadata,
+            DeferredAt = 1_700_000_000_000,
+        };
+
+        var asStruct = record.ToToolCallResult();
+
+        asStruct.IsDeferred.Should().BeTrue();
+        asStruct.DeferralMetadata.Should().BeSameAs(metadata);
+        asStruct.DeferredAt.Should().Be(1_700_000_000_000);
+        asStruct.ResolvedAt.Should().BeNull();
+        asStruct.ToolCallId.Should().Be("tc_5");
+        asStruct.Result.Should().Be("PENDING");
+    }
+
+    [Fact]
+    public void FromToolCallResult_PreservesDeferralFields()
+    {
+        var metadata = ImmutableDictionary.CreateRange(new Dictionary<string, string>
+        {
+            ["ticket"] = "T-100",
+        });
+        var asStruct = new ToolCallResult("tc_6", "PENDING")
+        {
+            ToolName = "send_email",
+            IsDeferred = true,
+            DeferralMetadata = metadata,
+            DeferredAt = 1_700_000_000_000,
+        };
+
+        var record = ToolCallResultMessage.FromToolCallResult(asStruct);
+
+        record.IsDeferred.Should().BeTrue();
+        record.DeferralMetadata.Should().BeSameAs(metadata);
+        record.DeferredAt.Should().Be(1_700_000_000_000);
+        record.ResolvedAt.Should().BeNull();
+        record.ToolCallId.Should().Be("tc_6");
+        record.Result.Should().Be("PENDING");
+    }
+
+    [Fact]
+    public void RecordToStructToRecord_RoundTrip_IsLossless_ForDeferralFields()
+    {
+        var metadata = ImmutableDictionary.CreateRange(new Dictionary<string, string>
+        {
+            ["ticket"] = "T-101",
+            ["priority"] = "high",
+        });
+        var original = new ToolCallResultMessage
+        {
+            ToolCallId = "tc_7",
+            Result = "PENDING",
+            ToolName = "approve",
+            IsDeferred = true,
+            DeferralMetadata = metadata,
+            DeferredAt = 1_700_000_000_000,
+            ResolvedAt = null,
+        };
+
+        var roundTripped = ToolCallResultMessage.FromToolCallResult(original.ToToolCallResult());
+
+        roundTripped.IsDeferred.Should().Be(original.IsDeferred);
+        roundTripped.DeferralMetadata.Should().BeSameAs(original.DeferralMetadata);
+        roundTripped.DeferredAt.Should().Be(original.DeferredAt);
+        roundTripped.ResolvedAt.Should().Be(original.ResolvedAt);
+        roundTripped.ToolCallId.Should().Be(original.ToolCallId);
+        roundTripped.Result.Should().Be(original.Result);
+        roundTripped.ToolName.Should().Be(original.ToolName);
+    }
 }

--- a/tests/LmCore.Tests/Messages/ToolHandlerResultTests.cs
+++ b/tests/LmCore.Tests/Messages/ToolHandlerResultTests.cs
@@ -282,4 +282,24 @@ public class ToolHandlerResultTests
         tcr.ErrorCode.Should().Be("E_X");
         tcr.Result.Should().Be("oops");
     }
+
+    [Fact]
+    public void ToolCallResultBuilder_FromHandlerResult_PropagatesContentBlocks()
+    {
+        // Multi-modal payload survives the builder mapping by reference — no copy, no rewrap.
+        // Covered indirectly by MultiModalHandlerIntegrationTests; this is the direct unit test.
+        var blocks = new List<ToolResultContentBlock>
+        {
+            new TextToolResultBlock { Text = "caption" },
+            new ImageToolResultBlock { Data = "abc", MimeType = "image/png" },
+        };
+        var result = ToolHandlerResult.FromMultiModal("text", blocks);
+
+        var tcr = ToolCallResultBuilder.FromHandlerResult(result, "tc_mm", "image_tool");
+
+        tcr.ToolCallId.Should().Be("tc_mm");
+        tcr.ToolName.Should().Be("image_tool");
+        tcr.Result.Should().Be("text");
+        tcr.ContentBlocks.Should().BeSameAs(blocks);
+    }
 }

--- a/tests/LmCore.Tests/Messages/ToolHandlerResultTests.cs
+++ b/tests/LmCore.Tests/Messages/ToolHandlerResultTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Text.Json;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using FluentAssertions;
@@ -9,86 +8,72 @@ namespace AchieveAi.LmDotnetTools.LmCore.Tests.Messages;
 public class ToolHandlerResultTests
 {
     [Fact]
-    public void ImplicitConversion_FromString_ProducesResolved()
+    public void FromText_ProducesResolvedWithTextOnlyPayload()
     {
-        ToolHandlerResult result = "hello";
-
-        result.Should().BeOfType<ToolHandlerResult.Resolved>();
-        ((ToolHandlerResult.Resolved)result).Result.Result.Should().Be("hello");
-    }
-
-    [Fact]
-    public void FromString_FactoryHelper_ProducesResolved()
-    {
-        var result = ToolHandlerResult.FromString("payload");
-
-        result.Should().BeOfType<ToolHandlerResult.Resolved>();
-        result.Result.Result.Should().Be("payload");
-    }
-
-    [Fact]
-    public void ImplicitConversion_FromToolCallResult_ProducesResolved()
-    {
-        var inner = new ToolCallResult(null, "complex", new List<ToolResultContentBlock>
-        {
-            new TextToolResultBlock { Text = "rich" },
-        });
-        ToolHandlerResult result = inner;
+        var result = ToolHandlerResult.FromText("hello");
 
         result.Should().BeOfType<ToolHandlerResult.Resolved>();
         var resolved = (ToolHandlerResult.Resolved)result;
-        resolved.Result.Result.Should().Be("complex");
-        resolved.Result.ContentBlocks.Should().HaveCount(1);
+        resolved.Payload.Text.Should().Be("hello");
+        resolved.Payload.ContentBlocks.Should().BeNull();
+        resolved.Payload.IsError.Should().BeFalse();
+        resolved.Payload.ErrorCode.Should().BeNull();
     }
 
     [Fact]
-    public void Deferred_CarriesPlaceholderAndMetadata()
+    public void FromError_ProducesResolvedWithIsErrorTrue()
     {
-        var metadata = ImmutableDictionary.CreateRange(new Dictionary<string, string>
+        var result = ToolHandlerResult.FromError("bad input", errorCode: "E_INPUT");
+
+        result.Should().BeOfType<ToolHandlerResult.Resolved>();
+        var resolved = (ToolHandlerResult.Resolved)result;
+        resolved.Payload.Text.Should().Be("bad input");
+        resolved.Payload.IsError.Should().BeTrue();
+        resolved.Payload.ErrorCode.Should().Be("E_INPUT");
+    }
+
+    [Fact]
+    public void FromMultiModal_ProducesResolvedWithContentBlocks()
+    {
+        var blocks = new List<ToolResultContentBlock>
         {
-            ["correlation_id"] = "abc-123",
-            ["expected_wait_seconds"] = "60",
-        });
+            new TextToolResultBlock { Text = "rich" },
+            new ImageToolResultBlock { Data = "data", MimeType = "image/png" },
+        };
 
-        var deferred = new ToolHandlerResult.Deferred("PENDING approval", metadata);
+        var result = ToolHandlerResult.FromMultiModal("complex", blocks);
 
-        deferred.Placeholder.Should().Be("PENDING approval");
-        deferred.Metadata.Should().NotBeNull();
-        deferred.Metadata!["correlation_id"].Should().Be("abc-123");
+        result.Should().BeOfType<ToolHandlerResult.Resolved>();
+        var resolved = (ToolHandlerResult.Resolved)result;
+        resolved.Payload.Text.Should().Be("complex");
+        resolved.Payload.ContentBlocks.Should().BeSameAs(blocks);
     }
 
     [Fact]
-    public void ResultText_OnResolved_ReturnsValue()
+    public void Deferred_IsEmptyRecord()
     {
-        ToolHandlerResult resolved = new ToolHandlerResult.Resolved(new ToolCallResult(null, "payload"));
-        resolved.ResultText.Should().Be("payload");
-    }
+        var d1 = new ToolHandlerResult.Deferred();
+        var d2 = new ToolHandlerResult.Deferred();
 
-    [Fact]
-    public void ResultText_OnDeferred_Throws()
-    {
-        ToolHandlerResult deferred = new ToolHandlerResult.Deferred("pending");
-
-        var act = () => _ = deferred.ResultText;
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage("*deferred*");
+        // Empty record — value equality is structural, both instances are equal.
+        d1.Should().Be(d2);
     }
 
     [Fact]
     public void PatternMatch_DistinguishesVariantsExhaustively()
     {
-        ToolHandlerResult resolved = new ToolHandlerResult.Resolved(new ToolCallResult(null, "ok"));
-        ToolHandlerResult deferred = new ToolHandlerResult.Deferred("pending");
+        ToolHandlerResult resolved = ToolHandlerResult.FromText("ok");
+        ToolHandlerResult deferred = new ToolHandlerResult.Deferred();
 
         string Match(ToolHandlerResult r) => r switch
         {
-            ToolHandlerResult.Resolved x => $"resolved:{x.Result.Result}",
-            ToolHandlerResult.Deferred x => $"deferred:{x.Placeholder}",
+            ToolHandlerResult.Resolved x => $"resolved:{x.Payload.Text}",
+            ToolHandlerResult.Deferred => "deferred",
             _ => throw new InvalidOperationException("unreachable"),
         };
 
         Match(resolved).Should().Be("resolved:ok");
-        Match(deferred).Should().Be("deferred:pending");
+        Match(deferred).Should().Be("deferred");
     }
 
     [Fact]
@@ -97,14 +82,10 @@ public class ToolHandlerResultTests
         var original = new ToolCallResultMessage
         {
             ToolCallId = "tc_1",
-            Result = "PENDING",
+            Result = string.Empty,
             ToolName = "approval_tool",
             IsDeferred = true,
             DeferredAt = 1_700_000_000_000,
-            DeferralMetadata = ImmutableDictionary.CreateRange(new Dictionary<string, string>
-            {
-                ["correlation"] = "abc",
-            }),
         };
 
         var json = JsonSerializer.Serialize(original);
@@ -114,8 +95,6 @@ public class ToolHandlerResultTests
         roundTripped!.ToolCallId.Should().Be("tc_1");
         roundTripped.IsDeferred.Should().BeTrue();
         roundTripped.DeferredAt.Should().Be(1_700_000_000_000);
-        roundTripped.DeferralMetadata.Should().NotBeNull();
-        roundTripped.DeferralMetadata!["correlation"].Should().Be("abc");
     }
 
     [Fact]
@@ -136,27 +115,20 @@ public class ToolHandlerResultTests
     [Fact]
     public void ToolCallResult_Struct_DeferredFields_AreSettableViaWith()
     {
-        var initial = new ToolCallResult("tc_1", "PENDING");
-        var metadata = ImmutableDictionary.CreateRange(new Dictionary<string, string>
-        {
-            ["correlation"] = "xyz",
-        });
+        var initial = new ToolCallResult("tc_1", string.Empty);
 
         var deferred = initial with
         {
             IsDeferred = true,
-            DeferralMetadata = metadata,
             DeferredAt = 1_700_000_000_000,
         };
 
         deferred.IsDeferred.Should().BeTrue();
-        deferred.DeferralMetadata.Should().NotBeNull();
-        deferred.DeferralMetadata!["correlation"].Should().Be("xyz");
         deferred.DeferredAt.Should().Be(1_700_000_000_000);
         deferred.ResolvedAt.Should().BeNull();
         // Existing fields preserved.
         deferred.ToolCallId.Should().Be("tc_1");
-        deferred.Result.Should().Be("PENDING");
+        deferred.Result.Should().Be(string.Empty);
     }
 
     [Fact]
@@ -165,7 +137,6 @@ public class ToolHandlerResultTests
         var plain = new ToolCallResult("tc_2", "ok");
 
         plain.IsDeferred.Should().BeFalse();
-        plain.DeferralMetadata.Should().BeNull();
         plain.DeferredAt.Should().BeNull();
         plain.ResolvedAt.Should().BeNull();
     }
@@ -173,27 +144,20 @@ public class ToolHandlerResultTests
     [Fact]
     public void ToolCallResult_Struct_JsonRoundTrip_PreservesDeferredFields()
     {
-        var original = new ToolCallResult("tc_3", "PENDING")
+        var original = new ToolCallResult("tc_3", string.Empty)
         {
             IsDeferred = true,
-            DeferralMetadata = ImmutableDictionary.CreateRange(new Dictionary<string, string>
-            {
-                ["wait_ms"] = "60000",
-            }),
             DeferredAt = 1_700_000_000_000,
         };
 
         var json = JsonSerializer.Serialize(original);
         json.Should().Contain("\"is_deferred\":true");
-        json.Should().Contain("\"deferral_metadata\"");
         json.Should().Contain("\"deferred_at\":1700000000000");
         // Resolved_at omitted on null.
         json.Should().NotContain("resolved_at");
 
         var roundTripped = JsonSerializer.Deserialize<ToolCallResult>(json);
         roundTripped.IsDeferred.Should().BeTrue();
-        roundTripped.DeferralMetadata.Should().NotBeNull();
-        roundTripped.DeferralMetadata!["wait_ms"].Should().Be("60000");
         roundTripped.DeferredAt.Should().Be(1_700_000_000_000);
         roundTripped.ResolvedAt.Should().BeNull();
     }
@@ -206,7 +170,6 @@ public class ToolHandlerResultTests
         var json = JsonSerializer.Serialize(plain);
 
         // Nullable deferral fields are omitted via [JsonIgnore(WhenWritingNull)].
-        json.Should().NotContain("deferral_metadata");
         json.Should().NotContain("deferred_at");
         json.Should().NotContain("resolved_at");
         // `is_deferred` is a non-nullable bool and always serializes (mirrors `is_error`),
@@ -217,70 +180,52 @@ public class ToolHandlerResultTests
     [Fact]
     public void ToToolCallResult_PreservesDeferralFields()
     {
-        var metadata = ImmutableDictionary.CreateRange(new Dictionary<string, string>
-        {
-            ["ticket"] = "T-99",
-        });
         var record = new ToolCallResultMessage
         {
             ToolCallId = "tc_5",
-            Result = "PENDING",
+            Result = string.Empty,
             ToolName = "send_email",
             IsDeferred = true,
-            DeferralMetadata = metadata,
             DeferredAt = 1_700_000_000_000,
         };
 
         var asStruct = record.ToToolCallResult();
 
         asStruct.IsDeferred.Should().BeTrue();
-        asStruct.DeferralMetadata.Should().BeSameAs(metadata);
         asStruct.DeferredAt.Should().Be(1_700_000_000_000);
         asStruct.ResolvedAt.Should().BeNull();
         asStruct.ToolCallId.Should().Be("tc_5");
-        asStruct.Result.Should().Be("PENDING");
+        asStruct.Result.Should().Be(string.Empty);
     }
 
     [Fact]
     public void FromToolCallResult_PreservesDeferralFields()
     {
-        var metadata = ImmutableDictionary.CreateRange(new Dictionary<string, string>
-        {
-            ["ticket"] = "T-100",
-        });
-        var asStruct = new ToolCallResult("tc_6", "PENDING")
+        var asStruct = new ToolCallResult("tc_6", string.Empty)
         {
             ToolName = "send_email",
             IsDeferred = true,
-            DeferralMetadata = metadata,
             DeferredAt = 1_700_000_000_000,
         };
 
         var record = ToolCallResultMessage.FromToolCallResult(asStruct);
 
         record.IsDeferred.Should().BeTrue();
-        record.DeferralMetadata.Should().BeSameAs(metadata);
         record.DeferredAt.Should().Be(1_700_000_000_000);
         record.ResolvedAt.Should().BeNull();
         record.ToolCallId.Should().Be("tc_6");
-        record.Result.Should().Be("PENDING");
+        record.Result.Should().Be(string.Empty);
     }
 
     [Fact]
     public void RecordToStructToRecord_RoundTrip_IsLossless_ForDeferralFields()
     {
-        var metadata = ImmutableDictionary.CreateRange(new Dictionary<string, string>
-        {
-            ["ticket"] = "T-101",
-            ["priority"] = "high",
-        });
         var original = new ToolCallResultMessage
         {
             ToolCallId = "tc_7",
-            Result = "PENDING",
+            Result = string.Empty,
             ToolName = "approve",
             IsDeferred = true,
-            DeferralMetadata = metadata,
             DeferredAt = 1_700_000_000_000,
             ResolvedAt = null,
         };
@@ -288,11 +233,53 @@ public class ToolHandlerResultTests
         var roundTripped = ToolCallResultMessage.FromToolCallResult(original.ToToolCallResult());
 
         roundTripped.IsDeferred.Should().Be(original.IsDeferred);
-        roundTripped.DeferralMetadata.Should().BeSameAs(original.DeferralMetadata);
         roundTripped.DeferredAt.Should().Be(original.DeferredAt);
         roundTripped.ResolvedAt.Should().Be(original.ResolvedAt);
         roundTripped.ToolCallId.Should().Be(original.ToolCallId);
         roundTripped.Result.Should().Be(original.Result);
         roundTripped.ToolName.Should().Be(original.ToolName);
+    }
+
+    [Fact]
+    public void ToolCallResultBuilder_FromHandlerResult_StampsToolCallIdAndToolName()
+    {
+        // Locks in the bug fix: the builder must always pull tool_call_id from context, never
+        // leave it null. Previously FunctionCallMiddleware.cs:106 hardcoded null.
+        var result = ToolHandlerResult.FromText("ok");
+
+        var tcr = ToolCallResultBuilder.FromHandlerResult(result, "tc_xyz", "my_tool");
+
+        tcr.ToolCallId.Should().Be("tc_xyz");
+        tcr.ToolName.Should().Be("my_tool");
+        tcr.Result.Should().Be("ok");
+        tcr.IsDeferred.Should().BeFalse();
+        tcr.IsError.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ToolCallResultBuilder_FromHandlerResult_DeferredProducesEmptyResultWithFlag()
+    {
+        var result = new ToolHandlerResult.Deferred();
+
+        var tcr = ToolCallResultBuilder.FromHandlerResult(result, "tc_def", "my_tool");
+
+        tcr.ToolCallId.Should().Be("tc_def");
+        tcr.ToolName.Should().Be("my_tool");
+        tcr.Result.Should().Be(string.Empty);
+        tcr.IsDeferred.Should().BeTrue();
+        tcr.DeferredAt.Should().NotBeNull();
+        tcr.DeferredAt!.Value.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void ToolCallResultBuilder_FromHandlerResult_PropagatesErrorPayload()
+    {
+        var result = ToolHandlerResult.FromError("oops", errorCode: "E_X");
+
+        var tcr = ToolCallResultBuilder.FromHandlerResult(result, "tc_err", "my_tool");
+
+        tcr.IsError.Should().BeTrue();
+        tcr.ErrorCode.Should().Be("E_X");
+        tcr.Result.Should().Be("oops");
     }
 }

--- a/tests/LmCore.Tests/Middleware/FunctionCallMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionCallMiddlewareTests.cs
@@ -16,7 +16,7 @@ public class FunctionCallMiddlewareTests
     public void Constructor_ShouldThrowArgumentNullException_WhenFunctionsIsNull()
     {
         // Arrange
-        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>();
+        var functionMap = new Dictionary<string, ToolHandler>();
 
         // Act & Assert
         var exception = Assert.Throws<ArgumentNullException>(() => new FunctionCallMiddleware(null!, functionMap));
@@ -47,9 +47,9 @@ public class FunctionCallMiddlewareTests
             },
         };
 
-        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
+        var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["add"] = args => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "10"))),
+            ["add"] = (args, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "10"))),
         };
 
         // Act & Assert
@@ -71,7 +71,7 @@ public class FunctionCallMiddlewareTests
         // Act & Assert
         var exception = Assert.Throws<ArgumentException>(() => new FunctionCallMiddleware(
             functions,
-            (IDictionary<string, Func<string, Task<ToolHandlerResult>>>)null!));
+            (IDictionary<string, ToolHandler>)null!));
 
         Assert.Contains("Function map must be provided", exception.Message);
         Assert.Equal("functionMap", exception.ParamName);
@@ -82,7 +82,7 @@ public class FunctionCallMiddlewareTests
     {
         // Arrange
         var functions = new List<FunctionContract>();
-        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>();
+        var functionMap = new Dictionary<string, ToolHandler>();
 
         // Act & Assert - no exception should be thrown
         var middleware = new FunctionCallMiddleware(functions, functionMap);
@@ -99,10 +99,10 @@ public class FunctionCallMiddlewareTests
             new() { Name = "function2", Description = "Test function 2" },
         };
 
-        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
+        var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["function1"] = args => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result1"))),
-            ["function2"] = args => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result2"))),
+            ["function1"] = (args, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result1"))),
+            ["function2"] = (args, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result2"))),
         };
 
         // Act & Assert - no exception should be thrown
@@ -442,9 +442,9 @@ public class FunctionCallMiddlewareTests
         {
             new() { Name = "approve_action", Description = "Asks human for approval" },
         };
-        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
+        var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["approve_action"] = _ => Task.FromResult<ToolHandlerResult>(
+            ["approve_action"] = (_, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Deferred("PENDING approval", metadata)),
         };
 
@@ -481,9 +481,9 @@ public class FunctionCallMiddlewareTests
         {
             new() { Name = "approve_action", Description = "Asks human for approval" },
         };
-        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
+        var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["approve_action"] = _ => Task.FromResult<ToolHandlerResult>(
+            ["approve_action"] = (_, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Deferred("PENDING approval")),
         };
 
@@ -522,11 +522,11 @@ public class FunctionCallMiddlewareTests
             new() { Name = "fast_lookup", Description = "Synchronous lookup" },
             new() { Name = "slow_approval", Description = "Deferred approval" },
         };
-        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
+        var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["fast_lookup"] = _ => Task.FromResult<ToolHandlerResult>(
+            ["fast_lookup"] = (_, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Resolved(new ToolCallResult(null, "result_42"))),
-            ["slow_approval"] = _ => Task.FromResult<ToolHandlerResult>(
+            ["slow_approval"] = (_, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Deferred("PENDING")),
         };
 
@@ -572,39 +572,118 @@ public class FunctionCallMiddlewareTests
         Assert.NotNull(slowResult.DeferredAt);
     }
 
-    private static Dictionary<string, Func<string, Task<ToolHandlerResult>>> CreateMockFunctionMap()
+    [Fact]
+    public async Task ToolHandler_ReceivesToolCallId_FromContext()
+    {
+        // Arrange — handler captures ctx.ToolCallId; middleware threads it through ToolCallExecutor.
+        ToolCallContext? capturedContext = null;
+        var functions = new List<FunctionContract>
+        {
+            new() { Name = "echo_id", Description = "Captures ctx.ToolCallId" },
+        };
+        var functionMap = new Dictionary<string, ToolHandler>
+        {
+            ["echo_id"] = (args, ctx) =>
+            {
+                capturedContext = ctx;
+                return Task.FromResult<ToolHandlerResult>(
+                    new ToolHandlerResult.Resolved(new ToolCallResult(null, "ok")));
+            },
+        };
+        var middleware = new FunctionCallMiddleware(functions, functionMap);
+
+        var toolCallMessage = new ToolsCallMessage
+        {
+            ToolCalls =
+            [
+                new ToolCall { FunctionName = "echo_id", FunctionArgs = "{}", ToolCallId = "call_abc123" },
+            ],
+            Role = Role.Assistant,
+        };
+        var context = new MiddlewareContext([toolCallMessage]);
+
+        // Act
+        _ = await middleware.InvokeAsync(context, new Mock<IAgent>().Object);
+
+        // Assert
+        Assert.NotNull(capturedContext);
+        Assert.Equal("call_abc123", capturedContext!.ToolCallId);
+    }
+
+    [Fact]
+    public async Task ToolHandler_ReceivesCancellationToken_FromMiddleware()
+    {
+        // Arrange — handler captures ctx.CancellationToken; we pass our own via InvokeAsync and
+        // verify the same token (or one wired to it) lands inside the handler.
+        CancellationToken capturedToken = default;
+        var functions = new List<FunctionContract>
+        {
+            new() { Name = "capture_ct", Description = "Captures ctx.CancellationToken" },
+        };
+        var functionMap = new Dictionary<string, ToolHandler>
+        {
+            ["capture_ct"] = (args, ctx) =>
+            {
+                capturedToken = ctx.CancellationToken;
+                return Task.FromResult<ToolHandlerResult>(
+                    new ToolHandlerResult.Resolved(new ToolCallResult(null, "ok")));
+            },
+        };
+        var middleware = new FunctionCallMiddleware(functions, functionMap);
+
+        var toolCallMessage = new ToolsCallMessage
+        {
+            ToolCalls =
+            [
+                new ToolCall { FunctionName = "capture_ct", FunctionArgs = "{}", ToolCallId = "call_ct" },
+            ],
+            Role = Role.Assistant,
+        };
+        var middlewareContext = new MiddlewareContext([toolCallMessage]);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel(); // pre-cancel so we can assert the token's state without racing
+
+        // Act
+        _ = await middleware.InvokeAsync(middlewareContext, new Mock<IAgent>().Object, cts.Token);
+
+        // Assert — the handler observed an already-cancelled token, proving propagation.
+        Assert.True(capturedToken.IsCancellationRequested);
+    }
+
+    private static Dictionary<string, ToolHandler> CreateMockFunctionMap()
     {
         static Task<ToolHandlerResult> Wrap(string text)
             => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, text)));
 
-        return new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
+        return new Dictionary<string, ToolHandler>
         {
-            ["getWeather"] = argsJson =>
+            ["getWeather"] = (argsJson, _) =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
                 return Wrap(GetWeatherAsync(argsJson));
             },
-            ["getWeatherHistory"] = argsJson =>
+            ["getWeatherHistory"] = (argsJson, _) =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
                 return Wrap(GetWeatherHistoryAsync(argsJson));
             },
-            ["add"] = argsJson =>
+            ["add"] = (argsJson, _) =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
                 return Wrap(AddAsync(argsJson));
             },
-            ["subtract"] = argsJson =>
+            ["subtract"] = (argsJson, _) =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
                 return Wrap(SubtractAsync(argsJson));
             },
-            ["multiply"] = argsJson =>
+            ["multiply"] = (argsJson, _) =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
                 return Wrap(MultiplyAsync(argsJson));
             },
-            ["divide"] = argsJson =>
+            ["divide"] = (argsJson, _) =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
                 return Wrap(DivideAsync(argsJson));

--- a/tests/LmCore.Tests/Middleware/FunctionCallMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionCallMiddlewareTests.cs
@@ -430,6 +430,148 @@ public class FunctionCallMiddlewareTests
         Assert.NotEmpty(toolCallResult.Result);
     }
 
+    [Fact]
+    public async Task InvokeAsync_DeferredHandler_FromInputToolCall_DoesNotThrowAndFlagsResult()
+    {
+        // Arrange — handler returns Deferred. Previously this threw NotSupportedException;
+        // now it must surface as a deferred-flagged ToolCallResult.
+        var metadata = System.Collections.Immutable.ImmutableDictionary.CreateRange(
+            new Dictionary<string, string> { ["correlation_id"] = "abc-123" });
+
+        var functions = new List<FunctionContract>
+        {
+            new() { Name = "approve_action", Description = "Asks human for approval" },
+        };
+        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
+        {
+            ["approve_action"] = _ => Task.FromResult<ToolHandlerResult>(
+                new ToolHandlerResult.Deferred("PENDING approval", metadata)),
+        };
+
+        var middleware = new FunctionCallMiddleware(functions, functionMap);
+        var toolCallMessage = CreateToolCallMessage("approve_action", new { action = "send_email" });
+        var context = new MiddlewareContext([toolCallMessage], new GenerateReplyOptions());
+        var mockAgent = new Mock<IAgent>();
+
+        // Act
+        var result = await middleware.InvokeAsync(context, mockAgent.Object);
+
+        // Assert
+        var resultMessage = Assert.IsType<ToolsCallResultMessage>(Assert.Single(result));
+        var deferredResult = Assert.Single(resultMessage.ToolCallResults);
+        Assert.True(deferredResult.IsDeferred);
+        Assert.Equal("PENDING approval", deferredResult.Result);
+        Assert.NotNull(deferredResult.DeferralMetadata);
+        Assert.Equal("abc-123", deferredResult.DeferralMetadata!["correlation_id"]);
+        Assert.NotNull(deferredResult.DeferredAt);
+        Assert.True(deferredResult.DeferredAt > 0);
+        Assert.Null(deferredResult.ResolvedAt);
+        Assert.False(deferredResult.IsError);
+        // ToolCallExecutor.cs:147 stamps ToolCallId; deferred state must survive the `with` clause.
+        Assert.NotNull(deferredResult.ToolCallId);
+        Assert.Equal("approve_action", deferredResult.ToolName);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_DeferredHandler_FromAgentReply_EmitsAggregateWithIsDeferredTrue()
+    {
+        // Arrange — agent generates a tool call; middleware executes the deferred handler
+        // and wraps it into a ToolsCallAggregateMessage.
+        var functions = new List<FunctionContract>
+        {
+            new() { Name = "approve_action", Description = "Asks human for approval" },
+        };
+        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
+        {
+            ["approve_action"] = _ => Task.FromResult<ToolHandlerResult>(
+                new ToolHandlerResult.Deferred("PENDING approval")),
+        };
+
+        var middleware = new FunctionCallMiddleware(functions, functionMap);
+        var userMessage = new TextMessage { Text = "Send the email", Role = Role.User };
+        var context = new MiddlewareContext([userMessage], new GenerateReplyOptions());
+
+        var mockAgent = new Mock<IAgent>();
+        var agentReply = CreateToolCallMessage("approve_action", new { action = "send_email" });
+        _ = mockAgent
+            .Setup(a => a.GenerateReplyAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([agentReply]);
+
+        // Act
+        var result = (await middleware.InvokeAsync(context, mockAgent.Object)).ToList();
+
+        // Assert
+        var aggregate = Assert.IsType<ToolsCallAggregateMessage>(Assert.Single(result));
+        var deferredResult = Assert.Single(aggregate.ToolsCallResult.ToolCallResults);
+        Assert.True(deferredResult.IsDeferred);
+        Assert.Equal("PENDING approval", deferredResult.Result);
+        Assert.NotNull(deferredResult.DeferredAt);
+        Assert.Null(deferredResult.ResolvedAt);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_MixedHandlers_OnlyDeferredOnesFlagged()
+    {
+        // Arrange — two parallel tool calls in the same assistant message: one resolves
+        // synchronously, one defers. Only the deferred one should carry IsDeferred=true.
+        var functions = new List<FunctionContract>
+        {
+            new() { Name = "fast_lookup", Description = "Synchronous lookup" },
+            new() { Name = "slow_approval", Description = "Deferred approval" },
+        };
+        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
+        {
+            ["fast_lookup"] = _ => Task.FromResult<ToolHandlerResult>(
+                new ToolHandlerResult.Resolved(new ToolCallResult(null, "result_42"))),
+            ["slow_approval"] = _ => Task.FromResult<ToolHandlerResult>(
+                new ToolHandlerResult.Deferred("PENDING")),
+        };
+
+        var middleware = new FunctionCallMiddleware(functions, functionMap);
+
+        var toolCallMessage = new ToolsCallMessage
+        {
+            ToolCalls =
+            [
+                new ToolCall
+                {
+                    FunctionName = "fast_lookup",
+                    FunctionArgs = "{}",
+                    ToolCallId = "tc_fast",
+                },
+                new ToolCall
+                {
+                    FunctionName = "slow_approval",
+                    FunctionArgs = "{}",
+                    ToolCallId = "tc_slow",
+                },
+            ],
+            Role = Role.Assistant,
+        };
+        var context = new MiddlewareContext([toolCallMessage], new GenerateReplyOptions());
+        var mockAgent = new Mock<IAgent>();
+
+        // Act
+        var result = await middleware.InvokeAsync(context, mockAgent.Object);
+
+        // Assert
+        var resultMessage = Assert.IsType<ToolsCallResultMessage>(Assert.Single(result));
+        Assert.Equal(2, resultMessage.ToolCallResults.Count);
+
+        var fastResult = resultMessage.ToolCallResults.First(r => r.ToolCallId == "tc_fast");
+        Assert.False(fastResult.IsDeferred);
+        Assert.Equal("result_42", fastResult.Result);
+        Assert.Null(fastResult.DeferredAt);
+
+        var slowResult = resultMessage.ToolCallResults.First(r => r.ToolCallId == "tc_slow");
+        Assert.True(slowResult.IsDeferred);
+        Assert.Equal("PENDING", slowResult.Result);
+        Assert.NotNull(slowResult.DeferredAt);
+    }
+
     private static Dictionary<string, Func<string, Task<ToolHandlerResult>>> CreateMockFunctionMap()
     {
         static Task<ToolHandlerResult> Wrap(string text)

--- a/tests/LmCore.Tests/Middleware/FunctionCallMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionCallMiddlewareTests.cs
@@ -49,7 +49,7 @@ public class FunctionCallMiddlewareTests
 
         var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["add"] = (args, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "10"))),
+            ["add"] = (args, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "10"))),
         };
 
         // Act & Assert
@@ -101,8 +101,8 @@ public class FunctionCallMiddlewareTests
 
         var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["function1"] = (args, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result1"))),
-            ["function2"] = (args, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result2"))),
+            ["function1"] = (args, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result1"))),
+            ["function2"] = (args, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result2"))),
         };
 
         // Act & Assert - no exception should be thrown
@@ -444,7 +444,7 @@ public class FunctionCallMiddlewareTests
         };
         var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["approve_action"] = (_, _) => Task.FromResult<ToolHandlerResult>(
+            ["approve_action"] = (_, _, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Deferred("PENDING approval", metadata)),
         };
 
@@ -483,7 +483,7 @@ public class FunctionCallMiddlewareTests
         };
         var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["approve_action"] = (_, _) => Task.FromResult<ToolHandlerResult>(
+            ["approve_action"] = (_, _, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Deferred("PENDING approval")),
         };
 
@@ -524,9 +524,9 @@ public class FunctionCallMiddlewareTests
         };
         var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["fast_lookup"] = (_, _) => Task.FromResult<ToolHandlerResult>(
+            ["fast_lookup"] = (_, _, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Resolved(new ToolCallResult(null, "result_42"))),
-            ["slow_approval"] = (_, _) => Task.FromResult<ToolHandlerResult>(
+            ["slow_approval"] = (_, _, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Deferred("PENDING")),
         };
 
@@ -583,7 +583,7 @@ public class FunctionCallMiddlewareTests
         };
         var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["echo_id"] = (args, ctx) =>
+            ["echo_id"] = (args, ctx, ct) =>
             {
                 capturedContext = ctx;
                 return Task.FromResult<ToolHandlerResult>(
@@ -613,18 +613,18 @@ public class FunctionCallMiddlewareTests
     [Fact]
     public async Task ToolHandler_ReceivesCancellationToken_FromMiddleware()
     {
-        // Arrange — handler captures ctx.CancellationToken; we pass our own via InvokeAsync and
-        // verify the same token (or one wired to it) lands inside the handler.
+        // Arrange — handler captures the CancellationToken parameter; we pass our own via
+        // InvokeAsync and verify the same token (or one wired to it) lands inside the handler.
         CancellationToken capturedToken = default;
         var functions = new List<FunctionContract>
         {
-            new() { Name = "capture_ct", Description = "Captures ctx.CancellationToken" },
+            new() { Name = "capture_ct", Description = "Captures the CancellationToken parameter" },
         };
         var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["capture_ct"] = (args, ctx) =>
+            ["capture_ct"] = (args, ctx, ct) =>
             {
-                capturedToken = ctx.CancellationToken;
+                capturedToken = ct;
                 return Task.FromResult<ToolHandlerResult>(
                     new ToolHandlerResult.Resolved(new ToolCallResult(null, "ok")));
             },
@@ -658,32 +658,32 @@ public class FunctionCallMiddlewareTests
 
         return new Dictionary<string, ToolHandler>
         {
-            ["getWeather"] = (argsJson, _) =>
+            ["getWeather"] = (argsJson, _, _) =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
                 return Wrap(GetWeatherAsync(argsJson));
             },
-            ["getWeatherHistory"] = (argsJson, _) =>
+            ["getWeatherHistory"] = (argsJson, _, _) =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
                 return Wrap(GetWeatherHistoryAsync(argsJson));
             },
-            ["add"] = (argsJson, _) =>
+            ["add"] = (argsJson, _, _) =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
                 return Wrap(AddAsync(argsJson));
             },
-            ["subtract"] = (argsJson, _) =>
+            ["subtract"] = (argsJson, _, _) =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
                 return Wrap(SubtractAsync(argsJson));
             },
-            ["multiply"] = (argsJson, _) =>
+            ["multiply"] = (argsJson, _, _) =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
                 return Wrap(MultiplyAsync(argsJson));
             },
-            ["divide"] = (argsJson, _) =>
+            ["divide"] = (argsJson, _, _) =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
                 return Wrap(DivideAsync(argsJson));

--- a/tests/LmCore.Tests/Middleware/FunctionCallMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionCallMiddlewareTests.cs
@@ -16,7 +16,7 @@ public class FunctionCallMiddlewareTests
     public void Constructor_ShouldThrowArgumentNullException_WhenFunctionsIsNull()
     {
         // Arrange
-        var functionMap = new Dictionary<string, Func<string, Task<string>>>();
+        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>();
 
         // Act & Assert
         var exception = Assert.Throws<ArgumentNullException>(() => new FunctionCallMiddleware(null!, functionMap));
@@ -47,9 +47,9 @@ public class FunctionCallMiddlewareTests
             },
         };
 
-        var functionMap = new Dictionary<string, Func<string, Task<string>>>
+        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
         {
-            ["add"] = args => Task.FromResult("10"),
+            ["add"] = args => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "10"))),
         };
 
         // Act & Assert
@@ -69,7 +69,9 @@ public class FunctionCallMiddlewareTests
         };
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentException>(() => new FunctionCallMiddleware(functions, null!));
+        var exception = Assert.Throws<ArgumentException>(() => new FunctionCallMiddleware(
+            functions,
+            (IDictionary<string, Func<string, Task<ToolHandlerResult>>>)null!));
 
         Assert.Contains("Function map must be provided", exception.Message);
         Assert.Equal("functionMap", exception.ParamName);
@@ -80,7 +82,7 @@ public class FunctionCallMiddlewareTests
     {
         // Arrange
         var functions = new List<FunctionContract>();
-        var functionMap = new Dictionary<string, Func<string, Task<string>>>();
+        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>();
 
         // Act & Assert - no exception should be thrown
         var middleware = new FunctionCallMiddleware(functions, functionMap);
@@ -97,10 +99,10 @@ public class FunctionCallMiddlewareTests
             new() { Name = "function2", Description = "Test function 2" },
         };
 
-        var functionMap = new Dictionary<string, Func<string, Task<string>>>
+        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
         {
-            ["function1"] = args => Task.FromResult("result1"),
-            ["function2"] = args => Task.FromResult("result2"),
+            ["function1"] = args => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result1"))),
+            ["function2"] = args => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result2"))),
         };
 
         // Act & Assert - no exception should be thrown
@@ -428,39 +430,42 @@ public class FunctionCallMiddlewareTests
         Assert.NotEmpty(toolCallResult.Result);
     }
 
-    private static Dictionary<string, Func<string, Task<string>>> CreateMockFunctionMap()
+    private static Dictionary<string, Func<string, Task<ToolHandlerResult>>> CreateMockFunctionMap()
     {
-        return new Dictionary<string, Func<string, Task<string>>>
+        static Task<ToolHandlerResult> Wrap(string text)
+            => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, text)));
+
+        return new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
         {
             ["getWeather"] = argsJson =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
-                return Task.FromResult(GetWeatherAsync(argsJson));
+                return Wrap(GetWeatherAsync(argsJson));
             },
             ["getWeatherHistory"] = argsJson =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
-                return Task.FromResult(GetWeatherHistoryAsync(argsJson));
+                return Wrap(GetWeatherHistoryAsync(argsJson));
             },
             ["add"] = argsJson =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
-                return Task.FromResult(AddAsync(argsJson));
+                return Wrap(AddAsync(argsJson));
             },
             ["subtract"] = argsJson =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
-                return Task.FromResult(SubtractAsync(argsJson));
+                return Wrap(SubtractAsync(argsJson));
             },
             ["multiply"] = argsJson =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
-                return Task.FromResult(MultiplyAsync(argsJson));
+                return Wrap(MultiplyAsync(argsJson));
             },
             ["divide"] = argsJson =>
             {
                 ArgumentNullException.ThrowIfNull(argsJson);
-                return Task.FromResult(DivideAsync(argsJson));
+                return Wrap(DivideAsync(argsJson));
             },
         };
     }
@@ -860,7 +865,7 @@ public class FunctionCallMiddlewareTests
 
         TestContextLogger.LogDebugMessage("Function map created");
 
-        var middleware = new FunctionCallMiddleware(functionContracts, functionMap);
+        var middleware = new FunctionCallMiddleware(functionContracts, LegacyHandlerAdapter.WrapToNewHandlers(functionMap));
 
         TestContextLogger.LogDebugMessage("Middleware created");
 
@@ -1101,7 +1106,7 @@ public class FunctionCallMiddlewareTests
             },
         };
 
-        var middleware = new FunctionCallMiddleware(functionContracts, functionMap);
+        var middleware = new FunctionCallMiddleware(functionContracts, LegacyHandlerAdapter.WrapToNewHandlers(functionMap));
 
         var messages = new List<IMessage>
         {
@@ -1179,7 +1184,7 @@ public class FunctionCallMiddlewareTests
         );
 
         // Create the middleware with the MCP tools
-        var middleware = new FunctionCallMiddleware(functions, functionMap, name: "McpCalculatorTest");
+        var middleware = new FunctionCallMiddleware(functions, LegacyHandlerAdapter.WrapToNewHandlers(functionMap), name: "McpCalculatorTest");
 
         // Create large numbers to test with
         var firstNumber = 9876543210.123;

--- a/tests/LmCore.Tests/Middleware/FunctionCallMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionCallMiddlewareTests.cs
@@ -510,6 +510,48 @@ public class FunctionCallMiddlewareTests
     }
 
     [Fact]
+    public async Task InvokeStreamingAsync_DeferredHandler_FromInputToolCall_FlagsResultAsDeferred()
+    {
+        // Mirrors InvokeAsync_DeferredHandler_FromInputToolCall_DoesNotThrowAndFlagsResult,
+        // but exercises the streaming code path (InvokeStreamingAsync). The deferred handler
+        // returns Deferred(); the middleware must surface IsDeferred=true with empty Result
+        // text and a non-null ToolCallId — same guarantees the non-streaming path provides.
+        var functions = new List<FunctionContract>
+        {
+            new() { Name = "approve_action", Description = "Asks human for approval" },
+        };
+        var functionMap = new Dictionary<string, ToolHandler>
+        {
+            ["approve_action"] = (_, _, _) => Task.FromResult<ToolHandlerResult>(
+                new ToolHandlerResult.Deferred()),
+        };
+
+        var middleware = new FunctionCallMiddleware(functions, functionMap);
+        var toolCallMessage = CreateToolCallMessage("approve_action", new { action = "send_email" });
+        var context = new MiddlewareContext([toolCallMessage], new GenerateReplyOptions());
+        var nextAgent = new MockStreamingAgent([]);
+
+        // Act
+        var resultStream = await middleware.InvokeStreamingAsync(context, nextAgent);
+        var results = new List<IMessage>();
+        await foreach (var msg in resultStream)
+        {
+            results.Add(msg);
+        }
+
+        // Assert
+        var resultMessage = Assert.IsType<ToolsCallResultMessage>(Assert.Single(results.OfType<ToolsCallResultMessage>()));
+        var deferredResult = Assert.Single(resultMessage.ToolCallResults);
+        Assert.True(deferredResult.IsDeferred);
+        Assert.Equal(string.Empty, deferredResult.Result);
+        Assert.NotNull(deferredResult.DeferredAt);
+        Assert.Null(deferredResult.ResolvedAt);
+        Assert.False(deferredResult.IsError);
+        Assert.NotNull(deferredResult.ToolCallId);
+        Assert.Equal("approve_action", deferredResult.ToolName);
+    }
+
+    [Fact]
     public async Task InvokeAsync_MixedHandlers_OnlyDeferredOnesFlagged()
     {
         // Arrange — two parallel tool calls in the same assistant message: one resolves

--- a/tests/LmCore.Tests/Middleware/FunctionCallMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionCallMiddlewareTests.cs
@@ -49,7 +49,7 @@ public class FunctionCallMiddlewareTests
 
         var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["add"] = (args, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "10"))),
+            ["add"] = (args, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText("10")),
         };
 
         // Act & Assert
@@ -101,8 +101,8 @@ public class FunctionCallMiddlewareTests
 
         var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["function1"] = (args, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result1"))),
-            ["function2"] = (args, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result2"))),
+            ["function1"] = (args, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText("result1")),
+            ["function2"] = (args, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText("result2")),
         };
 
         // Act & Assert - no exception should be thrown
@@ -433,11 +433,9 @@ public class FunctionCallMiddlewareTests
     [Fact]
     public async Task InvokeAsync_DeferredHandler_FromInputToolCall_DoesNotThrowAndFlagsResult()
     {
-        // Arrange — handler returns Deferred. Previously this threw NotSupportedException;
-        // now it must surface as a deferred-flagged ToolCallResult.
-        var metadata = System.Collections.Immutable.ImmutableDictionary.CreateRange(
-            new Dictionary<string, string> { ["correlation_id"] = "abc-123" });
-
+        // Arrange — handler returns Deferred. Surfaces as a deferred-flagged ToolCallResult
+        // with empty Result text and IsDeferred=true; ToolCallId/ToolName are stamped in by
+        // ToolCallResultBuilder from the call's context.
         var functions = new List<FunctionContract>
         {
             new() { Name = "approve_action", Description = "Asks human for approval" },
@@ -445,7 +443,7 @@ public class FunctionCallMiddlewareTests
         var functionMap = new Dictionary<string, ToolHandler>
         {
             ["approve_action"] = (_, _, _) => Task.FromResult<ToolHandlerResult>(
-                new ToolHandlerResult.Deferred("PENDING approval", metadata)),
+                new ToolHandlerResult.Deferred()),
         };
 
         var middleware = new FunctionCallMiddleware(functions, functionMap);
@@ -460,14 +458,13 @@ public class FunctionCallMiddlewareTests
         var resultMessage = Assert.IsType<ToolsCallResultMessage>(Assert.Single(result));
         var deferredResult = Assert.Single(resultMessage.ToolCallResults);
         Assert.True(deferredResult.IsDeferred);
-        Assert.Equal("PENDING approval", deferredResult.Result);
-        Assert.NotNull(deferredResult.DeferralMetadata);
-        Assert.Equal("abc-123", deferredResult.DeferralMetadata!["correlation_id"]);
+        Assert.Equal(string.Empty, deferredResult.Result);
         Assert.NotNull(deferredResult.DeferredAt);
         Assert.True(deferredResult.DeferredAt > 0);
         Assert.Null(deferredResult.ResolvedAt);
         Assert.False(deferredResult.IsError);
-        // ToolCallExecutor.cs:147 stamps ToolCallId; deferred state must survive the `with` clause.
+        // ToolCallResultBuilder pulls ToolCallId from ToolCallContext — guards against the
+        // historical "ToolCallId = null" bug at FunctionCallMiddleware.cs:106.
         Assert.NotNull(deferredResult.ToolCallId);
         Assert.Equal("approve_action", deferredResult.ToolName);
     }
@@ -484,7 +481,7 @@ public class FunctionCallMiddlewareTests
         var functionMap = new Dictionary<string, ToolHandler>
         {
             ["approve_action"] = (_, _, _) => Task.FromResult<ToolHandlerResult>(
-                new ToolHandlerResult.Deferred("PENDING approval")),
+                new ToolHandlerResult.Deferred()),
         };
 
         var middleware = new FunctionCallMiddleware(functions, functionMap);
@@ -507,7 +504,7 @@ public class FunctionCallMiddlewareTests
         var aggregate = Assert.IsType<ToolsCallAggregateMessage>(Assert.Single(result));
         var deferredResult = Assert.Single(aggregate.ToolsCallResult.ToolCallResults);
         Assert.True(deferredResult.IsDeferred);
-        Assert.Equal("PENDING approval", deferredResult.Result);
+        Assert.Equal(string.Empty, deferredResult.Result);
         Assert.NotNull(deferredResult.DeferredAt);
         Assert.Null(deferredResult.ResolvedAt);
     }
@@ -525,9 +522,9 @@ public class FunctionCallMiddlewareTests
         var functionMap = new Dictionary<string, ToolHandler>
         {
             ["fast_lookup"] = (_, _, _) => Task.FromResult<ToolHandlerResult>(
-                new ToolHandlerResult.Resolved(new ToolCallResult(null, "result_42"))),
+                ToolHandlerResult.FromText("result_42")),
             ["slow_approval"] = (_, _, _) => Task.FromResult<ToolHandlerResult>(
-                new ToolHandlerResult.Deferred("PENDING")),
+                new ToolHandlerResult.Deferred()),
         };
 
         var middleware = new FunctionCallMiddleware(functions, functionMap);
@@ -568,7 +565,7 @@ public class FunctionCallMiddlewareTests
 
         var slowResult = resultMessage.ToolCallResults.First(r => r.ToolCallId == "tc_slow");
         Assert.True(slowResult.IsDeferred);
-        Assert.Equal("PENDING", slowResult.Result);
+        Assert.Equal(string.Empty, slowResult.Result);
         Assert.NotNull(slowResult.DeferredAt);
     }
 
@@ -587,7 +584,7 @@ public class FunctionCallMiddlewareTests
             {
                 capturedContext = ctx;
                 return Task.FromResult<ToolHandlerResult>(
-                    new ToolHandlerResult.Resolved(new ToolCallResult(null, "ok")));
+                    ToolHandlerResult.FromText("ok"));
             },
         };
         var middleware = new FunctionCallMiddleware(functions, functionMap);
@@ -626,7 +623,7 @@ public class FunctionCallMiddlewareTests
             {
                 capturedToken = ct;
                 return Task.FromResult<ToolHandlerResult>(
-                    new ToolHandlerResult.Resolved(new ToolCallResult(null, "ok")));
+                    ToolHandlerResult.FromText("ok"));
             },
         };
         var middleware = new FunctionCallMiddleware(functions, functionMap);
@@ -654,7 +651,7 @@ public class FunctionCallMiddlewareTests
     private static Dictionary<string, ToolHandler> CreateMockFunctionMap()
     {
         static Task<ToolHandlerResult> Wrap(string text)
-            => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, text)));
+            => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText(text));
 
         return new Dictionary<string, ToolHandler>
         {

--- a/tests/LmCore.Tests/Middleware/FunctionCollisionDetectorTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionCollisionDetectorTests.cs
@@ -1,5 +1,6 @@
 using AchieveAi.LmDotnetTools.LmCore.Configuration;
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
 using Microsoft.Extensions.Logging;
 
 namespace AchieveAi.LmDotnetTools.LmCore.Tests.Middleware;
@@ -101,7 +102,7 @@ public class FunctionCollisionDetectorTests
                 ClassName = providerName,
                 Description = $"Test function {functionName}",
             },
-            Handler = _ => Task.FromResult($"Result from {functionName}"),
+            Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {functionName}"))),
             ProviderName = providerName,
         };
     }
@@ -402,7 +403,7 @@ public class FunctionCollisionDetectorTests
             new()
             {
                 Contract = new FunctionContract { Name = "func1" },
-                Handler = _ => Task.FromResult("result"),
+                Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result"))),
                 ProviderName = string.Empty,
             },
         };

--- a/tests/LmCore.Tests/Middleware/FunctionCollisionDetectorTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionCollisionDetectorTests.cs
@@ -102,7 +102,7 @@ public class FunctionCollisionDetectorTests
                 ClassName = providerName,
                 Description = $"Test function {functionName}",
             },
-            Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {functionName}"))),
+            Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {functionName}"))),
             ProviderName = providerName,
         };
     }
@@ -403,7 +403,7 @@ public class FunctionCollisionDetectorTests
             new()
             {
                 Contract = new FunctionContract { Name = "func1" },
-                Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result"))),
+                Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result"))),
                 ProviderName = string.Empty,
             },
         };

--- a/tests/LmCore.Tests/Middleware/FunctionCollisionDetectorTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionCollisionDetectorTests.cs
@@ -102,7 +102,7 @@ public class FunctionCollisionDetectorTests
                 ClassName = providerName,
                 Description = $"Test function {functionName}",
             },
-            Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {functionName}"))),
+            Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {functionName}"))),
             ProviderName = providerName,
         };
     }
@@ -403,7 +403,7 @@ public class FunctionCollisionDetectorTests
             new()
             {
                 Contract = new FunctionContract { Name = "func1" },
-                Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result"))),
+                Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result"))),
                 ProviderName = string.Empty,
             },
         };

--- a/tests/LmCore.Tests/Middleware/FunctionCollisionDetectorTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionCollisionDetectorTests.cs
@@ -102,7 +102,7 @@ public class FunctionCollisionDetectorTests
                 ClassName = providerName,
                 Description = $"Test function {functionName}",
             },
-            Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {functionName}"))),
+            Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText($"Result from {functionName}")),
             ProviderName = providerName,
         };
     }
@@ -403,7 +403,7 @@ public class FunctionCollisionDetectorTests
             new()
             {
                 Contract = new FunctionContract { Name = "func1" },
-                Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result"))),
+                Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText("result")),
                 ProviderName = string.Empty,
             },
         };

--- a/tests/LmCore.Tests/Middleware/FunctionFilterTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionFilterTests.cs
@@ -28,7 +28,7 @@ public class FunctionFilterTests
                 Name = functionName,
                 Description = $"Test function {functionName} from {providerName}",
             },
-            Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {functionName}"))),
+            Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {functionName}"))),
             ProviderName = providerName,
         };
     }
@@ -491,7 +491,7 @@ public class FunctionFilterTests
         var descriptor = new FunctionDescriptor
         {
             Contract = new FunctionContract { Name = "blocked" },
-            Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result"))),
+            Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result"))),
             ProviderName = string.Empty,
         };
 

--- a/tests/LmCore.Tests/Middleware/FunctionFilterTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionFilterTests.cs
@@ -1,5 +1,6 @@
 using AchieveAi.LmDotnetTools.LmCore.Configuration;
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
 using Microsoft.Extensions.Logging;
 
 namespace AchieveAi.LmDotnetTools.LmCore.Tests.Middleware;
@@ -27,7 +28,7 @@ public class FunctionFilterTests
                 Name = functionName,
                 Description = $"Test function {functionName} from {providerName}",
             },
-            Handler = _ => Task.FromResult($"Result from {functionName}"),
+            Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {functionName}"))),
             ProviderName = providerName,
         };
     }
@@ -490,7 +491,7 @@ public class FunctionFilterTests
         var descriptor = new FunctionDescriptor
         {
             Contract = new FunctionContract { Name = "blocked" },
-            Handler = _ => Task.FromResult("result"),
+            Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result"))),
             ProviderName = string.Empty,
         };
 

--- a/tests/LmCore.Tests/Middleware/FunctionFilterTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionFilterTests.cs
@@ -28,7 +28,7 @@ public class FunctionFilterTests
                 Name = functionName,
                 Description = $"Test function {functionName} from {providerName}",
             },
-            Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {functionName}"))),
+            Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {functionName}"))),
             ProviderName = providerName,
         };
     }
@@ -491,7 +491,7 @@ public class FunctionFilterTests
         var descriptor = new FunctionDescriptor
         {
             Contract = new FunctionContract { Name = "blocked" },
-            Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result"))),
+            Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result"))),
             ProviderName = string.Empty,
         };
 

--- a/tests/LmCore.Tests/Middleware/FunctionFilterTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionFilterTests.cs
@@ -28,7 +28,7 @@ public class FunctionFilterTests
                 Name = functionName,
                 Description = $"Test function {functionName} from {providerName}",
             },
-            Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {functionName}"))),
+            Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText($"Result from {functionName}")),
             ProviderName = providerName,
         };
     }
@@ -491,7 +491,7 @@ public class FunctionFilterTests
         var descriptor = new FunctionDescriptor
         {
             Contract = new FunctionContract { Name = "blocked" },
-            Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "result"))),
+            Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText("result")),
             ProviderName = string.Empty,
         };
 

--- a/tests/LmCore.Tests/Middleware/FunctionRegistryBuilderTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionRegistryBuilderTests.cs
@@ -324,10 +324,10 @@ public class FunctionRegistryBuilderTests
         Assert.DoesNotContain(contracts, c => c.Name == "getForecast");
 
         // Test handlers work
-        var searchResult = await handlers["search"]("{}");
+        var searchResult = await handlers["search"]("{}", new ToolCallContext());
         Assert.Equal("MCP-result", searchResult);
 
-        var weatherResult = await handlers["getCurrentWeather"]("{}");
+        var weatherResult = await handlers["getCurrentWeather"]("{}", new ToolCallContext());
         Assert.Equal("Weather-result", weatherResult);
     }
 
@@ -349,9 +349,9 @@ public class FunctionRegistryBuilderTests
         };
     }
 
-    private static Func<string, Task<ToolHandlerResult>> CreateTestHandler(string result)
+    private static ToolHandler CreateTestHandler(string result)
     {
-        return _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, result)));
+        return (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, result)));
     }
 
     private class TestFunctionProvider : IFunctionProvider
@@ -377,7 +377,7 @@ public class FunctionRegistryBuilderTests
                     Description = $"Test function {name}",
                     Parameters = [],
                 },
-                Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
+                Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
                 ProviderName = ProviderName,
             });
         }

--- a/tests/LmCore.Tests/Middleware/FunctionRegistryBuilderTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionRegistryBuilderTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using AchieveAi.LmDotnetTools.LmCore.Configuration;
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AchieveAi.LmDotnetTools.LmCore.Tests.Middleware;
@@ -348,9 +349,9 @@ public class FunctionRegistryBuilderTests
         };
     }
 
-    private static Func<string, Task<string>> CreateTestHandler(string result)
+    private static Func<string, Task<ToolHandlerResult>> CreateTestHandler(string result)
     {
-        return _ => Task.FromResult(result);
+        return _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, result)));
     }
 
     private class TestFunctionProvider : IFunctionProvider
@@ -376,7 +377,7 @@ public class FunctionRegistryBuilderTests
                     Description = $"Test function {name}",
                     Parameters = [],
                 },
-                Handler = _ => Task.FromResult($"{ProviderName}-result"),
+                Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
                 ProviderName = ProviderName,
             });
         }

--- a/tests/LmCore.Tests/Middleware/FunctionRegistryBuilderTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionRegistryBuilderTests.cs
@@ -324,10 +324,10 @@ public class FunctionRegistryBuilderTests
         Assert.DoesNotContain(contracts, c => c.Name == "getForecast");
 
         // Test handlers work
-        var searchResult = await handlers["search"]("{}", new ToolCallContext());
+        var searchResult = await handlers["search"]("{}", new ToolCallContext(), CancellationToken.None);
         Assert.Equal("MCP-result", searchResult);
 
-        var weatherResult = await handlers["getCurrentWeather"]("{}", new ToolCallContext());
+        var weatherResult = await handlers["getCurrentWeather"]("{}", new ToolCallContext(), CancellationToken.None);
         Assert.Equal("Weather-result", weatherResult);
     }
 
@@ -351,7 +351,7 @@ public class FunctionRegistryBuilderTests
 
     private static ToolHandler CreateTestHandler(string result)
     {
-        return (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, result)));
+        return (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, result)));
     }
 
     private class TestFunctionProvider : IFunctionProvider
@@ -377,7 +377,7 @@ public class FunctionRegistryBuilderTests
                     Description = $"Test function {name}",
                     Parameters = [],
                 },
-                Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
+                Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
                 ProviderName = ProviderName,
             });
         }

--- a/tests/LmCore.Tests/Middleware/FunctionRegistryBuilderTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionRegistryBuilderTests.cs
@@ -325,10 +325,10 @@ public class FunctionRegistryBuilderTests
 
         // Test handlers work
         var searchResult = await handlers["search"]("{}", new ToolCallContext(), CancellationToken.None);
-        Assert.Equal("MCP-result", searchResult);
+        Assert.Equal("MCP-result", searchResult.ResultText);
 
         var weatherResult = await handlers["getCurrentWeather"]("{}", new ToolCallContext(), CancellationToken.None);
-        Assert.Equal("Weather-result", weatherResult);
+        Assert.Equal("Weather-result", weatherResult.ResultText);
     }
 
     // Helper methods
@@ -351,7 +351,7 @@ public class FunctionRegistryBuilderTests
 
     private static ToolHandler CreateTestHandler(string result)
     {
-        return (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, result)));
+        return (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText(result));
     }
 
     private class TestFunctionProvider : IFunctionProvider
@@ -377,7 +377,7 @@ public class FunctionRegistryBuilderTests
                     Description = $"Test function {name}",
                     Parameters = [],
                 },
-                Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
+                Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText($"{ProviderName}-result")),
                 ProviderName = ProviderName,
             });
         }

--- a/tests/LmCore.Tests/Middleware/FunctionRegistryFilteringTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionRegistryFilteringTests.cs
@@ -258,7 +258,7 @@ public class FunctionRegistryFilteringTests
                         ClassName = useClassName ? providerName : null,
                         Description = $"Test function {name} from {providerName}",
                     },
-                    Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {name}"))),
+                    Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {name}"))),
                     ProviderName = ProviderName,
                 }),
             ];
@@ -554,7 +554,7 @@ public class FunctionRegistryFilteringTests
             .AddProvider(new TestFunctionProvider("Provider1", "func1", "func2"))
             .AddFunction(
                 new FunctionContract { Name = "func1", Description = "Override" },
-                _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "overridden result"))),
+                (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "overridden result"))),
                 "Explicit"
             )
             .WithFilterConfig(new FunctionFilterConfig { EnableFiltering = false });

--- a/tests/LmCore.Tests/Middleware/FunctionRegistryFilteringTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionRegistryFilteringTests.cs
@@ -258,7 +258,7 @@ public class FunctionRegistryFilteringTests
                         ClassName = useClassName ? providerName : null,
                         Description = $"Test function {name} from {providerName}",
                     },
-                    Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {name}"))),
+                    Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {name}"))),
                     ProviderName = ProviderName,
                 }),
             ];
@@ -554,7 +554,7 @@ public class FunctionRegistryFilteringTests
             .AddProvider(new TestFunctionProvider("Provider1", "func1", "func2"))
             .AddFunction(
                 new FunctionContract { Name = "func1", Description = "Override" },
-                (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "overridden result"))),
+                (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "overridden result"))),
                 "Explicit"
             )
             .WithFilterConfig(new FunctionFilterConfig { EnableFiltering = false });

--- a/tests/LmCore.Tests/Middleware/FunctionRegistryFilteringTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionRegistryFilteringTests.cs
@@ -1,5 +1,6 @@
 using AchieveAi.LmDotnetTools.LmCore.Configuration;
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 
@@ -257,7 +258,7 @@ public class FunctionRegistryFilteringTests
                         ClassName = useClassName ? providerName : null,
                         Description = $"Test function {name} from {providerName}",
                     },
-                    Handler = _ => Task.FromResult($"Result from {name}"),
+                    Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {name}"))),
                     ProviderName = ProviderName,
                 }),
             ];
@@ -553,7 +554,7 @@ public class FunctionRegistryFilteringTests
             .AddProvider(new TestFunctionProvider("Provider1", "func1", "func2"))
             .AddFunction(
                 new FunctionContract { Name = "func1", Description = "Override" },
-                _ => Task.FromResult("overridden result"),
+                _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "overridden result"))),
                 "Explicit"
             )
             .WithFilterConfig(new FunctionFilterConfig { EnableFiltering = false });

--- a/tests/LmCore.Tests/Middleware/FunctionRegistryFilteringTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionRegistryFilteringTests.cs
@@ -258,7 +258,7 @@ public class FunctionRegistryFilteringTests
                         ClassName = useClassName ? providerName : null,
                         Description = $"Test function {name} from {providerName}",
                     },
-                    Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"Result from {name}"))),
+                    Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText($"Result from {name}")),
                     ProviderName = ProviderName,
                 }),
             ];
@@ -554,7 +554,7 @@ public class FunctionRegistryFilteringTests
             .AddProvider(new TestFunctionProvider("Provider1", "func1", "func2"))
             .AddFunction(
                 new FunctionContract { Name = "func1", Description = "Override" },
-                (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, "overridden result"))),
+                (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText("overridden result")),
                 "Explicit"
             )
             .WithFilterConfig(new FunctionFilterConfig { EnableFiltering = false });

--- a/tests/LmCore.Tests/Middleware/FunctionRegistryTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionRegistryTests.cs
@@ -1,4 +1,5 @@
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Models;
 namespace AchieveAi.LmDotnetTools.LmCore.Tests.Middleware;
 
@@ -415,9 +416,9 @@ public class FunctionRegistryTests
         };
     }
 
-    internal static Func<string, Task<string>> CreateTestHandler(string result)
+    internal static Func<string, Task<ToolHandlerResult>> CreateTestHandler(string result)
     {
-        return _ => Task.FromResult(result);
+        return _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, result)));
     }
 
     private static FunctionContract CreateTestContractWithParameters(string name)
@@ -486,7 +487,7 @@ public class FunctionRegistryTests
                     Description = $"Test function {name}",
                     Parameters = [],
                 },
-                Handler = _ => Task.FromResult($"{ProviderName}-result"),
+                Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
                 ProviderName = ProviderName,
             });
         }
@@ -520,7 +521,7 @@ public class FunctionRegistryTests
                         Description = $"Test function {_functionName}",
                         Parameters = [],
                     },
-                    Handler = _ => Task.FromResult($"{ProviderName}-result"),
+                    Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
                     ProviderName = ProviderName,
                 },
             ];
@@ -555,7 +556,7 @@ public class FunctionRegistryTests
                         Description = $"Test function {_functionName}",
                         Parameters = [],
                     },
-                    Handler = _ => Task.FromResult($"{ProviderName}-result"),
+                    Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
                     ProviderName = ProviderName,
                 },
             ];

--- a/tests/LmCore.Tests/Middleware/FunctionRegistryTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionRegistryTests.cs
@@ -57,7 +57,7 @@ public class FunctionRegistryTests
         _ = Assert.Single(contracts);
         _ = Assert.Single(handlers);
 
-        var result = await handlers["func1"]("{}");
+        var result = await handlers["func1"]("{}", new ToolCallContext());
         Assert.Equal("explicit-result", result);
     }
 
@@ -99,7 +99,7 @@ public class FunctionRegistryTests
         _ = Assert.Single(contracts);
         _ = Assert.Single(handlers);
 
-        var result = await handlers["func1"]("{}");
+        var result = await handlers["func1"]("{}", new ToolCallContext());
         Assert.Equal("provider2-result", result); // provider2 has lower priority (100 < 200)
     }
 
@@ -122,7 +122,7 @@ public class FunctionRegistryTests
         _ = Assert.Single(contracts);
         _ = Assert.Single(handlers);
 
-        var result = await handlers["func1"]("{}");
+        var result = await handlers["func1"]("{}", new ToolCallContext());
         Assert.Equal("provider2-result", result);
     }
 
@@ -150,8 +150,8 @@ public class FunctionRegistryTests
         Assert.Contains("natural-func1", handlers.Keys); // Natural function with provider prefix
         Assert.Contains("mcp-func1", handlers.Keys); // MCP function with provider prefix
 
-        var naturalResult = await handlers["natural-func1"]("{}");
-        var mcpResult = await handlers["mcp-func1"]("{}");
+        var naturalResult = await handlers["natural-func1"]("{}", new ToolCallContext());
+        var mcpResult = await handlers["mcp-func1"]("{}", new ToolCallContext());
         Assert.Equal("natural-result", naturalResult);
         Assert.Equal("mcp-result", mcpResult);
     }
@@ -176,10 +176,10 @@ public class FunctionRegistryTests
         Assert.Equal(2, handlers.Count);
 
         // Both have same Contract.Name "func1", so collision detection prefixes with provider name
-        var naturalResult = await handlers["natural-func1"]("{}");
+        var naturalResult = await handlers["natural-func1"]("{}", new ToolCallContext());
         Assert.Equal("natural-result", naturalResult);
 
-        var mcpResult = await handlers["mcp-func1"]("{}");
+        var mcpResult = await handlers["mcp-func1"]("{}", new ToolCallContext());
         Assert.Equal("mcp-result", mcpResult);
     }
 
@@ -203,7 +203,7 @@ public class FunctionRegistryTests
         _ = Assert.Single(contracts);
         _ = Assert.Single(handlers);
 
-        var result = await handlers["func1"]("{}");
+        var result = await handlers["func1"]("{}", new ToolCallContext());
         Assert.Equal("provider1-result", result);
     }
 
@@ -416,9 +416,9 @@ public class FunctionRegistryTests
         };
     }
 
-    internal static Func<string, Task<ToolHandlerResult>> CreateTestHandler(string result)
+    internal static ToolHandler CreateTestHandler(string result)
     {
-        return _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, result)));
+        return (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, result)));
     }
 
     private static FunctionContract CreateTestContractWithParameters(string name)
@@ -487,7 +487,7 @@ public class FunctionRegistryTests
                     Description = $"Test function {name}",
                     Parameters = [],
                 },
-                Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
+                Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
                 ProviderName = ProviderName,
             });
         }
@@ -521,7 +521,7 @@ public class FunctionRegistryTests
                         Description = $"Test function {_functionName}",
                         Parameters = [],
                     },
-                    Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
+                    Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
                     ProviderName = ProviderName,
                 },
             ];
@@ -556,7 +556,7 @@ public class FunctionRegistryTests
                         Description = $"Test function {_functionName}",
                         Parameters = [],
                     },
-                    Handler = _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
+                    Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
                     ProviderName = ProviderName,
                 },
             ];

--- a/tests/LmCore.Tests/Middleware/FunctionRegistryTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionRegistryTests.cs
@@ -57,7 +57,7 @@ public class FunctionRegistryTests
         _ = Assert.Single(contracts);
         _ = Assert.Single(handlers);
 
-        var result = await handlers["func1"]("{}", new ToolCallContext());
+        var result = await handlers["func1"]("{}", new ToolCallContext(), CancellationToken.None);
         Assert.Equal("explicit-result", result);
     }
 
@@ -99,7 +99,7 @@ public class FunctionRegistryTests
         _ = Assert.Single(contracts);
         _ = Assert.Single(handlers);
 
-        var result = await handlers["func1"]("{}", new ToolCallContext());
+        var result = await handlers["func1"]("{}", new ToolCallContext(), CancellationToken.None);
         Assert.Equal("provider2-result", result); // provider2 has lower priority (100 < 200)
     }
 
@@ -122,7 +122,7 @@ public class FunctionRegistryTests
         _ = Assert.Single(contracts);
         _ = Assert.Single(handlers);
 
-        var result = await handlers["func1"]("{}", new ToolCallContext());
+        var result = await handlers["func1"]("{}", new ToolCallContext(), CancellationToken.None);
         Assert.Equal("provider2-result", result);
     }
 
@@ -150,8 +150,8 @@ public class FunctionRegistryTests
         Assert.Contains("natural-func1", handlers.Keys); // Natural function with provider prefix
         Assert.Contains("mcp-func1", handlers.Keys); // MCP function with provider prefix
 
-        var naturalResult = await handlers["natural-func1"]("{}", new ToolCallContext());
-        var mcpResult = await handlers["mcp-func1"]("{}", new ToolCallContext());
+        var naturalResult = await handlers["natural-func1"]("{}", new ToolCallContext(), CancellationToken.None);
+        var mcpResult = await handlers["mcp-func1"]("{}", new ToolCallContext(), CancellationToken.None);
         Assert.Equal("natural-result", naturalResult);
         Assert.Equal("mcp-result", mcpResult);
     }
@@ -176,10 +176,10 @@ public class FunctionRegistryTests
         Assert.Equal(2, handlers.Count);
 
         // Both have same Contract.Name "func1", so collision detection prefixes with provider name
-        var naturalResult = await handlers["natural-func1"]("{}", new ToolCallContext());
+        var naturalResult = await handlers["natural-func1"]("{}", new ToolCallContext(), CancellationToken.None);
         Assert.Equal("natural-result", naturalResult);
 
-        var mcpResult = await handlers["mcp-func1"]("{}", new ToolCallContext());
+        var mcpResult = await handlers["mcp-func1"]("{}", new ToolCallContext(), CancellationToken.None);
         Assert.Equal("mcp-result", mcpResult);
     }
 
@@ -203,7 +203,7 @@ public class FunctionRegistryTests
         _ = Assert.Single(contracts);
         _ = Assert.Single(handlers);
 
-        var result = await handlers["func1"]("{}", new ToolCallContext());
+        var result = await handlers["func1"]("{}", new ToolCallContext(), CancellationToken.None);
         Assert.Equal("provider1-result", result);
     }
 
@@ -418,7 +418,7 @@ public class FunctionRegistryTests
 
     internal static ToolHandler CreateTestHandler(string result)
     {
-        return (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, result)));
+        return (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, result)));
     }
 
     private static FunctionContract CreateTestContractWithParameters(string name)
@@ -487,7 +487,7 @@ public class FunctionRegistryTests
                     Description = $"Test function {name}",
                     Parameters = [],
                 },
-                Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
+                Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
                 ProviderName = ProviderName,
             });
         }
@@ -521,7 +521,7 @@ public class FunctionRegistryTests
                         Description = $"Test function {_functionName}",
                         Parameters = [],
                     },
-                    Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
+                    Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
                     ProviderName = ProviderName,
                 },
             ];
@@ -556,7 +556,7 @@ public class FunctionRegistryTests
                         Description = $"Test function {_functionName}",
                         Parameters = [],
                     },
-                    Handler = (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
+                    Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
                     ProviderName = ProviderName,
                 },
             ];

--- a/tests/LmCore.Tests/Middleware/FunctionRegistryTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionRegistryTests.cs
@@ -58,7 +58,7 @@ public class FunctionRegistryTests
         _ = Assert.Single(handlers);
 
         var result = await handlers["func1"]("{}", new ToolCallContext(), CancellationToken.None);
-        Assert.Equal("explicit-result", result);
+        Assert.Equal("explicit-result", result.ResultText);
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public class FunctionRegistryTests
         _ = Assert.Single(handlers);
 
         var result = await handlers["func1"]("{}", new ToolCallContext(), CancellationToken.None);
-        Assert.Equal("provider2-result", result); // provider2 has lower priority (100 < 200)
+        Assert.Equal("provider2-result", result.ResultText); // provider2 has lower priority (100 < 200)
     }
 
     [Fact]
@@ -123,7 +123,7 @@ public class FunctionRegistryTests
         _ = Assert.Single(handlers);
 
         var result = await handlers["func1"]("{}", new ToolCallContext(), CancellationToken.None);
-        Assert.Equal("provider2-result", result);
+        Assert.Equal("provider2-result", result.ResultText);
     }
 
     [Fact]
@@ -152,8 +152,8 @@ public class FunctionRegistryTests
 
         var naturalResult = await handlers["natural-func1"]("{}", new ToolCallContext(), CancellationToken.None);
         var mcpResult = await handlers["mcp-func1"]("{}", new ToolCallContext(), CancellationToken.None);
-        Assert.Equal("natural-result", naturalResult);
-        Assert.Equal("mcp-result", mcpResult);
+        Assert.Equal("natural-result", naturalResult.ResultText);
+        Assert.Equal("mcp-result", mcpResult.ResultText);
     }
 
     [Fact]
@@ -177,10 +177,10 @@ public class FunctionRegistryTests
 
         // Both have same Contract.Name "func1", so collision detection prefixes with provider name
         var naturalResult = await handlers["natural-func1"]("{}", new ToolCallContext(), CancellationToken.None);
-        Assert.Equal("natural-result", naturalResult);
+        Assert.Equal("natural-result", naturalResult.ResultText);
 
         var mcpResult = await handlers["mcp-func1"]("{}", new ToolCallContext(), CancellationToken.None);
-        Assert.Equal("mcp-result", mcpResult);
+        Assert.Equal("mcp-result", mcpResult.ResultText);
     }
 
     [Fact]
@@ -204,7 +204,7 @@ public class FunctionRegistryTests
         _ = Assert.Single(handlers);
 
         var result = await handlers["func1"]("{}", new ToolCallContext(), CancellationToken.None);
-        Assert.Equal("provider1-result", result);
+        Assert.Equal("provider1-result", result.ResultText);
     }
 
     [Fact]
@@ -418,7 +418,7 @@ public class FunctionRegistryTests
 
     internal static ToolHandler CreateTestHandler(string result)
     {
-        return (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, result)));
+        return (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText(result));
     }
 
     private static FunctionContract CreateTestContractWithParameters(string name)
@@ -487,7 +487,7 @@ public class FunctionRegistryTests
                     Description = $"Test function {name}",
                     Parameters = [],
                 },
-                Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
+                Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText($"{ProviderName}-result")),
                 ProviderName = ProviderName,
             });
         }
@@ -521,7 +521,7 @@ public class FunctionRegistryTests
                         Description = $"Test function {_functionName}",
                         Parameters = [],
                     },
-                    Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
+                    Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText($"{ProviderName}-result")),
                     ProviderName = ProviderName,
                 },
             ];
@@ -556,7 +556,7 @@ public class FunctionRegistryTests
                         Description = $"Test function {_functionName}",
                         Parameters = [],
                     },
-                    Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(new ToolCallResult(null, $"{ProviderName}-result"))),
+                    Handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText($"{ProviderName}-result")),
                     ProviderName = ProviderName,
                 },
             ];

--- a/tests/LmCore.Tests/Middleware/LegacyHandlerAdapterTests.cs
+++ b/tests/LmCore.Tests/Middleware/LegacyHandlerAdapterTests.cs
@@ -1,0 +1,104 @@
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using FluentAssertions;
+using Xunit;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.Middleware;
+
+public class LegacyHandlerAdapterTests
+{
+    [Fact]
+    public async Task ToLegacyHandler_Resolved_ReturnsPayloadText()
+    {
+        ToolHandler handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(
+            ToolHandlerResult.FromText("hello"));
+
+        var legacy = LegacyHandlerAdapter.ToLegacyHandler(handler, toolKey: "echo");
+
+        var text = await legacy("{}");
+        text.Should().Be("hello");
+    }
+
+    [Fact]
+    public async Task ToLegacyHandler_Deferred_ThrowsNotSupportedException()
+    {
+        // The legacy shape (Func<string, Task<string>>) has no resolution channel — deferral
+        // is the responsibility of MultiTurnAgentLoop, which uses ToolHandler directly.
+        // Adapters that bridge into the legacy shape (e.g., MCP server) must surface
+        // misuse loudly. This is the only guardrail.
+        ToolHandler handler = (_, _, _) => Task.FromResult<ToolHandlerResult>(
+            new ToolHandlerResult.Deferred());
+
+        var legacy = LegacyHandlerAdapter.ToLegacyHandler(handler, toolKey: "wait_for_human");
+
+        var act = async () => await legacy("{}");
+        var ex = await act.Should().ThrowAsync<NotSupportedException>();
+        ex.WithMessage("*wait_for_human*deferred*MultiTurnAgentLoop*");
+    }
+
+    [Fact]
+    public async Task WrapToLegacyHandlers_Deferred_ThrowsAtInvocationNotConstruction()
+    {
+        // Deferred handlers can be REGISTERED in a legacy-shape map without crashing — the
+        // NotSupportedException only fires at invocation time, when a tool is actually called.
+        var source = new Dictionary<string, ToolHandler>
+        {
+            ["safe"] = (_, _, _) => Task.FromResult<ToolHandlerResult>(
+                ToolHandlerResult.FromText("ok")),
+            ["bad"] = (_, _, _) => Task.FromResult<ToolHandlerResult>(
+                new ToolHandlerResult.Deferred()),
+        };
+
+        var wrapped = LegacyHandlerAdapter.WrapToLegacyHandlers(source);
+
+        wrapped.Should().HaveCount(2);
+        (await wrapped["safe"]("{}")).Should().Be("ok");
+
+        var act = async () => await wrapped["bad"]("{}");
+        await act.Should().ThrowAsync<NotSupportedException>()
+            .WithMessage("*bad*");
+    }
+
+    [Fact]
+    public async Task ToNewHandler_FromString_ProducesResolvedTextPayload()
+    {
+        Func<string, Task<string>> legacy = _ => Task.FromResult("legacy-result");
+
+        var handler = LegacyHandlerAdapter.ToNewHandler(legacy);
+
+        var result = await handler("{}", new ToolCallContext(), CancellationToken.None);
+        result.Should().BeOfType<ToolHandlerResult.Resolved>();
+        ((ToolHandlerResult.Resolved)result).Payload.Text.Should().Be("legacy-result");
+    }
+
+    [Fact]
+    public async Task ToNewHandler_FromToolCallResult_ProjectsPayloadFields()
+    {
+        // The legacy ToolCallResult shape carries text + content blocks + error fields. The
+        // adapter must project all four into ToolHandlerResultPayload; framework-controlled
+        // fields (tool_call_id, IsDeferred, timestamps) on the legacy result are dropped —
+        // the builder downstream is the only thing that should set them.
+        var blocks = new List<ToolResultContentBlock>
+        {
+            new TextToolResultBlock { Text = "rich" },
+        };
+        Func<string, Task<ToolCallResult>> legacy = _ => Task.FromResult(
+            new ToolCallResult(
+                toolCallId: "should-be-dropped",
+                result: "the-text",
+                contentBlocks: blocks)
+            {
+                IsError = true,
+                ErrorCode = "E_LEGACY",
+            });
+
+        var handler = LegacyHandlerAdapter.ToNewHandler(legacy);
+
+        var result = await handler("{}", new ToolCallContext(), CancellationToken.None);
+        var resolved = result.Should().BeOfType<ToolHandlerResult.Resolved>().Subject;
+        resolved.Payload.Text.Should().Be("the-text");
+        resolved.Payload.ContentBlocks.Should().BeSameAs(blocks);
+        resolved.Payload.IsError.Should().BeTrue();
+        resolved.Payload.ErrorCode.Should().Be("E_LEGACY");
+    }
+}

--- a/tests/LmCore.Tests/Middleware/MultiModalHandlerIntegrationTests.cs
+++ b/tests/LmCore.Tests/Middleware/MultiModalHandlerIntegrationTests.cs
@@ -15,7 +15,7 @@ public class MultiModalHandlerIntegrationTests
     [Fact]
     public void FunctionRegistry_Build_RetainsHandlerThatReturnsContentBlocks()
     {
-        var multiModalHandler = new Func<string, Task<ToolHandlerResult>>(_ =>
+        var multiModalHandler = new ToolHandler((_, _) =>
             Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(
                 new ToolCallResult(null, "multimodal", new List<ToolResultContentBlock>
                 {
@@ -43,9 +43,9 @@ public class MultiModalHandlerIntegrationTests
             new() { Name = "image_tool", Description = "Returns images" },
         };
 
-        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
+        var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["image_tool"] = _ => Task.FromResult<ToolHandlerResult>(
+            ["image_tool"] = (_, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Resolved(
                     new ToolCallResult(null, "multimodal text", new List<ToolResultContentBlock>
                     {
@@ -86,7 +86,7 @@ public class MultiModalHandlerIntegrationTests
     [Fact]
     public void FunctionRegistry_BuildMiddleware_AcceptsContentBlockHandlers()
     {
-        var multiModalHandler = new Func<string, Task<ToolHandlerResult>>(_ =>
+        var multiModalHandler = new ToolHandler((_, _) =>
             Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Resolved(new ToolCallResult(null, "mm result")))
         );

--- a/tests/LmCore.Tests/Middleware/MultiModalHandlerIntegrationTests.cs
+++ b/tests/LmCore.Tests/Middleware/MultiModalHandlerIntegrationTests.cs
@@ -15,7 +15,7 @@ public class MultiModalHandlerIntegrationTests
     [Fact]
     public void FunctionRegistry_Build_RetainsHandlerThatReturnsContentBlocks()
     {
-        var multiModalHandler = new ToolHandler((_, _) =>
+        var multiModalHandler = new ToolHandler((_, _, _) =>
             Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(
                 new ToolCallResult(null, "multimodal", new List<ToolResultContentBlock>
                 {
@@ -45,7 +45,7 @@ public class MultiModalHandlerIntegrationTests
 
         var functionMap = new Dictionary<string, ToolHandler>
         {
-            ["image_tool"] = (_, _) => Task.FromResult<ToolHandlerResult>(
+            ["image_tool"] = (_, _, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Resolved(
                     new ToolCallResult(null, "multimodal text", new List<ToolResultContentBlock>
                     {
@@ -86,7 +86,7 @@ public class MultiModalHandlerIntegrationTests
     [Fact]
     public void FunctionRegistry_BuildMiddleware_AcceptsContentBlockHandlers()
     {
-        var multiModalHandler = new ToolHandler((_, _) =>
+        var multiModalHandler = new ToolHandler((_, _, _) =>
             Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Resolved(new ToolCallResult(null, "mm result")))
         );

--- a/tests/LmCore.Tests/Middleware/MultiModalHandlerIntegrationTests.cs
+++ b/tests/LmCore.Tests/Middleware/MultiModalHandlerIntegrationTests.cs
@@ -1,125 +1,60 @@
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
 
 namespace AchieveAi.LmDotnetTools.LmCore.Tests.Middleware;
 
 /// <summary>
-///     Tests verifying that FunctionDescriptor's MultiModalHandler flows through
-///     FunctionRegistry and FunctionCallMiddleware correctly.
-///     These tests simulate the pattern used by McpClientFunctionProvider.CreateAsync
-///     after Step 4 changes: both Handler and MultiModalHandler are populated.
+///     Verifies that a unified <see cref="ToolHandlerResult.Resolved"/> handler whose wrapped
+///     <see cref="ToolCallResult"/> carries <see cref="ToolResultContentBlock"/>s propagates
+///     those blocks through <see cref="FunctionCallMiddleware"/> and <see cref="FunctionRegistry"/>
+///     to the result message.
 /// </summary>
 public class MultiModalHandlerIntegrationTests
 {
     [Fact]
-    public void FunctionDescriptor_WithMultiModalHandler_PreservesHandler()
+    public void FunctionRegistry_Build_RetainsHandlerThatReturnsContentBlocks()
     {
-        // Arrange & Act
-        var descriptor = new FunctionDescriptor
-        {
-            Contract = new FunctionContract { Name = "test_tool", Description = "A test tool" },
-            Handler = _ => Task.FromResult("text result"),
-            MultiModalHandler = _ =>
-                Task.FromResult(
-                    new ToolCallResult(null, "text result", new List<ToolResultContentBlock>
-                    {
-                        new ImageToolResultBlock { Data = "base64data", MimeType = "image/png" },
-                    })
-                ),
-            ProviderName = "McpClient",
-        };
-
-        // Assert
-        Assert.True(descriptor.HasMultiModalHandler);
-        Assert.NotNull(descriptor.MultiModalHandler);
-        Assert.NotNull(descriptor.Handler);
-    }
-
-    [Fact]
-    public void FunctionDescriptor_WithoutMultiModalHandler_HasNoHandler()
-    {
-        // Arrange & Act - simulates a non-MCP function
-        var descriptor = new FunctionDescriptor
-        {
-            Contract = new FunctionContract { Name = "local_func", Description = "A local function" },
-            Handler = _ => Task.FromResult("text result"),
-            ProviderName = "Local",
-        };
-
-        // Assert
-        Assert.False(descriptor.HasMultiModalHandler);
-        Assert.Null(descriptor.MultiModalHandler);
-    }
-
-    [Fact]
-    public void FunctionRegistry_BuildWithMultiModal_IncludesMultiModalHandlers()
-    {
-        // Arrange - simulates McpClientFunctionProvider producing descriptors with both handlers
-        var textHandler = new Func<string, Task<string>>(_ => Task.FromResult("text only"));
-        var multiModalHandler = new Func<string, Task<ToolCallResult>>(_ =>
-            Task.FromResult(new ToolCallResult(null, "multimodal", new List<ToolResultContentBlock>
-            {
-                new TextToolResultBlock { Text = "some text" },
-                new ImageToolResultBlock { Data = "base64img", MimeType = "image/jpeg" },
-            }))
-        );
-
-        var provider = new TestFunctionProvider("McpClient", new[]
-        {
-            new FunctionDescriptor
-            {
-                Contract = new FunctionContract { Name = "mcp_tool", Description = "MCP tool with images" },
-                Handler = textHandler,
-                MultiModalHandler = multiModalHandler,
-                ProviderName = "McpClient",
-            },
-            new FunctionDescriptor
-            {
-                Contract = new FunctionContract { Name = "local_tool", Description = "Local tool, text only" },
-                Handler = _ => Task.FromResult("local result"),
-                ProviderName = "Local",
-            },
-        });
+        var multiModalHandler = new Func<string, Task<ToolHandlerResult>>(_ =>
+            Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(
+                new ToolCallResult(null, "multimodal", new List<ToolResultContentBlock>
+                {
+                    new TextToolResultBlock { Text = "some text" },
+                    new ImageToolResultBlock { Data = "base64img", MimeType = "image/jpeg" },
+                }))));
 
         var registry = new FunctionRegistry();
-        registry.AddProvider(provider);
+        registry.AddFunction(
+            new FunctionContract { Name = "mcp_tool", Description = "MCP tool with images" },
+            multiModalHandler);
 
-        // Act
-        var (contracts, textHandlers, multiModalHandlers) = registry.BuildWithMultiModal();
+        var (contracts, handlers) = registry.Build();
 
-        // Assert
-        Assert.Equal(2, contracts.Count());
-        Assert.Equal(2, textHandlers.Count);
-        // Only the MCP tool should have a multimodal handler
-        Assert.Single(multiModalHandlers);
-        Assert.True(multiModalHandlers.ContainsKey("mcp_tool"));
-        Assert.False(multiModalHandlers.ContainsKey("local_tool"));
+        Assert.Single(contracts);
+        Assert.Single(handlers);
+        Assert.True(handlers.ContainsKey("mcp_tool"));
     }
 
     [Fact]
-    public async Task FunctionCallMiddleware_WithMultiModalMap_PrefersMultiModalHandler()
+    public async Task FunctionCallMiddleware_PropagatesContentBlocksFromUnifiedHandler()
     {
-        // Arrange - simulates the middleware receiving both maps (as produced by FunctionRegistry.BuildWithMultiModal)
         var functions = new List<FunctionContract>
         {
             new() { Name = "image_tool", Description = "Returns images" },
         };
 
-        var functionMap = new Dictionary<string, Func<string, Task<string>>>
+        var functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
         {
-            ["image_tool"] = _ => Task.FromResult("fallback text"),
+            ["image_tool"] = _ => Task.FromResult<ToolHandlerResult>(
+                new ToolHandlerResult.Resolved(
+                    new ToolCallResult(null, "multimodal text", new List<ToolResultContentBlock>
+                    {
+                        new TextToolResultBlock { Text = "rich text" },
+                        new ImageToolResultBlock { Data = "aW1hZ2VkYXRh", MimeType = "image/png" },
+                    }))),
         };
 
-        var multiModalMap = new Dictionary<string, Func<string, Task<ToolCallResult>>>
-        {
-            ["image_tool"] = _ =>
-                Task.FromResult(new ToolCallResult(null, "multimodal text", new List<ToolResultContentBlock>
-                {
-                    new TextToolResultBlock { Text = "rich text" },
-                    new ImageToolResultBlock { Data = "aW1hZ2VkYXRh", MimeType = "image/png" },
-                })),
-        };
-
-        var middleware = new FunctionCallMiddleware(functions, functionMap, multiModalMap);
+        var middleware = new FunctionCallMiddleware(functions, functionMap);
 
         var toolCallMessage = new ToolsCallMessage
         {
@@ -137,11 +72,8 @@ public class MultiModalHandlerIntegrationTests
         var context = new MiddlewareContext([toolCallMessage]);
         var mockAgent = new Mock<IAgent>();
 
-        // Act
         var result = await middleware.InvokeAsync(context, mockAgent.Object);
 
-        // Assert - should use the multimodal handler, so result should contain ContentBlocks
-        Assert.NotNull(result);
         var resultMessage = Assert.IsType<ToolsCallResultMessage>(result.First());
         var toolCallResult = resultMessage.ToolCallResults.First();
         Assert.Equal("multimodal text", toolCallResult.Result);
@@ -152,193 +84,21 @@ public class MultiModalHandlerIntegrationTests
     }
 
     [Fact]
-    public async Task FunctionCallMiddleware_WithMixedTools_UsesCorrectHandlerForEach()
+    public void FunctionRegistry_BuildMiddleware_AcceptsContentBlockHandlers()
     {
-        // Arrange - one tool has multimodal, the other is text-only
-        var functions = new List<FunctionContract>
-        {
-            new() { Name = "image_tool", Description = "Returns images" },
-            new() { Name = "text_tool", Description = "Returns text only" },
-        };
-
-        var functionMap = new Dictionary<string, Func<string, Task<string>>>
-        {
-            ["image_tool"] = _ => Task.FromResult("image fallback"),
-            ["text_tool"] = _ => Task.FromResult("text result"),
-        };
-
-        var multiModalMap = new Dictionary<string, Func<string, Task<ToolCallResult>>>
-        {
-            ["image_tool"] = _ =>
-                Task.FromResult(new ToolCallResult(null, "image multimodal", new List<ToolResultContentBlock>
-                {
-                    new ImageToolResultBlock { Data = "cG5nZGF0YQ==", MimeType = "image/png" },
-                })),
-        };
-
-        var middleware = new FunctionCallMiddleware(functions, functionMap, multiModalMap);
-
-        // Call text_tool (no multimodal handler)
-        var textToolCall = new ToolsCallMessage
-        {
-            ToolCalls =
-            [
-                new ToolCall { FunctionName = "text_tool", FunctionArgs = "{}", ToolCallId = "call_text" },
-            ],
-            Role = Role.Assistant,
-        };
-        var textContext = new MiddlewareContext([textToolCall]);
-        var mockAgent = new Mock<IAgent>();
-
-        var textResult = await middleware.InvokeAsync(textContext, mockAgent.Object);
-        var textResultMessage = Assert.IsType<ToolsCallResultMessage>(textResult.First());
-        var textToolResult = textResultMessage.ToolCallResults.First();
-        Assert.Equal("text result", textToolResult.Result);
-        Assert.Null(textToolResult.ContentBlocks);
-
-        // Call image_tool (has multimodal handler)
-        var imageToolCall = new ToolsCallMessage
-        {
-            ToolCalls =
-            [
-                new ToolCall { FunctionName = "image_tool", FunctionArgs = "{}", ToolCallId = "call_image" },
-            ],
-            Role = Role.Assistant,
-        };
-        var imageContext = new MiddlewareContext([imageToolCall]);
-
-        var imageResult = await middleware.InvokeAsync(imageContext, mockAgent.Object);
-        var imageResultMessage = Assert.IsType<ToolsCallResultMessage>(imageResult.First());
-        var imageToolResult = imageResultMessage.ToolCallResults.First();
-        Assert.Equal("image multimodal", imageToolResult.Result);
-        Assert.NotNull(imageToolResult.ContentBlocks);
-        Assert.Single(imageToolResult.ContentBlocks!);
-    }
-
-    [Fact]
-    public void FunctionRegistry_BuildMiddleware_PassesMultiModalHandlersThrough()
-    {
-        // Arrange - verify BuildMiddleware creates a middleware that has multimodal support
-        var multiModalHandler = new Func<string, Task<ToolCallResult>>(_ =>
-            Task.FromResult(new ToolCallResult(null, "mm result"))
+        var multiModalHandler = new Func<string, Task<ToolHandlerResult>>(_ =>
+            Task.FromResult<ToolHandlerResult>(
+                new ToolHandlerResult.Resolved(new ToolCallResult(null, "mm result")))
         );
 
-        var provider = new TestFunctionProvider("Test", new[]
-        {
-            new FunctionDescriptor
-            {
-                Contract = new FunctionContract { Name = "mm_func", Description = "Multimodal function" },
-                Handler = _ => Task.FromResult("text"),
-                MultiModalHandler = multiModalHandler,
-                ProviderName = "Test",
-            },
-        });
-
         var registry = new FunctionRegistry();
-        registry.AddProvider(provider);
+        registry.AddFunction(
+            new FunctionContract { Name = "mm_func", Description = "Multimodal function" },
+            multiModalHandler);
 
-        // Act - should not throw
         var middleware = registry.BuildMiddleware("TestMiddleware");
 
-        // Assert
         Assert.NotNull(middleware);
         Assert.Equal("TestMiddleware", middleware.Name);
-    }
-
-    /// <summary>
-    ///     Tests the streaming path (InvokeStreamingAsync) of FunctionCallMiddleware
-    ///     when a multimodal tool is invoked. When the last message in context is a
-    ///     ToolsCallMessage with a tool that has a multimodal handler, the streaming
-    ///     middleware should execute the multimodal handler and return ContentBlocks.
-    /// </summary>
-    [Fact]
-    public async Task FunctionCallMiddleware_InvokeStreamingAsync_WithMultiModalTool_ReturnsContentBlocks()
-    {
-        // Arrange - same tool setup as the non-streaming test, exercised through the streaming API
-        var functions = new List<FunctionContract>
-        {
-            new() { Name = "screenshot_tool", Description = "Captures a screenshot" },
-        };
-
-        var functionMap = new Dictionary<string, Func<string, Task<string>>>
-        {
-            ["screenshot_tool"] = _ => Task.FromResult("fallback text"),
-        };
-
-        var multiModalMap = new Dictionary<string, Func<string, Task<ToolCallResult>>>
-        {
-            ["screenshot_tool"] = _ =>
-                Task.FromResult(new ToolCallResult(null, "screenshot captured",
-                    [
-                        new TextToolResultBlock { Text = "Screenshot of the page" },
-                        new ImageToolResultBlock { Data = "cG5nZGF0YQ==", MimeType = "image/png" },
-                    ])),
-        };
-
-        var middleware = new FunctionCallMiddleware(functions, functionMap, multiModalMap);
-
-        // The last message is a ToolsCallMessage, which triggers the pending-tool-calls path
-        var toolCallMessage = new ToolsCallMessage
-        {
-            ToolCalls =
-            [
-                new ToolCall
-                {
-                    FunctionName = "screenshot_tool",
-                    FunctionArgs = "{}",
-                    ToolCallId = "call_stream_1",
-                },
-            ],
-            Role = Role.Assistant,
-        };
-        var context = new MiddlewareContext([toolCallMessage]);
-
-        // MockStreamingAgent is not invoked because the middleware handles pending tool calls directly
-        var mockAgent = new MockStreamingAgent([]);
-
-        // Act - use the streaming API
-        var responseStream = await middleware.InvokeStreamingAsync(context, mockAgent);
-
-        var results = new List<IMessage>();
-        await foreach (var message in responseStream)
-        {
-            results.Add(message);
-        }
-
-        // Assert - the result should be a ToolsCallResultMessage with ContentBlocks
-        Assert.Single(results);
-        var resultMessage = Assert.IsType<ToolsCallResultMessage>(results[0]);
-        var toolCallResult = resultMessage.ToolCallResults.First();
-
-        Assert.Equal("screenshot captured", toolCallResult.Result);
-        Assert.NotNull(toolCallResult.ContentBlocks);
-        Assert.Equal(2, toolCallResult.ContentBlocks!.Count);
-        Assert.IsType<TextToolResultBlock>(toolCallResult.ContentBlocks[0]);
-        Assert.IsType<ImageToolResultBlock>(toolCallResult.ContentBlocks[1]);
-
-        // Verify the image data is preserved
-        var imageBlock = (ImageToolResultBlock)toolCallResult.ContentBlocks[1];
-        Assert.Equal("cG5nZGF0YQ==", imageBlock.Data);
-        Assert.Equal("image/png", imageBlock.MimeType);
-    }
-
-    /// <summary>
-    ///     Simple test function provider for unit testing.
-    /// </summary>
-    private sealed class TestFunctionProvider : IFunctionProvider
-    {
-        private readonly IEnumerable<FunctionDescriptor> _functions;
-
-        public TestFunctionProvider(string providerName, IEnumerable<FunctionDescriptor> functions)
-        {
-            ProviderName = providerName;
-            _functions = functions;
-        }
-
-        public string ProviderName { get; }
-
-        public int Priority => 100;
-
-        public IEnumerable<FunctionDescriptor> GetFunctions() => _functions;
     }
 }

--- a/tests/LmCore.Tests/Middleware/MultiModalHandlerIntegrationTests.cs
+++ b/tests/LmCore.Tests/Middleware/MultiModalHandlerIntegrationTests.cs
@@ -16,12 +16,13 @@ public class MultiModalHandlerIntegrationTests
     public void FunctionRegistry_Build_RetainsHandlerThatReturnsContentBlocks()
     {
         var multiModalHandler = new ToolHandler((_, _, _) =>
-            Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Resolved(
-                new ToolCallResult(null, "multimodal", new List<ToolResultContentBlock>
+            Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromMultiModal(
+                "multimodal",
+                new List<ToolResultContentBlock>
                 {
                     new TextToolResultBlock { Text = "some text" },
                     new ImageToolResultBlock { Data = "base64img", MimeType = "image/jpeg" },
-                }))));
+                })));
 
         var registry = new FunctionRegistry();
         registry.AddFunction(
@@ -46,12 +47,13 @@ public class MultiModalHandlerIntegrationTests
         var functionMap = new Dictionary<string, ToolHandler>
         {
             ["image_tool"] = (_, _, _) => Task.FromResult<ToolHandlerResult>(
-                new ToolHandlerResult.Resolved(
-                    new ToolCallResult(null, "multimodal text", new List<ToolResultContentBlock>
+                ToolHandlerResult.FromMultiModal(
+                    "multimodal text",
+                    new List<ToolResultContentBlock>
                     {
                         new TextToolResultBlock { Text = "rich text" },
                         new ImageToolResultBlock { Data = "aW1hZ2VkYXRh", MimeType = "image/png" },
-                    }))),
+                    })),
         };
 
         var middleware = new FunctionCallMiddleware(functions, functionMap);
@@ -87,8 +89,7 @@ public class MultiModalHandlerIntegrationTests
     public void FunctionRegistry_BuildMiddleware_AcceptsContentBlockHandlers()
     {
         var multiModalHandler = new ToolHandler((_, _, _) =>
-            Task.FromResult<ToolHandlerResult>(
-                new ToolHandlerResult.Resolved(new ToolCallResult(null, "mm result")))
+            Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText("mm result"))
         );
 
         var registry = new FunctionRegistry();

--- a/tests/LmCore.Tests/Middleware/NaturalToolUseMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/NaturalToolUseMiddlewareTests.cs
@@ -8,7 +8,7 @@ public class NaturalToolUseMiddlewareTests
     // Common test context
     private readonly MiddlewareContext _defaultContext;
     private readonly List<FunctionContract> _functionContracts;
-    private readonly Dictionary<string, Func<string, Task<ToolHandlerResult>>> _functionMap;
+    private readonly Dictionary<string, ToolHandler> _functionMap;
     private readonly Mock<IAgent> _mockFallbackParser;
     private readonly Mock<IJsonSchemaValidator> _mockSchemaValidator;
 
@@ -42,9 +42,9 @@ public class NaturalToolUseMiddlewareTests
             },
         ];
 
-        _functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
+        _functionMap = new Dictionary<string, ToolHandler>
         {
-            { "GetWeather", _ => Task.FromResult<ToolHandlerResult>(
+            { "GetWeather", (_, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Resolved(new ToolCallResult(null, "{\"temperature\": 72, \"conditions\": \"sunny\"}"))) },
         };
 

--- a/tests/LmCore.Tests/Middleware/NaturalToolUseMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/NaturalToolUseMiddlewareTests.cs
@@ -1,4 +1,5 @@
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Models;
 namespace AchieveAi.LmDotnetTools.LmCore.Tests.Middleware;
 
@@ -7,7 +8,7 @@ public class NaturalToolUseMiddlewareTests
     // Common test context
     private readonly MiddlewareContext _defaultContext;
     private readonly List<FunctionContract> _functionContracts;
-    private readonly Dictionary<string, Func<string, Task<string>>> _functionMap;
+    private readonly Dictionary<string, Func<string, Task<ToolHandlerResult>>> _functionMap;
     private readonly Mock<IAgent> _mockFallbackParser;
     private readonly Mock<IJsonSchemaValidator> _mockSchemaValidator;
 
@@ -41,9 +42,10 @@ public class NaturalToolUseMiddlewareTests
             },
         ];
 
-        _functionMap = new Dictionary<string, Func<string, Task<string>>>
+        _functionMap = new Dictionary<string, Func<string, Task<ToolHandlerResult>>>
         {
-            { "GetWeather", async args => await Task.FromResult("{\"temperature\": 72, \"conditions\": \"sunny\"}") },
+            { "GetWeather", _ => Task.FromResult<ToolHandlerResult>(
+                new ToolHandlerResult.Resolved(new ToolCallResult(null, "{\"temperature\": 72, \"conditions\": \"sunny\"}"))) },
         };
 
         // Initialize default context

--- a/tests/LmCore.Tests/Middleware/NaturalToolUseMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/NaturalToolUseMiddlewareTests.cs
@@ -44,7 +44,7 @@ public class NaturalToolUseMiddlewareTests
 
         _functionMap = new Dictionary<string, ToolHandler>
         {
-            { "GetWeather", (_, _) => Task.FromResult<ToolHandlerResult>(
+            { "GetWeather", (_, _, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Resolved(new ToolCallResult(null, "{\"temperature\": 72, \"conditions\": \"sunny\"}"))) },
         };
 

--- a/tests/LmCore.Tests/Middleware/NaturalToolUseMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/NaturalToolUseMiddlewareTests.cs
@@ -45,7 +45,7 @@ public class NaturalToolUseMiddlewareTests
         _functionMap = new Dictionary<string, ToolHandler>
         {
             { "GetWeather", (_, _, _) => Task.FromResult<ToolHandlerResult>(
-                new ToolHandlerResult.Resolved(new ToolCallResult(null, "{\"temperature\": 72, \"conditions\": \"sunny\"}"))) },
+                ToolHandlerResult.FromText("{\"temperature\": 72, \"conditions\": \"sunny\"}")) },
         };
 
         // Initialize default context

--- a/tests/LmCore.Tests/Middleware/ToolCallExecutorTests.cs
+++ b/tests/LmCore.Tests/Middleware/ToolCallExecutorTests.cs
@@ -24,9 +24,9 @@ public class ToolCallExecutorTests
             Role = Role.Assistant,
         };
 
-        var functionMap = new Dictionary<string, Func<string, Task<ToolCallResult>>>
+        var functionMap = new Dictionary<string, ToolCallResultHandler>
         {
-            ["getWeather"] = _ => Task.FromResult(new ToolCallResult(null, "Sunny, 72F")),
+            ["getWeather"] = (_, _) => Task.FromResult(new ToolCallResult(null, "Sunny, 72F")),
         };
 
         // Act
@@ -62,9 +62,9 @@ public class ToolCallExecutorTests
             Role = Role.Assistant,
         };
 
-        var functionMap = new Dictionary<string, Func<string, Task<ToolCallResult>>>
+        var functionMap = new Dictionary<string, ToolCallResultHandler>
         {
-            ["failingFunction"] = _ => throw new InvalidOperationException("Something went wrong"),
+            ["failingFunction"] = (_, _) => throw new InvalidOperationException("Something went wrong"),
         };
 
         // Act
@@ -100,9 +100,9 @@ public class ToolCallExecutorTests
             Role = Role.Assistant,
         };
 
-        var functionMap = new Dictionary<string, Func<string, Task<ToolCallResult>>>
+        var functionMap = new Dictionary<string, ToolCallResultHandler>
         {
-            ["existingFunction"] = _ => Task.FromResult(new ToolCallResult(null, "ok")),
+            ["existingFunction"] = (_, _) => Task.FromResult(new ToolCallResult(null, "ok")),
         };
 
         // Act
@@ -152,10 +152,10 @@ public class ToolCallExecutorTests
             Role = Role.Assistant,
         };
 
-        var functionMap = new Dictionary<string, Func<string, Task<ToolCallResult>>>
+        var functionMap = new Dictionary<string, ToolCallResultHandler>
         {
-            ["successFunc"] = _ => Task.FromResult(new ToolCallResult(null, "ok")),
-            ["failFunc"] = _ => throw new Exception("boom"),
+            ["successFunc"] = (_, _) => Task.FromResult(new ToolCallResult(null, "ok")),
+            ["failFunc"] = (_, _) => throw new Exception("boom"),
         };
 
         // Act

--- a/tests/LmCore.Tests/Middleware/ToolCallExecutorTests.cs
+++ b/tests/LmCore.Tests/Middleware/ToolCallExecutorTests.cs
@@ -26,7 +26,7 @@ public class ToolCallExecutorTests
 
         var functionMap = new Dictionary<string, ToolCallResultHandler>
         {
-            ["getWeather"] = (_, _) => Task.FromResult(new ToolCallResult(null, "Sunny, 72F")),
+            ["getWeather"] = (_, _, _) => Task.FromResult(new ToolCallResult(null, "Sunny, 72F")),
         };
 
         // Act
@@ -64,7 +64,7 @@ public class ToolCallExecutorTests
 
         var functionMap = new Dictionary<string, ToolCallResultHandler>
         {
-            ["failingFunction"] = (_, _) => throw new InvalidOperationException("Something went wrong"),
+            ["failingFunction"] = (_, _, _) => throw new InvalidOperationException("Something went wrong"),
         };
 
         // Act
@@ -102,7 +102,7 @@ public class ToolCallExecutorTests
 
         var functionMap = new Dictionary<string, ToolCallResultHandler>
         {
-            ["existingFunction"] = (_, _) => Task.FromResult(new ToolCallResult(null, "ok")),
+            ["existingFunction"] = (_, _, _) => Task.FromResult(new ToolCallResult(null, "ok")),
         };
 
         // Act
@@ -154,8 +154,8 @@ public class ToolCallExecutorTests
 
         var functionMap = new Dictionary<string, ToolCallResultHandler>
         {
-            ["successFunc"] = (_, _) => Task.FromResult(new ToolCallResult(null, "ok")),
-            ["failFunc"] = (_, _) => throw new Exception("boom"),
+            ["successFunc"] = (_, _, _) => Task.FromResult(new ToolCallResult(null, "ok")),
+            ["failFunc"] = (_, _, _) => throw new Exception("boom"),
         };
 
         // Act

--- a/tests/LmCore.Tests/Middleware/ToolCallExecutorTests.cs
+++ b/tests/LmCore.Tests/Middleware/ToolCallExecutorTests.cs
@@ -1,3 +1,5 @@
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+
 namespace AchieveAi.LmDotnetTools.LmCore.Tests.Middleware;
 
 public class ToolCallExecutorTests
@@ -22,9 +24,9 @@ public class ToolCallExecutorTests
             Role = Role.Assistant,
         };
 
-        var functionMap = new Dictionary<string, Func<string, Task<string>>>
+        var functionMap = new Dictionary<string, Func<string, Task<ToolCallResult>>>
         {
-            ["getWeather"] = _ => Task.FromResult("Sunny, 72F"),
+            ["getWeather"] = _ => Task.FromResult(new ToolCallResult(null, "Sunny, 72F")),
         };
 
         // Act
@@ -60,7 +62,7 @@ public class ToolCallExecutorTests
             Role = Role.Assistant,
         };
 
-        var functionMap = new Dictionary<string, Func<string, Task<string>>>
+        var functionMap = new Dictionary<string, Func<string, Task<ToolCallResult>>>
         {
             ["failingFunction"] = _ => throw new InvalidOperationException("Something went wrong"),
         };
@@ -98,9 +100,9 @@ public class ToolCallExecutorTests
             Role = Role.Assistant,
         };
 
-        var functionMap = new Dictionary<string, Func<string, Task<string>>>
+        var functionMap = new Dictionary<string, Func<string, Task<ToolCallResult>>>
         {
-            ["existingFunction"] = _ => Task.FromResult("ok"),
+            ["existingFunction"] = _ => Task.FromResult(new ToolCallResult(null, "ok")),
         };
 
         // Act
@@ -150,9 +152,9 @@ public class ToolCallExecutorTests
             Role = Role.Assistant,
         };
 
-        var functionMap = new Dictionary<string, Func<string, Task<string>>>
+        var functionMap = new Dictionary<string, Func<string, Task<ToolCallResult>>>
         {
-            ["successFunc"] = _ => Task.FromResult("ok"),
+            ["successFunc"] = _ => Task.FromResult(new ToolCallResult(null, "ok")),
             ["failFunc"] = _ => throw new Exception("boom"),
         };
 

--- a/tests/LmCore.Tests/Middleware/TypeFunctionProviderTests.cs
+++ b/tests/LmCore.Tests/Middleware/TypeFunctionProviderTests.cs
@@ -81,7 +81,7 @@ public class TypeFunctionProviderTests
 
         // Act
         var args = JsonSerializer.Serialize(new { a = 5, b = 3 });
-        var result = await addFunction.Handler(args, new ToolCallContext());
+        var result = await addFunction.Handler(args, new ToolCallContext(), CancellationToken.None);
         var resultValue = JsonSerializer.Deserialize<int>(result.ResultText);
 
         // Assert
@@ -97,7 +97,7 @@ public class TypeFunctionProviderTests
 
         // Act
         var args = JsonSerializer.Serialize(new { x = 4, y = 7 });
-        var result = await multiplyFunction.Handler(args, new ToolCallContext());
+        var result = await multiplyFunction.Handler(args, new ToolCallContext(), CancellationToken.None);
         var resultValue = JsonSerializer.Deserialize<int>(result.ResultText);
 
         // Assert
@@ -114,7 +114,7 @@ public class TypeFunctionProviderTests
 
         // Act
         var args = JsonSerializer.Serialize(new { input = "test" });
-        var result = await asyncFunction.Handler(args, new ToolCallContext());
+        var result = await asyncFunction.Handler(args, new ToolCallContext(), CancellationToken.None);
         var resultValue = JsonSerializer.Deserialize<string>(result.ResultText);
 
         // Assert
@@ -131,7 +131,7 @@ public class TypeFunctionProviderTests
 
         // Act - Call without factor parameter (should use default)
         var args = JsonSerializer.Serialize(new { value = 10.0 });
-        var result = await calculateFunction.Handler(args, new ToolCallContext());
+        var result = await calculateFunction.Handler(args, new ToolCallContext(), CancellationToken.None);
         var resultValue = JsonSerializer.Deserialize<double>(result.ResultText);
 
         // Assert
@@ -148,7 +148,7 @@ public class TypeFunctionProviderTests
 
         // Act - Call with null
         var args = "{}"; // Empty args, text will be null
-        var result = await toUpperFunction.Handler(args, new ToolCallContext());
+        var result = await toUpperFunction.Handler(args, new ToolCallContext(), CancellationToken.None);
         var resultValue = JsonSerializer.Deserialize<string>(result.ResultText);
 
         // Assert
@@ -164,9 +164,9 @@ public class TypeFunctionProviderTests
         var incrementFunction = provider.GetFunctions().First(f => f.Contract.Name == "increment");
 
         // Act - Call multiple times
-        var result1 = await incrementFunction.Handler("{}", new ToolCallContext());
-        var result2 = await incrementFunction.Handler("{}", new ToolCallContext());
-        var result3 = await incrementFunction.Handler("{}", new ToolCallContext());
+        var result1 = await incrementFunction.Handler("{}", new ToolCallContext(), CancellationToken.None);
+        var result2 = await incrementFunction.Handler("{}", new ToolCallContext(), CancellationToken.None);
+        var result3 = await incrementFunction.Handler("{}", new ToolCallContext(), CancellationToken.None);
 
         // Assert
         Assert.Equal(1, JsonSerializer.Deserialize<int>(result1.ResultText));
@@ -184,7 +184,7 @@ public class TypeFunctionProviderTests
 
         // Act
         var args = JsonSerializer.Serialize(new { a = 10.0, b = 0.0 });
-        var result = await divideFunction.Handler(args, new ToolCallContext());
+        var result = await divideFunction.Handler(args, new ToolCallContext(), CancellationToken.None);
         var errorResult = JsonSerializer.Deserialize<Dictionary<string, string>>(result.ResultText);
 
         // Assert
@@ -203,7 +203,7 @@ public class TypeFunctionProviderTests
         var asyncErrorFunction = provider.GetFunctions().First(f => f.Contract.Name == "asyncError");
 
         // Act
-        var result = await asyncErrorFunction.Handler("{}", new ToolCallContext());
+        var result = await asyncErrorFunction.Handler("{}", new ToolCallContext(), CancellationToken.None);
         var errorResult = JsonSerializer.Deserialize<Dictionary<string, string>>(result.ResultText);
 
         // Assert
@@ -282,7 +282,7 @@ public class TypeFunctionProviderTests
 
         // Test execution through handler
         var calculateHandler = handlers["calculate"];
-        var result = await calculateHandler(JsonSerializer.Serialize(new { value = 5.0, factor = 3.0 }), new ToolCallContext());
+        var result = await calculateHandler(JsonSerializer.Serialize(new { value = 5.0, factor = 3.0 }), new ToolCallContext(), CancellationToken.None);
         Assert.Equal(15.0, JsonSerializer.Deserialize<double>(result.ResultText));
     }
 

--- a/tests/LmCore.Tests/Middleware/TypeFunctionProviderTests.cs
+++ b/tests/LmCore.Tests/Middleware/TypeFunctionProviderTests.cs
@@ -81,7 +81,7 @@ public class TypeFunctionProviderTests
 
         // Act
         var args = JsonSerializer.Serialize(new { a = 5, b = 3 });
-        var result = await addFunction.Handler(args);
+        var result = await addFunction.Handler(args, new ToolCallContext());
         var resultValue = JsonSerializer.Deserialize<int>(result.ResultText);
 
         // Assert
@@ -97,7 +97,7 @@ public class TypeFunctionProviderTests
 
         // Act
         var args = JsonSerializer.Serialize(new { x = 4, y = 7 });
-        var result = await multiplyFunction.Handler(args);
+        var result = await multiplyFunction.Handler(args, new ToolCallContext());
         var resultValue = JsonSerializer.Deserialize<int>(result.ResultText);
 
         // Assert
@@ -114,7 +114,7 @@ public class TypeFunctionProviderTests
 
         // Act
         var args = JsonSerializer.Serialize(new { input = "test" });
-        var result = await asyncFunction.Handler(args);
+        var result = await asyncFunction.Handler(args, new ToolCallContext());
         var resultValue = JsonSerializer.Deserialize<string>(result.ResultText);
 
         // Assert
@@ -131,7 +131,7 @@ public class TypeFunctionProviderTests
 
         // Act - Call without factor parameter (should use default)
         var args = JsonSerializer.Serialize(new { value = 10.0 });
-        var result = await calculateFunction.Handler(args);
+        var result = await calculateFunction.Handler(args, new ToolCallContext());
         var resultValue = JsonSerializer.Deserialize<double>(result.ResultText);
 
         // Assert
@@ -148,7 +148,7 @@ public class TypeFunctionProviderTests
 
         // Act - Call with null
         var args = "{}"; // Empty args, text will be null
-        var result = await toUpperFunction.Handler(args);
+        var result = await toUpperFunction.Handler(args, new ToolCallContext());
         var resultValue = JsonSerializer.Deserialize<string>(result.ResultText);
 
         // Assert
@@ -164,9 +164,9 @@ public class TypeFunctionProviderTests
         var incrementFunction = provider.GetFunctions().First(f => f.Contract.Name == "increment");
 
         // Act - Call multiple times
-        var result1 = await incrementFunction.Handler("{}");
-        var result2 = await incrementFunction.Handler("{}");
-        var result3 = await incrementFunction.Handler("{}");
+        var result1 = await incrementFunction.Handler("{}", new ToolCallContext());
+        var result2 = await incrementFunction.Handler("{}", new ToolCallContext());
+        var result3 = await incrementFunction.Handler("{}", new ToolCallContext());
 
         // Assert
         Assert.Equal(1, JsonSerializer.Deserialize<int>(result1.ResultText));
@@ -184,7 +184,7 @@ public class TypeFunctionProviderTests
 
         // Act
         var args = JsonSerializer.Serialize(new { a = 10.0, b = 0.0 });
-        var result = await divideFunction.Handler(args);
+        var result = await divideFunction.Handler(args, new ToolCallContext());
         var errorResult = JsonSerializer.Deserialize<Dictionary<string, string>>(result.ResultText);
 
         // Assert
@@ -203,7 +203,7 @@ public class TypeFunctionProviderTests
         var asyncErrorFunction = provider.GetFunctions().First(f => f.Contract.Name == "asyncError");
 
         // Act
-        var result = await asyncErrorFunction.Handler("{}");
+        var result = await asyncErrorFunction.Handler("{}", new ToolCallContext());
         var errorResult = JsonSerializer.Deserialize<Dictionary<string, string>>(result.ResultText);
 
         // Assert
@@ -282,7 +282,7 @@ public class TypeFunctionProviderTests
 
         // Test execution through handler
         var calculateHandler = handlers["calculate"];
-        var result = await calculateHandler(JsonSerializer.Serialize(new { value = 5.0, factor = 3.0 }));
+        var result = await calculateHandler(JsonSerializer.Serialize(new { value = 5.0, factor = 3.0 }), new ToolCallContext());
         Assert.Equal(15.0, JsonSerializer.Deserialize<double>(result.ResultText));
     }
 

--- a/tests/LmCore.Tests/Middleware/TypeFunctionProviderTests.cs
+++ b/tests/LmCore.Tests/Middleware/TypeFunctionProviderTests.cs
@@ -82,7 +82,7 @@ public class TypeFunctionProviderTests
         // Act
         var args = JsonSerializer.Serialize(new { a = 5, b = 3 });
         var result = await addFunction.Handler(args);
-        var resultValue = JsonSerializer.Deserialize<int>(result);
+        var resultValue = JsonSerializer.Deserialize<int>(result.ResultText);
 
         // Assert
         Assert.Equal(8, resultValue);
@@ -98,7 +98,7 @@ public class TypeFunctionProviderTests
         // Act
         var args = JsonSerializer.Serialize(new { x = 4, y = 7 });
         var result = await multiplyFunction.Handler(args);
-        var resultValue = JsonSerializer.Deserialize<int>(result);
+        var resultValue = JsonSerializer.Deserialize<int>(result.ResultText);
 
         // Assert
         Assert.Equal(28, resultValue);
@@ -115,7 +115,7 @@ public class TypeFunctionProviderTests
         // Act
         var args = JsonSerializer.Serialize(new { input = "test" });
         var result = await asyncFunction.Handler(args);
-        var resultValue = JsonSerializer.Deserialize<string>(result);
+        var resultValue = JsonSerializer.Deserialize<string>(result.ResultText);
 
         // Assert
         Assert.Equal("Processed: test", resultValue);
@@ -132,7 +132,7 @@ public class TypeFunctionProviderTests
         // Act - Call without factor parameter (should use default)
         var args = JsonSerializer.Serialize(new { value = 10.0 });
         var result = await calculateFunction.Handler(args);
-        var resultValue = JsonSerializer.Deserialize<double>(result);
+        var resultValue = JsonSerializer.Deserialize<double>(result.ResultText);
 
         // Assert
         Assert.Equal(20.0, resultValue);
@@ -149,7 +149,7 @@ public class TypeFunctionProviderTests
         // Act - Call with null
         var args = "{}"; // Empty args, text will be null
         var result = await toUpperFunction.Handler(args);
-        var resultValue = JsonSerializer.Deserialize<string>(result);
+        var resultValue = JsonSerializer.Deserialize<string>(result.ResultText);
 
         // Assert
         Assert.Equal(string.Empty, resultValue);
@@ -169,9 +169,9 @@ public class TypeFunctionProviderTests
         var result3 = await incrementFunction.Handler("{}");
 
         // Assert
-        Assert.Equal(1, JsonSerializer.Deserialize<int>(result1));
-        Assert.Equal(2, JsonSerializer.Deserialize<int>(result2));
-        Assert.Equal(3, JsonSerializer.Deserialize<int>(result3));
+        Assert.Equal(1, JsonSerializer.Deserialize<int>(result1.ResultText));
+        Assert.Equal(2, JsonSerializer.Deserialize<int>(result2.ResultText));
+        Assert.Equal(3, JsonSerializer.Deserialize<int>(result3.ResultText));
     }
 
     [Fact]
@@ -185,7 +185,7 @@ public class TypeFunctionProviderTests
         // Act
         var args = JsonSerializer.Serialize(new { a = 10.0, b = 0.0 });
         var result = await divideFunction.Handler(args);
-        var errorResult = JsonSerializer.Deserialize<Dictionary<string, string>>(result);
+        var errorResult = JsonSerializer.Deserialize<Dictionary<string, string>>(result.ResultText);
 
         // Assert
         Assert.NotNull(errorResult);
@@ -204,7 +204,7 @@ public class TypeFunctionProviderTests
 
         // Act
         var result = await asyncErrorFunction.Handler("{}");
-        var errorResult = JsonSerializer.Deserialize<Dictionary<string, string>>(result);
+        var errorResult = JsonSerializer.Deserialize<Dictionary<string, string>>(result.ResultText);
 
         // Assert
         Assert.NotNull(errorResult);
@@ -283,7 +283,7 @@ public class TypeFunctionProviderTests
         // Test execution through handler
         var calculateHandler = handlers["calculate"];
         var result = await calculateHandler(JsonSerializer.Serialize(new { value = 5.0, factor = 3.0 }));
-        Assert.Equal(15.0, JsonSerializer.Deserialize<double>(result));
+        Assert.Equal(15.0, JsonSerializer.Deserialize<double>(result.ResultText));
     }
 
     [Fact]

--- a/tests/LmMultiTurn.Tests/DeferredToolExecutionTests.cs
+++ b/tests/LmMultiTurn.Tests/DeferredToolExecutionTests.cs
@@ -42,7 +42,7 @@ public class DeferredToolExecutionTests
         var registry = new FunctionRegistry();
         registry.AddFunction(
             BuildContract("approve_directory_read"),
-            (_, _) => Task.FromResult<ToolHandlerResult>(
+            (_, _, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Deferred("PENDING approval for /foo")));
 
         await using var loop = new MultiTurnAgentLoop(
@@ -123,7 +123,7 @@ public class DeferredToolExecutionTests
         var registry = new FunctionRegistry();
         registry.AddFunction(
             BuildContract("long_running_op"),
-            (_, _) => Task.FromResult<ToolHandlerResult>(
+            (_, _, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Deferred("PENDING long op")));
 
         await using var loop = new MultiTurnAgentLoop(
@@ -242,7 +242,7 @@ public class DeferredToolExecutionTests
         var registry = new FunctionRegistry();
         registry.AddFunction(
             BuildContract("long_op"),
-            (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred("PENDING")));
+            (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred("PENDING")));
 
         await using var loop = new MultiTurnAgentLoop(
             _mockAgent.Object,
@@ -330,7 +330,7 @@ public class DeferredToolExecutionTests
         var registry = new FunctionRegistry();
         registry.AddFunction(
             BuildContract("op"),
-            (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred("PENDING")));
+            (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred("PENDING")));
 
         await using var loop = new MultiTurnAgentLoop(
             _mockAgent.Object,
@@ -384,7 +384,7 @@ public class DeferredToolExecutionTests
         var registry = new FunctionRegistry();
         registry.AddFunction(
             BuildContract("wait_for_human"),
-            (_, _) => Task.FromResult<ToolHandlerResult>(
+            (_, _, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Deferred("WAIT", System.Collections.Immutable.ImmutableDictionary
                     .CreateRange(new Dictionary<string, string> { ["ticket"] = "T-42" }))));
 

--- a/tests/LmMultiTurn.Tests/DeferredToolExecutionTests.cs
+++ b/tests/LmMultiTurn.Tests/DeferredToolExecutionTests.cs
@@ -42,7 +42,7 @@ public class DeferredToolExecutionTests
         var registry = new FunctionRegistry();
         registry.AddFunction(
             BuildContract("approve_directory_read"),
-            _ => Task.FromResult<ToolHandlerResult>(
+            (_, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Deferred("PENDING approval for /foo")));
 
         await using var loop = new MultiTurnAgentLoop(
@@ -123,7 +123,7 @@ public class DeferredToolExecutionTests
         var registry = new FunctionRegistry();
         registry.AddFunction(
             BuildContract("long_running_op"),
-            _ => Task.FromResult<ToolHandlerResult>(
+            (_, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Deferred("PENDING long op")));
 
         await using var loop = new MultiTurnAgentLoop(
@@ -242,7 +242,7 @@ public class DeferredToolExecutionTests
         var registry = new FunctionRegistry();
         registry.AddFunction(
             BuildContract("long_op"),
-            _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred("PENDING")));
+            (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred("PENDING")));
 
         await using var loop = new MultiTurnAgentLoop(
             _mockAgent.Object,
@@ -330,7 +330,7 @@ public class DeferredToolExecutionTests
         var registry = new FunctionRegistry();
         registry.AddFunction(
             BuildContract("op"),
-            _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred("PENDING")));
+            (_, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred("PENDING")));
 
         await using var loop = new MultiTurnAgentLoop(
             _mockAgent.Object,
@@ -384,7 +384,7 @@ public class DeferredToolExecutionTests
         var registry = new FunctionRegistry();
         registry.AddFunction(
             BuildContract("wait_for_human"),
-            _ => Task.FromResult<ToolHandlerResult>(
+            (_, _) => Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Deferred("WAIT", System.Collections.Immutable.ImmutableDictionary
                     .CreateRange(new Dictionary<string, string> { ["ticket"] = "T-42" }))));
 

--- a/tests/LmMultiTurn.Tests/DeferredToolExecutionTests.cs
+++ b/tests/LmMultiTurn.Tests/DeferredToolExecutionTests.cs
@@ -1,0 +1,446 @@
+using System.Runtime.CompilerServices;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmCore.Models;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+/// <summary>
+/// End-to-end tests for the deferred tool execution feature in <see cref="MultiTurnAgentLoop"/>.
+/// Each test arranges a mock LLM that emits a tool call, registers a handler that signals
+/// deferral, and exercises the full lifecycle: placeholder published, run ends, external
+/// resolution arrives, auto-resume fires, LLM sees the resolved value.
+/// </summary>
+public class DeferredToolExecutionTests
+{
+    private readonly Mock<IStreamingAgent> _mockAgent = new();
+    private readonly Mock<ILogger<MultiTurnAgentLoop>> _loggerMock = new();
+
+    [Fact]
+    public async Task DeferredHandler_RecordsPlaceholderAndEndsRun()
+    {
+        // Mock LLM emits a single tool call. The handler returns Deferred so the loop
+        // should record an IsDeferred=true placeholder and end the run after this turn.
+        var toolCall = new ToolCallMessage
+        {
+            FunctionName = "approve_directory_read",
+            FunctionArgs = "{\"path\": \"/foo\"}",
+            ToolCallId = "tc_1",
+            Role = Role.Assistant,
+        };
+
+        SetupOneTurnResponse(toolCall);
+
+        var registry = new FunctionRegistry();
+        registry.AddFunction(
+            BuildContract("approve_directory_read"),
+            _ => Task.FromResult<ToolHandlerResult>(
+                new ToolHandlerResult.Deferred("PENDING approval for /foo")));
+
+        await using var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            registry,
+            "test-thread",
+            logger: _loggerMock.Object);
+
+        using var cts = new CancellationTokenSource();
+        var runTask = loop.RunAsync(cts.Token);
+
+        var userInput = new UserInput([new TextMessage { Text = "Read /foo", Role = Role.User }]);
+        var messages = new List<IMessage>();
+        await foreach (var msg in loop.ExecuteRunAsync(userInput, cts.Token))
+        {
+            messages.Add(msg);
+        }
+
+        // Assert: tool call message published, deferred placeholder published, run completed.
+        messages.OfType<ToolCallMessage>().Should().ContainSingle(tc => tc.ToolCallId == "tc_1");
+        var deferredResult = messages.OfType<ToolCallResultMessage>().Should().ContainSingle().Subject;
+        deferredResult.ToolCallId.Should().Be("tc_1");
+        deferredResult.IsDeferred.Should().BeTrue();
+        deferredResult.Result.Should().Be("PENDING approval for /foo");
+        messages.OfType<RunCompletedMessage>().Should().NotBeEmpty();
+
+        // The mock LLM should have been called only once — no second turn fires while
+        // the deferred call is unresolved.
+        _mockAgent.Verify(a => a.GenerateReplyStreamingAsync(
+            It.IsAny<IEnumerable<IMessage>>(),
+            It.IsAny<GenerateReplyOptions>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        var pending = await loop.GetDeferredToolCallsAsync();
+        pending.Should().ContainSingle(p => p.ToolCallId == "tc_1");
+
+        await cts.CancelAsync();
+    }
+
+    [Fact]
+    public async Task ResolveToolCallAsync_ReplacesPlaceholderAndAutoResumesRun()
+    {
+        // Two-call mock LLM: first call returns the tool call, second call (after resume)
+        // returns final text. Capture the messages the second call sees so we can assert
+        // the resolved value reached the LLM.
+        var toolCall = new ToolCallMessage
+        {
+            FunctionName = "long_running_op",
+            FunctionArgs = "{}",
+            ToolCallId = "tc_long",
+            Role = Role.Assistant,
+        };
+        var finalAssistantText = new TextMessage
+        {
+            Text = "Operation completed successfully.",
+            Role = Role.Assistant,
+        };
+
+        var callCount = 0;
+        IEnumerable<IMessage>? secondCallMessages = null;
+        _mockAgent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>(
+                (msgs, _, _) =>
+                {
+                    callCount++;
+                    if (callCount == 1)
+                    {
+                        return Task.FromResult(ToAsyncEnumerable([toolCall]));
+                    }
+                    secondCallMessages = msgs.ToList();
+                    return Task.FromResult(ToAsyncEnumerable([finalAssistantText]));
+                });
+
+        var registry = new FunctionRegistry();
+        registry.AddFunction(
+            BuildContract("long_running_op"),
+            _ => Task.FromResult<ToolHandlerResult>(
+                new ToolHandlerResult.Deferred("PENDING long op")));
+
+        await using var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            registry,
+            "test-thread",
+            logger: _loggerMock.Object);
+
+        using var cts = new CancellationTokenSource();
+        var runTask = loop.RunAsync(cts.Token);
+
+        // Subscribe so we can wait for run completions.
+        var subscriberMessages = new List<IMessage>();
+        var subscribeTcs = new TaskCompletionSource<bool>();
+        var firstRunCompleted = new TaskCompletionSource<bool>();
+        var secondRunCompleted = new TaskCompletionSource<bool>();
+        var runCompleteCount = 0;
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                subscribeTcs.SetResult(true);
+                await foreach (var msg in loop.SubscribeAsync(cts.Token))
+                {
+                    subscriberMessages.Add(msg);
+                    if (msg is RunCompletedMessage)
+                    {
+                        runCompleteCount++;
+                        if (runCompleteCount == 1)
+                        {
+                            firstRunCompleted.TrySetResult(true);
+                        }
+                        else if (runCompleteCount == 2)
+                        {
+                            secondRunCompleted.TrySetResult(true);
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException) { }
+        }, cts.Token);
+
+        await subscribeTcs.Task;
+
+        // Send the first user input — kicks off run 1.
+        await loop.SendAsync([new TextMessage { Text = "Start the long op", Role = Role.User }]);
+
+        // Wait for run 1 to finish (handler deferred, run ends).
+        await firstRunCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Verify the deferred call is registered.
+        var pendingBefore = await loop.GetDeferredToolCallsAsync();
+        pendingBefore.Should().ContainSingle(p => p.ToolCallId == "tc_long");
+
+        // Resolve the deferred call. This should auto-trigger run 2.
+        await loop.ResolveToolCallAsync("tc_long", "{\"status\":\"done\"}");
+
+        // Wait for run 2 to complete (auto-resume).
+        await secondRunCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Mock LLM should have been called twice — initial + auto-resumed.
+        callCount.Should().Be(2);
+
+        // The second call to the LLM must see the resolved value in its messages.
+        // Note: MessageTransformationMiddleware aggregates singular ToolCallResultMessage
+        // entries into ToolsCallResultMessage on the upstream path, so we look for the
+        // resolved entry inside the plural form too.
+        secondCallMessages.Should().NotBeNull();
+        var allResults = secondCallMessages!
+            .OfType<ToolCallResultMessage>()
+            .Concat(
+                secondCallMessages!.OfType<ToolsCallResultMessage>()
+                    .SelectMany(m => m.ToolCallResults.Select(r => new ToolCallResultMessage
+                    {
+                        ToolCallId = r.ToolCallId,
+                        Result = r.Result,
+                        IsError = r.IsError,
+                    })))
+            .ToList();
+        var resolvedInHistory = allResults.Single(m => m.ToolCallId == "tc_long");
+        resolvedInHistory.Result.Should().Be("{\"status\":\"done\"}");
+
+        // The deferred set should now be empty.
+        var pendingAfter = await loop.GetDeferredToolCallsAsync();
+        pendingAfter.Should().BeEmpty();
+
+        await cts.CancelAsync();
+    }
+
+    [Fact]
+    public async Task ResolveToolCallAsync_IsIdempotent_ForByteEqualDuplicate()
+    {
+        var toolCall = new ToolCallMessage
+        {
+            FunctionName = "long_op",
+            FunctionArgs = "{}",
+            ToolCallId = "tc_idem",
+            Role = Role.Assistant,
+        };
+        var finalText = new TextMessage { Text = "done", Role = Role.Assistant };
+
+        var callCount = 0;
+        _mockAgent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>((_, _, _) =>
+            {
+                callCount++;
+                return callCount == 1
+                    ? Task.FromResult(ToAsyncEnumerable([(IMessage)toolCall]))
+                    : Task.FromResult(ToAsyncEnumerable([(IMessage)finalText]));
+            });
+
+        var registry = new FunctionRegistry();
+        registry.AddFunction(
+            BuildContract("long_op"),
+            _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred("PENDING")));
+
+        await using var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            registry,
+            "test-thread",
+            logger: _loggerMock.Object);
+
+        using var cts = new CancellationTokenSource();
+        var runTask = loop.RunAsync(cts.Token);
+
+        var firstRunCompleted = new TaskCompletionSource<bool>();
+        var secondRunCompleted = new TaskCompletionSource<bool>();
+        var completedRuns = 0;
+        _ = Task.Run(async () =>
+        {
+            await foreach (var msg in loop.SubscribeAsync(cts.Token))
+            {
+                if (msg is RunCompletedMessage)
+                {
+                    completedRuns++;
+                    if (completedRuns == 1) firstRunCompleted.TrySetResult(true);
+                    else if (completedRuns == 2) secondRunCompleted.TrySetResult(true);
+                }
+            }
+        }, cts.Token);
+
+        await loop.SendAsync([new TextMessage { Text = "Go", Role = Role.User }]);
+        await firstRunCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Resolve once — triggers auto-resume.
+        await loop.ResolveToolCallAsync("tc_idem", "FINAL");
+        await secondRunCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Resolve again with the SAME content. Should be a no-op (no exception, no third run).
+        await loop.ResolveToolCallAsync("tc_idem", "FINAL");
+
+        // Give any spurious resume a chance to fire — verify it didn't.
+        await Task.Delay(150);
+        callCount.Should().Be(2, "second resolve with identical content must be a no-op");
+
+        await cts.CancelAsync();
+    }
+
+    [Fact]
+    public async Task ResolveToolCallAsync_Throws_OnUnknownToolCallId()
+    {
+        var registry = new FunctionRegistry();
+        await using var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            registry,
+            "test-thread",
+            logger: _loggerMock.Object);
+
+        var act = async () => await loop.ResolveToolCallAsync("nonexistent", "value");
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*nonexistent*");
+    }
+
+    [Fact]
+    public async Task ResolveToolCallAsync_Throws_OnConflictingResolution()
+    {
+        var toolCall = new ToolCallMessage
+        {
+            FunctionName = "op",
+            FunctionArgs = "{}",
+            ToolCallId = "tc_conflict",
+            Role = Role.Assistant,
+        };
+        var finalText = new TextMessage { Text = "done", Role = Role.Assistant };
+
+        var callCount = 0;
+        _mockAgent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>((_, _, _) =>
+            {
+                callCount++;
+                return callCount == 1
+                    ? Task.FromResult(ToAsyncEnumerable([(IMessage)toolCall]))
+                    : Task.FromResult(ToAsyncEnumerable([(IMessage)finalText]));
+            });
+
+        var registry = new FunctionRegistry();
+        registry.AddFunction(
+            BuildContract("op"),
+            _ => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred("PENDING")));
+
+        await using var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            registry,
+            "test-thread",
+            logger: _loggerMock.Object);
+
+        using var cts = new CancellationTokenSource();
+        var runTask = loop.RunAsync(cts.Token);
+
+        var firstRunCompleted = new TaskCompletionSource<bool>();
+        var completedRuns = 0;
+        _ = Task.Run(async () =>
+        {
+            await foreach (var msg in loop.SubscribeAsync(cts.Token))
+            {
+                if (msg is RunCompletedMessage)
+                {
+                    completedRuns++;
+                    if (completedRuns == 1) firstRunCompleted.TrySetResult(true);
+                }
+            }
+        }, cts.Token);
+
+        await loop.SendAsync([new TextMessage { Text = "Go", Role = Role.User }]);
+        await firstRunCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // First resolution succeeds.
+        await loop.ResolveToolCallAsync("tc_conflict", "ANSWER_A");
+
+        // Second resolution with different content must throw.
+        var act = async () => await loop.ResolveToolCallAsync("tc_conflict", "ANSWER_B");
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*already been resolved*");
+
+        await cts.CancelAsync();
+    }
+
+    [Fact]
+    public async Task GetDeferredToolCallsAsync_ExposesFunctionAndArgsMetadata()
+    {
+        var toolCall = new ToolCallMessage
+        {
+            FunctionName = "wait_for_human",
+            FunctionArgs = "{\"prompt\":\"approve\"}",
+            ToolCallId = "tc_meta",
+            Role = Role.Assistant,
+        };
+        SetupOneTurnResponse(toolCall);
+
+        var registry = new FunctionRegistry();
+        registry.AddFunction(
+            BuildContract("wait_for_human"),
+            _ => Task.FromResult<ToolHandlerResult>(
+                new ToolHandlerResult.Deferred("WAIT", System.Collections.Immutable.ImmutableDictionary
+                    .CreateRange(new Dictionary<string, string> { ["ticket"] = "T-42" }))));
+
+        await using var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            registry,
+            "test-thread",
+            logger: _loggerMock.Object);
+
+        using var cts = new CancellationTokenSource();
+        var runTask = loop.RunAsync(cts.Token);
+
+        var userInput = new UserInput([new TextMessage { Text = "Go", Role = Role.User }]);
+        await foreach (var _ in loop.ExecuteRunAsync(userInput, cts.Token))
+        {
+            // drain
+        }
+
+        var pending = await loop.GetDeferredToolCallsAsync();
+        var info = pending.Should().ContainSingle().Subject;
+        info.ToolCallId.Should().Be("tc_meta");
+        info.FunctionName.Should().Be("wait_for_human");
+        info.FunctionArgs.Should().Be("{\"prompt\":\"approve\"}");
+        info.Placeholder.Should().Be("WAIT");
+        info.Metadata.Should().NotBeNull();
+        info.Metadata!["ticket"].Should().Be("T-42");
+
+        await cts.CancelAsync();
+    }
+
+    private void SetupOneTurnResponse(IMessage message)
+    {
+        _mockAgent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(ToAsyncEnumerable([message])));
+    }
+
+    private static FunctionContract BuildContract(string name) => new()
+    {
+        Name = name,
+        Description = $"Test contract for {name}",
+        Parameters = [],
+    };
+
+    private static async IAsyncEnumerable<IMessage> ToAsyncEnumerable(
+        IEnumerable<IMessage> messages,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        foreach (var msg in messages)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return msg;
+            await Task.Yield();
+        }
+    }
+}

--- a/tests/LmMultiTurn.Tests/DeferredToolExecutionTests.cs
+++ b/tests/LmMultiTurn.Tests/DeferredToolExecutionTests.cs
@@ -43,7 +43,7 @@ public class DeferredToolExecutionTests
         registry.AddFunction(
             BuildContract("approve_directory_read"),
             (_, _, _) => Task.FromResult<ToolHandlerResult>(
-                new ToolHandlerResult.Deferred("PENDING approval for /foo")));
+                new ToolHandlerResult.Deferred()));
 
         await using var loop = new MultiTurnAgentLoop(
             _mockAgent.Object,
@@ -66,7 +66,7 @@ public class DeferredToolExecutionTests
         var deferredResult = messages.OfType<ToolCallResultMessage>().Should().ContainSingle().Subject;
         deferredResult.ToolCallId.Should().Be("tc_1");
         deferredResult.IsDeferred.Should().BeTrue();
-        deferredResult.Result.Should().Be("PENDING approval for /foo");
+        deferredResult.Result.Should().Be(string.Empty);
         messages.OfType<RunCompletedMessage>().Should().NotBeEmpty();
 
         // The mock LLM should have been called only once — no second turn fires while
@@ -124,7 +124,7 @@ public class DeferredToolExecutionTests
         registry.AddFunction(
             BuildContract("long_running_op"),
             (_, _, _) => Task.FromResult<ToolHandlerResult>(
-                new ToolHandlerResult.Deferred("PENDING long op")));
+                new ToolHandlerResult.Deferred()));
 
         await using var loop = new MultiTurnAgentLoop(
             _mockAgent.Object,
@@ -242,7 +242,7 @@ public class DeferredToolExecutionTests
         var registry = new FunctionRegistry();
         registry.AddFunction(
             BuildContract("long_op"),
-            (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred("PENDING")));
+            (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred()));
 
         await using var loop = new MultiTurnAgentLoop(
             _mockAgent.Object,
@@ -330,7 +330,7 @@ public class DeferredToolExecutionTests
         var registry = new FunctionRegistry();
         registry.AddFunction(
             BuildContract("op"),
-            (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred("PENDING")));
+            (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred()));
 
         await using var loop = new MultiTurnAgentLoop(
             _mockAgent.Object,
@@ -384,9 +384,7 @@ public class DeferredToolExecutionTests
         var registry = new FunctionRegistry();
         registry.AddFunction(
             BuildContract("wait_for_human"),
-            (_, _, _) => Task.FromResult<ToolHandlerResult>(
-                new ToolHandlerResult.Deferred("WAIT", System.Collections.Immutable.ImmutableDictionary
-                    .CreateRange(new Dictionary<string, string> { ["ticket"] = "T-42" }))));
+            (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred()));
 
         await using var loop = new MultiTurnAgentLoop(
             _mockAgent.Object,
@@ -408,9 +406,72 @@ public class DeferredToolExecutionTests
         info.ToolCallId.Should().Be("tc_meta");
         info.FunctionName.Should().Be("wait_for_human");
         info.FunctionArgs.Should().Be("{\"prompt\":\"approve\"}");
-        info.Placeholder.Should().Be("WAIT");
-        info.Metadata.Should().NotBeNull();
-        info.Metadata!["ticket"].Should().Be("T-42");
+        info.DeferredAtUnixMs.Should().BeGreaterThan(0);
+
+        await cts.CancelAsync();
+    }
+
+    [Fact]
+    public async Task ExecuteTurn_Throws_WhenHistoryHasUnresolvedDeferredResult()
+    {
+        // Arrange — handler defers on the first call. After the deferral lands in history
+        // and the run ends, sending a NEW user input must NOT trigger another LLM call:
+        // the precondition guard in ExecuteTurnAsync should refuse to send a request while
+        // any deferred tool result is unresolved.
+        var toolCall = new ToolCallMessage
+        {
+            FunctionName = "wait",
+            FunctionArgs = "{}",
+            ToolCallId = "tc_guard",
+            Role = Role.Assistant,
+        };
+        SetupOneTurnResponse(toolCall);
+
+        var registry = new FunctionRegistry();
+        registry.AddFunction(
+            BuildContract("wait"),
+            (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred()));
+
+        await using var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            registry,
+            "test-thread",
+            logger: _loggerMock.Object);
+
+        using var cts = new CancellationTokenSource();
+        var runTask = loop.RunAsync(cts.Token);
+
+        // First run: tool call defers, run ends.
+        var firstUserInput = new UserInput([new TextMessage { Text = "Start", Role = Role.User }]);
+        await foreach (var _ in loop.ExecuteRunAsync(firstUserInput, cts.Token))
+        {
+            // drain
+        }
+
+        // Sanity: the deferred entry is in history and unresolved.
+        var pending = await loop.GetDeferredToolCallsAsync();
+        pending.Should().ContainSingle(p => p.ToolCallId == "tc_guard");
+
+        // Second user input while the deferral is unresolved. The loop's per-run try/catch
+        // converts the precondition guard's InvalidOperationException into a RunCompleted
+        // message with IsError=true (rather than letting it tear down the loop).
+        var followUpInput = new UserInput([new TextMessage { Text = "Hurry up", Role = Role.User }]);
+        var followUpMessages = new List<IMessage>();
+        await foreach (var msg in loop.ExecuteRunAsync(followUpInput, cts.Token))
+        {
+            followUpMessages.Add(msg);
+        }
+
+        var failedRun = followUpMessages.OfType<RunCompletedMessage>().Should().ContainSingle().Subject;
+        failedRun.IsError.Should().BeTrue();
+        failedRun.ErrorMessage.Should().Contain("tc_guard").And.Contain("deferred");
+
+        // Mock LLM should still have been called exactly once — the guard fired before
+        // any second provider request was sent.
+        _mockAgent.Verify(a => a.GenerateReplyStreamingAsync(
+            It.IsAny<IEnumerable<IMessage>>(),
+            It.IsAny<GenerateReplyOptions>(),
+            It.IsAny<CancellationToken>()), Times.Once);
 
         await cts.CancelAsync();
     }

--- a/tests/LmMultiTurn.Tests/DeferredToolExecutionTests.cs
+++ b/tests/LmMultiTurn.Tests/DeferredToolExecutionTests.cs
@@ -6,6 +6,7 @@ using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmCore.Models;
 using AchieveAi.LmDotnetTools.LmMultiTurn;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -474,6 +475,286 @@ public class DeferredToolExecutionTests
             It.IsAny<CancellationToken>()), Times.Once);
 
         await cts.CancelAsync();
+    }
+
+    [Fact]
+    public async Task MultipleDeferred_PartialResolution_AutoResumeOnlyAfterAllResolved()
+    {
+        // Two tool calls in one turn, both defer. Resolving the first must NOT trigger
+        // auto-resume (the second is still pending). Resolving the second MUST trigger
+        // auto-resume, and the LLM's next turn must see both resolved values.
+        var toolCallA = new ToolCallMessage
+        {
+            FunctionName = "wait_a", FunctionArgs = "{}", ToolCallId = "tc_a",
+            Role = Role.Assistant,
+        };
+        var toolCallB = new ToolCallMessage
+        {
+            FunctionName = "wait_b", FunctionArgs = "{}", ToolCallId = "tc_b",
+            Role = Role.Assistant,
+        };
+        var finalText = new TextMessage { Text = "all done", Role = Role.Assistant };
+
+        var callCount = 0;
+        IEnumerable<IMessage>? secondCallMessages = null;
+        _mockAgent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>(
+                (msgs, _, _) =>
+                {
+                    callCount++;
+                    if (callCount == 1)
+                    {
+                        return Task.FromResult(ToAsyncEnumerable(
+                            new IMessage[] { toolCallA, toolCallB }));
+                    }
+                    secondCallMessages = msgs.ToList();
+                    return Task.FromResult(ToAsyncEnumerable(new IMessage[] { finalText }));
+                });
+
+        var registry = new FunctionRegistry();
+        registry.AddFunction(BuildContract("wait_a"),
+            (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred()));
+        registry.AddFunction(BuildContract("wait_b"),
+            (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred()));
+
+        await using var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object, registry, "test-thread", logger: _loggerMock.Object);
+
+        using var cts = new CancellationTokenSource();
+        var runTask = loop.RunAsync(cts.Token);
+
+        var firstRunCompleted = new TaskCompletionSource<bool>();
+        var secondRunCompleted = new TaskCompletionSource<bool>();
+        var completedRuns = 0;
+        _ = Task.Run(async () =>
+        {
+            await foreach (var msg in loop.SubscribeAsync(cts.Token))
+            {
+                if (msg is RunCompletedMessage)
+                {
+                    completedRuns++;
+                    if (completedRuns == 1) firstRunCompleted.TrySetResult(true);
+                    else if (completedRuns == 2) secondRunCompleted.TrySetResult(true);
+                }
+            }
+        }, cts.Token);
+
+        await loop.SendAsync([new TextMessage { Text = "Go", Role = Role.User }]);
+        await firstRunCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Both deferrals registered.
+        var pending = await loop.GetDeferredToolCallsAsync();
+        pending.Should().HaveCount(2);
+
+        // Resolve A. Auto-resume should NOT fire because B is still deferred. We can't
+        // wait-for-not-happening, so wait a short moment and verify callCount unchanged.
+        await loop.ResolveToolCallAsync("tc_a", "result-a");
+        await Task.Delay(150);
+        callCount.Should().Be(1, "auto-resume must not fire while any deferral is pending");
+        secondRunCompleted.Task.IsCompleted.Should().BeFalse();
+
+        var stillPending = await loop.GetDeferredToolCallsAsync();
+        stillPending.Should().ContainSingle(p => p.ToolCallId == "tc_b");
+
+        // Resolve B. Now auto-resume must fire and the second LLM call must see BOTH
+        // resolved values.
+        await loop.ResolveToolCallAsync("tc_b", "result-b");
+        await secondRunCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        callCount.Should().Be(2);
+
+        secondCallMessages.Should().NotBeNull();
+        var allResults = secondCallMessages!
+            .OfType<ToolCallResultMessage>()
+            .Concat(
+                secondCallMessages!.OfType<ToolsCallResultMessage>()
+                    .SelectMany(m => m.ToolCallResults.Select(r => new ToolCallResultMessage
+                    {
+                        ToolCallId = r.ToolCallId,
+                        Result = r.Result,
+                        IsError = r.IsError,
+                    })))
+            .ToList();
+        allResults.Single(m => m.ToolCallId == "tc_a").Result.Should().Be("result-a");
+        allResults.Single(m => m.ToolCallId == "tc_b").Result.Should().Be("result-b");
+
+        await cts.CancelAsync();
+    }
+
+    [Fact]
+    public async Task OnHistoryRestoredAsync_RebuildsDeferredRegistry_FromPersistedHistory()
+    {
+        // Process restart scenario: a previous process recorded a deferred placeholder, then
+        // crashed/exited. New process loads from the store and must repopulate _deferred so
+        // GetDeferredToolCallsAsync surfaces the entry and a future ResolveToolCallAsync can
+        // complete it.
+        var threadId = "test-thread-restore";
+        var runId = "run_prev";
+        var generationId = "gen_prev";
+
+        var store = new InMemoryConversationStore();
+
+        // Pre-populate the store: one ToolCallMessage (so name/args can be recovered) and the
+        // matching ToolCallResultMessage with IsDeferred=true.
+        var toolCall = new ToolCallMessage
+        {
+            ToolCallId = "tc_persisted",
+            FunctionName = "wait_for_human",
+            FunctionArgs = "{\"prompt\":\"approve\"}",
+            Role = Role.Assistant,
+            FromAgent = "test",
+            GenerationId = generationId,
+            RunId = runId,
+        };
+        var deferredResult = new ToolCallResultMessage
+        {
+            ToolCallId = "tc_persisted",
+            ToolName = "wait_for_human",
+            Result = string.Empty,
+            IsDeferred = true,
+            DeferredAt = 1_700_000_000_000,
+            Role = Role.User,
+            GenerationId = generationId,
+            RunId = runId,
+        };
+
+        await store.AppendMessagesAsync(threadId, new List<PersistedMessage>
+        {
+            MessagePersistenceConverter.ToPersistedMessage(toolCall, threadId, runId),
+            MessagePersistenceConverter.ToPersistedMessage(deferredResult, threadId, runId),
+        });
+        await store.SaveMetadataAsync(threadId, new ThreadMetadata
+        {
+            ThreadId = threadId,
+            LatestRunId = runId,
+            LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        });
+
+        // New process: spin up a fresh loop pointed at the same store and recover.
+        var registry = new FunctionRegistry();
+        await using var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            registry,
+            threadId,
+            store: store,
+            logger: _loggerMock.Object);
+
+        var recovered = await loop.RecoverAsync();
+        recovered.Should().BeTrue();
+
+        // The deferred entry must surface from the in-memory _deferred registry — proving
+        // OnHistoryRestoredAsync ran and seeded it from the loaded history.
+        var pending = await loop.GetDeferredToolCallsAsync();
+        var info = pending.Should().ContainSingle().Subject;
+        info.ToolCallId.Should().Be("tc_persisted");
+        info.FunctionName.Should().Be("wait_for_human");
+        info.FunctionArgs.Should().Be("{\"prompt\":\"approve\"}");
+        info.RunId.Should().Be(runId);
+        info.GenerationId.Should().Be(generationId);
+        info.DeferredAtUnixMs.Should().Be(1_700_000_000_000);
+    }
+
+    [Fact]
+    public async Task ResolveToolCallAsync_ThrowsObjectDisposedException_AfterDispose()
+    {
+        // Resolutions arrive externally on arbitrary threads (webhook handlers, UI events).
+        // After the loop is disposed they must fail fast — silently mutating disposed state
+        // would corrupt _deferred / history for any subsequent process that re-opens the
+        // same store.
+        var registry = new FunctionRegistry();
+        var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            registry,
+            "test-thread",
+            logger: _loggerMock.Object);
+
+        await loop.DisposeAsync();
+
+        var act = async () => await loop.ResolveToolCallAsync("tc_x", "value");
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public async Task GetDeferredToolCallsAsync_ThrowsObjectDisposedException_AfterDispose()
+    {
+        var registry = new FunctionRegistry();
+        var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            registry,
+            "test-thread",
+            logger: _loggerMock.Object);
+
+        await loop.DisposeAsync();
+
+        var act = async () => await loop.GetDeferredToolCallsAsync();
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public async Task OperationCanceledException_FromHandler_PropagatesAsRunCanceled()
+    {
+        // ExecuteToolCallAsync's broad catch used to convert OperationCanceledException
+        // into LLM-visible error messages — silently swallowing user-initiated cancellation.
+        // The fix: rethrow when ct.IsCancellationRequested. The run loop's outer try/catch
+        // has `when (ex is not OperationCanceledException)` so cancellation propagates up
+        // and the whole RunAsync task winds down (rather than a RunCompleted{IsError=true}).
+        var toolCall = new ToolCallMessage
+        {
+            FunctionName = "slow_op",
+            FunctionArgs = "{}",
+            ToolCallId = "tc_cancel",
+            Role = Role.Assistant,
+        };
+        SetupOneTurnResponse(toolCall);
+
+        var registry = new FunctionRegistry();
+        registry.AddFunction(
+            BuildContract("slow_op"),
+            (_, _, ct) =>
+            {
+                ct.ThrowIfCancellationRequested();
+                throw new OperationCanceledException(ct);
+            });
+
+        await using var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            registry,
+            "test-thread",
+            logger: _loggerMock.Object);
+
+        using var cts = new CancellationTokenSource();
+        var runTask = loop.RunAsync(cts.Token);
+        cts.Cancel();
+
+        var userInput = new UserInput([new TextMessage { Text = "Go", Role = Role.User }]);
+
+        // Drain — the run should NOT yield a non-error RunCompleted with the tool error
+        // serialized into the message body. With the fix, cancellation propagates and the
+        // run-loop-level catch handles it cleanly. Drain may surface no messages or a
+        // cancellation; accept either, but verify no IsError=false RunCompleted with the
+        // swallowed-cancellation pattern.
+        var messages = new List<IMessage>();
+        try
+        {
+            await foreach (var msg in loop.ExecuteRunAsync(userInput, cts.Token))
+            {
+                messages.Add(msg);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // expected on cancellation
+        }
+
+        // The crucial check: no tool result with the swallowed-cancellation error JSON.
+        var swallowedCancel = messages
+            .OfType<ToolCallResultMessage>()
+            .Where(m => m.IsError && m.Result.Contains("OperationCanceled", StringComparison.OrdinalIgnoreCase));
+        swallowedCancel.Should().BeEmpty(
+            "OperationCanceledException must propagate, not be serialized into an LLM-visible error");
     }
 
     private void SetupOneTurnResponse(IMessage message)

--- a/tests/LmMultiTurn.Tests/MultiTurnAgentLoopTests.cs
+++ b/tests/LmMultiTurn.Tests/MultiTurnAgentLoopTests.cs
@@ -149,7 +149,8 @@ public class MultiTurnAgentLoopTests
             ],
         };
         registry.AddFunction(weatherContract, _ =>
-            Task.FromResult("{\"temperature\": \"72F\", \"condition\": \"sunny\"}"));
+            Task.FromResult<ToolHandlerResult>(
+                new ToolHandlerResult.Resolved(new ToolCallResult(null, "{\"temperature\": \"72F\", \"condition\": \"sunny\"}"))));
 
         await using var loop = new MultiTurnAgentLoop(
             _mockAgent.Object,

--- a/tests/LmMultiTurn.Tests/MultiTurnAgentLoopTests.cs
+++ b/tests/LmMultiTurn.Tests/MultiTurnAgentLoopTests.cs
@@ -148,7 +148,7 @@ public class MultiTurnAgentLoopTests
                 },
             ],
         };
-        registry.AddFunction(weatherContract, (_, _) =>
+        registry.AddFunction(weatherContract, (_, _, _) =>
             Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Resolved(new ToolCallResult(null, "{\"temperature\": \"72F\", \"condition\": \"sunny\"}"))));
 

--- a/tests/LmMultiTurn.Tests/MultiTurnAgentLoopTests.cs
+++ b/tests/LmMultiTurn.Tests/MultiTurnAgentLoopTests.cs
@@ -148,7 +148,7 @@ public class MultiTurnAgentLoopTests
                 },
             ],
         };
-        registry.AddFunction(weatherContract, _ =>
+        registry.AddFunction(weatherContract, (_, _) =>
             Task.FromResult<ToolHandlerResult>(
                 new ToolHandlerResult.Resolved(new ToolCallResult(null, "{\"temperature\": \"72F\", \"condition\": \"sunny\"}"))));
 

--- a/tests/LmMultiTurn.Tests/MultiTurnAgentLoopTests.cs
+++ b/tests/LmMultiTurn.Tests/MultiTurnAgentLoopTests.cs
@@ -150,7 +150,7 @@ public class MultiTurnAgentLoopTests
         };
         registry.AddFunction(weatherContract, (_, _, _) =>
             Task.FromResult<ToolHandlerResult>(
-                new ToolHandlerResult.Resolved(new ToolCallResult(null, "{\"temperature\": \"72F\", \"condition\": \"sunny\"}"))));
+                ToolHandlerResult.FromText("{\"temperature\": \"72F\", \"condition\": \"sunny\"}")));
 
         await using var loop = new MultiTurnAgentLoop(
             _mockAgent.Object,

--- a/tests/LmMultiTurn.Tests/Persistence/InMemoryConversationStoreTests.cs
+++ b/tests/LmMultiTurn.Tests/Persistence/InMemoryConversationStoreTests.cs
@@ -491,6 +491,55 @@ public class InMemoryConversationStoreTests
 
     #endregion
 
+    #region ReplaceMessageAsync Tests
+
+    [Fact]
+    public async Task ReplaceMessageAsync_ReplacesInPlace_AndPreservesTimestamp()
+    {
+        var store = new InMemoryConversationStore();
+        var original = CreateMessage("thread-1", "run-1", "msg-id", 1_000_000, messageOrderIdx: 0);
+        await store.AppendMessagesAsync("thread-1", [original]);
+
+        var replacement = original with
+        {
+            MessageJson = "{\"text\":\"replaced\"}",
+            Timestamp = 9_999_999, // store should ignore this and keep the original timestamp
+        };
+        await store.ReplaceMessageAsync("thread-1", replacement);
+
+        var loaded = await store.LoadMessagesAsync("thread-1");
+        loaded.Should().ContainSingle();
+        loaded[0].Id.Should().Be("msg-id");
+        loaded[0].MessageJson.Should().Be("{\"text\":\"replaced\"}");
+        loaded[0].Timestamp.Should().Be(1_000_000, "ReplaceMessageAsync must preserve the original timestamp");
+    }
+
+    [Fact]
+    public async Task ReplaceMessageAsync_Throws_WhenMessageIdNotFound()
+    {
+        var store = new InMemoryConversationStore();
+        await store.AppendMessagesAsync("thread-1", [CreateMessage("thread-1", "run-1", "existing", 1, 0)]);
+
+        var phantom = CreateMessage("thread-1", "run-1", "does-not-exist", 1, 0);
+
+        var act = () => store.ReplaceMessageAsync("thread-1", phantom);
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*does-not-exist*");
+    }
+
+    [Fact]
+    public async Task ReplaceMessageAsync_Throws_WhenThreadNotFound()
+    {
+        var store = new InMemoryConversationStore();
+        var msg = CreateMessage("thread-1", "run-1", "id", 1, 0);
+
+        var act = () => store.ReplaceMessageAsync("never-created-thread", msg);
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*never-created-thread*");
+    }
+
+    #endregion
+
     #region Test Helpers
 
     private static List<PersistedMessage> CreateTestMessages(string threadId, string runId, int count)

--- a/tests/LmMultiTurn.Tests/SubAgentManagerTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentManagerTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmMultiTurn;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
@@ -528,7 +529,7 @@ public class SubAgentManagerTests : IAsyncLifetime
         return new SubAgentManager(
             parentAgent: _parentMock.Object,
             parentContracts: [],
-            parentHandlers: new Dictionary<string, Func<string, Task<ToolHandlerResult>>>(),
+            parentHandlers: new Dictionary<string, ToolHandler>(),
             options: options);
     }
 

--- a/tests/LmMultiTurn.Tests/SubAgentManagerTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentManagerTests.cs
@@ -528,8 +528,7 @@ public class SubAgentManagerTests : IAsyncLifetime
         return new SubAgentManager(
             parentAgent: _parentMock.Object,
             parentContracts: [],
-            parentHandlers: new Dictionary<string, Func<string, Task<string>>>(),
-            parentMultiModalHandlers: null,
+            parentHandlers: new Dictionary<string, Func<string, Task<ToolHandlerResult>>>(),
             options: options);
     }
 

--- a/tests/LmMultiTurn.Tests/SubAgentToolProviderTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentToolProviderTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmMultiTurn;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
@@ -51,7 +52,7 @@ public class SubAgentToolProviderTests : IAsyncLifetime
         _manager = new SubAgentManager(
             parentAgent: _parentMock.Object,
             parentContracts: [],
-            parentHandlers: new Dictionary<string, Func<string, Task<ToolHandlerResult>>>(),
+            parentHandlers: new Dictionary<string, ToolHandler>(),
             options: options);
 
         _provider = new SubAgentToolProvider(
@@ -89,7 +90,7 @@ public class SubAgentToolProviderTests : IAsyncLifetime
         var args = JsonSerializer.Serialize(new { template_name = "researcher" });
 
         // Act
-        var act = () => agentHandler(args);
+        var act = () => agentHandler(args, new ToolCallContext());
 
         // Assert
         await act.Should().ThrowAsync<ArgumentException>()
@@ -105,7 +106,7 @@ public class SubAgentToolProviderTests : IAsyncLifetime
         var args = JsonSerializer.Serialize(new { task = "do something" });
 
         // Act
-        var act = () => agentHandler(args);
+        var act = () => agentHandler(args, new ToolCallContext());
 
         // Assert
         await act.Should().ThrowAsync<ArgumentException>()
@@ -121,7 +122,7 @@ public class SubAgentToolProviderTests : IAsyncLifetime
         var args = JsonSerializer.Serialize(new { });
 
         // Act
-        var act = () => checkHandler(args);
+        var act = () => checkHandler(args, new ToolCallContext());
 
         // Assert
         await act.Should().ThrowAsync<ArgumentException>()

--- a/tests/LmMultiTurn.Tests/SubAgentToolProviderTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentToolProviderTests.cs
@@ -90,7 +90,7 @@ public class SubAgentToolProviderTests : IAsyncLifetime
         var args = JsonSerializer.Serialize(new { template_name = "researcher" });
 
         // Act
-        var act = () => agentHandler(args, new ToolCallContext());
+        var act = () => agentHandler(args, new ToolCallContext(), CancellationToken.None);
 
         // Assert
         await act.Should().ThrowAsync<ArgumentException>()
@@ -106,7 +106,7 @@ public class SubAgentToolProviderTests : IAsyncLifetime
         var args = JsonSerializer.Serialize(new { task = "do something" });
 
         // Act
-        var act = () => agentHandler(args, new ToolCallContext());
+        var act = () => agentHandler(args, new ToolCallContext(), CancellationToken.None);
 
         // Assert
         await act.Should().ThrowAsync<ArgumentException>()
@@ -122,7 +122,7 @@ public class SubAgentToolProviderTests : IAsyncLifetime
         var args = JsonSerializer.Serialize(new { });
 
         // Act
-        var act = () => checkHandler(args, new ToolCallContext());
+        var act = () => checkHandler(args, new ToolCallContext(), CancellationToken.None);
 
         // Assert
         await act.Should().ThrowAsync<ArgumentException>()

--- a/tests/LmMultiTurn.Tests/SubAgentToolProviderTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentToolProviderTests.cs
@@ -51,8 +51,7 @@ public class SubAgentToolProviderTests : IAsyncLifetime
         _manager = new SubAgentManager(
             parentAgent: _parentMock.Object,
             parentContracts: [],
-            parentHandlers: new Dictionary<string, Func<string, Task<string>>>(),
-            parentMultiModalHandlers: null,
+            parentHandlers: new Dictionary<string, Func<string, Task<ToolHandlerResult>>>(),
             options: options);
 
         _provider = new SubAgentToolProvider(

--- a/tests/McpIntegrationTests/McpFunctionCallExtensionsBasicTests.cs
+++ b/tests/McpIntegrationTests/McpFunctionCallExtensionsBasicTests.cs
@@ -75,7 +75,7 @@ public class McpFunctionCallExtensionsBasicTests
         };
 
         // Act - create middleware with these functions
-        var middleware = new FunctionCallMiddleware(functionContracts, functionMap);
+        var middleware = new FunctionCallMiddleware(functionContracts, LegacyHandlerAdapter.WrapToNewHandlers(functionMap));
 
         // Assert
         Assert.NotNull(middleware);
@@ -131,7 +131,7 @@ public class McpFunctionCallExtensionsBasicTests
         };
 
         // Create middleware with these functions
-        var middleware = new FunctionCallMiddleware(functionContracts, functionMap);
+        var middleware = new FunctionCallMiddleware(functionContracts, LegacyHandlerAdapter.WrapToNewHandlers(functionMap));
 
         // Assert middleware is properly created
         Assert.NotNull(middleware);

--- a/tests/McpIntegrationTests/McpFunctionCallExtensionsTests.cs
+++ b/tests/McpIntegrationTests/McpFunctionCallExtensionsTests.cs
@@ -149,7 +149,7 @@ public class McpFunctionCallExtensionsTests
         // Create a middleware using a direct approach rather than assembly scanning
         var toolTypes = new[] { greetingToolType, calculatorToolType! };
         var (functions, functionMap) = McpFunctionCallExtensions.CreateFunctionCallComponentsFromTypes(toolTypes);
-        var middleware = new FunctionCallMiddleware(functions, functionMap, name: "FunctionCallMiddleware");
+        var middleware = new FunctionCallMiddleware(functions, LegacyHandlerAdapter.WrapToNewHandlers(functionMap), name: "FunctionCallMiddleware");
 
         // Assert
         Assert.NotNull(middleware);

--- a/tests/McpIntegrationTests/McpFunctionProviderTests.cs
+++ b/tests/McpIntegrationTests/McpFunctionProviderTests.cs
@@ -49,7 +49,7 @@ public class McpFunctionProviderTests
 
         // Act
         Assert.NotNull(addFunction);
-        var result = await addFunction.Handler("{\"a\": 5, \"b\": 3}", new ToolCallContext());
+        var result = await addFunction.Handler("{\"a\": 5, \"b\": 3}", new ToolCallContext(), CancellationToken.None);
 
         // Assert
         Assert.Contains("8", result.ResultText); // 5 + 3 = 8

--- a/tests/McpIntegrationTests/McpFunctionProviderTests.cs
+++ b/tests/McpIntegrationTests/McpFunctionProviderTests.cs
@@ -49,7 +49,7 @@ public class McpFunctionProviderTests
 
         // Act
         Assert.NotNull(addFunction);
-        var result = await addFunction.Handler("{\"a\": 5, \"b\": 3}");
+        var result = await addFunction.Handler("{\"a\": 5, \"b\": 3}", new ToolCallContext());
 
         // Assert
         Assert.Contains("8", result.ResultText); // 5 + 3 = 8

--- a/tests/McpIntegrationTests/McpFunctionProviderTests.cs
+++ b/tests/McpIntegrationTests/McpFunctionProviderTests.cs
@@ -52,7 +52,7 @@ public class McpFunctionProviderTests
         var result = await addFunction.Handler("{\"a\": 5, \"b\": 3}");
 
         // Assert
-        Assert.Contains("8", result); // 5 + 3 = 8
+        Assert.Contains("8", result.ResultText); // 5 + 3 = 8
     }
 
     [Fact]


### PR DESCRIPTION

## Problem

`MultiTurnAgentLoop` executes tool calls synchronously: the run loop awaits every handler via `Task.WhenAll(pendingToolCalls.Values)` before starting the next turn. This works for fast tools (filesystem reads, in-process computation, quick HTTP calls) but breaks down whenever a tool's result depends on something the loop can't drive forward on its own.

Concrete scenarios that don't fit the current model:

- **Human-in-the-loop approval.** LLM asks to read a directory; a human must approve before it proceeds. Approval may take minutes to hours.
- **External async APIs with callbacks.** A bank verification API accepts a request and fires a webhook 10 minutes later. Nothing useful to await locally.
- **Long-running batch jobs.** Submit work to a queue or scheduler; result comes back via a separate channel.
- **Sub-agents with their own tool loops.** Already long-lived; modeling them as deferred calls is a natural fit.

In all of these the handler can't reasonably block. Today, doing so would:

- Pin a turn (and the entire run loop) for the full duration.
- Prevent the loop from draining new inputs from `SendAsync` until the slow tool returns (`TryDrainInputs` runs at turn boundaries).
- Provide no cooperative cancellation — handler signatures are `Func<string, Task<string>>` with no `CancellationToken`.
- Hide partial progress from the UI and the LLM.

## The generalizing insight

Approval is not a special case. The unifying primitive is **deferred tool execution**: a handler that returns a placeholder synchronously and is resolved later by *something* outside the loop. The loop should not care whether that "something" is a human, a webhook, a worker, or a timer.

Specializations collapse into thin integration layers:

| Use case | What "resolves" the call |
|---|---|
| HITL approval | UI calls `ResolveToolCallAsync` when the human acts |
| Bank webhook | Webhook receiver calls `ResolveToolCallAsync` |
| Long batch job | Worker calls `ResolveToolCallAsync` on completion |
| Timeout/cancellation | Host timer calls `ResolveToolCallAsync` with an error |

## Why a placeholder is required, not optional

Both Anthropic and OpenAI enforce that every `tool_use` (or `tool_call`) ID in an assistant message must have a matching `tool_result` before the next assistant inference. There is no "partially answered tool calls" state in either contract.

So while the loop is waiting on a deferred resolution, it must still place *some* `tool_result` in history for protocol validity. A placeholder string (`"PENDING ..."`) plus a flag like `IsDeferred = true` on the message satisfies both the contract and the loop's own state-tracking needs.

When resolution arrives, the placeholder is replaced in-place by the real result (mutating history by `ToolCallId`). Appending a second `tool_result` for the same ID is not a defined operation and would produce an invalid request payload.

## Design implications worth noting

These are flagged here as motivation context; the actual design lives in `design.md` (TBD).

- **History as the single source of truth.** Pending state lives on `ToolCallResultMessage` (e.g., `IsDeferred`), not in a parallel registry. Persistence via `IConversationStore` is then automatic.
- **Resolution is one API.** `ResolveToolCallAsync(toolCallId, result, isError)` — used identically by every integrator. Approvals, webhooks, and timeouts all funnel through it.
- **Idempotency matters once async is in scope.** Webhooks retry; resolution must be safe against double-delivery in a way approvals never required.
- **Restart durability is the hardest open question.** When the process dies mid-deferral, the in-flight outbound work the handler initiated (HTTP request, queue publish) is *not* persisted. Handlers must be responsible for their own outbound idempotency / recovery; the loop should expose enough metadata (deferred call inspection on startup) to support that, but cannot solve it generically.
- **Progress updates use the existing subscriber stream.** Tool results are write-once; partial progress flows as separate published events to UI subscribers without resolving the placeholder.

## Out of scope (for now)

- Cross-process resolution and durable workflow integration (Temporal, Durable Functions). The first cut targets in-process async; durable hand-off is an explicit future concern.
- Built-in timeout policy. Timeouts are host-driven (host calls `ResolveToolCallAsync` with an error after its own deadline) rather than enforced by the loop. Helpers may follow.
- Streaming partial tool results into LLM context. The LLM only sees a deferred call's result on final resolution.
