### PR TITLE
Harden SystemInitEvent skills/agents against schema drift (#44)

### DIFF
--- a/src/ClaudeAgentSdkProvider/Models/JsonlEvents/NamedRefJsonConverter.cs
+++ b/src/ClaudeAgentSdkProvider/Models/JsonlEvents/NamedRefJsonConverter.cs
@@ -16,20 +16,30 @@ namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models.JsonlEvents;
 ///         <item><see cref="JsonTokenType.String"/> → <c>new NamedRef { Name = value }</c>.</item>
 ///         <item><see cref="JsonTokenType.StartObject"/> → deserialize as <see cref="NamedRef"/>
 ///             (including <see cref="NamedRef.Extra"/> overflow).</item>
-///         <item>Anything else → throw <see cref="JsonException"/>. <c>ParseLine</c>
-///             catches this and logs a warning, surfacing drift outside the tolerated
-///             envelope rather than silently swallowing it.</item>
+///         <item>Anything else, including a literal JSON <c>null</c> element, → throw
+///             <see cref="JsonException"/>. <c>ParseLine</c> catches this and logs a
+///             warning, surfacing drift outside the tolerated envelope rather than
+///             silently passing an element into a non-nullable list slot.</item>
 ///     </list>
 /// </summary>
 public sealed class NamedRefJsonConverter : JsonConverter<NamedRef>
 {
+    // Force STJ to route literal JSON `null` array elements through Read() instead
+    // of short-circuiting and inserting a raw null into List<NamedRef>; the Read()
+    // null-token branch then throws JsonException, matching the rest of the
+    // out-of-envelope handling.
+    public override bool HandleNull => true;
+
     public override NamedRef Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         return reader.TokenType switch
         {
             JsonTokenType.String => new NamedRef { Name = reader.GetString() },
             JsonTokenType.StartObject => ReadObject(ref reader),
-            JsonTokenType.Null => null!,
+            // Explicitly reject null array elements: List<NamedRef> declares a
+            // non-nullable element type, and silently letting null sneak into
+            // the list would reintroduce the same NRE-shaped failure mode this
+            // converter exists to prevent (consumers iterating `.Name` on null).
             _ => throw new JsonException(
                 $"Unexpected token '{reader.TokenType}' when reading NamedRef; expected String or StartObject."),
         };
@@ -87,7 +97,11 @@ public sealed class NamedRefJsonConverter : JsonConverter<NamedRef>
             }
 
             var propertyName = reader.GetString();
-            _ = reader.Read();
+            if (!reader.Read())
+            {
+                throw new JsonException(
+                    $"Unexpected end of JSON after property '{propertyName}' inside NamedRef object.");
+            }
 
             switch (propertyName)
             {

--- a/src/ClaudeAgentSdkProvider/Models/JsonlEvents/NamedRefJsonConverter.cs
+++ b/src/ClaudeAgentSdkProvider/Models/JsonlEvents/NamedRefJsonConverter.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models.JsonlEvents;
+
+/// <summary>
+///     Tolerant per-item converter for <see cref="NamedRef"/>.
+///     <para>
+///         The claude-agent-sdk CLI has shipped <c>system.init.plugins</c> as both
+///         <c>string[]</c> and <c>[{name, path}]</c> (see #42 / PR #43). The sibling
+///         <c>skills</c>/<c>agents</c> fields are at risk of the same drift.
+///         This converter accepts either shape per-item so that a single drifted
+///         element no longer drops the entire <c>system.init</c> frame.
+///     </para>
+///     <list type="bullet">
+///         <item><see cref="JsonTokenType.String"/> → <c>new NamedRef { Name = value }</c>.</item>
+///         <item><see cref="JsonTokenType.StartObject"/> → deserialize as <see cref="NamedRef"/>
+///             (including <see cref="NamedRef.Extra"/> overflow).</item>
+///         <item>Anything else → throw <see cref="JsonException"/>. <c>ParseLine</c>
+///             catches this and logs a warning, surfacing drift outside the tolerated
+///             envelope rather than silently swallowing it.</item>
+///     </list>
+/// </summary>
+public sealed class NamedRefJsonConverter : JsonConverter<NamedRef>
+{
+    public override NamedRef Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.String => new NamedRef { Name = reader.GetString() },
+            JsonTokenType.StartObject => ReadObject(ref reader),
+            JsonTokenType.Null => null!,
+            _ => throw new JsonException(
+                $"Unexpected token '{reader.TokenType}' when reading NamedRef; expected String or StartObject."),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, NamedRef value, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(value);
+
+        writer.WriteStartObject();
+        if (value.Name != null)
+        {
+            writer.WriteString("name", value.Name);
+        }
+
+        if (value.Path != null)
+        {
+            writer.WriteString("path", value.Path);
+        }
+
+        if (value.Extra != null)
+        {
+            foreach (var kvp in value.Extra)
+            {
+                writer.WritePropertyName(kvp.Key);
+                kvp.Value.WriteTo(writer);
+            }
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static NamedRef ReadObject(ref Utf8JsonReader reader)
+    {
+        string? name = null;
+        string? path = null;
+        Dictionary<string, JsonElement>? extra = null;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return new NamedRef
+                {
+                    Name = name,
+                    Path = path,
+                    Extra = extra,
+                };
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException($"Unexpected token '{reader.TokenType}' inside NamedRef object.");
+            }
+
+            var propertyName = reader.GetString();
+            _ = reader.Read();
+
+            switch (propertyName)
+            {
+                case "name":
+                    name = ReadOptionalString(ref reader, propertyName);
+                    break;
+                case "path":
+                    path = ReadOptionalString(ref reader, propertyName);
+                    break;
+                default:
+                    extra ??= [];
+                    using (var doc = JsonDocument.ParseValue(ref reader))
+                    {
+                        extra[propertyName!] = doc.RootElement.Clone();
+                    }
+                    break;
+            }
+        }
+
+        throw new JsonException("Unexpected end of JSON while reading NamedRef.");
+    }
+
+    private static string? ReadOptionalString(ref Utf8JsonReader reader, string propertyName)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.Null => null,
+            JsonTokenType.String => reader.GetString(),
+            _ => throw new JsonException(
+                $"Expected string or null for NamedRef property '{propertyName}'; got '{reader.TokenType}'."),
+        };
+    }
+}

