### PR TITLE
Bump version to 1.0.28

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <!-- Centralized Versioning - UPDATE ONLY THIS SECTION FOR NEW RELEASES -->
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>27</PatchVersion>
+    <PatchVersion>28</PatchVersion>
     <PreReleaseLabel></PreReleaseLabel>
     <!-- Use values like 'alpha', 'beta', 'rc.1' or leave empty for stable -->
     <!-- Computed Version Properties (DO NOT MODIFY) -->


### PR DESCRIPTION
Patch bump to 1.0.28. Packages already published to NuGet.org and local feed.

## What's in 1.0.28
- MCP migration: ModelContextProtocol 0.4.1-preview.1 → 1.3.0 (from PR #41)
- Mock provider streaming alignment (from PR #38)
- JSONL parser tolerance for system.init plugins/skills/agents schema drift (PRs #43, #44, #45)

## Verification
- ✅ Release build clean (0 warnings, 0 errors)
- ✅ All 10 packages published to NuGet.org at 1.0.28
- ✅ All 10 packages mirrored to local feed at `%USERPROFILE%\.nuget\local-feed`