### PR TITLE
fix(LmMultiTurn): surface unmapped Copilot sessionUpdate kinds at Information

### DIFF
--- a/src/LmMultiTurn/CopilotEventTranslator.cs
+++ b/src/LmMultiTurn/CopilotEventTranslator.cs
@@ -98,10 +98,10 @@ internal sealed class CopilotEventTranslator
                 // Plans are informational; surface as a summary reasoning message.
                 return ConvertPlan(update, runId, generationId);
             default:
-                _logger?.LogDebug(
+                _logger?.LogInformation(
                     "{event_type} {event_status} {provider} {provider_mode} {session_update_kind}",
                     "copilot.session_update.unmapped",
-                    "ignored",
+                    "dropped",
                     _options.Provider,
                     _options.ProviderMode,
                     kind);

--- a/tests/LmMultiTurn.Tests/CopilotEventTranslatorUnmappedKindTests.cs
+++ b/tests/LmMultiTurn.Tests/CopilotEventTranslatorUnmappedKindTests.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.CopilotSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+public class CopilotEventTranslatorUnmappedKindTests
+{
+    [Fact]
+    public void ConvertEventToMessages_UnmappedSessionUpdateKind_LogsInformationDroppedWithStructuredProps()
+    {
+        var logger = new ListLogger();
+        var options = new CopilotSdkOptions { Provider = "copilot", ProviderMode = "copilot" };
+        var translator = new CopilotEventTranslator(options, logger);
+
+        const string unmappedKind = "some_unknown_kind";
+        var envelope = JsonDocument.Parse($$"""
+            {
+              "type": "session/update",
+              "sessionId": "sess_x",
+              "update": { "sessionUpdate": "{{unmappedKind}}" }
+            }
+            """).RootElement;
+
+        var result = translator.ConvertEventToMessages(envelope, runId: "run_1", generationId: "gen_1");
+
+        result.Should().BeEmpty("unmapped kinds must not produce messages");
+
+        var matching = logger.Entries
+            .Where(e =>
+                e.Level == LogLevel.Information
+                && string.Equals(GetProp(e.State, "event_type"), "copilot.session_update.unmapped"))
+            .ToList();
+
+        matching.Should().HaveCount(1, "exactly one Information-level diagnostic must fire for an unmapped kind");
+
+        var entry = matching[0];
+        GetProp(entry.State, "event_status").Should().Be("dropped");
+        GetProp(entry.State, "provider").Should().Be("copilot");
+        GetProp(entry.State, "provider_mode").Should().Be("copilot");
+        GetProp(entry.State, "session_update_kind").Should().Be(unmappedKind);
+    }
+
+    private static string? GetProp(IReadOnlyList<KeyValuePair<string, object?>> state, string key)
+    {
+        foreach (var kv in state)
+        {
+            if (string.Equals(kv.Key, key, StringComparison.Ordinal))
+            {
+                return kv.Value?.ToString();
+            }
+        }
+
+        return null;
+    }
+
+    private sealed class ListLogger : ILogger
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var props = new List<KeyValuePair<string, object?>>();
+            if (state is IEnumerable<KeyValuePair<string, object?>> structured)
+            {
+                props.AddRange(structured);
+            }
+
+            Entries.Add(new LogEntry(logLevel, formatter(state, exception), props));
+        }
+    }
+
+    private sealed record LogEntry(
+        LogLevel Level,
+        string Message,
+        IReadOnlyList<KeyValuePair<string, object?>> State);
+}


### PR DESCRIPTION
[Gautam's Dev bot]

## Summary

Closes #52.

Tier 1 fix for the silent post-tool answer loss reported in #52: `CopilotEventTranslator`'s default switch arm logged unmapped `sessionUpdate.kind` values at `Debug` level with `event_status="ignored"`, hiding the signal in default-filtered logs and making the silent-drop hypothesis hard to disambiguate from a Copilot-side termination or an ACP race.

This PR converts that branch to `Information` level with `event_status="dropped"` so operators see the line under default filters when a new ACP `sessionUpdate.kind` shows up. No behavioural change beyond log level and status token — return shape (`[]`) and structured field names are identical, so downstream log consumers keying off `event_type=copilot.session_update.unmapped` keep working.

Tier 2 (adding case arms for `agent_message` / `final_response` / `message_complete`) is deferred to a follow-up issue once a verbose Information-level run captures the actual kind value(s) emitted by Copilot CLI 1.0.45+. Speculatively adding case arms risks miscategorising a full `agent_message` as a chunk delta or stomping accumulator state — a louder regression than the silent drop we are surfacing.

## Changes

- `src/LmMultiTurn/CopilotEventTranslator.cs` — switch default arm: `LogDebug` → `LogInformation`, `"ignored"` → `"dropped"`.
- `tests/LmMultiTurn.Tests/CopilotEventTranslatorUnmappedKindTests.cs` — new regression test that constructs the (internal) translator with a captured `ILogger`, feeds a `session/update` envelope carrying `sessionUpdate: "some_unknown_kind"`, and asserts:
  - Translator returns `[]` (no messages emitted).
  - Exactly one `Information`-level log entry fires for `event_type=copilot.session_update.unmapped`.
  - Structured properties carry `event_status=dropped`, `provider=copilot`, `provider_mode=copilot`, `session_update_kind=some_unknown_kind`.

`InternalsVisibleTo("LmMultiTurn.Tests")` was already present, so no csproj changes were needed.

## Out of scope

- No new `sessionUpdate.kind` case arms — Tier 2 follow-up.
- No changes to `BuildTerminalMessages` accumulator clear logic — Tier 3 only applies if Tier 2 shows post-tool tokens arrive after the existing accumulator window.
- No changes to `CopilotAgentLoop` — it remains a pass-through.

## Test plan

- [x] `dotnet build src/LmMultiTurn/AchieveAi.LmDotnetTools.LmMultiTurn.csproj` — clean.
- [x] `dotnet test tests/LmMultiTurn.Tests/LmMultiTurn.Tests.csproj --filter "FullyQualifiedName~CopilotEventTranslatorUnmappedKindTests"` — new test green.
- [x] `dotnet test tests/LmMultiTurn.Tests/LmMultiTurn.Tests.csproj --filter "FullyQualifiedName~Copilot"` — 13/13 existing Copilot translator/loop tests stay green.
- [x] `dotnet test tests/LmMultiTurn.Tests/LmMultiTurn.Tests.csproj` — 233/233 full LmMultiTurn test suite green.

## Follow-up

After this lands, please re-run `revobot probe-run-review --backend copilot` with `REVOBOT_LOG_LEVEL=Information` and post any captured `session_update_kind` values back on #52. Those values will drive the Tier 2 follow-up: `WI-52-followup: handle Copilot ACP <kind> for post-tool answer`. If no unmapped kinds are logged but the answer is still missing, the follow-up pivots to investigating `session/prompt/completed` timing.