### PR TITLE
Seed ClaudeAgentLoop.CurrentSessionId via constructor (Closes #47)

### DIFF
--- a/src/LmMultiTurn/ClaudeAgentLoop.cs
+++ b/src/LmMultiTurn/ClaudeAgentLoop.cs
@@ -41,6 +41,11 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
     /// Also written into <see cref="ThreadMetadata.SessionMappings"/> when a store
     /// is configured. SDK metadata such as <c>SystemInitMessage</c> is intentionally
     /// NOT published into the common message stream — read this property instead.
+    ///
+    /// May also be pre-populated via the <c>initialSessionId</c> constructor
+    /// parameter so callers driving session resumption can have the first
+    /// underlying run pass <c>--resume &lt;SessionId&gt;</c> before any
+    /// <c>SystemInitMessage</c> has been observed.
     /// </summary>
     public string? CurrentSessionId { get; private set; }
 
@@ -104,6 +109,19 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
     /// <param name="logger">Optional logger</param>
     /// <param name="loggerFactory">Optional logger factory for creating loggers for internal components</param>
     /// <param name="clientFactory">Optional factory for creating ClaudeAgentSdkClient (for testing/mocking)</param>
+    /// <param name="initialSessionId">
+    /// Optional Claude SDK session id to seed <see cref="CurrentSessionId"/> with before
+    /// the first run starts. When non-empty, the first <see cref="BuildClaudeAgentSdkRequest"/>
+    /// call will emit <c>--resume &lt;SessionId&gt;</c>, letting callers drive resumption of
+    /// a previously persisted Claude SDK session. <c>null</c> or empty leaves
+    /// <see cref="CurrentSessionId"/> unset. If the SDK later assigns a different id via
+    /// <see cref="SystemInitMessage"/> or <see cref="IClaudeAgentSdkClient.CurrentSession"/>,
+    /// that live value replaces the seed (the transition is logged at Warning level).
+    /// Note: when <see cref="ClaudeAgentSdkOptions.DisableSessionPersistence"/> is also true,
+    /// the CLI is likely to reject the resume because no session is persisted on disk —
+    /// the seed is preserved regardless so callers managing persistence externally are not
+    /// silently overridden, and a Warning is logged on each request build.
+    /// </param>
     public ClaudeAgentLoop(
         ClaudeAgentSdkOptions claudeOptions,
         Dictionary<string, McpServerConfig>? mcpServers,
@@ -115,7 +133,8 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
         IConversationStore? store = null,
         ILogger<ClaudeAgentLoop>? logger = null,
         ILoggerFactory? loggerFactory = null,
-        Func<ClaudeAgentSdkOptions, ILogger?, IClaudeAgentSdkClient>? clientFactory = null)
+        Func<ClaudeAgentSdkOptions, ILogger?, IClaudeAgentSdkClient>? clientFactory = null,
+        string? initialSessionId = null)
         : base(
             threadId,
             systemPrompt,
@@ -132,6 +151,15 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
         _mcpServers = mcpServers ?? [];
         _loggerFactory = loggerFactory;
         _clientFactory = clientFactory;
+
+        // Seed CurrentSessionId via the same mutation path used by live SDK
+        // events so there is a single source of truth for session-id state
+        // transitions. CaptureSessionId itself no-ops on null/empty/duplicate.
+        if (!string.IsNullOrEmpty(initialSessionId))
+        {
+            CaptureSessionId(initialSessionId, isSeed: true);
+        }
+
         // MUST remain the last statement in this constructor: the returned MaterializedProfile
         // owns a temp directory and is disposed by DisposeAsync. Any throw after this line would
         // leak the staging dir.
@@ -276,10 +304,31 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
     }
 
     /// <summary>
