### PR TITLE
Fix Codex mock provider routing

### DIFF
--- a/samples/LmStreaming.Sample/Services/ProviderRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/ProviderRegistry.cs
@@ -25,15 +25,8 @@ public sealed class ProviderRegistry
             new("claude", "Claude (CLI)"),
             new("codex", "Codex"),
             new("copilot", "Copilot (CLI)"),
-            // Mock entries with known follow-up limitations are tagged here so the UI can
-            // surface a caveat next to them. Wire-format gaps are tracked in dedicated issues
-            // (see body) — fixing those here lets the gate flip to null and the banner disappears.
             new("claude-mock", "Claude (CLI, Mock)"),
-            new(
-                "codex-mock",
-                "Codex (Mock)",
-                "Known limitation: Codex CLI defaults to /v1/responses which the mock host does "
-                + "not yet implement, so the run hangs. Tracked in #28."),
+            new("codex-mock", "Codex (Mock)"),
             new("copilot-mock", "Copilot (CLI, Mock)"),
         ];
 

--- a/src/CodexSdkProvider/Agents/CodexSdkClient.cs
+++ b/src/CodexSdkProvider/Agents/CodexSdkClient.cs
@@ -11,6 +11,10 @@ namespace AchieveAi.LmDotnetTools.CodexSdkProvider.Agents;
 
 public sealed class CodexSdkClient : ICodexSdkClient
 {
+    private const string OpenAiApiKeyEnvironmentVariable = "OPENAI_API_KEY";
+    private const string ResponsesModelProviderId = "lm-dotnet-tools-openai-responses";
+    private const string ResponsesModelProviderName = "LmDotnetTools OpenAI Responses";
+
     private readonly CodexSdkOptions _options;
     private readonly ILogger<CodexSdkClient>? _logger;
     private readonly JsonSerializerOptions _json;
@@ -660,6 +664,8 @@ public sealed class CodexSdkClient : ICodexSdkClient
             ["experimentalRawEvents"] = false,
         };
 
+        ApplyModelProviderOverride(parameters, options);
+
         if (options.DynamicTools is { Count: > 0 })
         {
             parameters["dynamicTools"] = options.DynamicTools.Select(tool =>
@@ -686,7 +692,7 @@ public sealed class CodexSdkClient : ICodexSdkClient
 
     private object BuildThreadResumeParams(CodexBridgeInitOptions options)
     {
-        return new Dictionary<string, object?>
+        var parameters = new Dictionary<string, object?>
         {
             ["threadId"] = options.ThreadId,
             ["model"] = options.Model,
@@ -697,6 +703,10 @@ public sealed class CodexSdkClient : ICodexSdkClient
             ["baseInstructions"] = options.BaseInstructions,
             ["developerInstructions"] = options.DeveloperInstructions,
         };
+
+        ApplyModelProviderOverride(parameters, options);
+
+        return parameters;
     }
 
     private static object BuildTurnStartParams(string threadId, string input)
@@ -716,6 +726,16 @@ public sealed class CodexSdkClient : ICodexSdkClient
         };
     }
 
+    private static void ApplyModelProviderOverride(
+        Dictionary<string, object?> parameters,
+        CodexBridgeInitOptions options)
+    {
+        if (!string.IsNullOrWhiteSpace(options.BaseUrl))
+        {
+            parameters["modelProvider"] = ResponsesModelProviderId;
+        }
+    }
+
     private static Dictionary<string, object?> BuildConfig(CodexBridgeInitOptions options)
     {
         var config = new Dictionary<string, object?>
@@ -725,6 +745,8 @@ public sealed class CodexSdkClient : ICodexSdkClient
                 network_access = options.NetworkAccessEnabled,
             },
         };
+
+        AddResponsesModelProviderConfig(config, options);
 
         if (!string.IsNullOrWhiteSpace(options.WebSearchMode))
         {
@@ -763,6 +785,36 @@ public sealed class CodexSdkClient : ICodexSdkClient
         }
 
         return config;
