### PR TITLE
feat: session-resume + run-fork parity follow-ups (#55)

### DIFF
--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -930,7 +930,9 @@ public partial class Program
             SyntheticMessageUpdateChunkChars = syntheticChunkSize,
             EnableRpcTrace = enableRpcTrace,
             RpcTraceFilePath = traceFilePath,
+#pragma warning disable CS0618 // Trace-only label; explicitly forwarded for RPC dump correlation.
             CodexSessionId = sessionId,
+#pragma warning restore CS0618
             ProviderMode = "codex",
             Provider = "codex",
         };

--- a/src/ClaudeAgentSdkProvider/Agents/ClaudeAgentSdkClient.cs
+++ b/src/ClaudeAgentSdkProvider/Agents/ClaudeAgentSdkClient.cs
@@ -994,6 +994,10 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
         {
             args.Add($"--resume {request.SessionId}");
         }
+        else if (!string.IsNullOrEmpty(request.AssignedSessionId))
+        {
+            args.Add($"--session-id {request.AssignedSessionId}");
+        }
 
         if (_systemPromptTempFile != null)
         {
@@ -1075,6 +1079,11 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
         {
             tokens.Add("--resume");
             tokens.Add(request.SessionId);
+        }
+        else if (!string.IsNullOrEmpty(request.AssignedSessionId))
+        {
+            tokens.Add("--session-id");
+            tokens.Add(request.AssignedSessionId);
         }
 
         if (_systemPromptTempFile != null)

--- a/src/ClaudeAgentSdkProvider/Configuration/ClaudeAgentSdkOptions.cs
+++ b/src/ClaudeAgentSdkProvider/Configuration/ClaudeAgentSdkOptions.cs
@@ -153,6 +153,27 @@ public record ClaudeAgentSdkOptions
     public AgentRuntimeProfile? Profile { get; init; }
 
     /// <summary>
+    ///     Host-chosen Claude SDK session id to assign on the FIRST run. When set,
+    ///     the spawned CLI is invoked with <c>--session-id &lt;guid&gt;</c> on the first
+    ///     run, which seeds the on-disk session under the supplied id. Subsequent
+    ///     runs use <c>--resume</c> against the captured id automatically. Mutually
+    ///     exclusive with the <c>initialSessionId</c> constructor parameter on
+    ///     <c>AchieveAi.LmDotnetTools.LmMultiTurn.ClaudeAgentLoop</c>:
+    ///     <c>--resume</c> attaches to an existing on-disk session, while
+    ///     <c>--session-id</c> creates a new one under the caller's id, so the two
+    ///     paths cannot run together. Use this to drive cross-run session reuse
+    ///     (e.g. PR review followed by re-review on the same persisted session)
+    ///     when there is no prior session on disk yet.
+    /// </summary>
+    /// <remarks>
+    ///     When combined with <see cref="DisableSessionPersistence"/> the assigned
+    ///     id is ephemeral — the SDK still accepts the flag but no session is
+    ///     persisted on disk, so subsequent <c>--resume</c> attempts will fail.
+    ///     The loop emits a one-time Warning per request build in that case.
+    /// </remarks>
+    public string? AssignSessionId { get; init; }
+
+    /// <summary>
     ///     Pluggable launcher used to spawn the underlying CLI process. Defaults to
     ///     <see cref="DefaultProcessLauncher.Instance"/> which executes the CLI
     ///     directly on the host. Inject a custom <see cref="IProcessLauncher"/>

--- a/src/ClaudeAgentSdkProvider/Models/ClaudeAgentSdkRequest.cs
+++ b/src/ClaudeAgentSdkProvider/Models/ClaudeAgentSdkRequest.cs
@@ -28,9 +28,21 @@ public record ClaudeAgentSdkRequest
     public int MaxThinkingTokens { get; init; } = 0;
 
     /// <summary>
-    ///     Session ID for resuming existing session (null for new session)
+    ///     Session ID for resuming existing session (null for new session).
+    ///     Emits <c>--resume &lt;id&gt;</c>. Mutually exclusive with
+    ///     <see cref="AssignedSessionId"/>; if both are set, <c>SessionId</c>
+    ///     wins (the captured live id takes precedence over the host-chosen
+    ///     seed). Callers in the multi-turn loop must populate at most one.
     /// </summary>
     public string? SessionId { get; init; }
+
+    /// <summary>
+    ///     Host-chosen session id for a first run. Emits <c>--session-id &lt;guid&gt;</c>,
+    ///     which directs the SDK to create a new on-disk session under the supplied id.
+    ///     Mutually exclusive with <see cref="SessionId"/> (the resume flag); see
+    ///     <see cref="SessionId"/> remarks for precedence.
+    /// </summary>
+    public string? AssignedSessionId { get; init; }
 
     /// <summary>
     ///     Comma-separated list of built-in tools available to the agent.

--- a/src/CodexSdkProvider/Configuration/CodexSdkOptions.cs
+++ b/src/CodexSdkProvider/Configuration/CodexSdkOptions.cs
@@ -68,7 +68,31 @@ public record CodexSdkOptions
 
     public string? RpcTraceFilePath { get; init; }
 
+    /// <summary>
+    /// Trace-only label forwarded to <c>CodexRpcTraceWriter</c>. Does NOT drive
+    /// conversation resume on the Codex app-server — Codex uses
+    /// <c>thread/resume</c> against <c>codex_thread_id</c> persisted by
+    /// <c>AchieveAi.LmDotnetTools.LmMultiTurn.CodexAgentLoop</c>.
+    /// </summary>
+    /// <remarks>
+    /// Use <see cref="InitialThreadId"/> to seed the first-run thread id when no
+    /// metadata is persisted yet.
+    /// </remarks>
+    [Obsolete("CodexSessionId is a trace-only label and does not control session lifetime. Use " + nameof(InitialThreadId) + " to drive cross-run thread resume.")]
     public string? CodexSessionId { get; init; }
+
+    /// <summary>
+    /// Optional first-run Codex thread id. Acts as a fallback when
+    /// <c>AchieveAi.LmDotnetTools.LmMultiTurn.CodexAgentLoop</c> has no
+    /// persisted <c>codex_thread_id</c> in <c>ThreadMetadata.Properties</c>
+    /// (i.e. on cold restarts where the store is empty). When non-empty AND
+    /// the metadata lookup misses, the value seeds <c>_codexThreadId</c> so the
+    /// first Codex app-server call goes through <c>thread/resume</c> instead of
+    /// <c>thread/start</c>. After the SDK reports its own thread id, the
+    /// captured value wins. Persisted metadata always wins over this seed —
+    /// the option only fills the void when nothing is stored.
+    /// </summary>
+    public string? InitialThreadId { get; init; }
 
     public bool ExposeCodexInternalToolsAsToolMessages { get; init; } = true;
 

--- a/src/CodexSdkProvider/Transport/CodexAppServerTransport.cs
+++ b/src/CodexSdkProvider/Transport/CodexAppServerTransport.cs
@@ -70,6 +70,7 @@ internal sealed class CodexAppServerTransport : IAsyncDisposable
 
             if (_options.EnableRpcTrace && !string.IsNullOrWhiteSpace(_options.RpcTraceFilePath))
             {
+#pragma warning disable CS0618 // CodexSessionId is trace-only by design; the obsolete attribute signals to consumers, not internal trace writers.
                 _rpcTraceWriter = new CodexRpcTraceWriter(_options.RpcTraceFilePath, _options.CodexSessionId, _logger);
                 _logger?.LogInformation(
                     "{event_type} {event_status} {provider} {provider_mode} {codex_session_id} {trace_file}",
@@ -79,6 +80,7 @@ internal sealed class CodexAppServerTransport : IAsyncDisposable
                     _options.ProviderMode,
                     _options.CodexSessionId ?? string.Empty,
                     _options.RpcTraceFilePath);
+#pragma warning restore CS0618
             }
 
             var envOverrides = new Dictionary<string, string?>(StringComparer.Ordinal);

--- a/src/CopilotSdkProvider/Agents/CopilotEventParser.cs
+++ b/src/CopilotSdkProvider/Agents/CopilotEventParser.cs
@@ -26,6 +26,37 @@ internal static class CopilotEventParser
             : null;
     }
 