-    /// Records the latest SDK-assigned session id. No-op for null/empty/duplicate
-    /// values. Logs at Debug on first capture and on change.
+    /// Tracks whether the current <see cref="CurrentSessionId"/> originated from the
+    /// <c>initialSessionId</c> constructor parameter (i.e. caller-seeded for
+    /// <c>--resume</c>) rather than from a live SDK event. Used by
+    /// <see cref="CaptureSessionId"/> to escalate the log level when a seeded id is
+    /// later replaced by a live one — that transition is a correctness signal for
+    /// callers driving resume workflows.
     /// </summary>
-    private void CaptureSessionId(string? sessionId)
+    private bool _sessionIdWasSeeded;
+
+    /// <summary>
+    /// Records a Claude SDK session id. No-op for null/empty/duplicate values.
+    /// Logging escalates with semantic importance:
+    /// <list type="bullet">
+    ///   <item><description>Information on first capture (whether from a live SDK event or a constructor seed).</description></item>
+    ///   <item><description>Information when a live SDK event replaces another live value.</description></item>
+    ///   <item><description>Warning when a live SDK event replaces a previously seeded value — surfaces resume mismatches.</description></item>
+    /// </list>
+    /// </summary>
+    /// <param name="sessionId">The session id to record.</param>
+    /// <param name="isSeed">
+    /// True when the source is the constructor's <c>initialSessionId</c> parameter; false
+    /// when the source is the live SDK (<see cref="SystemInitMessage"/> or
+    /// <see cref="IClaudeAgentSdkClient.CurrentSession"/>).
+    /// </param>
+    private void CaptureSessionId(string? sessionId, bool isSeed = false)
     {
         if (string.IsNullOrEmpty(sessionId) || sessionId == CurrentSessionId)
         {
@@ -287,14 +336,29 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
         }
 
         var previous = CurrentSessionId;
+        var previousWasSeeded = _sessionIdWasSeeded;
         CurrentSessionId = sessionId;
+        _sessionIdWasSeeded = isSeed;
+
         if (previous == null)
         {
-            Logger.LogDebug("Captured Claude SDK SessionId: {SessionId}", sessionId);
+            Logger.LogInformation(
+                "Captured Claude SDK SessionId: {SessionId} (seeded: {Seeded})",
+                sessionId,
+                isSeed);
+        }
+        else if (previousWasSeeded && !isSeed)
+        {
+            // Live SDK overrode a caller-seeded id — important enough to bump
+            // to Warning so callers driving --resume can audit the mismatch.
+            Logger.LogWarning(
+                "Claude SDK SessionId replaced caller-seeded value: {Seeded} -> {Live}",
+                previous,
+                sessionId);
         }
         else
         {
-            Logger.LogDebug(
+            Logger.LogInformation(
                 "Claude SDK SessionId changed: {Old} -> {New}",
                 previous,
                 sessionId);
@@ -970,8 +1034,23 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
         // Max thinking tokens from options
         var maxThinkingTokens = _claudeOptions.MaxThinkingTokens;
 
-        // Extract session ID: use preserved from previous run if available
+        // Extract session ID: use preserved from previous run if available.
+        // A non-null value here may originate from a live SDK event OR from the
+        // caller-supplied initialSessionId constructor parameter (see _sessionIdWasSeeded).
         var sessionId = CurrentSessionId;
+
+        if (_sessionIdWasSeeded
+            && !string.IsNullOrEmpty(sessionId)
+            && _claudeOptions.DisableSessionPersistence)
+        {
+            // The CLI is unlikely to find the seeded session on disk when the
+            // SDK is told to skip session persistence. We preserve the value
+            // because the caller may know better (e.g. manages persistence
+            // externally), but surface the conflict.
+            Logger.LogWarning(
+                "Seeded Claude SDK SessionId {SessionId} is being emitted to --resume even though DisableSessionPersistence=true; the CLI may reject the resume if the session is not persisted on disk",
+                sessionId);
+        }
 
         // Build MCP server configuration
         Dictionary<string, McpServerConfig>? mcpServers = null;

--- a/tests/LmMultiTurn.Tests/ClaudeAgentLoopInitialSessionIdTests.cs
+++ b/tests/LmMultiTurn.Tests/ClaudeAgentLoopInitialSessionIdTests.cs
@@ -1,0 +1,300 @@
+using System.Runtime.CompilerServices;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Agents;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using FluentAssertions;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+/// <summary>
+/// Validates that <see cref="ClaudeAgentLoop"/> accepts an <c>initialSessionId</c>
+/// constructor argument so callers can drive <c>--resume &lt;SessionId&gt;</c>
+/// on the very first underlying SDK run (issue #47).
+/// </summary>
+public class ClaudeAgentLoopInitialSessionIdTests
+{
+    [Fact]
+    public async Task Construction_WithInitialSessionId_PopulatesCurrentSessionIdBeforeFirstRun()
+    {
+        const string seededId = "sess-seeded-001";
+
+        var options = new ClaudeAgentSdkOptions
+        {
+            Mode = ClaudeAgentSdkMode.OneShot,
+            MaxTurnsPerRun = 5,
+        };
+
+        var mockClient = new CapturingClient(
+            scriptedMessages: [new ResultEventMessage { IsError = false }],
+            liveSessionId: null);
+
+        await using var loop = new ClaudeAgentLoop(
+            claudeOptions: options,
+            mcpServers: null,
+            threadId: "ctor-seed-pre-run",
+            clientFactory: (_, _) => mockClient,
+            initialSessionId: seededId);
+
+        loop.CurrentSessionId.Should().Be(seededId,
+            "constructor seed must populate CurrentSessionId synchronously, " +
+            "before any run starts");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task Construction_WithNullOrEmptyInitialSessionId_LeavesCurrentSessionIdNull(
+        string? seed)
+    {
+        var options = new ClaudeAgentSdkOptions
+        {
+            Mode = ClaudeAgentSdkMode.OneShot,
+            MaxTurnsPerRun = 5,
+        };
+
+        var mockClient = new CapturingClient(
+            scriptedMessages: [new ResultEventMessage { IsError = false }],
+            liveSessionId: null);
+
+        await using var loop = new ClaudeAgentLoop(
+            claudeOptions: options,
+            mcpServers: null,
+            threadId: "ctor-seed-null-empty",
+            clientFactory: (_, _) => mockClient,
+            initialSessionId: seed);
+
+        loop.CurrentSessionId.Should().BeNull(
+            "null and empty seeds must not propagate as a real session id");
+    }
+
+    [Fact]
+    public async Task Construction_WithInitialSessionId_EmitsResumeFlagViaRequest()
+    {
+        // BuildClaudeAgentSdkRequest is internal and synchronous; verify directly
+        // that the seeded id is what the first request would carry as --resume.
+        const string seededId = "sess-seeded-resume-002";
+
+        var options = new ClaudeAgentSdkOptions
+        {
+            Mode = ClaudeAgentSdkMode.OneShot,
+            MaxTurnsPerRun = 5,
+        };
+
+        var mockClient = new CapturingClient(
+            scriptedMessages: [new ResultEventMessage { IsError = false }],
+            liveSessionId: null);
+
+        await using var loop = new ClaudeAgentLoop(
+            claudeOptions: options,
+            mcpServers: null,
+            threadId: "ctor-seed-request-built",
+            clientFactory: (_, _) => mockClient,
+            initialSessionId: seededId);
+
+        var request = loop.BuildClaudeAgentSdkRequest();
+        request.SessionId.Should().Be(seededId,
+            "the constructor seed must flow into the SDK request as --resume " +
+            "on the very first run");
+    }
+
+    [Fact]
+    public async Task LiveSystemInitMessage_OverridesSeededValue()
+    {
+        const string seededId = "sess-seeded-pre";
+        const string liveId = "sess-live-actual";
+
+        var options = new ClaudeAgentSdkOptions
+        {
+            Mode = ClaudeAgentSdkMode.Interactive,
+            MaxTurnsPerRun = 5,
+        };
+
+        var mockClient = new CapturingClient(
+            scriptedMessages:
+            [
+                new SystemInitMessage { SessionId = liveId, Model = "claude-sonnet-4-6" },
+                new TextMessage { Text = "hello", Role = Role.Assistant },
+                new ResultEventMessage { IsError = false },
+            ],
+            liveSessionId: liveId);
+
+        await using var loop = new ClaudeAgentLoop(
+            claudeOptions: options,
+            mcpServers: null,
+            threadId: "ctor-seed-overridden",
+            clientFactory: (_, _) => mockClient,
+            initialSessionId: seededId);
+
+        loop.CurrentSessionId.Should().Be(seededId,
+            "sanity check: seed must be visible before the run starts");
+
+        await DriveOneRunAsync(loop);
+
+        loop.CurrentSessionId.Should().Be(liveId,
+            "a live SystemInitMessage must replace the caller-seeded value " +
+            "so the loop continues with the SDK's actual session id");
+    }
+
+    [Fact]
+    public async Task OneShot_SeededSessionId_SurvivesAfterRunDispose()
+    {
+        // OneShot disposes the client at the end of each run. A seeded id that
+        // never gets contradicted by the SDK (because no live id was reported)
+        // must still be observable on the loop.
+        const string seededId = "sess-seeded-survives-oneshot";
+
+        var options = new ClaudeAgentSdkOptions
+        {
+            Mode = ClaudeAgentSdkMode.OneShot,
+            MaxTurnsPerRun = 5,
+        };
+
+        // No SystemInitMessage; liveSessionId == null so CurrentSession stays
+        // null in the mock - mirrors a real-world resume where the SDK accepts
+        // the supplied --resume id without reporting a different one.
+        var mockClient = new CapturingClient(
+            scriptedMessages:
+            [
+                new TextMessage { Text = "hello", Role = Role.Assistant },
+                new ResultEventMessage { IsError = false },
+            ],
+            liveSessionId: null);
+
+        await using var loop = new ClaudeAgentLoop(
+            claudeOptions: options,
+            mcpServers: null,
+            threadId: "ctor-seed-oneshot-survives-dispose",
+            clientFactory: (_, _) => mockClient,
+            initialSessionId: seededId);
+
+        await DriveOneRunAsync(loop);
+
+        loop.CurrentSessionId.Should().Be(seededId,
+            "when the SDK never reports a different session id, OneShot's per-run " +
+            "client dispose must not drop the seeded value");
+    }
+
+    private static async Task<List<IMessage>> DriveOneRunAsync(ClaudeAgentLoop loop)
+    {
+        using var cts = new CancellationTokenSource();
+        var runTask = loop.RunAsync(cts.Token);
+
+        var userInput = new UserInput(
+            [new TextMessage { Text = "hi", Role = Role.User }],
+            InputId: "test-input");
+
+        var received = new List<IMessage>();
+        var executeTask = Task.Run(async () =>
+        {
+            await foreach (var msg in loop.ExecuteRunAsync(userInput, cts.Token))
+            {
+                received.Add(msg);
+            }
+        });
+
+        await executeTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        await cts.CancelAsync();
+        await loop.StopAsync();
+        return received;
+    }
+
+    /// <summary>
+    /// Replays a scripted message stream from both subscribe/send paths and
+    /// optionally reports a live session id via <see cref="CurrentSession"/>.
+    /// </summary>
+    private sealed class CapturingClient : IClaudeAgentSdkClient
+    {
+        private readonly IReadOnlyList<IMessage> _messages;
+        private readonly string? _liveSessionId;
+
+        public CapturingClient(IReadOnlyList<IMessage> scriptedMessages, string? liveSessionId)
+        {
+            _messages = scriptedMessages;
+            _liveSessionId = liveSessionId;
+        }
+
+        public bool IsRunning { get; private set; }
+
+        public SessionInfo? CurrentSession { get; private set; }
+
+        public ClaudeAgentSdkRequest? LastRequest { get; private set; }
+
+        public Task StartAsync(ClaudeAgentSdkRequest request, CancellationToken cancellationToken = default)
+        {
+            LastRequest = request;
+            IsRunning = true;
+            return Task.CompletedTask;
+        }
+
+        public async IAsyncEnumerable<IMessage> SendMessagesAsync(
+            IEnumerable<IMessage> messages,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            if (_liveSessionId != null)
+            {
+                CurrentSession = new SessionInfo
+                {
+                    SessionId = _liveSessionId,
+                    CreatedAt = DateTime.UtcNow,
+                    ProjectRoot = "test",
+                };
+            }
+
+            foreach (var msg in _messages)
+            {
+                await Task.Delay(1, cancellationToken);
+                yield return msg;
+            }
+
+            IsRunning = false;
+        }
+
+        public async IAsyncEnumerable<IMessage> SubscribeToMessagesAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            if (_liveSessionId != null)
+            {
+                CurrentSession = new SessionInfo
+                {
+                    SessionId = _liveSessionId,
+                    CreatedAt = DateTime.UtcNow,
+                    ProjectRoot = "test",
+                };
+            }
+
+            foreach (var msg in _messages)
+            {
+                await Task.Delay(5, cancellationToken);
+                yield return msg;
+            }
+        }
+
+        public Task SendAsync(IEnumerable<IMessage> messages, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<bool> SendExitCommandAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task ShutdownAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            IsRunning = false;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            IsRunning = false;
+            return ValueTask.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            IsRunning = false;
+        }
+    }
+}


### PR DESCRIPTION
[Gautam's Dev bot]

## Summary

Adds optional `initialSessionId` constructor parameter to `ClaudeAgentLoop` so callers can drive Claude SDK `--resume <SessionId>` on the very first run — without first having to observe a `SystemInitMessage`.

Implements the approved plan from issue comment [#4438655298](https://github.com/achieveai/LmDotnetTools/issues/47#issuecomment-4438655298).

Closes #47

## Changes

- `src/LmMultiTurn/ClaudeAgentLoop.cs`
  - New optional ctor parameter `initialSessionId` (additive — every existing call site compiles unchanged).
  - Seeded value flows through the existing `CaptureSessionId` mutation path, keeping a single source of truth for session-id state transitions.
  - `CaptureSessionId` now tracks whether the current id was seeded vs live; log level escalates with semantic importance:
    - Information on first capture.
    - Information on live→live replacement.
    - Warning when a live SDK event replaces a caller-seeded id — surfaces resume mismatches.
  - `BuildClaudeAgentSdkRequest` logs a Warning when a seeded id is being emitted while `DisableSessionPersistence=true` (CLI is unlikely to find the session on disk; value preserved for callers managing persistence externally).
  - XML doc on both the new parameter and the `CurrentSessionId` property covers the seeding contract.
- `tests/LmMultiTurn.Tests/ClaudeAgentLoopInitialSessionIdTests.cs` — new test file, 6 tests (5 in plan + a theory split for null/empty).

## Out of scope (per plan)

- `CodexAgentLoop` / `CopilotAgentLoop` — different session models. File a follow-up issue if needed.
- CLI behavior when the resumed session doesn't exist on disk — SDK-side concern.

## Test plan

- [x] `dotnet build LmDotnetTools.sln` — 0 warnings, 0 errors.
- [x] `dotnet test tests/LmMultiTurn.Tests/LmMultiTurn.Tests.csproj` — 216/216 passing (6 new + 210 pre-existing).
- [x] `dotnet format whitespace LmDotnetTools.sln --verify-no-changes` — clean.
- [x] Self-reviewed twice for: thread safety (no new contention), disposal leak risk (seed precedes `ProfileMaterializer.Materialize`, but `CaptureSessionId` is throw-free for the seed path), backwards compatibility (additive optional param).