### PR TITLE
Add AgentRuntimeProfile for unified provider runtime inputs

### DIFF
--- a/example/LmConfigUsageExample/Program.cs
+++ b/example/LmConfigUsageExample/Program.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 using AchieveAi.LmDotnetTools.LmConfig.Agents;
 using AchieveAi.LmDotnetTools.LmConfig.Services;
 using AchieveAi.LmDotnetTools.LmCore.Agents;

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -5,7 +5,7 @@ using System.Text;
 using AchieveAi.LmDotnetTools.AnthropicProvider.Agents;
 using AchieveAi.LmDotnetTools.AnthropicProvider.Models;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
-using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 using AchieveAi.LmDotnetTools.CodexSdkProvider.Configuration;
 using AchieveAi.LmDotnetTools.CodexSdkProvider.Models;
 using AchieveAi.LmDotnetTools.CopilotSdkProvider.Configuration;

--- a/src/ClaudeAgentSdkProvider/Agents/ClaudeAgentSdkClient.cs
+++ b/src/ClaudeAgentSdkProvider/Agents/ClaudeAgentSdkClient.cs
@@ -188,6 +188,9 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
             // these on the child process redirects the CLI away from the real Anthropic API.
             ApplyMockHostOverrides(startInfo.Environment, _options, _logger);
 
+            // Redirect the CLI's ~/.claude/ to the profile staging dir.
+            ApplyStagingDirectoryEnv(startInfo.Environment, request.StagingDirectory);
+
             // 6. Start process
             _process =
                 Process.Start(startInfo)
@@ -594,7 +597,11 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
                 }
 
                 return emitSystemInit
-                    ? [new SystemInitMessage { SessionId = systemInitEvent.SessionId, Model = systemInitEvent.Model }]
+                    ? [new SystemInitMessage
+                    {
+                        SessionId = systemInitEvent.SessionId,
+                        Model = systemInitEvent.Model,
+                    }]
                     : [];
 
             case StreamEvent streamEvent:
@@ -942,7 +949,17 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
 
         args.Add($"--max-turns {request.MaxTurns}");
         args.Add($"--permission-mode {request.PermissionMode}");
-        args.Add($"--setting-sources \"{request.SettingSources}\"");
+        // Tri-state semantics for --setting-sources:
+        //   null         -> omit the flag; CLI applies its own default
+        //                   (user,project,local) which surfaces installed
+        //                   plugins, sub-agents, skills, and worktree .mcp.json.
+        //   "" (empty)   -> emit the flag with empty value to disable every
+        //                   source (isolated agent).
+        //   "user,..."   -> emit the explicit subset.
+        if (request.SettingSources is not null)
+        {
+            args.Add($"--setting-sources \"{request.SettingSources}\"");
+        }
 
         if (request.Verbose)
         {
@@ -1469,5 +1486,17 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
         var first = TruncateForLog(textMessages[0].Text, maxLength);
         var last = textMessages.Count > 1 ? TruncateForLog(textMessages[^1].Text, maxLength) : null;
         return (first, last);
+    }
+
+    internal static void ApplyStagingDirectoryEnv(
+        IDictionary<string, string?> environment,
+        string? stagingDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        if (string.IsNullOrEmpty(stagingDirectory))
+        {
+            return;
+        }
+        environment["CLAUDE_CONFIG_DIR"] = stagingDirectory;
     }
 }

--- a/src/ClaudeAgentSdkProvider/Agents/ProfileMaterializer.cs
+++ b/src/ClaudeAgentSdkProvider/Agents/ProfileMaterializer.cs
@@ -1,0 +1,274 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Agents;
+
+/// <summary>
+///     Result of materializing an <see cref="AgentRuntimeProfile"/> into a staging
+///     directory the Claude CLI can discover.
+/// </summary>
+public sealed record MaterializedProfile : IDisposable
+{
+    /// <summary>
+    ///     Absolute path to the staging directory. Pass as <c>CLAUDE_CONFIG_DIR</c>
+    ///     on the child process so the CLI sees the staged skills/agents.
+    ///     <c>null</c> means the profile was empty and no staging dir was created.
+    /// </summary>
+    public string? StagingDirectory { get; init; }
+
+    /// <summary>
+    ///     MCP servers contributed by the profile. The caller merges these into the
+    ///     final MCP dictionary, with profile entries winning on key collision.
+    /// </summary>
+    public IReadOnlyDictionary<string, McpServerConfig> McpServers { get; init; }
+        = new Dictionary<string, McpServerConfig>();
+
+    /// <summary>
+    ///     System prompt supplied by the profile, or <c>null</c> if absent. The caller
+    ///     overlays this on top of any provider-level system prompt.
+    /// </summary>
+    public string? SystemPrompt { get; init; }
+
+    /// <summary>
+    ///     Deletes the staging directory on disposal.
+    /// </summary>
+    public void Dispose()
+    {
+        if (StagingDirectory is null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (Directory.Exists(StagingDirectory))
+            {
+                Directory.Delete(StagingDirectory, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; another process may still hold a file.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // ditto
+        }
+    }
+}
+
+/// <summary>
+///     Translates a provider-neutral <see cref="AgentRuntimeProfile"/> into the
+///     filesystem layout the Claude Agent SDK CLI expects under <c>CLAUDE_CONFIG_DIR</c>.
+/// </summary>
+/// <remarks>
+///     <para>Layout produced:</para>
+///     <list type="bullet">
+///         <item><description><c>&lt;staging&gt;/skills/&lt;Name&gt;/SKILL.md</c> for inline skills.</description></item>
+///         <item><description><c>&lt;staging&gt;/skills/&lt;Name&gt;/</c> for directory-sourced skills (recursive copy).</description></item>
+///         <item><description><c>&lt;staging&gt;/agents/&lt;Name&gt;.md</c> for both inline and file-sourced sub-agents.</description></item>
+///     </list>
+///     <para>
+///         Note: <c>CLAUDE_CONFIG_DIR</c> replaces the <c>~/.claude/</c> root entirely.
+///         The CLI's documented skill/agent directory layout (<c>~/.claude/skills/</c>,
+///         <c>~/.claude/agents/</c>) becomes <c>&lt;staging&gt;/skills/</c> and
+///         <c>&lt;staging&gt;/agents/</c> — no extra <c>.claude/</c> nesting.
+///     </para>
+/// </remarks>
+public static class ProfileMaterializer
+{
+    /// <summary>
+    ///     Materialize the profile to a fresh temp directory. Returns a disposable
+    ///     handle that includes the staging directory path, the MCP dictionary the
+    ///     caller should merge with host-loaded MCP, and the system prompt to overlay.
+    /// </summary>
+    /// <remarks>
+    ///     If the profile is <c>null</c> or contributes no Skills/SubAgents/McpServers/SystemPrompt,
+    ///     no staging directory is created and <see cref="MaterializedProfile.StagingDirectory"/>
+    ///     is <c>null</c>. The handle is still safe to dispose.
+    /// </remarks>
+    public static MaterializedProfile Materialize(AgentRuntimeProfile? profile)
+    {
+        if (profile is null
+            || (profile.Skills.Count == 0
+                && profile.SubAgents.Count == 0
+                && profile.McpServers.Count == 0
+                && string.IsNullOrEmpty(profile.SystemPrompt)))
+        {
+            return new MaterializedProfile();
+        }
+
+        string? stagingDir = null;
+        if (profile.Skills.Count > 0 || profile.SubAgents.Count > 0)
+        {
+            stagingDir = Path.Combine(Path.GetTempPath(), $"lm-claude-{Guid.NewGuid():N}");
+            _ = Directory.CreateDirectory(stagingDir);
+            try
+            {
+                MaterializeSkills(stagingDir, profile.Skills);
+                MaterializeSubAgents(stagingDir, profile.SubAgents);
+            }
+            catch
+            {
+                TryDeleteDirectory(stagingDir);
+                throw;
+            }
+        }
+
+        var mcpCopy = new Dictionary<string, McpServerConfig>(StringComparer.Ordinal);
+        foreach (var (name, config) in profile.McpServers)
+        {
+            mcpCopy[name] = config;
+        }
+
+        return new MaterializedProfile
+        {
+            StagingDirectory = stagingDir,
+            McpServers = mcpCopy,
+            SystemPrompt = string.IsNullOrEmpty(profile.SystemPrompt) ? null : profile.SystemPrompt,
+        };
+    }
+
+    private static void MaterializeSkills(string stagingDir, IReadOnlyList<AgentSkill> skills)
+    {
+        var skillsRoot = Path.Combine(stagingDir, "skills");
+        _ = Directory.CreateDirectory(skillsRoot);
+        foreach (var skill in skills)
+        {
+            ValidateName(skill.Name, "skill");
+            var dir = EnsureWithinRoot(skillsRoot, Path.Combine(skillsRoot, skill.Name));
+            _ = Directory.CreateDirectory(dir);
+            switch (skill.Source)
+            {
+                case ContentSource.FromInline inline:
+                    File.WriteAllText(Path.Combine(dir, "SKILL.md"), inline.Content);
+                    break;
+                case ContentSource.FromPath fromPath:
+                    CopySkillFromPath(skill.Name, fromPath.Value, dir);
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unhandled ContentSource variant for skill '{skill.Name}': {skill.Source.GetType().Name}");
+            }
+        }
+    }
+
+    private static void CopySkillFromPath(string skillName, string sourcePath, string destDir)
+    {
+        if (Directory.Exists(sourcePath))
+        {
+            CopyDirectory(sourcePath, destDir);
+        }
+        else if (File.Exists(sourcePath))
+        {
+            File.Copy(sourcePath, Path.Combine(destDir, "SKILL.md"), overwrite: true);
+        }
+        else
+        {
+            throw new FileNotFoundException(
+                $"Skill source path not found for '{skillName}': {sourcePath}",
+                sourcePath);
+        }
+    }
+
+    private static void MaterializeSubAgents(string stagingDir, IReadOnlyList<SubAgentDefinition> subAgents)
+    {
+        var agentsRoot = Path.Combine(stagingDir, "agents");
+        _ = Directory.CreateDirectory(agentsRoot);
+        foreach (var subAgent in subAgents)
+        {
+            ValidateName(subAgent.Name, "sub-agent");
+            var target = EnsureWithinRoot(agentsRoot, Path.Combine(agentsRoot, $"{subAgent.Name}.md"));
+            switch (subAgent.Source)
+            {
+                case ContentSource.FromInline inline:
+                    File.WriteAllText(target, inline.Content);
+                    break;
+                case ContentSource.FromPath fromPath:
+                    CopySubAgentFromPath(subAgent.Name, fromPath.Value, target);
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unhandled ContentSource variant for sub-agent '{subAgent.Name}': {subAgent.Source.GetType().Name}");
+            }
+        }
+    }
+
+    private static void CopySubAgentFromPath(string subAgentName, string sourcePath, string target)
+    {
+        if (File.Exists(sourcePath))
+        {
+            File.Copy(sourcePath, target, overwrite: true);
+            return;
+        }
+
+        if (!Directory.Exists(sourcePath))
+        {
+            throw new FileNotFoundException(
+                $"Sub-agent source path not found for '{subAgentName}': {sourcePath}",
+                sourcePath);
+        }
+
+        var firstMd = Directory.EnumerateFiles(sourcePath, "*.md").FirstOrDefault()
+            ?? throw new FileNotFoundException(
+                $"Sub-agent source dir contains no .md file for '{subAgentName}': {sourcePath}");
+        File.Copy(firstMd, target, overwrite: true);
+    }
+
+    private static void ValidateName(string name, string kind)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException($"Profile {kind} name cannot be empty.", nameof(name));
+        }
+
+        if (name.Contains("..", StringComparison.Ordinal)
+            || name.IndexOfAny(['/', '\\']) >= 0
+            || name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            throw new ArgumentException(
+                $"Profile {kind} name '{name}' contains invalid characters or path separators.",
+                nameof(name));
+        }
+    }
+
+    private static string EnsureWithinRoot(string root, string candidate)
+    {
+        var fullRoot = Path.GetFullPath(root);
+        var fullCandidate = Path.GetFullPath(candidate);
+        var rootWithSep = fullRoot.EndsWith(Path.DirectorySeparatorChar)
+            ? fullRoot
+            : fullRoot + Path.DirectorySeparatorChar;
+        if (!fullCandidate.StartsWith(rootWithSep, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Resolved path '{fullCandidate}' escapes staging root '{fullRoot}'.");
+        }
+        return fullCandidate;
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    private static void CopyDirectory(string source, string dest)
+    {
+        _ = Directory.CreateDirectory(dest);
+        foreach (var file in Directory.EnumerateFiles(source))
+        {
+            File.Copy(file, Path.Combine(dest, Path.GetFileName(file)), overwrite: true);
+        }
+        foreach (var subDir in Directory.EnumerateDirectories(source))
+        {
+            CopyDirectory(subDir, Path.Combine(dest, Path.GetFileName(subDir)));
+        }
+    }
+}

--- a/src/ClaudeAgentSdkProvider/Configuration/ClaudeAgentSdkOptions.cs
+++ b/src/ClaudeAgentSdkProvider/Configuration/ClaudeAgentSdkOptions.cs
@@ -1,3 +1,5 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
 namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
 
 /// <summary>
@@ -98,6 +100,27 @@ public record ClaudeAgentSdkOptions
     public string? ReasoningEffort { get; init; }
 
     /// <summary>
+    ///     Include user/global settings (skills, sub-agents, MCP servers, plugins from
+    ///     <c>~/.claude/</c>). Default: <c>true</c>. Set to <c>false</c> to hide the
+    ///     host user's personal configuration from the spawned agent.
+    /// </summary>
+    public bool IncludeUserSettings { get; init; } = true;
+
+    /// <summary>
+    ///     Include project-level settings (<c>.claude/</c> directory and <c>.mcp.json</c>
+    ///     in the working directory). Default: <c>true</c>. Set to <c>false</c> when the
+    ///     project tree is untrusted (e.g. reviewing a PR worktree) so its settings
+    ///     don't influence the agent.
+    /// </summary>
+    public bool IncludeProjectSettings { get; init; } = true;
+
+    /// <summary>
+    ///     Include local (machine-scoped, git-ignored) settings — typically
+    ///     <c>.claude/settings.local.json</c>. Default: <c>true</c>.
+    /// </summary>
+    public bool IncludeLocalSettings { get; init; } = true;
+
+    /// <summary>
     ///     Override the Anthropic API base URL the spawned Claude Agent SDK CLI talks to.
     ///     Mapped to the <c>ANTHROPIC_BASE_URL</c> environment variable on the child process.
     ///     Used by E2E tests that point the CLI at a local mock provider host.
@@ -116,4 +139,15 @@ public record ClaudeAgentSdkOptions
     ///     features (e.g., experimental model headers) the mock host does not implement.
     /// </summary>
     public bool DisableExperimentalBetas { get; init; }
+
+    /// <summary>
+    ///     Optional client-supplied runtime inputs (system prompt, sub-agents, skills,
+    ///     MCP servers). When set, the profile is materialized into a staging directory
+    ///     and the child CLI's <c>CLAUDE_CONFIG_DIR</c> environment variable is pointed
+    ///     at it. Host-installed content under <c>~/.claude/</c> stays gated by the
+    ///     <see cref="IncludeUserSettings"/>/<see cref="IncludeProjectSettings"/>/<see cref="IncludeLocalSettings"/>
+    ///     flags and is independent of the profile. Profile MCP entries take precedence
+    ///     over host-loaded MCP entries on key collision.
+    /// </summary>
+    public AgentRuntimeProfile? Profile { get; init; }
 }

--- a/src/ClaudeAgentSdkProvider/Models/ClaudeAgentSdkRequest.cs
+++ b/src/ClaudeAgentSdkProvider/Models/ClaudeAgentSdkRequest.cs
@@ -1,3 +1,5 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
 namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
 
 /// <summary>
@@ -67,12 +69,23 @@ public record ClaudeAgentSdkRequest
     public string PermissionMode { get; init; } = "bypassPermissions";
 
     /// <summary>
-    ///     Setting sources
+    ///     Comma-separated list of settings sources to load (e.g. "user,project,local").
+    ///     When null or empty, the flag is omitted and the CLI applies its own default
+    ///     (user,project,local). Pass an explicit value only when narrowing the set.
     /// </summary>
-    public string SettingSources { get; init; } = "";
+    public string? SettingSources { get; init; }
 
     /// <summary>
     ///     Reasoning effort level (low, medium, high, xhigh)
     /// </summary>
     public string? ReasoningEffort { get; init; }
+
+    /// <summary>
+    ///     Optional path to a directory the spawned CLI should treat as its
+    ///     <c>~/.claude/</c> root. Mapped to the <c>CLAUDE_CONFIG_DIR</c> environment
+    ///     variable on the child process. Used by <c>AgentRuntimeProfile</c>
+    ///     materialization to expose client-supplied skills, sub-agents, and MCP
+    ///     entries without polluting the host's real config.
+    /// </summary>
+    public string? StagingDirectory { get; init; }
 }