+    /// <summary>
+    /// Inspects an ACP <c>initialize</c> response for the
+    /// <c>agentCapabilities.sessions.load</c> boolean. Returns <c>true</c> only when
+    /// the agent explicitly advertises support; missing fields imply the agent does
+    /// not support <c>session/load</c> (per ACP spec — sessions.load defaults false).
+    /// </summary>
+    public static bool ExtractSupportsLoadSession(JsonElement? root)
+    {
+        if (!root.HasValue || root.Value.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (!root.Value.TryGetProperty("agentCapabilities", out var capabilities)
+            || capabilities.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (!capabilities.TryGetProperty("sessions", out var sessions)
+            || sessions.ValueKind != JsonValueKind.Object)
+        {
+            // Older Copilot CLI flattens the capability as agentCapabilities.loadSession.
+            return capabilities.TryGetProperty("loadSession", out var loadFlag)
+                && (loadFlag.ValueKind == JsonValueKind.True);
+        }
+
+        return sessions.TryGetProperty("load", out var loadProp)
+            && loadProp.ValueKind == JsonValueKind.True;
+    }
+
     public static string? ExtractErrorMessage(JsonElement payload)
     {
         if (TryGetProperty(payload, "error", out var error))

--- a/src/CopilotSdkProvider/Agents/CopilotSdkClient.cs
+++ b/src/CopilotSdkProvider/Agents/CopilotSdkClient.cs
@@ -29,6 +29,15 @@ public sealed class CopilotSdkClient : ICopilotSdkClient
     private Func<CopilotDynamicToolCallRequest, CancellationToken, Task<CopilotDynamicToolCallResponse>>? _dynamicToolExecutor;
     private int _isShuttingDown;
     private int _disposed;
+    private bool _loadSessionUnsupportedWarned;
+
+    /// <summary>
+    /// True when the Copilot CLI advertised <c>agentCapabilities.sessions.load=true</c>
+    /// on the most recent <c>initialize</c> exchange. Exposed for diagnostics and tests;
+    /// drives <c>session/load</c> vs <c>session/new</c> routing in
+    /// <see cref="StartOrResumeSessionAsync"/>.
+    /// </summary>
+    public bool SupportsLoadSession { get; private set; }
 
     public bool IsRunning => Volatile.Read(ref _transport) is { IsRunning: true };
 
@@ -122,11 +131,13 @@ public sealed class CopilotSdkClient : ICopilotSdkClient
                 EnsureModelAllowed(initializeResponse, effectiveOptions.Model);
             }
 
-            var sessionResponse = await transport.SendRequestAsync(
-                "session/new",
-                BuildSessionNewParams(effectiveOptions),
-                ct,
-                startupTimeout);
+            SupportsLoadSession = CopilotEventParser.ExtractSupportsLoadSession(initializeResponse);
+
+            var sessionResponse = await TryLoadOrCreateSessionAsync(
+                transport,
+                effectiveOptions,
+                startupTimeout,
+                ct);
 
             CurrentCopilotSessionId = CopilotEventParser.ExtractSessionId(sessionResponse) ?? effectiveOptions.SessionId;
             DependencyState = "ready";
@@ -660,6 +671,92 @@ public sealed class CopilotSdkClient : ICopilotSdkClient
             BaseUrl = string.IsNullOrWhiteSpace(options.BaseUrl) ? _options.BaseUrl : options.BaseUrl,
             ApiKey = string.IsNullOrWhiteSpace(options.ApiKey) ? _options.ApiKey : options.ApiKey,
             SessionId = string.IsNullOrWhiteSpace(options.SessionId) ? _options.CopilotSessionId : options.SessionId,
+        };
+    }
+
+    private async Task<JsonElement> TryLoadOrCreateSessionAsync(
+        CopilotAcpTransport transport,
+        CopilotBridgeInitOptions options,
+        TimeSpan startupTimeout,
+        CancellationToken ct)
+    {
+        if (SupportsLoadSession && !string.IsNullOrWhiteSpace(options.SessionId))
+        {
+            try
+            {
+                _logger?.LogInformation(
+                    "{event_type} {event_status} {provider} {provider_mode} {copilot_session_id}",
+                    "copilot.session.load",
+                    "started",
+                    _options.Provider,
+                    _options.ProviderMode,
+                    options.SessionId);
+                var loaded = await transport.SendRequestAsync(
+                    "session/load",
+                    BuildSessionLoadParams(options),
+                    ct,
+                    startupTimeout);
+                _logger?.LogInformation(
+                    "{event_type} {event_status} {provider} {provider_mode} {copilot_session_id}",
+                    "copilot.session.load",
+                    "completed",
+                    _options.Provider,
+                    _options.ProviderMode,
+                    options.SessionId);
+                return loaded;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // Common cases: server doesn't recognise the id (cold restart, id
+                // expired), or returns "method not found" for an older CLI build that
+                // mis-advertised the capability. Fall back to session/new so first-run
+                // semantics still hold.
+                _logger?.LogWarning(
+                    ex,
+                    "{event_type} {event_status} {provider} {provider_mode} {copilot_session_id} {error_kind}",
+                    "copilot.session.load",
+                    "failed_fallback_session_new",
+                    _options.Provider,
+                    _options.ProviderMode,
+                    options.SessionId,
+                    ex.GetType().Name);
+            }
+        }
+        else if (!SupportsLoadSession
+            && !string.IsNullOrWhiteSpace(options.SessionId)
+            && !_loadSessionUnsupportedWarned)
+        {
+            _loadSessionUnsupportedWarned = true;
+            _logger?.LogInformation(
+                "{event_type} {event_status} {provider} {provider_mode} {copilot_session_id}",
+                "copilot.session.load.unsupported",
+                "skipped",
+                _options.Provider,
+                _options.ProviderMode,
+                options.SessionId);
+        }
+
+        return await transport.SendRequestAsync(
+            "session/new",
+            BuildSessionNewParams(options),
+            ct,
+            startupTimeout);
+    }
+
+    private static object BuildSessionLoadParams(CopilotBridgeInitOptions options)
+    {
+        // ACP session/load shape mirrors session/new: cwd, mcpServers, sessionId.
+        // We deliberately do NOT send model/instructions on load — the server is
+        // expected to restore them from the persisted session record.
+        var cwd = !string.IsNullOrWhiteSpace(options.WorkingDirectory)
+            ? options.WorkingDirectory
+            : Environment.CurrentDirectory;
+
+        return new Dictionary<string, object?>
+        {
+            ["sessionId"] = options.SessionId,
+            ["cwd"] = cwd,
+            ["mcpServers"] = Array.Empty<object>(),
         };
     }
 