--- a/src/ClaudeAgentSdkProvider/Models/JsonlEvents/SystemInitEvent.cs
+++ b/src/ClaudeAgentSdkProvider/Models/JsonlEvents/SystemInitEvent.cs
@@ -85,6 +85,10 @@ public record NamedRef
     [JsonPropertyName("path")]
     public string? Path { get; init; }
 
-    [JsonExtensionData]
+    // [JsonExtensionData] is deliberately omitted: the custom NamedRefJsonConverter
+    // takes full control of (de)serialisation, so STJ never consults the attribute.
+    // Unknown fields are captured into Extra by the converter's object-reader fallback
+    // and emitted back by its Write loop — relying on the converter, not the attribute,
+    // keeps the wiring explicit and the property's role unambiguous.
     public Dictionary<string, JsonElement>? Extra { get; init; }
 }

--- a/src/ClaudeAgentSdkProvider/Models/JsonlEvents/SystemInitEvent.cs
+++ b/src/ClaudeAgentSdkProvider/Models/JsonlEvents/SystemInitEvent.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models.JsonlEvents;
@@ -42,13 +43,13 @@ public record SystemInitEvent : JsonlEventBase
     public string? OutputStyle { get; init; }
 
     [JsonPropertyName("agents")]
-    public List<string>? Agents { get; init; }
+    public List<NamedRef>? Agents { get; init; }
 
     [JsonPropertyName("skills")]
-    public List<string>? Skills { get; init; }
+    public List<NamedRef>? Skills { get; init; }
 
     [JsonPropertyName("plugins")]
-    public List<PluginRef>? Plugins { get; init; }
+    public List<NamedRef>? Plugins { get; init; }
 
     [JsonPropertyName("uuid")]
     public string? Uuid { get; init; }
@@ -67,13 +68,23 @@ public record McpServerStatus
 }
 
 /// <summary>
-///     Plugin reference emitted by claude-agent-sdk CLI v2.0.55+ in <c>system.init.plugins</c>.
+///     Named reference emitted by claude-agent-sdk CLI for entries in
+///     <c>system.init.plugins</c>, <c>system.init.skills</c>, and
+///     <c>system.init.agents</c>. The CLI has historically alternated between
+///     <c>string</c> and <c>{name, ...}</c> shapes for these fields
+///     (see #42 / PR #43 for the plugin drift); <see cref="NamedRefJsonConverter"/>
+///     accepts either at deserialisation time and <see cref="Extra"/> captures any
+///     additional fields without forcing another schema chase.
 /// </summary>