--- a/src/ClaudeAgentSdkProvider/Models/McpConfiguration.cs
+++ b/src/ClaudeAgentSdkProvider/Models/McpConfiguration.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+
+/// <summary>
+///     Root configuration object for MCP servers, matching the <c>.mcp.json</c>
+///     file shape used by the Claude Agent SDK.
+/// </summary>
+public record McpConfiguration
+{
+    [JsonPropertyName("mcpServers")]
+    public Dictionary<string, McpServerConfig> McpServers { get; init; } = [];
+}

--- a/src/CodexSdkProvider/AgentRuntime/McpServerConfigExtensions.cs
+++ b/src/CodexSdkProvider/AgentRuntime/McpServerConfigExtensions.cs
@@ -22,9 +22,8 @@ public static class McpServerConfigExtensions
             ? null
             : [.. source.Args];
 
-        IReadOnlyDictionary<string, string>? env = source.Env is null
-            ? null
-            : new Dictionary<string, string>(source.Env, StringComparer.Ordinal);
+        IReadOnlyDictionary<string, string>? env = source.Env?
+            .ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.Ordinal);
 
         return new CodexMcpServerConfig
         {

--- a/src/CodexSdkProvider/AgentRuntime/McpServerConfigExtensions.cs
+++ b/src/CodexSdkProvider/AgentRuntime/McpServerConfigExtensions.cs
@@ -1,0 +1,37 @@
+using AchieveAi.LmDotnetTools.CodexSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.CodexSdkProvider.AgentRuntime;
+
+/// <summary>
+///     Projection helpers from the neutral <see cref="McpServerConfig"/> to
+///     Codex-specific <see cref="CodexMcpServerConfig"/>.
+/// </summary>
+public static class McpServerConfigExtensions
+{
+    /// <summary>
+    ///     Maps shared MCP fields (command/args/env/url) onto a Codex-shaped record.
+    ///     Codex-only fields (<c>Enabled</c>, <c>EnabledTools</c>, <c>DisabledTools</c>,
+    ///     <c>ToolTimeoutSec</c>, <c>StartupTimeoutSec</c>) stay at their defaults.
+    /// </summary>
+    public static CodexMcpServerConfig ToCodexConfig(this McpServerConfig source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        IReadOnlyList<string>? args = source.Args is null
+            ? null
+            : [.. source.Args];
+
+        IReadOnlyDictionary<string, string>? env = source.Env is null
+            ? null
+            : new Dictionary<string, string>(source.Env, StringComparer.Ordinal);
+
+        return new CodexMcpServerConfig
+        {
+            Url = source.Url,
+            Command = source.Command,
+            Args = args,
+            Env = env,
+        };
+    }
+}

--- a/src/CodexSdkProvider/Configuration/CodexSdkOptions.cs
+++ b/src/CodexSdkProvider/Configuration/CodexSdkOptions.cs
@@ -1,3 +1,5 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
 namespace AchieveAi.LmDotnetTools.CodexSdkProvider.Configuration;
 
 public enum CodexToolBridgeMode
@@ -84,4 +86,15 @@ public record CodexSdkOptions
 
     // Retained for compatibility with existing env/config shape; ignored in raw streaming mode.
     public int SyntheticMessageUpdateChunkChars { get; init; } = 28;
+
+    /// <summary>
+    ///     Optional client-supplied runtime inputs (system prompt, MCP servers, etc.).
+    ///     Codex consumes <see cref="AgentRuntimeProfile.SystemPrompt"/> (overrides
+    ///     <see cref="DeveloperInstructions"/>) and <see cref="AgentRuntimeProfile.McpServers"/>
+    ///     (merged with bridge-init MCP, profile entries win on key collision).
+    ///     <see cref="AgentRuntimeProfile.Skills"/> and <see cref="AgentRuntimeProfile.SubAgents"/>
+    ///     are not supported by Codex's CLI; their presence triggers a one-time
+    ///     warning log entry per loop and otherwise has no effect.
+    /// </summary>
+    public AgentRuntimeProfile? Profile { get; init; }
 }

--- a/src/CopilotSdkProvider/Configuration/CopilotSdkOptions.cs
+++ b/src/CopilotSdkProvider/Configuration/CopilotSdkOptions.cs
@@ -1,3 +1,5 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
 namespace AchieveAi.LmDotnetTools.CopilotSdkProvider.Configuration;
 
 /// <summary>
@@ -73,4 +75,13 @@ public record CopilotSdkOptions
     public bool EmitSyntheticMessageUpdates { get; init; } = false;
 
     public int SyntheticMessageUpdateChunkChars { get; init; } = 28;
+
+    /// <summary>
+    ///     Optional client-supplied runtime inputs (system prompt, MCP servers, etc.).
+    ///     Copilot consumes only <see cref="AgentRuntimeProfile.SystemPrompt"/> (overrides
+    ///     <see cref="DeveloperInstructions"/>). The Copilot ACP protocol does not expose
+    ///     MCP servers, skills, or sub-agents; their presence triggers a one-time
+    ///     warning log entry per loop and otherwise has no effect.
+    /// </summary>
+    public AgentRuntimeProfile? Profile { get; init; }
 }

--- a/src/LmCore/AgentRuntime/AgentRuntimeProfile.cs
+++ b/src/LmCore/AgentRuntime/AgentRuntimeProfile.cs
@@ -1,0 +1,42 @@
+using System.Collections.Immutable;
+
+namespace AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+/// <summary>
+///     Provider-neutral bundle of runtime inputs supplied by a client application:
+///     system prompt, sub-agents, skills, and MCP servers.
+/// </summary>
+/// <remarks>
+///     Each provider projects whatever subset its underlying runtime supports.
+///     Providers MUST log a single warning per loop construction for any
+///     non-empty field they cannot honor, then ignore it. See each provider's
+///     <c>Options.Profile</c> XML doc for the per-provider support matrix.
+/// </remarks>
+public sealed record AgentRuntimeProfile
+{
+    /// <summary>
+    ///     System prompt text. When set, supported providers use this in place of
+    ///     their own system prompt / developer instructions.
+    /// </summary>
+    public string? SystemPrompt { get; init; }
+
+    /// <summary>
+    ///     Skills to expose to the spawned agent. Optional; providers that do not
+    ///     support skills log once and ignore.
+    /// </summary>
+    public IReadOnlyList<AgentSkill> Skills { get; init; } = [];
+
+    /// <summary>
+    ///     Sub-agents to expose to the spawned agent. Optional; providers that do
+    ///     not support sub-agents log once and ignore.
+    /// </summary>
+    public IReadOnlyList<SubAgentDefinition> SubAgents { get; init; } = [];
+
+    /// <summary>
+    ///     MCP servers to make available. Optional; providers that do not support
+    ///     MCP log once and ignore. Supporting providers MUST merge with host-loaded
+    ///     MCP config, with profile entries winning on key collision.
+    /// </summary>
+    public IReadOnlyDictionary<string, McpServerConfig> McpServers { get; init; }
+        = ImmutableDictionary<string, McpServerConfig>.Empty;
+}

--- a/src/LmCore/AgentRuntime/AgentSkill.cs
+++ b/src/LmCore/AgentRuntime/AgentSkill.cs
@@ -1,20 +1,29 @@
 namespace AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 
 /// <summary>
-///     Profile-supplied skill that materializes into <c>.claude/skills/&lt;Name&gt;/SKILL.md</c>
-///     for the Claude Agent SDK. Description and other metadata live in the
-///     SKILL.md frontmatter and are parsed by the consuming CLI, not by this SDK.
+///     Provider-neutral skill descriptor supplied via an <see cref="AgentRuntimeProfile"/>.
+///     Each consuming provider decides how (and whether) to surface skills to the
+///     spawned agent. Description and other metadata typically live in the markdown
+///     frontmatter and are parsed by the consuming provider, not by this SDK.
 /// </summary>
