### PR TITLE
Fix JsonlStreamParser on system.init plugins schema drift

### DIFF
--- a/src/ClaudeAgentSdkProvider/Models/JsonlEvents/SystemInitEvent.cs
+++ b/src/ClaudeAgentSdkProvider/Models/JsonlEvents/SystemInitEvent.cs
@@ -48,7 +48,7 @@ public record SystemInitEvent : JsonlEventBase
     public List<string>? Skills { get; init; }
 
     [JsonPropertyName("plugins")]
-    public List<string>? Plugins { get; init; }
+    public List<PluginRef>? Plugins { get; init; }
 
     [JsonPropertyName("uuid")]
     public string? Uuid { get; init; }
@@ -64,4 +64,16 @@ public record McpServerStatus
 
     [JsonPropertyName("status")]
     public string? Status { get; init; }
+}
+
+/// <summary>
+///     Plugin reference emitted by claude-agent-sdk CLI v2.0.55+ in <c>system.init.plugins</c>.
+/// </summary>
+public record PluginRef
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("path")]
+    public string? Path { get; init; }
 }

--- a/tests/ClaudeAgentSdkProvider.Tests/Parsers/JsonlStreamParser.Tests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Parsers/JsonlStreamParser.Tests.cs
@@ -476,6 +476,83 @@ public class JsonlStreamParserTests
     }
 
     [Fact]
+    public void ParseLine_SystemInitWithPluginObjects_DeserializesPluginsAndSessionId()
+    {
+        // Regression for issue #42: claude-agent-sdk CLI v2.0.55+ emits `plugins`
+        // as an array of {name, path} objects rather than strings, which previously
+        // caused the entire system.init frame (including session_id) to be dropped.
+        var systemInitJson = """
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "sess-abc-123",
+                "model": "claude-sonnet-4-5",
+                "cwd": "/tmp/work",
+                "plugins": [
+                    { "name": "code-search", "path": "/plugins/code-search" },
+                    { "name": "shell-runner", "path": "/plugins/shell-runner" }
+                ]
+            }
+            """;
+
+        var evt = _parser.ParseLine(systemInitJson);
+
+        var initEvent = Assert.IsType<SystemInitEvent>(evt);
+        Assert.Equal("sess-abc-123", initEvent.SessionId);
+        Assert.Equal("claude-sonnet-4-5", initEvent.Model);
+        Assert.NotNull(initEvent.Plugins);
+        Assert.Equal(2, initEvent.Plugins!.Count);
+        Assert.Equal("code-search", initEvent.Plugins[0].Name);
+        Assert.Equal("/plugins/code-search", initEvent.Plugins[0].Path);
+        Assert.Equal("shell-runner", initEvent.Plugins[1].Name);
+        Assert.Equal("/plugins/shell-runner", initEvent.Plugins[1].Path);
+    }
+
+    [Fact]
+    public void ParseLine_SystemInitWithEmptyPlugins_DeserializesSuccessfully()
+    {
+        var systemInitJson = """
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "sess-empty",
+                "model": "claude-sonnet-4-5",
+                "plugins": []
+            }
+            """;
+
+        var evt = _parser.ParseLine(systemInitJson);
+
+        var initEvent = Assert.IsType<SystemInitEvent>(evt);
+        Assert.Equal("sess-empty", initEvent.SessionId);
+        Assert.NotNull(initEvent.Plugins);
+        Assert.Empty(initEvent.Plugins!);
+    }
+
+    [Fact]
+    public void ParseLine_SystemInitWithPluginObjects_PreservesSessionIdForResume()
+    {
+        // Locks the resume path: SessionId from system.init must survive parsing
+        // so callers can persist it and pass it back via ClaudeAgentSdkRequest.SessionId.
+        const string expectedSessionId = "resume-session-xyz";
+        var systemInitJson = $$"""
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "{{expectedSessionId}}",
+                "model": "claude-sonnet-4-5",
+                "tools": ["bash", "read"],
+                "plugins": [{ "name": "p1", "path": "/p1" }]
+            }
+            """;
+
+        var evt = _parser.ParseLine(systemInitJson);
+
+        var initEvent = Assert.IsType<SystemInitEvent>(evt);
+        Assert.Equal(expectedSessionId, initEvent.SessionId);
+    }
+
+    [Fact]
     public void ConvertToMessages_UserMessageWithImageContent_CreatesImageMessage()
     {
         // Arrange - User message containing an image content block


### PR DESCRIPTION
[Gautam's Dev bot]

## Summary

Fixes the `JsonlStreamParser` failure on `system.init` frames emitted by `claude-agent-sdk` CLI v2.0.55+, where `plugins` changed from `string[]` to an array of `{name, path}` objects. Previously this drift caused the entire init frame (including `session_id` and `model`) to be silently dropped, breaking the `--resume` round-trip.

- Add `PluginRef` record (`Name`, `Path`) and switch `SystemInitEvent.Plugins` to `List<PluginRef>?`.
- No tolerant `JsonConverter` — clean swap (no in-repo consumers of the old shape).
- Add `JsonlStreamParser` tests covering object-form plugins, empty plugins, and a `SessionId` round-trip that locks the resume path.

## Test Plan

- [x] `dotnet test tests/ClaudeAgentSdkProvider.Tests/ClaudeAgentSdkProvider.Tests.csproj` — 29/29 passing locally (3 new)
- [x] Husky `format-verify` pre-commit hook clean

Closes #42