-public record PluginRef
+[JsonConverter(typeof(NamedRefJsonConverter))]
+public record NamedRef
 {
     [JsonPropertyName("name")]
     public string? Name { get; init; }
 
     [JsonPropertyName("path")]
     public string? Path { get; init; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? Extra { get; init; }
 }

--- a/tests/ClaudeAgentSdkProvider.Tests/Parsers/JsonlStreamParser.Tests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Parsers/JsonlStreamParser.Tests.cs
@@ -781,6 +781,113 @@ public class JsonlStreamParserTests
     }
 
     [Fact]
+    public void ParseLine_SystemInitWithStringPlugins_DeserializesPluginsAndSessionId()
+    {
+        // Symmetry with skills/agents string-form tests: plugins was re-typed from
+        // List<PluginRef> to List<NamedRef> in this PR, so the string-form path is
+        // now reachable through the same converter and deserves explicit coverage.
+        var systemInitJson = """
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "sess-plugins-strings",
+                "plugins": ["code-search", "shell-runner"]
+            }
+            """;
+
+        var evt = _parser.ParseLine(systemInitJson);
+
+        var initEvent = Assert.IsType<SystemInitEvent>(evt);
+        Assert.Equal("sess-plugins-strings", initEvent.SessionId);
+        Assert.NotNull(initEvent.Plugins);
+        Assert.Equal(2, initEvent.Plugins.Count);
+        Assert.Equal("code-search", initEvent.Plugins[0].Name);
+        Assert.Null(initEvent.Plugins[0].Path);
+        Assert.Equal("shell-runner", initEvent.Plugins[1].Name);
+    }
+
+    [Fact]
+    public void ParseLine_SystemInitWithNullSkillItem_FailsLoudly()
+    {
+        // List<NamedRef> declares a non-nullable element type; a literal JSON null
+        // must surface as a parse failure rather than sneaking a null reference
+        // into the list (which would re-introduce the very NRE failure mode the
+        // tolerant converter exists to prevent).
+        var systemInitJson = """
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "sess-null-element",
+                "skills": ["valid", null]
+            }
+            """;
+
+        var evt = _parser.ParseLine(systemInitJson);
+
+        Assert.Null(evt);
+    }
+
+    [Fact]
+    public void NamedRefJsonConverter_WritesObjectShape_WithNameAndPath()
+    {
+        var namedRef = new NamedRef { Name = "code-review", Path = "/skills/code-review" };
+
+        var json = JsonSerializer.Serialize(namedRef);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal(JsonValueKind.Object, root.ValueKind);
+        Assert.Equal("code-review", root.GetProperty("name").GetString());
+        Assert.Equal("/skills/code-review", root.GetProperty("path").GetString());
+    }
+
+    [Fact]
+    public void NamedRefJsonConverter_WritesExtraFieldsAlongsideNameAndPath()
+    {
+        var namedRef = new NamedRef
+        {
+            Name = "code-review",
+            Extra = new Dictionary<string, JsonElement>
+            {
+                ["version"] = JsonDocument.Parse("\"1.2.3\"").RootElement.Clone(),
+                ["source"] = JsonDocument.Parse("\"marketplace\"").RootElement.Clone(),
+            },
+        };
+
+        var json = JsonSerializer.Serialize(namedRef);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal("code-review", root.GetProperty("name").GetString());
+        Assert.False(root.TryGetProperty("path", out _), "path should be omitted when null");
+        Assert.Equal("1.2.3", root.GetProperty("version").GetString());
+        Assert.Equal("marketplace", root.GetProperty("source").GetString());
+    }
+
+    [Fact]
+    public void NamedRefJsonConverter_RoundTrip_PreservesNamePathAndExtra()
+    {
+        var original = new NamedRef
+        {
+            Name = "summarize",
+            Path = "/skills/summarize",
+            Extra = new Dictionary<string, JsonElement>
+            {
+                ["version"] = JsonDocument.Parse("\"2.0\"").RootElement.Clone(),
+            },
+        };
+
+        var json = JsonSerializer.Serialize(original);
+        var roundTripped = JsonSerializer.Deserialize<NamedRef>(json);
+
+        Assert.NotNull(roundTripped);
+        Assert.Equal("summarize", roundTripped.Name);
+        Assert.Equal("/skills/summarize", roundTripped.Path);
+        Assert.NotNull(roundTripped.Extra);
+        Assert.Equal("2.0", roundTripped.Extra["version"].GetString());
+    }
+
+    [Fact]
     public void ParseLine_SystemInitWithMalformedSkillItem_FailsLoudly()
     {
         // Drift outside the tolerated envelope (number, not string/object) must

--- a/tests/ClaudeAgentSdkProvider.Tests/Parsers/JsonlStreamParser.Tests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Parsers/JsonlStreamParser.Tests.cs
@@ -501,7 +501,7 @@ public class JsonlStreamParserTests
         Assert.Equal("sess-abc-123", initEvent.SessionId);
         Assert.Equal("claude-sonnet-4-5", initEvent.Model);
         Assert.NotNull(initEvent.Plugins);
-        Assert.Equal(2, initEvent.Plugins!.Count);
+        Assert.Equal(2, initEvent.Plugins.Count);
         Assert.Equal("code-search", initEvent.Plugins[0].Name);
         Assert.Equal("/plugins/code-search", initEvent.Plugins[0].Path);
         Assert.Equal("shell-runner", initEvent.Plugins[1].Name);
@@ -526,7 +526,7 @@ public class JsonlStreamParserTests
         var initEvent = Assert.IsType<SystemInitEvent>(evt);
         Assert.Equal("sess-empty", initEvent.SessionId);
         Assert.NotNull(initEvent.Plugins);
-        Assert.Empty(initEvent.Plugins!);
+        Assert.Empty(initEvent.Plugins);
     }
 
     [Fact]