+/// <remarks>
+///     See the provider-specific materializer (e.g. <c>ProfileMaterializer</c> in
+///     <c>ClaudeAgentSdkProvider</c>) for details on how a skill's <see cref="Name"/>
+///     and <see cref="Source"/> are mapped onto the underlying CLI's filesystem layout.
+/// </remarks>
 public sealed record AgentSkill
 {
     /// <summary>
-    ///     Directory name under <c>.claude/skills/</c>. Must be unique within the profile.
+    ///     Stable identifier for the skill. Must be unique within the profile and
+    ///     contain no path separators. Providers map this onto the per-provider
+    ///     filesystem layout (for example, a directory name).
     /// </summary>
     public required string Name { get; init; }
 
     /// <summary>
     ///     Where to read the skill content from. Path forms copy a directory tree or
-    ///     a single <c>SKILL.md</c> file; inline forms write a literal markdown body.
+    ///     a single markdown file; inline forms supply a literal markdown body. The
+    ///     provider materializer is responsible for any I/O.
     /// </summary>
     public required ContentSource Source { get; init; }
 

--- a/src/LmCore/AgentRuntime/AgentSkill.cs
+++ b/src/LmCore/AgentRuntime/AgentSkill.cs
@@ -1,0 +1,32 @@
+namespace AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+/// <summary>
+///     Profile-supplied skill that materializes into <c>.claude/skills/&lt;Name&gt;/SKILL.md</c>
+///     for the Claude Agent SDK. Description and other metadata live in the
+///     SKILL.md frontmatter and are parsed by the consuming CLI, not by this SDK.
+/// </summary>
+public sealed record AgentSkill
+{
+    /// <summary>
+    ///     Directory name under <c>.claude/skills/</c>. Must be unique within the profile.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    ///     Where to read the skill content from. Path forms copy a directory tree or
+    ///     a single <c>SKILL.md</c> file; inline forms write a literal markdown body.
+    /// </summary>
+    public required ContentSource Source { get; init; }
+
+    /// <summary>
+    ///     Sugar for inline-markdown skills.
+    /// </summary>
+    public static AgentSkill Inline(string name, string markdown)
+        => new() { Name = name, Source = new ContentSource.FromInline(markdown) };
+
+    /// <summary>
+    ///     Sugar for path-sourced skills.
+    /// </summary>
+    public static AgentSkill FromPath(string name, string path)
+        => new() { Name = name, Source = new ContentSource.FromPath(path) };
+}

--- a/src/LmCore/AgentRuntime/ContentSource.cs
+++ b/src/LmCore/AgentRuntime/ContentSource.cs
@@ -1,0 +1,27 @@
+namespace AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+/// <summary>
+///     Closed discriminated union describing how a profile-provided content fragment
+///     (skill body, sub-agent definition, etc.) is supplied to the SDK.
+/// </summary>
+/// <remarks>
+///     Construction is pure: no I/O happens here. Provider materializers own all file
+///     reads and writes when projecting a profile into a CLI staging directory.
+/// </remarks>
+public abstract record ContentSource
+{
+    private ContentSource() { }
+
+    /// <summary>
+    ///     Content is read from <see cref="Value"/> on the local filesystem. If the path
+    ///     points at a directory, the materializer copies its contents recursively.
+    ///     If it points at a file, the materializer copies the single file.
+    /// </summary>
+    public sealed record FromPath(string Value) : ContentSource;
+
+    /// <summary>
+    ///     Content is supplied inline as a literal markdown string. The materializer
+    ///     writes it verbatim to the canonical location for the consuming provider.
+    /// </summary>
+    public sealed record FromInline(string Content) : ContentSource;
+}

--- a/src/LmCore/AgentRuntime/McpServerConfig.cs
+++ b/src/LmCore/AgentRuntime/McpServerConfig.cs
@@ -1,10 +1,12 @@
 using System.Text.Json.Serialization;
 
-namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+namespace AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 
 /// <summary>
 ///     Configuration for an MCP (Model Context Protocol) server.
 ///     Supports both stdio (command-based) and http (URL-based) transports.
+///     Provider-neutral: consumed directly by Claude, projected to provider-specific
+///     shapes (e.g. <c>CodexMcpServerConfig</c>) for Codex.
 /// </summary>
 public record McpServerConfig
 {
@@ -56,11 +58,3 @@ public record McpServerConfig
     }
 }
 
-/// <summary>
-///     Root configuration object for MCP servers
-/// </summary>
-public record McpConfiguration
-{
-    [JsonPropertyName("mcpServers")]
-    public Dictionary<string, McpServerConfig> McpServers { get; init; } = [];
-}

--- a/src/LmCore/AgentRuntime/McpServerConfig.cs
+++ b/src/LmCore/AgentRuntime/McpServerConfig.cs
@@ -20,7 +20,7 @@ public record McpServerConfig
 
     [JsonPropertyName("args")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<string>? Args { get; init; }
+    public IReadOnlyList<string>? Args { get; init; }
 
     // For http type
     [JsonPropertyName("url")]
@@ -29,20 +29,20 @@ public record McpServerConfig
 
     [JsonPropertyName("headers")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public Dictionary<string, string>? Headers { get; init; }
+    public IReadOnlyDictionary<string, string>? Headers { get; init; }
 
     // Shared
     [JsonPropertyName("env")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public Dictionary<string, string>? Env { get; init; }
+    public IReadOnlyDictionary<string, string>? Env { get; init; }
 
     /// <summary>
     ///     Creates a stdio-based MCP server configuration.
     /// </summary>
     public static McpServerConfig CreateStdio(
         string command,
-        List<string> args,
-        Dictionary<string, string>? env = null)
+        IReadOnlyList<string> args,
+        IReadOnlyDictionary<string, string>? env = null)
     {
         return new McpServerConfig { Type = "stdio", Command = command, Args = args, Env = env };
     }
@@ -52,7 +52,7 @@ public record McpServerConfig
     /// </summary>
     public static McpServerConfig CreateHttp(
         string url,
-        Dictionary<string, string>? headers = null)
+        IReadOnlyDictionary<string, string>? headers = null)
     {
         return new McpServerConfig { Type = "http", Url = url, Headers = headers };
     }

--- a/src/LmCore/AgentRuntime/SubAgentDefinition.cs
+++ b/src/LmCore/AgentRuntime/SubAgentDefinition.cs
@@ -1,22 +1,31 @@
 namespace AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 
 /// <summary>
-///     Profile-supplied sub-agent that materializes into <c>.claude/agents/&lt;Name&gt;.md</c>
-///     for the Claude Agent SDK. Description, model, and tool list live in the
-///     <c>.md</c> frontmatter and are parsed by the consuming CLI.
+///     Provider-neutral sub-agent descriptor supplied via an
+///     <see cref="AgentRuntimeProfile"/>. Each consuming provider decides how (and
+///     whether) to surface sub-agents to the spawned agent. Description, model, and
+///     tool list typically live in the markdown frontmatter and are parsed by the
+///     consuming provider.
 /// </summary>
+/// <remarks>
+///     See the provider-specific materializer (e.g. <c>ProfileMaterializer</c> in
+///     <c>ClaudeAgentSdkProvider</c>) for details on how a sub-agent's <see cref="Name"/>
+///     and <see cref="Source"/> are mapped onto the underlying CLI's filesystem layout.
+/// </remarks>
 public sealed record SubAgentDefinition
 {
     /// <summary>
-    ///     File stem (without <c>.md</c>) under <c>.claude/agents/</c>. Must be unique
-    ///     within the profile.
+    ///     Stable identifier for the sub-agent. Must be unique within the profile and
+    ///     contain no path separators. Providers map this onto the per-provider
+    ///     filesystem layout (for example, a markdown file stem).
     /// </summary>
     public required string Name { get; init; }
 
     /// <summary>
     ///     Where to read the sub-agent definition from. Path forms copy a single
-    ///     <c>.md</c> file (or the first <c>.md</c> in a directory). Inline forms
-    ///     write a literal markdown body.
+    ///     markdown file (or the first markdown file in a directory). Inline forms
+    ///     supply a literal markdown body. The provider materializer is responsible
+    ///     for any I/O.
     /// </summary>
     public required ContentSource Source { get; init; }
 

--- a/src/LmCore/AgentRuntime/SubAgentDefinition.cs
+++ b/src/LmCore/AgentRuntime/SubAgentDefinition.cs
@@ -1,0 +1,34 @@
+namespace AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+/// <summary>
+///     Profile-supplied sub-agent that materializes into <c>.claude/agents/&lt;Name&gt;.md</c>
+///     for the Claude Agent SDK. Description, model, and tool list live in the
+///     <c>.md</c> frontmatter and are parsed by the consuming CLI.
+/// </summary>
+public sealed record SubAgentDefinition
+{
+    /// <summary>
+    ///     File stem (without <c>.md</c>) under <c>.claude/agents/</c>. Must be unique
+    ///     within the profile.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    ///     Where to read the sub-agent definition from. Path forms copy a single
+    ///     <c>.md</c> file (or the first <c>.md</c> in a directory). Inline forms
+    ///     write a literal markdown body.
+    /// </summary>
+    public required ContentSource Source { get; init; }
+
+    /// <summary>
+    ///     Sugar for inline-markdown sub-agents.
+    /// </summary>
+    public static SubAgentDefinition Inline(string name, string markdown)
+        => new() { Name = name, Source = new ContentSource.FromInline(markdown) };
+
+    /// <summary>
+    ///     Sugar for path-sourced sub-agents.
+    /// </summary>
+    public static SubAgentDefinition FromPath(string name, string path)
+        => new() { Name = name, Source = new ContentSource.FromPath(path) };
+}

--- a/src/LmMultiTurn/ClaudeAgentLoop.cs
+++ b/src/LmMultiTurn/ClaudeAgentLoop.cs
@@ -132,6 +132,9 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
         _mcpServers = mcpServers ?? [];
         _loggerFactory = loggerFactory;
         _clientFactory = clientFactory;
+        // MUST remain the last statement in this constructor: the returned MaterializedProfile
+        // owns a temp directory and is disposed by DisposeAsync. Any throw after this line would
+        // leak the staging dir.
         _materializedProfile = ProfileMaterializer.Materialize(claudeOptions.Profile);
     }
 

--- a/src/LmMultiTurn/ClaudeAgentLoop.cs
+++ b/src/LmMultiTurn/ClaudeAgentLoop.cs
@@ -4,6 +4,7 @@ using System.Threading.Channels;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Agents;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
@@ -29,6 +30,7 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
     private readonly ILoggerFactory? _loggerFactory;
     private readonly Func<ClaudeAgentSdkOptions, ILogger?, IClaudeAgentSdkClient>? _clientFactory;
     private readonly SemaphoreSlim _restartLock = new(1, 1);
+    private readonly MaterializedProfile _materializedProfile;
 
     private IClaudeAgentSdkClient? _client;
 
@@ -130,6 +132,7 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
         _mcpServers = mcpServers ?? [];
         _loggerFactory = loggerFactory;
         _clientFactory = clientFactory;
+        _materializedProfile = ProfileMaterializer.Materialize(claudeOptions.Profile);
     }
 
     /// <inheritdoc />
@@ -175,6 +178,7 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
         Logger.LogDebug("Disposing ClaudeAgentLoop resources");
         await DisposeClientResourcesAsync();
         _restartLock.Dispose();
+        _materializedProfile.Dispose();
     }
 
     /// <inheritdoc />
@@ -955,7 +959,7 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
     /// Build ClaudeAgentSdkRequest from current configuration and options.
     /// Moved from ClaudeAgentSdkAgent.
     /// </summary>
-    private ClaudeAgentSdkRequest BuildClaudeAgentSdkRequest()
+    internal ClaudeAgentSdkRequest BuildClaudeAgentSdkRequest()
     {
         var modelId = DefaultOptions.ModelId ?? "claude-sonnet-4-5-20250929";
         var maxTurns = _claudeOptions.MaxTurnsPerRun;
@@ -1005,6 +1009,17 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
             }
         }
 
+        // Profile-supplied MCP servers win on key collision (documented in
+        // ClaudeAgentSdkOptions.Profile XML doc).
+        if (_materializedProfile.McpServers.Count > 0)
+        {
+            mcpServers ??= [];
+            foreach (var (name, config) in _materializedProfile.McpServers)
+            {
+                mcpServers[name] = config;
+            }
+        }
+
         Logger.LogInformation(
             "Final MCP server configuration: {Count} servers configured",
             mcpServers?.Count ?? 0);
@@ -1019,11 +1034,50 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
             MaxTurns = maxTurns,
             MaxThinkingTokens = maxThinkingTokens,
             SessionId = sessionId,
-            SystemPrompt = SystemPrompt,
+            SystemPrompt = _materializedProfile.SystemPrompt ?? SystemPrompt,
             AllowedTools = allowedTools,
             McpServers = mcpServers,
             Verbose = true,
             ReasoningEffort = _claudeOptions.ReasoningEffort,
+            SettingSources = BuildSettingSources(_claudeOptions),
+            StagingDirectory = _materializedProfile.StagingDirectory,
         };
