### PR TITLE
Bump version to 1.0.27 and migrate ModelContextProtocol to 1.3.0 stable

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <!-- Centralized Versioning - UPDATE ONLY THIS SECTION FOR NEW RELEASES -->
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>26</PatchVersion>
+    <PatchVersion>27</PatchVersion>
     <PreReleaseLabel></PreReleaseLabel>
     <!-- Use values like 'alpha', 'beta', 'rc.1' or leave empty for stable -->
     <!-- Computed Version Properties (DO NOT MODIFY) -->

--- a/example/LmConfigUsageExample/LmConfigUsageExample.csproj
+++ b/example/LmConfigUsageExample/LmConfigUsageExample.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.5" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.1-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/src/McpMiddleware/AchieveAi.LmDotnetTools.McpMiddleware.csproj
+++ b/src/McpMiddleware/AchieveAi.LmDotnetTools.McpMiddleware.csproj
@@ -13,9 +13,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.1-preview.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.4.1-preview.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LmCore\AchieveAi.LmDotnetTools.LmCore.csproj" />

--- a/src/McpMiddleware/McpClientFunctionProvider.cs
+++ b/src/McpMiddleware/McpClientFunctionProvider.cs
@@ -689,11 +689,11 @@ public partial class McpClientFunctionProvider : IFunctionProvider
         var imageIndex = 0;
         foreach (var content in response.Content.Where(c => c?.Type == "image"))
         {
-            if (content is ImageContentBlock imgBlock && !string.IsNullOrEmpty(imgBlock.Data))
+            if (content is ImageContentBlock imgBlock && !imgBlock.Data.IsEmpty)
             {
                 try
                 {
-                    var bytes = Convert.FromBase64String(imgBlock.Data);
+                    var bytes = imgBlock.Data.ToArray();
                     var detectedMimeType = DetectImageMimeType(bytes, imgBlock.MimeType, logger);
 
                     if (detectedMimeType != imgBlock.MimeType)
@@ -719,7 +719,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                     }
 
                     imageBlocks.Add(
-                        new ImageToolResultBlock { Data = imgBlock.Data, MimeType = detectedMimeType }
+                        new ImageToolResultBlock { Data = Convert.ToBase64String(bytes), MimeType = detectedMimeType }
                     );
                 }
                 catch (FormatException ex)
@@ -729,7 +729,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                         "Invalid base64 data in MCP image response: ToolName={ToolName}, ImageIndex={ImageIndex}, DataLength={DataLength}",
                         toolName,
                         imageIndex,
-                        imgBlock.Data?.Length ?? 0
+                        imgBlock.Data.Length
                     );
                 }
                 catch (Exception ex)

--- a/src/McpMiddleware/McpClientFunctionProvider.cs
+++ b/src/McpMiddleware/McpClientFunctionProvider.cs
@@ -693,8 +693,8 @@ public partial class McpClientFunctionProvider : IFunctionProvider
             {
                 try
                 {
-                    var bytes = imgBlock.Data.ToArray();
-                    var detectedMimeType = DetectImageMimeType(bytes, imgBlock.MimeType, logger);
+                    var dataSpan = imgBlock.Data.Span;
+                    var detectedMimeType = DetectImageMimeType(dataSpan, imgBlock.MimeType, logger);
 
                     if (detectedMimeType != imgBlock.MimeType)
                     {
@@ -704,7 +704,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                             imageIndex,
                             imgBlock.MimeType,
                             detectedMimeType,
-                            bytes.Length
+                            dataSpan.Length
                         );
                     }
                     else
@@ -714,12 +714,12 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                             toolName,
                             imageIndex,
                             detectedMimeType,
-                            bytes.Length
+                            dataSpan.Length
                         );
                     }
 
                     imageBlocks.Add(
-                        new ImageToolResultBlock { Data = Convert.ToBase64String(bytes), MimeType = detectedMimeType }
+                        new ImageToolResultBlock { Data = Convert.ToBase64String(dataSpan), MimeType = detectedMimeType }
                     );
                 }
                 catch (Exception ex)
@@ -778,7 +778,7 @@ public partial class McpClientFunctionProvider : IFunctionProvider
     ///     Detects the MIME type of an image from its byte content.
     ///     Uses magic bytes to identify common image formats.
     /// </summary>
-    private static string DetectImageMimeType(byte[] bytes, string fallbackMimeType, ILogger logger)
+    private static string DetectImageMimeType(ReadOnlySpan<byte> bytes, string fallbackMimeType, ILogger logger)
     {
         if (bytes.Length >= 8)
         {

--- a/src/McpMiddleware/McpClientFunctionProvider.cs
+++ b/src/McpMiddleware/McpClientFunctionProvider.cs
@@ -722,16 +722,6 @@ public partial class McpClientFunctionProvider : IFunctionProvider
                         new ImageToolResultBlock { Data = Convert.ToBase64String(bytes), MimeType = detectedMimeType }
                     );
                 }