@@ -550,6 +550,253 @@ public class JsonlStreamParserTests
 
         var initEvent = Assert.IsType<SystemInitEvent>(evt);
         Assert.Equal(expectedSessionId, initEvent.SessionId);
+    }
+
+    // ---- #44 schema-drift tolerance for skills/agents (mirrors PR #43 plugin coverage) ----
+
+    [Fact]
+    public void ParseLine_SystemInitWithStringSkills_DeserializesSkillsAndSessionId()
+    {
+        var systemInitJson = """
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "sess-skills-strings",
+                "model": "claude-sonnet-4-5",
+                "skills": ["code-review", "summarize"]
+            }
+            """;
+
+        var evt = _parser.ParseLine(systemInitJson);
+
+        var initEvent = Assert.IsType<SystemInitEvent>(evt);
+        Assert.Equal("sess-skills-strings", initEvent.SessionId);
+        Assert.NotNull(initEvent.Skills);
+        Assert.Equal(2, initEvent.Skills.Count);
+        Assert.Equal("code-review", initEvent.Skills[0].Name);
+        Assert.Null(initEvent.Skills[0].Path);
+        Assert.Equal("summarize", initEvent.Skills[1].Name);
+    }
+
+    [Fact]
+    public void ParseLine_SystemInitWithObjectSkills_DeserializesAndPreservesSessionId()
+    {
+        // Drift simulation: CLI evolves skills from string[] to [{name, ...}]
+        // (mirrors the #42 plugins drift). SessionId must still survive.
+        var systemInitJson = """
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "sess-skills-objects",
+                "model": "claude-sonnet-4-5",
+                "skills": [
+                    { "name": "code-review", "path": "/skills/code-review" },
+                    { "name": "summarize", "path": "/skills/summarize" }
+                ]
+            }
+            """;
+
+        var evt = _parser.ParseLine(systemInitJson);
+
+        var initEvent = Assert.IsType<SystemInitEvent>(evt);
+        Assert.Equal("sess-skills-objects", initEvent.SessionId);
+        Assert.Equal("claude-sonnet-4-5", initEvent.Model);
+        Assert.NotNull(initEvent.Skills);
+        Assert.Equal(2, initEvent.Skills.Count);
+        Assert.Equal("code-review", initEvent.Skills[0].Name);
+        Assert.Equal("/skills/code-review", initEvent.Skills[0].Path);
+        Assert.Equal("summarize", initEvent.Skills[1].Name);
+        Assert.Equal("/skills/summarize", initEvent.Skills[1].Path);
+    }
+
+    [Fact]
+    public void ParseLine_SystemInitWithMixedSkills_DeserializesBothShapes()
+    {
+        // Item-level (not list-level) tolerance: one string, one object.
+        var systemInitJson = """
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "sess-skills-mixed",
+                "skills": [
+                    "code-review",
+                    { "name": "summarize", "path": "/skills/summarize" }
+                ]
+            }
+            """;
+
+        var evt = _parser.ParseLine(systemInitJson);
+
+        var initEvent = Assert.IsType<SystemInitEvent>(evt);
+        Assert.NotNull(initEvent.Skills);
+        Assert.Equal(2, initEvent.Skills.Count);
+        Assert.Equal("code-review", initEvent.Skills[0].Name);
+        Assert.Null(initEvent.Skills[0].Path);
+        Assert.Equal("summarize", initEvent.Skills[1].Name);
+        Assert.Equal("/skills/summarize", initEvent.Skills[1].Path);
+    }
+
+    [Fact]
+    public void ParseLine_SystemInitWithEmptySkills_DeserializesSuccessfully()
+    {
+        var systemInitJson = """
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "sess-skills-empty",
+                "skills": []
+            }
+            """;
+
+        var evt = _parser.ParseLine(systemInitJson);
+
+        var initEvent = Assert.IsType<SystemInitEvent>(evt);
+        Assert.Equal("sess-skills-empty", initEvent.SessionId);
+        Assert.NotNull(initEvent.Skills);
+        Assert.Empty(initEvent.Skills);
+    }
+
+    [Fact]
+    public void ParseLine_SystemInitWithStringAgents_DeserializesAgentsAndSessionId()
+    {
+        var systemInitJson = """
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "sess-agents-strings",
+                "agents": ["planner", "executor"]
+            }
+            """;
+
+        var evt = _parser.ParseLine(systemInitJson);
+
+        var initEvent = Assert.IsType<SystemInitEvent>(evt);
+        Assert.Equal("sess-agents-strings", initEvent.SessionId);
+        Assert.NotNull(initEvent.Agents);
+        Assert.Equal(2, initEvent.Agents.Count);
+        Assert.Equal("planner", initEvent.Agents[0].Name);
+        Assert.Equal("executor", initEvent.Agents[1].Name);
+    }
+
+    [Fact]
+    public void ParseLine_SystemInitWithObjectAgents_DeserializesAndPreservesSessionId()
+    {
+        var systemInitJson = """
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "sess-agents-objects",
+                "model": "claude-sonnet-4-5",
+                "agents": [
+                    { "name": "planner", "path": "/agents/planner" },
+                    { "name": "executor", "path": "/agents/executor" }
+                ]
+            }
+            """;
+
+        var evt = _parser.ParseLine(systemInitJson);
+
+        var initEvent = Assert.IsType<SystemInitEvent>(evt);
+        Assert.Equal("sess-agents-objects", initEvent.SessionId);
+        Assert.Equal("claude-sonnet-4-5", initEvent.Model);
+        Assert.NotNull(initEvent.Agents);
+        Assert.Equal(2, initEvent.Agents.Count);
+        Assert.Equal("planner", initEvent.Agents[0].Name);
+        Assert.Equal("/agents/planner", initEvent.Agents[0].Path);
+        Assert.Equal("executor", initEvent.Agents[1].Name);
+        Assert.Equal("/agents/executor", initEvent.Agents[1].Path);
+    }
+
+    [Fact]
+    public void ParseLine_SystemInitWithMixedAgents_DeserializesBothShapes()
+    {
+        var systemInitJson = """
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "sess-agents-mixed",
+                "agents": [
+                    "planner",
+                    { "name": "executor", "path": "/agents/executor" }
+                ]
+            }
+            """;
+
+        var evt = _parser.ParseLine(systemInitJson);
+
+        var initEvent = Assert.IsType<SystemInitEvent>(evt);
+        Assert.NotNull(initEvent.Agents);
+        Assert.Equal(2, initEvent.Agents.Count);
+        Assert.Equal("planner", initEvent.Agents[0].Name);
+        Assert.Null(initEvent.Agents[0].Path);
+        Assert.Equal("executor", initEvent.Agents[1].Name);
+        Assert.Equal("/agents/executor", initEvent.Agents[1].Path);
+    }
+
+    [Fact]
+    public void ParseLine_SystemInitWithEmptyAgents_DeserializesSuccessfully()
+    {
+        var systemInitJson = """
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "sess-agents-empty",
+                "agents": []
+            }
+            """;
+
+        var evt = _parser.ParseLine(systemInitJson);
+
+        var initEvent = Assert.IsType<SystemInitEvent>(evt);
+        Assert.Equal("sess-agents-empty", initEvent.SessionId);
+        Assert.NotNull(initEvent.Agents);
+        Assert.Empty(initEvent.Agents);
+    }
+
+    [Fact]
+    public void ParseLine_SystemInitWithObjectSkills_CapturesUnknownFieldsInExtra()
+    {
+        // Pins [JsonExtensionData] behaviour: future drift past `name`/`path`
+        // (e.g. `version`, `source`) is observably non-lossy.
+        var systemInitJson = """
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "sess-extra",
+                "skills": [
+                    { "name": "code-review", "version": "1.2.3", "source": "marketplace" }
+                ]
+            }
+            """;
+
+        var evt = _parser.ParseLine(systemInitJson);
+
+        var initEvent = Assert.IsType<SystemInitEvent>(evt);
+        Assert.NotNull(initEvent.Skills);
+        var skill = Assert.Single(initEvent.Skills);
+        Assert.Equal("code-review", skill.Name);
+        Assert.NotNull(skill.Extra);
+        Assert.Equal("1.2.3", skill.Extra["version"].GetString());
+        Assert.Equal("marketplace", skill.Extra["source"].GetString());
+    }
+
+    [Fact]
+    public void ParseLine_SystemInitWithMalformedSkillItem_FailsLoudly()
+    {
+        // Drift outside the tolerated envelope (number, not string/object) must
+        // surface as a parse failure rather than silently passing.
+        var systemInitJson = """
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "sess-malformed",
+                "skills": [123]
+            }
+            """;
+
+        var evt = _parser.ParseLine(systemInitJson);
+
+        Assert.Null(evt);
     }
 
     [Fact]


