### PR TITLE
Align Claude and Codex mock provider streaming

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <!-- Centralized Versioning - UPDATE ONLY THIS SECTION FOR NEW RELEASES -->
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>25</PatchVersion>
+    <PatchVersion>26</PatchVersion>
     <PreReleaseLabel></PreReleaseLabel>
     <!-- Use values like 'alpha', 'beta', 'rc.1' or leave empty for stable -->
     <!-- Computed Version Properties (DO NOT MODIFY) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <!-- Centralized Versioning - UPDATE ONLY THIS SECTION FOR NEW RELEASES -->
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>23</PatchVersion>
+    <PatchVersion>24</PatchVersion>
     <PreReleaseLabel></PreReleaseLabel>
     <!-- Use values like 'alpha', 'beta', 'rc.1' or leave empty for stable -->
     <!-- Computed Version Properties (DO NOT MODIFY) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <!-- Centralized Versioning - UPDATE ONLY THIS SECTION FOR NEW RELEASES -->
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>26</PatchVersion>
+    <PatchVersion>27</PatchVersion>
     <PreReleaseLabel></PreReleaseLabel>
     <!-- Use values like 'alpha', 'beta', 'rc.1' or leave empty for stable -->
     <!-- Computed Version Properties (DO NOT MODIFY) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <!-- Centralized Versioning - UPDATE ONLY THIS SECTION FOR NEW RELEASES -->
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>24</PatchVersion>
+    <PatchVersion>25</PatchVersion>
     <PreReleaseLabel></PreReleaseLabel>
     <!-- Use values like 'alpha', 'beta', 'rc.1' or leave empty for stable -->
     <!-- Computed Version Properties (DO NOT MODIFY) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <!-- Centralized Versioning - UPDATE ONLY THIS SECTION FOR NEW RELEASES -->
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>21</PatchVersion>
+    <PatchVersion>23</PatchVersion>
     <PreReleaseLabel></PreReleaseLabel>
     <!-- Use values like 'alpha', 'beta', 'rc.1' or leave empty for stable -->
     <!-- Computed Version Properties (DO NOT MODIFY) -->

--- a/example/LmConfigUsageExample/LmConfigUsageExample.csproj
+++ b/example/LmConfigUsageExample/LmConfigUsageExample.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.5" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.1-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/example/LmConfigUsageExample/Program.cs
+++ b/example/LmConfigUsageExample/Program.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 using AchieveAi.LmDotnetTools.LmConfig.Agents;
 using AchieveAi.LmDotnetTools.LmConfig.Services;
 using AchieveAi.LmDotnetTools.LmCore.Agents;

--- a/samples/LmStreaming.Sample/Agents/MultiTurnAgentPool.cs
+++ b/samples/LmStreaming.Sample/Agents/MultiTurnAgentPool.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Text.Json;
 using AchieveAi.LmDotnetTools.LmMultiTurn;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
 using LmStreaming.Sample.Models;
@@ -35,7 +36,8 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
         string? CurrentRunId,
         bool AgentIsRunning,
         bool RunTaskCompleted,
-        bool IsStale);
+        bool IsStale
+    );
 
     /// <summary>
     /// Result from the agent factory, including the agent and any owned resources
@@ -43,7 +45,8 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
     /// </summary>
     public sealed record AgentCreationResult(
         IMultiTurnAgent Agent,
-        IReadOnlyList<IAsyncDisposable>? OwnedResources = null);
+        IReadOnlyList<IAsyncDisposable>? OwnedResources = null
+    );
 
     /// <summary>
     /// Wrapper to track agent and its background task.
@@ -114,7 +117,8 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
         Func<string, ChatMode, string, string?, AgentCreationResult> agentFactory,
         ProviderRegistry? providerRegistry,
         IConversationStore? conversationStore,
-        ILogger<MultiTurnAgentPool> logger)
+        ILogger<MultiTurnAgentPool> logger
+    )
     {
         _agentFactory = agentFactory ?? throw new ArgumentNullException(nameof(agentFactory));
         _providerRegistry = providerRegistry;
@@ -129,17 +133,19 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
     /// </summary>
     public MultiTurnAgentPool(
         Func<string, ChatMode, string?, AgentCreationResult> agentFactory,
-        ILogger<MultiTurnAgentPool> logger)
+        ILogger<MultiTurnAgentPool> logger
+    )
         : this(
             agentFactory: WrapLegacyFactory(agentFactory),
             providerRegistry: null,
             conversationStore: null,
-            logger: logger)
-    {
-    }
+            logger: logger
+        )
+    { }
 
     private static Func<string, ChatMode, string, string?, AgentCreationResult> WrapLegacyFactory(
-        Func<string, ChatMode, string?, AgentCreationResult> agentFactory)
+        Func<string, ChatMode, string?, AgentCreationResult> agentFactory
+    )
     {
         ArgumentNullException.ThrowIfNull(agentFactory);
         return (threadId, mode, _, dump) => agentFactory(threadId, mode, dump);
@@ -161,10 +167,7 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
     /// If the agent doesn't exist, it's created and its RunAsync() is started.
     /// The provider id is resolved from persisted metadata (if any) or the registry default.
     /// </summary>
-    public IMultiTurnAgent GetOrCreateAgent(
-        string threadId,
-        ChatMode mode,
-        string? requestResponseDumpFileName = null)
+    public IMultiTurnAgent GetOrCreateAgent(string threadId, ChatMode mode, string? requestResponseDumpFileName = null)
     {
         return GetOrCreateAgent(threadId, mode, requestedProviderId: null, requestResponseDumpFileName);
     }
@@ -193,7 +196,8 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
         string threadId,
         ChatMode mode,
         string? requestedProviderId,
-        string? requestResponseDumpFileName)
+        string? requestResponseDumpFileName
+    )
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentException.ThrowIfNullOrEmpty(threadId);
@@ -233,17 +237,17 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
             _ = PersistProviderIfNeededAsync(threadId, resolvedProviderId);
         }
 
-        if (!string.IsNullOrWhiteSpace(requestResponseDumpFileName)
-            && !string.Equals(
-                entry.RequestResponseDumpFileName,
-                requestResponseDumpFileName,
-                StringComparison.Ordinal))
+        if (
+            !string.IsNullOrWhiteSpace(requestResponseDumpFileName)
+            && !string.Equals(entry.RequestResponseDumpFileName, requestResponseDumpFileName, StringComparison.Ordinal)
+        )
         {
             _logger.LogWarning(
-                "Request/response recording was requested for thread {ThreadId}, but an existing agent is being reused. " +
-                "Recording dump file is fixed at agent creation time. Existing dump base: {ExistingDumpBase}",
+                "Request/response recording was requested for thread {ThreadId}, but an existing agent is being reused. "
+                    + "Recording dump file is fixed at agent creation time. Existing dump base: {ExistingDumpBase}",
                 threadId,
-                entry.RequestResponseDumpFileName ?? "(none)");
+                entry.RequestResponseDumpFileName ?? "(none)"
+            );
         }
 
         return entry.Agent;
@@ -328,22 +332,44 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
             // The pool is already invoked from a request scope; making this whole code path
             // async would cascade through GetOrCreateAgent and break existing call sites.
             var metadata = _conversationStore.LoadMetadataAsync(threadId).GetAwaiter().GetResult();
-            if (metadata?.Properties != null
+            if (
+                metadata?.Properties != null
                 && metadata.Properties.TryGetValue(ProviderPropertyKey, out var raw)
-                && raw is string s
-                && !string.IsNullOrWhiteSpace(s))
+                && TryNormalizeProviderId(raw, out var providerId)
+            )
             {
-                return s.Trim().ToLowerInvariant();
+                return providerId;
             }
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex,
+            _logger.LogWarning(
+                ex,
                 "Failed to load persisted provider for thread {ThreadId}; falling back to default",
-                threadId);
+                threadId
+            );
         }
 
         return null;
+    }
+
+    private static bool TryNormalizeProviderId(object raw, out string providerId)
+    {
+        var value = raw switch
+        {
+            string s => s,
+            JsonElement { ValueKind: JsonValueKind.String } element => element.GetString(),
+            _ => null,
+        };
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            providerId = string.Empty;
+            return false;
+        }
+
+        providerId = value.Trim().ToLowerInvariant();
+        return true;
     }
 
     private async Task PersistProviderIfNeededAsync(string threadId, string providerId)
@@ -365,11 +391,14 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
             var properties = existing?.Properties ?? ImmutableDictionary<string, object>.Empty;
             properties = properties.SetItem(ProviderPropertyKey, providerId);
 
-            var updated = (existing ?? new ThreadMetadata
-            {
-                ThreadId = threadId,
-                LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            }) with
+            var updated = (
+                existing
+                ?? new ThreadMetadata
+                {
+                    ThreadId = threadId,
+                    LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                }
+            ) with
             {
                 Properties = properties,
                 LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
@@ -377,17 +406,16 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
 
             await _conversationStore.SaveMetadataAsync(threadId, updated).ConfigureAwait(false);
 
-            _logger.LogInformation(
-                "Persisted provider {ProviderId} for thread {ThreadId}",
-                providerId,
-                threadId);
+            _logger.LogInformation("Persisted provider {ProviderId} for thread {ThreadId}", providerId, threadId);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex,
+            _logger.LogWarning(
+                ex,
                 "Failed to persist provider {ProviderId} for thread {ThreadId}",
                 providerId,
-                threadId);
+                threadId
+            );
         }
     }
 
@@ -427,7 +455,8 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
                 CurrentRunId: null,
                 AgentIsRunning: false,
                 RunTaskCompleted: true,
-                IsStale: false);
+                IsStale: false
+            );
         }
 
         var currentRunId = entry.Agent.CurrentRunId;
@@ -441,7 +470,8 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
             CurrentRunId: currentRunId,
             AgentIsRunning: agentIsRunning,
             RunTaskCompleted: runTaskCompleted,
-            IsStale: isStale);
+            IsStale: isStale
+        );
     }
 
     /// <summary>
@@ -478,7 +508,8 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
             "Recreating agent for thread {ThreadId} with mode {ModeId} ({ModeName})",
             threadId,
             mode.Id,
-            mode.Name);
+            mode.Name
+        );
 
         // Resolve provider before re-entering the lock — the same persisted provider must
         // continue to be used after a mode-switch (mode-switch is not a provider switch).
@@ -509,7 +540,8 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
         string threadId,
         ChatMode mode,
         string providerId,
-        string? requestResponseDumpFileName)
+        string? requestResponseDumpFileName
+    )
     {
         _logger.LogInformation(
             "Creating new agent for thread {ThreadId} with mode {ModeId} ({ModeName}) and provider {ProviderId}, dump recording enabled: {DumpEnabled}",
@@ -517,28 +549,32 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
             mode.Id,
             mode.Name,
             providerId,
-            !string.IsNullOrWhiteSpace(requestResponseDumpFileName));
+            !string.IsNullOrWhiteSpace(requestResponseDumpFileName)
+        );
 
         var result = _agentFactory(threadId, mode, providerId, requestResponseDumpFileName);
         var agent = result.Agent;
         var cts = CancellationTokenSource.CreateLinkedTokenSource(_poolCts.Token);
 
         // Start the agent's background run loop
-        var runTask = Task.Run(async () =>
-        {
-            try
+        var runTask = Task.Run(
+            async () =>
             {
-                await agent.RunAsync(cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                _logger.LogDebug("Agent run loop cancelled for thread {ThreadId}", threadId);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Agent run loop failed for thread {ThreadId}", threadId);
-            }
-        }, cts.Token);
+                try
+                {
+                    await agent.RunAsync(cts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    _logger.LogDebug("Agent run loop cancelled for thread {ThreadId}", threadId);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Agent run loop failed for thread {ThreadId}", threadId);
+                }
+            },
+            cts.Token
+        );
 
         return new AgentEntry
         {

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -5,7 +5,7 @@ using System.Text;
 using AchieveAi.LmDotnetTools.AnthropicProvider.Agents;
 using AchieveAi.LmDotnetTools.AnthropicProvider.Models;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
-using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 using AchieveAi.LmDotnetTools.CodexSdkProvider.Configuration;
 using AchieveAi.LmDotnetTools.CodexSdkProvider.Models;
 using AchieveAi.LmDotnetTools.CopilotSdkProvider.Configuration;

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -53,36 +53,41 @@ try
     var builder = WebApplication.CreateBuilder(args);
 
     // Configure Serilog from appsettings.json with all enrichers
-    _ = builder.Host.UseSerilog((context, services, configuration) =>
-    {
-        var logPath = Path.Combine(AppContext.BaseDirectory, "logs", "lmstreaming-.jsonl");
+    _ = builder.Host.UseSerilog(
+        (context, services, configuration) =>
+        {
+            var logPath = Path.Combine(AppContext.BaseDirectory, "logs", "lmstreaming-.jsonl");
 
-        _ = configuration
-            .ReadFrom.Configuration(context.Configuration)
-            .ReadFrom.Services(services)
-            .Enrich.FromLogContext()
-            .Enrich.WithMachineName()
-            .Enrich.WithThreadId()
-            .Enrich.WithExceptionDetails()
-            .Enrich.WithProperty("Application", "LmStreaming.Sample")
-            // Add caller info: file path, line number, method name, namespace
-            .Enrich.WithCallerInfo(
-                includeFileInfo: true,
-                assemblyPrefix: "AchieveAi.",  // Match our assemblies
-                filePathDepth: 3)              // Include last 3 path segments
-                                               // File sink with structured JSON (includes all enriched properties)
-            .WriteTo.File(
-                new CompactJsonFormatter(),
-                logPath,
-                rollingInterval: RollingInterval.Day,
-                retainedFileCountLimit: 7,
-                shared: true)
-            // Console sink with readable format
-            .WriteTo.Console(
-                outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {SourceContext}{NewLine}    {Message:lj}{NewLine}{Exception}");
+            _ = configuration
+                .ReadFrom.Configuration(context.Configuration)
+                .ReadFrom.Services(services)
+                .Enrich.FromLogContext()
+                .Enrich.WithMachineName()
+                .Enrich.WithThreadId()
+                .Enrich.WithExceptionDetails()
+                .Enrich.WithProperty("Application", "LmStreaming.Sample")
+                // Add caller info: file path, line number, method name, namespace
+                .Enrich.WithCallerInfo(
+                    includeFileInfo: true,
+                    assemblyPrefix: "AchieveAi.", // Match our assemblies
+                    filePathDepth: 3
+                ) // Include last 3 path segments
+                  // File sink with structured JSON (includes all enriched properties)
+                .WriteTo.File(
+                    new CompactJsonFormatter(),
+                    logPath,
+                    rollingInterval: RollingInterval.Day,
+                    retainedFileCountLimit: 7,
+                    shared: true
+                )
+                // Console sink with readable format
+                .WriteTo.Console(
+                    outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {SourceContext}{NewLine}    {Message:lj}{NewLine}{Exception}"
+                );
 
-        Log.Information("Serilog configured. Log file location: {LogPath}", logPath);
-    });
+            Log.Information("Serilog configured. Log file location: {LogPath}", logPath);
+        }
+    );
 
     // Add LmStreaming services
     _ = builder.Services.AddLmStreaming(options =>
@@ -131,7 +136,8 @@ try
     // don't pay the startup cost and so the codex provider stays selectable from the
     // dropdown regardless of LM_PROVIDER_MODE.
     _ = builder.Services.AddSingleton<IFunctionProvider>(
-        new TypeFunctionProvider(typeof(SampleTools), providerName: "SampleTools"));
+        new TypeFunctionProvider(typeof(SampleTools), providerName: "SampleTools")
+    );
     _ = builder.Services.AddMcpFunctionProviderServerLazy(options =>
     {
         options.Port = codexMcpPort;
@@ -151,10 +157,11 @@ try
     // computed for the boot default so the global tools API stays stable; per-conversation
     // built-in tools are derived from the resolved provider id at agent-creation time.
     var builtInTools = GetBuiltInToolsForProvider(providerMode);
-    var builtInToolDefinitions = builtInTools?
-        .OfType<AnthropicBuiltInTool>()
-        .Select(t => new ToolDefinition { Name = t.Name, Description = $"Server-side {t.Name} tool ({t.Type})" })
-        .ToList()
+    var builtInToolDefinitions =
+        builtInTools
+            ?.OfType<AnthropicBuiltInTool>()
+            .Select(t => new ToolDefinition { Name = t.Name, Description = $"Server-side {t.Name} tool ({t.Type})" })
+            .ToList()
         ?? [];
     _ = builder.Services.AddSingleton<IReadOnlyList<ToolDefinition>>(builtInToolDefinitions);
 
@@ -169,24 +176,23 @@ try
     // Provider id → IStreamingAgent. Receives the per-conversation provider id resolved
     // by the pool (request → persisted → default), so this factory does not know about
     // LM_PROVIDER_MODE — it just dispatches by id.
-    _ = builder.Services.AddSingleton<Func<string, IStreamingAgent>>(sp => providerId =>
+    _ = builder.Services.AddSingleton<Func<string, IStreamingAgent>>(sp =>
+        providerId =>
         {
             var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
             return providerId.ToLowerInvariant() switch
             {
                 "openai" => CreateOpenAiAgent(loggerFactory),
                 "anthropic" => CreateAnthropicAgent(loggerFactory),
-                "test-anthropic" => CreateAnthropicTestAgent(
-                    loggerFactory,
-                    sp.GetRequiredService<ITestAgentBuilder>()),
-                "test" => CreateTestAgent(
-                    loggerFactory,
-                    sp.GetRequiredService<ITestAgentBuilder>()),
+                "test-anthropic" => CreateAnthropicTestAgent(loggerFactory, sp.GetRequiredService<ITestAgentBuilder>()),
+                "test" => CreateTestAgent(loggerFactory, sp.GetRequiredService<ITestAgentBuilder>()),
                 _ => throw new ProviderUnavailableException(
                     providerId,
-                    "no IStreamingAgent factory is registered for this provider"),
+                    "no IStreamingAgent factory is registered for this provider"
+                ),
             };
-        });
+        }
+    );
 
     // Read LlmQueryMcp config for books/question MCP servers
     var llmQueryMcpBaseUrl = builder.Configuration["LlmQueryMcp:BaseUrl"];
@@ -220,7 +226,9 @@ try
                     if (string.IsNullOrWhiteSpace(mockBaseUrl))
                     {
                         throw new ProviderUnavailableException(
-                            "codex-mock", "the in-process mock provider host is not running");
+                            "codex-mock",
+                            "the in-process mock provider host is not running"
+                        );
                     }
 
                     string codexEndpoint;
@@ -233,7 +241,8 @@ try
                         throw new ProviderUnavailableException(
                             "codex-mock",
                             $"MCP server failed to start: {ex.Message}",
-                            ex);
+                            ex
+                        );
                     }
 
                     return new MultiTurnAgentPool.AgentCreationResult(
@@ -248,7 +257,9 @@ try
                             mcpBaseUrl,
                             llmQueryMcpExamType,
                             mockBaseUrlOverride: $"{mockBaseUrl}/v1",
-                            mockApiKeyOverride: "mock-token"));
+                            mockApiKeyOverride: "mock-token"
+                        )
+                    );
                 }
 
                 if (string.Equals(normalizedProviderId, "claude-mock", StringComparison.Ordinal))
@@ -256,7 +267,9 @@ try
                     if (string.IsNullOrWhiteSpace(mockBaseUrl))
                     {
                         throw new ProviderUnavailableException(
-                            "claude-mock", "the in-process mock provider host is not running");
+                            "claude-mock",
+                            "the in-process mock provider host is not running"
+                        );
                     }
 
                     // Claude Agent SDK CLI appends /v1/messages itself, so the configured
@@ -273,24 +286,30 @@ try
                             mcpBaseUrl,
                             llmQueryMcpExamType,
                             mockBaseUrlOverride: claudeMockBaseUrl,
-                            mockAuthTokenOverride: "mock-token"));
+                            mockAuthTokenOverride: "mock-token"
+                        )
+                    );
                 }
 
                 if (string.Equals(normalizedProviderId, "copilot-mock", StringComparison.Ordinal))
                 {
                     return string.IsNullOrWhiteSpace(mockBaseUrl)
                         ? throw new ProviderUnavailableException(
-                            "copilot-mock", "the in-process mock provider host is not running")
+                            "copilot-mock",
+                            "the in-process mock provider host is not running"
+                        )
                         : new MultiTurnAgentPool.AgentCreationResult(
-                        CreateCopilotAgentLoop(
-                            threadId,
-                            mode,
-                            functionRegistry,
-                            requestResponseDumpFileName,
-                            conversationStore,
-                            loggerFactory,
-                            mockBaseUrlOverride: $"{mockBaseUrl}/v1",
-                            mockApiKeyOverride: "mock-token"));
+                            CreateCopilotAgentLoop(
+                                threadId,
+                                mode,
+                                functionRegistry,
+                                requestResponseDumpFileName,
+                                conversationStore,
+                                loggerFactory,
+                                mockBaseUrlOverride: $"{mockBaseUrl}/v1",
+                                mockApiKeyOverride: "mock-token"
+                            )
+                        );
                 }
 
                 if (string.Equals(normalizedProviderId, "codex", StringComparison.Ordinal))
@@ -308,7 +327,8 @@ try
                         throw new ProviderUnavailableException(
                             "codex",
                             $"MCP server failed to start: {ex.Message}",
-                            ex);
+                            ex
+                        );
                     }
 
                     return new MultiTurnAgentPool.AgentCreationResult(
@@ -321,7 +341,9 @@ try
                             loggerFactory,
                             codexEndpoint,
                             mcpBaseUrl,
-                            llmQueryMcpExamType));
+                            llmQueryMcpExamType
+                        )
+                    );
                 }
 
                 if (string.Equals(normalizedProviderId, "claude", StringComparison.Ordinal))
@@ -334,7 +356,9 @@ try
                             conversationStore,
                             loggerFactory,
                             mcpBaseUrl,
-                            llmQueryMcpExamType));
+                            llmQueryMcpExamType
+                        )
+                    );
                 }
 
                 if (string.Equals(normalizedProviderId, "copilot", StringComparison.Ordinal))
@@ -346,7 +370,9 @@ try
                             functionRegistry,
                             requestResponseDumpFileName,
                             conversationStore,
-                            loggerFactory));
+                            loggerFactory
+                        )
+                    );
                 }
 
                 var providerAgent = agentFactory(normalizedProviderId);
@@ -357,8 +383,10 @@ try
                 var filteredRegistry = new FunctionRegistry();
                 foreach (var contract in allContracts)
                 {
-                    if (allHandlers.TryGetValue(contract.Name, out var handler)
-                        && (enabledToolSet == null || enabledToolSet.Contains(contract.Name)))
+                    if (
+                        allHandlers.TryGetValue(contract.Name, out var handler)
+                        && (enabledToolSet == null || enabledToolSet.Contains(contract.Name))
+                    )
                     {
                         _ = filteredRegistry.AddFunction(contract, handler, "SampleTools");
                     }
@@ -370,8 +398,12 @@ try
                 if (!string.IsNullOrEmpty(mcpBaseUrl))
                 {
                     var (_, mcpClients) = ConnectLlmQueryMcpClients(
-                        filteredRegistry, threadId, mcpBaseUrl, llmQueryMcpExamType,
-                        loggerFactory);
+                        filteredRegistry,
+                        threadId,
+                        mcpBaseUrl,
+                        llmQueryMcpExamType,
+                        loggerFactory
+                    );
                     if (mcpClients.Count > 0)
                     {
                         ownedResources = [.. mcpClients.Cast<IAsyncDisposable>()];
@@ -388,19 +420,24 @@ try
 
                     // Enable extended thinking for Anthropic-compatible providers
                     var extraProperties = ImmutableDictionary<string, object?>.Empty;
-                    if (string.Equals(normalizedProviderId, "anthropic", StringComparison.Ordinal)
-                        || string.Equals(normalizedProviderId, "test-anthropic", StringComparison.Ordinal))
+                    if (
+                        string.Equals(normalizedProviderId, "anthropic", StringComparison.Ordinal)
+                        || string.Equals(normalizedProviderId, "test-anthropic", StringComparison.Ordinal)
+                    )
                     {
                         var budgetTokens = int.TryParse(
                             Environment.GetEnvironmentVariable("ANTHROPIC_THINKING_BUDGET"),
-                            out var parsed) ? parsed : 2048;
-                        extraProperties = extraProperties.Add(
-                            "Thinking", new AnthropicThinking(budgetTokens));
+                            out var parsed
+                        )
+                            ? parsed
+                            : 2048;
+                        extraProperties = extraProperties.Add("Thinking", new AnthropicThinking(budgetTokens));
                     }
 
                     // Test-mode DI seam: opt-in sub-agent orchestration. Real-provider modes
                     // never resolve this service, so production wiring is unchanged.
-                    var isTestMode = string.Equals(normalizedProviderId, "test", StringComparison.Ordinal)
+                    var isTestMode =
+                        string.Equals(normalizedProviderId, "test", StringComparison.Ordinal)
                         || string.Equals(normalizedProviderId, "test-anthropic", StringComparison.Ordinal);
                     var subAgentOptions = isTestMode
                         ? sp.GetRequiredService<ITestAgentBuilder>()
@@ -422,7 +459,8 @@ try
                         },
                         store: conversationStore,
                         logger: loggerFactory.CreateLogger<MultiTurnAgentLoop>(),
-                        subAgentOptions: subAgentOptions);
+                        subAgentOptions: subAgentOptions
+                    );
 
                     return new MultiTurnAgentPool.AgentCreationResult(agent, ownedResources);
                 }
@@ -433,8 +471,13 @@ try
                     {
                         foreach (var resource in ownedResources)
                         {
-                            try { resource.DisposeAsync().AsTask().GetAwaiter().GetResult(); }
-                            catch { /* ignore cleanup errors */ }
+                            try
+                            {
+                                resource.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                            }
+                            catch
+                            { /* ignore cleanup errors */
+                            }
                         }
                     }
 
@@ -443,7 +486,8 @@ try
             },
             providerRegistry: providerRegistry,
             conversationStore: conversationStore,
-            logger: loggerFactory.CreateLogger<MultiTurnAgentPool>());
+            logger: loggerFactory.CreateLogger<MultiTurnAgentPool>()
+        );
     });
 
     // Register the ChatWebSocketManager
@@ -455,15 +499,18 @@ try
     var logger = app.Services.GetRequiredService<ILogger<Program>>();
     logger.LogInformation(
         "Application started. Environment: {Environment}, WebSocket path: /ws",
-        app.Environment.EnvironmentName);
+        app.Environment.EnvironmentName
+    );
 
     // Use Serilog request logging for HTTP requests
-    _ = app.UseSerilogRequestLogging(options => options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
+    _ = app.UseSerilogRequestLogging(options =>
+        options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
         {
             diagnosticContext.Set("RequestHost", httpContext.Request.Host.Value ?? string.Empty);
             diagnosticContext.Set("RequestScheme", httpContext.Request.Scheme ?? string.Empty);
             diagnosticContext.Set("UserAgent", httpContext.Request.Headers.UserAgent.ToString() ?? string.Empty);
-        });
+        }
+    );
 
     // Enable Vite dev server in development
     if (app.Environment.IsDevelopment())
@@ -478,100 +525,106 @@ try
     _ = app.UseLmStreaming();
 
     // Map custom WebSocket endpoint for chat using ChatWebSocketManager
-    _ = app.Map("/ws", async (
-        HttpContext context,
-        ChatWebSocketManager wsManager,
-        IChatModeStore modeStore,
-        ILogger<Program> wsLogger,
-        CancellationToken cancellationToken) =>
-    {
-        if (!context.WebSockets.IsWebSocketRequest)
+    _ = app.Map(
+        "/ws",
+        async (
+            HttpContext context,
+            ChatWebSocketManager wsManager,
+            IChatModeStore modeStore,
+            ILogger<Program> wsLogger,
+            CancellationToken cancellationToken
+        ) =>
         {
-            context.Response.StatusCode = StatusCodes.Status400BadRequest;
-            await context.Response.WriteAsync("WebSocket connection required", cancellationToken);
-            return;
-        }
+            if (!context.WebSockets.IsWebSocketRequest)
+            {
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await context.Response.WriteAsync("WebSocket connection required", cancellationToken);
+                return;
+            }
 
-        // Get threadId from query string (required for agent routing)
-        var threadId = context.Request.Query["threadId"].FirstOrDefault()
-            ?? context.Request.Query["connectionId"].FirstOrDefault()
-            ?? Guid.NewGuid().ToString();
+            // Get threadId from query string (required for agent routing)
+            var threadId =
+                context.Request.Query["threadId"].FirstOrDefault()
+                ?? context.Request.Query["connectionId"].FirstOrDefault()
+                ?? Guid.NewGuid().ToString();
 
-        // Get modeId from query string (optional, defaults to system default)
-        var modeId = context.Request.Query["modeId"].FirstOrDefault();
-        var mode = !string.IsNullOrEmpty(modeId)
-            ? await modeStore.GetModeAsync(modeId, cancellationToken)
-            : null;
+            // Get modeId from query string (optional, defaults to system default)
+            var modeId = context.Request.Query["modeId"].FirstOrDefault();
+            var mode = !string.IsNullOrEmpty(modeId) ? await modeStore.GetModeAsync(modeId, cancellationToken) : null;
 
-        // Optional per-conversation provider override. Honored only when the thread has
-        // not yet locked in a provider (first message). Persisted threads keep their
-        // original provider regardless of what the client sends.
-        var providerId = context.Request.Query["providerId"].FirstOrDefault();
+            // Optional per-conversation provider override. Honored only when the thread has
+            // not yet locked in a provider (first message). Persisted threads keep their
+            // original provider regardless of what the client sends.
+            var providerId = context.Request.Query["providerId"].FirstOrDefault();
 
-        var recordEnabled = app.Environment.IsDevelopment()
-            && IsRecordingEnabled(context.Request.Query["record"].FirstOrDefault());
+            var recordEnabled =
+                app.Environment.IsDevelopment() && IsRecordingEnabled(context.Request.Query["record"].FirstOrDefault());
 
-        StreamWriter? recordWriter = null;
-        string? requestResponseDumpFileName = null;
-        if (recordEnabled)
-        {
-            var recordingsDir = Path.Combine(app.Environment.ContentRootPath, "recordings");
-            _ = Directory.CreateDirectory(recordingsDir);
-            var sessionBaseName = $"{threadId}_{DateTime.UtcNow:yyyyMMddTHHmmss}";
+            StreamWriter? recordWriter = null;
+            string? requestResponseDumpFileName = null;
+            if (recordEnabled)
+            {
+                var recordingsDir = Path.Combine(app.Environment.ContentRootPath, "recordings");
+                _ = Directory.CreateDirectory(recordingsDir);
+                var sessionBaseName = $"{threadId}_{DateTime.UtcNow:yyyyMMddTHHmmss}";
 
-            var wsFileName = $"{sessionBaseName}.ws.jsonl";
-            recordWriter = new StreamWriter(
-                Path.Combine(
-                    recordingsDir,
-                    wsFileName),
-                false,
-                new UTF8Encoding(false));
+                var wsFileName = $"{sessionBaseName}.ws.jsonl";
+                recordWriter = new StreamWriter(
+                    Path.Combine(recordingsDir, wsFileName),
+                    false,
+                    new UTF8Encoding(false)
+                );
 
-            requestResponseDumpFileName = Path.Combine(recordingsDir, $"{sessionBaseName}.llm");
+                requestResponseDumpFileName = Path.Combine(recordingsDir, $"{sessionBaseName}.llm");
 
+                wsLogger.LogInformation(
+                    "Recording enabled for thread {ThreadId}. WS file: {WsFile}, LLM dump base: {DumpBase}",
+                    threadId,
+                    wsFileName,
+                    requestResponseDumpFileName
+                );
+            }
+
+            var webSocket = await context.WebSockets.AcceptWebSocketAsync();
             wsLogger.LogInformation(
-                "Recording enabled for thread {ThreadId}. WS file: {WsFile}, LLM dump base: {DumpBase}",
+                "WebSocket connection established for thread {ThreadId} with mode {ModeId}",
                 threadId,
-                wsFileName,
-                requestResponseDumpFileName);
-        }
+                mode?.Id ?? "default"
+            );
 
-        var webSocket = await context.WebSockets.AcceptWebSocketAsync();
-        wsLogger.LogInformation(
-            "WebSocket connection established for thread {ThreadId} with mode {ModeId}",
-            threadId,
-            mode?.Id ?? "default");
-
-        try
-        {
-            await wsManager.HandleConnectionAsync(
-                webSocket,
-                threadId,
-                mode,
-                providerId,
-                requestResponseDumpFileName,
-                recordWriter,
-                cancellationToken);
-        }
-        finally
-        {
-            if (recordWriter != null)
+            try
             {
-                await recordWriter.DisposeAsync();
+                await wsManager.HandleConnectionAsync(
+                    webSocket,
+                    threadId,
+                    mode,
+                    providerId,
+                    requestResponseDumpFileName,
+                    recordWriter,
+                    cancellationToken
+                );
             }
-
-            if (webSocket.State == System.Net.WebSockets.WebSocketState.Open)
+            finally
             {
-                await webSocket.CloseAsync(
-                    System.Net.WebSockets.WebSocketCloseStatus.NormalClosure,
-                    "Server closing",
-                    CancellationToken.None);
-            }
+                if (recordWriter != null)
+                {
+                    await recordWriter.DisposeAsync();
+                }
 
-            webSocket.Dispose();
-            wsLogger.LogInformation("WebSocket connection closed for thread {ThreadId}", threadId);
+                if (webSocket.State == System.Net.WebSockets.WebSocketState.Open)
+                {
+                    await webSocket.CloseAsync(
+                        System.Net.WebSockets.WebSocketCloseStatus.NormalClosure,
+                        "Server closing",
+                        CancellationToken.None
+                    );
+                }
+
+                webSocket.Dispose();
+                wsLogger.LogInformation("WebSocket connection closed for thread {ThreadId}", threadId);
+            }
         }
-    });
+    );
 
     // Map controllers (conversations, chat-modes, tools, diagnostics)
     _ = app.MapControllers();
@@ -604,21 +657,17 @@ public partial class Program
     /// <summary>
     ///     Creates a test-mode agent using an <see cref="ITestAgentBuilder"/>-supplied handler.
     /// </summary>
-    private static IStreamingAgent CreateTestAgent(
-        ILoggerFactory loggerFactory,
-        ITestAgentBuilder testAgentBuilder)
+    private static IStreamingAgent CreateTestAgent(ILoggerFactory loggerFactory, ITestAgentBuilder testAgentBuilder)
     {
         var testHandler = testAgentBuilder.CreateHandler("test", loggerFactory);
 
-        var httpClient = new HttpClient(testHandler)
-        {
-            BaseAddress = new Uri("http://test-mode/v1"),
-        };
+        var httpClient = new HttpClient(testHandler) { BaseAddress = new Uri("http://test-mode/v1") };
 
         var openClient = new OpenClient(
             httpClient,
             "http://test-mode/v1",
-            logger: loggerFactory.CreateLogger<OpenClient>());
+            logger: loggerFactory.CreateLogger<OpenClient>()
+        );
 
         return new OpenClientAgent("MockLLM", openClient, loggerFactory.CreateLogger<OpenClientAgent>());
     }
@@ -632,14 +681,12 @@ public partial class Program
         var apiKey = EnvironmentHelper.GetApiKeyFromEnv("OPENAI_API_KEY");
         var baseUrl = EnvironmentHelper.GetApiBaseUrlFromEnv(
             "OPENAI_BASE_URL",
-            defaultValue: "https://api.openai.com/v1");
+            defaultValue: "https://api.openai.com/v1"
+        );
 
         Log.Information("Creating OpenAI agent with base URL: {BaseUrl}", baseUrl);
 
-        var openClient = new OpenClient(
-            apiKey,
-            baseUrl,
-            logger: loggerFactory.CreateLogger<OpenClient>());
+        var openClient = new OpenClient(apiKey, baseUrl, logger: loggerFactory.CreateLogger<OpenClient>());
 
         return new OpenClientAgent("OpenAI", openClient, loggerFactory.CreateLogger<OpenClientAgent>());
     }
@@ -653,14 +700,16 @@ public partial class Program
         var apiKey = EnvironmentHelper.GetApiKeyFromEnv("ANTHROPIC_API_KEY");
         var baseUrl = EnvironmentHelper.GetApiBaseUrlFromEnv(
             "ANTHROPIC_BASE_URL",
-            defaultValue: "https://api.anthropic.com/v1");
+            defaultValue: "https://api.anthropic.com/v1"
+        );
 
         Log.Information("Creating Anthropic agent with base URL: {BaseUrl}", baseUrl);
 
         var anthropicClient = new AnthropicClient(
             apiKey,
             baseUrl: baseUrl,
-            logger: loggerFactory.CreateLogger<AnthropicClient>());
+            logger: loggerFactory.CreateLogger<AnthropicClient>()
+        );
 
         return new AnthropicAgent("Anthropic", anthropicClient, loggerFactory.CreateLogger<AnthropicAgent>());
     }
@@ -674,24 +723,20 @@ public partial class Program
     /// </summary>
     private static IStreamingAgent CreateAnthropicTestAgent(
         ILoggerFactory loggerFactory,
-        ITestAgentBuilder testAgentBuilder)
+        ITestAgentBuilder testAgentBuilder
+    )
     {
         var testHandler = testAgentBuilder.CreateHandler("test-anthropic", loggerFactory);
 
-        var httpClient = new HttpClient(testHandler)
-        {
-            BaseAddress = new Uri("http://test-mode/v1"),
-        };
+        var httpClient = new HttpClient(testHandler) { BaseAddress = new Uri("http://test-mode/v1") };
 
         var anthropicClient = new AnthropicClient(
             httpClient,
             baseUrl: "http://test-mode/v1",
-            logger: loggerFactory.CreateLogger<AnthropicClient>());
+            logger: loggerFactory.CreateLogger<AnthropicClient>()
+        );
 
-        return new AnthropicAgent(
-            "MockAnthropic",
-            anthropicClient,
-            loggerFactory.CreateLogger<AnthropicAgent>());
+        return new AnthropicAgent("MockAnthropic", anthropicClient, loggerFactory.CreateLogger<AnthropicAgent>());
     }
 
     private static CodexAgentLoop CreateCodexAgentLoop(
@@ -705,7 +750,8 @@ public partial class Program
         string? llmQueryMcpBaseUrl,
         string? llmQueryMcpExamType,
         string? mockBaseUrlOverride = null,
-        string? mockApiKeyOverride = null)
+        string? mockApiKeyOverride = null
+    )
     {
         var enabledTools = mode.EnabledTools;
         var codexOptions = CreateCodexOptions(requestResponseDumpFileName, threadId);
@@ -758,12 +804,13 @@ public partial class Program
             },
             store: conversationStore,
             logger: loggerFactory.CreateLogger<CodexAgentLoop>(),
-            loggerFactory: loggerFactory);
+            loggerFactory: loggerFactory
+        );
     }
 
     private static CodexSdkOptions CreateCodexOptions(string? requestResponseDumpFileName, string threadId)
     {
-        var codexCliPath = Environment.GetEnvironmentVariable("CODEX_CLI_PATH") ?? "codex";
+        var codexCliPath = ResolveCodexCliPath(Environment.GetEnvironmentVariable("CODEX_CLI_PATH"));
         var codexCliMinVersion = Environment.GetEnvironmentVariable("CODEX_CLI_MIN_VERSION") ?? "0.101.0";
         var apiKey = Environment.GetEnvironmentVariable("CODEX_API_KEY");
         var webSearchMode = Environment.GetEnvironmentVariable("CODEX_WEB_SEARCH_MODE") ?? "disabled";
@@ -775,65 +822,80 @@ public partial class Program
         var developerInstructions = Environment.GetEnvironmentVariable("CODEX_DEVELOPER_INSTRUCTIONS");
         var modelInstructionsFile = Environment.GetEnvironmentVariable("CODEX_MODEL_INSTRUCTIONS_FILE");
         var toolBridgeModeRaw = Environment.GetEnvironmentVariable("CODEX_TOOL_BRIDGE_MODE") ?? "hybrid";
-        var exposeInternalToolsAsToolMessages = !bool.TryParse(
-            Environment.GetEnvironmentVariable("CODEX_EXPOSE_INTERNAL_TOOLS_AS_TOOL_MESSAGES"),
-            out var parsedExposeInternalToolsAsToolMessages) || parsedExposeInternalToolsAsToolMessages;
-        var emitLegacyInternalToolReasoningSummaries = bool.TryParse(
-            Environment.GetEnvironmentVariable("CODEX_EMIT_LEGACY_INTERNAL_TOOL_REASONING_SUMMARIES"),
-            out var parsedEmitLegacyInternalToolReasoningSummaries) && parsedEmitLegacyInternalToolReasoningSummaries;
-        var networkEnabled = !bool.TryParse(
-            Environment.GetEnvironmentVariable("CODEX_NETWORK_ACCESS_ENABLED"),
-            out var parsedNetworkEnabled) || parsedNetworkEnabled;
-        var skipGitRepoCheck = !bool.TryParse(
-            Environment.GetEnvironmentVariable("CODEX_SKIP_GIT_REPO_CHECK"),
-            out var parsedSkipGit) || parsedSkipGit;
-        var emitSyntheticUpdates = bool.TryParse(
-            Environment.GetEnvironmentVariable("CODEX_EMIT_SYNTHETIC_MESSAGE_UPDATES"),
-            out var parsedEmitSyntheticUpdates) && parsedEmitSyntheticUpdates;
+        var exposeInternalToolsAsToolMessages =
+            !bool.TryParse(
+                Environment.GetEnvironmentVariable("CODEX_EXPOSE_INTERNAL_TOOLS_AS_TOOL_MESSAGES"),
+                out var parsedExposeInternalToolsAsToolMessages
+            ) || parsedExposeInternalToolsAsToolMessages;
+        var emitLegacyInternalToolReasoningSummaries =
+            bool.TryParse(
+                Environment.GetEnvironmentVariable("CODEX_EMIT_LEGACY_INTERNAL_TOOL_REASONING_SUMMARIES"),
+                out var parsedEmitLegacyInternalToolReasoningSummaries
+            ) && parsedEmitLegacyInternalToolReasoningSummaries;
+        var networkEnabled =
+            !bool.TryParse(
+                Environment.GetEnvironmentVariable("CODEX_NETWORK_ACCESS_ENABLED"),
+                out var parsedNetworkEnabled
+            ) || parsedNetworkEnabled;
+        var skipGitRepoCheck =
+            !bool.TryParse(Environment.GetEnvironmentVariable("CODEX_SKIP_GIT_REPO_CHECK"), out var parsedSkipGit)
+            || parsedSkipGit;
+        var emitSyntheticUpdates =
+            bool.TryParse(
+                Environment.GetEnvironmentVariable("CODEX_EMIT_SYNTHETIC_MESSAGE_UPDATES"),
+                out var parsedEmitSyntheticUpdates
+            ) && parsedEmitSyntheticUpdates;
         // Retained as a diagnostic-only compatibility knob; raw provider streaming remains default.
         var syntheticChunkSize = int.TryParse(
             Environment.GetEnvironmentVariable("CODEX_SYNTHETIC_MESSAGE_UPDATE_CHUNK_CHARS"),
-            out var parsedChunkSize)
+            out var parsedChunkSize
+        )
             ? parsedChunkSize
             : 28;
         var modelInstructionsThresholdChars = int.TryParse(
             Environment.GetEnvironmentVariable("CODEX_MODEL_INSTRUCTIONS_THRESHOLD_CHARS"),
-            out var parsedModelInstructionsThresholdChars)
+            out var parsedModelInstructionsThresholdChars
+        )
             ? parsedModelInstructionsThresholdChars
             : 8000;
         var appServerStartupTimeoutMs = int.TryParse(
             Environment.GetEnvironmentVariable("CODEX_APP_SERVER_STARTUP_TIMEOUT_MS"),
-            out var parsedAppServerStartupTimeoutMs)
+            out var parsedAppServerStartupTimeoutMs
+        )
             ? parsedAppServerStartupTimeoutMs
             : 30000;
         var turnCompletionTimeoutMs = int.TryParse(
             Environment.GetEnvironmentVariable("CODEX_TURN_COMPLETION_TIMEOUT_MS"),
-            out var parsedTurnCompletionTimeoutMs)
+            out var parsedTurnCompletionTimeoutMs
+        )
             ? parsedTurnCompletionTimeoutMs
             : 120000;
         var turnInterruptGracePeriodMs = int.TryParse(
             Environment.GetEnvironmentVariable("CODEX_TURN_INTERRUPT_GRACE_PERIOD_MS"),
-            out var parsedTurnInterruptGracePeriodMs)
+            out var parsedTurnInterruptGracePeriodMs
+        )
             ? parsedTurnInterruptGracePeriodMs
             : 5000;
-        var rpcTraceEnabledFromEnv = bool.TryParse(
-            Environment.GetEnvironmentVariable("CODEX_RPC_TRACE_ENABLED"),
-            out var parsedRpcTraceEnabled)
+        var rpcTraceEnabledFromEnv =
+            bool.TryParse(Environment.GetEnvironmentVariable("CODEX_RPC_TRACE_ENABLED"), out var parsedRpcTraceEnabled)
             && parsedRpcTraceEnabled;
         var rpcTraceFileFromEnv = Environment.GetEnvironmentVariable("CODEX_RPC_TRACE_FILE");
 
-        var toolBridgeMode = Enum.TryParse<CodexToolBridgeMode>(toolBridgeModeRaw, ignoreCase: true, out var parsedToolBridgeMode)
+        var toolBridgeMode = Enum.TryParse<CodexToolBridgeMode>(
+            toolBridgeModeRaw,
+            ignoreCase: true,
+            out var parsedToolBridgeMode
+        )
             ? parsedToolBridgeMode
             : CodexToolBridgeMode.Hybrid;
 
         var sessionId = !string.IsNullOrWhiteSpace(requestResponseDumpFileName)
             ? Path.GetFileName(requestResponseDumpFileName)
             : $"{threadId}-{DateTimeOffset.UtcNow:yyyyMMddTHHmmssfff}";
-        var traceFilePath = !string.IsNullOrWhiteSpace(requestResponseDumpFileName)
-            ? $"{requestResponseDumpFileName}.codex.rpc.jsonl"
-            : string.IsNullOrWhiteSpace(rpcTraceFileFromEnv)
-                ? null
-                : rpcTraceFileFromEnv;
+        var traceFilePath =
+            !string.IsNullOrWhiteSpace(requestResponseDumpFileName) ? $"{requestResponseDumpFileName}.codex.rpc.jsonl"
+            : string.IsNullOrWhiteSpace(rpcTraceFileFromEnv) ? null
+            : rpcTraceFileFromEnv;
         var enableRpcTrace = rpcTraceEnabledFromEnv || !string.IsNullOrWhiteSpace(requestResponseDumpFileName);
         if (enableRpcTrace && string.IsNullOrWhiteSpace(traceFilePath))
         {
@@ -874,6 +936,47 @@ public partial class Program
         };
     }
 
+    private static string ResolveCodexCliPath(string? configuredPath)
+    {
+        return ResolveCodexCliPath(
+            configuredPath,
+            OperatingSystem.IsWindows(),
+            Environment.GetEnvironmentVariable("PATH")
+        );
+    }
+
+    private static string ResolveCodexCliPath(string? configuredPath, bool isWindows, string? path)
+    {
+        if (!string.IsNullOrWhiteSpace(configuredPath))
+        {
+            return configuredPath;
+        }
+
+        if (!isWindows)
+        {
+            return "codex";
+        }
+
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return "codex";
+        }
+
+        foreach (var directory in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var executableName in new[] { "codex.exe", "codex.cmd" })
+            {
+                var candidate = Path.Combine(directory, executableName);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return "codex";
+    }
+
     private static string GetModelIdForProvider(string providerMode)
     {
         return providerMode.ToLowerInvariant() switch
@@ -903,9 +1006,11 @@ public partial class Program
 
     private static int ResolveCodexMcpPort()
     {
-        if (int.TryParse(Environment.GetEnvironmentVariable("CODEX_MCP_PORT"), out var port)
+        if (
+            int.TryParse(Environment.GetEnvironmentVariable("CODEX_MCP_PORT"), out var port)
             && port > 0
-            && port <= 65535)
+            && port <= 65535
+        )
         {
             if (IsPortAvailable(port))
             {
@@ -916,7 +1021,8 @@ public partial class Program
             Log.Warning(
                 "Configured CODEX_MCP_PORT {ConfiguredPort} is already in use. Falling back to port {FallbackPort}.",
                 port,
-                fallbackPort);
+                fallbackPort
+            );
             return fallbackPort;
         }
 
@@ -930,7 +1036,8 @@ public partial class Program
         Log.Warning(
             "Default CODEX_MCP_PORT {DefaultPort} is already in use. Falling back to port {FallbackPort}.",
             defaultPort,
-            fallback);
+            fallback
+        );
         return fallback;
     }
 
@@ -964,8 +1071,10 @@ public partial class Program
     internal static bool IsRecordingEnabled(string? recordValue)
     {
         return recordValue is not null
-            && (string.Equals(recordValue, "1", StringComparison.Ordinal)
-                || string.Equals(recordValue, "true", StringComparison.OrdinalIgnoreCase));
+            && (
+                string.Equals(recordValue, "1", StringComparison.Ordinal)
+                || string.Equals(recordValue, "true", StringComparison.OrdinalIgnoreCase)
+            );
     }
 
     private static ClaudeAgentLoop CreateClaudeAgentLoop(
@@ -977,15 +1086,15 @@ public partial class Program
         string? llmQueryMcpBaseUrl,
         string? llmQueryMcpExamType,
         string? mockBaseUrlOverride = null,
-        string? mockAuthTokenOverride = null)
+        string? mockAuthTokenOverride = null
+    )
     {
         // Build AllowedTools from mode's enabled tools:
         // null = use defaults, empty = no built-in tools (MCP only), non-empty = specific tools
-        var allowedTools = mode.EnabledTools == null
-            ? "Read,WebSearch,WebFetch"
-            : mode.EnabledTools.Count > 0
-                ? string.Join(",", mode.EnabledTools)
-                : string.Empty;
+        var allowedTools =
+            mode.EnabledTools == null ? "Read,WebSearch,WebFetch"
+            : mode.EnabledTools.Count > 0 ? string.Join(",", mode.EnabledTools)
+            : string.Empty;
 
         // claude-agent-sdk CLI v0.1.55 does not recognize --no-checkpoints /
         // --no-session-persistence. Setting DisableCheckpoints / DisableSessionPersistence makes
@@ -1017,7 +1126,8 @@ public partial class Program
             },
             store: conversationStore,
             logger: loggerFactory.CreateLogger<ClaudeAgentLoop>(),
-            loggerFactory: loggerFactory);
+            loggerFactory: loggerFactory
+        );
     }
 
     private static CopilotAgentLoop CreateCopilotAgentLoop(
@@ -1028,7 +1138,8 @@ public partial class Program
         IConversationStore conversationStore,
         ILoggerFactory loggerFactory,
         string? mockBaseUrlOverride = null,
-        string? mockApiKeyOverride = null)
+        string? mockApiKeyOverride = null
+    )
     {
         var copilotCliPath = Environment.GetEnvironmentVariable("COPILOT_CLI_PATH") ?? "copilot";
         var copilotCliMinVersion = Environment.GetEnvironmentVariable("COPILOT_CLI_MIN_VERSION") ?? "0.0.410";
@@ -1037,23 +1148,26 @@ public partial class Program
         var baseUrl = Environment.GetEnvironmentVariable("COPILOT_BASE_URL");
         var workingDirectory = Environment.GetEnvironmentVariable("COPILOT_WORKING_DIRECTORY");
         var rpcTraceFileFromEnv = Environment.GetEnvironmentVariable("COPILOT_RPC_TRACE_FILE");
-        var rpcTraceEnabledFromEnv = bool.TryParse(
-            Environment.GetEnvironmentVariable("COPILOT_RPC_TRACE_ENABLED"),
-            out var parsedRpcTraceEnabled)
-            && parsedRpcTraceEnabled;
-        var modelAllowlistProbeEnabled = !bool.TryParse(
-            Environment.GetEnvironmentVariable("COPILOT_MODEL_ALLOWLIST_PROBE_ENABLED"),
-            out var parsedModelProbe) || parsedModelProbe;
-        var defaultPermissionDecision = Environment.GetEnvironmentVariable("COPILOT_DEFAULT_PERMISSION_DECISION") ?? "allow";
+        var rpcTraceEnabledFromEnv =
+            bool.TryParse(
+                Environment.GetEnvironmentVariable("COPILOT_RPC_TRACE_ENABLED"),
+                out var parsedRpcTraceEnabled
+            ) && parsedRpcTraceEnabled;
+        var modelAllowlistProbeEnabled =
+            !bool.TryParse(
+                Environment.GetEnvironmentVariable("COPILOT_MODEL_ALLOWLIST_PROBE_ENABLED"),
+                out var parsedModelProbe
+            ) || parsedModelProbe;
+        var defaultPermissionDecision =
+            Environment.GetEnvironmentVariable("COPILOT_DEFAULT_PERMISSION_DECISION") ?? "allow";
 
         var sessionId = !string.IsNullOrWhiteSpace(requestResponseDumpFileName)
             ? Path.GetFileName(requestResponseDumpFileName)
             : $"{threadId}-{DateTimeOffset.UtcNow:yyyyMMddTHHmmssfff}";
-        var traceFilePath = !string.IsNullOrWhiteSpace(requestResponseDumpFileName)
-            ? $"{requestResponseDumpFileName}.copilot.rpc.jsonl"
-            : string.IsNullOrWhiteSpace(rpcTraceFileFromEnv)
-                ? null
-                : rpcTraceFileFromEnv;
+        var traceFilePath =
+            !string.IsNullOrWhiteSpace(requestResponseDumpFileName) ? $"{requestResponseDumpFileName}.copilot.rpc.jsonl"
+            : string.IsNullOrWhiteSpace(rpcTraceFileFromEnv) ? null
+            : rpcTraceFileFromEnv;
         var enableRpcTrace = rpcTraceEnabledFromEnv || !string.IsNullOrWhiteSpace(requestResponseDumpFileName);
         if (enableRpcTrace && string.IsNullOrWhiteSpace(traceFilePath))
         {
@@ -1069,8 +1183,8 @@ public partial class Program
         var effectiveApiKey = string.IsNullOrWhiteSpace(mockApiKeyOverride) ? apiKey : mockApiKeyOverride;
         // The Copilot CLI's model allowlist probe phones home to GitHub before the first turn —
         // the mock host doesn't implement it, so disable the probe whenever a mock URL is set.
-        var effectiveModelAllowlistProbeEnabled = string.IsNullOrWhiteSpace(mockBaseUrlOverride)
-            && modelAllowlistProbeEnabled;
+        var effectiveModelAllowlistProbeEnabled =
+            string.IsNullOrWhiteSpace(mockBaseUrlOverride) && modelAllowlistProbeEnabled;
 
         var copilotOptions = new CopilotSdkOptions
         {
@@ -1104,7 +1218,8 @@ public partial class Program
             },
             store: conversationStore,
             logger: loggerFactory.CreateLogger<CopilotAgentLoop>(),
-            loggerFactory: loggerFactory);
+            loggerFactory: loggerFactory
+        );
     }
 
     /// <summary>
@@ -1114,7 +1229,8 @@ public partial class Program
     private static Dictionary<string, McpServerConfig> BuildLlmQueryMcpServers(
         string conversationId,
         string? baseUrl,
-        string? examType)
+        string? examType
+    )
     {
         if (string.IsNullOrEmpty(baseUrl))
         {
@@ -1143,7 +1259,8 @@ public partial class Program
         string threadId,
         string baseUrl,
         string? examType,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory
+    )
     {
         var createdClients = new List<McpClient>();
         var logger = loggerFactory.CreateLogger<Program>();
@@ -1155,34 +1272,32 @@ public partial class Program
                 ["X-Session-Id"] = threadId,
             };
 
-            var booksTransport = new HttpClientTransport(new HttpClientTransportOptions
-            {
-                Name = "books",
-                Endpoint = new Uri($"{baseUrl}/mcp/query"),
-                AdditionalHeaders = headers,
-            });
+            var booksTransport = new HttpClientTransport(
+                new HttpClientTransportOptions
+                {
+                    Name = "books",
+                    Endpoint = new Uri($"{baseUrl}/mcp/query"),
+                    AdditionalHeaders = headers,
+                }
+            );
 
             // Sync-over-async: acceptable in sample app (no SynchronizationContext)
             var booksClient = McpClient.CreateAsync(booksTransport).GetAwaiter().GetResult();
             createdClients.Add(booksClient);
 
-            var mcpClients = new Dictionary<string, McpClient>
-            {
-                ["books"] = booksClient,
-            };
+            var mcpClients = new Dictionary<string, McpClient> { ["books"] = booksClient };
 
             _ = registry.AddMcpClientsAsync(mcpClients, "LlmQuery").GetAwaiter().GetResult();
 
-            logger.LogInformation(
-                "Connected to LlmQuery book search MCP server for thread {ThreadId}",
-                threadId);
+            logger.LogInformation("Connected to LlmQuery book search MCP server for thread {ThreadId}", threadId);
         }
         catch (Exception ex)
         {
             logger.LogWarning(
                 ex,
                 "Failed to connect to LlmQuery MCP server at {BaseUrl} — continuing without MCP tools",
-                baseUrl);
+                baseUrl
+            );
         }
 
         return (registry, createdClients);
@@ -1216,9 +1331,11 @@ public partial class Program
                 return envTestPath;
             }
 
-            if (dir.GetFiles("*.sln").Length > 0
+            if (
+                dir.GetFiles("*.sln").Length > 0
                 || dir.GetDirectories(".git").Length > 0
-                || File.Exists(Path.Combine(dir.FullName, ".git")))
+                || File.Exists(Path.Combine(dir.FullName, ".git"))
+            )
             {
                 break;
             }

--- a/samples/MockProviderHost/JsonScenarioLoader.cs
+++ b/samples/MockProviderHost/JsonScenarioLoader.cs
@@ -28,7 +28,7 @@ namespace AchieveAi.LmDotnetTools.MockProviderHost;
 /// }
 /// </code>
 /// Match types: <c>always</c>, <c>system_contains</c> (value), <c>tool</c> (name),
-/// <c>user_contains</c> (value).
+/// <c>user_contains</c> (value), <c>tool_result</c>.
 /// </para>
 /// </remarks>
 public static class JsonScenarioLoader
@@ -66,7 +66,8 @@ public static class JsonScenarioLoader
         ScenarioDocument document;
         try
         {
-            document = JsonSerializer.Deserialize<ScenarioDocument>(json, ParseOptions)
+            document =
+                JsonSerializer.Deserialize<ScenarioDocument>(json, ParseOptions)
                 ?? throw new JsonScenarioFormatException("Scenario JSON deserialised to null.");
         }
         catch (JsonException ex)
@@ -109,10 +110,7 @@ public static class JsonScenarioLoader
 
         // Try alongside the host binary first — `samples/MockProviderHost/scenarios/<name>.json`
         // is copied to the build output by the .csproj.
-        var sideloadPath = Path.Combine(
-            AppContext.BaseDirectory,
-            "scenarios",
-            EnsureJsonExtension(nameOrPath));
+        var sideloadPath = Path.Combine(AppContext.BaseDirectory, "scenarios", EnsureJsonExtension(nameOrPath));
         if (File.Exists(sideloadPath))
         {
             return File.ReadAllText(sideloadPath);
@@ -131,52 +129,63 @@ public static class JsonScenarioLoader
 
         throw new FileNotFoundException(
             $"Scenario '{nameOrPath}' was not found on disk or as an embedded resource.",
-            nameOrPath);
+            nameOrPath
+        );
     }
 
     private static string EnsureJsonExtension(string nameOrPath)
     {
-        return nameOrPath.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
-            ? nameOrPath
-            : nameOrPath + ".json";
+        return nameOrPath.EndsWith(".json", StringComparison.OrdinalIgnoreCase) ? nameOrPath : nameOrPath + ".json";
     }
 
     private static Func<ScriptedRequestContext, bool> BuildMatcher(string roleKey, ScenarioMatch? match)
     {
-        if (match is null || string.IsNullOrWhiteSpace(match.Type)
+        if (
+            match is null
+            || string.IsNullOrWhiteSpace(match.Type)
             || match.Type.Equals("always", StringComparison.OrdinalIgnoreCase)
-            || match.Type.Equals("any", StringComparison.OrdinalIgnoreCase))
+            || match.Type.Equals("any", StringComparison.OrdinalIgnoreCase)
+        )
         {
             return _ => true;
         }
 
         if (match.Type.Equals("system_contains", StringComparison.OrdinalIgnoreCase))
         {
-            var value = match.Value
+            var value =
+                match.Value
                 ?? throw new JsonScenarioFormatException(
-                    $"Role '{roleKey}': system_contains match requires a 'value' field.");
+                    $"Role '{roleKey}': system_contains match requires a 'value' field."
+                );
             return ctx => ctx.SystemPromptContains(value);
         }
 
         if (match.Type.Equals("user_contains", StringComparison.OrdinalIgnoreCase))
         {
-            var value = match.Value
+            var value =
+                match.Value
                 ?? throw new JsonScenarioFormatException(
-                    $"Role '{roleKey}': user_contains match requires a 'value' field.");
-            return ctx => ctx.LatestUserMessage is not null
+                    $"Role '{roleKey}': user_contains match requires a 'value' field."
+                );
+            return ctx =>
+                ctx.LatestUserMessage is not null
                 && ctx.LatestUserMessage.Contains(value, StringComparison.OrdinalIgnoreCase);
         }
 
         if (match.Type.Equals("tool", StringComparison.OrdinalIgnoreCase))
         {
-            var name = match.Name
-                ?? throw new JsonScenarioFormatException(
-                    $"Role '{roleKey}': tool match requires a 'name' field.");
+            var name =
+                match.Name
+                ?? throw new JsonScenarioFormatException($"Role '{roleKey}': tool match requires a 'name' field.");
             return ctx => ctx.HasTool(name);
         }
 
-        throw new JsonScenarioFormatException(
-            $"Role '{roleKey}': unknown match type '{match.Type}'.");
+        if (match.Type.Equals("tool_result", StringComparison.OrdinalIgnoreCase))
+        {
+            return ctx => ctx.HasToolResult;
+        }
+
+        throw new JsonScenarioFormatException($"Role '{roleKey}': unknown match type '{match.Type}'.");
     }
 
     private static void ApplyTurn(InstructionPlanBuilder plan, ScenarioTurn turn)
@@ -212,8 +221,7 @@ public static class JsonScenarioLoader
         {
             if (message.WordCount is not { } wordCount || wordCount <= 0)
             {
-                throw new JsonScenarioFormatException(
-                    "text_len message requires a positive 'wordCount' field.");
+                throw new JsonScenarioFormatException("text_len message requires a positive 'wordCount' field.");
             }
 
             _ = plan.TextLen(wordCount);
@@ -240,10 +248,12 @@ public static class JsonScenarioLoader
     /// <summary>Returns the names of built-in scenarios shipped as embedded resources.</summary>
     public static IReadOnlyList<string> ListBuiltinScenarios()
     {
-        var names = typeof(JsonScenarioLoader).Assembly
-            .GetManifestResourceNames()
-            .Where(n => n.StartsWith(BuiltinScenarioPrefix, StringComparison.Ordinal)
-                && n.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+        var names = typeof(JsonScenarioLoader)
+            .Assembly.GetManifestResourceNames()
+            .Where(n =>
+                n.StartsWith(BuiltinScenarioPrefix, StringComparison.Ordinal)
+                && n.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
+            )
             .Select(n => Path.GetFileNameWithoutExtension(n[BuiltinScenarioPrefix.Length..]))
             .ToArray();
 
@@ -291,7 +301,8 @@ public static class JsonScenarioLoader
 /// </summary>
 public sealed class JsonScenarioFormatException : Exception
 {
-    public JsonScenarioFormatException(string message) : base(message) { }
+    public JsonScenarioFormatException(string message)
+        : base(message) { }
 
     public JsonScenarioFormatException(string message, Exception innerException)
         : base(message, innerException) { }

--- a/samples/MockProviderHost/README.md
+++ b/samples/MockProviderHost/README.md
@@ -3,11 +3,12 @@
 A standalone, runnable HTTP service that wraps `ScriptedSseResponder`
 (`src/LmTestUtils/TestMode/`) behind OpenAI- and Anthropic-compatible endpoints,
 so external CLI tools (Claude Agent SDK, Codex, Copilot CLI) can be redirected
-at the same scripted scenarios our unit tests use.
+at the same mock transports our unit tests use.
 
 This is a **thin transport wrapper**. The host adds no SSE framing; every byte
-streamed back to the client originates from `SseStreamHttpContent` /
-`AnthropicSseStreamHttpContent`, the same emitters used by the in-process tests.
+streamed back to the client originates from `SseStreamHttpContent`,
+`AnthropicSseStreamHttpContent`, or `OpenAiResponsesEventStreamWriter`, the same
+emitters used by the in-process tests.
 
 ## Endpoints
 
@@ -16,7 +17,7 @@ streamed back to the client originates from `SseStreamHttpContent` /
 | GET    | `/healthz`              | text/plain `ok`                   | Liveness probe.                                                      |
 | POST   | `/v1/chat/completions`  | OpenAI SSE                        | Streaming chat completion.                                           |
 | POST   | `/v1/messages`          | Anthropic SSE                     | Streaming Anthropic messages.                                        |
-| POST   | `/v1/responses`         | OpenAI Responses API SSE          | Streaming `response.create` events (text + function-call).           |
+| POST   | `/v1/responses`         | OpenAI Responses API SSE          | Streaming `response.create` events (reasoning + text + function-call). |
 | GET    | `/v1/responses` (Upgrade: websocket) | OpenAI Responses API JSON frames | WebSocket transport — accepts multiple `response.create` frames per socket. |
 
 `Authorization` and `x-api-key` headers are accepted and ignored — the inner
@@ -35,7 +36,7 @@ deliver byte-equal events at the JSON layer.
 Supported event types (server→client):
 
 - `response.created` / `response.in_progress` / `response.completed`
-- `response.output_item.added` / `response.output_item.done` (text and function_call items)
+- `response.output_item.added` / `response.output_item.done` (reasoning, text, and function_call items)
 - `response.content_part.added` / `response.content_part.done` (text parts)
 - `response.output_text.delta` / `response.output_text.done`
 - `response.function_call_arguments.delta` / `response.function_call_arguments.done`
@@ -62,8 +63,9 @@ dotnet run --project samples/MockProviderHost -- --port 5099 --scenario /path/to
 LM_MOCK_SCENARIO=demo dotnet run --project samples/MockProviderHost
 ```
 
-Scenario JSON schema (see `samples/MockProviderHost/scenarios/demo.json` for a full
-example). For programmatic scenarios in tests, build a `ScriptedSseResponder` directly via
+Scenario JSON schema for `/v1/chat/completions`, `/v1/messages`, and `/v1/responses` (see
+`samples/MockProviderHost/scenarios/demo.json` for a full example). For
+programmatic scenarios in tests, build a `ScriptedSseResponder` directly via
 `ScriptedSseResponder.New()` and pass it to `MockProviderHostBuilder.Build(...)`.
 
 ```json
@@ -83,6 +85,11 @@ example). For programmatic scenarios in tests, build a `ScriptedSseResponder` di
 Match types: `always`, `system_contains` (with `value`), `user_contains` (with `value`),
 `tool` (with `name`). Message kinds: `text`, `text_len` (with `wordCount`), `tool_call`
 (with `name` and optional `args`).
+
+`/v1/responses` uses embedded instruction chains from the latest user input as an
+override. If no instruction chain is present, it consumes the same JSON scenario
+turn queue as `/v1/chat/completions` and `/v1/messages`; if no scenario matches,
+it emits the scripted fallback response.
 
 ## Embedded use (the common case)
 
@@ -111,8 +118,9 @@ var baseUrl = app.Urls.First();           // e.g., http://127.0.0.1:51234
 ## Authoring scenarios
 
 The instruction-chain script format and `ScriptedSseResponder` builder are
-documented inline at `src/LmTestUtils/TestMode/ScriptedSseResponder.cs` and
-`src/LmTestUtils/TestMode/InstructionChainParser.cs`.
+documented inline at `src/LmTestUtils/TestMode/InstructionChainParser.cs`,
+`src/LmTestUtils/TestMode/OpenAiResponsesInstructionPlanResolver.cs`, and
+`src/LmTestUtils/TestMode/ScriptedSseResponder.cs`.
 
 ## Out of scope (today)
 
@@ -204,12 +212,11 @@ remove the existing `COPILOT_BASE_URL` mapping.**
 |------------------------------------------|--------------------------------------|---------------------------------|
 | `COPILOT_PROVIDER_TYPE=openai`,<br>`COPILOT_PROVIDER_WIRE_API=completions` | `POST /v1/chat/completions` | Already implemented today.      |
 | `COPILOT_PROVIDER_TYPE=anthropic`        | `POST /v1/messages`                  | Already implemented today.      |
-| `COPILOT_PROVIDER_WIRE_API=responses`    | (none)                               | Out of scope — follow-up issue. |
+| `COPILOT_PROVIDER_WIRE_API=responses`    | `POST /v1/responses`                 | Implemented for text, reasoning, and function-call events. |
 
 Newer Copilot model paths (GPT-5 family) use `/v1/responses`. If the probe
-finds the CLI defaults to that route on the version under test, the
-follow-up E2E issue must add a `/v1/responses` route to
-`MockProviderHostBuilder` before E2E coverage is possible.
+finds the CLI defaults to that route on the version under test, use the
+implemented `/v1/responses` route in `MockProviderHostBuilder`.
 
 ### Probe matrix (the empirical step)
 

--- a/src/ClaudeAgentSdkProvider/Agents/ClaudeAgentSdkClient.cs
+++ b/src/ClaudeAgentSdkProvider/Agents/ClaudeAgentSdkClient.cs
@@ -923,17 +923,26 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
         GC.SuppressFinalize(this);
     }
 
-    private string BuildCliArguments(ClaudeAgentSdkRequest request)
+    internal string BuildCliArguments(ClaudeAgentSdkRequest request)
     {
         var args = new List<string>
         {
             $"--output-format {request.OutputFormat}",
             $"--input-format {request.InputFormat}",
-            $"--model {request.ModelId}",
-            $"--max-turns {request.MaxTurns}",
-            $"--permission-mode {request.PermissionMode}",
-            $"--setting-sources \"{request.SettingSources}\"",
         };
+
+        // Only emit --model when a non-empty model id was supplied; otherwise
+        // let the CLI pick its default model. Emitting "--model " with no value
+        // causes the next flag (e.g. --max-turns) to be parsed as the model name,
+        // which the API then rejects with a 404 "model: --max-turns" error.
+        if (!string.IsNullOrWhiteSpace(request.ModelId))
+        {
+            args.Add($"--model {request.ModelId}");
+        }
+
+        args.Add($"--max-turns {request.MaxTurns}");
+        args.Add($"--permission-mode {request.PermissionMode}");
+        args.Add($"--setting-sources \"{request.SettingSources}\"");
 
         if (request.Verbose)
         {

--- a/src/ClaudeAgentSdkProvider/Agents/ClaudeAgentSdkClient.cs
+++ b/src/ClaudeAgentSdkProvider/Agents/ClaudeAgentSdkClient.cs
@@ -79,7 +79,8 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
             "StartAsync called. Current state: {State}, IsRunning: {IsRunning}, HasProcess: {HasProcess}",
             _state,
             IsRunning,
-            _process != null);
+            _process != null
+        );
 
         // Store the request for potential restart
         LastRequest = request;
@@ -99,20 +100,23 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
                         "State desync detected: _state={State}, IsRunning={IsRunning}, HasExited={HasExited}. Resetting to allow restart.",
                         currentState,
                         IsRunning,
-                        _process?.HasExited);
+                        _process?.HasExited
+                    );
                     // Force state to Stopped, then try again
                     _ = Interlocked.Exchange(ref _state, 4);
                     currentState = Interlocked.CompareExchange(ref _state, 1, 4);
                     if (currentState != 4)
                     {
                         throw new InvalidOperationException(
-                            $"Cannot start after state reset: state is {currentState}.");
+                            $"Cannot start after state reset: state is {currentState}."
+                        );
                     }
                 }
                 else
                 {
                     throw new InvalidOperationException(
-                        $"Cannot start: invalid state {currentState}. Expected NotStarted(0) or Stopped(4).");
+                        $"Cannot start: invalid state {currentState}. Expected NotStarted(0) or Stopped(4)."
+                    );
                 }
             }
         }
@@ -168,14 +172,16 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
                 "medium" => "4096",
                 "high" => "8192",
                 "xhigh" => "16384",
-                _ => null
+                _ => null,
             };
             if (thinkingTokens != null)
             {
                 startInfo.Environment["MAX_THINKING_TOKENS"] = thinkingTokens;
                 _logger?.LogInformation(
                     "Reasoning effort '{Effort}' mapped to MAX_THINKING_TOKENS={Tokens}",
-                    request.ReasoningEffort, thinkingTokens);
+                    request.ReasoningEffort,
+                    thinkingTokens
+                );
             }
 
             // Optional overrides for E2E tests against a mock provider host. Setting any of
@@ -183,13 +189,16 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
             ApplyMockHostOverrides(startInfo.Environment, _options, _logger);
 
             // 6. Start process
-            _process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start claude-agent-sdk process");
+            _process =
+                Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Failed to start claude-agent-sdk process");
 
             // Use UTF-8 WITHOUT BOM for writing to Node.js process
             // BOM would corrupt the first JSON line and cause parsing failures
             _stdinWriter = new StreamWriter(
                 _process.StandardInput.BaseStream,
-                new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false))
+                new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false)
+            )
             {
                 AutoFlush = false, // We manually flush after writing
             };
@@ -247,14 +256,16 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
             "SendMessagesAsync called. State: {State}, IsRunning: {IsRunning}, Mode: {Mode}",
             _state,
             IsRunning,
-            _options.Mode);
+            _options.Mode
+        );
 
         // In Interactive mode, throw to guide users to the new API
         if (_options.Mode == ClaudeAgentSdkMode.Interactive)
         {
             throw new InvalidOperationException(
-                "SendMessagesAsync is not supported in Interactive mode. " +
-                "Use SendAsync() to write messages and SubscribeToMessagesAsync() to read responses.");
+                "SendMessagesAsync is not supported in Interactive mode. "
+                    + "Use SendAsync() to write messages and SubscribeToMessagesAsync() to read responses."
+            );
         }
 
         if (!IsRunning)
@@ -290,7 +301,8 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
                 CurrentSession?.SessionId,
                 userMessages.Count,
                 firstText ?? "(none)",
-                lastText ?? "(same as first)");
+                lastText ?? "(same as first)"
+            );
 
             await _stdinWriter.WriteLineAsync(jsonLine);
             await _stdinWriter.FlushAsync(cancellationToken);
@@ -319,82 +331,22 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
 
             if (jsonlEvent == null)
             {
-                _logger?.LogWarning("Failed to parse JSONL line (length={Length}): {Line}",
-                    line.Length, line.Length > 200 ? line[..200] + "..." : line);
+                _logger?.LogWarning(
+                    "Failed to parse JSONL line (length={Length}): {Line}",
+                    line.Length,
+                    line.Length > 200 ? line[..200] + "..." : line
+                );
                 continue;
             }
 
-            if (jsonlEvent is AssistantMessageEvent assistantEvent)
+            if (jsonlEvent is ResultEvent resultEvent)
             {
-                // Check for API errors (e.g., billing_error) before processing normal messages
-                if (assistantEvent.IsApiErrorMessage)
-                {
-                    var errorText = assistantEvent.Message?.Content?.FirstOrDefault()?.Text;
-                    _logger?.LogError(
-                        "[Agent:{SessionId}] API error received: Type={ErrorType}, Message={ErrorMessage}. Agent must be recreated.",
-                        CurrentSession?.SessionId,
-                        assistantEvent.Error,
-                        errorText);
-
-                    throw new BillingErrorException(
-                        assistantEvent.Error,
-                        errorText,
-                        CurrentSession?.SessionId);
-                }
-
-                var eventMessages = _parser.ConvertToMessages(assistantEvent).ToList();
                 _logger?.LogTrace(
-                    "AssistantMessageEvent: MessageId={MessageId}, BlockCount={BlockCount}, Messages=[{Messages}]",
-                    assistantEvent.Message?.Id,
-                    assistantEvent.Message?.Content?.Count ?? 0,
-                    string.Join("; ", eventMessages.Select(m => FormatMessageForLog(m, 80))));
-                foreach (var msg in eventMessages)
-                {
-                    isWorking = true;
-                    yield return msg;
-                }
-            }
-            // User messages contain tool results and other user inputs
-            else if (jsonlEvent is UserMessageEvent userEvent)
-            {
-                var eventMessages = _parser.ConvertToMessages(userEvent).ToList();
-                _logger?.LogTrace(
-                    "UserMessageEvent: Uuid={Uuid}, Role={Role}, Messages=[{Messages}]",
-                    userEvent.Uuid,
-                    userEvent.Message?.Role,
-                    string.Join("; ", eventMessages.Select(m => FormatMessageForLog(m, 80))));
-                foreach (var msg in eventMessages)
-                {
-                    yield return msg;
-                }
-            }
-            // Summary events are informational, we can log them but don't emit as messages
-            else if (jsonlEvent is SummaryEvent summaryEvent)
-            {
-                _logger?.LogDebug("Summary: {Summary}", summaryEvent.Summary);
-            }
-            // System init events contain session info and available tools
-            else if (jsonlEvent is SystemInitEvent systemInitEvent)
-            {
-                _logger?.LogInformation(
-                    "[Agent:{SessionId}] System initialized - Model: {Model}, Tools: {ToolCount}, MCP Servers: {McpServers}",
-                    CurrentSession?.SessionId,
-                    systemInitEvent.Model,
-                    systemInitEvent.Tools?.Count ?? 0,
-                    string.Join(", ", systemInitEvent.McpServers?.Select(s => $"{s.Name}({s.Status})") ?? [])
+                    "Received ResultEvent: IsError={IsError}, NumTurns={NumTurns}, SessionId={SessionId}",
+                    resultEvent.IsError,
+                    resultEvent.NumTurns,
+                    resultEvent.SessionId
                 );
-
-                // Update current session with info from init event
-                if (CurrentSession != null && !string.IsNullOrEmpty(systemInitEvent.SessionId))
-                {
-                    CurrentSession = CurrentSession with { SessionId = systemInitEvent.SessionId };
-                }
-            }
-            // Result events contain final execution summary with usage and cost info
-            else if (jsonlEvent is ResultEvent resultEvent)
-            {
-                _logger?.LogTrace("Received ResultEvent: IsError={IsError}, NumTurns={NumTurns}, SessionId={SessionId}",
-                    resultEvent.IsError, resultEvent.NumTurns, resultEvent.SessionId);
                 if (resultEvent.IsError)
                 {
                     if (isWorking && _stdinWriter != null)
@@ -413,15 +365,11 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
                                 Message = new InputMessage
                                 {
                                     Role = "user",
-                                    Content =
-                                    [
-                                        new InputTextContentBlock
-                                        {
-                                            Text = "retry...."
-                                        }
-                                    ]
-                                }
-                            }, _jsonOptions);
+                                    Content = [new InputTextContentBlock { Text = "retry...." }],
+                                },
+                            },
+                            _jsonOptions
+                        );
 
                         _logger?.LogDebug(
                             "Sending JSONL message to claude-agent-sdk: {Message}",
@@ -446,10 +394,7 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
                 // ResultEvent signals the end of current turn in BOTH modes
                 // In OneShot mode: stdin is already closed, process will exit
                 // In Interactive mode: stdin remains open for next SendMessagesAsync call
-                _logger?.LogDebug(
-                    "{Mode} mode: ResultEvent received, ending current turn",
-                    _options.Mode
-                );
+                _logger?.LogDebug("{Mode} mode: ResultEvent received, ending current turn", _options.Mode);
 
                 // In OneShot mode, clean up BEFORE returning from the iterator
                 if (_options.Mode == ClaudeAgentSdkMode.OneShot)
@@ -459,17 +404,24 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
 
                 yield break;
             }
-            else
+
+            var eventMessages = ConvertNonTerminalJsonlEventToMessages(jsonlEvent, emitSystemInit: false);
+            foreach (var msg in eventMessages)
             {
-                _logger?.LogWarning("Unhandled JSONL event type: {EventType}. Line was not processed.",
-                    jsonlEvent.GetType().Name);
+                if (jsonlEvent is AssistantMessageEvent)
+                {
+                    isWorking = true;
+                }
+
+                yield return msg;
             }
         }
     }
 
     /// <inheritdoc />
     public async IAsyncEnumerable<IMessage> SubscribeToMessagesAsync(
-        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
     {
         if (!IsRunning)
         {
@@ -479,7 +431,8 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
         if (_subscriptionActive)
         {
             throw new InvalidOperationException(
-                "A subscription is already active. Only one subscriber is allowed at a time.");
+                "A subscription is already active. Only one subscriber is allowed at a time."
+            );
         }
 
         _subscriptionActive = true;
@@ -501,94 +454,29 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
                     _logger?.LogWarning(
                         "Failed to parse JSONL line (length={Length}): {Line}",
                         line.Length,
-                        line.Length > 200 ? line[..200] + "..." : line);
+                        line.Length > 200 ? line[..200] + "..." : line
+                    );
                     continue;
                 }
 
-                if (jsonlEvent is AssistantMessageEvent assistantEvent)
+                if (jsonlEvent is ResultEvent resultEvent)
                 {
-                    // Check for API errors (e.g., billing_error) before processing normal messages
-                    if (assistantEvent.IsApiErrorMessage)
-                    {
-                        var errorText = assistantEvent.Message?.Content?.FirstOrDefault()?.Text;
-                        _logger?.LogError(
-                            "[Agent:{SessionId}] API error received: Type={ErrorType}, Message={ErrorMessage}. Agent must be recreated.",
-                            CurrentSession?.SessionId,
-                            assistantEvent.Error,
-                            errorText);
-
-                        throw new BillingErrorException(
-                            assistantEvent.Error,
-                            errorText,
-                            CurrentSession?.SessionId);
-                    }
-
-                    var eventMessages = _parser.ConvertToMessages(assistantEvent).ToList();
                     _logger?.LogTrace(
-                        "AssistantMessageEvent: MessageId={MessageId}, BlockCount={BlockCount}, Messages=[{Messages}]",
-                        assistantEvent.Message?.Id,
-                        assistantEvent.Message?.Content?.Count ?? 0,
-                        string.Join("; ", eventMessages.Select(m => FormatMessageForLog(m, 80))));
-
-                    foreach (var msg in eventMessages)
-                    {
-                        yield return msg;
-                    }
-                }
-                else if (jsonlEvent is UserMessageEvent userEvent)
-                {
-                    var eventMessages = _parser.ConvertToMessages(userEvent).ToList();
-                    _logger?.LogTrace(
-                        "UserMessageEvent: Uuid={Uuid}, Role={Role}, Messages=[{Messages}]",
-                        userEvent.Uuid,
-                        userEvent.Message?.Role,
-                        string.Join("; ", eventMessages.Select(m => FormatMessageForLog(m, 80))));
-
-                    foreach (var msg in eventMessages)
-                    {
-                        yield return msg;
-                    }
-                }
-                else if (jsonlEvent is SummaryEvent summaryEvent)
-                {
-                    _logger?.LogDebug("Summary: {Summary}", summaryEvent.Summary);
-                }
-                else if (jsonlEvent is SystemInitEvent systemInitEvent)
-                {
-                    _logger?.LogInformation(
-                        "[Agent:{SessionId}] System initialized - Model: {Model}, Tools: {ToolCount}",
-                        CurrentSession?.SessionId,
-                        systemInitEvent.Model,
-                        systemInitEvent.Tools?.Count ?? 0);
-
-                    if (CurrentSession != null && !string.IsNullOrEmpty(systemInitEvent.SessionId))
-                    {
-                        CurrentSession = CurrentSession with { SessionId = systemInitEvent.SessionId };
-                    }
-
-                    // Yield SystemInitMessage to signal run start
-                    yield return new SystemInitMessage
-                    {
-                        SessionId = systemInitEvent.SessionId,
-                        Model = systemInitEvent.Model,
-                    };
-                }
-                else if (jsonlEvent is ResultEvent resultEvent)
-                {
-                    _logger?.LogTrace("Received ResultEvent: IsError={IsError}, NumTurns={NumTurns}, SessionId={SessionId}",
-                        resultEvent.IsError, resultEvent.NumTurns, resultEvent.SessionId);
+                        "Received ResultEvent: IsError={IsError}, NumTurns={NumTurns}, SessionId={SessionId}",
+                        resultEvent.IsError,
+                        resultEvent.NumTurns,
+                        resultEvent.SessionId
+                    );
 
                     // Yield a marker message so caller knows turn is complete
-                    yield return new ResultEventMessage
-                    {
-                        IsError = resultEvent.IsError,
-                        Result = resultEvent.Result,
-                    };
+                    yield return new ResultEventMessage { IsError = resultEvent.IsError, Result = resultEvent.Result };
                 }
                 else
                 {
-                    _logger?.LogWarning("Unhandled JSONL event type: {EventType}. Line was not processed.",
-                        jsonlEvent.GetType().Name);
+                    foreach (var msg in ConvertNonTerminalJsonlEventToMessages(jsonlEvent, emitSystemInit: true))
+                    {
+                        yield return msg;
+                    }
                 }
             }
         }
@@ -624,7 +512,8 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
 
             _logger?.LogDebug(
                 "Sending JSONL message to claude-agent-sdk: {Message}",
-                jsonLine.Length > 200 ? jsonLine[..200] + "..." : jsonLine);
+                jsonLine.Length > 200 ? jsonLine[..200] + "..." : jsonLine
+            );
 
             var (firstText, lastText) = GetFirstLastTextMessages(userMessages);
             _logger?.LogInformation(
@@ -632,7 +521,8 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
                 CurrentSession?.SessionId,
                 userMessages.Count,
                 firstText ?? "(none)",
-                lastText ?? "(same as first)");
+                lastText ?? "(same as first)"
+            );
 
             await _stdinWriter.WriteLineAsync(jsonLine);
             await _stdinWriter.FlushAsync(cancellationToken);
@@ -640,6 +530,87 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
         finally
         {
             _stdinSemaphore.Release();
+        }
+    }
+
+    internal IReadOnlyList<IMessage> ConvertNonTerminalJsonlEventToMessages(
+        JsonlEventBase jsonlEvent,
+        bool emitSystemInit
+    )
+    {
+        ArgumentNullException.ThrowIfNull(jsonlEvent);
+
+        switch (jsonlEvent)
+        {
+            case AssistantMessageEvent assistantEvent:
+                if (assistantEvent.IsApiErrorMessage)
+                {
+                    var errorText = assistantEvent.Message?.Content?.FirstOrDefault()?.Text;
+                    _logger?.LogError(
+                        "[Agent:{SessionId}] API error received: Type={ErrorType}, Message={ErrorMessage}. Agent must be recreated.",
+                        CurrentSession?.SessionId,
+                        assistantEvent.Error,
+                        errorText
+                    );
+
+                    throw new BillingErrorException(assistantEvent.Error, errorText, CurrentSession?.SessionId);
+                }
+
+                var assistantMessages = _parser.ConvertToMessages(assistantEvent).ToList();
+                _logger?.LogTrace(
+                    "AssistantMessageEvent: MessageId={MessageId}, BlockCount={BlockCount}, Messages=[{Messages}]",
+                    assistantEvent.Message?.Id,
+                    assistantEvent.Message?.Content?.Count ?? 0,
+                    string.Join("; ", assistantMessages.Select(m => FormatMessageForLog(m, 80)))
+                );
+                return assistantMessages;
+
+            case UserMessageEvent userEvent:
+                var userMessages = _parser.ConvertToMessages(userEvent).ToList();
+                _logger?.LogTrace(
+                    "UserMessageEvent: Uuid={Uuid}, Role={Role}, Messages=[{Messages}]",
+                    userEvent.Uuid,
+                    userEvent.Message?.Role,
+                    string.Join("; ", userMessages.Select(m => FormatMessageForLog(m, 80)))
+                );
+                return userMessages;
+
+            case SummaryEvent summaryEvent:
+                _logger?.LogDebug("Summary: {Summary}", summaryEvent.Summary);
+                return [];
+
+            case SystemInitEvent systemInitEvent:
+                _logger?.LogInformation(
+                    "[Agent:{SessionId}] System initialized - Model: {Model}, Tools: {ToolCount}, MCP Servers: {McpServers}",
+                    CurrentSession?.SessionId,
+                    systemInitEvent.Model,
+                    systemInitEvent.Tools?.Count ?? 0,
+                    string.Join(", ", systemInitEvent.McpServers?.Select(s => $"{s.Name}({s.Status})") ?? [])
+                );
+
+                if (CurrentSession != null && !string.IsNullOrEmpty(systemInitEvent.SessionId))
+                {
+                    CurrentSession = CurrentSession with { SessionId = systemInitEvent.SessionId };
+                }
+
+                return emitSystemInit
+                    ? [new SystemInitMessage { SessionId = systemInitEvent.SessionId, Model = systemInitEvent.Model }]
+                    : [];
+
+            case StreamEvent streamEvent:
+                _logger?.LogTrace(
+                    "StreamEvent ignored: Type={StreamEventType}, Uuid={Uuid}",
+                    streamEvent.EventType,
+                    streamEvent.Uuid
+                );
+                return [];
+
+            default:
+                _logger?.LogWarning(
+                    "Unhandled JSONL event type: {EventType}. Line was not processed.",
+                    jsonlEvent.GetType().Name
+                );
+                return [];
         }
     }
 
@@ -670,7 +641,11 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
             return;
         }
 
-        _logger?.LogDebug("[Agent:{SessionId}] Keepalive task started with interval: {Interval}", CurrentSession?.SessionId, _options.KeepAliveInterval);
+        _logger?.LogDebug(
+            "[Agent:{SessionId}] Keepalive task started with interval: {Interval}",
+            CurrentSession?.SessionId,
+            _options.KeepAliveInterval
+        );
 
         using var timer = new PeriodicTimer(_options.KeepAliveInterval);
 
@@ -776,11 +751,7 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
             var exitMsg = new InputMessageWrapper
             {
                 Type = "user",
-                Message = new InputMessage
-                {
-                    Role = "user",
-                    Content = [new InputTextContentBlock { Text = "/exit" }],
-                },
+                Message = new InputMessage { Role = "user", Content = [new InputTextContentBlock { Text = "/exit" }] },
             };
 
             var json = JsonSerializer.Serialize(exitMsg, _jsonOptions);
@@ -967,6 +938,11 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
         if (request.Verbose)
         {
             args.Add("--verbose");
+        }
+
+        if (string.Equals(request.OutputFormat, "stream-json", StringComparison.OrdinalIgnoreCase))
+        {
+            args.Add("--include-partial-messages");
         }
 
         if (!string.IsNullOrEmpty(request.AllowedTools))
@@ -1242,7 +1218,8 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
         _logger?.LogDebug(
             "WaitForOneShotCompletionAsync: Cleaning up resources. ProcessId: {Pid}, HasExited: {HasExited}",
             _process?.Id,
-            _process?.HasExited);
+            _process?.HasExited
+        );
 
         _shutdownCts?.Dispose();
         _shutdownCts = null;
@@ -1277,7 +1254,8 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
     internal static void ApplyMockHostOverrides(
         IDictionary<string, string?> environment,
         ClaudeAgentSdkOptions options,
-        ILogger? logger = null)
+        ILogger? logger = null
+    )
     {
         ArgumentNullException.ThrowIfNull(environment);
         ArgumentNullException.ThrowIfNull(options);
@@ -1289,11 +1267,12 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
             {
                 logger?.LogWarning(
                     "ClaudeAgentSdkOptions.BaseUrl '{ConfiguredBaseUrl}' ends in '/v1'; the Anthropic SDK CLI "
-                    + "re-appends '/v1/messages', which would produce '/v1/v1/messages' (issue #29). "
-                    + "Stripping to '{NormalizedBaseUrl}' for ANTHROPIC_BASE_URL — please update the caller "
-                    + "to drop the '/v1' suffix.",
+                        + "re-appends '/v1/messages', which would produce '/v1/v1/messages' (issue #29). "
+                        + "Stripping to '{NormalizedBaseUrl}' for ANTHROPIC_BASE_URL — please update the caller "
+                        + "to drop the '/v1' suffix.",
                     options.BaseUrl,
-                    normalized);
+                    normalized
+                );
             }
             environment["ANTHROPIC_BASE_URL"] = normalized;
         }
@@ -1399,8 +1378,17 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
             }
 
             // WebP: 52 49 46 46 ... 57 45 42 50
-            if (bytes[0] == 0x52 && bytes[1] == 0x49 && bytes[2] == 0x46 && bytes[3] == 0x46 &&
-                bytes.Length >= 12 && bytes[8] == 0x57 && bytes[9] == 0x45 && bytes[10] == 0x42 && bytes[11] == 0x50)
+            if (
+                bytes[0] == 0x52
+                && bytes[1] == 0x49
+                && bytes[2] == 0x46
+                && bytes[3] == 0x46
+                && bytes.Length >= 12
+                && bytes[8] == 0x57
+                && bytes[9] == 0x45
+                && bytes[10] == 0x42
+                && bytes[11] == 0x50
+            )
             {
                 return "image/webp";
             }
@@ -1418,12 +1406,18 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
     {
         return msg switch
         {
-            TextMessage text => $"\n  [Text] ({text.Text?.Length ?? 0} chars)\n    {TruncateForLog(text.Text, maxContentLength)}",
-            ReasoningMessage reasoning => $"\n  [Thinking] ({reasoning.Reasoning?.Length ?? 0} chars)\n    {TruncateForLog(reasoning.Reasoning, maxContentLength)}",
-            ToolCallMessage toolCall => $"\n  [ToolCall] {toolCall.FunctionName}\n    args={TruncateForLog(toolCall.FunctionArgs, 80)}",
-            ToolCallResultMessage toolResult => $"\n  [ToolResult] id={toolResult.ToolCallId}\n    result={TruncateForLog(toolResult.Result, maxContentLength)}",
-            ImageMessage image => $"\n  [Image]\n    mediaType={image.ImageData.MediaType}\n    size={image.ImageData.ToMemory().Length} bytes",
-            UsageMessage usage => $"\n  [Usage] prompt={usage.Usage?.PromptTokens}, completion={usage.Usage?.CompletionTokens}, total={usage.Usage?.TotalTokens}, cacheRead={usage.Usage?.TotalCachedTokens}",
+            TextMessage text =>
+                $"\n  [Text] ({text.Text?.Length ?? 0} chars)\n    {TruncateForLog(text.Text, maxContentLength)}",
+            ReasoningMessage reasoning =>
+                $"\n  [Thinking] ({reasoning.Reasoning?.Length ?? 0} chars)\n    {TruncateForLog(reasoning.Reasoning, maxContentLength)}",
+            ToolCallMessage toolCall =>
+                $"\n  [ToolCall] {toolCall.FunctionName}\n    args={TruncateForLog(toolCall.FunctionArgs, 80)}",
+            ToolCallResultMessage toolResult =>
+                $"\n  [ToolResult] id={toolResult.ToolCallId}\n    result={TruncateForLog(toolResult.Result, maxContentLength)}",
+            ImageMessage image =>
+                $"\n  [Image]\n    mediaType={image.ImageData.MediaType}\n    size={image.ImageData.ToMemory().Length} bytes",
+            UsageMessage usage =>
+                $"\n  [Usage] prompt={usage.Usage?.PromptTokens}, completion={usage.Usage?.CompletionTokens}, total={usage.Usage?.TotalTokens}, cacheRead={usage.Usage?.TotalCachedTokens}",
             _ => $"\n  [{msg.GetType().Name}]",
         };
     }
@@ -1444,11 +1438,9 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
         // Trim leading/trailing whitespace
         preview = preview.Trim();
 
-        return string.IsNullOrEmpty(preview)
-            ? "(whitespace only)"
-            : preview.Length <= maxLength
-                ? preview
-                : preview[..maxLength] + "...";
+        return string.IsNullOrEmpty(preview) ? "(whitespace only)"
+            : preview.Length <= maxLength ? preview
+            : preview[..maxLength] + "...";
     }
 
     /// <summary>
@@ -1456,7 +1448,8 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
     /// </summary>
     private static (string? First, string? Last) GetFirstLastTextMessages(
         IEnumerable<IMessage> messages,
-        int maxLength = 100)
+        int maxLength = 100
+    )
     {
         var textMessages = messages.OfType<TextMessage>().ToList();
         if (textMessages.Count == 0)
@@ -1465,9 +1458,7 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
         }
 
         var first = TruncateForLog(textMessages[0].Text, maxLength);
-        var last = textMessages.Count > 1
-            ? TruncateForLog(textMessages[^1].Text, maxLength)
-            : null;
+        var last = textMessages.Count > 1 ? TruncateForLog(textMessages[^1].Text, maxLength) : null;
         return (first, last);
     }
 }

--- a/src/ClaudeAgentSdkProvider/Agents/ClaudeAgentSdkClient.cs
+++ b/src/ClaudeAgentSdkProvider/Agents/ClaudeAgentSdkClient.cs
@@ -188,6 +188,9 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
             // these on the child process redirects the CLI away from the real Anthropic API.
             ApplyMockHostOverrides(startInfo.Environment, _options, _logger);
 
+            // Redirect the CLI's ~/.claude/ to the profile staging dir.
+            ApplyStagingDirectoryEnv(startInfo.Environment, request.StagingDirectory);
+
             // 6. Start process
             _process =
                 Process.Start(startInfo)
@@ -594,7 +597,11 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
                 }
 
                 return emitSystemInit
-                    ? [new SystemInitMessage { SessionId = systemInitEvent.SessionId, Model = systemInitEvent.Model }]
+                    ? [new SystemInitMessage
+                    {
+                        SessionId = systemInitEvent.SessionId,
+                        Model = systemInitEvent.Model,
+                    }]
                     : [];
 
             case StreamEvent streamEvent:
@@ -942,7 +949,17 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
 
         args.Add($"--max-turns {request.MaxTurns}");
         args.Add($"--permission-mode {request.PermissionMode}");
-        args.Add($"--setting-sources \"{request.SettingSources}\"");
+        // Tri-state semantics for --setting-sources:
+        //   null         -> omit the flag; CLI applies its own default
+        //                   (user,project,local) which surfaces installed
+        //                   plugins, sub-agents, skills, and worktree .mcp.json.
+        //   "" (empty)   -> emit the flag with empty value to disable every
+        //                   source (isolated agent).
+        //   "user,..."   -> emit the explicit subset.
+        if (request.SettingSources is not null)
+        {
+            args.Add($"--setting-sources \"{request.SettingSources}\"");
+        }
 
         if (request.Verbose)
         {
@@ -1469,5 +1486,17 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
         var first = TruncateForLog(textMessages[0].Text, maxLength);
         var last = textMessages.Count > 1 ? TruncateForLog(textMessages[^1].Text, maxLength) : null;
         return (first, last);
+    }
+
+    internal static void ApplyStagingDirectoryEnv(
+        IDictionary<string, string?> environment,
+        string? stagingDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        if (string.IsNullOrEmpty(stagingDirectory))
+        {
+            return;
+        }
+        environment["CLAUDE_CONFIG_DIR"] = stagingDirectory;
     }
 }

--- a/src/ClaudeAgentSdkProvider/Agents/ProfileMaterializer.cs
+++ b/src/ClaudeAgentSdkProvider/Agents/ProfileMaterializer.cs
@@ -1,0 +1,274 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Agents;
+
+/// <summary>
+///     Result of materializing an <see cref="AgentRuntimeProfile"/> into a staging
+///     directory the Claude CLI can discover.
+/// </summary>
+public sealed record MaterializedProfile : IDisposable
+{
+    /// <summary>
+    ///     Absolute path to the staging directory. Pass as <c>CLAUDE_CONFIG_DIR</c>
+    ///     on the child process so the CLI sees the staged skills/agents.
+    ///     <c>null</c> means the profile was empty and no staging dir was created.
+    /// </summary>
+    public string? StagingDirectory { get; init; }
+
+    /// <summary>
+    ///     MCP servers contributed by the profile. The caller merges these into the
+    ///     final MCP dictionary, with profile entries winning on key collision.
+    /// </summary>
+    public IReadOnlyDictionary<string, McpServerConfig> McpServers { get; init; }
+        = new Dictionary<string, McpServerConfig>();
+
+    /// <summary>
+    ///     System prompt supplied by the profile, or <c>null</c> if absent. The caller
+    ///     overlays this on top of any provider-level system prompt.
+    /// </summary>
+    public string? SystemPrompt { get; init; }
+
+    /// <summary>
+    ///     Deletes the staging directory on disposal.
+    /// </summary>
+    public void Dispose()
+    {
+        if (StagingDirectory is null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (Directory.Exists(StagingDirectory))
+            {
+                Directory.Delete(StagingDirectory, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; another process may still hold a file.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // ditto
+        }
+    }
+}
+
+/// <summary>
+///     Translates a provider-neutral <see cref="AgentRuntimeProfile"/> into the
+///     filesystem layout the Claude Agent SDK CLI expects under <c>CLAUDE_CONFIG_DIR</c>.
+/// </summary>
+/// <remarks>
+///     <para>Layout produced:</para>
+///     <list type="bullet">
+///         <item><description><c>&lt;staging&gt;/skills/&lt;Name&gt;/SKILL.md</c> for inline skills.</description></item>
+///         <item><description><c>&lt;staging&gt;/skills/&lt;Name&gt;/</c> for directory-sourced skills (recursive copy).</description></item>
+///         <item><description><c>&lt;staging&gt;/agents/&lt;Name&gt;.md</c> for both inline and file-sourced sub-agents.</description></item>
+///     </list>
+///     <para>
+///         Note: <c>CLAUDE_CONFIG_DIR</c> replaces the <c>~/.claude/</c> root entirely.
+///         The CLI's documented skill/agent directory layout (<c>~/.claude/skills/</c>,
+///         <c>~/.claude/agents/</c>) becomes <c>&lt;staging&gt;/skills/</c> and
+///         <c>&lt;staging&gt;/agents/</c> — no extra <c>.claude/</c> nesting.
+///     </para>
+/// </remarks>
+public static class ProfileMaterializer
+{
+    /// <summary>
+    ///     Materialize the profile to a fresh temp directory. Returns a disposable
+    ///     handle that includes the staging directory path, the MCP dictionary the
+    ///     caller should merge with host-loaded MCP, and the system prompt to overlay.
+    /// </summary>
+    /// <remarks>
+    ///     If the profile is <c>null</c> or contributes no Skills/SubAgents/McpServers/SystemPrompt,
+    ///     no staging directory is created and <see cref="MaterializedProfile.StagingDirectory"/>
+    ///     is <c>null</c>. The handle is still safe to dispose.
+    /// </remarks>
+    public static MaterializedProfile Materialize(AgentRuntimeProfile? profile)
+    {
+        if (profile is null
+            || (profile.Skills.Count == 0
+                && profile.SubAgents.Count == 0
+                && profile.McpServers.Count == 0
+                && string.IsNullOrEmpty(profile.SystemPrompt)))
+        {
+            return new MaterializedProfile();
+        }
+
+        string? stagingDir = null;
+        if (profile.Skills.Count > 0 || profile.SubAgents.Count > 0)
+        {
+            stagingDir = Path.Combine(Path.GetTempPath(), $"lm-claude-{Guid.NewGuid():N}");
+            _ = Directory.CreateDirectory(stagingDir);
+            try
+            {
+                MaterializeSkills(stagingDir, profile.Skills);
+                MaterializeSubAgents(stagingDir, profile.SubAgents);
+            }
+            catch
+            {
+                TryDeleteDirectory(stagingDir);
+                throw;
+            }
+        }
+
+        var mcpCopy = new Dictionary<string, McpServerConfig>(StringComparer.Ordinal);
+        foreach (var (name, config) in profile.McpServers)
+        {
+            mcpCopy[name] = config;
+        }
+
+        return new MaterializedProfile
+        {
+            StagingDirectory = stagingDir,
+            McpServers = mcpCopy,
+            SystemPrompt = string.IsNullOrEmpty(profile.SystemPrompt) ? null : profile.SystemPrompt,
+        };
+    }
+
+    private static void MaterializeSkills(string stagingDir, IReadOnlyList<AgentSkill> skills)
+    {
+        var skillsRoot = Path.Combine(stagingDir, "skills");
+        _ = Directory.CreateDirectory(skillsRoot);
+        foreach (var skill in skills)
+        {
+            ValidateName(skill.Name, "skill");
+            var dir = EnsureWithinRoot(skillsRoot, Path.Combine(skillsRoot, skill.Name));
+            _ = Directory.CreateDirectory(dir);
+            switch (skill.Source)
+            {
+                case ContentSource.FromInline inline:
+                    File.WriteAllText(Path.Combine(dir, "SKILL.md"), inline.Content);
+                    break;
+                case ContentSource.FromPath fromPath:
+                    CopySkillFromPath(skill.Name, fromPath.Value, dir);
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unhandled ContentSource variant for skill '{skill.Name}': {skill.Source.GetType().Name}");
+            }
+        }
+    }
+
+    private static void CopySkillFromPath(string skillName, string sourcePath, string destDir)
+    {
+        if (Directory.Exists(sourcePath))
+        {
+            CopyDirectory(sourcePath, destDir);
+        }
+        else if (File.Exists(sourcePath))
+        {
+            File.Copy(sourcePath, Path.Combine(destDir, "SKILL.md"), overwrite: true);
+        }
+        else
+        {
+            throw new FileNotFoundException(
+                $"Skill source path not found for '{skillName}': {sourcePath}",
+                sourcePath);
+        }
+    }
+
+    private static void MaterializeSubAgents(string stagingDir, IReadOnlyList<SubAgentDefinition> subAgents)
+    {
+        var agentsRoot = Path.Combine(stagingDir, "agents");
+        _ = Directory.CreateDirectory(agentsRoot);
+        foreach (var subAgent in subAgents)
+        {
+            ValidateName(subAgent.Name, "sub-agent");
+            var target = EnsureWithinRoot(agentsRoot, Path.Combine(agentsRoot, $"{subAgent.Name}.md"));
+            switch (subAgent.Source)
+            {
+                case ContentSource.FromInline inline:
+                    File.WriteAllText(target, inline.Content);
+                    break;
+                case ContentSource.FromPath fromPath:
+                    CopySubAgentFromPath(subAgent.Name, fromPath.Value, target);
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unhandled ContentSource variant for sub-agent '{subAgent.Name}': {subAgent.Source.GetType().Name}");
+            }
+        }
+    }
+
+    private static void CopySubAgentFromPath(string subAgentName, string sourcePath, string target)
+    {
+        if (File.Exists(sourcePath))
+        {
+            File.Copy(sourcePath, target, overwrite: true);
+            return;
+        }
+
+        if (!Directory.Exists(sourcePath))
+        {
+            throw new FileNotFoundException(
+                $"Sub-agent source path not found for '{subAgentName}': {sourcePath}",
+                sourcePath);
+        }
+
+        var firstMd = Directory.EnumerateFiles(sourcePath, "*.md").FirstOrDefault()
+            ?? throw new FileNotFoundException(
+                $"Sub-agent source dir contains no .md file for '{subAgentName}': {sourcePath}");
+        File.Copy(firstMd, target, overwrite: true);
+    }
+
+    private static void ValidateName(string name, string kind)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException($"Profile {kind} name cannot be empty.", nameof(name));
+        }
+
+        if (name.Contains("..", StringComparison.Ordinal)
+            || name.IndexOfAny(['/', '\\']) >= 0
+            || name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            throw new ArgumentException(
+                $"Profile {kind} name '{name}' contains invalid characters or path separators.",
+                nameof(name));
+        }
+    }
+
+    private static string EnsureWithinRoot(string root, string candidate)
+    {
+        var fullRoot = Path.GetFullPath(root);
+        var fullCandidate = Path.GetFullPath(candidate);
+        var rootWithSep = fullRoot.EndsWith(Path.DirectorySeparatorChar)
+            ? fullRoot
+            : fullRoot + Path.DirectorySeparatorChar;
+        if (!fullCandidate.StartsWith(rootWithSep, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Resolved path '{fullCandidate}' escapes staging root '{fullRoot}'.");
+        }
+        return fullCandidate;
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    private static void CopyDirectory(string source, string dest)
+    {
+        _ = Directory.CreateDirectory(dest);
+        foreach (var file in Directory.EnumerateFiles(source))
+        {
+            File.Copy(file, Path.Combine(dest, Path.GetFileName(file)), overwrite: true);
+        }
+        foreach (var subDir in Directory.EnumerateDirectories(source))
+        {
+            CopyDirectory(subDir, Path.Combine(dest, Path.GetFileName(subDir)));
+        }
+    }
+}

--- a/src/ClaudeAgentSdkProvider/Configuration/ClaudeAgentSdkOptions.cs
+++ b/src/ClaudeAgentSdkProvider/Configuration/ClaudeAgentSdkOptions.cs
@@ -1,3 +1,5 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
 namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
 
 /// <summary>
@@ -98,6 +100,27 @@ public record ClaudeAgentSdkOptions
     public string? ReasoningEffort { get; init; }
 
     /// <summary>
+    ///     Include user/global settings (skills, sub-agents, MCP servers, plugins from
+    ///     <c>~/.claude/</c>). Default: <c>true</c>. Set to <c>false</c> to hide the
+    ///     host user's personal configuration from the spawned agent.
+    /// </summary>
+    public bool IncludeUserSettings { get; init; } = true;
+
+    /// <summary>
+    ///     Include project-level settings (<c>.claude/</c> directory and <c>.mcp.json</c>
+    ///     in the working directory). Default: <c>true</c>. Set to <c>false</c> when the
+    ///     project tree is untrusted (e.g. reviewing a PR worktree) so its settings
+    ///     don't influence the agent.
+    /// </summary>
+    public bool IncludeProjectSettings { get; init; } = true;
+
+    /// <summary>
+    ///     Include local (machine-scoped, git-ignored) settings — typically
+    ///     <c>.claude/settings.local.json</c>. Default: <c>true</c>.
+    /// </summary>
+    public bool IncludeLocalSettings { get; init; } = true;
+
+    /// <summary>
     ///     Override the Anthropic API base URL the spawned Claude Agent SDK CLI talks to.
     ///     Mapped to the <c>ANTHROPIC_BASE_URL</c> environment variable on the child process.
     ///     Used by E2E tests that point the CLI at a local mock provider host.
@@ -116,4 +139,15 @@ public record ClaudeAgentSdkOptions
     ///     features (e.g., experimental model headers) the mock host does not implement.
     /// </summary>
     public bool DisableExperimentalBetas { get; init; }
+
+    /// <summary>
+    ///     Optional client-supplied runtime inputs (system prompt, sub-agents, skills,
+    ///     MCP servers). When set, the profile is materialized into a staging directory
+    ///     and the child CLI's <c>CLAUDE_CONFIG_DIR</c> environment variable is pointed
+    ///     at it. Host-installed content under <c>~/.claude/</c> stays gated by the
+    ///     <see cref="IncludeUserSettings"/>/<see cref="IncludeProjectSettings"/>/<see cref="IncludeLocalSettings"/>
+    ///     flags and is independent of the profile. Profile MCP entries take precedence
+    ///     over host-loaded MCP entries on key collision.
+    /// </summary>
+    public AgentRuntimeProfile? Profile { get; init; }
 }

--- a/src/ClaudeAgentSdkProvider/Models/ClaudeAgentSdkRequest.cs
+++ b/src/ClaudeAgentSdkProvider/Models/ClaudeAgentSdkRequest.cs
@@ -1,3 +1,5 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
 namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
 
 /// <summary>
@@ -67,12 +69,23 @@ public record ClaudeAgentSdkRequest
     public string PermissionMode { get; init; } = "bypassPermissions";
 
     /// <summary>
-    ///     Setting sources
+    ///     Comma-separated list of settings sources to load (e.g. "user,project,local").
+    ///     When null or empty, the flag is omitted and the CLI applies its own default
+    ///     (user,project,local). Pass an explicit value only when narrowing the set.
     /// </summary>
-    public string SettingSources { get; init; } = "";
+    public string? SettingSources { get; init; }
 
     /// <summary>
     ///     Reasoning effort level (low, medium, high, xhigh)
     /// </summary>
     public string? ReasoningEffort { get; init; }
+
+    /// <summary>
+    ///     Optional path to a directory the spawned CLI should treat as its
+    ///     <c>~/.claude/</c> root. Mapped to the <c>CLAUDE_CONFIG_DIR</c> environment
+    ///     variable on the child process. Used by <c>AgentRuntimeProfile</c>
+    ///     materialization to expose client-supplied skills, sub-agents, and MCP
+    ///     entries without polluting the host's real config.
+    /// </summary>
+    public string? StagingDirectory { get; init; }
 }

--- a/src/ClaudeAgentSdkProvider/Models/JsonlEvents/JsonlEventBase.cs
+++ b/src/ClaudeAgentSdkProvider/Models/JsonlEvents/JsonlEventBase.cs
@@ -12,6 +12,7 @@ namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models.JsonlEvents;
 [JsonDerivedType(typeof(FileHistorySnapshotEvent), "file-history-snapshot")]
 [JsonDerivedType(typeof(SystemInitEvent), "system")]
 [JsonDerivedType(typeof(ResultEvent), "result")]
+[JsonDerivedType(typeof(StreamEvent), "stream_event")]
 public abstract record JsonlEventBase
 {
     // Note: The 'type' property is handled by JsonPolymorphic discriminator,

--- a/src/ClaudeAgentSdkProvider/Models/JsonlEvents/StreamEvent.cs
+++ b/src/ClaudeAgentSdkProvider/Models/JsonlEvents/StreamEvent.cs
@@ -1,0 +1,29 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models.JsonlEvents;
+
+/// <summary>
+///     Low-level stream event emitted when Claude CLI is run with partial messages enabled.
+/// </summary>
+public record StreamEvent : JsonlEventBase
+{
+    [JsonPropertyName("event")]
+    public required JsonElement Event { get; init; }
+
+    [JsonPropertyName("session_id")]
+    public required string SessionId { get; init; }
+
+    [JsonPropertyName("parent_tool_use_id")]
+    public string? ParentToolUseId { get; init; }
+
+    [JsonPropertyName("uuid")]
+    public required string Uuid { get; init; }
+
+    public string? EventType =>
+        Event.ValueKind == JsonValueKind.Object
+        && Event.TryGetProperty("type", out var type)
+        && type.ValueKind == JsonValueKind.String
+            ? type.GetString()
+            : null;
+}

--- a/src/ClaudeAgentSdkProvider/Models/McpConfiguration.cs
+++ b/src/ClaudeAgentSdkProvider/Models/McpConfiguration.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+
+/// <summary>
+///     Root configuration object for MCP servers, matching the <c>.mcp.json</c>
+///     file shape used by the Claude Agent SDK.
+/// </summary>
+public record McpConfiguration
+{
+    [JsonPropertyName("mcpServers")]
+    public Dictionary<string, McpServerConfig> McpServers { get; init; } = [];
+}

--- a/src/CodexSdkProvider/AgentRuntime/McpServerConfigExtensions.cs
+++ b/src/CodexSdkProvider/AgentRuntime/McpServerConfigExtensions.cs
@@ -22,9 +22,8 @@ public static class McpServerConfigExtensions
             ? null
             : [.. source.Args];
 
-        IReadOnlyDictionary<string, string>? env = source.Env is null
-            ? null
-            : new Dictionary<string, string>(source.Env, StringComparer.Ordinal);
+        IReadOnlyDictionary<string, string>? env = source.Env?
+            .ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.Ordinal);
 
         return new CodexMcpServerConfig
         {

--- a/src/CodexSdkProvider/AgentRuntime/McpServerConfigExtensions.cs
+++ b/src/CodexSdkProvider/AgentRuntime/McpServerConfigExtensions.cs
@@ -1,0 +1,37 @@
+using AchieveAi.LmDotnetTools.CodexSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.CodexSdkProvider.AgentRuntime;
+
+/// <summary>
+///     Projection helpers from the neutral <see cref="McpServerConfig"/> to
+///     Codex-specific <see cref="CodexMcpServerConfig"/>.
+/// </summary>
+public static class McpServerConfigExtensions
+{
+    /// <summary>
+    ///     Maps shared MCP fields (command/args/env/url) onto a Codex-shaped record.
+    ///     Codex-only fields (<c>Enabled</c>, <c>EnabledTools</c>, <c>DisabledTools</c>,
+    ///     <c>ToolTimeoutSec</c>, <c>StartupTimeoutSec</c>) stay at their defaults.
+    /// </summary>
+    public static CodexMcpServerConfig ToCodexConfig(this McpServerConfig source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        IReadOnlyList<string>? args = source.Args is null
+            ? null
+            : [.. source.Args];
+
+        IReadOnlyDictionary<string, string>? env = source.Env is null
+            ? null
+            : new Dictionary<string, string>(source.Env, StringComparer.Ordinal);
+
+        return new CodexMcpServerConfig
+        {
+            Url = source.Url,
+            Command = source.Command,
+            Args = args,
+            Env = env,
+        };
+    }
+}

--- a/src/CodexSdkProvider/Configuration/CodexSdkOptions.cs
+++ b/src/CodexSdkProvider/Configuration/CodexSdkOptions.cs
@@ -1,3 +1,5 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
 namespace AchieveAi.LmDotnetTools.CodexSdkProvider.Configuration;
 
 public enum CodexToolBridgeMode
@@ -84,4 +86,15 @@ public record CodexSdkOptions
 
     // Retained for compatibility with existing env/config shape; ignored in raw streaming mode.
     public int SyntheticMessageUpdateChunkChars { get; init; } = 28;
+
+    /// <summary>
+    ///     Optional client-supplied runtime inputs (system prompt, MCP servers, etc.).
+    ///     Codex consumes <see cref="AgentRuntimeProfile.SystemPrompt"/> (overrides
+    ///     <see cref="DeveloperInstructions"/>) and <see cref="AgentRuntimeProfile.McpServers"/>
+    ///     (merged with bridge-init MCP, profile entries win on key collision).
+    ///     <see cref="AgentRuntimeProfile.Skills"/> and <see cref="AgentRuntimeProfile.SubAgents"/>
+    ///     are not supported by Codex's CLI; their presence triggers a one-time
+    ///     warning log entry per loop and otherwise has no effect.
+    /// </summary>
+    public AgentRuntimeProfile? Profile { get; init; }
 }

--- a/src/CopilotSdkProvider/Configuration/CopilotSdkOptions.cs
+++ b/src/CopilotSdkProvider/Configuration/CopilotSdkOptions.cs
@@ -1,3 +1,5 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
 namespace AchieveAi.LmDotnetTools.CopilotSdkProvider.Configuration;
 
 /// <summary>
@@ -73,4 +75,13 @@ public record CopilotSdkOptions
     public bool EmitSyntheticMessageUpdates { get; init; } = false;
 
     public int SyntheticMessageUpdateChunkChars { get; init; } = 28;
+
+    /// <summary>
+    ///     Optional client-supplied runtime inputs (system prompt, MCP servers, etc.).
+    ///     Copilot consumes only <see cref="AgentRuntimeProfile.SystemPrompt"/> (overrides
+    ///     <see cref="DeveloperInstructions"/>). The Copilot ACP protocol does not expose
+    ///     MCP servers, skills, or sub-agents; their presence triggers a one-time
+    ///     warning log entry per loop and otherwise has no effect.
+    /// </summary>
+    public AgentRuntimeProfile? Profile { get; init; }
 }

--- a/src/LmCore/AgentRuntime/AgentRuntimeProfile.cs
+++ b/src/LmCore/AgentRuntime/AgentRuntimeProfile.cs
@@ -1,0 +1,42 @@
+using System.Collections.Immutable;
+
+namespace AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+/// <summary>
+///     Provider-neutral bundle of runtime inputs supplied by a client application:
+///     system prompt, sub-agents, skills, and MCP servers.
+/// </summary>
+/// <remarks>
+///     Each provider projects whatever subset its underlying runtime supports.
+///     Providers MUST log a single warning per loop construction for any
+///     non-empty field they cannot honor, then ignore it. See each provider's
+///     <c>Options.Profile</c> XML doc for the per-provider support matrix.
+/// </remarks>
+public sealed record AgentRuntimeProfile
+{
+    /// <summary>
+    ///     System prompt text. When set, supported providers use this in place of
+    ///     their own system prompt / developer instructions.
+    /// </summary>
+    public string? SystemPrompt { get; init; }
+
+    /// <summary>
+    ///     Skills to expose to the spawned agent. Optional; providers that do not
+    ///     support skills log once and ignore.
+    /// </summary>
+    public IReadOnlyList<AgentSkill> Skills { get; init; } = [];
+
+    /// <summary>
+    ///     Sub-agents to expose to the spawned agent. Optional; providers that do
+    ///     not support sub-agents log once and ignore.
+    /// </summary>
+    public IReadOnlyList<SubAgentDefinition> SubAgents { get; init; } = [];
+
+    /// <summary>
+    ///     MCP servers to make available. Optional; providers that do not support
+    ///     MCP log once and ignore. Supporting providers MUST merge with host-loaded
+    ///     MCP config, with profile entries winning on key collision.
+    /// </summary>
+    public IReadOnlyDictionary<string, McpServerConfig> McpServers { get; init; }
+        = ImmutableDictionary<string, McpServerConfig>.Empty;
+}

--- a/src/LmCore/AgentRuntime/AgentSkill.cs
+++ b/src/LmCore/AgentRuntime/AgentSkill.cs
@@ -1,20 +1,29 @@
 namespace AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 
 /// <summary>
-///     Profile-supplied skill that materializes into <c>.claude/skills/&lt;Name&gt;/SKILL.md</c>
-///     for the Claude Agent SDK. Description and other metadata live in the
-///     SKILL.md frontmatter and are parsed by the consuming CLI, not by this SDK.
+///     Provider-neutral skill descriptor supplied via an <see cref="AgentRuntimeProfile"/>.
+///     Each consuming provider decides how (and whether) to surface skills to the
+///     spawned agent. Description and other metadata typically live in the markdown
+///     frontmatter and are parsed by the consuming provider, not by this SDK.
 /// </summary>
+/// <remarks>
+///     See the provider-specific materializer (e.g. <c>ProfileMaterializer</c> in
+///     <c>ClaudeAgentSdkProvider</c>) for details on how a skill's <see cref="Name"/>
+///     and <see cref="Source"/> are mapped onto the underlying CLI's filesystem layout.
+/// </remarks>
 public sealed record AgentSkill
 {
     /// <summary>
-    ///     Directory name under <c>.claude/skills/</c>. Must be unique within the profile.
+    ///     Stable identifier for the skill. Must be unique within the profile and
+    ///     contain no path separators. Providers map this onto the per-provider
+    ///     filesystem layout (for example, a directory name).
     /// </summary>
     public required string Name { get; init; }
 
     /// <summary>
     ///     Where to read the skill content from. Path forms copy a directory tree or
-    ///     a single <c>SKILL.md</c> file; inline forms write a literal markdown body.
+    ///     a single markdown file; inline forms supply a literal markdown body. The
+    ///     provider materializer is responsible for any I/O.
     /// </summary>
     public required ContentSource Source { get; init; }
 

--- a/src/LmCore/AgentRuntime/AgentSkill.cs
+++ b/src/LmCore/AgentRuntime/AgentSkill.cs
@@ -1,0 +1,32 @@
+namespace AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+/// <summary>
+///     Profile-supplied skill that materializes into <c>.claude/skills/&lt;Name&gt;/SKILL.md</c>
+///     for the Claude Agent SDK. Description and other metadata live in the
+///     SKILL.md frontmatter and are parsed by the consuming CLI, not by this SDK.
+/// </summary>
+public sealed record AgentSkill
+{
+    /// <summary>
+    ///     Directory name under <c>.claude/skills/</c>. Must be unique within the profile.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    ///     Where to read the skill content from. Path forms copy a directory tree or
+    ///     a single <c>SKILL.md</c> file; inline forms write a literal markdown body.
+    /// </summary>
+    public required ContentSource Source { get; init; }
+
+    /// <summary>
+    ///     Sugar for inline-markdown skills.
+    /// </summary>
+    public static AgentSkill Inline(string name, string markdown)
+        => new() { Name = name, Source = new ContentSource.FromInline(markdown) };
+
+    /// <summary>
+    ///     Sugar for path-sourced skills.
+    /// </summary>
+    public static AgentSkill FromPath(string name, string path)
+        => new() { Name = name, Source = new ContentSource.FromPath(path) };
+}

--- a/src/LmCore/AgentRuntime/ContentSource.cs
+++ b/src/LmCore/AgentRuntime/ContentSource.cs
@@ -1,0 +1,27 @@
+namespace AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+/// <summary>
+///     Closed discriminated union describing how a profile-provided content fragment
+///     (skill body, sub-agent definition, etc.) is supplied to the SDK.
+/// </summary>
+/// <remarks>
+///     Construction is pure: no I/O happens here. Provider materializers own all file
+///     reads and writes when projecting a profile into a CLI staging directory.
+/// </remarks>
+public abstract record ContentSource
+{
+    private ContentSource() { }
+
+    /// <summary>
+    ///     Content is read from <see cref="Value"/> on the local filesystem. If the path
+    ///     points at a directory, the materializer copies its contents recursively.
+    ///     If it points at a file, the materializer copies the single file.
+    /// </summary>
+    public sealed record FromPath(string Value) : ContentSource;
+
+    /// <summary>
+    ///     Content is supplied inline as a literal markdown string. The materializer
+    ///     writes it verbatim to the canonical location for the consuming provider.
+    /// </summary>
+    public sealed record FromInline(string Content) : ContentSource;
+}

--- a/src/LmCore/AgentRuntime/McpServerConfig.cs
+++ b/src/LmCore/AgentRuntime/McpServerConfig.cs
@@ -1,10 +1,12 @@
 using System.Text.Json.Serialization;
 
-namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+namespace AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 
 /// <summary>
 ///     Configuration for an MCP (Model Context Protocol) server.
 ///     Supports both stdio (command-based) and http (URL-based) transports.
+///     Provider-neutral: consumed directly by Claude, projected to provider-specific
+///     shapes (e.g. <c>CodexMcpServerConfig</c>) for Codex.
 /// </summary>
 public record McpServerConfig
 {
@@ -56,11 +58,3 @@ public record McpServerConfig
     }
 }
 
-/// <summary>
-///     Root configuration object for MCP servers
-/// </summary>
-public record McpConfiguration
-{
-    [JsonPropertyName("mcpServers")]
-    public Dictionary<string, McpServerConfig> McpServers { get; init; } = [];
-}

--- a/src/LmCore/AgentRuntime/McpServerConfig.cs
+++ b/src/LmCore/AgentRuntime/McpServerConfig.cs
@@ -20,7 +20,7 @@ public record McpServerConfig
 
     [JsonPropertyName("args")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<string>? Args { get; init; }
+    public IReadOnlyList<string>? Args { get; init; }
 
     // For http type
     [JsonPropertyName("url")]
@@ -29,20 +29,20 @@ public record McpServerConfig
 
     [JsonPropertyName("headers")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public Dictionary<string, string>? Headers { get; init; }
+    public IReadOnlyDictionary<string, string>? Headers { get; init; }
 
     // Shared
     [JsonPropertyName("env")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public Dictionary<string, string>? Env { get; init; }
+    public IReadOnlyDictionary<string, string>? Env { get; init; }
 
     /// <summary>
     ///     Creates a stdio-based MCP server configuration.
     /// </summary>
     public static McpServerConfig CreateStdio(
         string command,
-        List<string> args,
-        Dictionary<string, string>? env = null)
+        IReadOnlyList<string> args,
+        IReadOnlyDictionary<string, string>? env = null)
     {
         return new McpServerConfig { Type = "stdio", Command = command, Args = args, Env = env };
     }
@@ -52,7 +52,7 @@ public record McpServerConfig
     /// </summary>
     public static McpServerConfig CreateHttp(
         string url,
-        Dictionary<string, string>? headers = null)
+        IReadOnlyDictionary<string, string>? headers = null)
     {
         return new McpServerConfig { Type = "http", Url = url, Headers = headers };
     }

--- a/src/LmCore/AgentRuntime/SubAgentDefinition.cs
+++ b/src/LmCore/AgentRuntime/SubAgentDefinition.cs
@@ -1,22 +1,31 @@
 namespace AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 
 /// <summary>
-///     Profile-supplied sub-agent that materializes into <c>.claude/agents/&lt;Name&gt;.md</c>
-///     for the Claude Agent SDK. Description, model, and tool list live in the
-///     <c>.md</c> frontmatter and are parsed by the consuming CLI.
+///     Provider-neutral sub-agent descriptor supplied via an
+///     <see cref="AgentRuntimeProfile"/>. Each consuming provider decides how (and
+///     whether) to surface sub-agents to the spawned agent. Description, model, and
+///     tool list typically live in the markdown frontmatter and are parsed by the
+///     consuming provider.
 /// </summary>
+/// <remarks>
+///     See the provider-specific materializer (e.g. <c>ProfileMaterializer</c> in
+///     <c>ClaudeAgentSdkProvider</c>) for details on how a sub-agent's <see cref="Name"/>
+///     and <see cref="Source"/> are mapped onto the underlying CLI's filesystem layout.
+/// </remarks>
 public sealed record SubAgentDefinition
 {
     /// <summary>
-    ///     File stem (without <c>.md</c>) under <c>.claude/agents/</c>. Must be unique
-    ///     within the profile.
+    ///     Stable identifier for the sub-agent. Must be unique within the profile and
+    ///     contain no path separators. Providers map this onto the per-provider
+    ///     filesystem layout (for example, a markdown file stem).
     /// </summary>
     public required string Name { get; init; }
 
     /// <summary>
     ///     Where to read the sub-agent definition from. Path forms copy a single
-    ///     <c>.md</c> file (or the first <c>.md</c> in a directory). Inline forms
-    ///     write a literal markdown body.
+    ///     markdown file (or the first markdown file in a directory). Inline forms
+    ///     supply a literal markdown body. The provider materializer is responsible
+    ///     for any I/O.
     /// </summary>
     public required ContentSource Source { get; init; }
 

--- a/src/LmCore/AgentRuntime/SubAgentDefinition.cs
+++ b/src/LmCore/AgentRuntime/SubAgentDefinition.cs
@@ -1,0 +1,34 @@
+namespace AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+/// <summary>
+///     Profile-supplied sub-agent that materializes into <c>.claude/agents/&lt;Name&gt;.md</c>
+///     for the Claude Agent SDK. Description, model, and tool list live in the
+///     <c>.md</c> frontmatter and are parsed by the consuming CLI.
+/// </summary>
+public sealed record SubAgentDefinition
+{
+    /// <summary>
+    ///     File stem (without <c>.md</c>) under <c>.claude/agents/</c>. Must be unique
+    ///     within the profile.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    ///     Where to read the sub-agent definition from. Path forms copy a single
+    ///     <c>.md</c> file (or the first <c>.md</c> in a directory). Inline forms
+    ///     write a literal markdown body.
+    /// </summary>
+    public required ContentSource Source { get; init; }
+
+    /// <summary>
+    ///     Sugar for inline-markdown sub-agents.
+    /// </summary>
+    public static SubAgentDefinition Inline(string name, string markdown)
+        => new() { Name = name, Source = new ContentSource.FromInline(markdown) };
+
+    /// <summary>
+    ///     Sugar for path-sourced sub-agents.
+    /// </summary>
+    public static SubAgentDefinition FromPath(string name, string path)
+        => new() { Name = name, Source = new ContentSource.FromPath(path) };
+}

--- a/src/LmMultiTurn/ClaudeAgentLoop.cs
+++ b/src/LmMultiTurn/ClaudeAgentLoop.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Threading.Channels;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Agents;
@@ -39,8 +40,13 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
     /// <summary>
     /// Tracks inputs sent to CLI, awaiting enqueue/dequeue confirmation.
     /// Used for correlating queue-operation events with original user inputs.
+    /// Concurrent because writers run on the run-loop thread (Enqueue) while
+    /// readers can run on Claude SDK event-handler threads (TryDequeue from
+    /// <see cref="OnDequeueDetectedAsync"/>) and on the run-loop thread again
+    /// (TryDequeue from <see cref="FlushPendingRunAssignmentsAsync"/>).
+    /// Internal for direct test coverage of the flush path.
     /// </summary>
-    private readonly Queue<(QueuedInput Input, RunAssignment Assignment)> _pendingCliInputs = new();
+    internal readonly ConcurrentQueue<(QueuedInput Input, RunAssignment Assignment)> _pendingCliInputs = new();
 
     /// <summary>
     /// The active subscription to stdout messages (Interactive mode).
@@ -50,8 +56,10 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
     /// <summary>
     /// Track if we're waiting for a dequeue (previous send not yet assigned).
     /// When true, new messages should be queued locally instead of sent to CLI.
+    /// Volatile because the field is read on Claude SDK event-handler threads
+    /// while the run-loop thread mutates it.
     /// </summary>
-    private bool _awaitingDequeue;
+    private volatile bool _awaitingDequeue;
     private string? _lastObservedGenerationId;
 
     /// <summary>
@@ -338,6 +346,14 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
                 }
                 finally
                 {
+                    // Safety net: if the dequeue heuristic never fired (e.g., CLI exited
+                    // without producing a recognizable signal, mock providers, or a
+                    // partial protocol response), the RunAssignmentMessage was never
+                    // published and consumers correlating completion to assignment via
+                    // receipt id would hang. Flush any still-pending inputs now so the
+                    // completion below can be matched.
+                    await FlushPendingRunAssignmentsAsync(assignment.RunId, ct);
+
                     // Pass pending message count so workflows know if more runs will follow
                     await CompleteRunAsync(
                         assignment.RunId,
@@ -691,6 +707,42 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
                 "OnDequeueDetected: {QueueSize} messages in local queue, will be processed in RunLoopAsync",
                 _localMessageQueue.Count);
         }
+    }
+
+    /// <summary>
+    /// Drain any inputs whose RunAssignmentMessage hasn't yet been published for
+    /// <paramref name="runId"/> and publish them before run completion. This is a
+    /// safety net for cases where the dequeue heuristic in
+    /// <see cref="OnDequeueDetectedAsync"/> never fired — without it, consumers
+    /// correlating <see cref="RunCompletedMessage"/> to <see cref="RunAssignmentMessage"/>
+    /// would never see an assignment for this run.
+    /// </summary>
+    internal async Task FlushPendingRunAssignmentsAsync(string runId, CancellationToken ct)
+    {
+        // Only drain inputs belonging to this run; later runs' inputs stay queued.
+        while (_pendingCliInputs.TryPeek(out var peeked) &&
+               string.Equals(peeked.Assignment.RunId, runId, StringComparison.Ordinal))
+        {
+            if (!_pendingCliInputs.TryDequeue(out var pending))
+            {
+                break;
+            }
+
+            Logger.LogWarning(
+                "Publishing deferred RunAssignmentMessage at run completion (dequeue heuristic missed) - RunId: {RunId}, ReceiptId: {ReceiptId}",
+                pending.Assignment.RunId,
+                pending.Input.ReceiptId);
+
+            await PublishToAllAsync(new RunAssignmentMessage
+            {
+                Assignment = pending.Assignment,
+                ThreadId = ThreadId,
+            }, ct);
+        }
+
+        // We've published whatever we owed; clear awaiting flag so subsequent runs
+        // start clean.
+        _awaitingDequeue = false;
     }
 
     /// <summary>

--- a/src/LmMultiTurn/ClaudeAgentLoop.cs
+++ b/src/LmMultiTurn/ClaudeAgentLoop.cs
@@ -132,6 +132,9 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
         _mcpServers = mcpServers ?? [];
         _loggerFactory = loggerFactory;
         _clientFactory = clientFactory;
+        // MUST remain the last statement in this constructor: the returned MaterializedProfile
+        // owns a temp directory and is disposed by DisposeAsync. Any throw after this line would
+        // leak the staging dir.
         _materializedProfile = ProfileMaterializer.Materialize(claudeOptions.Profile);
     }
 

--- a/src/LmMultiTurn/ClaudeAgentLoop.cs
+++ b/src/LmMultiTurn/ClaudeAgentLoop.cs
@@ -33,9 +33,14 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
     private IClaudeAgentSdkClient? _client;
 
     /// <summary>
-    /// Tracks the session ID across process restarts (for OneShot mode session continuity).
+    /// The most recent session ID observed from the underlying claude-agent-sdk run.
+    /// Becomes non-null shortly after the first message is observed in a run, and
+    /// persists across runs so it can be passed as <c>--resume</c> on the next run.
+    /// Also written into <see cref="ThreadMetadata.SessionMappings"/> when a store
+    /// is configured. SDK metadata such as <c>SystemInitMessage</c> is intentionally
+    /// NOT published into the common message stream — read this property instead.
     /// </summary>
-    private string? _lastSessionId;
+    public string? CurrentSessionId { get; private set; }
 
     /// <summary>
     /// Tracks inputs sent to CLI, awaiting enqueue/dequeue confirmation.
@@ -185,6 +190,53 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
     }
 
     /// <summary>
+    /// Persist the latest Claude SDK session id into <see cref="ThreadMetadata.SessionMappings"/>
+    /// alongside the base metadata. The mapping uses the conventional
+    /// <c>"claude-sdk:{sessionId}"</c> key shape so it does not collide with mappings
+    /// from other providers.
+    /// </summary>
+    protected override async Task UpdateMetadataAsync(CancellationToken ct)
+    {
+        if (Store == null)
+        {
+            return;
+        }
+
+        try
+        {
+            var latestRun = LatestRunId;
+            var existing = await Store.LoadMetadataAsync(ThreadId, ct);
+
+            // Merge claude-sdk session mapping into the existing dictionary.
+            var sessionMappings = existing?.SessionMappings;
+            if (!string.IsNullOrEmpty(CurrentSessionId) && !string.IsNullOrEmpty(latestRun))
+            {
+                var merged = sessionMappings == null
+                    ? []
+                    : new Dictionary<string, string>(sessionMappings);
+                merged[$"claude-sdk:{CurrentSessionId}"] = latestRun;
+                sessionMappings = merged;
+            }
+
+            var metadata = new ThreadMetadata
+            {
+                ThreadId = ThreadId,
+                CurrentRunId = null,
+                LatestRunId = latestRun,
+                LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                Properties = existing?.Properties,
+                SessionMappings = sessionMappings,
+            };
+
+            await Store.SaveMetadataAsync(ThreadId, metadata, ct);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to update thread metadata");
+        }
+    }
+
+    /// <summary>
     /// Disposes the client and clears references asynchronously.
     /// </summary>
     private async Task DisposeClientResourcesAsync()
@@ -204,8 +256,42 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
             _activeSubscription = null;
         }
 
+        // Snapshot session id from the client before tearing it down so
+        // OneShot mode (which disposes the client after every run) doesn't
+        // lose the session id assigned by the SDK during the run.
+        if (_client?.CurrentSession?.SessionId is { } sid)
+        {
+            CaptureSessionId(sid);
+        }
+
         (_client as IDisposable)?.Dispose();
         _client = null;
+    }
+
+    /// <summary>
+    /// Records the latest SDK-assigned session id. No-op for null/empty/duplicate
+    /// values. Logs at Debug on first capture and on change.
+    /// </summary>
+    private void CaptureSessionId(string? sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId) || sessionId == CurrentSessionId)
+        {
+            return;
+        }
+
+        var previous = CurrentSessionId;
+        CurrentSessionId = sessionId;
+        if (previous == null)
+        {
+            Logger.LogDebug("Captured Claude SDK SessionId: {SessionId}", sessionId);
+        }
+        else
+        {
+            Logger.LogDebug(
+                "Claude SDK SessionId changed: {Old} -> {New}",
+                previous,
+                sessionId);
+        }
     }
 
     /// <summary>
@@ -421,12 +507,13 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
                 var msg = _activeSubscription.Current;
 
                 // HEURISTIC 1: If we get SystemInit (RunStarted), previous enqueue likely processed or reset
-                if (msg is SystemInitMessage)
+                if (msg is SystemInitMessage systemInit)
                 {
                     await OnDequeueDetectedAsync("SystemInitMessage", ct);
-                    // Publish so consumers can capture SessionId (e.g. for --resume on a later run);
-                    // skip AddToHistory because this is SDK metadata, not a conversational turn.
-                    await PublishToAllAsync(msg, ct);
+                    // Capture SessionId for --resume on later runs and for consumers
+                    // reading CurrentSessionId. SystemInitMessage is SDK metadata —
+                    // intentionally NOT published into the common message stream.
+                    CaptureSessionId(systemInit.SessionId);
                     continue;
                 }
 
@@ -805,6 +892,12 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
 
             // Add to conversation history
             AddToHistory(msg);
+
+            // OneShot's SendMessagesAsync intentionally suppresses SystemInitMessage,
+            // but the underlying client still updates CurrentSession.SessionId when
+            // it parses the system init event. Poll it so CurrentSessionId becomes
+            // available without leaking SDK metadata into the public message stream.
+            CaptureSessionId(_client?.CurrentSession?.SessionId);
         }
 
         // OneShot: any inputs that arrived during run stay in queue for next iteration
@@ -823,11 +916,7 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
         if (!_client.IsRunning)
         {
             // Preserve session ID from previous run (for session continuity)
-            if (_client.CurrentSession?.SessionId != null)
-            {
-                _lastSessionId = _client.CurrentSession.SessionId;
-                Logger.LogDebug("Preserved sessionId from previous run: {SessionId}", _lastSessionId);
-            }
+            CaptureSessionId(_client.CurrentSession?.SessionId);
 
             var request = BuildClaudeAgentSdkRequest();
             Logger.LogInformation(
@@ -875,7 +964,7 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
         var maxThinkingTokens = _claudeOptions.MaxThinkingTokens;
 
         // Extract session ID: use preserved from previous run if available
-        var sessionId = _lastSessionId;
+        var sessionId = CurrentSessionId;
 
         // Build MCP server configuration
         Dictionary<string, McpServerConfig>? mcpServers = null;

--- a/src/LmMultiTurn/ClaudeAgentLoop.cs
+++ b/src/LmMultiTurn/ClaudeAgentLoop.cs
@@ -27,7 +27,7 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
     private readonly ClaudeAgentSdkOptions _claudeOptions;
     private readonly Dictionary<string, McpServerConfig> _mcpServers;
     private readonly ILoggerFactory? _loggerFactory;
-    private readonly Func<ClaudeAgentSdkOptions, ILogger?, ClaudeAgentSdkClient>? _clientFactory;
+    private readonly Func<ClaudeAgentSdkOptions, ILogger?, IClaudeAgentSdkClient>? _clientFactory;
     private readonly SemaphoreSlim _restartLock = new(1, 1);
 
     private IClaudeAgentSdkClient? _client;
@@ -108,7 +108,7 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
         IConversationStore? store = null,
         ILogger<ClaudeAgentLoop>? logger = null,
         ILoggerFactory? loggerFactory = null,
-        Func<ClaudeAgentSdkOptions, ILogger?, ClaudeAgentSdkClient>? clientFactory = null)
+        Func<ClaudeAgentSdkOptions, ILogger?, IClaudeAgentSdkClient>? clientFactory = null)
         : base(
             threadId,
             systemPrompt,
@@ -424,7 +424,9 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
                 if (msg is SystemInitMessage)
                 {
                     await OnDequeueDetectedAsync("SystemInitMessage", ct);
-                    // Don't publish this message to subscribers
+                    // Publish so consumers can capture SessionId (e.g. for --resume on a later run);
+                    // skip AddToHistory because this is SDK metadata, not a conversational turn.
+                    await PublishToAllAsync(msg, ct);
                     continue;
                 }
 

--- a/src/LmMultiTurn/ClaudeAgentLoop.cs
+++ b/src/LmMultiTurn/ClaudeAgentLoop.cs
@@ -4,6 +4,7 @@ using System.Threading.Channels;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Agents;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
@@ -29,6 +30,7 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
     private readonly ILoggerFactory? _loggerFactory;
     private readonly Func<ClaudeAgentSdkOptions, ILogger?, IClaudeAgentSdkClient>? _clientFactory;
     private readonly SemaphoreSlim _restartLock = new(1, 1);
+    private readonly MaterializedProfile _materializedProfile;
 
     private IClaudeAgentSdkClient? _client;
 
@@ -130,6 +132,7 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
         _mcpServers = mcpServers ?? [];
         _loggerFactory = loggerFactory;
         _clientFactory = clientFactory;
+        _materializedProfile = ProfileMaterializer.Materialize(claudeOptions.Profile);
     }
 
     /// <inheritdoc />
@@ -175,6 +178,7 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
         Logger.LogDebug("Disposing ClaudeAgentLoop resources");
         await DisposeClientResourcesAsync();
         _restartLock.Dispose();
+        _materializedProfile.Dispose();
     }
 
     /// <inheritdoc />
@@ -955,7 +959,7 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
     /// Build ClaudeAgentSdkRequest from current configuration and options.
     /// Moved from ClaudeAgentSdkAgent.
     /// </summary>
-    private ClaudeAgentSdkRequest BuildClaudeAgentSdkRequest()
+    internal ClaudeAgentSdkRequest BuildClaudeAgentSdkRequest()
     {
         var modelId = DefaultOptions.ModelId ?? "claude-sonnet-4-5-20250929";
         var maxTurns = _claudeOptions.MaxTurnsPerRun;
@@ -1005,6 +1009,17 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
             }
         }
 
+        // Profile-supplied MCP servers win on key collision (documented in
+        // ClaudeAgentSdkOptions.Profile XML doc).
+        if (_materializedProfile.McpServers.Count > 0)
+        {
+            mcpServers ??= [];
+            foreach (var (name, config) in _materializedProfile.McpServers)
+            {
+                mcpServers[name] = config;
+            }
+        }
+
         Logger.LogInformation(
             "Final MCP server configuration: {Count} servers configured",
             mcpServers?.Count ?? 0);
@@ -1019,11 +1034,50 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
             MaxTurns = maxTurns,
             MaxThinkingTokens = maxThinkingTokens,
             SessionId = sessionId,
-            SystemPrompt = SystemPrompt,
+            SystemPrompt = _materializedProfile.SystemPrompt ?? SystemPrompt,
             AllowedTools = allowedTools,
             McpServers = mcpServers,
             Verbose = true,
             ReasoningEffort = _claudeOptions.ReasoningEffort,
+            SettingSources = BuildSettingSources(_claudeOptions),
+            StagingDirectory = _materializedProfile.StagingDirectory,
         };
+    }
+
+    // Maps the IncludeUser/Project/LocalSettings booleans to the CLI's
+    // --setting-sources value. Tri-state semantics:
+    //   all true  => null  (omit flag, CLI uses its own default of user,project,local)
+    //   all false => ""    (emit empty value, CLI loads nothing -> isolated agent)
+    //   mixed     => comma-joined list of the enabled sources
+    internal static string? BuildSettingSources(ClaudeAgentSdkOptions options)
+    {
+        var user = options.IncludeUserSettings;
+        var project = options.IncludeProjectSettings;
+        var local = options.IncludeLocalSettings;
+
+        if (user && project && local)
+        {
+            return null;
+        }
+
+        if (!user && !project && !local)
+        {
+            return string.Empty;
+        }
+
+        var parts = new List<string>(3);
+        if (user)
+        {
+            parts.Add("user");
+        }
+        if (project)
+        {
+            parts.Add("project");
+        }
+        if (local)
+        {
+            parts.Add("local");
+        }
+        return string.Join(',', parts);
     }
 }

--- a/src/LmMultiTurn/CodexAgentLoop.cs
+++ b/src/LmMultiTurn/CodexAgentLoop.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
+using AchieveAi.LmDotnetTools.CodexSdkProvider.AgentRuntime;
 using AchieveAi.LmDotnetTools.CodexSdkProvider.Agents;
 using AchieveAi.LmDotnetTools.CodexSdkProvider.Configuration;
 using AchieveAi.LmDotnetTools.CodexSdkProvider.Models;
@@ -27,6 +28,7 @@ public sealed class CodexAgentLoop : MultiTurnAgentBase
     private ICodexSdkClient? _client;
     private string? _codexThreadId;
     private string? _generatedModelInstructionsFile;
+    private bool _profileUnsupportedWarningLogged;
 
     public CodexAgentLoop(
         CodexSdkOptions options,
@@ -148,9 +150,10 @@ public sealed class CodexAgentLoop : MultiTurnAgentBase
         var effectiveWebSearchMode = _toolPolicy.IsBuiltInAllowed("web_search")
             ? _options.WebSearchMode
             : "disabled";
-        var effectiveMcpServers = _options.ToolBridgeMode == CodexToolBridgeMode.Dynamic
-            ? new Dictionary<string, CodexMcpServerConfig>()
-            : _mcpServers;
+        var effectiveMcpServers = ApplyProfile(
+            _options.ToolBridgeMode == CodexToolBridgeMode.Dynamic
+                ? new Dictionary<string, CodexMcpServerConfig>()
+                : _mcpServers);
         var dynamicTools = _options.ToolBridgeMode == CodexToolBridgeMode.Mcp
             ? null
             : _dynamicToolBridge?.GetToolSpecs();
@@ -185,6 +188,49 @@ public sealed class CodexAgentLoop : MultiTurnAgentBase
             _options.ProviderMode,
             ThreadId,
             _codexThreadId);
+    }
+
+    private IReadOnlyDictionary<string, CodexMcpServerConfig> ApplyProfile(
+        IReadOnlyDictionary<string, CodexMcpServerConfig> baseServers)
+    {
+        var profile = _options.Profile;
+        if (profile is null)
+        {
+            return baseServers;
+        }
+
+        if (!_profileUnsupportedWarningLogged
+            && (profile.Skills.Count > 0 || profile.SubAgents.Count > 0))
+        {
+            Logger.LogWarning(
+                "{event_type} {event_status} {provider} {provider_mode} {thread_id} {skill_count} {sub_agent_count}",
+                "codex.profile.unsupported",
+                "ignored",
+                _options.Provider,
+                _options.ProviderMode,
+                ThreadId,
+                profile.Skills.Count,
+                profile.SubAgents.Count);
+            _profileUnsupportedWarningLogged = true;
+        }
+
+        if (profile.McpServers.Count == 0)
+        {
+            return baseServers;
+        }
+
+        if (_options.ToolBridgeMode == CodexToolBridgeMode.Dynamic)
+        {
+            return baseServers;
+        }
+
+        var merged = new Dictionary<string, CodexMcpServerConfig>(baseServers, StringComparer.Ordinal);
+        foreach (var (name, config) in profile.McpServers)
+        {
+            merged[name] = config.ToCodexConfig();
+        }
+
+        return merged;
     }
 
     protected override async Task OnDisposeAsync()
@@ -498,11 +544,14 @@ public sealed class CodexAgentLoop : MultiTurnAgentBase
         var baseInstructions = string.IsNullOrWhiteSpace(_options.BaseInstructions)
             ? null
             : _options.BaseInstructions;
-        var developerInstructions = !string.IsNullOrWhiteSpace(SystemPrompt)
-            ? SystemPrompt
-            : string.IsNullOrWhiteSpace(_options.DeveloperInstructions)
-                ? null
-                : _options.DeveloperInstructions;
+        var profileSystemPrompt = _options.Profile?.SystemPrompt;
+        var developerInstructions = !string.IsNullOrWhiteSpace(profileSystemPrompt)
+            ? profileSystemPrompt
+            : !string.IsNullOrWhiteSpace(SystemPrompt)
+                ? SystemPrompt
+                : string.IsNullOrWhiteSpace(_options.DeveloperInstructions)
+                    ? null
+                    : _options.DeveloperInstructions;
         var modelInstructionsFile = string.IsNullOrWhiteSpace(_options.ModelInstructionsFile)
             ? null
             : _options.ModelInstructionsFile;

--- a/src/LmMultiTurn/CodexAgentLoop.cs
+++ b/src/LmMultiTurn/CodexAgentLoop.cs
@@ -544,14 +544,10 @@ public sealed class CodexAgentLoop : MultiTurnAgentBase
         var baseInstructions = string.IsNullOrWhiteSpace(_options.BaseInstructions)
             ? null
             : _options.BaseInstructions;
-        var profileSystemPrompt = _options.Profile?.SystemPrompt;
-        var developerInstructions = !string.IsNullOrWhiteSpace(profileSystemPrompt)
-            ? profileSystemPrompt
-            : !string.IsNullOrWhiteSpace(SystemPrompt)
-                ? SystemPrompt
-                : string.IsNullOrWhiteSpace(_options.DeveloperInstructions)
-                    ? null
-                    : _options.DeveloperInstructions;
+        var developerInstructions = ProfileSystemPromptResolver.Resolve(
+            _options.Profile,
+            SystemPrompt,
+            _options.DeveloperInstructions);
         var modelInstructionsFile = string.IsNullOrWhiteSpace(_options.ModelInstructionsFile)
             ? null
             : _options.ModelInstructionsFile;

--- a/src/LmMultiTurn/CopilotAgentLoop.cs
+++ b/src/LmMultiTurn/CopilotAgentLoop.cs
@@ -430,14 +430,10 @@ public sealed class CopilotAgentLoop : MultiTurnAgentBase
     private (string? BaseInstructions, string? DeveloperInstructions, string? ModelInstructionsFile) ResolveInstructions()
     {
         var baseInstructions = string.IsNullOrWhiteSpace(_options.BaseInstructions) ? null : _options.BaseInstructions;
-        var profileSystemPrompt = _options.Profile?.SystemPrompt;
-        var developerInstructions = !string.IsNullOrWhiteSpace(profileSystemPrompt)
-            ? profileSystemPrompt
-            : !string.IsNullOrWhiteSpace(SystemPrompt)
-                ? SystemPrompt
-                : string.IsNullOrWhiteSpace(_options.DeveloperInstructions)
-                    ? null
-                    : _options.DeveloperInstructions;
+        var developerInstructions = ProfileSystemPromptResolver.Resolve(
+            _options.Profile,
+            SystemPrompt,
+            _options.DeveloperInstructions);
         var modelInstructionsFile = string.IsNullOrWhiteSpace(_options.ModelInstructionsFile)
             ? null
             : _options.ModelInstructionsFile;

--- a/src/LmMultiTurn/CopilotAgentLoop.cs
+++ b/src/LmMultiTurn/CopilotAgentLoop.cs
@@ -30,6 +30,7 @@ public sealed class CopilotAgentLoop : MultiTurnAgentBase
     private ICopilotSdkClient? _client;
     private string? _copilotSessionId;
     private string? _generatedModelInstructionsFile;
+    private bool _profileUnsupportedWarningLogged;
 
     public CopilotAgentLoop(
         CopilotSdkOptions options,
@@ -142,6 +143,7 @@ public sealed class CopilotAgentLoop : MultiTurnAgentBase
             _client.ConfigureDynamicToolExecutor(null);
         }
 
+        LogProfileUnsupportedOnce();
         var (baseInstructions, developerInstructions, modelInstructionsFile) = ResolveInstructions();
         var tools = _dynamicToolBridge?.GetToolSpecs();
 
@@ -391,14 +393,51 @@ public sealed class CopilotAgentLoop : MultiTurnAgentBase
         public int BridgeEventCount { get; set; }
     }
 
+    private void LogProfileUnsupportedOnce()
+    {
+        if (_profileUnsupportedWarningLogged)
+        {
+            return;
+        }
+
+        var profile = _options.Profile;
+        if (profile is null)
+        {
+            return;
+        }
+
+        var mcpCount = profile.McpServers.Count;
+        var skillCount = profile.Skills.Count;
+        var subAgentCount = profile.SubAgents.Count;
+        if (mcpCount == 0 && skillCount == 0 && subAgentCount == 0)
+        {
+            return;
+        }
+
+        Logger.LogWarning(
+            "{event_type} {event_status} {provider} {provider_mode} {thread_id} {mcp_count} {skill_count} {sub_agent_count}",
+            "copilot.profile.unsupported",
+            "ignored",
+            _options.Provider,
+            _options.ProviderMode,
+            ThreadId,
+            mcpCount,
+            skillCount,
+            subAgentCount);
+        _profileUnsupportedWarningLogged = true;
+    }
+
     private (string? BaseInstructions, string? DeveloperInstructions, string? ModelInstructionsFile) ResolveInstructions()
     {
         var baseInstructions = string.IsNullOrWhiteSpace(_options.BaseInstructions) ? null : _options.BaseInstructions;
-        var developerInstructions = !string.IsNullOrWhiteSpace(SystemPrompt)
-            ? SystemPrompt
-            : string.IsNullOrWhiteSpace(_options.DeveloperInstructions)
-                ? null
-                : _options.DeveloperInstructions;
+        var profileSystemPrompt = _options.Profile?.SystemPrompt;
+        var developerInstructions = !string.IsNullOrWhiteSpace(profileSystemPrompt)
+            ? profileSystemPrompt
+            : !string.IsNullOrWhiteSpace(SystemPrompt)
+                ? SystemPrompt
+                : string.IsNullOrWhiteSpace(_options.DeveloperInstructions)
+                    ? null
+                    : _options.DeveloperInstructions;
         var modelInstructionsFile = string.IsNullOrWhiteSpace(_options.ModelInstructionsFile)
             ? null
             : _options.ModelInstructionsFile;

--- a/src/LmMultiTurn/MultiTurnAgentBase.cs
+++ b/src/LmMultiTurn/MultiTurnAgentBase.cs
@@ -83,6 +83,13 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     /// </summary>
     protected IConversationStore? Store { get; }
 
+    /// <summary>
+    /// Grace period the deferred-fallback in <see cref="ExecuteRunAsync"/> waits
+    /// for additional channel activity before firing on a completion that has no
+    /// receipt-correlated assignment. Override in tests to keep them fast.
+    /// </summary>
+    protected virtual TimeSpan FallbackGracePeriod => TimeSpan.FromSeconds(2);
+
     #endregion
 
     #region Public Properties
@@ -633,27 +640,99 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
 
             Logger.LogDebug("ExecuteRun queued. ReceiptId: {ReceiptId}", receiptId);
 
+            // Receipt-id correlation is the primary signal. The deferred fallback below
+            // only engages when an implementation publishes a RunCompletedMessage for a
+            // run whose RunAssignmentMessage we observed but did NOT list our receipt
+            // (a publisher bug — the concrete production case is a Claude dequeue
+            // heuristic that misses, leaving the receipt-correlated assignment never
+            // emitted).
             string? targetRunId = null;
+            string? pendingFallbackRunId = null;
+            var observedAssignmentRunIds = new HashSet<string>(StringComparer.Ordinal);
 
-            // Yield messages until run completes
-            await foreach (var msg in outputChannel.Reader.ReadAllAsync(ct))
+            // Yield messages until run completes. We use a manual read loop instead of
+            // ReadAllAsync because the deferred-fallback path needs a grace period to
+            // distinguish "prior in-flight run completed and our run is about to start"
+            // (a new RunAssignmentMessage will arrive shortly — abort the fallback)
+            // from "publisher bug on our actual run" (no further messages come — fire
+            // the fallback). Without this, an immediate fallback on completion would
+            // race-terminate the iterator before the caller's run executes.
+            while (true)
             {
-                yield return msg;
-
-                // Track run assignment for our receipt
-                if (msg is RunAssignmentMessage assignment &&
-                    assignment.Assignment.InputIds?.Contains(receiptId) == true)
+                bool hasMessage;
+                if (pendingFallbackRunId != null)
                 {
-                    targetRunId = assignment.Assignment.RunId;
-                    Logger.LogDebug("ExecuteRun assigned to RunId: {RunId}", targetRunId);
+                    using var graceCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    graceCts.CancelAfter(FallbackGracePeriod);
+                    try
+                    {
+                        hasMessage = await outputChannel.Reader.WaitToReadAsync(graceCts.Token);
+                    }
+                    catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+                    {
+                        // Grace period elapsed without any further activity — the
+                        // pending completion is the terminal one. Fire fallback.
+                        Logger.LogWarning(
+                            "ExecuteRun terminating on RunId {RunId} via deferred fallback — receipt {ReceiptId} was never observed in a RunAssignmentMessage and no further messages arrived within {GraceMs}ms. "
+                            + "This indicates the implementation did not publish a receipt-correlated assignment for this run.",
+                            pendingFallbackRunId,
+                            receiptId,
+                            (int)FallbackGracePeriod.TotalMilliseconds);
+                        yield break;
+                    }
+                }
+                else
+                {
+                    hasMessage = await outputChannel.Reader.WaitToReadAsync(ct);
                 }
 
-                // Check for run completion
-                if (msg is RunCompletedMessage completed &&
-                    completed.CompletedRunId == targetRunId)
+                if (!hasMessage)
                 {
-                    Logger.LogDebug("ExecuteRun completed for RunId: {RunId}", targetRunId);
+                    // Channel completed — exit cleanly.
                     yield break;
+                }
+
+                while (outputChannel.Reader.TryRead(out var msg))
+                {
+                    yield return msg;
+
+                    if (msg is RunAssignmentMessage assignment)
+                    {
+                        var runId = assignment.Assignment.RunId;
+                        if (!string.IsNullOrEmpty(runId))
+                        {
+                            _ = observedAssignmentRunIds.Add(runId);
+                        }
+
+                        // A new assignment arrived — any pending fallback was for an
+                        // earlier run, not ours. Clear it.
+                        pendingFallbackRunId = null;
+
+                        if (assignment.Assignment.InputIds?.Contains(receiptId) == true)
+                        {
+                            targetRunId = runId;
+                            Logger.LogDebug("ExecuteRun assigned to RunId: {RunId}", targetRunId);
+                        }
+                    }
+
+                    if (msg is RunCompletedMessage completed && !string.IsNullOrEmpty(completed.CompletedRunId))
+                    {
+                        // Primary: receipt-correlated match — exit immediately.
+                        if (targetRunId != null && completed.CompletedRunId == targetRunId)
+                        {
+                            Logger.LogDebug("ExecuteRun completed for RunId: {RunId}", targetRunId);
+                            yield break;
+                        }
+
+                        // Defer: receipt-id correlation never fired, and this completion
+                        // is for a run whose assignment we observed since subscribing.
+                        // We don't break yet — a subsequent RunAssignmentMessage would
+                        // indicate this completion belonged to an earlier run, not ours.
+                        if (targetRunId == null && observedAssignmentRunIds.Contains(completed.CompletedRunId))
+                        {
+                            pendingFallbackRunId = completed.CompletedRunId;
+                        }
+                    }
                 }
             }
         }

--- a/src/LmMultiTurn/MultiTurnAgentBase.cs
+++ b/src/LmMultiTurn/MultiTurnAgentBase.cs
@@ -112,6 +112,22 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     /// <inheritdoc />
     public bool IsRunning => _runTask != null && !_runTask.IsCompleted;
 
+    /// <summary>
+    /// The most recent run id observed (current or last completed). Available to
+    /// subclasses overriding metadata persistence — for example, recording a
+    /// provider session id alongside the run it belongs to.
+    /// </summary>
+    protected string? LatestRunId
+    {
+        get
+        {
+            lock (_stateLock)
+            {
+                return _latestRunId;
+            }
+        }
+    }
+
     #endregion
 
     #region Constructor

--- a/src/LmMultiTurn/ProfileSystemPromptResolver.cs
+++ b/src/LmMultiTurn/ProfileSystemPromptResolver.cs
@@ -1,0 +1,50 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn;
+
+/// <summary>
+///     Shared helper that resolves the precedence cascade for an agent's developer
+///     instructions:
+///     <list type="number">
+///         <item><description><see cref="AgentRuntimeProfile.SystemPrompt"/> when supplied.</description></item>
+///         <item><description>Constructor-supplied <c>systemPrompt</c> (e.g. base loop's <c>SystemPrompt</c>).</description></item>
+///         <item><description>Provider-level <c>DeveloperInstructions</c> option.</description></item>
+///     </list>
+///     Centralizing the cascade keeps the Codex and Copilot loops from drifting
+///     when one side fixes a bug or changes the order.
+/// </summary>
+internal static class ProfileSystemPromptResolver
+{
+    /// <summary>
+    ///     Picks the highest-priority non-empty developer instructions string. Returns
+    ///     <c>null</c> if all three inputs are null or whitespace.
+    /// </summary>
+    /// <param name="profile">
+    ///     Optional <see cref="AgentRuntimeProfile"/>. Its <see cref="AgentRuntimeProfile.SystemPrompt"/>
+    ///     wins when non-empty.
+    /// </param>
+    /// <param name="systemPrompt">
+    ///     Constructor-supplied system prompt (typically the base loop's <c>SystemPrompt</c>).
+    /// </param>
+    /// <param name="developerInstructions">
+    ///     Provider option fallback (e.g. <c>CodexSdkOptions.DeveloperInstructions</c>).
+    /// </param>
+    public static string? Resolve(
+        AgentRuntimeProfile? profile,
+        string? systemPrompt,
+        string? developerInstructions)
+    {
+        var profileSystemPrompt = profile?.SystemPrompt;
+        if (!string.IsNullOrWhiteSpace(profileSystemPrompt))
+        {
+            return profileSystemPrompt;
+        }
+
+        if (!string.IsNullOrWhiteSpace(systemPrompt))
+        {
+            return systemPrompt;
+        }
+
+        return string.IsNullOrWhiteSpace(developerInstructions) ? null : developerInstructions;
+    }
+}

--- a/src/LmTestUtils/Logging/CapturingLogger.cs
+++ b/src/LmTestUtils/Logging/CapturingLogger.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Logging;
+
+namespace AchieveAi.LmDotnetTools.LmTestUtils.Logging;
+
+public sealed class CapturingLogger<T> : ILogger<T>
+{
+    private readonly List<(LogLevel Level, string Text)> _entries = [];
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        _entries.Add((logLevel, formatter(state, exception)));
+    }
+
+    public int WarningCount(string substring)
+        => _entries.Count(e => e.Level == LogLevel.Warning
+            && e.Text.Contains(substring, StringComparison.Ordinal));
+}

--- a/src/LmTestUtils/TestMode/AnthropicSseStreamHttpContent.cs
+++ b/src/LmTestUtils/TestMode/AnthropicSseStreamHttpContent.cs
@@ -52,7 +52,9 @@ public sealed class AnthropicSseStreamHttpContent : HttpContent
     protected override Stream CreateContentReadStream(CancellationToken cancellationToken)
     {
         var pipe = new Pipe();
-        var logger = LoggerFactory.Create(builder => builder.AddConsole()).CreateLogger<AnthropicSseStreamHttpContent>();
+        var logger = LoggerFactory
+            .Create(builder => builder.AddConsole())
+            .CreateLogger<AnthropicSseStreamHttpContent>();
 
         _ = Task.Run(
             async () =>
@@ -209,13 +211,16 @@ public sealed class AnthropicSseStreamHttpContent : HttpContent
             }
         }
 
+        var stopReason =
+            _instructionPlan?.Messages.Any(message => message.ToolCalls?.Count > 0) == true ? "tool_use" : "end_turn";
+
         // Write message_delta event with usage
         await WriteSseEventAsync(
             "message_delta",
             new
             {
                 type = "message_delta",
-                delta = new { stop_reason = "end_turn", stop_sequence = (string?)null },
+                delta = new { stop_reason = stopReason, stop_sequence = (string?)null },
                 usage = new { input_tokens = 100, output_tokens = 50 },
             }
         );
@@ -305,7 +310,8 @@ public sealed class AnthropicSseStreamHttpContent : HttpContent
             _ => $"{result.Name}_tool_result",
         };
 
-        var toolUseId = result.ToolUseId ?? (toolUseIds.TryGetValue(result.Name, out var id) ? id : $"srvtoolu_{Guid.NewGuid():N}");
+        var toolUseId =
+            result.ToolUseId ?? (toolUseIds.TryGetValue(result.Name, out var id) ? id : $"srvtoolu_{Guid.NewGuid():N}");
 
         object content;
         if (result.ErrorCode != null)
@@ -354,7 +360,8 @@ public sealed class AnthropicSseStreamHttpContent : HttpContent
         CancellationToken ct
     )
     {
-        var text = textWithCitations.Text
+        var text =
+            textWithCitations.Text
             ?? (
                 textWithCitations.Length is int len
                     ? string.Join(" ", GenerateLoremChunks(len, _wordsPerChunk))
@@ -364,8 +371,8 @@ public sealed class AnthropicSseStreamHttpContent : HttpContent
         object? citations = null;
         if (textWithCitations.Citations != null && textWithCitations.Citations.Count > 0)
         {
-            citations = textWithCitations.Citations
-                .Select(c => new
+            citations = textWithCitations
+                .Citations.Select(c => new
                 {
                     type = c.Type,
                     url = c.Url,
@@ -376,20 +383,26 @@ public sealed class AnthropicSseStreamHttpContent : HttpContent
         }
 
         // content_block_start with citations
-        var startEvent = citations != null
-            ? new
-            {
-                type = "content_block_start",
-                index = contentIndex,
-                content_block = new { type = "text", text = "", citations },
-            }
-            : (object)
-                new
+        var startEvent =
+            citations != null
+                ? new
                 {
                     type = "content_block_start",
                     index = contentIndex,
-                    content_block = new { type = "text", text = "" },
-                };
+                    content_block = new
+                    {
+                        type = "text",
+                        text = "",
+                        citations,
+                    },
+                }
+                : (object)
+                    new
+                    {
+                        type = "content_block_start",
+                        index = contentIndex,
+                        content_block = new { type = "text", text = "" },
+                    };
 
         await writer.WriteAsync("event: content_block_start\n");
         await writer.WriteAsync($"data: {JsonSerializer.Serialize(startEvent)}\n\n");

--- a/src/LmTestUtils/TestMode/OpenAiResponsesEventStreamWriter.cs
+++ b/src/LmTestUtils/TestMode/OpenAiResponsesEventStreamWriter.cs
@@ -16,7 +16,7 @@ namespace AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
 ///     ResponsesByteIdentity tests rely on.
 ///     </para>
 ///     <para>
-///     v1 supports plain text streaming and function-call streaming. Server-side tools
+///     v1 supports reasoning items, plain text streaming, and function-call streaming. Server-side tools
 ///     (<c>web_search_call</c>, <c>codex.rate_limits</c>) are out of scope and produce no events;
 ///     the InstructionPlan items for those flow through unchanged so future expansion is local
 ///     to this writer.
@@ -58,7 +58,12 @@ public static class OpenAiResponsesEventStreamWriter
             {
                 Type = ResponseEventTypes.ResponseCreated,
                 SequenceNumber = seq++,
-                Response = BuildResponseSnapshot(effectiveResponseId, effectiveModel, status: "in_progress", usage: null),
+                Response = BuildResponseSnapshot(
+                    effectiveResponseId,
+                    effectiveModel,
+                    status: "in_progress",
+                    usage: null
+                ),
             }
         );
 
@@ -67,11 +72,23 @@ public static class OpenAiResponsesEventStreamWriter
             {
                 Type = ResponseEventTypes.ResponseInProgress,
                 SequenceNumber = seq++,
-                Response = BuildResponseSnapshot(effectiveResponseId, effectiveModel, status: "in_progress", usage: null),
+                Response = BuildResponseSnapshot(
+                    effectiveResponseId,
+                    effectiveModel,
+                    status: "in_progress",
+                    usage: null
+                ),
             }
         );
 
         var outputIndex = 0;
+        if (plan.ReasoningLength is int reasoningLength && reasoningLength > 0)
+        {
+            var reasoningText = string.Join(' ', GenerateLoremWords(reasoningLength));
+            AppendReasoningOutput(events, ref seq, outputIndex, reasoningText);
+            outputIndex++;
+        }
+
         foreach (var msg in plan.Messages)
         {
             if (msg.ToolCalls is { Count: > 0 } toolCalls)
@@ -117,6 +134,42 @@ public static class OpenAiResponsesEventStreamWriter
         return events;
     }
 
+    private static void AppendReasoningOutput(
+        List<ResponseEvent> events,
+        ref int seq,
+        int outputIndex,
+        string reasoningText
+    )
+    {
+        var itemId = $"rs_{Guid.NewGuid():N}";
+        var itemJson = new JsonObject
+        {
+            ["id"] = itemId,
+            ["type"] = "reasoning",
+            ["summary"] = new JsonArray(new JsonObject { ["type"] = "summary_text", ["text"] = reasoningText }),
+        };
+
+        events.Add(
+            new ResponseOutputItemEvent
+            {
+                Type = ResponseEventTypes.OutputItemAdded,
+                SequenceNumber = seq++,
+                OutputIndex = outputIndex,
+                Item = ToJsonElement(itemJson),
+            }
+        );
+
+        events.Add(
+            new ResponseOutputItemEvent
+            {
+                Type = ResponseEventTypes.OutputItemDone,
+                SequenceNumber = seq++,
+                OutputIndex = outputIndex,
+                Item = ToJsonElement(itemJson),
+            }
+        );
+    }
+
     private static void AppendTextOutput(
         List<ResponseEvent> events,
         ref int seq,
@@ -147,11 +200,7 @@ public static class OpenAiResponsesEventStreamWriter
             }
         );
 
-        var partAddedJson = new JsonObject
-        {
-            ["type"] = "output_text",
-            ["text"] = string.Empty,
-        };
+        var partAddedJson = new JsonObject { ["type"] = "output_text", ["text"] = string.Empty };
 
         events.Add(
             new ResponseContentPartEvent
@@ -192,11 +241,7 @@ public static class OpenAiResponsesEventStreamWriter
             }
         );
 
-        var partDoneJson = new JsonObject
-        {
-            ["type"] = "output_text",
-            ["text"] = text,
-        };
+        var partDoneJson = new JsonObject { ["type"] = "output_text", ["text"] = text };
 
         events.Add(
             new ResponseContentPartEvent
@@ -216,13 +261,7 @@ public static class OpenAiResponsesEventStreamWriter
             ["type"] = "message",
             ["status"] = "completed",
             ["role"] = "assistant",
-            ["content"] = new JsonArray(
-                new JsonObject
-                {
-                    ["type"] = "output_text",
-                    ["text"] = text,
-                }
-            ),
+            ["content"] = new JsonArray(new JsonObject { ["type"] = "output_text", ["text"] = text }),
         };
 
         events.Add(

--- a/src/LmTestUtils/TestMode/OpenAiResponsesInstructionPlanResolver.cs
+++ b/src/LmTestUtils/TestMode/OpenAiResponsesInstructionPlanResolver.cs
@@ -1,0 +1,286 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+
+/// <summary>
+///     Resolves OpenAI Responses API mock output from embedded instruction-chain tags.
+/// </summary>
+public static class OpenAiResponsesInstructionPlanResolver
+{
+    /// <summary>
+    ///     Resolves the instruction plan for a <c>response.create</c> request body.
+    /// </summary>
+    public static InstructionPlan ResolvePlan(
+        JsonElement root,
+        IInstructionChainParser? chainParser = null,
+        ILogger? logger = null
+    )
+    {
+        return TryResolvePlan(root, chainParser, logger)
+            ?? new InstructionPlan("fallback", null, [InstructionMessage.ForText(20)]);
+    }
+
+    /// <summary>
+    ///     Resolves an instruction-chain plan when the request contains embedded instructions;
+    ///     returns <c>null</c> when normal scenario dispatch should handle the request.
+    /// </summary>
+    public static InstructionPlan? TryResolvePlan(
+        JsonElement root,
+        IInstructionChainParser? chainParser = null,
+        ILogger? logger = null
+    )
+    {
+        chainParser ??= new InstructionChainParser(NullLogger<InstructionChainParser>.Instance);
+        logger ??= NullLogger.Instance;
+
+        var (chain, assistantCount) = FindInstructionChain(root, chainParser);
+
+        if (chain != null)
+        {
+            if (assistantCount < chain.Length)
+            {
+                logger.LogDebug(
+                    "Executing instruction {Index} of {Total} from Responses instruction chain",
+                    assistantCount + 1,
+                    chain.Length
+                );
+                var plan = chain[assistantCount];
+                ResolveDynamicMessages(plan, root, logger);
+                return plan;
+            }
+
+            logger.LogDebug(
+                "Responses instruction chain exhausted after {Count} executions; emitting completion",
+                assistantCount
+            );
+            return new InstructionPlan("completion", null, [InstructionMessage.ForText(5)]);
+        }
+
+        var latest = ResponsesInputReader.ExtractLatestUserText(root, concatenateAll: false) ?? string.Empty;
+        var plans = chainParser.ExtractInstructionChain(latest);
+        if (plans is { Length: > 0 })
+        {
+            var plan = plans[0];
+            ResolveDynamicMessages(plan, root, logger);
+            return plan;
+        }
+
+        logger.LogDebug("No instruction chain in Responses request");
+        return null;
+    }
+
+    private static void ResolveDynamicMessages(InstructionPlan plan, JsonElement requestRoot, ILogger logger)
+    {
+        foreach (var message in plan.Messages)
+        {
+            if (message.ExplicitText == "__SYSTEM_PROMPT__")
+            {
+                message.ExplicitText = ExtractSystemPrompt(requestRoot);
+                continue;
+            }
+
+            if (message.ExplicitText == "__TOOLS_LIST__")
+            {
+                message.ExplicitText = ExtractToolsList(requestRoot);
+                logger.LogDebug("Resolved Responses __TOOLS_LIST__ placeholder to: {ToolsList}", message.ExplicitText);
+                continue;
+            }
+
+            if (
+                message.ExplicitText != null
+                && message.ExplicitText.StartsWith("__REQUEST_PARAMS__", StringComparison.Ordinal)
+            )
+            {
+                var fields = message.ExplicitText.Contains(':')
+                    ? message.ExplicitText.Split(':', 2)[1].Split(',')
+                    : null;
+                message.ExplicitText = ExtractRequestParams(requestRoot, fields);
+            }
+        }
+    }
+
+    private static string ExtractSystemPrompt(JsonElement root)
+    {
+        return
+            root.TryGetProperty("instructions", out var instructions)
+            && instructions.ValueKind == JsonValueKind.String
+            && !string.IsNullOrWhiteSpace(instructions.GetString())
+            ? instructions.GetString()!
+            : "No system prompt configured";
+    }
+
+    private static string ExtractToolsList(JsonElement root)
+    {
+        if (!root.TryGetProperty("tools", out var tools) || tools.ValueKind != JsonValueKind.Array)
+        {
+            return "No tools available";
+        }
+
+        var toolNames = new List<string>();
+        var uniqueToolNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var tool in tools.EnumerateArray())
+        {
+            if (tool.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            if (TryAddResponseToolName(tool, uniqueToolNames, toolNames))
+            {
+                continue;
+            }
+
+            _ = TryAddOpenAiChatToolName(tool, uniqueToolNames, toolNames);
+        }
+
+        return toolNames.Count == 0 ? "No tools available" : string.Join(", ", toolNames);
+    }
+
+    private static bool TryAddResponseToolName(
+        JsonElement tool,
+        HashSet<string> uniqueToolNames,
+        List<string> toolNames
+    )
+    {
+        if (!tool.TryGetProperty("name", out var name) || name.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        var toolName = name.GetString();
+        if (string.IsNullOrWhiteSpace(toolName) || !uniqueToolNames.Add(toolName))
+        {
+            return false;
+        }
+
+        toolNames.Add(toolName);
+        return true;
+    }
+
+    private static bool TryAddOpenAiChatToolName(
+        JsonElement tool,
+        HashSet<string> uniqueToolNames,
+        List<string> toolNames
+    )
+    {
+        if (
+            !tool.TryGetProperty("function", out var function)
+            || function.ValueKind != JsonValueKind.Object
+            || !function.TryGetProperty("name", out var name)
+            || name.ValueKind != JsonValueKind.String
+        )
+        {
+            return false;
+        }
+
+        var toolName = name.GetString();
+        if (string.IsNullOrWhiteSpace(toolName) || !uniqueToolNames.Add(toolName))
+        {
+            return false;
+        }
+
+        toolNames.Add(toolName);
+        return true;
+    }
+
+    private static string ExtractRequestParams(JsonElement root, string[]? fields)
+    {
+        if (fields == null || fields.Length == 0)
+        {
+            return root.GetRawText();
+        }
+
+        var result = new Dictionary<string, string>();
+        foreach (var field in fields.Select(f => f.Trim()).Where(f => !string.IsNullOrEmpty(f)))
+        {
+            if (root.TryGetProperty(field, out var value))
+            {
+                result[field] = value.ToString();
+            }
+        }
+
+        return result.Count == 0 ? "No matching params" : JsonSerializer.Serialize(result);
+    }
+
+    private static (InstructionPlan[]? chain, int assistantCount) FindInstructionChain(
+        JsonElement root,
+        IInstructionChainParser chainParser
+    )
+    {
+        if (!root.TryGetProperty("input", out var input) || input.ValueKind != JsonValueKind.Array)
+        {
+            return (null, 0);
+        }
+
+        var items = input.EnumerateArray().ToList();
+
+        // Walk newest -> oldest looking for an instruction chain in any user item's input_text.
+        for (var i = items.Count - 1; i >= 0; i--)
+        {
+            var item = items[i];
+            if (item.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            if (!IsRole(item, "user"))
+            {
+                continue;
+            }
+
+            var text = ResponsesInputReader.ReadContentText(item, concatenateAll: false);
+            if (string.IsNullOrEmpty(text))
+            {
+                continue;
+            }
+
+            var chain = chainParser.ExtractInstructionChain(text);
+            if (chain is { Length: > 0 })
+            {
+                var assistantCount = CountAssistantOutputsAfter(items, i);
+                return (chain, assistantCount);
+            }
+        }
+
+        return (null, 0);
+    }
+
+    private static int CountAssistantOutputsAfter(IReadOnlyList<JsonElement> items, int chainIndex)
+    {
+        var count = 0;
+        for (var i = chainIndex + 1; i < items.Count; i++)
+        {
+            var item = items[i];
+            if (item.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            // In the Responses input array, a "message" with role=assistant counts as one
+            // model turn. Function-call/function-call-output items belong to a turn but don't
+            // bump the response counter.
+            if (IsRole(item, "assistant") && IsType(item, "message"))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static bool IsRole(JsonElement item, string role)
+    {
+        return item.TryGetProperty("role", out var r)
+            && r.ValueKind == JsonValueKind.String
+            && string.Equals(r.GetString(), role, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsType(JsonElement item, string type)
+    {
+        return item.TryGetProperty("type", out var t)
+            && t.ValueKind == JsonValueKind.String
+            && string.Equals(t.GetString(), type, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/LmTestUtils/TestMode/OpenAiResponsesTestSseMessageHandler.cs
+++ b/src/LmTestUtils/TestMode/OpenAiResponsesTestSseMessageHandler.cs
@@ -28,8 +28,7 @@ public sealed class OpenAiResponsesTestSseMessageHandler : HttpMessageHandler
     private readonly ILogger<OpenAiResponsesTestSseMessageHandler> _logger;
 
     public OpenAiResponsesTestSseMessageHandler()
-        : this(NullLogger<OpenAiResponsesTestSseMessageHandler>.Instance)
-    { }
+        : this(NullLogger<OpenAiResponsesTestSseMessageHandler>.Instance) { }
 
     public OpenAiResponsesTestSseMessageHandler(
         ILogger<OpenAiResponsesTestSseMessageHandler> logger,
@@ -37,8 +36,7 @@ public sealed class OpenAiResponsesTestSseMessageHandler : HttpMessageHandler
     )
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _chainParser =
-            chainParser ?? new InstructionChainParser(NullLogger<InstructionChainParser>.Instance);
+        _chainParser = chainParser ?? new InstructionChainParser(NullLogger<InstructionChainParser>.Instance);
     }
 
     public int WordsPerChunk { get; set; } = DefaultWordsPerChunk;
@@ -61,9 +59,10 @@ public sealed class OpenAiResponsesTestSseMessageHandler : HttpMessageHandler
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         }
 
-        var body = request.Content == null
-            ? string.Empty
-            : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        var body =
+            request.Content == null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(body))
         {
@@ -107,8 +106,8 @@ public sealed class OpenAiResponsesTestSseMessageHandler : HttpMessageHandler
                 };
             }
 
-            var model = root.TryGetProperty("model", out var modelProp)
-                && modelProp.ValueKind == JsonValueKind.String
+            var model =
+                root.TryGetProperty("model", out var modelProp) && modelProp.ValueKind == JsonValueKind.String
                     ? modelProp.GetString()
                     : "gpt-mock-responses";
 
@@ -131,120 +130,6 @@ public sealed class OpenAiResponsesTestSseMessageHandler : HttpMessageHandler
     /// </summary>
     private InstructionPlan ResolvePlan(JsonElement root)
     {
-        var (chain, assistantCount) = FindInstructionChain(root);
-
-        if (chain != null)
-        {
-            if (assistantCount < chain.Length)
-            {
-                _logger.LogDebug(
-                    "Executing instruction {Index} of {Total} from chain",
-                    assistantCount + 1,
-                    chain.Length
-                );
-                return chain[assistantCount];
-            }
-
-            _logger.LogDebug("Instruction chain exhausted after {Count} executions; emitting completion", assistantCount);
-            return new InstructionPlan("completion", null, [InstructionMessage.ForText(5)]);
-        }
-
-        var latest = ResponsesInputReader.ExtractLatestUserText(root, concatenateAll: false) ?? string.Empty;
-        var (singlePlan, _) = TrySingleInstruction(latest);
-        if (singlePlan != null)
-        {
-            return singlePlan;
-        }
-
-        _logger.LogDebug("No instruction chain in /v1/responses request; using fallback");
-        return new InstructionPlan("fallback", null, [InstructionMessage.ForText(20)]);
-    }
-
-    private (InstructionPlan? plan, string fallback) TrySingleInstruction(string userMessage)
-    {
-        var plans = _chainParser.ExtractInstructionChain(userMessage);
-        if (plans is { Length: > 0 })
-        {
-            return (plans[0], userMessage);
-        }
-
-        return (null, userMessage);
-    }
-
-    private (InstructionPlan[]? chain, int assistantCount) FindInstructionChain(JsonElement root)
-    {
-        if (!root.TryGetProperty("input", out var input) || input.ValueKind != JsonValueKind.Array)
-        {
-            return (null, 0);
-        }
-
-        var items = input.EnumerateArray().ToList();
-
-        // Walk newest → oldest looking for an instruction chain in any user item's input_text.
-        for (var i = items.Count - 1; i >= 0; i--)
-        {
-            var item = items[i];
-            if (item.ValueKind != JsonValueKind.Object)
-            {
-                continue;
-            }
-
-            if (!IsRole(item, "user"))
-            {
-                continue;
-            }
-
-            var text = ResponsesInputReader.ReadContentText(item, concatenateAll: false);
-            if (string.IsNullOrEmpty(text))
-            {
-                continue;
-            }
-
-            var chain = _chainParser.ExtractInstructionChain(text);
-            if (chain is { Length: > 0 })
-            {
-                var assistantCount = CountAssistantOutputsAfter(items, i);
-                return (chain, assistantCount);
-            }
-        }
-
-        return (null, 0);
-    }
-
-    private static int CountAssistantOutputsAfter(IReadOnlyList<JsonElement> items, int chainIndex)
-    {
-        var count = 0;
-        for (var i = chainIndex + 1; i < items.Count; i++)
-        {
-            var item = items[i];
-            if (item.ValueKind != JsonValueKind.Object)
-            {
-                continue;
-            }
-
-            // In the Responses input array, a "message" with role=assistant counts as one
-            // model turn. Function-call/function-call-output items belong to a turn but don't
-            // bump the response counter — they're internal mechanics of the same turn.
-            if (IsRole(item, "assistant") && IsType(item, "message"))
-            {
-                count++;
-            }
-        }
-
-        return count;
-    }
-
-    private static bool IsRole(JsonElement item, string role)
-    {
-        return item.TryGetProperty("role", out var r)
-            && r.ValueKind == JsonValueKind.String
-            && string.Equals(r.GetString(), role, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool IsType(JsonElement item, string type)
-    {
-        return item.TryGetProperty("type", out var t)
-            && t.ValueKind == JsonValueKind.String
-            && string.Equals(t.GetString(), type, StringComparison.OrdinalIgnoreCase);
+        return OpenAiResponsesInstructionPlanResolver.ResolvePlan(root, _chainParser, _logger);
     }
 }

--- a/src/LmTestUtils/TestMode/ScriptedSseResponder.cs
+++ b/src/LmTestUtils/TestMode/ScriptedSseResponder.cs
@@ -17,11 +17,9 @@ namespace AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Unlike <see cref="TestSseMessageHandler"/> which extracts instruction chains embedded in user
-/// messages, <see cref="ScriptedSseResponder"/> classifies each request by its shape (system
-/// prompt, tool list) and pops the next plan from the matching role's queue. This lets parent
-/// and sub-agent scripts stay fully independent — useful for exercising the
-/// parent → <c>SubAgentManager</c> → sub-agent fan-out through <c>MultiTurnAgentPool</c>.
+/// OpenAI and Anthropic chat-style requests are classified by request shape (system prompt,
+/// tool list) and pop the next plan from the matching role's queue. OpenAI Responses requests
+/// use embedded instruction-chain tags instead, matching the Codex mock transport.
 /// </para>
 /// <para>
 /// The responder produces <see cref="HttpMessageHandler"/> instances for both OpenAI and
@@ -88,8 +86,13 @@ public sealed class ScriptedSseResponder
         ArgumentNullException.ThrowIfNull(socket);
         ArgumentNullException.ThrowIfNull(ctx);
 
-        var plan = TakeNextPlan(ctx)
-            ?? new InstructionPlan("scripted-fallback", null, [InstructionMessage.ForExplicitText("ok")]);
+        var plan =
+            ctx.Wire == ScriptedWireFormat.OpenAiResponses
+                ? OpenAiResponsesInstructionPlanResolver.TryResolvePlan(ctx.RequestBody, logger: _logger)
+                    ?? TakeNextPlan(ctx)
+                    ?? new InstructionPlan("scripted-fallback", null, [InstructionMessage.ForExplicitText("ok")])
+                : TakeNextPlan(ctx)
+                    ?? new InstructionPlan("scripted-fallback", null, [InstructionMessage.ForExplicitText("ok")]);
 
         var events = OpenAiResponsesEventStreamWriter.Write(plan, model);
         foreach (var ev in events)
@@ -98,12 +101,14 @@ public sealed class ScriptedSseResponder
 
             var json = ResponseEventParser.ToJsonObject(ev).ToJsonString();
             var bytes = Encoding.UTF8.GetBytes(json);
-            await socket.SendAsync(
-                new ArraySegment<byte>(bytes),
-                WebSocketMessageType.Text,
-                endOfMessage: true,
-                cancellationToken
-            ).ConfigureAwait(false);
+            await socket
+                .SendAsync(
+                    new ArraySegment<byte>(bytes),
+                    WebSocketMessageType.Text,
+                    endOfMessage: true,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
         }
     }
 
@@ -118,10 +123,7 @@ public sealed class ScriptedSseResponder
             if (role.Matches(ctx))
             {
                 var plan = role.TryDequeue();
-                _logger.LogDebug(
-                    "Matched role {Role}; plan={Plan}",
-                    role.Key,
-                    plan?.IdMessage ?? "<exhausted>");
+                _logger.LogDebug("Matched role {Role}; plan={Plan}", role.Key, plan?.IdMessage ?? "<exhausted>");
                 return plan;
             }
         }
@@ -131,8 +133,7 @@ public sealed class ScriptedSseResponder
     }
 
     /// <summary>Snapshot of remaining plan counts per role — useful for assertions.</summary>
-    public IReadOnlyDictionary<string, int> RemainingTurns =>
-        _roles.ToDictionary(r => r.Key, r => r.Remaining);
+    public IReadOnlyDictionary<string, int> RemainingTurns => _roles.ToDictionary(r => r.Key, r => r.Remaining);
 }
 
 /// <summary>Fluent builder for <see cref="ScriptedSseResponder"/>.</summary>
@@ -318,6 +319,9 @@ public sealed class ScriptedRequestContext
     /// <summary>Text of the most recent user message (may be null).</summary>
     public string? LatestUserMessage { get; init; }
 
+    /// <summary>True when the request includes at least one tool_result content block.</summary>
+    public bool HasToolResult { get; init; }
+
     /// <summary>Convenience: true if the request advertises a tool named <paramref name="name"/>.</summary>
     public bool HasTool(string name)
     {
@@ -327,8 +331,7 @@ public sealed class ScriptedRequestContext
     /// <summary>Convenience: true if the system prompt contains <paramref name="substring"/>.</summary>
     public bool SystemPromptContains(string substring)
     {
-        return !string.IsNullOrEmpty(substring)
-            && SystemPrompt.Contains(substring, StringComparison.OrdinalIgnoreCase);
+        return !string.IsNullOrEmpty(substring) && SystemPrompt.Contains(substring, StringComparison.OrdinalIgnoreCase);
     }
 }
 
@@ -397,14 +400,16 @@ internal sealed class ScriptedHandler : HttpMessageHandler
 
     protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken
+    )
     {
         if (request.Method != HttpMethod.Post || request.RequestUri == null)
         {
             _logger.LogWarning(
                 "Rejecting non-POST/no-URI request: method={Method} uri={Uri}",
                 request.Method,
-                request.RequestUri);
+                request.RequestUri
+            );
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         }
 
@@ -420,13 +425,15 @@ internal sealed class ScriptedHandler : HttpMessageHandler
                 "Path {Path} does not end with expected suffix {Suffix} (wire={Wire})",
                 request.RequestUri.AbsolutePath,
                 expectedSuffix,
-                _wire);
+                _wire
+            );
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         }
 
-        var body = request.Content == null
-            ? string.Empty
-            : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        var body =
+            request.Content == null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(body))
         {
@@ -447,7 +454,8 @@ internal sealed class ScriptedHandler : HttpMessageHandler
                 ex,
                 "Failed to parse scripted SSE request body as JSON (wire={Wire}): {ErrorMessage}",
                 _wire,
-                ex.Message);
+                ex.Message
+            );
             return new HttpResponseMessage(HttpStatusCode.BadRequest)
             {
                 Content = new StringContent($"Invalid JSON: {ex.Message}"),
@@ -459,25 +467,27 @@ internal sealed class ScriptedHandler : HttpMessageHandler
             var root = doc.RootElement;
             var ctx = BuildContext(root);
 
-            var plan = _responder.TakeNextPlan(ctx);
+            var plan =
+                _wire == ScriptedWireFormat.OpenAiResponses
+                    ? OpenAiResponsesInstructionPlanResolver.TryResolvePlan(root, logger: _logger)
+                        ?? _responder.TakeNextPlan(ctx)
+                    : _responder.TakeNextPlan(ctx);
             if (plan is null)
             {
                 // Fallback: simple "ok" text so the run can complete without blowing up.
                 _logger.LogWarning(
                     "No role matched or queue exhausted; emitting fallback text. Wire={Wire} SystemPrompt={SystemPromptPreview}",
                     _wire,
-                    Preview(ctx.SystemPrompt));
-                plan = new InstructionPlan(
-                    "scripted-fallback",
-                    null,
-                    [InstructionMessage.ForExplicitText("ok")]);
+                    Preview(ctx.SystemPrompt)
+                );
+                plan = new InstructionPlan("scripted-fallback", null, [InstructionMessage.ForExplicitText("ok")]);
             }
 
-            var stream = root.TryGetProperty("stream", out var streamProp)
-                && streamProp.ValueKind == JsonValueKind.True;
+            var stream =
+                root.TryGetProperty("stream", out var streamProp) && streamProp.ValueKind == JsonValueKind.True;
 
-            var model = root.TryGetProperty("model", out var modelProp)
-                && modelProp.ValueKind == JsonValueKind.String
+            var model =
+                root.TryGetProperty("model", out var modelProp) && modelProp.ValueKind == JsonValueKind.String
                     ? modelProp.GetString()
                     : null;
 
@@ -493,7 +503,12 @@ internal sealed class ScriptedHandler : HttpMessageHandler
 
             HttpContent content = _wire switch
             {
-                ScriptedWireFormat.OpenAi => new SseStreamHttpContent(plan, model, DefaultWordsPerChunk, DefaultChunkDelayMs),
+                ScriptedWireFormat.OpenAi => new SseStreamHttpContent(
+                    plan,
+                    model,
+                    DefaultWordsPerChunk,
+                    DefaultChunkDelayMs
+                ),
                 ScriptedWireFormat.OpenAiResponses => OpenAiResponsesSseStreamHttpContent.FromPlan(
                     plan,
                     model,
@@ -532,6 +547,8 @@ internal sealed class ScriptedHandler : HttpMessageHandler
             SystemPrompt = systemPrompt,
             Tools = tools,
             LatestUserMessage = latestUser,
+            HasToolResult =
+                ContainsContentBlockType(root, "tool_result") || ContainsInputItemType(root, "function_call_output"),
         };
     }
 
@@ -544,8 +561,7 @@ internal sealed class ScriptedHandler : HttpMessageHandler
         {
             foreach (var msg in messages.EnumerateArray())
             {
-                if (!msg.TryGetProperty("role", out var roleProp)
-                    || roleProp.ValueKind != JsonValueKind.String)
+                if (!msg.TryGetProperty("role", out var roleProp) || roleProp.ValueKind != JsonValueKind.String)
                 {
                     continue;
                 }
@@ -575,8 +591,8 @@ internal sealed class ScriptedHandler : HttpMessageHandler
     private static (string systemPrompt, string? latestUser) ExtractOpenAiResponses(JsonElement root)
     {
         // System prompt lives in `instructions` (string) on the Responses request.
-        var systemPrompt = root.TryGetProperty("instructions", out var instr)
-            && instr.ValueKind == JsonValueKind.String
+        var systemPrompt =
+            root.TryGetProperty("instructions", out var instr) && instr.ValueKind == JsonValueKind.String
                 ? instr.GetString() ?? string.Empty
                 : string.Empty;
 
@@ -594,11 +610,15 @@ internal sealed class ScriptedHandler : HttpMessageHandler
                 JsonValueKind.String => sysProp.GetString() ?? string.Empty,
                 JsonValueKind.Array => string.Join(
                     '\n',
-                    sysProp.EnumerateArray()
-                        .Where(e => e.ValueKind == JsonValueKind.Object
+                    sysProp
+                        .EnumerateArray()
+                        .Where(e =>
+                            e.ValueKind == JsonValueKind.Object
                             && e.TryGetProperty("text", out var t)
-                            && t.ValueKind == JsonValueKind.String)
-                        .Select(e => e.GetProperty("text").GetString() ?? string.Empty)),
+                            && t.ValueKind == JsonValueKind.String
+                        )
+                        .Select(e => e.GetProperty("text").GetString() ?? string.Empty)
+                ),
                 _ => string.Empty,
             };
         }
@@ -608,9 +628,11 @@ internal sealed class ScriptedHandler : HttpMessageHandler
         {
             foreach (var msg in messages.EnumerateArray())
             {
-                if (!msg.TryGetProperty("role", out var roleProp)
+                if (
+                    !msg.TryGetProperty("role", out var roleProp)
                     || roleProp.ValueKind != JsonValueKind.String
-                    || !string.Equals(roleProp.GetString(), "user", StringComparison.OrdinalIgnoreCase))
+                    || !string.Equals(roleProp.GetString(), "user", StringComparison.OrdinalIgnoreCase)
+                )
                 {
                     continue;
                 }
@@ -639,12 +661,14 @@ internal sealed class ScriptedHandler : HttpMessageHandler
             var sb = new StringBuilder();
             foreach (var item in content.EnumerateArray())
             {
-                if (item.ValueKind == JsonValueKind.Object
+                if (
+                    item.ValueKind == JsonValueKind.Object
                     && item.TryGetProperty("type", out var type)
                     && type.ValueKind == JsonValueKind.String
                     && type.GetString() == "text"
                     && item.TryGetProperty("text", out var textProp)
-                    && textProp.ValueKind == JsonValueKind.String)
+                    && textProp.ValueKind == JsonValueKind.String
+                )
                 {
                     if (sb.Length > 0)
                     {
@@ -677,10 +701,12 @@ internal sealed class ScriptedHandler : HttpMessageHandler
             }
 
             // OpenAI chat-completions shape: { type: "function", function: { name: "..." } }
-            if (tool.TryGetProperty("function", out var fn)
+            if (
+                tool.TryGetProperty("function", out var fn)
                 && fn.ValueKind == JsonValueKind.Object
                 && fn.TryGetProperty("name", out var fnName)
-                && fnName.ValueKind == JsonValueKind.String)
+                && fnName.ValueKind == JsonValueKind.String
+            )
             {
                 names.Add(fnName.GetString()!);
                 continue;
@@ -696,6 +722,60 @@ internal sealed class ScriptedHandler : HttpMessageHandler
         }
 
         return names;
+    }
+
+    private static bool ContainsContentBlockType(JsonElement root, string contentType)
+    {
+        if (!root.TryGetProperty("messages", out var messages) || messages.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        foreach (var message in messages.EnumerateArray())
+        {
+            if (!message.TryGetProperty("content", out var content) || content.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            foreach (var item in content.EnumerateArray())
+            {
+                if (
+                    item.ValueKind == JsonValueKind.Object
+                    && item.TryGetProperty("type", out var type)
+                    && type.ValueKind == JsonValueKind.String
+                    && string.Equals(type.GetString(), contentType, StringComparison.OrdinalIgnoreCase)
+                )
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsInputItemType(JsonElement root, string itemType)
+    {
+        if (!root.TryGetProperty("input", out var input) || input.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        foreach (var item in input.EnumerateArray())
+        {
+            if (
+                item.ValueKind == JsonValueKind.Object
+                && item.TryGetProperty("type", out var type)
+                && type.ValueKind == JsonValueKind.String
+                && string.Equals(type.GetString(), itemType, StringComparison.OrdinalIgnoreCase)
+            )
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string Preview(string s)

--- a/src/McpMiddleware/AchieveAi.LmDotnetTools.McpMiddleware.csproj
+++ b/src/McpMiddleware/AchieveAi.LmDotnetTools.McpMiddleware.csproj
@@ -13,9 +13,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.1-preview.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.4.1-preview.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LmCore\AchieveAi.LmDotnetTools.LmCore.csproj" />

--- a/src/McpMiddleware/McpClientFunctionProvider.cs
+++ b/src/McpMiddleware/McpClientFunctionProvider.cs
@@ -689,11 +689,11 @@ public partial class McpClientFunctionProvider : IFunctionProvider
         var imageIndex = 0;
         foreach (var content in response.Content.Where(c => c?.Type == "image"))
         {
-            if (content is ImageContentBlock imgBlock && !string.IsNullOrEmpty(imgBlock.Data))
+            if (content is ImageContentBlock imgBlock && !imgBlock.Data.IsEmpty)
             {
                 try
                 {
-                    var bytes = Convert.FromBase64String(imgBlock.Data);
+                    var bytes = imgBlock.Data.ToArray();
                     var detectedMimeType = DetectImageMimeType(bytes, imgBlock.MimeType, logger);
 
                     if (detectedMimeType != imgBlock.MimeType)
@@ -719,7 +719,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                     }
 
                     imageBlocks.Add(
-                        new ImageToolResultBlock { Data = imgBlock.Data, MimeType = detectedMimeType }
+                        new ImageToolResultBlock { Data = Convert.ToBase64String(bytes), MimeType = detectedMimeType }
                     );
                 }
                 catch (FormatException ex)
@@ -729,7 +729,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                         "Invalid base64 data in MCP image response: ToolName={ToolName}, ImageIndex={ImageIndex}, DataLength={DataLength}",
                         toolName,
                         imageIndex,
-                        imgBlock.Data?.Length ?? 0
+                        imgBlock.Data.Length
                     );
                 }
                 catch (Exception ex)

--- a/src/McpMiddleware/McpClientFunctionProvider.cs
+++ b/src/McpMiddleware/McpClientFunctionProvider.cs
@@ -693,8 +693,8 @@ public partial class McpClientFunctionProvider : IFunctionProvider
             {
                 try
                 {
-                    var bytes = imgBlock.Data.ToArray();
-                    var detectedMimeType = DetectImageMimeType(bytes, imgBlock.MimeType, logger);
+                    var dataSpan = imgBlock.Data.Span;
+                    var detectedMimeType = DetectImageMimeType(dataSpan, imgBlock.MimeType, logger);
 
                     if (detectedMimeType != imgBlock.MimeType)
                     {
@@ -704,7 +704,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                             imageIndex,
                             imgBlock.MimeType,
                             detectedMimeType,
-                            bytes.Length
+                            dataSpan.Length
                         );
                     }
                     else
@@ -714,12 +714,12 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                             toolName,
                             imageIndex,
                             detectedMimeType,
-                            bytes.Length
+                            dataSpan.Length
                         );
                     }
 
                     imageBlocks.Add(
-                        new ImageToolResultBlock { Data = Convert.ToBase64String(bytes), MimeType = detectedMimeType }
+                        new ImageToolResultBlock { Data = Convert.ToBase64String(dataSpan), MimeType = detectedMimeType }
                     );
                 }
                 catch (Exception ex)
@@ -778,7 +778,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
     ///     Detects the MIME type of an image from its byte content.
     ///     Uses magic bytes to identify common image formats.
     /// </summary>
-    private static string DetectImageMimeType(byte[] bytes, string fallbackMimeType, ILogger logger)
+    private static string DetectImageMimeType(ReadOnlySpan<byte> bytes, string fallbackMimeType, ILogger logger)
     {
         if (bytes.Length >= 8)
         {

--- a/src/McpMiddleware/McpClientFunctionProvider.cs
+++ b/src/McpMiddleware/McpClientFunctionProvider.cs
@@ -722,16 +722,6 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                         new ImageToolResultBlock { Data = Convert.ToBase64String(bytes), MimeType = detectedMimeType }
                     );
                 }
-                catch (FormatException ex)
-                {
-                    logger.LogWarning(
-                        ex,
-                        "Invalid base64 data in MCP image response: ToolName={ToolName}, ImageIndex={ImageIndex}, DataLength={DataLength}",
-                        toolName,
-                        imageIndex,
-                        imgBlock.Data.Length
-                    );
-                }
                 catch (Exception ex)
                 {
                     logger.LogWarning(

--- a/src/McpSampleServer/AchieveAi.LmDotnetTools.McpSampleServer.csproj
+++ b/src/McpSampleServer/AchieveAi.LmDotnetTools.McpSampleServer.csproj
@@ -13,6 +13,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.1-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
   </ItemGroup>
 </Project>

--- a/src/McpServer.AspNetCore/AchieveAi.LmDotnetTools.McpServer.AspNetCore.csproj
+++ b/src/McpServer.AspNetCore/AchieveAi.LmDotnetTools.McpServer.AspNetCore.csproj
@@ -11,9 +11,9 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol" Version="0.4.1-preview.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.4.1-preview.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LmCore\AchieveAi.LmDotnetTools.LmCore.csproj" />

--- a/src/OpenAiResponsesProvider/Agents/OpenAiResponsesAgent.cs
+++ b/src/OpenAiResponsesProvider/Agents/OpenAiResponsesAgent.cs
@@ -148,9 +148,11 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
                     break;
 
                 case ResponseOutputItemEvent itemEvent when itemEvent.Type == ResponseEventTypes.OutputItemAdded:
-                    if (TryReadString(itemEvent.Item, "type", out var itemType)
+                    if (
+                        TryReadString(itemEvent.Item, "type", out var itemType)
                         && itemType == "function_call"
-                        && TryReadString(itemEvent.Item, "id", out var fnItemId))
+                        && TryReadString(itemEvent.Item, "id", out var fnItemId)
+                    )
                     {
                         pendingFunctionCalls[fnItemId] = new PendingFunctionCall(
                             ItemId: fnItemId,
@@ -161,6 +163,25 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
                             ),
                             OutputIndex: itemEvent.OutputIndex
                         );
+                    }
+
+                    break;
+
+                case ResponseOutputItemEvent itemEvent
+                    when itemEvent.Type == ResponseEventTypes.OutputItemDone
+                        && TryReadString(itemEvent.Item, "type", out var reasoningItemType)
+                        && reasoningItemType == "reasoning":
+                    if (TryExtractReasoning(itemEvent.Item, out var reasoning, out var visibility))
+                    {
+                        yield return new ReasoningMessage
+                        {
+                            Reasoning = reasoning,
+                            Visibility = visibility,
+                            Role = Role.Assistant,
+                            FromAgent = fromAgent,
+                            GenerationId = generationId,
+                            MessageOrderIdx = itemEvent.OutputIndex,
+                        };
                     }
 
                     break;
@@ -185,8 +206,10 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
 
                 case ResponseOutputTextDoneEvent doneEvent:
                     var finalText = doneEvent.Text;
-                    if (string.IsNullOrEmpty(finalText)
-                        && textBuffers.TryGetValue(doneEvent.OutputIndex, out var accumulated))
+                    if (
+                        string.IsNullOrEmpty(finalText)
+                        && textBuffers.TryGetValue(doneEvent.OutputIndex, out var accumulated)
+                    )
                     {
                         finalText = accumulated.ToString();
                     }
@@ -279,19 +302,68 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
         return true;
     }
 
-    private static bool TryExtractUsage(JsonElement responseElement, out Usage usage)
+    private static bool TryExtractReasoning(JsonElement item, out string reasoning, out ReasoningVisibility visibility)
     {
-        usage = new Usage();
-        if (responseElement.ValueKind != JsonValueKind.Object
-            || !responseElement.TryGetProperty("usage", out var usageEl)
-            || usageEl.ValueKind != JsonValueKind.Object)
+        reasoning = string.Empty;
+        visibility = ReasoningVisibility.Plain;
+
+        if (item.ValueKind != JsonValueKind.Object)
         {
             return false;
         }
 
-        var inputTokens = usageEl.TryGetProperty("input_tokens", out var inEl) && inEl.ValueKind == JsonValueKind.Number
-            ? inEl.GetInt32()
-            : 0;
+        if (item.TryGetProperty("summary", out var summary) && summary.ValueKind == JsonValueKind.Array)
+        {
+            var builder = new StringBuilder();
+            foreach (var summaryItem in summary.EnumerateArray())
+            {
+                if (TryReadString(summaryItem, "text", out var text) && !string.IsNullOrEmpty(text))
+                {
+                    if (builder.Length > 0)
+                    {
+                        _ = builder.AppendLine();
+                    }
+
+                    _ = builder.Append(text);
+                }
+            }
+
+            if (builder.Length > 0)
+            {
+                reasoning = builder.ToString();
+                return true;
+            }
+        }
+
+        if (
+            TryReadString(item, "encrypted_content", out var encryptedContent)
+            && !string.IsNullOrEmpty(encryptedContent)
+        )
+        {
+            reasoning = encryptedContent;
+            visibility = ReasoningVisibility.Encrypted;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryExtractUsage(JsonElement responseElement, out Usage usage)
+    {
+        usage = new Usage();
+        if (
+            responseElement.ValueKind != JsonValueKind.Object
+            || !responseElement.TryGetProperty("usage", out var usageEl)
+            || usageEl.ValueKind != JsonValueKind.Object
+        )
+        {
+            return false;
+        }
+
+        var inputTokens =
+            usageEl.TryGetProperty("input_tokens", out var inEl) && inEl.ValueKind == JsonValueKind.Number
+                ? inEl.GetInt32()
+                : 0;
         var outputTokens =
             usageEl.TryGetProperty("output_tokens", out var outEl) && outEl.ValueKind == JsonValueKind.Number
                 ? outEl.GetInt32()

--- a/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.CliArguments.Tests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.CliArguments.Tests.cs
@@ -21,4 +21,43 @@ public class ClaudeAgentSdkClientCliArgumentsTests
 
         Assert.Contains("--include-partial-messages", args);
     }
+
+    [Fact]
+    public void BuildCliArguments_OmitsModelFlag_WhenModelIdIsEmpty()
+    {
+        // Regression for: --max-turns being parsed as the model name when ModelId
+        // is empty. The old builder always emitted "--model {value}", producing
+        // "--model --max-turns 50 ..." which the CLI parsed as Model="--max-turns".
+        var client = new ClaudeAgentSdkClient(new ClaudeAgentSdkOptions());
+        var request = new ClaudeAgentSdkRequest { ModelId = string.Empty, MaxTurns = 50 };
+
+        var args = client.BuildCliArguments(request);
+
+        Assert.DoesNotContain("--model", args);
+        Assert.Contains("--max-turns 50", args);
+    }
+
+    [Fact]
+    public void BuildCliArguments_OmitsModelFlag_WhenModelIdIsWhitespace()
+    {
+        var client = new ClaudeAgentSdkClient(new ClaudeAgentSdkOptions());
+        var request = new ClaudeAgentSdkRequest { ModelId = "   ", MaxTurns = 50 };
+
+        var args = client.BuildCliArguments(request);
+
+        Assert.DoesNotContain("--model", args);
+        Assert.Contains("--max-turns 50", args);
+    }
+
+    [Fact]
+    public void BuildCliArguments_EmitsModelFlag_WhenModelIdIsProvided()
+    {
+        var client = new ClaudeAgentSdkClient(new ClaudeAgentSdkOptions());
+        var request = new ClaudeAgentSdkRequest { ModelId = "claude-sonnet-4-6", MaxTurns = 50 };
+
+        var args = client.BuildCliArguments(request);
+
+        Assert.Contains("--model claude-sonnet-4-6", args);
+        Assert.Contains("--max-turns 50", args);
+    }
 }

--- a/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.CliArguments.Tests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.CliArguments.Tests.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Agents;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+
+namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Tests.Agents;
+
+public class ClaudeAgentSdkClientCliArgumentsTests
+{
+    [Fact]
+    public void BuildCliArguments_IncludesPartialMessagesForToolCallVisibility()
+    {
+        var client = new ClaudeAgentSdkClient(new ClaudeAgentSdkOptions());
+        var method = typeof(ClaudeAgentSdkClient).GetMethod(
+            "BuildCliArguments",
+            BindingFlags.Instance | BindingFlags.NonPublic
+        );
+        var request = new ClaudeAgentSdkRequest { ModelId = "claude-sonnet-4-6", AllowedTools = "Read" };
+
+        var args = Assert.IsType<string>(method?.Invoke(client, [request]));
+
+        Assert.Contains("--include-partial-messages", args);
+    }
+}

--- a/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.CliArguments.Tests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.CliArguments.Tests.cs
@@ -60,4 +60,75 @@ public class ClaudeAgentSdkClientCliArgumentsTests
         Assert.Contains("--model claude-sonnet-4-6", args);
         Assert.Contains("--max-turns 50", args);
     }
+
+    [Fact]
+    public void BuildCliArguments_OmitsSettingSourcesFlag_WhenUnset()
+    {
+        // Regression for: --setting-sources "" was always emitted, causing the
+        // CLI to load no settings at all (no plugins, no skills, no sub-agents,
+        // no worktree .mcp.json). Omitting the flag lets the CLI fall back to
+        // its own default of user,project,local.
+        var client = new ClaudeAgentSdkClient(new ClaudeAgentSdkOptions());
+        var request = new ClaudeAgentSdkRequest { ModelId = "claude-sonnet-4-6" };
+
+        var args = client.BuildCliArguments(request);
+
+        Assert.DoesNotContain("--setting-sources", args);
+    }
+
+    [Fact]
+    public void BuildCliArguments_EmitsSettingSourcesFlag_WhenSet()
+    {
+        var client = new ClaudeAgentSdkClient(new ClaudeAgentSdkOptions());
+        var request = new ClaudeAgentSdkRequest { ModelId = "claude-sonnet-4-6", SettingSources = "user" };
+
+        var args = client.BuildCliArguments(request);
+
+        Assert.Contains("--setting-sources \"user\"", args);
+    }
+
+    [Fact]
+    public void BuildCliArguments_EmitsEmptySettingSources_WhenIsolated()
+    {
+        // Explicit empty value tells the CLI to load no settings sources at all
+        // (no user, no project, no local). Distinct from null / omitted, which
+        // lets the CLI fall back to its own default of user,project,local.
+        var client = new ClaudeAgentSdkClient(new ClaudeAgentSdkOptions());
+        var request = new ClaudeAgentSdkRequest { ModelId = "claude-sonnet-4-6", SettingSources = string.Empty };
+
+        var args = client.BuildCliArguments(request);
+
+        Assert.Contains("--setting-sources \"\"", args);
+    }
+
+    [Fact]
+    public void ApplyStagingDirectoryEnv_SetsClaudeConfigDir_WhenStagingDirectoryProvided()
+    {
+        var env = new Dictionary<string, string?>();
+
+        ClaudeAgentSdkClient.ApplyStagingDirectoryEnv(env, "/tmp/lm-claude-abc");
+
+        Assert.True(env.ContainsKey("CLAUDE_CONFIG_DIR"));
+        Assert.Equal("/tmp/lm-claude-abc", env["CLAUDE_CONFIG_DIR"]);
+    }
+
+    [Fact]
+    public void ApplyStagingDirectoryEnv_DoesNotSet_WhenStagingDirectoryNull()
+    {
+        var env = new Dictionary<string, string?>();
+
+        ClaudeAgentSdkClient.ApplyStagingDirectoryEnv(env, null);
+
+        Assert.False(env.ContainsKey("CLAUDE_CONFIG_DIR"));
+    }
+
+    [Fact]
+    public void ApplyStagingDirectoryEnv_DoesNotSet_WhenStagingDirectoryEmpty()
+    {
+        var env = new Dictionary<string, string?>();
+
+        ClaudeAgentSdkClient.ApplyStagingDirectoryEnv(env, string.Empty);
+
+        Assert.False(env.ContainsKey("CLAUDE_CONFIG_DIR"));
+    }
 }

--- a/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.JsonlEventHandling.Tests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.JsonlEventHandling.Tests.cs
@@ -41,4 +41,5 @@ public class ClaudeAgentSdkClientJsonlEventHandlingTests
         var text = Assert.Single(messages.OfType<TextMessage>());
         Assert.Equal("assistant survived stream event", text.Text);
     }
+
 }

--- a/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.JsonlEventHandling.Tests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.JsonlEventHandling.Tests.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Agents;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models.JsonlEvents;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+
+namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Tests.Agents;
+
+public class ClaudeAgentSdkClientJsonlEventHandlingTests
+{
+    [Fact]
+    public void ConvertNonTerminalJsonlEventToMessages_IgnoresStreamEventAndPreservesAssistantMessages()
+    {
+        var client = new ClaudeAgentSdkClient(new ClaudeAgentSdkOptions());
+        var events = new JsonlEventBase[]
+        {
+            new StreamEvent
+            {
+                Event = JsonDocument.Parse("""{"type":"content_block_delta"}""").RootElement,
+                SessionId = "session-1",
+                Uuid = "stream-1",
+            },
+            new AssistantMessageEvent
+            {
+                Uuid = "assistant-1",
+                SessionId = "session-1",
+                Message = new AssistantMessage
+                {
+                    Id = "msg-1",
+                    Model = "claude-test",
+                    Role = "assistant",
+                    Content = [new ContentBlock { Type = "text", Text = "assistant survived stream event" }],
+                },
+            },
+        };
+
+        var messages = events
+            .SelectMany(e => client.ConvertNonTerminalJsonlEventToMessages(e, emitSystemInit: false))
+            .ToList();
+
+        var text = Assert.Single(messages.OfType<TextMessage>());
+        Assert.Equal("assistant survived stream event", text.Text);
+    }
+}

--- a/tests/ClaudeAgentSdkProvider.Tests/Agents/ProfileMaterializationTests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Agents/ProfileMaterializationTests.cs
@@ -162,4 +162,140 @@ public class ProfileMaterializationTests
         Assert.Equal("node", result.McpServers["alpha"].Command);
         Assert.Equal("https://example.com", result.McpServers["beta"].Url);
     }
+
+    [Theory]
+    [InlineData("../escape")]
+    [InlineData("foo/bar")]
+    [InlineData("foo\\bar")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Materialize_SkillWithMaliciousName_ThrowsArgumentException(string name)
+    {
+        var profile = new AgentRuntimeProfile
+        {
+            Skills = [new AgentSkill { Name = name, Source = new ContentSource.FromInline("body") }],
+        };
+
+        Assert.Throws<ArgumentException>(() => ProfileMaterializer.Materialize(profile));
+    }
+
+    [Theory]
+    [InlineData("../escape")]
+    [InlineData("foo/bar")]
+    [InlineData("foo\\bar")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Materialize_SubAgentWithMaliciousName_ThrowsArgumentException(string name)
+    {
+        var profile = new AgentRuntimeProfile
+        {
+            SubAgents = [new SubAgentDefinition { Name = name, Source = new ContentSource.FromInline("body") }],
+        };
+
+        Assert.Throws<ArgumentException>(() => ProfileMaterializer.Materialize(profile));
+    }
+
+    [Fact]
+    public void Materialize_ValidateNameThrows_StagingDirectoryIsCleanedUp()
+    {
+        // First skill is valid, second one trips ValidateName so the throw happens
+        // mid-materialization after the staging dir has been created.
+        var profile = new AgentRuntimeProfile
+        {
+            Skills =
+            [
+                AgentSkill.Inline("good", "body"),
+                new AgentSkill { Name = "../escape", Source = new ContentSource.FromInline("body") },
+            ],
+        };
+
+        // Snapshot temp dir contents matching our prefix to detect leaks.
+        var tempRoot = Path.GetTempPath();
+        var before = new HashSet<string>(
+            Directory.EnumerateDirectories(tempRoot, "lm-claude-*"),
+            StringComparer.OrdinalIgnoreCase);
+
+        Assert.Throws<ArgumentException>(() => ProfileMaterializer.Materialize(profile));
+
+        var after = Directory.EnumerateDirectories(tempRoot, "lm-claude-*");
+        var leaked = after.Where(d => !before.Contains(d)).ToList();
+        Assert.Empty(leaked);
+    }
+
+    [Fact]
+    public void Materialize_PathSubAgentFromFile_CopiesToAgentsDir()
+    {
+        var srcFile = Path.Combine(Path.GetTempPath(), $"sub-agent-src-{Guid.NewGuid():N}.md");
+        File.WriteAllText(srcFile, "agent body from file");
+        try
+        {
+            var profile = new AgentRuntimeProfile
+            {
+                SubAgents = [SubAgentDefinition.FromPath("from-file", srcFile)],
+            };
+
+            using var result = ProfileMaterializer.Materialize(profile);
+            var dest = Path.Combine(result.StagingDirectory!, "agents", "from-file.md");
+
+            Assert.True(File.Exists(dest));
+            Assert.Equal("agent body from file", File.ReadAllText(dest));
+        }
+        finally
+        {
+            if (File.Exists(srcFile))
+            {
+                File.Delete(srcFile);
+            }
+        }
+    }
+
+    [Fact]
+    public void Materialize_PathSubAgentFromDirectory_FirstMdCopied()
+    {
+        var srcDir = Path.Combine(Path.GetTempPath(), $"sub-agent-dir-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(srcDir);
+        // Two .md files; we just need to assert one of them is picked up. The exact
+        // ordering returned by Directory.EnumerateFiles is filesystem-specific, so
+        // we write the same body to both to keep the test deterministic.
+        File.WriteAllText(Path.Combine(srcDir, "alpha.md"), "agent body from dir");
+        File.WriteAllText(Path.Combine(srcDir, "beta.md"), "agent body from dir");
+        try
+        {
+            var profile = new AgentRuntimeProfile
+            {
+                SubAgents = [SubAgentDefinition.FromPath("from-dir", srcDir)],
+            };
+
+            using var result = ProfileMaterializer.Materialize(profile);
+            var dest = Path.Combine(result.StagingDirectory!, "agents", "from-dir.md");
+
+            Assert.True(File.Exists(dest));
+            Assert.Equal("agent body from dir", File.ReadAllText(dest));
+        }
+        finally
+        {
+            Directory.Delete(srcDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Materialize_PathSubAgentFromDirWithNoMd_ThrowsFileNotFound()
+    {
+        var srcDir = Path.Combine(Path.GetTempPath(), $"sub-agent-empty-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(Path.Combine(srcDir, "not-markdown.txt"), "ignored");
+        try
+        {
+            var profile = new AgentRuntimeProfile
+            {
+                SubAgents = [SubAgentDefinition.FromPath("no-md", srcDir)],
+            };
+
+            Assert.Throws<FileNotFoundException>(() => ProfileMaterializer.Materialize(profile));
+        }
+        finally
+        {
+            Directory.Delete(srcDir, recursive: true);
+        }
+    }
 }

--- a/tests/ClaudeAgentSdkProvider.Tests/Agents/ProfileMaterializationTests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Agents/ProfileMaterializationTests.cs
@@ -1,0 +1,165 @@
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Agents;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Tests.Agents;
+
+public class ProfileMaterializationTests
+{
+    [Fact]
+    public void Materialize_NullProfile_ReturnsEmptyHandle()
+    {
+        using var result = ProfileMaterializer.Materialize(null);
+
+        Assert.Null(result.StagingDirectory);
+        Assert.Empty(result.McpServers);
+        Assert.Null(result.SystemPrompt);
+    }
+
+    [Fact]
+    public void Materialize_EmptyProfile_ReturnsEmptyHandle()
+    {
+        using var result = ProfileMaterializer.Materialize(new AgentRuntimeProfile());
+
+        Assert.Null(result.StagingDirectory);
+        Assert.Empty(result.McpServers);
+        Assert.Null(result.SystemPrompt);
+    }
+
+    [Fact]
+    public void Materialize_OnlyMcpAndSystemPrompt_NoStagingDirCreated()
+    {
+        var profile = new AgentRuntimeProfile
+        {
+            SystemPrompt = "hello",
+            McpServers = new Dictionary<string, McpServerConfig>
+            {
+                ["m"] = McpServerConfig.CreateStdio("node", ["a.js"]),
+            },
+        };
+
+        using var result = ProfileMaterializer.Materialize(profile);
+
+        Assert.Null(result.StagingDirectory);
+        Assert.Equal("hello", result.SystemPrompt);
+        Assert.True(result.McpServers.ContainsKey("m"));
+    }
+
+    [Fact]
+    public void Materialize_InlineSkill_WritesSkillMd()
+    {
+        var profile = new AgentRuntimeProfile
+        {
+            Skills = [AgentSkill.Inline("my-skill", "# Skill body")],
+        };
+
+        using var result = ProfileMaterializer.Materialize(profile);
+
+        Assert.NotNull(result.StagingDirectory);
+        var skillFile = Path.Combine(result.StagingDirectory!, "skills", "my-skill", "SKILL.md");
+        Assert.True(File.Exists(skillFile));
+        Assert.Equal("# Skill body", File.ReadAllText(skillFile));
+    }
+
+    [Fact]
+    public void Materialize_InlineSubAgent_WritesAgentMd()
+    {
+        var profile = new AgentRuntimeProfile
+        {
+            SubAgents = [SubAgentDefinition.Inline("my-agent", "agent body")],
+        };
+
+        using var result = ProfileMaterializer.Materialize(profile);
+
+        Assert.NotNull(result.StagingDirectory);
+        var agentFile = Path.Combine(result.StagingDirectory!, "agents", "my-agent.md");
+        Assert.True(File.Exists(agentFile));
+        Assert.Equal("agent body", File.ReadAllText(agentFile));
+    }
+
+    [Fact]
+    public void Materialize_PathSkillFromFile_CopiedToSkillMd()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"skill-src-{Guid.NewGuid():N}.md");
+        File.WriteAllText(tempFile, "file body");
+        try
+        {
+            var profile = new AgentRuntimeProfile
+            {
+                Skills = [AgentSkill.FromPath("name", tempFile)],
+            };
+
+            using var result = ProfileMaterializer.Materialize(profile);
+            var skillFile = Path.Combine(result.StagingDirectory!, "skills", "name", "SKILL.md");
+
+            Assert.True(File.Exists(skillFile));
+            Assert.Equal("file body", File.ReadAllText(skillFile));
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void Materialize_PathSkillFromDirectory_TreeReplicated()
+    {
+        var srcDir = Path.Combine(Path.GetTempPath(), $"skill-dir-{Guid.NewGuid():N}");
+        var subDir = Path.Combine(srcDir, "nested");
+        Directory.CreateDirectory(subDir);
+        File.WriteAllText(Path.Combine(srcDir, "SKILL.md"), "top");
+        File.WriteAllText(Path.Combine(subDir, "helper.md"), "nested");
+        try
+        {
+            var profile = new AgentRuntimeProfile
+            {
+                Skills = [AgentSkill.FromPath("name", srcDir)],
+            };
+
+            using var result = ProfileMaterializer.Materialize(profile);
+            var destSkillRoot = Path.Combine(result.StagingDirectory!, "skills", "name");
+
+            Assert.Equal("top", File.ReadAllText(Path.Combine(destSkillRoot, "SKILL.md")));
+            Assert.Equal("nested", File.ReadAllText(Path.Combine(destSkillRoot, "nested", "helper.md")));
+        }
+        finally
+        {
+            Directory.Delete(srcDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Materialize_StagingDir_DeletedOnDispose()
+    {
+        var profile = new AgentRuntimeProfile
+        {
+            Skills = [AgentSkill.Inline("x", "y")],
+        };
+        string? stagingPath;
+        using (var result = ProfileMaterializer.Materialize(profile))
+        {
+            stagingPath = result.StagingDirectory;
+            Assert.True(Directory.Exists(stagingPath));
+        }
+
+        Assert.False(Directory.Exists(stagingPath));
+    }
+
+    [Fact]
+    public void Materialize_McpServers_AreCopiedIntoHandle()
+    {
+        var profile = new AgentRuntimeProfile
+        {
+            McpServers = new Dictionary<string, McpServerConfig>
+            {
+                ["alpha"] = McpServerConfig.CreateStdio("node", ["a.js"]),
+                ["beta"] = McpServerConfig.CreateHttp("https://example.com"),
+            },
+        };
+
+        using var result = ProfileMaterializer.Materialize(profile);
+
+        Assert.Equal(2, result.McpServers.Count);
+        Assert.Equal("node", result.McpServers["alpha"].Command);
+        Assert.Equal("https://example.com", result.McpServers["beta"].Url);
+    }
+}

--- a/tests/ClaudeAgentSdkProvider.Tests/Models/McpConfigurationTests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Models/McpConfigurationTests.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+
+namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Tests.Models;
+
+/// <summary>
+///     Pins down the JSON contract for <see cref="McpConfiguration"/>. The
+///     <c>mcpServers</c> property name is the integration point with the Claude CLI's
+///     <c>.mcp.json</c> file format and must remain case-sensitive and exact.
+/// </summary>
+public class McpConfigurationTests
+{
+    [Fact]
+    public void Deserialize_McpServersJson_PopulatesDictionary()
+    {
+        const string json = """{"mcpServers":{"server1":{"command":"node","args":["a.js"]}}}""";
+
+        var config = JsonSerializer.Deserialize<McpConfiguration>(json);
+
+        Assert.NotNull(config);
+        Assert.Single(config!.McpServers);
+        Assert.True(config.McpServers.ContainsKey("server1"));
+        Assert.Equal("node", config.McpServers["server1"].Command);
+        Assert.NotNull(config.McpServers["server1"].Args);
+        Assert.Equal(["a.js"], config.McpServers["server1"].Args!);
+    }
+
+    [Fact]
+    public void Serialize_McpConfiguration_PreservesMcpServersPropertyName()
+    {
+        var config = new McpConfiguration
+        {
+            McpServers =
+            {
+                ["server1"] = new LmCore.AgentRuntime.McpServerConfig
+                {
+                    Type = "stdio",
+                    Command = "node",
+                    Args = ["a.js"],
+                },
+            },
+        };
+
+        var json = JsonSerializer.Serialize(config);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        // Case-sensitive: the property must be `mcpServers`, not `McpServers` or `mcpservers`.
+        Assert.True(root.TryGetProperty("mcpServers", out var serversElement));
+        Assert.False(root.TryGetProperty("McpServers", out _));
+        Assert.Equal(JsonValueKind.Object, serversElement.ValueKind);
+        Assert.True(serversElement.TryGetProperty("server1", out var server1));
+        Assert.Equal("node", server1.GetProperty("command").GetString());
+    }
+
+    [Fact]
+    public void RoundTrip_PreservesContents()
+    {
+        const string json = """{"mcpServers":{"server1":{"command":"node","args":["a.js"]}}}""";
+
+        var roundTripped = JsonSerializer.Serialize(
+            JsonSerializer.Deserialize<McpConfiguration>(json));
+        using var doc = JsonDocument.Parse(roundTripped);
+        var server1 = doc.RootElement.GetProperty("mcpServers").GetProperty("server1");
+
+        Assert.Equal("node", server1.GetProperty("command").GetString());
+        var args = server1.GetProperty("args").EnumerateArray().Select(a => a.GetString()).ToList();
+        Assert.Equal(["a.js"], args);
+    }
+}

--- a/tests/ClaudeAgentSdkProvider.Tests/Parsers/JsonlStreamParser.Tests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Parsers/JsonlStreamParser.Tests.cs
@@ -17,6 +17,34 @@ public class JsonlStreamParserTests
     // }
 
     [Fact]
+    public void ParseLine_StreamEvent_ReturnsStreamEvent()
+    {
+        var json = """
+            {
+              "type": "stream_event",
+              "event": {
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {
+                  "type": "tool_use",
+                  "id": "toolu_123",
+                  "name": "Read",
+                  "input": {}
+                }
+              },
+              "session_id": "session-123",
+              "parent_tool_use_id": null,
+              "uuid": "event-uuid-123"
+            }
+            """;
+
+        var parsed = _parser.ParseLine(json);
+
+        Assert.NotNull(parsed);
+        Assert.Equal("StreamEvent", parsed.GetType().Name);
+    }
+
+    [Fact]
     public void ConvertToMessages_TextContent_CreatesTextMessage()
     {
         // Arrange
@@ -499,11 +527,7 @@ public class JsonlStreamParserTests
         {
             Uuid = "user-uuid-image",
             SessionId = "session-image",
-            Message = new UserMessage
-            {
-                Role = "user",
-                Content = JsonDocument.Parse(imageContentJson).RootElement,
-            },
+            Message = new UserMessage { Role = "user", Content = JsonDocument.Parse(imageContentJson).RootElement },
         };
 
         // Act

--- a/tests/CodexSdkProvider.Tests/AgentRuntime/McpServerConfigExtensionsTests.cs
+++ b/tests/CodexSdkProvider.Tests/AgentRuntime/McpServerConfigExtensionsTests.cs
@@ -1,0 +1,48 @@
+using AchieveAi.LmDotnetTools.CodexSdkProvider.AgentRuntime;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.CodexSdkProvider.Tests.AgentRuntime;
+
+public class McpServerConfigExtensionsTests
+{
+    [Fact]
+    public void ToCodexConfig_StdioSource_MapsCommandArgsEnv()
+    {
+        var source = McpServerConfig.CreateStdio(
+            "node",
+            ["a.js", "--flag"],
+            new Dictionary<string, string> { ["K"] = "V" });
+
+        var codex = source.ToCodexConfig();
+
+        codex.Command.Should().Be("node");
+        codex.Args.Should().Equal("a.js", "--flag");
+        codex.Env.Should().ContainKey("K").WhoseValue.Should().Be("V");
+        codex.Url.Should().BeNull();
+        codex.Enabled.Should().BeNull();
+        codex.EnabledTools.Should().BeNull();
+        codex.DisabledTools.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToCodexConfig_HttpSource_MapsUrl()
+    {
+        var source = McpServerConfig.CreateHttp("https://mcp.example/v1");
+
+        var codex = source.ToCodexConfig();
+
+        codex.Url.Should().Be("https://mcp.example/v1");
+        codex.Command.Should().BeNull();
+        codex.Args.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToCodexConfig_NullSource_Throws()
+    {
+        McpServerConfig? source = null;
+
+        var act = () => source!.ToCodexConfig();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/LmCore.Tests/AchieveAi.LmDotnetTools.LmCore.Tests.csproj
+++ b/tests/LmCore.Tests/AchieveAi.LmDotnetTools.LmCore.Tests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="dotenv.net" Version="3.2.1" />
     <PackageReference Include="FluentAssertions" Version="7.1.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="System.Text.Json" Version="10.0.0" />
+    <PackageReference Include="System.Text.Json" Version="10.0.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/LmCore.Tests/AgentRuntime/AgentRuntimeProfileTests.cs
+++ b/tests/LmCore.Tests/AgentRuntime/AgentRuntimeProfileTests.cs
@@ -1,0 +1,43 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.AgentRuntime;
+
+public class AgentRuntimeProfileTests
+{
+    [Fact]
+    public void Defaults_AreEmpty()
+    {
+        var profile = new AgentRuntimeProfile();
+
+        Assert.Null(profile.SystemPrompt);
+        Assert.Empty(profile.Skills);
+        Assert.Empty(profile.SubAgents);
+        Assert.Empty(profile.McpServers);
+    }
+
+    [Fact]
+    public void InitOnly_PreservesAllFields()
+    {
+        var skills = new[] { AgentSkill.Inline("s1", "body") };
+        var subs = new[] { SubAgentDefinition.Inline("a1", "body") };
+        var mcp = new Dictionary<string, McpServerConfig>
+        {
+            ["m1"] = McpServerConfig.CreateStdio("node", ["a.js"]),
+        };
+
+        var profile = new AgentRuntimeProfile
+        {
+            SystemPrompt = "sp",
+            Skills = skills,
+            SubAgents = subs,
+            McpServers = mcp,
+        };
+
+        Assert.Equal("sp", profile.SystemPrompt);
+        Assert.Single(profile.Skills);
+        Assert.Equal("s1", profile.Skills[0].Name);
+        Assert.Single(profile.SubAgents);
+        Assert.Equal("a1", profile.SubAgents[0].Name);
+        Assert.True(profile.McpServers.ContainsKey("m1"));
+    }
+}

--- a/tests/LmCore.Tests/AgentRuntime/ContentSourceTests.cs
+++ b/tests/LmCore.Tests/AgentRuntime/ContentSourceTests.cs
@@ -1,0 +1,52 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.AgentRuntime;
+
+public class ContentSourceTests
+{
+    [Fact]
+    public void PatternMatch_HandlesBothVariants()
+    {
+        ContentSource fromPath = new ContentSource.FromPath("/tmp/skill.md");
+        ContentSource fromInline = new ContentSource.FromInline("inline body");
+
+        Assert.Equal("path:/tmp/skill.md", Render(fromPath));
+        Assert.Equal("inline:inline body", Render(fromInline));
+
+        static string Render(ContentSource source) => source switch
+        {
+            ContentSource.FromPath p => $"path:{p.Value}",
+            ContentSource.FromInline i => $"inline:{i.Content}",
+            _ => throw new InvalidOperationException(),
+        };
+    }
+
+    [Fact]
+    public void AgentSkill_InlineFactory_BuildsFromInline()
+    {
+        var skill = AgentSkill.Inline("name", "body");
+
+        Assert.Equal("name", skill.Name);
+        var inline = Assert.IsType<ContentSource.FromInline>(skill.Source);
+        Assert.Equal("body", inline.Content);
+    }
+
+    [Fact]
+    public void AgentSkill_FromPathFactory_BuildsFromPath()
+    {
+        var skill = AgentSkill.FromPath("name", "/some/path");
+
+        var fromPath = Assert.IsType<ContentSource.FromPath>(skill.Source);
+        Assert.Equal("/some/path", fromPath.Value);
+    }
+
+    [Fact]
+    public void SubAgentDefinition_Factories_RoundTrip()
+    {
+        var inline = SubAgentDefinition.Inline("sa", "body");
+        var path = SubAgentDefinition.FromPath("sa", "/p.md");
+
+        Assert.IsType<ContentSource.FromInline>(inline.Source);
+        Assert.IsType<ContentSource.FromPath>(path.Source);
+    }
+}

--- a/tests/LmMultiTurn.Tests/ClaudeAgentLoopFlushTests.cs
+++ b/tests/LmMultiTurn.Tests/ClaudeAgentLoopFlushTests.cs
@@ -1,0 +1,116 @@
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using FluentAssertions;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+/// <summary>
+/// Verifies the safety-net publish in <c>ClaudeAgentLoop.FlushPendingRunAssignmentsAsync</c>
+/// — when the dequeue heuristic misses, the deferred RunAssignmentMessage must still
+/// be emitted before run completion so consumers correlating the receipt id can
+/// match the run.
+/// </summary>
+public class ClaudeAgentLoopFlushTests
+{
+    [Fact]
+    public async Task FlushPendingRunAssignmentsAsync_PublishesPendingAssignment_WhenDequeueHeuristicMissed()
+    {
+        // Arrange: construct a ClaudeAgentLoop without ever starting the run loop.
+        // We use the internal-visibility hooks to seed _pendingCliInputs and invoke
+        // the flush method directly — this isolates the flush behavior from the
+        // CLI process and dequeue heuristic.
+        var options = new ClaudeAgentSdkOptions
+        {
+            Mode = ClaudeAgentSdkMode.OneShot,
+        };
+
+        await using var loop = new ClaudeAgentLoop(
+            claudeOptions: options,
+            mcpServers: null,
+            threadId: "flush-test-thread");
+
+        var receiptId = "test-receipt-id";
+        var runId = "test-run-id";
+        var generationId = "test-gen-id";
+
+        var queuedInput = new QueuedInput(
+            new UserInput([new TextMessage { Text = "Hello", Role = Role.User }], InputId: receiptId),
+            receiptId,
+            DateTimeOffset.UtcNow);
+        var assignment = new RunAssignment(runId, generationId, [receiptId]);
+
+        loop._pendingCliInputs.Enqueue((queuedInput, assignment));
+
+        // Subscribe before flush so we can observe the published RunAssignmentMessage.
+        var receivedMessages = new List<IMessage>();
+        var subscriberCts = new CancellationTokenSource();
+        var subscribeTask = Task.Run(async () =>
+        {
+            await foreach (var msg in loop.SubscribeAsync(subscriberCts.Token))
+            {
+                receivedMessages.Add(msg);
+            }
+        });
+
+        // Give the subscriber a moment to register.
+        await Task.Delay(50);
+
+        // Act: invoke the flush directly (simulating run-loop completion calling
+        // it from the finally block).
+        await loop.FlushPendingRunAssignmentsAsync(runId, CancellationToken.None);
+
+        // Allow time for the published message to propagate to the subscriber.
+        await Task.Delay(50);
+        await subscriberCts.CancelAsync();
+        try { await subscribeTask; } catch (OperationCanceledException) { }
+
+        // Assert: a RunAssignmentMessage was published carrying our receipt id,
+        // and the pending queue was drained.
+        var assignmentMsg = receivedMessages.OfType<RunAssignmentMessage>().SingleOrDefault();
+        assignmentMsg.Should().NotBeNull("flush should publish exactly one RunAssignmentMessage for the run");
+        assignmentMsg!.Assignment.RunId.Should().Be(runId);
+        assignmentMsg.Assignment.InputIds.Should().Contain(receiptId,
+            "the published assignment must list the original receipt so consumers can correlate");
+
+        loop._pendingCliInputs.Should().BeEmpty("pending entries for the flushed run must be drained");
+    }
+
+    [Fact]
+    public async Task FlushPendingRunAssignmentsAsync_DoesNotDrainEntriesForOtherRuns()
+    {
+        // Arrange: two pending entries for different runs; flush should only
+        // drain the matching one.
+        var options = new ClaudeAgentSdkOptions { Mode = ClaudeAgentSdkMode.OneShot };
+        await using var loop = new ClaudeAgentLoop(
+            claudeOptions: options,
+            mcpServers: null,
+            threadId: "flush-isolation-test");
+
+        var runIdA = "run-a";
+        var runIdB = "run-b";
+
+        var inputA = new QueuedInput(
+            new UserInput([new TextMessage { Text = "A", Role = Role.User }], InputId: "rcpt-a"),
+            "rcpt-a",
+            DateTimeOffset.UtcNow);
+        var inputB = new QueuedInput(
+            new UserInput([new TextMessage { Text = "B", Role = Role.User }], InputId: "rcpt-b"),
+            "rcpt-b",
+            DateTimeOffset.UtcNow);
+
+        loop._pendingCliInputs.Enqueue((inputA, new RunAssignment(runIdA, "gen-a", ["rcpt-a"])));
+        loop._pendingCliInputs.Enqueue((inputB, new RunAssignment(runIdB, "gen-b", ["rcpt-b"])));
+
+        // Act: flush only runIdA. Note runIdA is at the head of the queue; the
+        // flush stops at the first entry whose RunId differs.
+        await loop.FlushPendingRunAssignmentsAsync(runIdA, CancellationToken.None);
+
+        // Assert: only runIdB's entry remains.
+        loop._pendingCliInputs.Should().HaveCount(1);
+        loop._pendingCliInputs.TryPeek(out var remaining).Should().BeTrue();
+        remaining.Assignment.RunId.Should().Be(runIdB);
+    }
+}

--- a/tests/LmMultiTurn.Tests/ClaudeAgentLoopProfileTests.cs
+++ b/tests/LmMultiTurn.Tests/ClaudeAgentLoopProfileTests.cs
@@ -1,0 +1,98 @@
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using FluentAssertions;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+public class ClaudeAgentLoopProfileTests
+{
+    [Fact]
+    public async Task BuildRequest_ProfileMcp_OverridesHostMcp_OnKeyCollision()
+    {
+        var hostMcp = new Dictionary<string, McpServerConfig>
+        {
+            ["alpha"] = McpServerConfig.CreateStdio("host-alpha", ["x"]),
+            ["shared"] = McpServerConfig.CreateStdio("host-shared", ["x"]),
+        };
+        var profileMcp = new Dictionary<string, McpServerConfig>
+        {
+            ["beta"] = McpServerConfig.CreateStdio("profile-beta", ["y"]),
+            ["shared"] = McpServerConfig.CreateStdio("profile-shared", ["y"]),
+        };
+
+        await using var loop = new ClaudeAgentLoop(
+            new ClaudeAgentSdkOptions
+            {
+                Profile = new AgentRuntimeProfile { McpServers = profileMcp },
+            },
+            mcpServers: hostMcp,
+            threadId: "thread-claude-profile-1");
+
+        var request = loop.BuildClaudeAgentSdkRequest();
+
+        request.McpServers.Should().NotBeNull();
+        request.McpServers!["alpha"].Command.Should().Be("host-alpha");
+        request.McpServers["beta"].Command.Should().Be("profile-beta");
+        request.McpServers["shared"].Command.Should().Be("profile-shared");
+    }
+
+    [Fact]
+    public async Task BuildRequest_ProfileNull_PreservesHostMcp()
+    {
+        var hostMcp = new Dictionary<string, McpServerConfig>
+        {
+            ["alpha"] = McpServerConfig.CreateStdio("host-alpha", ["x"]),
+        };
+
+        await using var loop = new ClaudeAgentLoop(
+            new ClaudeAgentSdkOptions(),
+            mcpServers: hostMcp,
+            threadId: "thread-claude-profile-2");
+
+        var request = loop.BuildClaudeAgentSdkRequest();
+
+        request.McpServers.Should().ContainKey("alpha");
+        request.McpServers!["alpha"].Command.Should().Be("host-alpha");
+        request.StagingDirectory.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BuildRequest_ProfileSystemPrompt_OverridesOptionsSystemPrompt()
+    {
+        await using var loop = new ClaudeAgentLoop(
+            new ClaudeAgentSdkOptions
+            {
+                Profile = new AgentRuntimeProfile { SystemPrompt = "profile-wins" },
+            },
+            mcpServers: null,
+            threadId: "thread-claude-profile-3",
+            systemPrompt: "ctor-prompt");
+
+        var request = loop.BuildClaudeAgentSdkRequest();
+
+        request.SystemPrompt.Should().Be("profile-wins");
+    }
+
+    [Fact]
+    public async Task BuildRequest_ProfileWithInlineSkill_SetsStagingDirectory()
+    {
+        var profile = new AgentRuntimeProfile
+        {
+            Skills = [AgentSkill.Inline("skill-1", "# body")],
+        };
+
+        await using var loop = new ClaudeAgentLoop(
+            new ClaudeAgentSdkOptions { Profile = profile },
+            mcpServers: null,
+            threadId: "thread-claude-profile-4");
+
+        var request = loop.BuildClaudeAgentSdkRequest();
+
+        request.StagingDirectory.Should().NotBeNullOrEmpty();
+        Directory.Exists(request.StagingDirectory).Should().BeTrue();
+        var skillFile = Path.Combine(request.StagingDirectory!, "skills", "skill-1", "SKILL.md");
+        File.Exists(skillFile).Should().BeTrue();
+    }
+}

--- a/tests/LmMultiTurn.Tests/ClaudeAgentLoopSettingSourcesTests.cs
+++ b/tests/LmMultiTurn.Tests/ClaudeAgentLoopSettingSourcesTests.cs
@@ -1,0 +1,81 @@
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+/// <summary>
+/// Locks in the boolean-to-string mapping ClaudeAgentLoop uses for the
+/// --setting-sources CLI flag. The three flags (user/project/local) drive a
+/// tri-state output:
+///   all true  -> null  (omit the flag, CLI uses its own default)
+///   all false -> ""    (emit empty value, isolated agent)
+///   mixed     -> comma-joined list of the enabled sources
+/// </summary>
+public class ClaudeAgentLoopSettingSourcesTests
+{
+    [Fact]
+    public void BuildSettingSources_AllTrue_ReturnsNull_SoFlagIsOmitted()
+    {
+        var options = new ClaudeAgentSdkOptions
+        {
+            IncludeUserSettings = true,
+            IncludeProjectSettings = true,
+            IncludeLocalSettings = true,
+        };
+
+        var result = ClaudeAgentLoop.BuildSettingSources(options);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void BuildSettingSources_AllFalse_ReturnsEmptyString_ForIsolatedAgent()
+    {
+        var options = new ClaudeAgentSdkOptions
+        {
+            IncludeUserSettings = false,
+            IncludeProjectSettings = false,
+            IncludeLocalSettings = false,
+        };
+
+        var result = ClaudeAgentLoop.BuildSettingSources(options);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Theory]
+    [InlineData(true, false, false, "user")]
+    [InlineData(false, true, false, "project")]
+    [InlineData(false, false, true, "local")]
+    [InlineData(true, true, false, "user,project")]
+    [InlineData(true, false, true, "user,local")]
+    [InlineData(false, true, true, "project,local")]
+    public void BuildSettingSources_Mixed_ReturnsCommaJoinedSubset(
+        bool user, bool project, bool local, string expected)
+    {
+        var options = new ClaudeAgentSdkOptions
+        {
+            IncludeUserSettings = user,
+            IncludeProjectSettings = project,
+            IncludeLocalSettings = local,
+        };
+
+        var result = ClaudeAgentLoop.BuildSettingSources(options);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ClaudeAgentSdkOptions_Defaults_IncludeAllSettings()
+    {
+        // Regression: defaults must keep the host's installed plugins, sub-agents,
+        // skills, and worktree .mcp.json visible to the spawned agent.
+        var options = new ClaudeAgentSdkOptions();
+
+        Assert.True(options.IncludeUserSettings);
+        Assert.True(options.IncludeProjectSettings);
+        Assert.True(options.IncludeLocalSettings);
+        Assert.Null(ClaudeAgentLoop.BuildSettingSources(options));
+    }
+}

--- a/tests/LmMultiTurn.Tests/ClaudeAgentLoopSystemInitRelayTests.cs
+++ b/tests/LmMultiTurn.Tests/ClaudeAgentLoopSystemInitRelayTests.cs
@@ -5,35 +5,44 @@ using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmMultiTurn;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
 using FluentAssertions;
 using Xunit;
 
 namespace LmMultiTurn.Tests;
 
 /// <summary>
-/// Regression for Bug 3: SystemInitMessage (carrying SessionId/Model) was being
-/// dropped by ClaudeAgentLoop when handling the dequeue heuristic in Interactive
-/// mode, blocking consumers (e.g. session-resume continuity) from observing the
-/// session id assigned to a run.
+/// Validates how <see cref="ClaudeAgentLoop"/> surfaces the Claude SDK session id
+/// without leaking <see cref="SystemInitMessage"/> into the public message stream.
+///
+/// Contract:
+///   * <c>SystemInitMessage</c> is SDK metadata and must NOT appear in messages
+///     observed by consumers via <c>ExecuteRunAsync</c> or <c>SubscribeAsync</c>.
+///   * The session id assigned by the SDK MUST be observable via
+///     <see cref="ClaudeAgentLoop.CurrentSessionId"/> in BOTH Interactive
+///     (where the SDK emits <c>SystemInitMessage</c>) and OneShot mode (where
+///     it does not — only <see cref="IClaudeAgentSdkClient.CurrentSession"/> is
+///     updated).
+///   * When a persistence store is configured, the latest session id is written
+///     into <see cref="ThreadMetadata.SessionMappings"/> under the
+///     <c>"claude-sdk:{sessionId}"</c> key, mapped to the <c>RunId</c>.
 /// </summary>
 public class ClaudeAgentLoopSystemInitRelayTests
 {
     [Fact]
-    public async Task ExecuteRunAsync_RelaysSystemInitMessage_WithSessionId()
+    public async Task Interactive_ExposesSessionId_AndDoesNotLeakSystemInitMessage()
     {
-        // Arrange: an in-process mock SDK client that yields a SystemInitMessage
-        // with a known SessionId followed by a ResultEventMessage to terminate
-        // the Interactive subscription.
-        const string expectedSessionId = "sess-test-123";
+        const string expectedSessionId = "sess-interactive-123";
         const string expectedModel = "claude-sonnet-4-6";
 
         var scriptedMessages = new List<IMessage>
         {
             new SystemInitMessage { SessionId = expectedSessionId, Model = expectedModel },
+            new TextMessage { Text = "hello", Role = Role.Assistant },
             new ResultEventMessage { IsError = false },
         };
 
-        var mockClient = new ScriptedClaudeAgentSdkClient(scriptedMessages);
+        var mockClient = new ScriptedClaudeAgentSdkClient(scriptedMessages, expectedSessionId);
 
         var options = new ClaudeAgentSdkOptions
         {
@@ -44,53 +53,181 @@ public class ClaudeAgentLoopSystemInitRelayTests
         await using var loop = new ClaudeAgentLoop(
             claudeOptions: options,
             mcpServers: null,
-            threadId: "system-init-relay-test",
+            threadId: "interactive-session-test",
             clientFactory: (_, _) => mockClient);
 
+        var (received, _) = await DriveOneRunAsync(loop);
+
+        received.OfType<SystemInitMessage>().Should().BeEmpty(
+            "SystemInitMessage is SDK metadata and must not be published to consumers");
+        received.OfType<TextMessage>().Should().Contain(t => t.Text == "hello");
+
+        loop.CurrentSessionId.Should().Be(expectedSessionId,
+            "Interactive mode must capture SessionId from SystemInitMessage");
+    }
+
+    [Fact]
+    public async Task OneShot_ExposesSessionId_FromClientCurrentSession()
+    {
+        // Critical: OneShot mode's SendMessagesAsync intentionally suppresses
+        // SystemInitMessage (emitSystemInit:false in ClaudeAgentSdkClient.cs).
+        // The loop must instead poll the underlying client's CurrentSession.
+        const string expectedSessionId = "sess-oneshot-456";
+
+        // No SystemInitMessage in scripted stream — mirrors real OneShot behavior.
+        var scriptedMessages = new List<IMessage>
+        {
+            new TextMessage { Text = "hello", Role = Role.Assistant },
+            new ResultEventMessage { IsError = false },
+        };
+
+        var mockClient = new ScriptedClaudeAgentSdkClient(scriptedMessages, expectedSessionId);
+
+        var options = new ClaudeAgentSdkOptions
+        {
+            Mode = ClaudeAgentSdkMode.OneShot,
+            MaxTurnsPerRun = 5,
+        };
+
+        await using var loop = new ClaudeAgentLoop(
+            claudeOptions: options,
+            mcpServers: null,
+            threadId: "oneshot-session-test",
+            clientFactory: (_, _) => mockClient);
+
+        var (received, _) = await DriveOneRunAsync(loop);
+
+        received.OfType<SystemInitMessage>().Should().BeEmpty(
+            "OneShot path must not publish SystemInitMessage either");
+
+        loop.CurrentSessionId.Should().Be(expectedSessionId,
+            "OneShot mode must capture SessionId from IClaudeAgentSdkClient.CurrentSession " +
+            "since the SDK does not surface SystemInitMessage in this path");
+    }
+
+    [Fact]
+    public async Task OneShot_PersistsSessionId_InThreadMetadataSessionMappings()
+    {
+        const string expectedSessionId = "sess-oneshot-persist-789";
+
+        var scriptedMessages = new List<IMessage>
+        {
+            new TextMessage { Text = "hello", Role = Role.Assistant },
+            new ResultEventMessage { IsError = false },
+        };
+
+        var mockClient = new ScriptedClaudeAgentSdkClient(scriptedMessages, expectedSessionId);
+        var store = new InMemoryConversationStore();
+        var threadId = "oneshot-persist-test";
+
+        var options = new ClaudeAgentSdkOptions
+        {
+            Mode = ClaudeAgentSdkMode.OneShot,
+            MaxTurnsPerRun = 5,
+        };
+
+        await using (var loop = new ClaudeAgentLoop(
+            claudeOptions: options,
+            mcpServers: null,
+            threadId: threadId,
+            store: store,
+            clientFactory: (_, _) => mockClient))
+        {
+            await DriveOneRunAsync(loop);
+        }
+
+        var metadata = await store.LoadMetadataAsync(threadId);
+        metadata.Should().NotBeNull();
+        metadata!.SessionMappings.Should().NotBeNull();
+        metadata.SessionMappings!.Should().ContainKey($"claude-sdk:{expectedSessionId}",
+            "ClaudeAgentLoop must persist the SDK session id into ThreadMetadata.SessionMappings " +
+            "so a later process can resume the session");
+        metadata.LatestRunId.Should().NotBeNullOrEmpty();
+        metadata.SessionMappings![$"claude-sdk:{expectedSessionId}"]
+            .Should().Be(metadata.LatestRunId,
+                "the mapping value must be the run id the session id belongs to");
+    }
+
+    [Fact]
+    public async Task OneShot_CapturesSessionId_EvenWhenClientIsDisposedBetweenRuns()
+    {
+        // OneShot disposes the client at the end of each run via
+        // OnAfterRunAsync->DisposeClientResourcesAsync. Make sure the session id
+        // is snapshotted before disposal so it is still available afterwards.
+        const string expectedSessionId = "sess-oneshot-survives-dispose";
+
+        var scriptedMessages = new List<IMessage>
+        {
+            new TextMessage { Text = "hello", Role = Role.Assistant },
+            new ResultEventMessage { IsError = false },
+        };
+
+        var mockClient = new ScriptedClaudeAgentSdkClient(scriptedMessages, expectedSessionId);
+
+        var options = new ClaudeAgentSdkOptions
+        {
+            Mode = ClaudeAgentSdkMode.OneShot,
+            MaxTurnsPerRun = 5,
+        };
+
+        await using var loop = new ClaudeAgentLoop(
+            claudeOptions: options,
+            mcpServers: null,
+            threadId: "oneshot-dispose-test",
+            clientFactory: (_, _) => mockClient);
+
+        await DriveOneRunAsync(loop);
+
+        // After OneShot completes, OnAfterRunAsync has already disposed the
+        // client. The session id must still be readable from the loop.
+        loop.CurrentSessionId.Should().Be(expectedSessionId);
+    }
+
+    /// <summary>
+    /// Drives the loop through exactly one run via ExecuteRunAsync and returns
+    /// the messages observed plus the run task.
+    /// </summary>
+    private static async Task<(List<IMessage> Messages, Task Run)> DriveOneRunAsync(ClaudeAgentLoop loop)
+    {
         using var cts = new CancellationTokenSource();
         var runTask = loop.RunAsync(cts.Token);
 
         var userInput = new UserInput(
-            [new TextMessage { Text = "Hello", Role = Role.User }],
+            [new TextMessage { Text = "hi", Role = Role.User }],
             InputId: "test-input");
 
-        // Act: enumerate ExecuteRunAsync until completion (RunCompletedMessage
-        // ends the iteration). Use WaitAsync so a hang fails cleanly.
-        var receivedMessages = new List<IMessage>();
+        var received = new List<IMessage>();
         var executeTask = Task.Run(async () =>
         {
             await foreach (var msg in loop.ExecuteRunAsync(userInput, cts.Token))
             {
-                receivedMessages.Add(msg);
+                received.Add(msg);
             }
         });
 
         await executeTask.WaitAsync(TimeSpan.FromSeconds(10));
 
-        // Assert: SystemInitMessage with our SessionId reached the consumer.
-        var initMessages = receivedMessages.OfType<SystemInitMessage>().ToList();
-        initMessages.Should().NotBeEmpty(
-            "ClaudeAgentLoop must relay SystemInitMessage so consumers can capture SessionId for --resume");
-        initMessages[0].SessionId.Should().Be(expectedSessionId);
-        initMessages[0].Model.Should().Be(expectedModel);
-
-        // Cleanup
         await cts.CancelAsync();
         await loop.StopAsync();
+        return (received, runTask);
     }
 
     /// <summary>
-    /// Minimal in-process mock that replays a scripted message stream from
-    /// SubscribeToMessagesAsync and no-ops everything else. Stays alive across
-    /// Start/Send so ClaudeAgentLoop's Interactive code path can drive it.
+    /// Minimal in-process mock that:
+    ///   * Replays a scripted message stream from BOTH SubscribeToMessagesAsync
+    ///     (Interactive) and SendMessagesAsync (OneShot).
+    ///   * Reports the supplied session id via <see cref="CurrentSession"/> so
+    ///     the OneShot capture path can poll it.
     /// </summary>
     private sealed class ScriptedClaudeAgentSdkClient : IClaudeAgentSdkClient
     {
         private readonly IReadOnlyList<IMessage> _messages;
+        private readonly string _sessionId;
 
-        public ScriptedClaudeAgentSdkClient(IReadOnlyList<IMessage> messages)
+        public ScriptedClaudeAgentSdkClient(IReadOnlyList<IMessage> messages, string sessionId)
         {
             _messages = messages;
+            _sessionId = sessionId;
         }
 
         public bool IsRunning { get; private set; }
@@ -103,12 +240,9 @@ public class ClaudeAgentLoopSystemInitRelayTests
         {
             LastRequest = request;
             IsRunning = true;
-            CurrentSession = new SessionInfo
-            {
-                SessionId = request.SessionId ?? "scripted-session",
-                CreatedAt = DateTime.UtcNow,
-                ProjectRoot = "test",
-            };
+            // Real client populates CurrentSession only AFTER the SystemInitEvent
+            // arrives. Mirror that by leaving CurrentSession null until the first
+            // message is yielded below.
             return Task.CompletedTask;
         }
 
@@ -116,16 +250,36 @@ public class ClaudeAgentLoopSystemInitRelayTests
             IEnumerable<IMessage> messages,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
+            // Simulate the SDK populating CurrentSession when it parses
+            // SystemInitEvent — happens before the first message is yielded
+            // back to the caller.
+            CurrentSession = new SessionInfo
+            {
+                SessionId = _sessionId,
+                CreatedAt = DateTime.UtcNow,
+                ProjectRoot = "test",
+            };
+
             foreach (var msg in _messages)
             {
                 await Task.Delay(1, cancellationToken);
                 yield return msg;
             }
+
+            // OneShot: process exits at end of stream.
+            IsRunning = false;
         }
 
         public async IAsyncEnumerable<IMessage> SubscribeToMessagesAsync(
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
+            CurrentSession = new SessionInfo
+            {
+                SessionId = _sessionId,
+                CreatedAt = DateTime.UtcNow,
+                ProjectRoot = "test",
+            };
+
             foreach (var msg in _messages)
             {
                 await Task.Delay(5, cancellationToken);

--- a/tests/LmMultiTurn.Tests/ClaudeAgentLoopSystemInitRelayTests.cs
+++ b/tests/LmMultiTurn.Tests/ClaudeAgentLoopSystemInitRelayTests.cs
@@ -1,0 +1,159 @@
+using System.Runtime.CompilerServices;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Agents;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using FluentAssertions;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+/// <summary>
+/// Regression for Bug 3: SystemInitMessage (carrying SessionId/Model) was being
+/// dropped by ClaudeAgentLoop when handling the dequeue heuristic in Interactive
+/// mode, blocking consumers (e.g. session-resume continuity) from observing the
+/// session id assigned to a run.
+/// </summary>
+public class ClaudeAgentLoopSystemInitRelayTests
+{
+    [Fact]
+    public async Task ExecuteRunAsync_RelaysSystemInitMessage_WithSessionId()
+    {
+        // Arrange: an in-process mock SDK client that yields a SystemInitMessage
+        // with a known SessionId followed by a ResultEventMessage to terminate
+        // the Interactive subscription.
+        const string expectedSessionId = "sess-test-123";
+        const string expectedModel = "claude-sonnet-4-6";
+
+        var scriptedMessages = new List<IMessage>
+        {
+            new SystemInitMessage { SessionId = expectedSessionId, Model = expectedModel },
+            new ResultEventMessage { IsError = false },
+        };
+
+        var mockClient = new ScriptedClaudeAgentSdkClient(scriptedMessages);
+
+        var options = new ClaudeAgentSdkOptions
+        {
+            Mode = ClaudeAgentSdkMode.Interactive,
+            MaxTurnsPerRun = 5,
+        };
+
+        await using var loop = new ClaudeAgentLoop(
+            claudeOptions: options,
+            mcpServers: null,
+            threadId: "system-init-relay-test",
+            clientFactory: (_, _) => mockClient);
+
+        using var cts = new CancellationTokenSource();
+        var runTask = loop.RunAsync(cts.Token);
+
+        var userInput = new UserInput(
+            [new TextMessage { Text = "Hello", Role = Role.User }],
+            InputId: "test-input");
+
+        // Act: enumerate ExecuteRunAsync until completion (RunCompletedMessage
+        // ends the iteration). Use WaitAsync so a hang fails cleanly.
+        var receivedMessages = new List<IMessage>();
+        var executeTask = Task.Run(async () =>
+        {
+            await foreach (var msg in loop.ExecuteRunAsync(userInput, cts.Token))
+            {
+                receivedMessages.Add(msg);
+            }
+        });
+
+        await executeTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Assert: SystemInitMessage with our SessionId reached the consumer.
+        var initMessages = receivedMessages.OfType<SystemInitMessage>().ToList();
+        initMessages.Should().NotBeEmpty(
+            "ClaudeAgentLoop must relay SystemInitMessage so consumers can capture SessionId for --resume");
+        initMessages[0].SessionId.Should().Be(expectedSessionId);
+        initMessages[0].Model.Should().Be(expectedModel);
+
+        // Cleanup
+        await cts.CancelAsync();
+        await loop.StopAsync();
+    }
+
+    /// <summary>
+    /// Minimal in-process mock that replays a scripted message stream from
+    /// SubscribeToMessagesAsync and no-ops everything else. Stays alive across
+    /// Start/Send so ClaudeAgentLoop's Interactive code path can drive it.
+    /// </summary>
+    private sealed class ScriptedClaudeAgentSdkClient : IClaudeAgentSdkClient
+    {
+        private readonly IReadOnlyList<IMessage> _messages;
+
+        public ScriptedClaudeAgentSdkClient(IReadOnlyList<IMessage> messages)
+        {
+            _messages = messages;
+        }
+
+        public bool IsRunning { get; private set; }
+
+        public SessionInfo? CurrentSession { get; private set; }
+
+        public ClaudeAgentSdkRequest? LastRequest { get; private set; }
+
+        public Task StartAsync(ClaudeAgentSdkRequest request, CancellationToken cancellationToken = default)
+        {
+            LastRequest = request;
+            IsRunning = true;
+            CurrentSession = new SessionInfo
+            {
+                SessionId = request.SessionId ?? "scripted-session",
+                CreatedAt = DateTime.UtcNow,
+                ProjectRoot = "test",
+            };
+            return Task.CompletedTask;
+        }
+
+        public async IAsyncEnumerable<IMessage> SendMessagesAsync(
+            IEnumerable<IMessage> messages,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            foreach (var msg in _messages)
+            {
+                await Task.Delay(1, cancellationToken);
+                yield return msg;
+            }
+        }
+
+        public async IAsyncEnumerable<IMessage> SubscribeToMessagesAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            foreach (var msg in _messages)
+            {
+                await Task.Delay(5, cancellationToken);
+                yield return msg;
+            }
+        }
+
+        public Task SendAsync(IEnumerable<IMessage> messages, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<bool> SendExitCommandAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task ShutdownAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            IsRunning = false;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            IsRunning = false;
+            return ValueTask.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            IsRunning = false;
+        }
+    }
+}

--- a/tests/LmMultiTurn.Tests/CodexAgentLoopProfileTests.cs
+++ b/tests/LmMultiTurn.Tests/CodexAgentLoopProfileTests.cs
@@ -1,0 +1,273 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.CodexSdkProvider.Agents;
+using AchieveAi.LmDotnetTools.CodexSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.CodexSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using AchieveAi.LmDotnetTools.LmTestUtils.Logging;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace LmMultiTurn.Tests;
+
+public class CodexAgentLoopProfileTests : LoggingTestBase
+{
+    public CodexAgentLoopProfileTests(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public async Task Profile_SystemPrompt_OverridesDeveloperInstructions()
+    {
+        var fakeClient = new RecordingCodexClient(SuccessfulTurnEvents());
+
+        await using var loop = new CodexAgentLoop(
+            new CodexSdkOptions
+            {
+                DeveloperInstructions = "host-level",
+                Profile = new AgentRuntimeProfile { SystemPrompt = "profile-level" },
+            },
+            new Dictionary<string, CodexMcpServerConfig>(),
+            functionRegistry: null,
+            enabledTools: null,
+            threadId: "thread-profile-1",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CodexAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        fakeClient.LastStartOptions.Should().NotBeNull();
+        fakeClient.LastStartOptions!.DeveloperInstructions.Should().Be("profile-level");
+    }
+
+    [Fact]
+    public async Task Profile_McpServers_MergeWithHostMcp_ProfileWinsOnCollision()
+    {
+        var fakeClient = new RecordingCodexClient(SuccessfulTurnEvents());
+
+        var hostMcp = new Dictionary<string, CodexMcpServerConfig>
+        {
+            ["alpha"] = new() { Command = "host-alpha" },
+            ["shared"] = new() { Command = "host-shared" },
+        };
+
+        var profileMcp = new Dictionary<string, McpServerConfig>
+        {
+            ["beta"] = McpServerConfig.CreateStdio("profile-beta", ["x"]),
+            ["shared"] = McpServerConfig.CreateStdio("profile-shared", ["y"]),
+        };
+
+        await using var loop = new CodexAgentLoop(
+            new CodexSdkOptions
+            {
+                Profile = new AgentRuntimeProfile { McpServers = profileMcp },
+            },
+            hostMcp,
+            functionRegistry: null,
+            enabledTools: null,
+            threadId: "thread-profile-2",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CodexAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        var sent = fakeClient.LastStartOptions!.McpServers!;
+        sent.Should().ContainKey("alpha").WhoseValue.Command.Should().Be("host-alpha");
+        sent.Should().ContainKey("beta").WhoseValue.Command.Should().Be("profile-beta");
+        sent.Should().ContainKey("shared").WhoseValue.Command.Should().Be("profile-shared");
+    }
+
+    [Fact]
+    public async Task Profile_ProfileSystemPrompt_OverridesConstructorSystemPrompt()
+    {
+        var fakeClient = new RecordingCodexClient(SuccessfulTurnEvents());
+
+        await using var loop = new CodexAgentLoop(
+            new CodexSdkOptions
+            {
+                Profile = new AgentRuntimeProfile { SystemPrompt = "profile-wins" },
+            },
+            new Dictionary<string, CodexMcpServerConfig>(),
+            functionRegistry: null,
+            enabledTools: null,
+            threadId: "thread-profile-precedence-1",
+            systemPrompt: "ctor-prompt",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CodexAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        fakeClient.LastStartOptions!.DeveloperInstructions.Should().Be("profile-wins");
+    }
+
+    [Fact]
+    public async Task NoProfile_ConstructorSystemPrompt_WinsOverDeveloperInstructions()
+    {
+        var fakeClient = new RecordingCodexClient(SuccessfulTurnEvents());
+
+        await using var loop = new CodexAgentLoop(
+            new CodexSdkOptions { DeveloperInstructions = "host-level" },
+            new Dictionary<string, CodexMcpServerConfig>(),
+            functionRegistry: null,
+            enabledTools: null,
+            threadId: "thread-profile-precedence-2",
+            systemPrompt: "ctor-prompt",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CodexAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        fakeClient.LastStartOptions!.DeveloperInstructions.Should().Be("ctor-prompt");
+    }
+
+    [Fact]
+    public async Task Profile_WithSkillsOrSubAgents_WarningLoggedOnce_AcrossMultipleTurns()
+    {
+        var fakeClient = new RecordingCodexClient([.. SuccessfulTurnEvents(), .. SuccessfulTurnEvents()]);
+        var capture = new CapturingLogger<CodexAgentLoop>();
+
+        await using var loop = new CodexAgentLoop(
+            new CodexSdkOptions
+            {
+                Profile = new AgentRuntimeProfile
+                {
+                    Skills = [AgentSkill.Inline("s", "body")],
+                },
+            },
+            new Dictionary<string, CodexMcpServerConfig>(),
+            functionRegistry: null,
+            enabledTools: null,
+            threadId: "thread-codex-warning-once",
+            clientFactory: (_, _) => fakeClient,
+            logger: capture);
+
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+        var input = new UserInput([new TextMessage { Role = Role.User, Text = "hi" }]);
+        await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token)) { }
+        await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token)) { }
+        await cts.CancelAsync();
+
+        capture.WarningCount("codex.profile.unsupported").Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Profile_WithSkillsOrSubAgents_DoesNotAlterMcp_ButRuns()
+    {
+        var fakeClient = new RecordingCodexClient(SuccessfulTurnEvents());
+
+        await using var loop = new CodexAgentLoop(
+            new CodexSdkOptions
+            {
+                Profile = new AgentRuntimeProfile
+                {
+                    Skills = [AgentSkill.Inline("s", "body")],
+                    SubAgents = [SubAgentDefinition.Inline("a", "body")],
+                },
+            },
+            new Dictionary<string, CodexMcpServerConfig>(),
+            functionRegistry: null,
+            enabledTools: null,
+            threadId: "thread-profile-3",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CodexAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        fakeClient.LastStartOptions.Should().NotBeNull();
+        fakeClient.LastStartOptions!.McpServers.Should().BeEmpty();
+    }
+
+    private static async Task RunOneTurnAsync(CodexAgentLoop loop)
+    {
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+        var input = new UserInput([new TextMessage { Role = Role.User, Text = "hi" }]);
+        await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token))
+        {
+        }
+        await cts.CancelAsync();
+    }
+
+    private static IReadOnlyList<CodexTurnEventEnvelope> SuccessfulTurnEvents()
+    {
+        return
+        [
+            Event("thread.started", """{"type":"thread.started","thread_id":"t1"}"""),
+            Event("turn.completed", """{"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":0,"output_tokens":1}}"""),
+        ];
+    }
+
+    private static CodexTurnEventEnvelope Event(string name, string json)
+    {
+        var element = JsonDocument.Parse(json).RootElement.Clone();
+        return new CodexTurnEventEnvelope
+        {
+            Type = name,
+            Event = element,
+            RequestId = Guid.NewGuid().ToString("N"),
+            ThreadId = null,
+        };
+    }
+
+    private sealed class RecordingCodexClient : ICodexSdkClient
+    {
+        private readonly IReadOnlyList<CodexTurnEventEnvelope> _events;
+
+        public RecordingCodexClient(IReadOnlyList<CodexTurnEventEnvelope> events)
+        {
+            _events = events;
+        }
+
+        public CodexBridgeInitOptions? LastStartOptions { get; private set; }
+
+        public bool IsRunning { get; private set; }
+
+        public string? CurrentCodexThreadId { get; private set; }
+
+        public string? CurrentTurnId => null;
+
+        public string DependencyState => "ready";
+
+        public void ConfigureDynamicToolExecutor(
+            Func<CodexDynamicToolCallRequest, CancellationToken, Task<CodexDynamicToolCallResponse>>? executor)
+        {
+        }
+
+        public Task StartOrResumeThreadAsync(CodexBridgeInitOptions options, CancellationToken ct = default)
+        {
+            IsRunning = true;
+            CurrentCodexThreadId = options.ThreadId;
+            LastStartOptions = options;
+            return Task.CompletedTask;
+        }
+
+        public Task EnsureStartedAsync(CodexBridgeInitOptions options, CancellationToken ct = default)
+            => StartOrResumeThreadAsync(options, ct);
+
+        public async IAsyncEnumerable<CodexTurnEventEnvelope> RunStreamingAsync(
+            string input,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            foreach (var item in _events)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return item;
+                await Task.Yield();
+            }
+        }
+
+        public Task ShutdownAsync(TimeSpan? timeout = null, CancellationToken ct = default)
+        {
+            IsRunning = false;
+            return Task.CompletedTask;
+        }
+
+        public Task InterruptTurnAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/LmMultiTurn.Tests/CopilotAgentLoopProfileTests.cs
+++ b/tests/LmMultiTurn.Tests/CopilotAgentLoopProfileTests.cs
@@ -92,6 +92,35 @@ public class CopilotAgentLoopProfileTests : LoggingTestBase
     }
 
     [Fact]
+    public async Task Profile_WithSkillsAndSubAgents_TriggersWarningOnce()
+    {
+        var fakeClient = new RecordingCopilotClient([PromptCompleted(), PromptCompleted()]);
+        var capture = new CapturingLogger<CopilotAgentLoop>();
+
+        await using var loop = new CopilotAgentLoop(
+            new CopilotSdkOptions
+            {
+                Profile = new AgentRuntimeProfile
+                {
+                    Skills = [AgentSkill.Inline("s", "body")],
+                    SubAgents = [SubAgentDefinition.Inline("a", "body")],
+                },
+            },
+            threadId: "thread-copilot-warning-skills-subagents",
+            clientFactory: (_, _) => fakeClient,
+            logger: capture);
+
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+        var input = new UserInput([new TextMessage { Role = Role.User, Text = "hi" }]);
+        await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token)) { }
+        await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token)) { }
+        await cts.CancelAsync();
+
+        capture.WarningCount("copilot.profile.unsupported").Should().Be(1);
+    }
+
+    [Fact]
     public async Task Profile_WithUnsupportedInputs_DoesNotCrash()
     {
         var fakeClient = new RecordingCopilotClient([PromptCompleted()]);

--- a/tests/LmMultiTurn.Tests/CopilotAgentLoopProfileTests.cs
+++ b/tests/LmMultiTurn.Tests/CopilotAgentLoopProfileTests.cs
@@ -1,0 +1,201 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.CopilotSdkProvider.Agents;
+using AchieveAi.LmDotnetTools.CopilotSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.CopilotSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using AchieveAi.LmDotnetTools.LmTestUtils.Logging;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace LmMultiTurn.Tests;
+
+public class CopilotAgentLoopProfileTests : LoggingTestBase
+{
+    public CopilotAgentLoopProfileTests(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public async Task Profile_SystemPrompt_OverridesDeveloperInstructions()
+    {
+        var fakeClient = new RecordingCopilotClient([PromptCompleted()]);
+
+        await using var loop = new CopilotAgentLoop(
+            new CopilotSdkOptions
+            {
+                DeveloperInstructions = "host-level",
+                Profile = new AgentRuntimeProfile { SystemPrompt = "profile-level" },
+            },
+            threadId: "thread-copilot-profile-1",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CopilotAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        fakeClient.LastStartOptions.Should().NotBeNull();
+        fakeClient.LastStartOptions!.DeveloperInstructions.Should().Be("profile-level");
+    }
+
+    [Fact]
+    public async Task Profile_ProfileSystemPrompt_OverridesConstructorSystemPrompt()
+    {
+        var fakeClient = new RecordingCopilotClient([PromptCompleted()]);
+
+        await using var loop = new CopilotAgentLoop(
+            new CopilotSdkOptions
+            {
+                Profile = new AgentRuntimeProfile { SystemPrompt = "profile-wins" },
+            },
+            threadId: "thread-copilot-profile-2",
+            systemPrompt: "ctor-prompt",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CopilotAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        fakeClient.LastStartOptions!.DeveloperInstructions.Should().Be("profile-wins");
+    }
+
+    [Fact]
+    public async Task Profile_WithUnsupportedInputs_WarningLoggedOnce_AcrossMultipleTurns()
+    {
+        var fakeClient = new RecordingCopilotClient([PromptCompleted(), PromptCompleted()]);
+        var capture = new CapturingLogger<CopilotAgentLoop>();
+
+        await using var loop = new CopilotAgentLoop(
+            new CopilotSdkOptions
+            {
+                Profile = new AgentRuntimeProfile
+                {
+                    McpServers = new Dictionary<string, McpServerConfig>
+                    {
+                        ["m"] = McpServerConfig.CreateStdio("node", ["a.js"]),
+                    },
+                },
+            },
+            threadId: "thread-copilot-warning-once",
+            clientFactory: (_, _) => fakeClient,
+            logger: capture);
+
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+        var input = new UserInput([new TextMessage { Role = Role.User, Text = "hi" }]);
+        await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token)) { }
+        await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token)) { }
+        await cts.CancelAsync();
+
+        capture.WarningCount("copilot.profile.unsupported").Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Profile_WithUnsupportedInputs_DoesNotCrash()
+    {
+        var fakeClient = new RecordingCopilotClient([PromptCompleted()]);
+
+        await using var loop = new CopilotAgentLoop(
+            new CopilotSdkOptions
+            {
+                Profile = new AgentRuntimeProfile
+                {
+                    Skills = [AgentSkill.Inline("s", "body")],
+                    SubAgents = [SubAgentDefinition.Inline("a", "body")],
+                    McpServers = new Dictionary<string, McpServerConfig>
+                    {
+                        ["ignored"] = McpServerConfig.CreateStdio("node", ["a.js"]),
+                    },
+                },
+            },
+            threadId: "thread-copilot-profile-3",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CopilotAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        fakeClient.LastStartOptions.Should().NotBeNull();
+    }
+
+    private static async Task RunOneTurnAsync(CopilotAgentLoop loop)
+    {
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+        var input = new UserInput([new TextMessage { Role = Role.User, Text = "hi" }]);
+        await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token))
+        {
+        }
+        await cts.CancelAsync();
+    }
+
+    private static CopilotTurnEventEnvelope PromptCompleted()
+    {
+        const string json = """{"type":"session/prompt/completed","usage":{"inputTokens":1,"outputTokens":1}}""";
+        var element = JsonDocument.Parse(json).RootElement.Clone();
+        return new CopilotTurnEventEnvelope
+        {
+            Type = "event",
+            Event = element,
+            RequestId = Guid.NewGuid().ToString("N"),
+            SessionId = null,
+        };
+    }
+
+    private sealed class RecordingCopilotClient : ICopilotSdkClient
+    {
+        private readonly IReadOnlyList<CopilotTurnEventEnvelope> _events;
+
+        public RecordingCopilotClient(IReadOnlyList<CopilotTurnEventEnvelope> events)
+        {
+            _events = events;
+        }
+
+        public CopilotBridgeInitOptions? LastStartOptions { get; private set; }
+
+        public bool IsRunning { get; private set; }
+
+        public string? CurrentCopilotSessionId { get; private set; }
+
+        public string DependencyState => "ready";
+
+        public void ConfigureDynamicToolExecutor(
+            Func<CopilotDynamicToolCallRequest, CancellationToken, Task<CopilotDynamicToolCallResponse>>? executor)
+        {
+        }
+
+        public Task StartOrResumeSessionAsync(CopilotBridgeInitOptions options, CancellationToken ct = default)
+        {
+            IsRunning = true;
+            LastStartOptions = options;
+            CurrentCopilotSessionId = "session-mock";
+            return Task.CompletedTask;
+        }
+
+        public Task EnsureStartedAsync(CopilotBridgeInitOptions options, CancellationToken ct = default)
+            => StartOrResumeSessionAsync(options, ct);
+
+        public async IAsyncEnumerable<CopilotTurnEventEnvelope> RunStreamingAsync(
+            string input,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            foreach (var item in _events)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return item;
+                await Task.Yield();
+            }
+        }
+
+        public Task InterruptTurnAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task ShutdownAsync(TimeSpan? timeout = null, CancellationToken ct = default)
+        {
+            IsRunning = false;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+}

--- a/tests/LmMultiTurn.Tests/LmMultiTurn.Tests.csproj
+++ b/tests/LmMultiTurn.Tests/LmMultiTurn.Tests.csproj
@@ -21,7 +21,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="7.1.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LmMultiTurn\AchieveAi.LmDotnetTools.LmMultiTurn.csproj" />

--- a/tests/LmMultiTurn.Tests/MultiTurnAgentBaseTests.cs
+++ b/tests/LmMultiTurn.Tests/MultiTurnAgentBaseTests.cs
@@ -23,6 +23,8 @@ public class MultiTurnAgentBaseTests
     private class TestMultiTurnAgent : MultiTurnAgentBase
     {
         private readonly List<IMessage> _messagesToReturn;
+        private readonly bool _stripReceiptIdsFromAssignment;
+        private readonly TimeSpan _fallbackGracePeriod;
 
         public int ExecuteCallCount { get; private set; }
         public string? LastRunId { get; private set; }
@@ -34,12 +36,18 @@ public class MultiTurnAgentBaseTests
             bool shouldFork = false,
             string? systemPrompt = null,
             ILogger? logger = null,
-            IConversationStore? store = null)
+            IConversationStore? store = null,
+            bool stripReceiptIdsFromAssignment = false,
+            TimeSpan? fallbackGracePeriod = null)
             : base(threadId, systemPrompt, store: store, logger: logger)
         {
             _messagesToReturn = messagesToReturn ?? [];
+            _stripReceiptIdsFromAssignment = stripReceiptIdsFromAssignment;
+            _fallbackGracePeriod = fallbackGracePeriod ?? TimeSpan.FromMilliseconds(100);
             _ = shouldFork; // No longer used but kept for API compatibility
         }
+
+        protected override TimeSpan FallbackGracePeriod => _fallbackGracePeriod;
 
         protected override async Task RunLoopAsync(CancellationToken ct)
         {
@@ -64,9 +72,16 @@ public class MultiTurnAgentBaseTests
                 LastRunId = assignment.RunId;
                 LastGenerationId = assignment.GenerationId;
 
+                // Optionally strip InputIds to model implementations (e.g.,
+                // ClaudeAgentLoop's dequeue-deferred publisher) that may publish a
+                // RunAssignmentMessage that doesn't list the caller's receipt.
+                var publishedAssignment = _stripReceiptIdsFromAssignment
+                    ? assignment with { InputIds = [] }
+                    : assignment;
+
                 await PublishToAllAsync(new RunAssignmentMessage
                 {
-                    Assignment = assignment,
+                    Assignment = publishedAssignment,
                     ThreadId = ThreadId,
                 }, ct);
 
@@ -209,6 +224,179 @@ public class MultiTurnAgentBaseTests
         await cts.CancelAsync();
         await agent.StopAsync();
         await agent.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ExecuteRunAsync_TerminatesViaFallback_WhenAssignmentMissesReceiptId()
+    {
+        // Arrange: an agent that simulates an implementation publishing a
+        // RunAssignmentMessage with empty InputIds (e.g., ClaudeAgentLoop's
+        // dequeue-deferred publish path missing the dequeue signal).
+        var testMessage = new TextMessage { Text = "Response", Role = Role.Assistant };
+        var agent = new TestMultiTurnAgent(
+            "test-thread",
+            messagesToReturn: [testMessage],
+            stripReceiptIdsFromAssignment: true,
+            fallbackGracePeriod: TimeSpan.FromMilliseconds(100));
+
+        using var cts = new CancellationTokenSource();
+        var runTask = agent.RunAsync(cts.Token);
+
+        var userInput = new UserInput(
+            [new TextMessage { Text = "Hello", Role = Role.User }],
+            InputId: "fallback-test-input");
+
+        // Act: enumerate ExecuteRunAsync. Wraps in WaitAsync so a hang fails the
+        // test cleanly with TimeoutException instead of bleeding into xUnit's
+        // outer timeout.
+        var receivedMessages = new List<IMessage>();
+        var executeTask = Task.Run(async () =>
+        {
+            await foreach (var msg in agent.ExecuteRunAsync(userInput, cts.Token))
+            {
+                receivedMessages.Add(msg);
+            }
+        });
+
+        await executeTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        receivedMessages.OfType<RunAssignmentMessage>().Should().NotBeEmpty();
+        receivedMessages.OfType<RunCompletedMessage>().Should().NotBeEmpty();
+
+        // Cleanup
+        await cts.CancelAsync();
+        await agent.StopAsync();
+        await agent.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ExecuteRunAsync_DoesNotTerminateOnPriorRunCompletion_WhenOurRunStillPending()
+    {
+        // Regression: the deferred fallback must NOT trip on a prior in-flight
+        // run's completion before our run has even started. The agent here
+        // strips receipt ids on the FIRST run only — modeling: a prior run was
+        // already in flight when we subscribed (its RunAssignmentMessage came
+        // through but didn't list our receipt because we hadn't sent yet), then
+        // our run starts and is correctly receipt-correlated. Without the
+        // deferred-fallback grace logic, the immediate fallback would fire on
+        // run #1's completion and yield-break before run #2 (our run) ran.
+        var firstResponse = new TextMessage { Text = "First run response", Role = Role.Assistant };
+        var secondResponse = new TextMessage { Text = "Second run response", Role = Role.Assistant };
+        var agent = new TwoRunTestAgent(
+            "test-thread",
+            firstRunMessages: [firstResponse],
+            secondRunMessages: [secondResponse],
+            stripReceiptOnFirstRun: true,
+            fallbackGracePeriod: TimeSpan.FromMilliseconds(200));
+
+        using var cts = new CancellationTokenSource();
+        var runTask = agent.RunAsync(cts.Token);
+
+        // Pre-queue an input that will become run #1 BEFORE we subscribe via
+        // ExecuteRunAsync. This input belongs to a different caller (us, here,
+        // simulating concurrent callers).
+        await agent.SendAsync(
+            [new TextMessage { Text = "First", Role = Role.User }],
+            inputId: "prior-input");
+
+        // Brief delay so run #1 starts and its assignment is published.
+        await Task.Delay(50);
+
+        var userInput = new UserInput(
+            [new TextMessage { Text = "Second", Role = Role.User }],
+            InputId: "our-input");
+
+        var receivedMessages = new List<IMessage>();
+        var executeTask = Task.Run(async () =>
+        {
+            await foreach (var msg in agent.ExecuteRunAsync(userInput, cts.Token))
+            {
+                receivedMessages.Add(msg);
+            }
+        });
+
+        await executeTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Must have observed BOTH responses — the iterator should not have
+        // terminated on run #1's completion.
+        receivedMessages.OfType<TextMessage>().Should().Contain(m => m.Text == "Second run response",
+            "ExecuteRunAsync must wait for our actual run, not yield-break on a prior run's completion");
+
+        await cts.CancelAsync();
+        await agent.StopAsync();
+        await agent.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Test agent that distinguishes the first run from later runs so we can
+    /// model a prior in-flight run that did not include the caller's receipt.
+    /// </summary>
+    private sealed class TwoRunTestAgent : MultiTurnAgentBase
+    {
+        private readonly List<IMessage> _firstRunMessages;
+        private readonly List<IMessage> _secondRunMessages;
+        private readonly bool _stripReceiptOnFirstRun;
+        private readonly TimeSpan _fallbackGracePeriod;
+        private int _runIndex;
+
+        public TwoRunTestAgent(
+            string threadId,
+            List<IMessage> firstRunMessages,
+            List<IMessage> secondRunMessages,
+            bool stripReceiptOnFirstRun,
+            TimeSpan fallbackGracePeriod)
+            : base(threadId)
+        {
+            _firstRunMessages = firstRunMessages;
+            _secondRunMessages = secondRunMessages;
+            _stripReceiptOnFirstRun = stripReceiptOnFirstRun;
+            _fallbackGracePeriod = fallbackGracePeriod;
+        }
+
+        protected override TimeSpan FallbackGracePeriod => _fallbackGracePeriod;
+
+        protected override async Task RunLoopAsync(CancellationToken ct)
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                if (!await InputReader.WaitToReadAsync(ct))
+                {
+                    break;
+                }
+
+                TryDrainInputs(out var batch);
+                if (batch.Count == 0)
+                {
+                    continue;
+                }
+
+                _runIndex++;
+                var assignment = StartRun(batch);
+                var stripReceipts = _stripReceiptOnFirstRun && _runIndex == 1;
+                var publishedAssignment = stripReceipts
+                    ? assignment with { InputIds = [] }
+                    : assignment;
+
+                await PublishToAllAsync(new RunAssignmentMessage
+                {
+                    Assignment = publishedAssignment,
+                    ThreadId = ThreadId,
+                }, ct);
+
+                var messagesForThisRun = _runIndex == 1 ? _firstRunMessages : _secondRunMessages;
+                try
+                {
+                    foreach (var msg in messagesForThisRun)
+                    {
+                        await PublishToAllAsync(msg, ct);
+                    }
+                }
+                finally
+                {
+                    await CompleteRunAsync(assignment.RunId, assignment.GenerationId, false, null, 0, ct: ct);
+                }
+            }
+        }
     }
 
     [Fact]

--- a/tests/LmMultiTurn.Tests/ProfileSystemPromptResolverTests.cs
+++ b/tests/LmMultiTurn.Tests/ProfileSystemPromptResolverTests.cs
@@ -1,0 +1,22 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using FluentAssertions;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+public class ProfileSystemPromptResolverTests
+{
+    [Theory]
+    [InlineData("profile", null, null, "profile")]      // profile wins
+    [InlineData(null, "ctor", null, "ctor")]              // ctor wins
+    [InlineData(null, null, "dev", "dev")]                // devInstructions wins
+    [InlineData(null, null, null, null)]                   // all null
+    [InlineData("profile", "ctor", "dev", "profile")]     // profile beats all
+    [InlineData("  ", "ctor", null, "ctor")]              // whitespace profile skipped
+    public void Resolve_PrecedenceCascade(string? profilePrompt, string? ctorPrompt, string? devInstructions, string? expected)
+    {
+        var profile = profilePrompt is null ? null : new AgentRuntimeProfile { SystemPrompt = profilePrompt };
+        ProfileSystemPromptResolver.Resolve(profile, ctorPrompt, devInstructions).Should().Be(expected);
+    }
+}

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/BrowserWebAppFactory.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/BrowserWebAppFactory.cs
@@ -1,3 +1,4 @@
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
 using LmStreaming.Sample.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
@@ -36,6 +37,7 @@ public sealed class BrowserWebAppFactory : WebApplicationFactory<Program>
 {
     private readonly string _providerMode;
     private readonly ITestAgentBuilder? _builder;
+    private readonly string _conversationPath;
     private IHost? _kestrelHost;
     private string? _serverAddress;
 
@@ -63,13 +65,17 @@ public sealed class BrowserWebAppFactory : WebApplicationFactory<Program>
 
         if (isScriptedMode && builder is null)
         {
-            throw new ArgumentNullException(
-                nameof(builder),
-                "Scripted provider modes require an ITestAgentBuilder.");
+            throw new ArgumentNullException(nameof(builder), "Scripted provider modes require an ITestAgentBuilder.");
         }
 
         _providerMode = providerMode;
         _builder = builder;
+        _conversationPath = Path.Combine(
+            Path.GetTempPath(),
+            "lm-streaming-browser-e2e",
+            Guid.NewGuid().ToString("N"),
+            "conversations"
+        );
 
         // Program.cs reads LM_PROVIDER_MODE at the top-level, well before any host-builder
         // callback fires. Set it here so the sample picks the right test-mode agent factory.
@@ -94,18 +100,21 @@ public sealed class BrowserWebAppFactory : WebApplicationFactory<Program>
     {
         builder.UseEnvironment("Production");
 
-        // ConfigureTestServices runs after Program.cs's default registrations, so
-        // AddSingleton + RemoveAll last-wins semantics guarantee our builder is resolved.
-        // For *-mock modes the builder is unused (real CLI drives the in-process mock host),
-        // so leave the default registration in place when none is supplied.
-        if (_builder is not null)
+        builder.ConfigureTestServices(services =>
         {
-            builder.ConfigureTestServices(services =>
+            services.RemoveAll<IConversationStore>();
+            services.AddSingleton<IConversationStore>(new FileConversationStore(_conversationPath));
+
+            // ConfigureTestServices runs after Program.cs's default registrations, so
+            // AddSingleton + RemoveAll last-wins semantics guarantee our builder is resolved.
+            // For *-mock modes the builder is unused (real CLI drives the in-process mock host),
+            // so leave the default registration in place when none is supplied.
+            if (_builder is not null)
             {
                 services.RemoveAll<ITestAgentBuilder>();
                 services.AddSingleton(_builder);
-            });
-        }
+            }
+        });
     }
 
     protected override IHost CreateHost(IHostBuilder builder)
@@ -131,9 +140,7 @@ public sealed class BrowserWebAppFactory : WebApplicationFactory<Program>
         var server = host.Services.GetRequiredService<IServer>();
         var addressesFeature =
             server.Features.Get<IServerAddressesFeature>()
-            ?? throw new InvalidOperationException(
-                "Kestrel did not expose IServerAddressesFeature."
-            );
+            ?? throw new InvalidOperationException("Kestrel did not expose IServerAddressesFeature.");
 
         _serverAddress =
             addressesFeature.Addresses.FirstOrDefault()
@@ -169,9 +176,7 @@ public sealed class BrowserWebAppFactory : WebApplicationFactory<Program>
 
         if (_kestrelHost == null)
         {
-            throw new InvalidOperationException(
-                "Kestrel host was not captured — CreateHost override did not run."
-            );
+            throw new InvalidOperationException("Kestrel host was not captured — CreateHost override did not run.");
         }
     }
 
@@ -192,6 +197,12 @@ public sealed class BrowserWebAppFactory : WebApplicationFactory<Program>
                 _kestrelHost.Dispose();
                 _kestrelHost = null;
             }
+
+            var factoryTempDirectory = Directory.GetParent(_conversationPath)?.FullName;
+            if (!string.IsNullOrWhiteSpace(factoryTempDirectory) && Directory.Exists(factoryTempDirectory))
+            {
+                Directory.Delete(factoryTempDirectory, recursive: true);
+            }
         }
         finally
         {
@@ -205,5 +216,4 @@ public sealed class BrowserWebAppFactory : WebApplicationFactory<Program>
             base.Dispose(disposing);
         }
     }
-
 }

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs
@@ -31,6 +31,12 @@ public static class UiHelpers
         return page.GetByTestId("clear-button");
     }
 
+    /// <summary>New-chat button in the sidebar.</summary>
+    public static ILocator NewChatButton(this IPage page)
+    {
+        return page.GetByRole(AriaRole.Button, new PageGetByRoleOptions { Name = "+ New Chat" });
+    }
+
     /// <summary>Error banner — rendered only when an error is present.</summary>
     public static ILocator ErrorBanner(this IPage page)
     {
@@ -77,6 +83,15 @@ public static class UiHelpers
     public static ILocator ToolCallPills(this IPage page)
     {
         return page.GetByTestId("tool-call-pill");
+    }
+
+    /// <summary>Returns rendered tool-call names from metadata pills.</summary>
+    public static Task<string[]> ToolCallNamesAsync(this IPage page)
+    {
+        return page.ToolCallPills()
+            .EvaluateAllAsync<string[]>(
+                "nodes => nodes.map(n => (n.getAttribute('data-tool-name') || n.textContent || '').trim())"
+            );
     }
 
     /// <summary>Mode selector button in the header.</summary>

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/ClaudeMockProviderTests.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/ClaudeMockProviderTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using LmStreaming.Sample.Browser.E2E.Tests.Infrastructure;
 
@@ -32,11 +33,9 @@ public sealed class ClaudeMockProviderTests
     public async Task Claude_mock_renders_assistant_text_in_chat_ui()
     {
         Skip.IfNot(
-            string.Equals(
-                Environment.GetEnvironmentVariable("LMDOTNET_RUN_CLAUDE_E2E"),
-                "1",
-                StringComparison.Ordinal),
-            "Set LMDOTNET_RUN_CLAUDE_E2E=1 to run claude-mock browser E2E tests.");
+            string.Equals(Environment.GetEnvironmentVariable("LMDOTNET_RUN_CLAUDE_E2E"), "1", StringComparison.Ordinal),
+            "Set LMDOTNET_RUN_CLAUDE_E2E=1 to run claude-mock browser E2E tests."
+        );
         Skip.IfNot(ClaudeCliIsAvailable(), "Claude CLI not found on PATH or via CLAUDE_CLI_PATH.");
 
         await using var factory = new BrowserWebAppFactory("claude-mock", builder: null);
@@ -45,6 +44,7 @@ public sealed class ClaudeMockProviderTests
 
         await page.GotoAsync(factory.ServerAddress);
         await page.Textarea().WaitForAsync();
+        await page.NewChatButton().ClickAsync();
 
         await page.SendMessageAsync("say hello");
         await page.WaitForStreamIdleAsync(timeoutMs: 60_000);
@@ -52,8 +52,118 @@ public sealed class ClaudeMockProviderTests
         await page.AssistantText().WaitForCountAtLeastAsync(1);
         var assistantTexts = await page.AssistantText().AllInnerTextsAsync();
         var combined = string.Join(" ", assistantTexts).Trim();
-        combined.Should().NotBeEmpty(
-            "issue #29: claude-mock previously completed silently with no rendered text");
+        combined.Should().NotBeEmpty("issue #29: claude-mock previously completed silently with no rendered text");
+    }
+
+    [SkippableFact]
+    public async Task Claude_mock_scenario_discovers_cli_tools_and_renders_tool_call_pills()
+    {
+        Skip.IfNot(
+            string.Equals(Environment.GetEnvironmentVariable("LMDOTNET_RUN_CLAUDE_E2E"), "1", StringComparison.Ordinal),
+            "Set LMDOTNET_RUN_CLAUDE_E2E=1 to run claude-mock browser E2E tests."
+        );
+        Skip.IfNot(ClaudeCliIsAvailable(), "Claude CLI not found on PATH or via CLAUDE_CLI_PATH.");
+
+        var fixturePath = Path.Combine(Path.GetTempPath(), $"claude-mock-read-{Guid.NewGuid():N}.txt");
+        var scenarioPath = Path.Combine(Path.GetTempPath(), $"claude-mock-tools-{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(fixturePath, "Claude mock browser E2E fixture for the Read tool.");
+        await File.WriteAllTextAsync(scenarioPath, BuildClaudeToolScenario(fixturePath));
+
+        var previousScenario = Environment.GetEnvironmentVariable("LM_MOCK_SCENARIO");
+        Environment.SetEnvironmentVariable("LM_MOCK_SCENARIO", scenarioPath);
+
+        try
+        {
+            await using var factory = new BrowserWebAppFactory("claude-mock", builder: null);
+            await using var context = await _fixture.Browser.NewContextAsync();
+            var page = await context.NewPageAsync();
+
+            await page.GotoAsync(factory.ServerAddress);
+            await page.Textarea().WaitForAsync();
+            await page.NewChatButton().ClickAsync();
+
+            await page.SendMessageAsync("discover available tools, then read the fixture twice");
+            await page.WaitForStreamIdleAsync(timeoutMs: 120_000);
+
+            await page.ToolCallPills().WaitForCountAtLeastAsync(2, timeoutMs: 45_000);
+            var toolNames = await page.ToolCallNamesAsync();
+            toolNames
+                .Count(name => name.Contains("Read", StringComparison.OrdinalIgnoreCase))
+                .Should()
+                .BeGreaterThanOrEqualTo(2);
+
+            await page.AssistantText().WaitForCountAtLeastAsync(1, timeoutMs: 30_000);
+            var assistantTexts = await page.AssistantText().AllInnerTextsAsync();
+            var combined = string.Join(" ", assistantTexts);
+            combined.Should().Contain("BROWSER_CLAUDE_TOOLS_DISCOVERED");
+            combined.Should().Contain("Read");
+            combined.Should().Contain("WebFetch");
+            combined.Should().Contain("BROWSER_CLAUDE_TOOL_FLOW_COMPLETE");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("LM_MOCK_SCENARIO", previousScenario);
+            File.Delete(scenarioPath);
+            File.Delete(fixturePath);
+        }
+    }
+
+    private static string BuildClaudeToolScenario(string fixturePath)
+    {
+        var scenario = new
+        {
+            roles = new object[]
+            {
+                new
+                {
+                    key = "claude-mock-tools-initial",
+                    match = new { type = "user_contains", value = "discover available tools" },
+                    turns = new[]
+                    {
+                        new
+                        {
+                            messages = new object[]
+                            {
+                                new
+                                {
+                                    kind = "text",
+                                    text = "BROWSER_CLAUDE_TOOLS_DISCOVERED: Read, WebSearch, WebFetch",
+                                },
+                                new
+                                {
+                                    kind = "tool_call",
+                                    name = "Read",
+                                    args = new { file_path = fixturePath },
+                                },
+                                new
+                                {
+                                    kind = "tool_call",
+                                    name = "Read",
+                                    args = new { file_path = fixturePath },
+                                },
+                            },
+                        },
+                    },
+                },
+                new
+                {
+                    key = "claude-mock-tools-final",
+                    match = new { type = "tool_result" },
+                    turns = new[]
+                    {
+                        new
+                        {
+                            messages = new object[]
+                            {
+                                new { kind = "text", text = "BROWSER_CLAUDE_TOOL_FLOW_COMPLETE" },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        return JsonSerializer.Serialize(scenario, new JsonSerializerOptions { WriteIndented = true });
     }
 
     private static bool ClaudeCliIsAvailable()
@@ -71,9 +181,7 @@ public sealed class ClaudeMockProviderTests
         }
 
         var separator = OperatingSystem.IsWindows() ? ';' : ':';
-        var exeNames = OperatingSystem.IsWindows()
-            ? new[] { "claude.exe", "claude.cmd", "claude.ps1" }
-            : ["claude"];
+        var exeNames = OperatingSystem.IsWindows() ? new[] { "claude.exe", "claude.cmd", "claude.ps1" } : ["claude"];
 
         foreach (var dir in pathEnv.Split(separator, StringSplitOptions.RemoveEmptyEntries))
         {

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/CodexMockProviderTests.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/CodexMockProviderTests.cs
@@ -1,0 +1,181 @@
+using FluentAssertions;
+using LmStreaming.Sample.Browser.E2E.Tests.Infrastructure;
+
+namespace LmStreaming.Sample.Browser.E2E.Tests.Scenarios;
+
+/// <summary>
+/// Browser-level regression for the Codex mock Responses transport: embedded instruction
+/// chains should drive the rendered assistant text instead of the mock host's fallback.
+/// </summary>
+/// <remarks>
+/// Skipped unless <c>LMDOTNET_RUN_CODEX_E2E=1</c> and a <c>codex</c> CLI binary is reachable on
+/// PATH or via <c>CODEX_CLI_PATH</c>. This mirrors the other CLI-backed browser E2E tests so
+/// machines without the external CLI skip cleanly.
+/// </remarks>
+[Collection(PlaywrightCollection.Name)]
+public sealed class CodexMockProviderTests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public CodexMockProviderTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [SkippableFact]
+    public async Task Codex_mock_honors_instruction_chain_in_chat_ui()
+    {
+        Skip.IfNot(
+            string.Equals(Environment.GetEnvironmentVariable("LMDOTNET_RUN_CODEX_E2E"), "1", StringComparison.Ordinal),
+            "Set LMDOTNET_RUN_CODEX_E2E=1 to run codex-mock browser E2E tests."
+        );
+        Skip.IfNot(CodexCliIsAvailable(), "Codex CLI not found on PATH or via CODEX_CLI_PATH.");
+
+        await using var factory = new BrowserWebAppFactory("codex-mock", builder: null);
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync(factory.ServerAddress);
+        await page.Textarea().WaitForAsync();
+        await page.NewChatButton().ClickAsync();
+
+        const string marker = "BROWSER_CODEX_CHAIN_OUTPUT";
+        const string instructionChain = """
+            <|instruction_start|>
+            {
+              "instruction_chain": [
+                {
+                  "id": "browser-codex-chain",
+                  "id_message": "browser codex instruction chain should win",
+                  "messages": [
+                    {
+                      "text": "BROWSER_CODEX_CHAIN_OUTPUT"
+                    }
+                  ]
+                }
+              ]
+            }
+            <|instruction_end|>
+            """;
+
+        await page.SendMessageAsync(instructionChain);
+        await page.WaitForStreamIdleAsync(timeoutMs: 90_000);
+
+        await page.AssistantText().WaitForCountAtLeastAsync(1, timeoutMs: 30_000);
+        var assistantTexts = await page.AssistantText().AllInnerTextsAsync();
+        string.Join(" ", assistantTexts).Should().Contain(marker);
+    }
+
+    [SkippableFact]
+    public async Task Codex_mock_discovers_sample_tools_and_renders_function_call_pills()
+    {
+        Skip.IfNot(
+            string.Equals(Environment.GetEnvironmentVariable("LMDOTNET_RUN_CODEX_E2E"), "1", StringComparison.Ordinal),
+            "Set LMDOTNET_RUN_CODEX_E2E=1 to run codex-mock browser E2E tests."
+        );
+        Skip.IfNot(CodexCliIsAvailable(), "Codex CLI not found on PATH or via CODEX_CLI_PATH.");
+
+        await using var factory = new BrowserWebAppFactory("codex-mock", builder: null);
+        await using var context = await _fixture.Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync(factory.ServerAddress);
+        await page.Textarea().WaitForAsync();
+        await page.NewChatButton().ClickAsync();
+
+        const string marker = "BROWSER_CODEX_TOOL_FLOW_COMPLETE";
+        const string discoveryMarker = "BROWSER_CODEX_TOOLS_DISCOVERED";
+        const string instructionChain = """
+            <|instruction_start|>
+            {
+              "instruction_chain": [
+                {
+                  "id": "browser-codex-tool-chain",
+                  "id_message": "browser codex tool chain",
+                  "messages": [
+                    {
+                      "text": "BROWSER_CODEX_TOOLS_DISCOVERED"
+                    },
+                    {
+                      "tools_list": {}
+                    },
+                    {
+                      "tool_call": [
+                        {
+                          "name": "calculate",
+                          "args": {
+                            "a": 7,
+                            "operation": "multiply",
+                            "b": 6
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "tool_call": [
+                        {
+                          "name": "get_weather",
+                          "args": {
+                            "location": "Seattle"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "text": "BROWSER_CODEX_TOOL_FLOW_COMPLETE"
+                    }
+                  ]
+                }
+              ]
+            }
+            <|instruction_end|>
+            """;
+
+        await page.SendMessageAsync(instructionChain);
+        await page.WaitForStreamIdleAsync(timeoutMs: 120_000);
+
+        await page.ToolCallPills().WaitForCountAtLeastAsync(2, timeoutMs: 45_000);
+        var toolNames = await page.ToolCallNamesAsync();
+        toolNames.Should().Contain(name => name.Contains("calculate", StringComparison.OrdinalIgnoreCase));
+        toolNames.Should().Contain(name => name.Contains("get_weather", StringComparison.OrdinalIgnoreCase));
+
+        await page.AssistantText().WaitForCountAtLeastAsync(1, timeoutMs: 30_000);
+        var assistantTexts = await page.AssistantText().AllInnerTextsAsync();
+        var combined = string.Join(" ", assistantTexts);
+        combined.Should().Contain(discoveryMarker);
+        combined.Should().Contain("calculate");
+        combined.Should().Contain("get_weather");
+        combined.Should().Contain(marker);
+    }
+
+    private static bool CodexCliIsAvailable()
+    {
+        var explicitPath = Environment.GetEnvironmentVariable("CODEX_CLI_PATH");
+        if (!string.IsNullOrWhiteSpace(explicitPath) && File.Exists(explicitPath))
+        {
+            return true;
+        }
+
+        var pathEnv = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathEnv))
+        {
+            return false;
+        }
+
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+        var executableNames = OperatingSystem.IsWindows() ? new[] { "codex.exe", "codex.cmd", "codex.ps1" } : ["codex"];
+
+        foreach (var directory in pathEnv.Split(separator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var executableName in executableNames)
+            {
+                if (File.Exists(Path.Combine(directory, executableName)))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Agents/MultiTurnAgentPoolTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Agents/MultiTurnAgentPoolTests.cs
@@ -68,7 +68,8 @@ public class MultiTurnAgentPoolTests
             },
             registry.ToReal(),
             store,
-            NullLogger<MultiTurnAgentPool>.Instance);
+            NullLogger<MultiTurnAgentPool>.Instance
+        );
 
         var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
         _ = pool.GetOrCreateAgent("thread-x", mode, requestedProviderId: "openai", requestResponseDumpFileName: null);
@@ -85,14 +86,18 @@ public class MultiTurnAgentPoolTests
     {
         var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test", "openai", "anthropic"]);
         var store = new InMemoryConversationStore();
-        await store.SaveMetadataAsync("thread-y", new ThreadMetadata
-        {
-            ThreadId = "thread-y",
-            LastUpdated = 1,
-            Properties = ImmutableDictionary<string, object>.Empty.SetItem(
-                MultiTurnAgentPool.ProviderPropertyKey,
-                "anthropic"),
-        });
+        await store.SaveMetadataAsync(
+            "thread-y",
+            new ThreadMetadata
+            {
+                ThreadId = "thread-y",
+                LastUpdated = 1,
+                Properties = ImmutableDictionary<string, object>.Empty.SetItem(
+                    MultiTurnAgentPool.ProviderPropertyKey,
+                    "anthropic"
+                ),
+            }
+        );
 
         var providerSeen = new List<string>();
         await using var pool = new MultiTurnAgentPool(
@@ -103,7 +108,8 @@ public class MultiTurnAgentPoolTests
             },
             registry.ToReal(),
             store,
-            NullLogger<MultiTurnAgentPool>.Instance);
+            NullLogger<MultiTurnAgentPool>.Instance
+        );
 
         var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
         _ = pool.GetOrCreateAgent("thread-y", mode, requestedProviderId: "openai", requestResponseDumpFileName: null);
@@ -112,30 +118,81 @@ public class MultiTurnAgentPoolTests
     }
 
     [Fact]
+    public async Task GetOrCreateAgent_PersistedJsonElementProviderWins_OverRequested()
+    {
+        var registry = new FakeProviderRegistry(
+            defaultProviderId: "test",
+            available: ["test", "codex-mock", "anthropic"]
+        );
+        var store = new InMemoryConversationStore();
+        using var providerDocument = JsonDocument.Parse("\"codex-mock\"");
+        var providerElement = providerDocument.RootElement.Clone();
+        await store.SaveMetadataAsync(
+            "thread-json",
+            new ThreadMetadata
+            {
+                ThreadId = "thread-json",
+                LastUpdated = 1,
+                Properties = ImmutableDictionary<string, object>.Empty.SetItem(
+                    MultiTurnAgentPool.ProviderPropertyKey,
+                    providerElement
+                ),
+            }
+        );
+
+        var providerSeen = new List<string>();
+        await using var pool = new MultiTurnAgentPool(
+            (threadId, _, providerId, _) =>
+            {
+                providerSeen.Add(providerId);
+                return new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId));
+            },
+            registry.ToReal(),
+            store,
+            NullLogger<MultiTurnAgentPool>.Instance
+        );
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        _ = pool.GetOrCreateAgent(
+            "thread-json",
+            mode,
+            requestedProviderId: "anthropic",
+            requestResponseDumpFileName: null
+        );
+
+        providerSeen.Should().ContainSingle().Which.Should().Be("codex-mock");
+    }
+
+    [Fact]
     public async Task GetOrCreateAgent_Throws_WhenPersistedProviderUnavailable()
     {
         var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test"]);
         var store = new InMemoryConversationStore();
-        await store.SaveMetadataAsync("thread-z", new ThreadMetadata
-        {
-            ThreadId = "thread-z",
-            LastUpdated = 1,
-            Properties = ImmutableDictionary<string, object>.Empty.SetItem(
-                MultiTurnAgentPool.ProviderPropertyKey,
-                "openai"),
-        });
+        await store.SaveMetadataAsync(
+            "thread-z",
+            new ThreadMetadata
+            {
+                ThreadId = "thread-z",
+                LastUpdated = 1,
+                Properties = ImmutableDictionary<string, object>.Empty.SetItem(
+                    MultiTurnAgentPool.ProviderPropertyKey,
+                    "openai"
+                ),
+            }
+        );
 
         await using var pool = new MultiTurnAgentPool(
             (threadId, _, _, _) => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId)),
             registry.ToReal(),
             store,
-            NullLogger<MultiTurnAgentPool>.Instance);
+            NullLogger<MultiTurnAgentPool>.Instance
+        );
 
         var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
-        var act = () => pool.GetOrCreateAgent("thread-z", mode, requestedProviderId: null, requestResponseDumpFileName: null);
+        var act = () =>
+            pool.GetOrCreateAgent("thread-z", mode, requestedProviderId: null, requestResponseDumpFileName: null);
 
-        act.Should().Throw<ProviderUnavailableException>()
-            .Which.ProviderId.Should().Be("openai");
+        act.Should().Throw<ProviderUnavailableException>().Which.ProviderId.Should().Be("openai");
     }
 
     [Fact]
@@ -148,13 +205,14 @@ public class MultiTurnAgentPoolTests
             (threadId, _, _, _) => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId)),
             registry.ToReal(),
             store,
-            NullLogger<MultiTurnAgentPool>.Instance);
+            NullLogger<MultiTurnAgentPool>.Instance
+        );
 
         var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
-        var act = () => pool.GetOrCreateAgent("thread-q", mode, requestedProviderId: "openai", requestResponseDumpFileName: null);
+        var act = () =>
+            pool.GetOrCreateAgent("thread-q", mode, requestedProviderId: "openai", requestResponseDumpFileName: null);
 
-        act.Should().Throw<ProviderUnavailableException>()
-            .Which.ProviderId.Should().Be("openai");
+        act.Should().Throw<ProviderUnavailableException>().Which.ProviderId.Should().Be("openai");
     }
 
     [Fact]
@@ -172,7 +230,8 @@ public class MultiTurnAgentPoolTests
             },
             registry.ToReal(),
             store,
-            NullLogger<MultiTurnAgentPool>.Instance);
+            NullLogger<MultiTurnAgentPool>.Instance
+        );
 
         var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
         _ = pool.GetOrCreateAgent("thread-d", mode, requestedProviderId: null, requestResponseDumpFileName: null);
@@ -193,7 +252,8 @@ public class MultiTurnAgentPoolTests
                 providerSeen.Add("default-sentinel-observed");
                 return new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId));
             },
-            NullLogger<MultiTurnAgentPool>.Instance);
+            NullLogger<MultiTurnAgentPool>.Instance
+        );
 
         var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
         _ = pool.GetOrCreateAgent("thread-legacy", mode);
@@ -206,20 +266,25 @@ public class MultiTurnAgentPoolTests
     {
         var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test"]);
         var store = new InMemoryConversationStore();
-        await store.SaveMetadataAsync("thread-eff", new ThreadMetadata
-        {
-            ThreadId = "thread-eff",
-            LastUpdated = 1,
-            Properties = ImmutableDictionary<string, object>.Empty.SetItem(
-                MultiTurnAgentPool.ProviderPropertyKey,
-                "openai"),
-        });
+        await store.SaveMetadataAsync(
+            "thread-eff",
+            new ThreadMetadata
+            {
+                ThreadId = "thread-eff",
+                LastUpdated = 1,
+                Properties = ImmutableDictionary<string, object>.Empty.SetItem(
+                    MultiTurnAgentPool.ProviderPropertyKey,
+                    "openai"
+                ),
+            }
+        );
 
         await using var pool = new MultiTurnAgentPool(
             (threadId, _, _, _) => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId)),
             registry.ToReal(),
             store,
-            NullLogger<MultiTurnAgentPool>.Instance);
+            NullLogger<MultiTurnAgentPool>.Instance
+        );
 
         pool.GetEffectiveProviderId("thread-eff", null).Should().Be("openai");
     }
@@ -234,7 +299,8 @@ public class MultiTurnAgentPoolTests
             (threadId, _, _, _) => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId)),
             registry.ToReal(),
             store,
-            NullLogger<MultiTurnAgentPool>.Instance);
+            NullLogger<MultiTurnAgentPool>.Instance
+        );
 
         pool.GetEffectiveProviderId("thread-fresh", null).Should().Be("test");
     }
@@ -243,22 +309,26 @@ public class MultiTurnAgentPoolTests
     {
         return new MultiTurnAgentPool(
             (threadId, _, _) => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId)),
-            NullLogger<MultiTurnAgentPool>.Instance);
+            NullLogger<MultiTurnAgentPool>.Instance
+        );
     }
 
     private static async Task<string?> WaitForPersistedProviderAsync(
         IConversationStore store,
         string threadId,
-        int timeoutMs = 1000)
+        int timeoutMs = 1000
+    )
     {
         var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
         while (DateTime.UtcNow < deadline)
         {
             var metadata = await store.LoadMetadataAsync(threadId);
-            if (metadata?.Properties != null
+            if (
+                metadata?.Properties != null
                 && metadata.Properties.TryGetValue(MultiTurnAgentPool.ProviderPropertyKey, out var raw)
                 && raw is string s
-                && !string.IsNullOrWhiteSpace(s))
+                && !string.IsNullOrWhiteSpace(s)
+            )
             {
                 return s;
             }
@@ -303,13 +373,15 @@ internal sealed class FakeProviderRegistry
         {
             Environment.SetEnvironmentVariable("LM_PROVIDER_MODE", _defaultProviderId);
             Environment.SetEnvironmentVariable("OPENAI_API_KEY", _available.Contains("openai") ? "sk-fake" : null);
-            Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", _available.Contains("anthropic") ? "sk-fake" : null);
+            Environment.SetEnvironmentVariable(
+                "ANTHROPIC_API_KEY",
+                _available.Contains("anthropic") ? "sk-fake" : null
+            );
             Environment.SetEnvironmentVariable("CLAUDE_CLI_PATH", null);
             Environment.SetEnvironmentVariable("COPILOT_CLI_PATH", null);
 
-            var probe = new FakeFileSystemProbe(
-                executablesOnPath: BuildCliList());
-            return new ProviderRegistry(probe);
+            var probe = new FakeFileSystemProbe(executablesOnPath: BuildCliList());
+            return new ProviderRegistry(probe, mockHostIsRunning: () => HasAvailableMockProvider());
         }
         finally
         {
@@ -322,13 +394,18 @@ internal sealed class FakeProviderRegistry
 
     private IEnumerable<string> BuildCliList()
     {
-        if (_available.Contains("claude"))
+        if (_available.Contains("claude") || _available.Contains("claude-mock"))
         {
             yield return "claude";
         }
-        if (_available.Contains("copilot"))
+        if (_available.Contains("copilot") || _available.Contains("copilot-mock"))
         {
             yield return "copilot";
         }
+    }
+
+    private bool HasAvailableMockProvider()
+    {
+        return _available.Any(providerId => providerId.EndsWith("-mock", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/tests/LmStreaming.Sample.Tests/ProgramCodexOptionsTests.cs
+++ b/tests/LmStreaming.Sample.Tests/ProgramCodexOptionsTests.cs
@@ -17,9 +17,7 @@ public class ProgramCodexOptionsTests
 
             var programType = typeof(LmStreaming.Sample.Controllers.DiagnosticsController).Assembly.GetType("Program");
             programType.Should().NotBeNull();
-            var method = programType!.GetMethod(
-                "CreateCodexOptions",
-                BindingFlags.NonPublic | BindingFlags.Static);
+            var method = programType!.GetMethod("CreateCodexOptions", BindingFlags.NonPublic | BindingFlags.Static);
             method.Should().NotBeNull();
 
             var dumpBase = "/tmp/thread_20260217T120000.llm";
@@ -50,9 +48,7 @@ public class ProgramCodexOptionsTests
 
             var programType = typeof(LmStreaming.Sample.Controllers.DiagnosticsController).Assembly.GetType("Program");
             programType.Should().NotBeNull();
-            var method = programType!.GetMethod(
-                "CreateCodexOptions",
-                BindingFlags.NonPublic | BindingFlags.Static);
+            var method = programType!.GetMethod("CreateCodexOptions", BindingFlags.NonPublic | BindingFlags.Static);
             method.Should().NotBeNull();
 
             var result = method!.Invoke(null, [null, "thread-2"]);
@@ -83,9 +79,7 @@ public class ProgramCodexOptionsTests
 
             var programType = typeof(LmStreaming.Sample.Controllers.DiagnosticsController).Assembly.GetType("Program");
             programType.Should().NotBeNull();
-            var method = programType!.GetMethod(
-                "CreateCodexOptions",
-                BindingFlags.NonPublic | BindingFlags.Static);
+            var method = programType!.GetMethod("CreateCodexOptions", BindingFlags.NonPublic | BindingFlags.Static);
             method.Should().NotBeNull();
 
             var result = method!.Invoke(null, [null, "thread-3"]);
@@ -99,6 +93,92 @@ public class ProgramCodexOptionsTests
         {
             Environment.SetEnvironmentVariable("CODEX_EXPOSE_INTERNAL_TOOLS_AS_TOOL_MESSAGES", previousExpose);
             Environment.SetEnvironmentVariable("CODEX_EMIT_LEGACY_INTERNAL_TOOL_REASONING_SUMMARIES", previousLegacy);
+        }
+    }
+
+    [Fact]
+    public void ResolveCodexCliPath_UsesConfiguredPath()
+    {
+        InvokeResolveCodexCliPath("custom-codex", isWindows: true, pathValue: "ignored").Should().Be("custom-codex");
+    }
+
+    [Fact]
+    public void ResolveCodexCliPath_PrefersWindowsExeOverCmdShim()
+    {
+        using var tempPath = TemporaryCodexPath.Create(("codex.cmd", "@echo off\r\n"), ("codex.exe", string.Empty));
+
+        InvokeResolveCodexCliPath(null, isWindows: true, tempPath.PathValue)
+            .Should()
+            .Be(Path.Combine(tempPath.DirectoryPath, "codex.exe"));
+    }
+
+    [Fact]
+    public void ResolveCodexCliPath_ResolvesWindowsCmdShim()
+    {
+        using var tempPath = TemporaryCodexPath.Create(("codex.cmd", "@echo off\r\n"));
+
+        InvokeResolveCodexCliPath(null, isWindows: true, tempPath.PathValue)
+            .Should()
+            .Be(Path.Combine(tempPath.DirectoryPath, "codex.cmd"));
+    }
+
+    [Theory]
+    [InlineData(true, "")]
+    [InlineData(false, "ignored")]
+    public void ResolveCodexCliPath_FallsBackToCodexCommand(bool isWindows, string? pathValue)
+    {
+        InvokeResolveCodexCliPath(null, isWindows, pathValue).Should().Be("codex");
+    }
+
+    private static string InvokeResolveCodexCliPath(string? configuredPath, bool isWindows, string? pathValue)
+    {
+        var programType = typeof(LmStreaming.Sample.Controllers.DiagnosticsController).Assembly.GetType("Program");
+        programType.Should().NotBeNull();
+        var method = programType!.GetMethod(
+            "ResolveCodexCliPath",
+            BindingFlags.NonPublic | BindingFlags.Static,
+            binder: null,
+            types: [typeof(string), typeof(bool), typeof(string)],
+            modifiers: null
+        );
+        method.Should().NotBeNull();
+
+        return ((string?)method!.Invoke(null, [configuredPath, isWindows, pathValue]))
+            .Should()
+            .NotBeNull()
+            .And.Subject!;
+    }
+
+    private sealed class TemporaryCodexPath : IDisposable
+    {
+        private TemporaryCodexPath(string directoryPath)
+        {
+            DirectoryPath = directoryPath;
+            PathValue = directoryPath;
+        }
+
+        public string DirectoryPath { get; }
+
+        public string PathValue { get; }
+
+        public static TemporaryCodexPath Create(params (string FileName, string Content)[] files)
+        {
+            var directory = Path.Combine(Path.GetTempPath(), $"codex-shim-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(directory);
+            foreach (var (fileName, content) in files)
+            {
+                File.WriteAllText(Path.Combine(directory, fileName), content);
+            }
+
+            return new TemporaryCodexPath(directory);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(DirectoryPath))
+            {
+                Directory.Delete(DirectoryPath, recursive: true);
+            }
         }
     }
 }

--- a/tests/LmTestUtils.Tests/TestMode/AnthropicSseStreamHttpContentTests.cs
+++ b/tests/LmTestUtils.Tests/TestMode/AnthropicSseStreamHttpContentTests.cs
@@ -6,6 +6,33 @@ namespace LmTestUtils.Tests.TestMode;
 public class AnthropicSseStreamHttpContentTests
 {
     [Fact]
+    public async Task ToolUseStream_StopsWithToolUseReason()
+    {
+        var plan = new InstructionPlan(
+            "tool-use-stop-reason-test",
+            reasoningLength: null,
+            messages:
+            [
+                InstructionMessage.ForExplicitText("I will read the file."),
+                InstructionMessage.ForToolCalls([new InstructionToolCall("Read", """{"file_path":"test.txt"}""")]),
+            ]
+        );
+        var content = new AnthropicSseStreamHttpContent(
+            plan,
+            model: "claude-sonnet-4-5-20250929",
+            wordsPerChunk: 4,
+            chunkDelayMs: 0
+        );
+
+        using var stream = new MemoryStream();
+        await content.CopyToAsync(stream);
+        var sse = Encoding.UTF8.GetString(stream.ToArray());
+
+        Assert.Contains("\"type\":\"tool_use\"", sse);
+        Assert.Contains("\"stop_reason\":\"tool_use\"", sse);
+    }
+
+    [Fact]
     public async Task ReasoningStream_EmitsThinkingAndSignatureDeltas()
     {
         var plan = new InstructionPlan(

--- a/tests/McpIntegrationTests/McpIntegrationTests.csproj
+++ b/tests/McpIntegrationTests/McpIntegrationTests.csproj
@@ -14,8 +14,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.1-preview.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.4.1-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/McpServer.AspNetCore.Tests/McpServer.AspNetCore.Tests.csproj
+++ b/tests/McpServer.AspNetCore.Tests/McpServer.AspNetCore.Tests.csproj
@@ -15,8 +15,8 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.1-preview.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.4.1-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\McpServer.AspNetCore\AchieveAi.LmDotnetTools.McpServer.AspNetCore.csproj" />

--- a/tests/MockProviderHost.Tests/JsonScenarioLoaderTests.cs
+++ b/tests/MockProviderHost.Tests/JsonScenarioLoaderTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using AchieveAi.LmDotnetTools.OpenAIProvider.Agents;
 using AchieveAi.LmDotnetTools.OpenAIProvider.Models;
 using FluentAssertions;
@@ -16,8 +17,7 @@ public sealed class JsonScenarioLoaderTests
         var responder = JsonScenarioLoader.Load("demo");
 
         // The shipped scenario has one role ("demo") with three turns.
-        responder.RemainingTurns.Should().ContainKey("demo")
-            .WhoseValue.Should().Be(3);
+        responder.RemainingTurns.Should().ContainKey("demo").WhoseValue.Should().Be(3);
     }
 
     [Fact]
@@ -43,6 +43,9 @@ public sealed class JsonScenarioLoaderTests
                 ]},
                 { "key": "delta", "match": { "type": "tool", "name": "echo" }, "turns": [
                     { "messages": [{ "kind": "text", "text": "d" }] }
+                ]},
+                { "key": "epsilon", "match": { "type": "tool_result" }, "turns": [
+                    { "messages": [{ "kind": "text", "text": "e" }] }
                 ]}
               ]
             }
@@ -50,7 +53,7 @@ public sealed class JsonScenarioLoaderTests
 
         var responder = JsonScenarioLoader.Parse(json);
 
-        responder.RemainingTurns.Keys.Should().BeEquivalentTo(["alpha", "beta", "gamma", "delta"]);
+        responder.RemainingTurns.Keys.Should().BeEquivalentTo(["alpha", "beta", "gamma", "delta", "epsilon"]);
     }
 
     [Fact]
@@ -80,8 +83,7 @@ public sealed class JsonScenarioLoaderTests
     {
         Action act = () => JsonScenarioLoader.Parse("""{ "roles": [] }""");
 
-        act.Should().Throw<JsonScenarioFormatException>()
-            .WithMessage("*at least one role*");
+        act.Should().Throw<JsonScenarioFormatException>().WithMessage("*at least one role*");
     }
 
     [Fact]
@@ -95,8 +97,7 @@ public sealed class JsonScenarioLoaderTests
 
         Action act = () => JsonScenarioLoader.Parse(json);
 
-        act.Should().Throw<JsonScenarioFormatException>()
-            .WithMessage("*non-empty 'key'*");
+        act.Should().Throw<JsonScenarioFormatException>().WithMessage("*non-empty 'key'*");
     }
 
     [Fact]
@@ -110,8 +111,7 @@ public sealed class JsonScenarioLoaderTests
 
         Action act = () => JsonScenarioLoader.Parse(json);
 
-        act.Should().Throw<JsonScenarioFormatException>()
-            .WithMessage("*weather*");
+        act.Should().Throw<JsonScenarioFormatException>().WithMessage("*weather*");
     }
 
     [Fact]
@@ -125,8 +125,7 @@ public sealed class JsonScenarioLoaderTests
 
         Action act = () => JsonScenarioLoader.Parse(json);
 
-        act.Should().Throw<JsonScenarioFormatException>()
-            .WithMessage("*system_contains*'value'*");
+        act.Should().Throw<JsonScenarioFormatException>().WithMessage("*system_contains*'value'*");
     }
 
     [Fact]
@@ -140,8 +139,7 @@ public sealed class JsonScenarioLoaderTests
 
         Action act = () => JsonScenarioLoader.Parse(json);
 
-        act.Should().Throw<JsonScenarioFormatException>()
-            .WithMessage("*user_contains*'value'*");
+        act.Should().Throw<JsonScenarioFormatException>().WithMessage("*user_contains*'value'*");
     }
 
     [Fact]
@@ -155,8 +153,7 @@ public sealed class JsonScenarioLoaderTests
 
         Action act = () => JsonScenarioLoader.Parse(json);
 
-        act.Should().Throw<JsonScenarioFormatException>()
-            .WithMessage("*tool match*'name'*");
+        act.Should().Throw<JsonScenarioFormatException>().WithMessage("*tool match*'name'*");
     }
 
     [Fact]
@@ -170,8 +167,7 @@ public sealed class JsonScenarioLoaderTests
 
         Action act = () => JsonScenarioLoader.Parse(json);
 
-        act.Should().Throw<JsonScenarioFormatException>()
-            .WithMessage("*Text message*'text'*");
+        act.Should().Throw<JsonScenarioFormatException>().WithMessage("*Text message*'text'*");
     }
 
     [Fact]
@@ -185,8 +181,7 @@ public sealed class JsonScenarioLoaderTests
 
         Action act = () => JsonScenarioLoader.Parse(json);
 
-        act.Should().Throw<JsonScenarioFormatException>()
-            .WithMessage("*text_len*wordCount*");
+        act.Should().Throw<JsonScenarioFormatException>().WithMessage("*text_len*wordCount*");
     }
 
     [Fact]
@@ -200,8 +195,7 @@ public sealed class JsonScenarioLoaderTests
 
         Action act = () => JsonScenarioLoader.Parse(json);
 
-        act.Should().Throw<JsonScenarioFormatException>()
-            .WithMessage("*tool_call*'name'*");
+        act.Should().Throw<JsonScenarioFormatException>().WithMessage("*tool_call*'name'*");
     }
 
     [Fact]
@@ -215,8 +209,7 @@ public sealed class JsonScenarioLoaderTests
 
         Action act = () => JsonScenarioLoader.Parse(json);
 
-        act.Should().Throw<JsonScenarioFormatException>()
-            .WithMessage("*image*");
+        act.Should().Throw<JsonScenarioFormatException>().WithMessage("*image*");
     }
 
     [Fact]
@@ -224,19 +217,21 @@ public sealed class JsonScenarioLoaderTests
     {
         Action act = () => JsonScenarioLoader.Parse("not json");
 
-        act.Should().Throw<JsonScenarioFormatException>()
-            .WithMessage("*malformed*");
+        act.Should().Throw<JsonScenarioFormatException>().WithMessage("*malformed*");
     }
 
     [Fact]
     public void Load_reads_an_absolute_file_path()
     {
         var temp = Path.Combine(Path.GetTempPath(), $"scenario-{Guid.NewGuid():N}.json");
-        File.WriteAllText(temp, """
+        File.WriteAllText(
+            temp,
+            """
             { "roles": [{ "key": "from-disk", "match": { "type": "always" }, "turns": [
                 { "messages": [{ "kind": "text", "text": "from disk" }] }
             ]}]}
-            """);
+            """
+        );
 
         try
         {
@@ -299,18 +294,113 @@ public sealed class JsonScenarioLoaderTests
         responder.RemainingTurns["fallback"].Should().Be(1);
     }
 
+    [Fact]
+    public async Task Parse_tool_result_matcher_dispatches_on_anthropic_tool_result_request()
+    {
+        const string json = """
+            {
+              "roles": [
+                { "key": "after-tool", "match": { "type": "tool_result" }, "turns": [
+                    { "messages": [{ "kind": "text", "text": "after tool result" }] }
+                ]},
+                { "key": "fallback", "match": { "type": "always" }, "turns": [
+                    { "messages": [{ "kind": "text", "text": "fallback reply" }] }
+                ]}
+              ]
+            }
+            """;
+
+        var responder = JsonScenarioLoader.Parse(json);
+        await using var fixture = await EphemeralHostFixture.StartAsync(responder);
+        using var httpClient = new HttpClient();
+        var request = new StringContent(
+            """
+            {
+              "model": "claude-test",
+              "max_tokens": 1024,
+              "stream": true,
+              "messages": [
+                {
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "tool_result",
+                      "tool_use_id": "toolu_123",
+                      "content": "fixture output"
+                    }
+                  ]
+                }
+              ]
+            }
+            """,
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        using var response = await httpClient.PostAsync($"{fixture.BaseUrl}/v1/messages", request);
+        var sse = await response.Content.ReadAsStringAsync();
+
+        response.EnsureSuccessStatusCode();
+        sse.Should().Contain("after tool result");
+        responder.RemainingTurns["after-tool"].Should().Be(0);
+        responder.RemainingTurns["fallback"].Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Parse_tool_result_matcher_dispatches_on_openai_responses_function_call_output_request()
+    {
+        const string json = """
+            {
+              "roles": [
+                { "key": "after-tool", "match": { "type": "tool_result" }, "turns": [
+                    { "messages": [{ "kind": "text", "text": "after responses tool output" }] }
+                ]},
+                { "key": "fallback", "match": { "type": "always" }, "turns": [
+                    { "messages": [{ "kind": "text", "text": "fallback reply" }] }
+                ]}
+              ]
+            }
+            """;
+
+        var responder = JsonScenarioLoader.Parse(json);
+        await using var fixture = await EphemeralHostFixture.StartAsync(responder);
+        using var httpClient = new HttpClient();
+        var request = new StringContent(
+            """
+            {
+              "model": "gpt-test",
+              "stream": true,
+              "input": [
+                {
+                  "type": "function_call_output",
+                  "call_id": "call_123",
+                  "output": "fixture output"
+                }
+              ]
+            }
+            """,
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        using var response = await httpClient.PostAsync($"{fixture.BaseUrl}/v1/responses", request);
+        var sse = await response.Content.ReadAsStringAsync();
+
+        response.EnsureSuccessStatusCode();
+        sse.Should().Contain("after responses tool output");
+        responder.RemainingTurns["after-tool"].Should().Be(0);
+        responder.RemainingTurns["fallback"].Should().Be(1);
+    }
+
     private static async Task ConsumeAsync(OpenClient openClient, string userMessage)
     {
         var request = new ChatCompletionRequest(
             "gpt-test",
-            [
-                new ChatMessage { Role = RoleEnum.User, Content = ChatMessage.CreateContent(userMessage) },
-            ])
+            [new ChatMessage { Role = RoleEnum.User, Content = ChatMessage.CreateContent(userMessage) }]
+        )
         {
             Stream = true,
         };
-        await foreach (var _ in openClient.StreamingChatCompletionsAsync(request))
-        {
-        }
+        await foreach (var _ in openClient.StreamingChatCompletionsAsync(request)) { }
     }
 }

--- a/tests/MockProviderHost.Tests/OpenAiResponsesProviderConsumptionTests.cs
+++ b/tests/MockProviderHost.Tests/OpenAiResponsesProviderConsumptionTests.cs
@@ -13,11 +13,12 @@ namespace AchieveAi.LmDotnetTools.MockProviderHost.Tests;
 public sealed class OpenAiResponsesProviderConsumptionTests
 {
     [Fact]
-    public async Task OpenAiResponsesClient_streams_scripted_text_through_HTTP_endpoint()
+    public async Task OpenAiResponsesClient_streams_instruction_chain_text_through_HTTP_endpoint()
     {
-        var responder = ScriptedSseResponder.New()
+        var responder = ScriptedSseResponder
+            .New()
             .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
-                .Turn(t => t.Text("hello from the mock host"))
+            .Turn(t => t.Text("hello from the mock host"))
             .Build();
 
         await using var fixture = await EphemeralHostFixture.StartAsync(responder);
@@ -35,7 +36,20 @@ public sealed class OpenAiResponsesProviderConsumptionTests
                 {
                     Type = "message",
                     Role = "user",
-                    Content = [new ResponseInputContent { Type = "input_text", Text = "say hello" }],
+                    Content =
+                    [
+                        new ResponseInputContent
+                        {
+                            Type = "input_text",
+                            Text = """
+                                <|instruction_start|>
+                                {"instruction_chain":[
+                                    {"id":"http-chain","messages":[{"text":"hello from the instruction chain"}]}
+                                ]}
+                                <|instruction_end|>
+                                """,
+                        },
+                    ],
                 },
             ],
         };
@@ -50,16 +64,15 @@ public sealed class OpenAiResponsesProviderConsumptionTests
         events[^1].Type.Should().Be(ResponseEventTypes.ResponseCompleted);
 
         var text = string.Concat(events.OfType<ResponseOutputTextDeltaEvent>().Select(d => d.Delta));
-        text.Should().Contain("hello from the mock host");
-        responder.RemainingTurns["parent"].Should().Be(0);
+        text.Should().Contain("hello from the instruction chain");
+        text.Should().NotContain("hello from the mock host");
+        responder.RemainingTurns["parent"].Should().Be(1);
     }
 
     [Fact]
     public async Task HTTP_endpoint_propagates_responses_content_type()
     {
-        var responder = ScriptedSseResponder.New()
-            .ForRole("any", _ => true).Turn(t => t.Text("ok"))
-            .Build();
+        var responder = ScriptedSseResponder.New().ForRole("any", _ => true).Turn(t => t.Text("ok")).Build();
 
         await using var fixture = await EphemeralHostFixture.StartAsync(responder);
         using var http = new HttpClient { BaseAddress = new Uri(fixture.BaseUrl) };

--- a/tests/MockProviderHost.Tests/OpenAiResponsesWebSocketTests.cs
+++ b/tests/MockProviderHost.Tests/OpenAiResponsesWebSocketTests.cs
@@ -16,11 +16,9 @@ namespace AchieveAi.LmDotnetTools.MockProviderHost.Tests;
 public sealed class OpenAiResponsesWebSocketTests
 {
     [Fact]
-    public async Task Single_response_create_returns_full_event_sequence()
+    public async Task Single_response_create_without_instruction_chain_consumes_scenario_turn()
     {
-        var responder = ScriptedSseResponder.New()
-            .ForRole("ws-role", _ => true).Turn(t => t.Text("ws hello"))
-            .Build();
+        var responder = ScriptedSseResponder.New().ForRole("ws-role", _ => true).Turn(t => t.Text("ws hello")).Build();
         await using var fixture = await EphemeralHostFixture.StartAsync(responder);
 
         using var socket = new ClientWebSocket();
@@ -34,15 +32,80 @@ public sealed class OpenAiResponsesWebSocketTests
         events[^1].Type.Should().Be(ResponseEventTypes.ResponseCompleted);
         var text = string.Concat(events.OfType<ResponseOutputTextDeltaEvent>().Select(d => d.Delta));
         text.Should().Contain("ws hello");
+        text.Should().NotContain("lorem ipsum");
+        text.Should().NotBe("ok");
+        responder.RemainingTurns["ws-role"].Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Response_create_with_instruction_chain_uses_chain_output()
+    {
+        var responder = ScriptedSseResponder
+            .New()
+            .ForRole("scenario", _ => true)
+            .Turn(t => t.Text("SCENARIO_SHOULD_NOT_WIN"))
+            .Build();
+        await using var fixture = await EphemeralHostFixture.StartAsync(responder);
+
+        using var socket = new ClientWebSocket();
+        await socket.ConnectAsync(BuildWsUri(fixture.BaseUrl), CancellationToken.None);
+
+        const string chainPrompt = """
+            <|instruction_start|>
+            {"instruction_chain":[
+                {"id":"ws-chain","messages":[{"text":"WS_CHAIN_OUTPUT"}]}
+            ]}
+            <|instruction_end|>
+            """;
+        await SendJsonAsync(socket, BuildResponseCreate(chainPrompt));
+
+        var events = await ReadStreamUntilCompletedAsync(socket);
+        var text = string.Concat(events.OfType<ResponseOutputTextDeltaEvent>().Select(d => d.Delta));
+
+        text.Should().Contain("WS_CHAIN_OUTPUT");
+        text.Should().NotContain("SCENARIO_SHOULD_NOT_WIN");
+        responder.RemainingTurns["scenario"].Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Response_create_with_tools_list_instruction_returns_advertised_response_tools()
+    {
+        var responder = ScriptedSseResponder
+            .New()
+            .ForRole("scenario", _ => true)
+            .Turn(t => t.Text("SCENARIO_SHOULD_NOT_WIN"))
+            .Build();
+        await using var fixture = await EphemeralHostFixture.StartAsync(responder);
+
+        using var socket = new ClientWebSocket();
+        await socket.ConnectAsync(BuildWsUri(fixture.BaseUrl), CancellationToken.None);
+
+        const string chainPrompt = """
+            <|instruction_start|>
+            {"instruction_chain":[
+                {"id":"ws-tools-list","messages":[{"tools_list":{}}]}
+            ]}
+            <|instruction_end|>
+            """;
+        await SendJsonAsync(socket, BuildResponseCreateWithTools(chainPrompt));
+
+        var events = await ReadStreamUntilCompletedAsync(socket);
+        var text = string.Concat(events.OfType<ResponseOutputTextDeltaEvent>().Select(d => d.Delta));
+
+        text.Should().Contain("calculate");
+        text.Should().Contain("get_weather");
+        text.Should().NotContain("__TOOLS_LIST__");
+        text.Should().NotContain("SCENARIO_SHOULD_NOT_WIN");
     }
 
     [Fact]
     public async Task Multiple_response_create_frames_share_one_socket()
     {
-        var responder = ScriptedSseResponder.New()
+        var responder = ScriptedSseResponder
+            .New()
             .ForRole("ws-role", _ => true)
-                .Turn(t => t.Text("first turn"))
-                .Turn(t => t.Text("second turn"))
+            .Turn(t => t.Text("first turn"))
+            .Turn(t => t.Text("second turn"))
             .Build();
         await using var fixture = await EphemeralHostFixture.StartAsync(responder);
 
@@ -53,11 +116,13 @@ public sealed class OpenAiResponsesWebSocketTests
         var firstEvents = await ReadStreamUntilCompletedAsync(socket);
         var firstText = string.Concat(firstEvents.OfType<ResponseOutputTextDeltaEvent>().Select(d => d.Delta));
         firstText.Should().Contain("first turn");
+        firstText.Should().NotContain("lorem ipsum");
 
         await SendJsonAsync(socket, BuildResponseCreate("second prompt"));
         var secondEvents = await ReadStreamUntilCompletedAsync(socket);
         var secondText = string.Concat(secondEvents.OfType<ResponseOutputTextDeltaEvent>().Select(d => d.Delta));
         secondText.Should().Contain("second turn");
+        secondText.Should().NotContain("lorem ipsum");
 
         await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None);
         responder.RemainingTurns["ws-role"].Should().Be(0);
@@ -66,9 +131,7 @@ public sealed class OpenAiResponsesWebSocketTests
     [Fact]
     public async Task Malformed_frame_closes_with_invalid_payload_status()
     {
-        var responder = ScriptedSseResponder.New()
-            .ForRole("any", _ => true).Turn(t => t.Text("unused"))
-            .Build();
+        var responder = ScriptedSseResponder.New().ForRole("any", _ => true).Turn(t => t.Text("unused")).Build();
         await using var fixture = await EphemeralHostFixture.StartAsync(responder);
 
         using var socket = new ClientWebSocket();
@@ -100,9 +163,7 @@ public sealed class OpenAiResponsesWebSocketTests
     [Fact]
     public async Task Frame_with_wrong_type_is_rejected()
     {
-        var responder = ScriptedSseResponder.New()
-            .ForRole("any", _ => true).Turn(t => t.Text("unused"))
-            .Build();
+        var responder = ScriptedSseResponder.New().ForRole("any", _ => true).Turn(t => t.Text("unused")).Build();
         await using var fixture = await EphemeralHostFixture.StartAsync(responder);
 
         using var socket = new ClientWebSocket();
@@ -126,9 +187,7 @@ public sealed class OpenAiResponsesWebSocketTests
     [Fact]
     public async Task GET_without_websocket_upgrade_returns_426()
     {
-        var responder = ScriptedSseResponder.New()
-            .ForRole("any", _ => true).Turn(t => t.Text("unused"))
-            .Build();
+        var responder = ScriptedSseResponder.New().ForRole("any", _ => true).Turn(t => t.Text("unused")).Build();
         await using var fixture = await EphemeralHostFixture.StartAsync(responder);
 
         using var http = new HttpClient { BaseAddress = new Uri(fixture.BaseUrl) };
@@ -148,14 +207,33 @@ public sealed class OpenAiResponsesWebSocketTests
 
     private static string BuildResponseCreate(string userText) =>
         $$"""
-        {
-          "type": "response.create",
-          "model": "gpt-test",
-          "input": [
-            {"type":"message","role":"user","content":[{"type":"input_text","text":"{{userText}}"}]}
-          ]
-        }
-        """;
+            {
+              "type": "response.create",
+              "model": "gpt-test",
+              "input": [
+                {"type":"message","role":"user","content":[{"type":"input_text","text":{{JsonSerializer.Serialize(
+                userText
+            )}}}]}
+              ]
+            }
+            """;
+
+    private static string BuildResponseCreateWithTools(string userText) =>
+        $$$"""
+            {
+              "type": "response.create",
+              "model": "gpt-test",
+              "tools": [
+                {"type":"function","name":"calculate","parameters":{"type":"object"}},
+                {"type":"function","name":"get_weather","parameters":{"type":"object"}}
+              ],
+              "input": [
+                {"type":"message","role":"user","content":[{"type":"input_text","text":{{{JsonSerializer.Serialize(
+                userText
+            )}}}}]}
+              ]
+            }
+            """;
 
     private static async Task SendJsonAsync(WebSocket socket, string json)
     {

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentTests.cs
@@ -80,6 +80,41 @@ public sealed class OpenAiResponsesAgentTests
     }
 
     [Fact]
+    public async Task Agent_emits_reasoning_message_for_response_reasoning_item()
+    {
+        await using var rig = TestRig.Create();
+        const string prompt = """
+            <|instruction_start|>
+            {"instruction_chain":[
+                {"reasoning":{"length":4},"messages":[{"text":"final answer"}]}
+            ]}
+            <|instruction_end|>
+            """;
+        var messages = new IMessage[]
+        {
+            new TextMessage { Role = Role.User, Text = prompt },
+        };
+
+        var stream = await rig.Agent.GenerateReplyStreamingAsync(messages);
+
+        var collected = new List<IMessage>();
+        await foreach (var m in stream)
+        {
+            collected.Add(m);
+        }
+
+        var reasoning = collected.OfType<ReasoningMessage>().Single();
+        reasoning.Role.Should().Be(Role.Assistant);
+        reasoning.Visibility.Should().Be(ReasoningVisibility.Plain);
+        reasoning.Reasoning.Should().NotBeNullOrWhiteSpace();
+        reasoning.MessageOrderIdx.Should().Be(0);
+
+        var finalText = collected.OfType<TextMessage>().Single();
+        finalText.Text.Should().Be("final answer");
+        finalText.MessageOrderIdx.Should().Be(1);
+    }
+
+    [Fact]
     public async Task Agent_emits_usage_message_after_completed_lifecycle()
     {
         await using var rig = TestRig.Create();

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesEventStreamWriterTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesEventStreamWriterTests.cs
@@ -14,26 +14,24 @@ public sealed class OpenAiResponsesEventStreamWriterTests
     [Fact]
     public void Plain_text_plan_emits_canonical_event_sequence()
     {
-        var plan = new InstructionPlan(
-            "single-text",
-            null,
-            [InstructionMessage.ForExplicitText("hello world")]
-        );
+        var plan = new InstructionPlan("single-text", null, [InstructionMessage.ForExplicitText("hello world")]);
 
         var events = OpenAiResponsesEventStreamWriter.Write(plan, model: "gpt-test");
 
         var types = events.Select(e => e.Type).ToList();
-        types.Should().Equal(
-            ResponseEventTypes.ResponseCreated,
-            ResponseEventTypes.ResponseInProgress,
-            ResponseEventTypes.OutputItemAdded,
-            ResponseEventTypes.ContentPartAdded,
-            ResponseEventTypes.OutputTextDelta,
-            ResponseEventTypes.OutputTextDone,
-            ResponseEventTypes.ContentPartDone,
-            ResponseEventTypes.OutputItemDone,
-            ResponseEventTypes.ResponseCompleted
-        );
+        types
+            .Should()
+            .Equal(
+                ResponseEventTypes.ResponseCreated,
+                ResponseEventTypes.ResponseInProgress,
+                ResponseEventTypes.OutputItemAdded,
+                ResponseEventTypes.ContentPartAdded,
+                ResponseEventTypes.OutputTextDelta,
+                ResponseEventTypes.OutputTextDone,
+                ResponseEventTypes.ContentPartDone,
+                ResponseEventTypes.OutputItemDone,
+                ResponseEventTypes.ResponseCompleted
+            );
 
         // Sequence numbers are dense and monotonic.
         events.Select(e => e.SequenceNumber).Should().Equal(Enumerable.Range(0, events.Count).Cast<int?>());
@@ -50,8 +48,7 @@ public sealed class OpenAiResponsesEventStreamWriterTests
 
         var events = OpenAiResponsesEventStreamWriter.Write(plan);
 
-        var fnAdded = events.OfType<ResponseOutputItemEvent>()
-            .First(e => e.Type == ResponseEventTypes.OutputItemAdded);
+        var fnAdded = events.OfType<ResponseOutputItemEvent>().First(e => e.Type == ResponseEventTypes.OutputItemAdded);
         fnAdded.Item.GetProperty("type").GetString().Should().Be("function_call");
         fnAdded.Item.GetProperty("name").GetString().Should().Be("get_weather");
 
@@ -59,6 +56,35 @@ public sealed class OpenAiResponsesEventStreamWriterTests
         argsDone.Arguments.Should().Be("""{"city":"Paris"}""");
 
         events.Last().Type.Should().Be(ResponseEventTypes.ResponseCompleted);
+    }
+
+    [Fact]
+    public void Reasoning_plan_emits_reasoning_item_before_text_items()
+    {
+        var plan = new InstructionPlan("thinking-then-text", 4, [InstructionMessage.ForExplicitText("final answer")]);
+
+        var events = OpenAiResponsesEventStreamWriter.Write(plan);
+
+        var itemEvents = events
+            .OfType<ResponseOutputItemEvent>()
+            .Where(e => e.Type == ResponseEventTypes.OutputItemAdded)
+            .ToList();
+
+        itemEvents.Should().HaveCount(2);
+        itemEvents[0].OutputIndex.Should().Be(0);
+        itemEvents[0].Item.GetProperty("type").GetString().Should().Be("reasoning");
+        itemEvents[0]
+            .Item.GetProperty("summary")
+            .EnumerateArray()
+            .Should()
+            .ContainSingle()
+            .Which.GetProperty("text")
+            .GetString()
+            .Should()
+            .NotBeNullOrWhiteSpace();
+
+        itemEvents[1].OutputIndex.Should().Be(1);
+        itemEvents[1].Item.GetProperty("type").GetString().Should().Be("message");
     }
 
     [Fact]
@@ -80,18 +106,14 @@ public sealed class OpenAiResponsesEventStreamWriterTests
     [Fact]
     public void Completed_lifecycle_carries_usage_block()
     {
-        var plan = new InstructionPlan(
-            "with-usage",
-            null,
-            [InstructionMessage.ForExplicitText("ok")]
-        );
+        var plan = new InstructionPlan("with-usage", null, [InstructionMessage.ForExplicitText("ok")]);
 
         var events = OpenAiResponsesEventStreamWriter.Write(plan);
 
-        var completed = events.OfType<ResponseLifecycleEvent>()
+        var completed = events
+            .OfType<ResponseLifecycleEvent>()
             .Single(e => e.Type == ResponseEventTypes.ResponseCompleted);
-        completed.Response.GetProperty("usage").GetProperty("input_tokens").GetInt32()
-            .Should().BeGreaterThan(0);
+        completed.Response.GetProperty("usage").GetProperty("input_tokens").GetInt32().Should().BeGreaterThan(0);
     }
 
     [Fact]
@@ -100,15 +122,13 @@ public sealed class OpenAiResponsesEventStreamWriterTests
         var plan = new InstructionPlan(
             "multi",
             null,
-            [
-                InstructionMessage.ForExplicitText("first"),
-                InstructionMessage.ForExplicitText("second"),
-            ]
+            [InstructionMessage.ForExplicitText("first"), InstructionMessage.ForExplicitText("second")]
         );
 
         var events = OpenAiResponsesEventStreamWriter.Write(plan);
 
-        var indexes = events.OfType<ResponseOutputItemEvent>()
+        var indexes = events
+            .OfType<ResponseOutputItemEvent>()
             .Where(e => e.Type == ResponseEventTypes.OutputItemAdded)
             .Select(e => e.OutputIndex)
             .ToList();
@@ -135,7 +155,8 @@ public sealed class OpenAiResponsesEventStreamWriterTests
 
         var events = OpenAiResponsesEventStreamWriter.Write(plan, responseId: "resp_fixed");
 
-        var lifecycleIds = events.OfType<ResponseLifecycleEvent>()
+        var lifecycleIds = events
+            .OfType<ResponseLifecycleEvent>()
             .Select(e => e.Response.GetProperty("id").GetString())
             .Distinct();
         lifecycleIds.Should().ContainSingle().Which.Should().Be("resp_fixed");


### PR DESCRIPTION
## Summary
Aligns `Codex (Mock)` with `Claude (Mock)` so the streaming sample renders consistent thinking/text output and scripted tool-call flows for both mock providers.

## Changes
- Preserve instruction-chain override priority for OpenAI Responses mock routing before falling back to scripted scenarios.
- Emit and map OpenAI Responses reasoning output as `ReasoningMessage` so Codex mock message shape follows Claude.
- Add Claude CLI partial-message support, parse low-level `stream_event` records, and keep higher-level assistant/user JSONL records for UI tool-call rendering.
- Add JSON scenario `tool_result` matching for both Anthropic `tool_result` content and OpenAI Responses `function_call_output` input.
- Add Claude and Codex mock browser E2Es plus unit coverage for stream events, tool-result matching, scenario consumption, and Codex CLI path resolution.

## Testing
- `dotnet test LmDotnetTools.sln --logger "trx;LogFilePrefix=pr-final2" --results-directory .logs\test-results\pr-final2`

## Related Issues
Fixes #37