+    }
+
+    // Maps the IncludeUser/Project/LocalSettings booleans to the CLI's
+    // --setting-sources value. Tri-state semantics:
+    //   all true  => null  (omit flag, CLI uses its own default of user,project,local)
+    //   all false => ""    (emit empty value, CLI loads nothing -> isolated agent)
+    //   mixed     => comma-joined list of the enabled sources
+    internal static string? BuildSettingSources(ClaudeAgentSdkOptions options)
+    {
+        var user = options.IncludeUserSettings;
+        var project = options.IncludeProjectSettings;
+        var local = options.IncludeLocalSettings;
+
+        if (user && project && local)
+        {
+            return null;
+        }
+
+        if (!user && !project && !local)
+        {
+            return string.Empty;
+        }
+
+        var parts = new List<string>(3);
+        if (user)
+        {
+            parts.Add("user");
+        }
+        if (project)
+        {
+            parts.Add("project");
+        }
+        if (local)
+        {
+            parts.Add("local");
+        }
+        return string.Join(',', parts);
     }
 }

--- a/src/LmMultiTurn/CodexAgentLoop.cs
+++ b/src/LmMultiTurn/CodexAgentLoop.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
+using AchieveAi.LmDotnetTools.CodexSdkProvider.AgentRuntime;
 using AchieveAi.LmDotnetTools.CodexSdkProvider.Agents;
 using AchieveAi.LmDotnetTools.CodexSdkProvider.Configuration;
 using AchieveAi.LmDotnetTools.CodexSdkProvider.Models;
@@ -27,6 +28,7 @@ public sealed class CodexAgentLoop : MultiTurnAgentBase
     private ICodexSdkClient? _client;
     private string? _codexThreadId;
     private string? _generatedModelInstructionsFile;
+    private bool _profileUnsupportedWarningLogged;
 
     public CodexAgentLoop(
         CodexSdkOptions options,
@@ -148,9 +150,10 @@ public sealed class CodexAgentLoop : MultiTurnAgentBase
         var effectiveWebSearchMode = _toolPolicy.IsBuiltInAllowed("web_search")
             ? _options.WebSearchMode
             : "disabled";
-        var effectiveMcpServers = _options.ToolBridgeMode == CodexToolBridgeMode.Dynamic
-            ? new Dictionary<string, CodexMcpServerConfig>()
-            : _mcpServers;
+        var effectiveMcpServers = ApplyProfile(
+            _options.ToolBridgeMode == CodexToolBridgeMode.Dynamic
+                ? new Dictionary<string, CodexMcpServerConfig>()
+                : _mcpServers);
         var dynamicTools = _options.ToolBridgeMode == CodexToolBridgeMode.Mcp
             ? null
             : _dynamicToolBridge?.GetToolSpecs();
@@ -185,6 +188,49 @@ public sealed class CodexAgentLoop : MultiTurnAgentBase
             _options.ProviderMode,
             ThreadId,
             _codexThreadId);
+    }
+
+    private IReadOnlyDictionary<string, CodexMcpServerConfig> ApplyProfile(
+        IReadOnlyDictionary<string, CodexMcpServerConfig> baseServers)
+    {
+        var profile = _options.Profile;
+        if (profile is null)
+        {
+            return baseServers;
+        }
+
+        if (!_profileUnsupportedWarningLogged
+            && (profile.Skills.Count > 0 || profile.SubAgents.Count > 0))
+        {
+            Logger.LogWarning(
+                "{event_type} {event_status} {provider} {provider_mode} {thread_id} {skill_count} {sub_agent_count}",
+                "codex.profile.unsupported",
+                "ignored",
+                _options.Provider,
+                _options.ProviderMode,
+                ThreadId,
+                profile.Skills.Count,
+                profile.SubAgents.Count);
+            _profileUnsupportedWarningLogged = true;
+        }
+
+        if (profile.McpServers.Count == 0)
+        {
+            return baseServers;
+        }
+
+        if (_options.ToolBridgeMode == CodexToolBridgeMode.Dynamic)
+        {
+            return baseServers;
+        }
+
+        var merged = new Dictionary<string, CodexMcpServerConfig>(baseServers, StringComparer.Ordinal);
+        foreach (var (name, config) in profile.McpServers)
+        {
+            merged[name] = config.ToCodexConfig();
+        }
+
+        return merged;
     }
 
     protected override async Task OnDisposeAsync()
@@ -498,11 +544,14 @@ public sealed class CodexAgentLoop : MultiTurnAgentBase
         var baseInstructions = string.IsNullOrWhiteSpace(_options.BaseInstructions)
             ? null
             : _options.BaseInstructions;
-        var developerInstructions = !string.IsNullOrWhiteSpace(SystemPrompt)
-            ? SystemPrompt
-            : string.IsNullOrWhiteSpace(_options.DeveloperInstructions)
-                ? null
-                : _options.DeveloperInstructions;
+        var profileSystemPrompt = _options.Profile?.SystemPrompt;
+        var developerInstructions = !string.IsNullOrWhiteSpace(profileSystemPrompt)
+            ? profileSystemPrompt
+            : !string.IsNullOrWhiteSpace(SystemPrompt)
+                ? SystemPrompt
+                : string.IsNullOrWhiteSpace(_options.DeveloperInstructions)
+                    ? null
+                    : _options.DeveloperInstructions;
         var modelInstructionsFile = string.IsNullOrWhiteSpace(_options.ModelInstructionsFile)
             ? null
             : _options.ModelInstructionsFile;

--- a/src/LmMultiTurn/CodexAgentLoop.cs
+++ b/src/LmMultiTurn/CodexAgentLoop.cs
@@ -544,14 +544,10 @@ public sealed class CodexAgentLoop : MultiTurnAgentBase
         var baseInstructions = string.IsNullOrWhiteSpace(_options.BaseInstructions)
             ? null
             : _options.BaseInstructions;
-        var profileSystemPrompt = _options.Profile?.SystemPrompt;
-        var developerInstructions = !string.IsNullOrWhiteSpace(profileSystemPrompt)
-            ? profileSystemPrompt
-            : !string.IsNullOrWhiteSpace(SystemPrompt)
-                ? SystemPrompt
-                : string.IsNullOrWhiteSpace(_options.DeveloperInstructions)
-                    ? null
-                    : _options.DeveloperInstructions;
+        var developerInstructions = ProfileSystemPromptResolver.Resolve(
+            _options.Profile,
+            SystemPrompt,
+            _options.DeveloperInstructions);
         var modelInstructionsFile = string.IsNullOrWhiteSpace(_options.ModelInstructionsFile)
             ? null
             : _options.ModelInstructionsFile;

--- a/src/LmMultiTurn/CopilotAgentLoop.cs
+++ b/src/LmMultiTurn/CopilotAgentLoop.cs
@@ -430,14 +430,10 @@ public sealed class CopilotAgentLoop : MultiTurnAgentBase
     private (string? BaseInstructions, string? DeveloperInstructions, string? ModelInstructionsFile) ResolveInstructions()
     {
         var baseInstructions = string.IsNullOrWhiteSpace(_options.BaseInstructions) ? null : _options.BaseInstructions;
-        var profileSystemPrompt = _options.Profile?.SystemPrompt;
-        var developerInstructions = !string.IsNullOrWhiteSpace(profileSystemPrompt)
-            ? profileSystemPrompt
-            : !string.IsNullOrWhiteSpace(SystemPrompt)
-                ? SystemPrompt
-                : string.IsNullOrWhiteSpace(_options.DeveloperInstructions)
-                    ? null
-                    : _options.DeveloperInstructions;
+        var developerInstructions = ProfileSystemPromptResolver.Resolve(
+            _options.Profile,
+            SystemPrompt,
+            _options.DeveloperInstructions);
         var modelInstructionsFile = string.IsNullOrWhiteSpace(_options.ModelInstructionsFile)
             ? null
             : _options.ModelInstructionsFile;

--- a/src/LmMultiTurn/CopilotAgentLoop.cs
+++ b/src/LmMultiTurn/CopilotAgentLoop.cs
@@ -30,6 +30,7 @@ public sealed class CopilotAgentLoop : MultiTurnAgentBase
     private ICopilotSdkClient? _client;
     private string? _copilotSessionId;
     private string? _generatedModelInstructionsFile;
+    private bool _profileUnsupportedWarningLogged;
 
     public CopilotAgentLoop(
         CopilotSdkOptions options,
@@ -142,6 +143,7 @@ public sealed class CopilotAgentLoop : MultiTurnAgentBase
             _client.ConfigureDynamicToolExecutor(null);
         }
 
+        LogProfileUnsupportedOnce();
         var (baseInstructions, developerInstructions, modelInstructionsFile) = ResolveInstructions();
         var tools = _dynamicToolBridge?.GetToolSpecs();
 
@@ -391,14 +393,51 @@ public sealed class CopilotAgentLoop : MultiTurnAgentBase
         public int BridgeEventCount { get; set; }
     }
 
+    private void LogProfileUnsupportedOnce()
+    {
+        if (_profileUnsupportedWarningLogged)
+        {
+            return;
+        }
+
+        var profile = _options.Profile;
+        if (profile is null)
+        {
+            return;
+        }
+
+        var mcpCount = profile.McpServers.Count;
+        var skillCount = profile.Skills.Count;
+        var subAgentCount = profile.SubAgents.Count;
+        if (mcpCount == 0 && skillCount == 0 && subAgentCount == 0)
+        {
+            return;
+        }
+
+        Logger.LogWarning(
+            "{event_type} {event_status} {provider} {provider_mode} {thread_id} {mcp_count} {skill_count} {sub_agent_count}",
+            "copilot.profile.unsupported",
+            "ignored",
+            _options.Provider,
+            _options.ProviderMode,
+            ThreadId,
+            mcpCount,
+            skillCount,
+            subAgentCount);
+        _profileUnsupportedWarningLogged = true;
+    }
+
     private (string? BaseInstructions, string? DeveloperInstructions, string? ModelInstructionsFile) ResolveInstructions()
     {
         var baseInstructions = string.IsNullOrWhiteSpace(_options.BaseInstructions) ? null : _options.BaseInstructions;
-        var developerInstructions = !string.IsNullOrWhiteSpace(SystemPrompt)
-            ? SystemPrompt
-            : string.IsNullOrWhiteSpace(_options.DeveloperInstructions)
-                ? null
-                : _options.DeveloperInstructions;
+        var profileSystemPrompt = _options.Profile?.SystemPrompt;
+        var developerInstructions = !string.IsNullOrWhiteSpace(profileSystemPrompt)
+            ? profileSystemPrompt
+            : !string.IsNullOrWhiteSpace(SystemPrompt)
+                ? SystemPrompt
+                : string.IsNullOrWhiteSpace(_options.DeveloperInstructions)
+                    ? null
+                    : _options.DeveloperInstructions;
         var modelInstructionsFile = string.IsNullOrWhiteSpace(_options.ModelInstructionsFile)
             ? null
             : _options.ModelInstructionsFile;

--- a/src/LmMultiTurn/ProfileSystemPromptResolver.cs
+++ b/src/LmMultiTurn/ProfileSystemPromptResolver.cs
@@ -1,0 +1,50 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn;
+
+/// <summary>
+///     Shared helper that resolves the precedence cascade for an agent's developer
+///     instructions:
+///     <list type="number">
+///         <item><description><see cref="AgentRuntimeProfile.SystemPrompt"/> when supplied.</description></item>
+///         <item><description>Constructor-supplied <c>systemPrompt</c> (e.g. base loop's <c>SystemPrompt</c>).</description></item>
+///         <item><description>Provider-level <c>DeveloperInstructions</c> option.</description></item>
+///     </list>
+///     Centralizing the cascade keeps the Codex and Copilot loops from drifting
+///     when one side fixes a bug or changes the order.
+/// </summary>
+internal static class ProfileSystemPromptResolver
+{
+    /// <summary>
+    ///     Picks the highest-priority non-empty developer instructions string. Returns
+    ///     <c>null</c> if all three inputs are null or whitespace.
+    /// </summary>
+    /// <param name="profile">
+    ///     Optional <see cref="AgentRuntimeProfile"/>. Its <see cref="AgentRuntimeProfile.SystemPrompt"/>
+    ///     wins when non-empty.
+    /// </param>
+    /// <param name="systemPrompt">
+    ///     Constructor-supplied system prompt (typically the base loop's <c>SystemPrompt</c>).
+    /// </param>
+    /// <param name="developerInstructions">
+    ///     Provider option fallback (e.g. <c>CodexSdkOptions.DeveloperInstructions</c>).
+    /// </param>
+    public static string? Resolve(
+        AgentRuntimeProfile? profile,
+        string? systemPrompt,
+        string? developerInstructions)
+    {
+        var profileSystemPrompt = profile?.SystemPrompt;
+        if (!string.IsNullOrWhiteSpace(profileSystemPrompt))
+        {
+            return profileSystemPrompt;
+        }
+
+        if (!string.IsNullOrWhiteSpace(systemPrompt))
+        {
+            return systemPrompt;
+        }
+
+        return string.IsNullOrWhiteSpace(developerInstructions) ? null : developerInstructions;
+    }
+}

--- a/src/LmTestUtils/Logging/CapturingLogger.cs
+++ b/src/LmTestUtils/Logging/CapturingLogger.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Logging;
+
+namespace AchieveAi.LmDotnetTools.LmTestUtils.Logging;
+
+public sealed class CapturingLogger<T> : ILogger<T>
+{
+    private readonly List<(LogLevel Level, string Text)> _entries = [];
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        _entries.Add((logLevel, formatter(state, exception)));
+    }
+
+    public int WarningCount(string substring)
+        => _entries.Count(e => e.Level == LogLevel.Warning
+            && e.Text.Contains(substring, StringComparison.Ordinal));
+}