--- a/src/CopilotSdkProvider/Configuration/CopilotSdkOptions.cs
+++ b/src/CopilotSdkProvider/Configuration/CopilotSdkOptions.cs
@@ -46,6 +46,16 @@ public record CopilotSdkOptions
 
     public string? RpcTraceFilePath { get; init; }
 
+    /// <summary>
+    /// Best-effort Copilot ACP session id used to drive cross-run session reuse.
+    /// When the Copilot CLI advertises <c>agentCapabilities.sessions.load=true</c>
+    /// on the <c>initialize</c> response, the client calls <c>session/load</c> with
+    /// this id and falls back to <c>session/new</c> on any RPC error (the id is
+    /// also forwarded into <c>session/new</c> params, where the server is
+    /// authoritative on whether the id is honoured). When the CLI does not
+    /// advertise <c>sessions.load</c> the client goes straight to <c>session/new</c>
+    /// and emits a one-time <c>copilot.session.load.unsupported</c> log entry.
+    /// </summary>
     public string? CopilotSessionId { get; init; }
 
     public int ProcessTimeoutMs { get; init; } = 600_000;

--- a/src/LmMultiTurn/ClaudeAgentLoop.cs
+++ b/src/LmMultiTurn/ClaudeAgentLoop.cs
@@ -121,6 +121,8 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
     /// the CLI is likely to reject the resume because no session is persisted on disk —
     /// the seed is preserved regardless so callers managing persistence externally are not
     /// silently overridden, and a Warning is logged on each request build.