-                catch (FormatException ex)
-                {
-                    logger.LogWarning(
-                        ex,
-                        "Invalid base64 data in MCP image response: ToolName={ToolName}, ImageIndex={ImageIndex}, DataLength={DataLength}",
-                        toolName,
-                        imageIndex,
-                        imgBlock.Data.Length
-                    );
-                }
                 catch (Exception ex)
                 {
                     logger.LogWarning(

--- a/src/McpSampleServer/AchieveAi.LmDotnetTools.McpSampleServer.csproj
+++ b/src/McpSampleServer/AchieveAi.LmDotnetTools.McpSampleServer.csproj
@@ -13,6 +13,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.1-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
   </ItemGroup>
 </Project>

--- a/src/McpServer.AspNetCore/AchieveAi.LmDotnetTools.McpServer.AspNetCore.csproj
+++ b/src/McpServer.AspNetCore/AchieveAi.LmDotnetTools.McpServer.AspNetCore.csproj
@@ -11,9 +11,9 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol" Version="0.4.1-preview.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.4.1-preview.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LmCore\AchieveAi.LmDotnetTools.LmCore.csproj" />

--- a/tests/LmCore.Tests/AchieveAi.LmDotnetTools.LmCore.Tests.csproj
+++ b/tests/LmCore.Tests/AchieveAi.LmDotnetTools.LmCore.Tests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="dotenv.net" Version="3.2.1" />
     <PackageReference Include="FluentAssertions" Version="7.1.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="System.Text.Json" Version="10.0.0" />
+    <PackageReference Include="System.Text.Json" Version="10.0.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/LmMultiTurn.Tests/LmMultiTurn.Tests.csproj
+++ b/tests/LmMultiTurn.Tests/LmMultiTurn.Tests.csproj
@@ -21,7 +21,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="7.1.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LmMultiTurn\AchieveAi.LmDotnetTools.LmMultiTurn.csproj" />

--- a/tests/McpIntegrationTests/McpIntegrationTests.csproj
+++ b/tests/McpIntegrationTests/McpIntegrationTests.csproj
@@ -14,8 +14,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.1-preview.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.4.1-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/McpServer.AspNetCore.Tests/McpServer.AspNetCore.Tests.csproj
+++ b/tests/McpServer.AspNetCore.Tests/McpServer.AspNetCore.Tests.csproj
@@ -15,8 +15,8 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.1-preview.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.4.1-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\McpServer.AspNetCore\AchieveAi.LmDotnetTools.McpServer.AspNetCore.csproj" />


### PR DESCRIPTION
## Summary

- Bump release version to **1.0.27** (Directory.Build.props). Published all 10 packages to NuGet.org from this branch.
- Migrate `ModelContextProtocol` and `ModelContextProtocol.AspNetCore` from `0.4.1-preview.1` to **1.3.0 stable** across all consuming projects.

## Why

`dotnet pack` was failing for `McpMiddleware` and `McpSampleServer` with **NU5104** (`Warning As Error: A stable release of a package should not have a prerelease dependency`). That blocked the AgentRuntimeProfile release from publishing those two packages. Bumping MCP to a stable line unblocks packing.

## Changes

**Version bump** (`d3b28ad` → cherry-picked as `1a48360`):
- `Directory.Build.props`: PatchVersion 26 → 27.

**MCP migration** (`1e311a4` → cherry-picked as `6ec7b7b`):
- Updated 6 csproj files referencing MCP to `1.3.0`:
  - `src/McpMiddleware`, `src/McpSampleServer`, `src/McpServer.AspNetCore`
  - `tests/McpIntegrationTests`, `tests/McpServer.AspNetCore.Tests`
  - `example/LmConfigUsageExample`
- Bumped transitive dependency floors required by MCP 1.3.0:
  - `Microsoft.Extensions.Logging.Abstractions` 10.0.0 → 10.0.7
  - `Microsoft.Extensions.DependencyInjection.Abstractions` 10.0.0 → 10.0.7
  - `System.Text.Json` 10.0.0 → 10.0.6
- Adapted `src/McpMiddleware/McpClientFunctionProvider.cs` to MCP 1.x breaking change: `ImageContentBlock.Data` is now `ReadOnlyMemory<byte>` (raw decoded bytes) instead of `string` (base64). Decode is now a no-op; re-encode to base64 when producing `ImageToolResultBlock` for the LmCore tool-result contract.

## Verification

- `dotnet build LmDotnetTools.sln -c Release` — **0 errors, 0 warnings**
- `dotnet test` — all publishable-package tests pass:
  - `LmCore.Tests`: 730 passed
  - `ClaudeAgentSdkProvider.Tests`: 64 passed
  - `LmMultiTurn.Tests`: 210 passed
  - `McpIntegrationTests`: 21 passed
- All 10 packages **already published** to NuGet.org as `1.0.27` from this branch.

## Out of scope

`samples/McpServer.AspNetCore.Sample/Tools/ExampleTools.cs` has 4 pre-existing build errors against the `ToolHandler` delegate signature. Verified pre-existing via `git stash`. Not packaged. Should be tracked separately.

## Test plan

- [x] Solution builds clean
- [x] All publishable-package test suites pass
- [x] `dotnet pack` succeeds for all 10 packages at 1.0.27
- [x] `dotnet nuget push` succeeds for all 10 packages