+    }
+
+    private static void AddResponsesModelProviderConfig(
+        Dictionary<string, object?> config,
+        CodexBridgeInitOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.BaseUrl))
+        {
+            return;
+        }
+
+        var provider = new Dictionary<string, object?>
+        {
+            ["name"] = ResponsesModelProviderName,
+            ["base_url"] = options.BaseUrl,
+            ["wire_api"] = "responses",
+            ["requires_openai_auth"] = false,
+            ["supports_websockets"] = true,
+        };
+
+        if (!string.IsNullOrWhiteSpace(options.ApiKey))
+        {
+            provider["env_key"] = OpenAiApiKeyEnvironmentVariable;
+        }
+
+        config["model_provider"] = ResponsesModelProviderId;
+        config["model_providers"] = new Dictionary<string, object?>
+        {
+            [ResponsesModelProviderId] = provider,
+        };
     }
 
     private string BuildDefaultCommandApprovalDecision()

--- a/tests/CodexSdkProvider.Tests/Agents/CodexAppServerRequestConfigTests.cs
+++ b/tests/CodexSdkProvider.Tests/Agents/CodexAppServerRequestConfigTests.cs
@@ -1,0 +1,93 @@
+using System.Reflection;
+using AchieveAi.LmDotnetTools.CodexSdkProvider.Agents;
+using AchieveAi.LmDotnetTools.CodexSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.CodexSdkProvider.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AchieveAi.LmDotnetTools.CodexSdkProvider.Tests.Agents;
+
+public sealed class CodexAppServerRequestConfigTests
+{
+    private const string ProviderId = "lm-dotnet-tools-openai-responses";
+
+    [Theory]
+    [InlineData("BuildThreadStartParams")]
+    [InlineData("BuildThreadResumeParams")]
+    public void BuildThreadParams_BaseUrlSet_RoutesThroughExplicitResponsesModelProvider(string methodName)
+    {
+        var options = new CodexBridgeInitOptions
+        {
+            Model = "gpt-5.3-codex",
+            ApprovalPolicy = "never",
+            SandboxMode = "read-only",
+            WorkingDirectory = @"B:\sources\LmDotnetTools",
+            BaseUrl = "http://127.0.0.1:5099/v1",
+            ApiKey = "mock-token",
+            ThreadId = "thread-1",
+        };
+
+        var parameters = InvokeThreadParams(methodName, options);
+
+        parameters["modelProvider"].Should().Be(ProviderId);
+        var config = parameters["config"].Should().BeAssignableTo<Dictionary<string, object?>>().Subject;
+        config["model_provider"].Should().Be(ProviderId);
+
+        var modelProviders = config["model_providers"]
+            .Should()
+            .BeAssignableTo<Dictionary<string, object?>>()
+            .Subject;
+        var provider = modelProviders[ProviderId]
+            .Should()
+            .BeAssignableTo<Dictionary<string, object?>>()
+            .Subject;
+
+        provider["name"].Should().Be("LmDotnetTools OpenAI Responses");
+        provider["base_url"].Should().Be("http://127.0.0.1:5099/v1");
+        provider["wire_api"].Should().Be("responses");
+        provider["env_key"].Should().Be("OPENAI_API_KEY");
+        provider["requires_openai_auth"].Should().Be(false);
+        provider["supports_websockets"].Should().Be(true);
+        provider.Should().NotContainKey("experimental_bearer_token");
+    }
+
+    [Fact]
+    public void BuildThreadParams_BaseUrlWithoutApiKey_DoesNotRequireEnvKey()
+    {
+        var options = new CodexBridgeInitOptions
+        {
+            Model = "gpt-5.3-codex",
+            BaseUrl = "http://127.0.0.1:5099/v1",
+        };
+
+        var parameters = InvokeThreadParams("BuildThreadStartParams", options);
+        var config = parameters["config"].Should().BeAssignableTo<Dictionary<string, object?>>().Subject;
+        var modelProviders = config["model_providers"]
+            .Should()
+            .BeAssignableTo<Dictionary<string, object?>>()
+            .Subject;
+        var provider = modelProviders[ProviderId]
+            .Should()
+            .BeAssignableTo<Dictionary<string, object?>>()
+            .Subject;
+
+        provider.Should().NotContainKey("env_key");
+    }
+
+    private static Dictionary<string, object?> InvokeThreadParams(
+        string methodName,
+        CodexBridgeInitOptions options)
+    {
+        var client = new CodexSdkClient(
+            new CodexSdkOptions(),
+            NullLogger<CodexSdkClient>.Instance);
+        var method = typeof(CodexSdkClient).GetMethod(
+            methodName,
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingMethodException(nameof(CodexSdkClient), methodName);
+
+        return method.Invoke(client, [options])
+                .Should()
+                .BeAssignableTo<Dictionary<string, object?>>()
+                .Subject;
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/ProviderRegistryTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ProviderRegistryTests.cs
@@ -316,22 +316,15 @@ public class ProviderRegistryTests
     [Fact]
     public void KnownLimitation_TaggedOnBrokenMocks_UnsetOnHealthyOnes()
     {
-        // Surfaces the UX banner that points users at the follow-up issues for the broken
-        // mock variants. #29 (claude-mock) is fixed; only #28 (codex-mock) still carries a
-        // caveat. When that lands, this assertion flips.
+        // Mock variants that work end-to-end must NOT carry a caveat.
         using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
         var probe = new FakeFileSystemProbe(executablesOnPath: ["claude", "copilot"]);
 
         var registry = new ProviderRegistry(probe, () => true);
         var byId = registry.ListAll().ToDictionary(p => p.Id);
 
-        byId["codex-mock"].KnownLimitation.Should().NotBeNullOrWhiteSpace()
-            .And.Subject.Should().Contain("#28");
-
-        // claude-mock works end-to-end after issue #29 fix and must NOT carry a caveat.
+        byId["codex-mock"].KnownLimitation.Should().BeNull();
         byId["claude-mock"].KnownLimitation.Should().BeNull();
-
-        // copilot-mock works end-to-end against the mock host and must NOT carry a caveat.
         byId["copilot-mock"].KnownLimitation.Should().BeNull();
 
         // Non-mock entries inherit the default null.


### PR DESCRIPTION
## Summary
Fixes Codex(Mock) routing so a mock `BaseUrl` is passed to Codex app-server as an explicit OpenAI Responses-compatible custom model provider instead of relying only on `OPENAI_BASE_URL`.

This allows Codex app-server to use `MockProviderHost` for Responses/WebSocket traffic and removes the stale `codex-mock` known-limitation banner from the sample provider registry.

## Changes
- Add explicit `modelProvider` and `config.model_provider/model_providers` wiring when `CodexBridgeInitOptions.BaseUrl` is set.
- Configure the custom provider with `wire_api = responses`, `requires_openai_auth = false`, and `supports_websockets = true`.
- Add regression tests for start/resume app-server config generation.
- Remove the outdated Codex(Mock) limitation message from `LmStreaming.Sample`.

## Testing
- `dotnet format whitespace LmDotnetTools.sln --verify-no-changes`
- `dotnet test tests\CodexSdkProvider.Tests\CodexSdkProvider.Tests.csproj --no-restore`
- `dotnet test tests\LmStreaming.Sample.Tests\LmStreaming.Sample.Tests.csproj --no-restore --filter "FullyQualifiedName~ProviderRegistryTests|FullyQualifiedName~CodexAgentLoopTests"`
- `dotnet test tests\MockProviderHost.Tests\MockProviderHost.Tests.csproj --no-restore --filter "FullyQualifiedName~Responses"`
- `dotnet build LmDotnetTools.sln --no-restore`
- Live smoke: `CodexSdkClient` + `MockProviderHost` consumed the scripted mock turn (`remaining_turns=0`) and emitted visible mock text.

## Related Issues
Fixes #28