### PR DESCRIPTION
[Gautam's Dev bot]

## Summary

Hardens `SystemInitEvent.skills` / `.agents` against the same `system.init` schema-drift class as `.plugins` (#42 / PR #43). With the prior PR, only `plugins` was protected; the sibling fields stayed `List<string>?` and would silently drop the entire `system.init` frame (including `SessionId`/`Model`, breaking `--resume`) if the CLI ever evolved them to `[{name, ...}]`.

This PR applies the defensive typing strategy across all three fields:

- Replace `PluginRef` with a single tolerant `NamedRef` record that captures unknown fields in `Extra` via `[JsonExtensionData]`, future-proofing against further drift (`version`, `source`, …).
- Add `NamedRefJsonConverter` that accepts either a JSON string or `{name, path, ...}` object **per list element**, so a single drifted item no longer drops the whole frame. Tokens outside the tolerated envelope (numbers, arrays) still surface as `JsonException`, which `ParseLine` catches and logs.
- Re-type `SystemInitEvent.Agents` / `.Skills` / `.Plugins` to `List<NamedRef>?`.

No public API of `ClaudeAgentSdkClient` changes; `PluginRef` had no in-repo consumers outside `JsonlStreamParser.Tests`, which only dereferenced `.Name` / `.Path` (both still present).

## Test plan

- [x] New `JsonlStreamParser.Tests` cases mirror the PR #43 plugin matrix for both Skills and Agents: string-only, object-only, mixed string/object, empty.
- [x] `ParseLine_SystemInitWithObjectSkills_CapturesUnknownFieldsInExtra` pins extension-data behaviour against `{name, version, source}`.
- [x] `ParseLine_SystemInitWithMalformedSkillItem_FailsLoudly` asserts drift outside the tolerated envelope (`[123]`) still surfaces as a parse failure rather than silently passing.
- [x] Existing PR #43 plugin tests continue to pass (rename only).
- [x] Full solution build succeeds with `TreatWarningsAsErrors`.
- [x] `dotnet format --verify-no-changes` is clean.

Closes #44