--- a/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.CliArguments.Tests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.CliArguments.Tests.cs
@@ -60,4 +60,75 @@ public class ClaudeAgentSdkClientCliArgumentsTests
         Assert.Contains("--model claude-sonnet-4-6", args);
         Assert.Contains("--max-turns 50", args);
     }
+
+    [Fact]
+    public void BuildCliArguments_OmitsSettingSourcesFlag_WhenUnset()
+    {
+        // Regression for: --setting-sources "" was always emitted, causing the
+        // CLI to load no settings at all (no plugins, no skills, no sub-agents,
+        // no worktree .mcp.json). Omitting the flag lets the CLI fall back to
+        // its own default of user,project,local.
+        var client = new ClaudeAgentSdkClient(new ClaudeAgentSdkOptions());
+        var request = new ClaudeAgentSdkRequest { ModelId = "claude-sonnet-4-6" };
+
+        var args = client.BuildCliArguments(request);
+
+        Assert.DoesNotContain("--setting-sources", args);
+    }
+
+    [Fact]
+    public void BuildCliArguments_EmitsSettingSourcesFlag_WhenSet()
+    {
+        var client = new ClaudeAgentSdkClient(new ClaudeAgentSdkOptions());
+        var request = new ClaudeAgentSdkRequest { ModelId = "claude-sonnet-4-6", SettingSources = "user" };
+
+        var args = client.BuildCliArguments(request);
+
+        Assert.Contains("--setting-sources \"user\"", args);
+    }
+
+    [Fact]
+    public void BuildCliArguments_EmitsEmptySettingSources_WhenIsolated()
+    {
+        // Explicit empty value tells the CLI to load no settings sources at all
+        // (no user, no project, no local). Distinct from null / omitted, which
+        // lets the CLI fall back to its own default of user,project,local.
+        var client = new ClaudeAgentSdkClient(new ClaudeAgentSdkOptions());
+        var request = new ClaudeAgentSdkRequest { ModelId = "claude-sonnet-4-6", SettingSources = string.Empty };
+
+        var args = client.BuildCliArguments(request);
+
+        Assert.Contains("--setting-sources \"\"", args);
+    }
+
+    [Fact]
+    public void ApplyStagingDirectoryEnv_SetsClaudeConfigDir_WhenStagingDirectoryProvided()
+    {
+        var env = new Dictionary<string, string?>();
+
+        ClaudeAgentSdkClient.ApplyStagingDirectoryEnv(env, "/tmp/lm-claude-abc");
+
+        Assert.True(env.ContainsKey("CLAUDE_CONFIG_DIR"));
+        Assert.Equal("/tmp/lm-claude-abc", env["CLAUDE_CONFIG_DIR"]);
+    }
+
+    [Fact]
+    public void ApplyStagingDirectoryEnv_DoesNotSet_WhenStagingDirectoryNull()
+    {
+        var env = new Dictionary<string, string?>();
+
+        ClaudeAgentSdkClient.ApplyStagingDirectoryEnv(env, null);
+
+        Assert.False(env.ContainsKey("CLAUDE_CONFIG_DIR"));
+    }
+
+    [Fact]
+    public void ApplyStagingDirectoryEnv_DoesNotSet_WhenStagingDirectoryEmpty()
+    {
+        var env = new Dictionary<string, string?>();
+
+        ClaudeAgentSdkClient.ApplyStagingDirectoryEnv(env, string.Empty);
+
+        Assert.False(env.ContainsKey("CLAUDE_CONFIG_DIR"));
+    }
 }

--- a/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.JsonlEventHandling.Tests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.JsonlEventHandling.Tests.cs
@@ -41,4 +41,5 @@ public class ClaudeAgentSdkClientJsonlEventHandlingTests
         var text = Assert.Single(messages.OfType<TextMessage>());
         Assert.Equal("assistant survived stream event", text.Text);
     }
+
 }

--- a/tests/ClaudeAgentSdkProvider.Tests/Agents/ProfileMaterializationTests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Agents/ProfileMaterializationTests.cs
@@ -162,4 +162,140 @@ public class ProfileMaterializationTests
         Assert.Equal("node", result.McpServers["alpha"].Command);
         Assert.Equal("https://example.com", result.McpServers["beta"].Url);
     }