+    /// Mutually exclusive with <see cref="ClaudeAgentSdkOptions.AssignSessionId"/>; passing
+    /// both throws <see cref="ArgumentException"/>.
     /// </param>
     public ClaudeAgentLoop(
         ClaudeAgentSdkOptions claudeOptions,
@@ -146,6 +148,17 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
             logger)
     {
         ArgumentNullException.ThrowIfNull(claudeOptions);
+
+        if (!string.IsNullOrEmpty(initialSessionId)
+            && !string.IsNullOrEmpty(claudeOptions.AssignSessionId))
+        {
+            throw new ArgumentException(
+                "initialSessionId drives --resume against an existing on-disk session, while "
+                + nameof(ClaudeAgentSdkOptions.AssignSessionId)
+                + " drives --session-id to create a new session under a host-chosen id. "
+                + "Set at most one.",
+                nameof(initialSessionId));
+        }
 
         _claudeOptions = claudeOptions;
         _mcpServers = mcpServers ?? [];
@@ -1044,6 +1057,23 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
         // caller-supplied initialSessionId constructor parameter (see _sessionIdWasSeeded).
         var sessionId = CurrentSessionId;
 
+        // Host-chosen first-run session id (--session-id). Mutually exclusive
+        // with --resume: only emitted when no live or seeded session id is
+        // captured yet, so the first run materialises the chosen id and
+        // subsequent runs flip back to --resume automatically.
+        string? assignedSessionId = null;
+        if (string.IsNullOrEmpty(sessionId)
+            && !string.IsNullOrEmpty(_claudeOptions.AssignSessionId))
+        {
+            assignedSessionId = _claudeOptions.AssignSessionId;
+            if (_claudeOptions.DisableSessionPersistence)
+            {
+                Logger.LogWarning(
+                    "AssignSessionId {SessionId} is being emitted to --session-id even though DisableSessionPersistence=true; the assigned session will not be persisted to disk so subsequent --resume attempts will fail",
+                    assignedSessionId);
+            }
+        }
+
         if (_sessionIdWasSeeded
             && !string.IsNullOrEmpty(sessionId)
             && _claudeOptions.DisableSessionPersistence)
@@ -1121,6 +1151,7 @@ public sealed class ClaudeAgentLoop : MultiTurnAgentBase
             MaxTurns = maxTurns,
             MaxThinkingTokens = maxThinkingTokens,
             SessionId = sessionId,
+            AssignedSessionId = assignedSessionId,
             SystemPrompt = _materializedProfile.SystemPrompt ?? SystemPrompt,
             AllowedTools = allowedTools,
             McpServers = mcpServers,

--- a/src/LmMultiTurn/CodexAgentLoop.cs
+++ b/src/LmMultiTurn/CodexAgentLoop.cs
@@ -88,6 +88,15 @@ public sealed class CodexAgentLoop : MultiTurnAgentBase
         _loggerFactory = loggerFactory;
         _clientFactory = clientFactory;
 
+        // Seed _codexThreadId with the host-supplied InitialThreadId so the first
+        // call to OnBeforeRunAsync goes through thread/resume. RecoverAsync later
+        // OVERRIDES this with the persisted thread id when ThreadMetadata exists,
+        // matching the documented precedence: store > options.InitialThreadId.
+        if (!string.IsNullOrWhiteSpace(_options.InitialThreadId))
+        {
+            _codexThreadId = _options.InitialThreadId;
+        }
+
         IReadOnlyList<FunctionContract> dynamicContracts = [];
         IDictionary<string, Func<string, Task<string>>> dynamicHandlers = new Dictionary<string, Func<string, Task<string>>>(StringComparer.OrdinalIgnoreCase);
         if (functionRegistry != null && _options.ToolBridgeMode is CodexToolBridgeMode.Dynamic or CodexToolBridgeMode.Hybrid)

--- a/src/LmMultiTurn/Messages/RunCompletedMessage.cs
+++ b/src/LmMultiTurn/Messages/RunCompletedMessage.cs
@@ -9,7 +9,28 @@ namespace AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
 public record RunCompletedMessage : IMessage
 {
     public required string CompletedRunId { get; init; }
+
+    /// <summary>
+    /// Surface flag — <c>true</c> when this run was initiated via
+    /// <c>SendAsync(parentRunId: …)</c> (i.e. the batch carried at least one
+    /// caller-supplied <c>ParentRunId</c>). The flag reflects caller INTENT to
+    /// fork. It does NOT imply that the new run inherits the parent's provider
+    /// context: the underlying agent process starts from a fresh model context,
+    /// and any grounding the parent run accumulated (tool results, file reads,
+    /// reasoning) is not re-shown to the model. Callers needing context
+    /// continuity must restate the relevant inputs in the next prompt.
+    /// </summary>
+    /// <remarks>
+    /// A cross-provider <c>TranscriptReplay</c> primitive that would seed the
+    /// fresh provider context with the parent run's transcript is tracked
+    /// separately (see <c>src/LmMultiTurn/README.md</c> §"Fork semantics"). The
+    /// per-provider Claude/Copilot/Codex session-resume paths
+    /// (<c>--resume</c> / <c>session/load</c> / <c>thread/resume</c>) are
+    /// distinct from forking — resume attaches to an existing session, fork
+    /// branches into a new run id without re-attaching.
+    /// </remarks>
     public bool WasForked { get; init; }
+
     public string? ForkedToRunId { get; init; }
 
     /// <summary>

--- a/src/LmMultiTurn/README.md
+++ b/src/LmMultiTurn/README.md
@@ -171,6 +171,27 @@ Rules implemented by `ResolveBatchParent` and all loops:
    a UI thread) without changes to provider invocation. No `--resume`/transcript-replay is wired
    in by this contract.
 
+#### What forking does NOT do (intentional non-goal)
+
+`WasForked = true` is a **surface flag only**. The new run starts from a **fresh provider context**:
+
+- The underlying agent process is started normally — no transcript from the parent run is
+  replayed into the model's working memory.
+- Any tool results, file reads, or reasoning the parent run accumulated are **not** re-shown.
+- Callers that need context continuity in a forked run must restate the relevant inputs in the
+  prompt themselves.
+
+This is distinct from per-provider **session resume** (`--resume <id>` on Claude,
+`session/load` on Copilot, `thread/resume` on Codex), which attaches a NEW run to an EXISTING
+provider-side session. Resume threads through `initialSessionId`/`AssignSessionId` on the loop;
+fork threads through `SendAsync(parentRunId: ...)` on individual inputs. They compose:
+a forked run can also resume, but the two are independently controlled signals.
+
+A cross-provider `TranscriptReplay` primitive (seed the fresh context with a summarized parent
+transcript) is intentionally **not implemented**. Callers needing this today open a fresh loop
+with a self-contained prompt; that trade-off is preferred over baking a one-size-fits-all replay
+policy into the base loop. See issue #55 §4 for the rationale.
+
 ### Lifecycle Management
 
 The multi-turn agents support a complete lifecycle with graceful shutdown and restart capabilities:

--- a/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.AssignSessionIdArgs.Tests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.AssignSessionIdArgs.Tests.cs
@@ -1,0 +1,103 @@
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Agents;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+
+namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Tests.Agents;
+
+/// <summary>
+/// Argv-level coverage for the host-chosen <c>--session-id &lt;guid&gt;</c> path
+/// added by issue #55. Both <c>BuildCliArguments</c> (diagnostic string form)
+/// and <c>BuildCliArgumentTokens</c> (runtime pre-tokenized form) must agree.
+/// </summary>
+public class ClaudeAgentSdkClientAssignSessionIdArgsTests
+{
+    private const string AssignedId = "00000000-0000-4000-8000-000000000abc";
+    private const string ResumeId = "11111111-1111-4111-8111-111111111111";
+
+    private static ClaudeAgentSdkClient NewClient() =>
+        new(new ClaudeAgentSdkOptions());
+
+    [Fact]
+    public void BuildCliArguments_EmitsSessionIdFlag_WhenAssignedSessionIdSetAndSessionIdEmpty()
+    {
+        var client = NewClient();
+        var request = new ClaudeAgentSdkRequest
+        {
+            ModelId = "claude-sonnet-4-6",
+            AssignedSessionId = AssignedId,
+        };
+
+        var args = client.BuildCliArguments(request);
+
+        Assert.Contains($"--session-id {AssignedId}", args);
+        Assert.DoesNotContain("--resume", args);
+    }
+
+    [Fact]
+    public void BuildCliArguments_ResumeWins_WhenBothSessionIdAndAssignedSessionIdSet()
+    {
+        // Defence-in-depth: ClaudeAgentLoop guarantees they are not both set,
+        // but the argv builder must not double-emit if someone bypasses the loop.
+        var client = NewClient();
+        var request = new ClaudeAgentSdkRequest
+        {
+            ModelId = "claude-sonnet-4-6",
+            SessionId = ResumeId,
+            AssignedSessionId = AssignedId,
+        };
+
+        var args = client.BuildCliArguments(request);
+
+        Assert.Contains($"--resume {ResumeId}", args);
+        Assert.DoesNotContain("--session-id", args);
+    }
+
+    [Fact]
+    public void BuildCliArguments_OmitsBothFlags_WhenNeitherSet()
+    {
+        var client = NewClient();
+        var request = new ClaudeAgentSdkRequest { ModelId = "claude-sonnet-4-6" };
+
+        var args = client.BuildCliArguments(request);
+
+        Assert.DoesNotContain("--resume", args);
+        Assert.DoesNotContain("--session-id", args);
+    }
+
+    [Fact]
+    public void BuildCliArgumentTokens_EmitsTokenPair_WhenAssignedSessionIdSet()
+    {
+        var client = NewClient();
+        var request = new ClaudeAgentSdkRequest
+        {
+            ModelId = "claude-sonnet-4-6",
+            AssignedSessionId = AssignedId,
+        };
+
+        var tokens = client.BuildCliArgumentTokens(request);
+
+        var idx = tokens.ToList().IndexOf("--session-id");
+        Assert.True(idx >= 0, "expected --session-id token in argv");
+        Assert.Equal(AssignedId, tokens[idx + 1]);
+        Assert.DoesNotContain("--resume", tokens);
+    }
+
+    [Fact]
+    public void BuildCliArgumentTokens_ResumeWins_WhenBothSet()
+    {
+        var client = NewClient();
+        var request = new ClaudeAgentSdkRequest
+        {
+            ModelId = "claude-sonnet-4-6",
+            SessionId = ResumeId,
+            AssignedSessionId = AssignedId,
+        };
+
+        var tokens = client.BuildCliArgumentTokens(request);
+
+        var idx = tokens.ToList().IndexOf("--resume");
+        Assert.True(idx >= 0, "expected --resume token when SessionId is set");
+        Assert.Equal(ResumeId, tokens[idx + 1]);
+        Assert.DoesNotContain("--session-id", tokens);
+    }
+}

--- a/tests/CopilotSdkProvider.Tests/Agents/CopilotEventParserTests.cs
+++ b/tests/CopilotSdkProvider.Tests/Agents/CopilotEventParserTests.cs
@@ -175,4 +175,82 @@ public class CopilotEventParserTests
     {
         CopilotEventParser.Truncate(input!).Should().Be(string.Empty);
     }
+
+    // -- ExtractSupportsLoadSession (issue #55) --
+    //
+    // ACP initialize response surfaces the capability either nested under
+    // agentCapabilities.sessions.load (current spec) or flat under
+    // agentCapabilities.loadSession (older Copilot CLI builds). The parser
+    // MUST default to false when absent or wrong-typed so we never call
+    // session/load against an agent that did not advertise it.
+
+    [Fact]
+    public void ExtractSupportsLoadSession_NestedSessionsLoadTrue_ReturnsTrue()
+    {
+        var el = Parse("""{"agentCapabilities": {"sessions": {"load": true}}}""");
+        CopilotEventParser.ExtractSupportsLoadSession(el).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ExtractSupportsLoadSession_NestedSessionsLoadFalse_ReturnsFalse()
+    {
+        var el = Parse("""{"agentCapabilities": {"sessions": {"load": false}}}""");
+        CopilotEventParser.ExtractSupportsLoadSession(el).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExtractSupportsLoadSession_FlatLoadSessionTrue_ReturnsTrue()
+    {
+        // Legacy Copilot CLI flattens the capability.
+        var el = Parse("""{"agentCapabilities": {"loadSession": true}}""");
+        CopilotEventParser.ExtractSupportsLoadSession(el).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ExtractSupportsLoadSession_FlatLoadSessionFalse_ReturnsFalse()
+    {
+        var el = Parse("""{"agentCapabilities": {"loadSession": false}}""");
+        CopilotEventParser.ExtractSupportsLoadSession(el).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExtractSupportsLoadSession_MissingAgentCapabilities_ReturnsFalse()
+    {
+        var el = Parse("""{"other": {}}""");
+        CopilotEventParser.ExtractSupportsLoadSession(el).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExtractSupportsLoadSession_EmptyAgentCapabilities_ReturnsFalse()
+    {
+        var el = Parse("""{"agentCapabilities": {}}""");
+        CopilotEventParser.ExtractSupportsLoadSession(el).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExtractSupportsLoadSession_NestedSessionsWithoutLoad_ReturnsFalse()
+    {
+        var el = Parse("""{"agentCapabilities": {"sessions": {"new": true}}}""");
+        CopilotEventParser.ExtractSupportsLoadSession(el).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExtractSupportsLoadSession_LoadAsNonBoolean_ReturnsFalse()
+    {
+        var el = Parse("""{"agentCapabilities": {"sessions": {"load": "yes"}}}""");
+        CopilotEventParser.ExtractSupportsLoadSession(el).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExtractSupportsLoadSession_NullRoot_ReturnsFalse()
+    {
+        CopilotEventParser.ExtractSupportsLoadSession(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExtractSupportsLoadSession_NonObjectRoot_ReturnsFalse()
+    {
+        var el = Parse("""[]""");
+        CopilotEventParser.ExtractSupportsLoadSession(el).Should().BeFalse();
+    }
 }

--- a/tests/LmMultiTurn.Tests/ClaudeAgentLoopAssignSessionIdTests.cs
+++ b/tests/LmMultiTurn.Tests/ClaudeAgentLoopAssignSessionIdTests.cs
@@ -1,0 +1,296 @@
+using System.Runtime.CompilerServices;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Agents;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using FluentAssertions;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+/// <summary>
+/// Validates the host-chosen <c>AssignSessionId</c> path added by issue #55:
+/// the CLI is invoked with <c>--session-id &lt;guid&gt;</c> on the very first run
+/// (creating a new on-disk session under the caller's id), and subsequent runs
+/// flip to <c>--resume &lt;id&gt;</c> once the SDK reports it back via
+/// <see cref="SystemInitMessage"/>. Mutually exclusive with the
+/// <c>initialSessionId</c> constructor parameter.
+/// </summary>
+public class ClaudeAgentLoopAssignSessionIdTests
+{
+    private const string AssignedId = "00000000-0000-4000-8000-00000000abcd";
+    private const string SeedId = "sess-pre-existing-001";
+
+    [Fact]
+    public async Task Construction_WithBothInitialSessionIdAndAssignSessionId_Throws()
+    {
+        var options = new ClaudeAgentSdkOptions
+        {
+            Mode = ClaudeAgentSdkMode.OneShot,
+            MaxTurnsPerRun = 5,
+            AssignSessionId = AssignedId,
+        };
+
+        var mockClient = new CapturingClient(
+            scriptedMessages: [new ResultEventMessage { IsError = false }],
+            liveSessionId: null);
+
+        var act = async () =>
+        {
+            await using var loop = new ClaudeAgentLoop(
+                claudeOptions: options,
+                mcpServers: null,
+                threadId: "ctor-mutex",
+                clientFactory: (_, _) => mockClient,
+                initialSessionId: SeedId);
+        };
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .Where(ex => ex.ParamName == "initialSessionId");
+    }
+
+    [Fact]
+    public async Task BuildRequest_FirstRun_EmitsAssignedSessionIdOnly()
+    {
+        var options = new ClaudeAgentSdkOptions
+        {
+            Mode = ClaudeAgentSdkMode.OneShot,
+            MaxTurnsPerRun = 5,
+            AssignSessionId = AssignedId,
+        };
+
+        var mockClient = new CapturingClient(
+            scriptedMessages: [new ResultEventMessage { IsError = false }],
+            liveSessionId: null);
+
+        await using var loop = new ClaudeAgentLoop(
+            claudeOptions: options,
+            mcpServers: null,
+            threadId: "first-run-assign",
+            clientFactory: (_, _) => mockClient);
+
+        var request = loop.BuildClaudeAgentSdkRequest();
+
+        request.AssignedSessionId.Should().Be(AssignedId,
+            "first run must carry the host-chosen id as --session-id");
+        request.SessionId.Should().BeNullOrEmpty(
+            "no captured/seeded session id exists yet, so --resume must not be emitted");
+    }
+
+    [Fact]
+    public async Task BuildRequest_NoAssignedId_LeavesBothEmpty()
+    {
+        var options = new ClaudeAgentSdkOptions
+        {
+            Mode = ClaudeAgentSdkMode.OneShot,
+            MaxTurnsPerRun = 5,
+        };
+
+        var mockClient = new CapturingClient(
+            scriptedMessages: [new ResultEventMessage { IsError = false }],
+            liveSessionId: null);
+
+        await using var loop = new ClaudeAgentLoop(
+            claudeOptions: options,
+            mcpServers: null,
+            threadId: "no-assign",
+            clientFactory: (_, _) => mockClient);
+
+        var request = loop.BuildClaudeAgentSdkRequest();
+
+        request.AssignedSessionId.Should().BeNullOrEmpty();
+        request.SessionId.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task SubsequentRun_AfterSdkReportsSessionId_FlipsToResume()
+    {
+        // First run advertises --session-id; the SDK echoes a SystemInitMessage
+        // carrying the same id. From the second run onward, the loop must emit
+        // --resume <id> instead — never both at the same time.
+        var options = new ClaudeAgentSdkOptions
+        {
+            Mode = ClaudeAgentSdkMode.Interactive,
+            MaxTurnsPerRun = 5,
+            AssignSessionId = AssignedId,
+        };
+
+        var mockClient = new CapturingClient(
+            scriptedMessages:
+            [
+                new SystemInitMessage { SessionId = AssignedId, Model = "claude-sonnet-4-6" },
+                new TextMessage { Text = "ok", Role = Role.Assistant },
+                new ResultEventMessage { IsError = false },
+            ],
+            liveSessionId: AssignedId);
+
+        await using var loop = new ClaudeAgentLoop(
+            claudeOptions: options,
+            mcpServers: null,
+            threadId: "assign-then-resume",
+            clientFactory: (_, _) => mockClient);
+
+        // Pre-run: --session-id path
+        var firstRequest = loop.BuildClaudeAgentSdkRequest();
+        firstRequest.AssignedSessionId.Should().Be(AssignedId);
+        firstRequest.SessionId.Should().BeNullOrEmpty();
+
+        await DriveOneRunAsync(loop);
+
+        loop.CurrentSessionId.Should().Be(AssignedId,
+            "the SDK's SystemInitMessage must populate CurrentSessionId after the first run");
+
+        var secondRequest = loop.BuildClaudeAgentSdkRequest();
+        secondRequest.SessionId.Should().Be(AssignedId,
+            "after capture, subsequent runs must emit --resume against the captured id");
+        secondRequest.AssignedSessionId.Should().BeNullOrEmpty(
+            "--session-id and --resume are mutually exclusive; resume wins once an id is known");
+    }
+
+    [Fact]
+    public async Task BuildRequest_WithSeededSessionId_PrefersResumeOverAssign()
+    {
+        // Defence-in-depth: even though the constructor blocks both being set,
+        // a captured seed must dominate any stale AssignSessionId in BuildRequest.
+        var options = new ClaudeAgentSdkOptions
+        {
+            Mode = ClaudeAgentSdkMode.OneShot,
+            MaxTurnsPerRun = 5,
+            // NOTE: AssignSessionId is left null here to satisfy the ctor mutex;
+            // the test verifies resume wins when CurrentSessionId is populated.
+        };
+
+        var mockClient = new CapturingClient(
+            scriptedMessages: [new ResultEventMessage { IsError = false }],
+            liveSessionId: null);
+
+        await using var loop = new ClaudeAgentLoop(
+            claudeOptions: options,
+            mcpServers: null,
+            threadId: "seed-vs-assign",
+            clientFactory: (_, _) => mockClient,
+            initialSessionId: SeedId);
+
+        var request = loop.BuildClaudeAgentSdkRequest();
+        request.SessionId.Should().Be(SeedId);
+        request.AssignedSessionId.Should().BeNullOrEmpty();
+    }
+
+    private static async Task<List<IMessage>> DriveOneRunAsync(ClaudeAgentLoop loop)
+    {
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+
+        var userInput = new UserInput(
+            [new TextMessage { Text = "hi", Role = Role.User }],
+            InputId: "test-input");
+
+        var received = new List<IMessage>();
+        var executeTask = Task.Run(async () =>
+        {
+            await foreach (var msg in loop.ExecuteRunAsync(userInput, cts.Token))
+            {
+                received.Add(msg);
+            }
+        });
+
+        await executeTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        await cts.CancelAsync();
+        await loop.StopAsync();
+        return received;
+    }
+
+    private sealed class CapturingClient : IClaudeAgentSdkClient
+    {
+        private readonly IReadOnlyList<IMessage> _messages;
+        private readonly string? _liveSessionId;
+
+        public CapturingClient(IReadOnlyList<IMessage> scriptedMessages, string? liveSessionId)
+        {
+            _messages = scriptedMessages;
+            _liveSessionId = liveSessionId;
+        }
+
+        public bool IsRunning { get; private set; }
+
+        public SessionInfo? CurrentSession { get; private set; }
+
+        public ClaudeAgentSdkRequest? LastRequest { get; private set; }
+
+        public Task StartAsync(ClaudeAgentSdkRequest request, CancellationToken cancellationToken = default)
+        {
+            LastRequest = request;
+            IsRunning = true;
+            return Task.CompletedTask;
+        }
+
+        public async IAsyncEnumerable<IMessage> SendMessagesAsync(
+            IEnumerable<IMessage> messages,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            if (_liveSessionId != null)
+            {
+                CurrentSession = new SessionInfo
+                {
+                    SessionId = _liveSessionId,
+                    CreatedAt = DateTime.UtcNow,
+                    ProjectRoot = "test",
+                };
+            }
+
+            foreach (var msg in _messages)
+            {
+                await Task.Delay(1, cancellationToken);
+                yield return msg;
+            }
+
+            IsRunning = false;
+        }
+
+        public async IAsyncEnumerable<IMessage> SubscribeToMessagesAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            if (_liveSessionId != null)
+            {
+                CurrentSession = new SessionInfo
+                {
+                    SessionId = _liveSessionId,
+                    CreatedAt = DateTime.UtcNow,
+                    ProjectRoot = "test",
+                };
+            }
+
+            foreach (var msg in _messages)
+            {
+                await Task.Delay(5, cancellationToken);
+                yield return msg;
+            }
+        }
+
+        public Task SendAsync(IEnumerable<IMessage> messages, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<bool> SendExitCommandAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task ShutdownAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            IsRunning = false;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            IsRunning = false;
+            return ValueTask.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            IsRunning = false;
+        }
+    }
+}

--- a/tests/LmMultiTurn.Tests/CodexAgentLoopInitialThreadIdTests.cs
+++ b/tests/LmMultiTurn.Tests/CodexAgentLoopInitialThreadIdTests.cs
@@ -1,0 +1,275 @@
+using System.Runtime.CompilerServices;
+using System.Collections.Immutable;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.CodexSdkProvider.Agents;
+using AchieveAi.LmDotnetTools.CodexSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.CodexSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
+using AchieveAi.LmDotnetTools.LmTestUtils.Logging;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace LmMultiTurn.Tests;
+
+/// <summary>
+/// Validates the host-supplied <c>InitialThreadId</c> path added by issue #55.
+/// Documented precedence: persisted <c>codex_thread_id</c> in
+/// <see cref="ThreadMetadata.Properties"/> &gt; <see cref="CodexSdkOptions.InitialThreadId"/>.
+/// InitialThreadId only fills the void when no metadata is stored — once any
+/// real thread id has been captured (live or persisted), it dominates.
+/// </summary>
+public class CodexAgentLoopInitialThreadIdTests : LoggingTestBase
+{
+    public CodexAgentLoopInitialThreadIdTests(ITestOutputHelper output) : base(output) { }
+
+    private const string Seeded = "codex_thread_seeded_from_option";
+    private const string Persisted = "codex_thread_persisted_in_store";
+
+    [Fact]
+    public async Task FirstRun_WithInitialThreadIdAndEmptyStore_PassesSeedToClient()
+    {
+        var fakeClient = new FakeCodexClient(
+        [
+            Event("turn.completed", """
+                {"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":0,"output_tokens":1}}
+                """),
+        ]);
+
+        var options = new CodexSdkOptions { InitialThreadId = Seeded };
+        var store = new InMemoryConversationStore();
+
+        await using var loop = new CodexAgentLoop(
+            options,
+            new Dictionary<string, CodexMcpServerConfig>(),
+            functionRegistry: null,
+            enabledTools: null,
+            threadId: "initial-thread-empty-store",
+            store: store,
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CodexAgentLoop>());
+
+        // RecoverAsync runs but finds no metadata — seed must survive.
+        await loop.RecoverAsync(CancellationToken.None);
+        await DriveOneRunAsync(loop);
+
+        fakeClient.LastStartOptions.Should().NotBeNull();
+        fakeClient.LastStartOptions!.ThreadId.Should().Be(Seeded,
+            "with no persisted metadata, InitialThreadId must seed _codexThreadId so " +
+            "the first app-server call uses thread/resume against the supplied id");
+    }
+
+    [Fact]
+    public async Task FirstRun_WithInitialThreadIdAndStoreOverride_StoreWins()
+    {
+        var fakeClient = new FakeCodexClient(
+        [
+            Event("turn.completed", """
+                {"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":0,"output_tokens":1}}
+                """),
+        ]);
+
+        var options = new CodexSdkOptions { InitialThreadId = Seeded };
+        var store = new InMemoryConversationStore();
+        const string threadId = "initial-thread-store-wins";
+
+        await store.SaveMetadataAsync(
+            threadId,
+            new ThreadMetadata
+            {
+                ThreadId = threadId,
+                LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                Properties = ImmutableDictionary.CreateRange(
+                [
+                    new KeyValuePair<string, object>("codex_thread_id", Persisted),
+                ]),
+            },
+            CancellationToken.None);
+
+        await using var loop = new CodexAgentLoop(
+            options,
+            new Dictionary<string, CodexMcpServerConfig>(),
+            functionRegistry: null,
+            enabledTools: null,
+            threadId: threadId,
+            store: store,
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CodexAgentLoop>());
+
+        // RecoverAsync must overwrite the seeded value with the persisted thread id.
+        await loop.RecoverAsync(CancellationToken.None);
+        await DriveOneRunAsync(loop);
+
+        fakeClient.LastStartOptions!.ThreadId.Should().Be(Persisted,
+            "persisted codex_thread_id MUST win over InitialThreadId so cold-restart " +
+            "callers can still set a fallback without trampling real saved state");
+    }
+
+    [Fact]
+    public async Task FirstRun_WithoutInitialThreadIdOrStore_PassesNullThreadId()
+    {
+        var fakeClient = new FakeCodexClient(
+        [
+            Event("turn.completed", """
+                {"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":0,"output_tokens":1}}
+                """),
+        ]);
+
+        var options = new CodexSdkOptions();
+        var store = new InMemoryConversationStore();
+
+        await using var loop = new CodexAgentLoop(
+            options,
+            new Dictionary<string, CodexMcpServerConfig>(),
+            functionRegistry: null,
+            enabledTools: null,
+            threadId: "no-seed-no-store",
+            store: store,
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CodexAgentLoop>());
+
+        await loop.RecoverAsync(CancellationToken.None);
+        await DriveOneRunAsync(loop);
+
+        fakeClient.LastStartOptions!.ThreadId.Should().BeNull(
+            "no seed and no persisted metadata means the first call should go through " +
+            "thread/start (null ThreadId), not thread/resume");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task NullEmptyOrWhitespaceInitialThreadId_IsTreatedAsUnset(string? seed)
+    {
+        var fakeClient = new FakeCodexClient(
+        [
+            Event("turn.completed", """
+                {"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":0,"output_tokens":1}}
+                """),
+        ]);
+
+        var options = new CodexSdkOptions { InitialThreadId = seed };
+        var store = new InMemoryConversationStore();
+
+        await using var loop = new CodexAgentLoop(
+            options,
+            new Dictionary<string, CodexMcpServerConfig>(),
+            functionRegistry: null,
+            enabledTools: null,
+            threadId: "blank-seed",
+            store: store,
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CodexAgentLoop>());
+
+        await loop.RecoverAsync(CancellationToken.None);
+        await DriveOneRunAsync(loop);
+
+        fakeClient.LastStartOptions!.ThreadId.Should().BeNull(
+            "null/empty/whitespace seeds must not propagate as a real thread id");
+    }
+
+    private static async Task DriveOneRunAsync(CodexAgentLoop loop)
+    {
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+
+        var input = new UserInput(
+            [new TextMessage { Role = Role.User, Text = "hello" }]);
+
+        var executeTask = Task.Run(async () =>
+        {
+            await foreach (var _ in loop.ExecuteRunAsync(input, cts.Token))
+            {
+            }
+        });
+
+        await executeTask.WaitAsync(TimeSpan.FromSeconds(10));
+        await cts.CancelAsync();
+    }
+
+    private static CodexTurnEventEnvelope Event(string name, string json)
+    {
+        var element = JsonDocument.Parse(json).RootElement.Clone();
+        return new CodexTurnEventEnvelope
+        {
+            Type = name,
+            Event = element,
+            RequestId = Guid.NewGuid().ToString("N"),
+            ThreadId = null,
+        };
+    }
+
+    private sealed class FakeCodexClient : ICodexSdkClient
+    {
+        private readonly IReadOnlyList<CodexTurnEventEnvelope> _events;
+
+        public FakeCodexClient(IReadOnlyList<CodexTurnEventEnvelope> events)
+        {
+            _events = events;
+        }
+
+        public CodexBridgeInitOptions? LastStartOptions { get; private set; }
+
+        public string? LastRunInput { get; private set; }
+
+        public bool IsRunning { get; private set; }
+
+        public string? CurrentCodexThreadId { get; private set; }
+
+        public string? CurrentTurnId { get; private set; }
+
+        public string DependencyState => "ready";
+
+        public void ConfigureDynamicToolExecutor(
+            Func<CodexDynamicToolCallRequest, CancellationToken, Task<CodexDynamicToolCallResponse>>? executor)
+        {
+        }
+
+        public Task StartOrResumeThreadAsync(CodexBridgeInitOptions options, CancellationToken ct = default)
+        {
+            IsRunning = true;
+            CurrentCodexThreadId = options.ThreadId;
+            LastStartOptions = options;
+            return Task.CompletedTask;
+        }
+
+        public Task EnsureStartedAsync(CodexBridgeInitOptions options, CancellationToken ct = default)
+        {
+            return StartOrResumeThreadAsync(options, ct);
+        }
+
+        public async IAsyncEnumerable<CodexTurnEventEnvelope> RunStreamingAsync(
+            string input,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            LastRunInput = input;
+            foreach (var item in _events)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return item;
+                await Task.Yield();
+            }
+        }
+
+        public Task ShutdownAsync(TimeSpan? timeout = null, CancellationToken ct = default)
+        {
+            IsRunning = false;
+            return Task.CompletedTask;
+        }
+
+        public Task InterruptTurnAsync(CancellationToken ct = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/ProgramCodexOptionsTests.cs
+++ b/tests/LmStreaming.Sample.Tests/ProgramCodexOptionsTests.cs
@@ -27,7 +27,9 @@ public class ProgramCodexOptionsTests
             var options = (CodexSdkOptions)result!;
             options.EnableRpcTrace.Should().BeTrue();
             options.RpcTraceFilePath.Should().Be($"{dumpBase}.codex.rpc.jsonl");
+#pragma warning disable CS0618 // CodexSessionId remains a trace-only label by design.
             options.CodexSessionId.Should().Be("thread_20260217T120000.llm");
+#pragma warning restore CS0618
         }
         finally
         {


### PR DESCRIPTION
## Summary

Four follow-up tasks from PR #51 review (issue #55):

1. **Claude `--session-id`**: host-chosen first-run id (`ClaudeAgentSdkOptions.AssignSessionId`)
2. **Copilot `session/load`**: capability-gated, with one-shot fallback to `session/new`
3. **Codex `InitialThreadId`**: cold-restart seed; `CodexSessionId` marked `[Obsolete]` (trace-only label)
4. **Fork semantics docs**: `RunCompletedMessage.WasForked` xmldoc + README §"What forking does NOT do"

Closes #55

## Details

### 1. Claude `--session-id` (host-chosen first run)

- `ClaudeAgentSdkOptions.AssignSessionId` → `ClaudeAgentSdkRequest.AssignedSessionId` → argv emits `--session-id <guid>`.
- Mutex enforced at three layers (defence-in-depth):
  - `ClaudeAgentLoop` ctor throws when caller sets both `initialSessionId` + `AssignSessionId`.
  - `BuildClaudeAgentSdkRequest` only populates one field of the pair.
  - `BuildCliArguments`/`BuildCliArgumentTokens` falls through to `--resume` first; `--session-id` only emitted when no captured/seeded id exists.
- Once the SDK reports its own `SessionId` via `SystemInitMessage`, subsequent runs flip to `--resume` automatically.
- One-time `Warning` emitted when `AssignSessionId` + `DisableSessionPersistence` are combined (ephemeral id won't survive).

### 2. Copilot `session/load`

- New `CopilotSdkClient.SupportsLoadSession` populated from `agentCapabilities.sessions.load` on the `initialize` response (with `loadSession` flat fallback for older CLI builds).
- `TryLoadOrCreateSessionAsync` routes `session/load` when capability advertised + session id present, falls back to `session/new` on any RPC error.
- Emits one-time `copilot.session.load.unsupported` log when the CLI lacks the capability but a session id is supplied.

### 3. Codex `InitialThreadId`

- New `CodexSdkOptions.InitialThreadId` seeds `_codexThreadId` in the constructor so the first app-server call goes through `thread/resume`.
- Precedence: **persisted `codex_thread_id` metadata > `InitialThreadId` seed > `thread/start`**. `RecoverAsync` overwrites the seed only when metadata exists.
- `CodexSessionId` marked `[Obsolete]` (trace-only label that does NOT control session lifetime). CS0618 pragmas tightly scoped to the trace-writer construction and the one E2E test verifying it.

### 4. Fork-semantics documentation (scope-cleanup, no behavior change)

- `RunCompletedMessage.WasForked` xmldoc clarifies: surface flag only — no transcript replay, no provider context inheritance.
- `src/LmMultiTurn/README.md` §"What forking does NOT do" lists the non-goals and contrasts fork (new run id) vs resume (existing session attach). `TranscriptReplay` primitive intentionally deferred.

## Test plan (E2E + unit)

New tests:

- [x] `tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.AssignSessionIdArgs.Tests.cs` — 5 tests: argv form `--session-id` emission, resume wins when both set, neither flag when neither set, plus token-form equivalents.
- [x] `tests/LmMultiTurn.Tests/ClaudeAgentLoopAssignSessionIdTests.cs` — 5 tests: ctor mutex throws, first-run carries `AssignedSessionId`, no-assign path, flip from `--session-id` to `--resume` after live `SystemInitMessage`, seed-vs-assign precedence.
- [x] `tests/CopilotSdkProvider.Tests/Agents/CopilotEventParserTests.cs` — 10 new `ExtractSupportsLoadSession` tests: nested true/false, flat true/false, missing/empty caps, sessions-without-load, non-bool, null root, non-object root.
- [x] `tests/LmMultiTurn.Tests/CodexAgentLoopInitialThreadIdTests.cs` — 6 tests: seed propagates when store empty, store wins over seed, no-seed-no-store goes through `thread/start`, null/empty/whitespace seed handling.

Existing coverage that protects regressions: `MessagesTests.WasForked*`, `ClaudeAgentLoopForkSemanticsTests`, `CodexAndCopilotForkSemanticsTests`, `MultiTurnAgentLoopForkSemanticsTests`, `ClaudeAgentLoopInitialSessionIdTests`.

### Build / test

- [x] `dotnet build` clean (0 warnings, 0 errors) on **both net8.0 and net9.0** for all touched projects (`LmMultiTurn`, `ClaudeAgentSdkProvider`, `CopilotSdkProvider`, `CodexSdkProvider`).
- [x] Full test suite green on net9.0 across `LmMultiTurn.Tests` (244), `ClaudeAgentSdkProvider.Tests` (101), `CopilotSdkProvider.Tests` (93), `CodexSdkProvider.Tests` (143), `LmCore.Tests` (730), and all other unit/integration projects. Pre-existing environmental failures in `McpIntegrationTests` (transport) and `LmStreaming.Sample.Browser.E2E.Tests` (no Playwright browser) are unrelated to this change.

[Gautam's Dev bot]