+
+    [Theory]
+    [InlineData("../escape")]
+    [InlineData("foo/bar")]
+    [InlineData("foo\\bar")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Materialize_SkillWithMaliciousName_ThrowsArgumentException(string name)
+    {
+        var profile = new AgentRuntimeProfile
+        {
+            Skills = [new AgentSkill { Name = name, Source = new ContentSource.FromInline("body") }],
+        };
+
+        Assert.Throws<ArgumentException>(() => ProfileMaterializer.Materialize(profile));
+    }
+
+    [Theory]
+    [InlineData("../escape")]
+    [InlineData("foo/bar")]
+    [InlineData("foo\\bar")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Materialize_SubAgentWithMaliciousName_ThrowsArgumentException(string name)
+    {
+        var profile = new AgentRuntimeProfile
+        {
+            SubAgents = [new SubAgentDefinition { Name = name, Source = new ContentSource.FromInline("body") }],
+        };
+
+        Assert.Throws<ArgumentException>(() => ProfileMaterializer.Materialize(profile));
+    }
+
+    [Fact]
+    public void Materialize_ValidateNameThrows_StagingDirectoryIsCleanedUp()
+    {
+        // First skill is valid, second one trips ValidateName so the throw happens
+        // mid-materialization after the staging dir has been created.
+        var profile = new AgentRuntimeProfile
+        {
+            Skills =
+            [
+                AgentSkill.Inline("good", "body"),
+                new AgentSkill { Name = "../escape", Source = new ContentSource.FromInline("body") },
+            ],
+        };
+
+        // Snapshot temp dir contents matching our prefix to detect leaks.
+        var tempRoot = Path.GetTempPath();
+        var before = new HashSet<string>(
+            Directory.EnumerateDirectories(tempRoot, "lm-claude-*"),
+            StringComparer.OrdinalIgnoreCase);
+
+        Assert.Throws<ArgumentException>(() => ProfileMaterializer.Materialize(profile));
+
+        var after = Directory.EnumerateDirectories(tempRoot, "lm-claude-*");
+        var leaked = after.Where(d => !before.Contains(d)).ToList();
+        Assert.Empty(leaked);
+    }
+
+    [Fact]
+    public void Materialize_PathSubAgentFromFile_CopiesToAgentsDir()
+    {
+        var srcFile = Path.Combine(Path.GetTempPath(), $"sub-agent-src-{Guid.NewGuid():N}.md");
+        File.WriteAllText(srcFile, "agent body from file");
+        try
+        {
+            var profile = new AgentRuntimeProfile
+            {
+                SubAgents = [SubAgentDefinition.FromPath("from-file", srcFile)],
+            };
+
+            using var result = ProfileMaterializer.Materialize(profile);
+            var dest = Path.Combine(result.StagingDirectory!, "agents", "from-file.md");
+
+            Assert.True(File.Exists(dest));
+            Assert.Equal("agent body from file", File.ReadAllText(dest));
+        }
+        finally
+        {
+            if (File.Exists(srcFile))
+            {
+                File.Delete(srcFile);
+            }
+        }
+    }
+
+    [Fact]
+    public void Materialize_PathSubAgentFromDirectory_FirstMdCopied()
+    {
+        var srcDir = Path.Combine(Path.GetTempPath(), $"sub-agent-dir-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(srcDir);
+        // Two .md files; we just need to assert one of them is picked up. The exact
+        // ordering returned by Directory.EnumerateFiles is filesystem-specific, so
+        // we write the same body to both to keep the test deterministic.
+        File.WriteAllText(Path.Combine(srcDir, "alpha.md"), "agent body from dir");
+        File.WriteAllText(Path.Combine(srcDir, "beta.md"), "agent body from dir");
+        try
+        {
+            var profile = new AgentRuntimeProfile
+            {
+                SubAgents = [SubAgentDefinition.FromPath("from-dir", srcDir)],
+            };
+
+            using var result = ProfileMaterializer.Materialize(profile);
+            var dest = Path.Combine(result.StagingDirectory!, "agents", "from-dir.md");
+
+            Assert.True(File.Exists(dest));
+            Assert.Equal("agent body from dir", File.ReadAllText(dest));
+        }
+        finally
+        {
+            Directory.Delete(srcDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Materialize_PathSubAgentFromDirWithNoMd_ThrowsFileNotFound()
+    {
+        var srcDir = Path.Combine(Path.GetTempPath(), $"sub-agent-empty-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(Path.Combine(srcDir, "not-markdown.txt"), "ignored");
+        try
+        {
+            var profile = new AgentRuntimeProfile
+            {
+                SubAgents = [SubAgentDefinition.FromPath("no-md", srcDir)],
+            };
+
+            Assert.Throws<FileNotFoundException>(() => ProfileMaterializer.Materialize(profile));
+        }
+        finally
+        {
+            Directory.Delete(srcDir, recursive: true);
+        }
+    }
 }

--- a/tests/ClaudeAgentSdkProvider.Tests/Agents/ProfileMaterializationTests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Agents/ProfileMaterializationTests.cs
@@ -1,0 +1,165 @@
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Agents;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Tests.Agents;
+
+public class ProfileMaterializationTests
+{
+    [Fact]
+    public void Materialize_NullProfile_ReturnsEmptyHandle()
+    {
+        using var result = ProfileMaterializer.Materialize(null);
+
+        Assert.Null(result.StagingDirectory);
+        Assert.Empty(result.McpServers);
+        Assert.Null(result.SystemPrompt);
+    }
+
+    [Fact]
+    public void Materialize_EmptyProfile_ReturnsEmptyHandle()
+    {
+        using var result = ProfileMaterializer.Materialize(new AgentRuntimeProfile());
+
+        Assert.Null(result.StagingDirectory);
+        Assert.Empty(result.McpServers);
+        Assert.Null(result.SystemPrompt);
+    }
+
+    [Fact]
+    public void Materialize_OnlyMcpAndSystemPrompt_NoStagingDirCreated()
+    {
+        var profile = new AgentRuntimeProfile
+        {
+            SystemPrompt = "hello",
+            McpServers = new Dictionary<string, McpServerConfig>
+            {
+                ["m"] = McpServerConfig.CreateStdio("node", ["a.js"]),
+            },
+        };
+
+        using var result = ProfileMaterializer.Materialize(profile);
+
+        Assert.Null(result.StagingDirectory);
+        Assert.Equal("hello", result.SystemPrompt);
+        Assert.True(result.McpServers.ContainsKey("m"));
+    }
+
+    [Fact]
+    public void Materialize_InlineSkill_WritesSkillMd()
+    {
+        var profile = new AgentRuntimeProfile
+        {
+            Skills = [AgentSkill.Inline("my-skill", "# Skill body")],
+        };
+
+        using var result = ProfileMaterializer.Materialize(profile);
+
+        Assert.NotNull(result.StagingDirectory);
+        var skillFile = Path.Combine(result.StagingDirectory!, "skills", "my-skill", "SKILL.md");
+        Assert.True(File.Exists(skillFile));
+        Assert.Equal("# Skill body", File.ReadAllText(skillFile));
+    }
+
+    [Fact]
+    public void Materialize_InlineSubAgent_WritesAgentMd()
+    {
+        var profile = new AgentRuntimeProfile
+        {
+            SubAgents = [SubAgentDefinition.Inline("my-agent", "agent body")],
+        };
+
+        using var result = ProfileMaterializer.Materialize(profile);
+
+        Assert.NotNull(result.StagingDirectory);
+        var agentFile = Path.Combine(result.StagingDirectory!, "agents", "my-agent.md");
+        Assert.True(File.Exists(agentFile));
+        Assert.Equal("agent body", File.ReadAllText(agentFile));
+    }
+
+    [Fact]
+    public void Materialize_PathSkillFromFile_CopiedToSkillMd()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"skill-src-{Guid.NewGuid():N}.md");
+        File.WriteAllText(tempFile, "file body");
+        try
+        {
+            var profile = new AgentRuntimeProfile
+            {
+                Skills = [AgentSkill.FromPath("name", tempFile)],
+            };
+
+            using var result = ProfileMaterializer.Materialize(profile);
+            var skillFile = Path.Combine(result.StagingDirectory!, "skills", "name", "SKILL.md");
+
+            Assert.True(File.Exists(skillFile));
+            Assert.Equal("file body", File.ReadAllText(skillFile));
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void Materialize_PathSkillFromDirectory_TreeReplicated()
+    {
+        var srcDir = Path.Combine(Path.GetTempPath(), $"skill-dir-{Guid.NewGuid():N}");
+        var subDir = Path.Combine(srcDir, "nested");
+        Directory.CreateDirectory(subDir);
+        File.WriteAllText(Path.Combine(srcDir, "SKILL.md"), "top");
+        File.WriteAllText(Path.Combine(subDir, "helper.md"), "nested");
+        try
+        {
+            var profile = new AgentRuntimeProfile
+            {
+                Skills = [AgentSkill.FromPath("name", srcDir)],
+            };
+
+            using var result = ProfileMaterializer.Materialize(profile);
+            var destSkillRoot = Path.Combine(result.StagingDirectory!, "skills", "name");
+
+            Assert.Equal("top", File.ReadAllText(Path.Combine(destSkillRoot, "SKILL.md")));
+            Assert.Equal("nested", File.ReadAllText(Path.Combine(destSkillRoot, "nested", "helper.md")));
+        }
+        finally
+        {
+            Directory.Delete(srcDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Materialize_StagingDir_DeletedOnDispose()
+    {
+        var profile = new AgentRuntimeProfile
+        {
+            Skills = [AgentSkill.Inline("x", "y")],
+        };
+        string? stagingPath;
+        using (var result = ProfileMaterializer.Materialize(profile))
+        {
+            stagingPath = result.StagingDirectory;
+            Assert.True(Directory.Exists(stagingPath));
+        }
+
+        Assert.False(Directory.Exists(stagingPath));
+    }
+
+    [Fact]
+    public void Materialize_McpServers_AreCopiedIntoHandle()
+    {
+        var profile = new AgentRuntimeProfile
+        {
+            McpServers = new Dictionary<string, McpServerConfig>
+            {
+                ["alpha"] = McpServerConfig.CreateStdio("node", ["a.js"]),
+                ["beta"] = McpServerConfig.CreateHttp("https://example.com"),
+            },
+        };
+
+        using var result = ProfileMaterializer.Materialize(profile);
+
+        Assert.Equal(2, result.McpServers.Count);
+        Assert.Equal("node", result.McpServers["alpha"].Command);
+        Assert.Equal("https://example.com", result.McpServers["beta"].Url);
+    }
+}

--- a/tests/ClaudeAgentSdkProvider.Tests/Models/McpConfigurationTests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Models/McpConfigurationTests.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+
+namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Tests.Models;
+
+/// <summary>
+///     Pins down the JSON contract for <see cref="McpConfiguration"/>. The
+///     <c>mcpServers</c> property name is the integration point with the Claude CLI's
+///     <c>.mcp.json</c> file format and must remain case-sensitive and exact.
+/// </summary>
+public class McpConfigurationTests
+{
+    [Fact]
+    public void Deserialize_McpServersJson_PopulatesDictionary()
+    {
+        const string json = """{"mcpServers":{"server1":{"command":"node","args":["a.js"]}}}""";
+
+        var config = JsonSerializer.Deserialize<McpConfiguration>(json);
+
+        Assert.NotNull(config);
+        Assert.Single(config!.McpServers);
+        Assert.True(config.McpServers.ContainsKey("server1"));
+        Assert.Equal("node", config.McpServers["server1"].Command);
+        Assert.NotNull(config.McpServers["server1"].Args);
+        Assert.Equal(["a.js"], config.McpServers["server1"].Args!);
+    }
+
+    [Fact]
+    public void Serialize_McpConfiguration_PreservesMcpServersPropertyName()
+    {
+        var config = new McpConfiguration
+        {
+            McpServers =
+            {
+                ["server1"] = new LmCore.AgentRuntime.McpServerConfig
+                {
+                    Type = "stdio",
+                    Command = "node",
+                    Args = ["a.js"],
+                },
+            },
+        };
+
+        var json = JsonSerializer.Serialize(config);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        // Case-sensitive: the property must be `mcpServers`, not `McpServers` or `mcpservers`.
+        Assert.True(root.TryGetProperty("mcpServers", out var serversElement));
+        Assert.False(root.TryGetProperty("McpServers", out _));
+        Assert.Equal(JsonValueKind.Object, serversElement.ValueKind);
+        Assert.True(serversElement.TryGetProperty("server1", out var server1));
+        Assert.Equal("node", server1.GetProperty("command").GetString());
+    }
+
+    [Fact]
+    public void RoundTrip_PreservesContents()
+    {
+        const string json = """{"mcpServers":{"server1":{"command":"node","args":["a.js"]}}}""";
+
+        var roundTripped = JsonSerializer.Serialize(
+            JsonSerializer.Deserialize<McpConfiguration>(json));
+        using var doc = JsonDocument.Parse(roundTripped);
+        var server1 = doc.RootElement.GetProperty("mcpServers").GetProperty("server1");
+
+        Assert.Equal("node", server1.GetProperty("command").GetString());
+        var args = server1.GetProperty("args").EnumerateArray().Select(a => a.GetString()).ToList();
+        Assert.Equal(["a.js"], args);
+    }
+}

--- a/tests/CodexSdkProvider.Tests/AgentRuntime/McpServerConfigExtensionsTests.cs
+++ b/tests/CodexSdkProvider.Tests/AgentRuntime/McpServerConfigExtensionsTests.cs
@@ -1,0 +1,48 @@
+using AchieveAi.LmDotnetTools.CodexSdkProvider.AgentRuntime;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.CodexSdkProvider.Tests.AgentRuntime;
+
+public class McpServerConfigExtensionsTests
+{
+    [Fact]
+    public void ToCodexConfig_StdioSource_MapsCommandArgsEnv()
+    {
+        var source = McpServerConfig.CreateStdio(
+            "node",
+            ["a.js", "--flag"],
+            new Dictionary<string, string> { ["K"] = "V" });
+
+        var codex = source.ToCodexConfig();
+
+        codex.Command.Should().Be("node");
+        codex.Args.Should().Equal("a.js", "--flag");
+        codex.Env.Should().ContainKey("K").WhoseValue.Should().Be("V");
+        codex.Url.Should().BeNull();
+        codex.Enabled.Should().BeNull();
+        codex.EnabledTools.Should().BeNull();
+        codex.DisabledTools.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToCodexConfig_HttpSource_MapsUrl()
+    {
+        var source = McpServerConfig.CreateHttp("https://mcp.example/v1");
+
+        var codex = source.ToCodexConfig();
+
+        codex.Url.Should().Be("https://mcp.example/v1");
+        codex.Command.Should().BeNull();
+        codex.Args.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToCodexConfig_NullSource_Throws()
+    {
+        McpServerConfig? source = null;
+
+        var act = () => source!.ToCodexConfig();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/LmCore.Tests/AgentRuntime/AgentRuntimeProfileTests.cs
+++ b/tests/LmCore.Tests/AgentRuntime/AgentRuntimeProfileTests.cs
@@ -1,0 +1,43 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.AgentRuntime;
+
+public class AgentRuntimeProfileTests
+{
+    [Fact]
+    public void Defaults_AreEmpty()
+    {
+        var profile = new AgentRuntimeProfile();
+
+        Assert.Null(profile.SystemPrompt);
+        Assert.Empty(profile.Skills);
+        Assert.Empty(profile.SubAgents);
+        Assert.Empty(profile.McpServers);
+    }
+
+    [Fact]
+    public void InitOnly_PreservesAllFields()
+    {
+        var skills = new[] { AgentSkill.Inline("s1", "body") };
+        var subs = new[] { SubAgentDefinition.Inline("a1", "body") };
+        var mcp = new Dictionary<string, McpServerConfig>
+        {
+            ["m1"] = McpServerConfig.CreateStdio("node", ["a.js"]),
+        };
+
+        var profile = new AgentRuntimeProfile
+        {
+            SystemPrompt = "sp",
+            Skills = skills,
+            SubAgents = subs,
+            McpServers = mcp,
+        };
+
+        Assert.Equal("sp", profile.SystemPrompt);
+        Assert.Single(profile.Skills);
+        Assert.Equal("s1", profile.Skills[0].Name);
+        Assert.Single(profile.SubAgents);
+        Assert.Equal("a1", profile.SubAgents[0].Name);
+        Assert.True(profile.McpServers.ContainsKey("m1"));
+    }
+}

--- a/tests/LmCore.Tests/AgentRuntime/ContentSourceTests.cs
+++ b/tests/LmCore.Tests/AgentRuntime/ContentSourceTests.cs
@@ -1,0 +1,52 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.AgentRuntime;
+
+public class ContentSourceTests
+{
+    [Fact]
+    public void PatternMatch_HandlesBothVariants()
+    {
+        ContentSource fromPath = new ContentSource.FromPath("/tmp/skill.md");
+        ContentSource fromInline = new ContentSource.FromInline("inline body");
+
+        Assert.Equal("path:/tmp/skill.md", Render(fromPath));
+        Assert.Equal("inline:inline body", Render(fromInline));
+
+        static string Render(ContentSource source) => source switch
+        {
+            ContentSource.FromPath p => $"path:{p.Value}",
+            ContentSource.FromInline i => $"inline:{i.Content}",
+            _ => throw new InvalidOperationException(),
+        };
+    }
+
+    [Fact]
+    public void AgentSkill_InlineFactory_BuildsFromInline()
+    {
+        var skill = AgentSkill.Inline("name", "body");
+
+        Assert.Equal("name", skill.Name);
+        var inline = Assert.IsType<ContentSource.FromInline>(skill.Source);
+        Assert.Equal("body", inline.Content);
+    }
+
+    [Fact]
+    public void AgentSkill_FromPathFactory_BuildsFromPath()
+    {
+        var skill = AgentSkill.FromPath("name", "/some/path");
+
+        var fromPath = Assert.IsType<ContentSource.FromPath>(skill.Source);
+        Assert.Equal("/some/path", fromPath.Value);
+    }
+
+    [Fact]
+    public void SubAgentDefinition_Factories_RoundTrip()
+    {
+        var inline = SubAgentDefinition.Inline("sa", "body");
+        var path = SubAgentDefinition.FromPath("sa", "/p.md");
+
+        Assert.IsType<ContentSource.FromInline>(inline.Source);
+        Assert.IsType<ContentSource.FromPath>(path.Source);
+    }
+}

--- a/tests/LmMultiTurn.Tests/ClaudeAgentLoopProfileTests.cs
+++ b/tests/LmMultiTurn.Tests/ClaudeAgentLoopProfileTests.cs
@@ -1,0 +1,98 @@
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using FluentAssertions;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+public class ClaudeAgentLoopProfileTests
+{
+    [Fact]
+    public async Task BuildRequest_ProfileMcp_OverridesHostMcp_OnKeyCollision()
+    {
+        var hostMcp = new Dictionary<string, McpServerConfig>
+        {
+            ["alpha"] = McpServerConfig.CreateStdio("host-alpha", ["x"]),
+            ["shared"] = McpServerConfig.CreateStdio("host-shared", ["x"]),
+        };
+        var profileMcp = new Dictionary<string, McpServerConfig>
+        {
+            ["beta"] = McpServerConfig.CreateStdio("profile-beta", ["y"]),
+            ["shared"] = McpServerConfig.CreateStdio("profile-shared", ["y"]),
+        };
+
+        await using var loop = new ClaudeAgentLoop(
+            new ClaudeAgentSdkOptions
+            {
+                Profile = new AgentRuntimeProfile { McpServers = profileMcp },
+            },
+            mcpServers: hostMcp,
+            threadId: "thread-claude-profile-1");
+
+        var request = loop.BuildClaudeAgentSdkRequest();
+
+        request.McpServers.Should().NotBeNull();
+        request.McpServers!["alpha"].Command.Should().Be("host-alpha");
+        request.McpServers["beta"].Command.Should().Be("profile-beta");
+        request.McpServers["shared"].Command.Should().Be("profile-shared");
+    }
+
+    [Fact]
+    public async Task BuildRequest_ProfileNull_PreservesHostMcp()
+    {
+        var hostMcp = new Dictionary<string, McpServerConfig>
+        {
+            ["alpha"] = McpServerConfig.CreateStdio("host-alpha", ["x"]),
+        };
+
+        await using var loop = new ClaudeAgentLoop(
+            new ClaudeAgentSdkOptions(),
+            mcpServers: hostMcp,
+            threadId: "thread-claude-profile-2");
+
+        var request = loop.BuildClaudeAgentSdkRequest();
+
+        request.McpServers.Should().ContainKey("alpha");
+        request.McpServers!["alpha"].Command.Should().Be("host-alpha");
+        request.StagingDirectory.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BuildRequest_ProfileSystemPrompt_OverridesOptionsSystemPrompt()
+    {
+        await using var loop = new ClaudeAgentLoop(
+            new ClaudeAgentSdkOptions
+            {
+                Profile = new AgentRuntimeProfile { SystemPrompt = "profile-wins" },
+            },
+            mcpServers: null,
+            threadId: "thread-claude-profile-3",
+            systemPrompt: "ctor-prompt");
+
+        var request = loop.BuildClaudeAgentSdkRequest();
+
+        request.SystemPrompt.Should().Be("profile-wins");
+    }
+
+    [Fact]
+    public async Task BuildRequest_ProfileWithInlineSkill_SetsStagingDirectory()
+    {
+        var profile = new AgentRuntimeProfile
+        {
+            Skills = [AgentSkill.Inline("skill-1", "# body")],
+        };
+
+        await using var loop = new ClaudeAgentLoop(
+            new ClaudeAgentSdkOptions { Profile = profile },
+            mcpServers: null,
+            threadId: "thread-claude-profile-4");
+
+        var request = loop.BuildClaudeAgentSdkRequest();
+
+        request.StagingDirectory.Should().NotBeNullOrEmpty();
+        Directory.Exists(request.StagingDirectory).Should().BeTrue();
+        var skillFile = Path.Combine(request.StagingDirectory!, "skills", "skill-1", "SKILL.md");
+        File.Exists(skillFile).Should().BeTrue();
+    }
+}

--- a/tests/LmMultiTurn.Tests/ClaudeAgentLoopSettingSourcesTests.cs
+++ b/tests/LmMultiTurn.Tests/ClaudeAgentLoopSettingSourcesTests.cs
@@ -1,0 +1,81 @@
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+/// <summary>
+/// Locks in the boolean-to-string mapping ClaudeAgentLoop uses for the
+/// --setting-sources CLI flag. The three flags (user/project/local) drive a
+/// tri-state output:
+///   all true  -> null  (omit the flag, CLI uses its own default)
+///   all false -> ""    (emit empty value, isolated agent)
+///   mixed     -> comma-joined list of the enabled sources
+/// </summary>
+public class ClaudeAgentLoopSettingSourcesTests
+{
+    [Fact]
+    public void BuildSettingSources_AllTrue_ReturnsNull_SoFlagIsOmitted()
+    {
+        var options = new ClaudeAgentSdkOptions
+        {
+            IncludeUserSettings = true,
+            IncludeProjectSettings = true,
+            IncludeLocalSettings = true,
+        };
+
+        var result = ClaudeAgentLoop.BuildSettingSources(options);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void BuildSettingSources_AllFalse_ReturnsEmptyString_ForIsolatedAgent()
+    {
+        var options = new ClaudeAgentSdkOptions
+        {
+            IncludeUserSettings = false,
+            IncludeProjectSettings = false,
+            IncludeLocalSettings = false,
+        };
+
+        var result = ClaudeAgentLoop.BuildSettingSources(options);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Theory]
+    [InlineData(true, false, false, "user")]
+    [InlineData(false, true, false, "project")]
+    [InlineData(false, false, true, "local")]
+    [InlineData(true, true, false, "user,project")]
+    [InlineData(true, false, true, "user,local")]
+    [InlineData(false, true, true, "project,local")]
+    public void BuildSettingSources_Mixed_ReturnsCommaJoinedSubset(
+        bool user, bool project, bool local, string expected)
+    {
+        var options = new ClaudeAgentSdkOptions
+        {
+            IncludeUserSettings = user,
+            IncludeProjectSettings = project,
+            IncludeLocalSettings = local,
+        };
+
+        var result = ClaudeAgentLoop.BuildSettingSources(options);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ClaudeAgentSdkOptions_Defaults_IncludeAllSettings()
+    {
+        // Regression: defaults must keep the host's installed plugins, sub-agents,
+        // skills, and worktree .mcp.json visible to the spawned agent.
+        var options = new ClaudeAgentSdkOptions();
+
+        Assert.True(options.IncludeUserSettings);
+        Assert.True(options.IncludeProjectSettings);
+        Assert.True(options.IncludeLocalSettings);
+        Assert.Null(ClaudeAgentLoop.BuildSettingSources(options));
+    }
+}

--- a/tests/LmMultiTurn.Tests/CodexAgentLoopProfileTests.cs
+++ b/tests/LmMultiTurn.Tests/CodexAgentLoopProfileTests.cs
@@ -1,0 +1,273 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.CodexSdkProvider.Agents;
+using AchieveAi.LmDotnetTools.CodexSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.CodexSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using AchieveAi.LmDotnetTools.LmTestUtils.Logging;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace LmMultiTurn.Tests;
+
+public class CodexAgentLoopProfileTests : LoggingTestBase
+{
+    public CodexAgentLoopProfileTests(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public async Task Profile_SystemPrompt_OverridesDeveloperInstructions()
+    {
+        var fakeClient = new RecordingCodexClient(SuccessfulTurnEvents());
+
+        await using var loop = new CodexAgentLoop(
+            new CodexSdkOptions
+            {
+                DeveloperInstructions = "host-level",
+                Profile = new AgentRuntimeProfile { SystemPrompt = "profile-level" },
+            },
+            new Dictionary<string, CodexMcpServerConfig>(),
+            functionRegistry: null,
+            enabledTools: null,
+            threadId: "thread-profile-1",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CodexAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        fakeClient.LastStartOptions.Should().NotBeNull();
+        fakeClient.LastStartOptions!.DeveloperInstructions.Should().Be("profile-level");
+    }
+
+    [Fact]
+    public async Task Profile_McpServers_MergeWithHostMcp_ProfileWinsOnCollision()
+    {
+        var fakeClient = new RecordingCodexClient(SuccessfulTurnEvents());
+
+        var hostMcp = new Dictionary<string, CodexMcpServerConfig>
+        {
+            ["alpha"] = new() { Command = "host-alpha" },
+            ["shared"] = new() { Command = "host-shared" },
+        };
+
+        var profileMcp = new Dictionary<string, McpServerConfig>
+        {
+            ["beta"] = McpServerConfig.CreateStdio("profile-beta", ["x"]),
+            ["shared"] = McpServerConfig.CreateStdio("profile-shared", ["y"]),
+        };
+
+        await using var loop = new CodexAgentLoop(
+            new CodexSdkOptions
+            {
+                Profile = new AgentRuntimeProfile { McpServers = profileMcp },
+            },
+            hostMcp,
+            functionRegistry: null,
+            enabledTools: null,
+            threadId: "thread-profile-2",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CodexAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        var sent = fakeClient.LastStartOptions!.McpServers!;
+        sent.Should().ContainKey("alpha").WhoseValue.Command.Should().Be("host-alpha");
+        sent.Should().ContainKey("beta").WhoseValue.Command.Should().Be("profile-beta");
+        sent.Should().ContainKey("shared").WhoseValue.Command.Should().Be("profile-shared");
+    }
+
+    [Fact]
+    public async Task Profile_ProfileSystemPrompt_OverridesConstructorSystemPrompt()
+    {
+        var fakeClient = new RecordingCodexClient(SuccessfulTurnEvents());
+
+        await using var loop = new CodexAgentLoop(
+            new CodexSdkOptions
+            {
+                Profile = new AgentRuntimeProfile { SystemPrompt = "profile-wins" },
+            },
+            new Dictionary<string, CodexMcpServerConfig>(),
+            functionRegistry: null,
+            enabledTools: null,
+            threadId: "thread-profile-precedence-1",
+            systemPrompt: "ctor-prompt",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CodexAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        fakeClient.LastStartOptions!.DeveloperInstructions.Should().Be("profile-wins");
+    }
+
+    [Fact]
+    public async Task NoProfile_ConstructorSystemPrompt_WinsOverDeveloperInstructions()
+    {
+        var fakeClient = new RecordingCodexClient(SuccessfulTurnEvents());
+
+        await using var loop = new CodexAgentLoop(
+            new CodexSdkOptions { DeveloperInstructions = "host-level" },
+            new Dictionary<string, CodexMcpServerConfig>(),
+            functionRegistry: null,
+            enabledTools: null,
+            threadId: "thread-profile-precedence-2",
+            systemPrompt: "ctor-prompt",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CodexAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        fakeClient.LastStartOptions!.DeveloperInstructions.Should().Be("ctor-prompt");
+    }
+
+    [Fact]
+    public async Task Profile_WithSkillsOrSubAgents_WarningLoggedOnce_AcrossMultipleTurns()
+    {
+        var fakeClient = new RecordingCodexClient([.. SuccessfulTurnEvents(), .. SuccessfulTurnEvents()]);
+        var capture = new CapturingLogger<CodexAgentLoop>();
+
+        await using var loop = new CodexAgentLoop(
+            new CodexSdkOptions
+            {
+                Profile = new AgentRuntimeProfile
+                {
+                    Skills = [AgentSkill.Inline("s", "body")],
+                },
+            },
+            new Dictionary<string, CodexMcpServerConfig>(),
+            functionRegistry: null,
+            enabledTools: null,
+            threadId: "thread-codex-warning-once",
+            clientFactory: (_, _) => fakeClient,
+            logger: capture);
+
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+        var input = new UserInput([new TextMessage { Role = Role.User, Text = "hi" }]);
+        await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token)) { }
+        await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token)) { }
+        await cts.CancelAsync();
+
+        capture.WarningCount("codex.profile.unsupported").Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Profile_WithSkillsOrSubAgents_DoesNotAlterMcp_ButRuns()
+    {
+        var fakeClient = new RecordingCodexClient(SuccessfulTurnEvents());
+
+        await using var loop = new CodexAgentLoop(
+            new CodexSdkOptions
+            {
+                Profile = new AgentRuntimeProfile
+                {
+                    Skills = [AgentSkill.Inline("s", "body")],
+                    SubAgents = [SubAgentDefinition.Inline("a", "body")],
+                },
+            },
+            new Dictionary<string, CodexMcpServerConfig>(),
+            functionRegistry: null,
+            enabledTools: null,
+            threadId: "thread-profile-3",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CodexAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        fakeClient.LastStartOptions.Should().NotBeNull();
+        fakeClient.LastStartOptions!.McpServers.Should().BeEmpty();
+    }
+
+    private static async Task RunOneTurnAsync(CodexAgentLoop loop)
+    {
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+        var input = new UserInput([new TextMessage { Role = Role.User, Text = "hi" }]);
+        await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token))
+        {
+        }
+        await cts.CancelAsync();
+    }
+
+    private static IReadOnlyList<CodexTurnEventEnvelope> SuccessfulTurnEvents()
+    {
+        return
+        [
+            Event("thread.started", """{"type":"thread.started","thread_id":"t1"}"""),
+            Event("turn.completed", """{"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":0,"output_tokens":1}}"""),
+        ];
+    }
+
+    private static CodexTurnEventEnvelope Event(string name, string json)
+    {
+        var element = JsonDocument.Parse(json).RootElement.Clone();
+        return new CodexTurnEventEnvelope
+        {
+            Type = name,
+            Event = element,
+            RequestId = Guid.NewGuid().ToString("N"),
+            ThreadId = null,
+        };
+    }
+
+    private sealed class RecordingCodexClient : ICodexSdkClient
+    {
+        private readonly IReadOnlyList<CodexTurnEventEnvelope> _events;
+
+        public RecordingCodexClient(IReadOnlyList<CodexTurnEventEnvelope> events)
+        {
+            _events = events;
+        }
+
+        public CodexBridgeInitOptions? LastStartOptions { get; private set; }
+
+        public bool IsRunning { get; private set; }
+
+        public string? CurrentCodexThreadId { get; private set; }
+
+        public string? CurrentTurnId => null;
+
+        public string DependencyState => "ready";
+
+        public void ConfigureDynamicToolExecutor(
+            Func<CodexDynamicToolCallRequest, CancellationToken, Task<CodexDynamicToolCallResponse>>? executor)
+        {
+        }
+
+        public Task StartOrResumeThreadAsync(CodexBridgeInitOptions options, CancellationToken ct = default)
+        {
+            IsRunning = true;
+            CurrentCodexThreadId = options.ThreadId;
+            LastStartOptions = options;
+            return Task.CompletedTask;
+        }
+
+        public Task EnsureStartedAsync(CodexBridgeInitOptions options, CancellationToken ct = default)
+            => StartOrResumeThreadAsync(options, ct);
+
+        public async IAsyncEnumerable<CodexTurnEventEnvelope> RunStreamingAsync(
+            string input,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            foreach (var item in _events)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return item;
+                await Task.Yield();
+            }
+        }
+
+        public Task ShutdownAsync(TimeSpan? timeout = null, CancellationToken ct = default)
+        {
+            IsRunning = false;
+            return Task.CompletedTask;
+        }
+
+        public Task InterruptTurnAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/LmMultiTurn.Tests/CopilotAgentLoopProfileTests.cs
+++ b/tests/LmMultiTurn.Tests/CopilotAgentLoopProfileTests.cs
@@ -92,6 +92,35 @@ public class CopilotAgentLoopProfileTests : LoggingTestBase
     }
 
     [Fact]
+    public async Task Profile_WithSkillsAndSubAgents_TriggersWarningOnce()
+    {
+        var fakeClient = new RecordingCopilotClient([PromptCompleted(), PromptCompleted()]);
+        var capture = new CapturingLogger<CopilotAgentLoop>();
+
+        await using var loop = new CopilotAgentLoop(
+            new CopilotSdkOptions
+            {
+                Profile = new AgentRuntimeProfile
+                {
+                    Skills = [AgentSkill.Inline("s", "body")],
+                    SubAgents = [SubAgentDefinition.Inline("a", "body")],
+                },
+            },
+            threadId: "thread-copilot-warning-skills-subagents",
+            clientFactory: (_, _) => fakeClient,
+            logger: capture);
+
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+        var input = new UserInput([new TextMessage { Role = Role.User, Text = "hi" }]);
+        await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token)) { }
+        await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token)) { }
+        await cts.CancelAsync();
+
+        capture.WarningCount("copilot.profile.unsupported").Should().Be(1);
+    }
+
+    [Fact]
     public async Task Profile_WithUnsupportedInputs_DoesNotCrash()
     {
         var fakeClient = new RecordingCopilotClient([PromptCompleted()]);

--- a/tests/LmMultiTurn.Tests/CopilotAgentLoopProfileTests.cs
+++ b/tests/LmMultiTurn.Tests/CopilotAgentLoopProfileTests.cs
@@ -1,0 +1,201 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.CopilotSdkProvider.Agents;
+using AchieveAi.LmDotnetTools.CopilotSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.CopilotSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using AchieveAi.LmDotnetTools.LmTestUtils.Logging;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace LmMultiTurn.Tests;
+
+public class CopilotAgentLoopProfileTests : LoggingTestBase
+{
+    public CopilotAgentLoopProfileTests(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public async Task Profile_SystemPrompt_OverridesDeveloperInstructions()
+    {
+        var fakeClient = new RecordingCopilotClient([PromptCompleted()]);
+
+        await using var loop = new CopilotAgentLoop(
+            new CopilotSdkOptions
+            {
+                DeveloperInstructions = "host-level",
+                Profile = new AgentRuntimeProfile { SystemPrompt = "profile-level" },
+            },
+            threadId: "thread-copilot-profile-1",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CopilotAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        fakeClient.LastStartOptions.Should().NotBeNull();
+        fakeClient.LastStartOptions!.DeveloperInstructions.Should().Be("profile-level");
+    }
+
+    [Fact]
+    public async Task Profile_ProfileSystemPrompt_OverridesConstructorSystemPrompt()
+    {
+        var fakeClient = new RecordingCopilotClient([PromptCompleted()]);
+
+        await using var loop = new CopilotAgentLoop(
+            new CopilotSdkOptions
+            {
+                Profile = new AgentRuntimeProfile { SystemPrompt = "profile-wins" },
+            },
+            threadId: "thread-copilot-profile-2",
+            systemPrompt: "ctor-prompt",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CopilotAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        fakeClient.LastStartOptions!.DeveloperInstructions.Should().Be("profile-wins");
+    }
+
+    [Fact]
+    public async Task Profile_WithUnsupportedInputs_WarningLoggedOnce_AcrossMultipleTurns()
+    {
+        var fakeClient = new RecordingCopilotClient([PromptCompleted(), PromptCompleted()]);
+        var capture = new CapturingLogger<CopilotAgentLoop>();
+
+        await using var loop = new CopilotAgentLoop(
+            new CopilotSdkOptions
+            {
+                Profile = new AgentRuntimeProfile
+                {
+                    McpServers = new Dictionary<string, McpServerConfig>
+                    {
+                        ["m"] = McpServerConfig.CreateStdio("node", ["a.js"]),
+                    },
+                },
+            },
+            threadId: "thread-copilot-warning-once",
+            clientFactory: (_, _) => fakeClient,
+            logger: capture);
+
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+        var input = new UserInput([new TextMessage { Role = Role.User, Text = "hi" }]);
+        await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token)) { }
+        await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token)) { }
+        await cts.CancelAsync();
+
+        capture.WarningCount("copilot.profile.unsupported").Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Profile_WithUnsupportedInputs_DoesNotCrash()
+    {
+        var fakeClient = new RecordingCopilotClient([PromptCompleted()]);
+
+        await using var loop = new CopilotAgentLoop(
+            new CopilotSdkOptions
+            {
+                Profile = new AgentRuntimeProfile
+                {
+                    Skills = [AgentSkill.Inline("s", "body")],
+                    SubAgents = [SubAgentDefinition.Inline("a", "body")],
+                    McpServers = new Dictionary<string, McpServerConfig>
+                    {
+                        ["ignored"] = McpServerConfig.CreateStdio("node", ["a.js"]),
+                    },
+                },
+            },
+            threadId: "thread-copilot-profile-3",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CopilotAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        fakeClient.LastStartOptions.Should().NotBeNull();
+    }
+
+    private static async Task RunOneTurnAsync(CopilotAgentLoop loop)
+    {
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+        var input = new UserInput([new TextMessage { Role = Role.User, Text = "hi" }]);
+        await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token))
+        {
+        }
+        await cts.CancelAsync();
+    }
+
+    private static CopilotTurnEventEnvelope PromptCompleted()
+    {
+        const string json = """{"type":"session/prompt/completed","usage":{"inputTokens":1,"outputTokens":1}}""";
+        var element = JsonDocument.Parse(json).RootElement.Clone();
+        return new CopilotTurnEventEnvelope
+        {
+            Type = "event",
+            Event = element,
+            RequestId = Guid.NewGuid().ToString("N"),
+            SessionId = null,
+        };
+    }
+
+    private sealed class RecordingCopilotClient : ICopilotSdkClient
+    {
+        private readonly IReadOnlyList<CopilotTurnEventEnvelope> _events;
+
+        public RecordingCopilotClient(IReadOnlyList<CopilotTurnEventEnvelope> events)
+        {
+            _events = events;
+        }
+
+        public CopilotBridgeInitOptions? LastStartOptions { get; private set; }
+
+        public bool IsRunning { get; private set; }
+
+        public string? CurrentCopilotSessionId { get; private set; }
+
+        public string DependencyState => "ready";
+
+        public void ConfigureDynamicToolExecutor(
+            Func<CopilotDynamicToolCallRequest, CancellationToken, Task<CopilotDynamicToolCallResponse>>? executor)
+        {
+        }
+
+        public Task StartOrResumeSessionAsync(CopilotBridgeInitOptions options, CancellationToken ct = default)
+        {
+            IsRunning = true;
+            LastStartOptions = options;
+            CurrentCopilotSessionId = "session-mock";
+            return Task.CompletedTask;
+        }
+
+        public Task EnsureStartedAsync(CopilotBridgeInitOptions options, CancellationToken ct = default)
+            => StartOrResumeSessionAsync(options, ct);
+
+        public async IAsyncEnumerable<CopilotTurnEventEnvelope> RunStreamingAsync(
+            string input,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            foreach (var item in _events)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return item;
+                await Task.Yield();
+            }
+        }
+
+        public Task InterruptTurnAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task ShutdownAsync(TimeSpan? timeout = null, CancellationToken ct = default)
+        {
+            IsRunning = false;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+}

--- a/tests/LmMultiTurn.Tests/ProfileSystemPromptResolverTests.cs
+++ b/tests/LmMultiTurn.Tests/ProfileSystemPromptResolverTests.cs
@@ -1,0 +1,22 @@
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using FluentAssertions;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+public class ProfileSystemPromptResolverTests
+{
+    [Theory]
+    [InlineData("profile", null, null, "profile")]      // profile wins
+    [InlineData(null, "ctor", null, "ctor")]              // ctor wins
+    [InlineData(null, null, "dev", "dev")]                // devInstructions wins
+    [InlineData(null, null, null, null)]                   // all null
+    [InlineData("profile", "ctor", "dev", "profile")]     // profile beats all
+    [InlineData("  ", "ctor", null, "ctor")]              // whitespace profile skipped
+    public void Resolve_PrecedenceCascade(string? profilePrompt, string? ctorPrompt, string? devInstructions, string? expected)
+    {
+        var profile = profilePrompt is null ? null : new AgentRuntimeProfile { SystemPrompt = profilePrompt };
+        ProfileSystemPromptResolver.Resolve(profile, ctorPrompt, devInstructions).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces `AgentRuntimeProfile` in `LmCore.AgentRuntime` — a provider-neutral DTO bundling SystemPrompt, Skills, SubAgents, and McpServers. Each provider (Claude, Codex, Copilot) projects whatever subset its underlying CLI/protocol supports; anything unsupported is logged as a one-shot warning.

## Provider support matrix

| Input          | Claude | Codex     | Copilot   |
|----------------|--------|-----------|-----------|
| SystemPrompt   | ✅     | ✅        | ✅        |
| McpServers     | ✅     | ✅        | ⚠️ warn   |
| Skills         | ✅     | ⚠️ warn   | ⚠️ warn   |
| SubAgents      | ✅     | ⚠️ warn   | ⚠️ warn   |

## What changed

- **LmCore.AgentRuntime** (new namespace): `AgentRuntimeProfile`, `AgentSkill`, `SubAgentDefinition`, `ContentSource` closed discriminated union (`FromPath` / `FromInline`). `McpServerConfig` promoted here from `ClaudeAgentSdkProvider`.
- **Claude provider**: `ProfileMaterializer` writes inline skills/sub-agents to a `%TEMP%/lm-claude-{guid}/` staging tree; `ClaudeAgentSdkClient` injects `CLAUDE_CONFIG_DIR` so the CLI discovers them. Profile MCP merges with host MCP — profile wins on key collision. Path-traversal guard + cleanup-on-throw on the materializer.
- **Codex provider**: `SystemPrompt` overrides `DeveloperInstructions`; `McpServers` project to `CodexMcpServerConfig` via `McpServerConfigExtensions.ToCodexConfig`. Skills/SubAgents log a single warning per loop construction.
- **Copilot provider**: `SystemPrompt` overrides `DeveloperInstructions`. MCP/Skills/SubAgents log a single warning.
- **Tests**: 1,200+ tests across `LmCore.Tests`, `ClaudeAgentSdkProvider.Tests`, `CodexSdkProvider.Tests`, `CopilotSdkProvider.Tests`, `LmMultiTurn.Tests` — all pass.
- Shared `CapturingLogger<T>` test helper in `LmTestUtils.Logging`.

## Design choices

- `ContentSource.FromInline` does **not** write at construction; provider materializers own all I/O. Profile values stay pure.
- `AgentSkill` and `SubAgentDefinition` kept as separate records (not merged via a `Kind` enum) — they materialize into different directories on Claude (`skills/<Name>/` vs `agents/<Name>.md`).
- System-prompt precedence: `profile.SystemPrompt` > constructor `systemPrompt` > `options.DeveloperInstructions`.
- Unsupported-input warnings fire once per loop construction (not per turn) to avoid log spam.

## Out of scope

- Native skill/sub-agent materialization on Codex/Copilot — their CLIs lack `~/.claude/skills/`-style discovery; deferred to follow-up.
- Frontmatter parsing — the Claude CLI does it itself.
- Mutating consumer-owned `<ProjectRoot>/.claude/`. Staging via `CLAUDE_CONFIG_DIR` only.

## Base branch

Targets `fix/37-mock-provider-alignment` because this work depends on the six commits in PR #38 (CLI argument fixes, system-init relay rework). Will retarget to `main` once #38 merges.

## Related Issues

Fixes #39