### PR TITLE
Bump to 1.0.32: recover MCP server passthrough + review fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <!-- Centralized Versioning - UPDATE ONLY THIS SECTION FOR NEW RELEASES -->
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>28</PatchVersion>
+    <PatchVersion>30</PatchVersion>
     <PreReleaseLabel></PreReleaseLabel>
     <!-- Use values like 'alpha', 'beta', 'rc.1' or leave empty for stable -->
     <!-- Computed Version Properties (DO NOT MODIFY) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <!-- Centralized Versioning - UPDATE ONLY THIS SECTION FOR NEW RELEASES -->
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>31</PatchVersion>
+    <PatchVersion>32</PatchVersion>
     <PreReleaseLabel></PreReleaseLabel>
     <!-- Use values like 'alpha', 'beta', 'rc.1' or leave empty for stable -->
     <!-- Computed Version Properties (DO NOT MODIFY) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <!-- Centralized Versioning - UPDATE ONLY THIS SECTION FOR NEW RELEASES -->
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>30</PatchVersion>
+    <PatchVersion>31</PatchVersion>
     <PreReleaseLabel></PreReleaseLabel>
     <!-- Use values like 'alpha', 'beta', 'rc.1' or leave empty for stable -->
     <!-- Computed Version Properties (DO NOT MODIFY) -->

--- a/publish-nuget-packages.ps1
+++ b/publish-nuget-packages.ps1
@@ -91,7 +91,14 @@ $projects = @(
     "src/Misc/AchieveAi.LmDotnetTools.Misc.csproj",
     "src/ClaudeAgentSdkProvider/AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.csproj",
     "src/LmMultiTurn/AchieveAi.LmDotnetTools.LmMultiTurn.csproj",
-    "src/ProcessLauncher/AchieveAi.LmDotnetTools.ProcessLauncher.csproj"
+    "src/ProcessLauncher/AchieveAi.LmDotnetTools.ProcessLauncher.csproj",
+    "src/OpenAiResponsesProvider/AchieveAi.LmDotnetTools.OpenAiResponsesProvider.csproj",
+    "src/LmStreaming.AspNetCore/AchieveAi.LmDotnetTools.LmStreaming.AspNetCore.csproj",
+    "src/McpServer.AspNetCore/AchieveAi.LmDotnetTools.McpServer.AspNetCore.csproj",
+    "src/CopilotSdkProvider/AchieveAi.LmDotnetTools.CopilotSdkProvider.csproj",
+    "src/CodexSdkProvider/AchieveAi.LmDotnetTools.CodexSdkProvider.csproj",
+    "src/LmTestUtils/LmTestUtils.csproj",
+    "samples/MockProviderHost/MockProviderHost.csproj"
 )
 
 # Get current version from Directory.Build.props

--- a/publish-nuget-packages.ps1
+++ b/publish-nuget-packages.ps1
@@ -90,7 +90,8 @@ $projects = @(
     "src/McpSampleServer/AchieveAi.LmDotnetTools.McpSampleServer.csproj",
     "src/Misc/AchieveAi.LmDotnetTools.Misc.csproj",
     "src/ClaudeAgentSdkProvider/AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.csproj",
-    "src/LmMultiTurn/AchieveAi.LmDotnetTools.LmMultiTurn.csproj"
+    "src/LmMultiTurn/AchieveAi.LmDotnetTools.LmMultiTurn.csproj",
+    "src/ProcessLauncher/AchieveAi.LmDotnetTools.ProcessLauncher.csproj"
 )
 
 # Get current version from Directory.Build.props

--- a/samples/MockProviderHost/MockProviderHost.csproj
+++ b/samples/MockProviderHost/MockProviderHost.csproj
@@ -5,6 +5,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>AchieveAi.LmDotnetTools.MockProviderHost</RootNamespace>
     <AssemblyName>AchieveAi.LmDotnetTools.MockProviderHost</AssemblyName>
+    <IsPackable>true</IsPackable>
+    <PackageId>AchieveAi.LmDotnetTools.MockProviderHost</PackageId>
+    <Description>In-process ASP.NET Core mock provider host that exposes OpenAI- and Anthropic-compatible SSE/WebSocket endpoints over a real TCP socket. Drives external CLIs (Claude Agent SDK, Codex, Copilot) in end-to-end tests by wrapping a ScriptedSseResponder.</Description>
+    <PackageTags>$(PackageTags);testing;mocks;aspnetcore;sse;e2e</PackageTags>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>

--- a/src/CopilotSdkProvider/Agents/CopilotSdkClient.cs
+++ b/src/CopilotSdkProvider/Agents/CopilotSdkClient.cs
@@ -654,10 +654,10 @@ public sealed class CopilotSdkClient : ICopilotSdkClient
 
     private CopilotBridgeInitOptions ResolveEffectiveOptions(CopilotBridgeInitOptions options)
     {
-        // Per-call McpServers wins over the constructor default; null/empty falls
-        // back to whatever the SDK options carry. We never merge: a caller asking
-        // for "no MCP" must pass an empty dictionary explicitly, matching the
-        // semantics of the other override fields here.
+        // McpServers follows the same fallback semantics as the IsNullOrWhiteSpace
+        // siblings below: a non-empty per-call dictionary overrides; null or empty
+        // falls back to the SDK options. To disable MCP entirely, leave both
+        // CopilotSdkOptions.McpServers and the per-call dictionary empty.
         var mcpServers = options.McpServers is { Count: > 0 }
             ? options.McpServers
             : _options.McpServers;

--- a/src/CopilotSdkProvider/Agents/CopilotSdkClient.cs
+++ b/src/CopilotSdkProvider/Agents/CopilotSdkClient.cs
@@ -5,6 +5,7 @@ using System.Threading.Channels;
 using AchieveAi.LmDotnetTools.CopilotSdkProvider.Configuration;
 using AchieveAi.LmDotnetTools.CopilotSdkProvider.Models;
 using AchieveAi.LmDotnetTools.CopilotSdkProvider.Transport;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 using Microsoft.Extensions.Logging;
 
 namespace AchieveAi.LmDotnetTools.CopilotSdkProvider.Agents;
@@ -13,7 +14,10 @@ namespace AchieveAi.LmDotnetTools.CopilotSdkProvider.Agents;
 /// Default <see cref="ICopilotSdkClient"/> implementation. Owns the ACP transport
 /// lifecycle, the <c>initialize</c>/<c>session/new</c>/model allowlist probe sequence,
 /// and per-turn <c>session/prompt</c> streaming. Intentionally leaner than the Codex
-/// client: no internal-tool span tracking, no MCP config, no feature-flag routing.
+/// client: no internal-tool span tracking and no feature-flag routing. External MCP
+/// servers (when supplied via <see cref="CopilotBridgeInitOptions.McpServers"/> or
+/// the equivalent <see cref="CopilotSdkOptions.McpServers"/>) are projected to the
+/// ACP <c>mcpServers</c> array on <c>session/new</c>.
 /// </summary>
 public sealed class CopilotSdkClient : ICopilotSdkClient
 {
@@ -650,6 +654,14 @@ public sealed class CopilotSdkClient : ICopilotSdkClient
 
     private CopilotBridgeInitOptions ResolveEffectiveOptions(CopilotBridgeInitOptions options)
     {
+        // Per-call McpServers wins over the constructor default; null/empty falls
+        // back to whatever the SDK options carry. We never merge: a caller asking
+        // for "no MCP" must pass an empty dictionary explicitly, matching the
+        // semantics of the other override fields here.
+        var mcpServers = options.McpServers is { Count: > 0 }
+            ? options.McpServers
+            : _options.McpServers;
+
         return options with
         {
             Model = string.IsNullOrWhiteSpace(options.Model) ? _options.Model : options.Model,
@@ -660,6 +672,7 @@ public sealed class CopilotSdkClient : ICopilotSdkClient
             BaseUrl = string.IsNullOrWhiteSpace(options.BaseUrl) ? _options.BaseUrl : options.BaseUrl,
             ApiKey = string.IsNullOrWhiteSpace(options.ApiKey) ? _options.ApiKey : options.ApiKey,
             SessionId = string.IsNullOrWhiteSpace(options.SessionId) ? _options.CopilotSessionId : options.SessionId,
+            McpServers = mcpServers,
         };
     }
 
@@ -667,8 +680,8 @@ public sealed class CopilotSdkClient : ICopilotSdkClient
     {
         // Copilot CLI 1.0.x validates session/new params with Zod: `cwd` must be a non-null string
         // and `mcpServers` must be an array (even when empty). Default cwd to the current process
-        // directory when the caller did not specify one, and always include an empty mcpServers
-        // array since the dynamic tool bridge owns tool dispatch (no external MCP servers).
+        // directory when the caller did not specify one, and project any caller-provided
+        // McpServers dictionary to the ACP array shape (empty when unset).
         var cwd = !string.IsNullOrWhiteSpace(options.WorkingDirectory)
             ? options.WorkingDirectory
             : Environment.CurrentDirectory;
@@ -677,7 +690,7 @@ public sealed class CopilotSdkClient : ICopilotSdkClient
         {
             ["model"] = options.Model,
             ["cwd"] = cwd,
-            ["mcpServers"] = Array.Empty<object>(),
+            ["mcpServers"] = BuildMcpServerArray(options.McpServers),
         };
 
         if (!string.IsNullOrWhiteSpace(options.SessionId))
@@ -721,6 +734,111 @@ public sealed class CopilotSdkClient : ICopilotSdkClient
         }
 
         return parameters;
+    }
+
+    /// <summary>
+    /// Project a neutral <see cref="McpServerConfig"/> dictionary onto the ACP
+    /// <c>mcpServers</c> array shape Copilot's <c>session/new</c> Zod schema
+    /// validates. Each entry becomes <c>{ name, command, args, env: [{ name, value }] }</c>
+    /// for stdio transport. HTTP entries are forwarded best-effort with
+    /// <c>{ name, type: "http", url, headers: [{ name, value }] }</c>; older
+    /// Copilot CLI builds may reject these because raw ACP <c>session/new</c>
+    /// is stdio-centric. Entries missing required fields are skipped after a
+    /// warning so a single misconfigured server cannot block the whole session.
+    /// </summary>
+    private IReadOnlyList<object> BuildMcpServerArray(IReadOnlyDictionary<string, McpServerConfig>? mcpServers)
+    {
+        if (mcpServers is null || mcpServers.Count == 0)
+        {
+            return [];
+        }
+
+        var result = new List<object>(mcpServers.Count);
+        foreach (var (name, config) in mcpServers)
+        {
+            if (string.IsNullOrWhiteSpace(name) || config is null)
+            {
+                _logger?.LogWarning(
+                    "{event_type} {event_status} {server_name} {reason}",
+                    "copilot.mcp.server.skip",
+                    "skipped",
+                    name ?? "<null>",
+                    "name_or_config_null");
+                continue;
+            }
+
+            var entry = new Dictionary<string, object?> { ["name"] = name };
+
+            var transport = string.IsNullOrWhiteSpace(config.Type) ? "stdio" : config.Type;
+            if (string.Equals(transport, "http", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(transport, "sse", StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.IsNullOrWhiteSpace(config.Url))
+                {
+                    _logger?.LogWarning(
+                        "{event_type} {event_status} {server_name} {reason}",
+                        "copilot.mcp.server.skip",
+                        "skipped",
+                        name,
+                        "http_missing_url");
+                    continue;
+                }
+
+                entry["type"] = transport;
+                entry["url"] = config.Url;
+                if (config.Headers is { Count: > 0 })
+                {
+                    entry["headers"] = ToAcpNameValuePairs(config.Headers);
+                }
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(config.Command))
+                {
+                    _logger?.LogWarning(
+                        "{event_type} {event_status} {server_name} {reason}",
+                        "copilot.mcp.server.skip",
+                        "skipped",
+                        name,
+                        "stdio_missing_command");
+                    continue;
+                }
+
+                entry["command"] = config.Command;
+                // ACP `args` is a required string array; emit `[]` rather than omit
+                // so the wire shape matches the Zod schema even for argument-less
+                // commands (e.g. `npx some-mcp`).
+                string[] args = config.Args is null ? [] : [.. config.Args];
+                entry["args"] = args;
+                if (config.Env is { Count: > 0 })
+                {
+                    entry["env"] = ToAcpNameValuePairs(config.Env);
+                }
+            }
+
+            result.Add(entry);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// ACP encodes env/headers as an array of <c>{ name, value }</c> objects rather
+    /// than a plain object so order and duplicate keys are preserved over the wire.
+    /// </summary>
+    private static IReadOnlyList<object> ToAcpNameValuePairs(IReadOnlyDictionary<string, string> source)
+    {
+        var pairs = new List<object>(source.Count);
+        foreach (var (key, value) in source)
+        {
+            pairs.Add(new Dictionary<string, object?>
+            {
+                ["name"] = key,
+                ["value"] = value,
+            });
+        }
+
+        return pairs;
     }
 
     private static object BuildSessionPromptParams(string sessionId, string input)

--- a/src/CopilotSdkProvider/Configuration/CopilotSdkOptions.cs
+++ b/src/CopilotSdkProvider/Configuration/CopilotSdkOptions.cs
@@ -1,11 +1,13 @@
+using System.Collections.Immutable;
 using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 using AchieveAi.LmDotnetTools.ProcessLauncher;
 
 namespace AchieveAi.LmDotnetTools.CopilotSdkProvider.Configuration;
 
 /// <summary>
-/// Extensibility enum for Copilot tool bridging. Currently only the direct ACP
-/// dynamic tool bridge is supported (no MCP path).
+/// Extensibility enum for Copilot tool bridging. The dynamic ACP tool bridge
+/// hosts client-side tool implementations; orthogonally, external MCP servers
+/// can be advertised to the Copilot CLI via <see cref="CopilotSdkOptions.McpServers"/>.
 /// </summary>
 public enum CopilotToolBridgeMode
 {
@@ -79,12 +81,26 @@ public record CopilotSdkOptions
 
     /// <summary>
     ///     Optional client-supplied runtime inputs (system prompt, MCP servers, etc.).
-    ///     Copilot consumes only <see cref="AgentRuntimeProfile.SystemPrompt"/> (overrides
-    ///     <see cref="DeveloperInstructions"/>). The Copilot ACP protocol does not expose
-    ///     MCP servers, skills, or sub-agents; their presence triggers a one-time
-    ///     warning log entry per loop and otherwise has no effect.
+    ///     Copilot consumes <see cref="AgentRuntimeProfile.SystemPrompt"/> (overrides
+    ///     <see cref="DeveloperInstructions"/>). External MCP servers are taken from
+    ///     <see cref="McpServers"/> rather than the profile; profile-level
+    ///     <see cref="AgentRuntimeProfile.McpServers"/> are ignored (with a one-time
+    ///     warning) so callers have a single, explicit knob. Profile <c>Skills</c>
+    ///     and <c>SubAgents</c> remain unsupported by the Copilot ACP protocol.
     /// </summary>
     public AgentRuntimeProfile? Profile { get; init; }
+
+    /// <summary>
+    ///     External MCP servers to advertise to the Copilot CLI in the
+    ///     <c>session/new</c> ACP request, keyed by server name. Empty (the
+    ///     default) means the agent runs with no external MCP-served tools and
+    ///     the wire field is emitted as <c>[]</c>. Stdio-typed entries are
+    ///     forwarded in full; HTTP-typed entries are forwarded best-effort
+    ///     (raw ACP <c>session/new</c> is stdio-centric) and may be dropped or
+    ///     rejected by older Copilot CLI builds.
+    /// </summary>
+    public IReadOnlyDictionary<string, McpServerConfig> McpServers { get; init; }
+        = ImmutableDictionary<string, McpServerConfig>.Empty;
 
     /// <summary>
     ///     Pluggable launcher used to spawn the Copilot CLI process. Defaults to

--- a/src/CopilotSdkProvider/Models/CopilotBridgeProtocol.cs
+++ b/src/CopilotSdkProvider/Models/CopilotBridgeProtocol.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 
 namespace AchieveAi.LmDotnetTools.CopilotSdkProvider.Models;
 
@@ -39,6 +40,16 @@ public sealed record CopilotBridgeInitOptions
 
     [JsonPropertyName("sessionId")]
     public string? SessionId { get; init; }
+
+    /// <summary>
+    /// External MCP servers to advertise to the Copilot CLI on <c>session/new</c>.
+    /// The Copilot ACP server validates <c>mcpServers</c> as a required array, so
+    /// the SDK client always emits the field (empty when unset); non-null entries
+    /// here are projected to the ACP array shape with name + transport-specific
+    /// fields.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyDictionary<string, McpServerConfig>? McpServers { get; init; }
 }
 
 /// <summary>

--- a/src/LmCore/AchieveAi.LmDotnetTools.LmCore.csproj
+++ b/src/LmCore/AchieveAi.LmDotnetTools.LmCore.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.5" />
-    <PackageReference Include="Scriban" Version="7.1.0" />
+    <PackageReference Include="Scriban" Version="7.2.0" />
     <PackageReference Include="System.Memory.Data" Version="9.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.5" Condition=" '$(TargetFramework)' == 'net9.0' " />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />

--- a/src/LmMultiTurn/CopilotAgentLoop.cs
+++ b/src/LmMultiTurn/CopilotAgentLoop.cs
@@ -159,6 +159,11 @@ public sealed class CopilotAgentLoop : MultiTurnAgentBase
                 BaseUrl = _options.BaseUrl,
                 ApiKey = _options.ApiKey,
                 SessionId = _copilotSessionId,
+                // Forward MCP servers explicitly even though ResolveEffectiveOptions
+                // falls back to _options.McpServers — keeping the wiring visible at
+                // the call site means future per-turn overrides have a single edit
+                // point and tests can stub the client without surprise behavior.
+                McpServers = _options.McpServers,
             });
 
         Logger.LogInformation(
@@ -409,6 +414,10 @@ public sealed class CopilotAgentLoop : MultiTurnAgentBase
             return;
         }
 
+        // Profile.McpServers is the legacy/profile-driven knob; callers should
+        // route MCP via CopilotSdkOptions.McpServers instead so the single
+        // explicit field controls what reaches the ACP `session/new` array.
+        // The warning still counts profile entries so misuse is observable.
         var mcpCount = profile.McpServers.Count;
         var skillCount = profile.Skills.Count;
         var subAgentCount = profile.SubAgents.Count;

--- a/src/LmTestUtils/LmTestUtils.csproj
+++ b/src/LmTestUtils/LmTestUtils.csproj
@@ -3,8 +3,12 @@
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>
+    <RootNamespace>AchieveAi.LmDotnetTools.LmTestUtils</RootNamespace>
+    <AssemblyName>AchieveAi.LmDotnetTools.LmTestUtils</AssemblyName>
+    <PackageId>AchieveAi.LmDotnetTools.LmTestUtils</PackageId>
+    <Description>Test utilities for LmDotnetTools: fake HTTP message handlers, scripted SSE responders, provider test data generators, and Serilog/xUnit logging helpers. Use to mock OpenAI/Anthropic/OpenAI-Responses providers in unit and integration tests.</Description>
+    <PackageTags>$(PackageTags);testing;mocks;http-mocks;xunit;sse</PackageTags>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>

--- a/src/ProcessLauncher/SystemProcessHandle.cs
+++ b/src/ProcessLauncher/SystemProcessHandle.cs
@@ -76,7 +76,7 @@ internal sealed class SystemProcessHandle : IProcessHandle
         // OS — no busy-wait. Honour the BCL convention: a negative TimeSpan
         // (e.g. Timeout.InfiniteTimeSpan) maps to Timeout.Infinite (-1), which
         // waits indefinitely.
-        int ms = timeout < TimeSpan.Zero
+        var ms = timeout < TimeSpan.Zero
             ? Timeout.Infinite
             : (int)Math.Min(int.MaxValue, timeout.TotalMilliseconds);
         return _process.WaitForExit(ms);

--- a/tests/CopilotSdkProvider.Tests/Agents/CopilotSdkClientMcpServerShapeTests.cs
+++ b/tests/CopilotSdkProvider.Tests/Agents/CopilotSdkClientMcpServerShapeTests.cs
@@ -1,0 +1,230 @@
+using System.Reflection;
+using AchieveAi.LmDotnetTools.CopilotSdkProvider.Agents;
+using AchieveAi.LmDotnetTools.CopilotSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.CopilotSdkProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+
+namespace AchieveAi.LmDotnetTools.CopilotSdkProvider.Tests.Agents;
+
+/// <summary>
+/// Pins the ACP <c>session/new</c> <c>mcpServers</c> wire shape so the
+/// Copilot CLI's Zod validator keeps accepting it. The wire shape is an
+/// array (NOT a map) of <c>{ name, command, args, env: [{name,value}] }</c>
+/// entries for stdio transport, and <c>{ name, type, url, headers }</c> for
+/// http/sse transports. Reflection is used so the shape contract can be
+/// exercised without exposing <c>BuildSessionNewParams</c> publicly.
+/// </summary>
+public sealed class CopilotSdkClientMcpServerShapeTests
+{
+    /// <summary>
+    /// Hand-rolled options for the unit (no real transport spun up).
+    /// </summary>
+    private static CopilotSdkOptions NewOptions(
+        IReadOnlyDictionary<string, McpServerConfig>? mcpServers = null)
+    {
+        return new CopilotSdkOptions
+        {
+            CopilotCliPath = "copilot",
+            McpServers = mcpServers ?? new Dictionary<string, McpServerConfig>(),
+        };
+    }
+
+    /// <summary>
+    /// Invoke the private <c>BuildSessionNewParams</c> method through reflection
+    /// and return the resulting parameter dictionary so tests can assert on the
+    /// exact wire keys/values.
+    /// </summary>
+    private static IDictionary<string, object?> InvokeBuildSessionNewParams(
+        CopilotSdkClient client,
+        CopilotBridgeInitOptions options)
+    {
+        var method = typeof(CopilotSdkClient).GetMethod(
+            "BuildSessionNewParams",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        var result = method!.Invoke(client, [options]);
+        Assert.NotNull(result);
+        Assert.IsAssignableFrom<IDictionary<string, object?>>(result);
+        return (IDictionary<string, object?>)result!;
+    }
+
+    private static IList<object> McpServerArray(IDictionary<string, object?> parameters)
+    {
+        Assert.True(parameters.ContainsKey("mcpServers"));
+        var raw = parameters["mcpServers"];
+        Assert.NotNull(raw);
+        return Materialize(raw!);
+    }
+
+    /// <summary>
+    /// Materialize a non-generic <see cref="System.Collections.IEnumerable"/> to a
+    /// <see cref="List{Object}"/> without using LINQ — analyzer IDE0305 fires on
+    /// <c>.Cast&lt;object&gt;().ToList()</c> in tests.
+    /// </summary>
+    private static IList<object> Materialize(object raw)
+    {
+        var enumerable = Assert.IsAssignableFrom<System.Collections.IEnumerable>(raw);
+        var list = new List<object>();
+        foreach (var item in enumerable)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+
+    private static IDictionary<string, object?> AsEntry(object entry)
+    {
+        Assert.IsAssignableFrom<IDictionary<string, object?>>(entry);
+        return (IDictionary<string, object?>)entry;
+    }
+
+    [Fact]
+    public void Empty_mcpServers_emits_empty_array()
+    {
+        var client = new CopilotSdkClient(NewOptions());
+        var options = new CopilotBridgeInitOptions { Model = "m", WorkingDirectory = "/tmp" };
+
+        var parameters = InvokeBuildSessionNewParams(client, options);
+
+        Assert.Empty(McpServerArray(parameters));
+    }
+
+    [Fact]
+    public void Stdio_entry_is_projected_to_acp_shape()
+    {
+        var mcp = new Dictionary<string, McpServerConfig>
+        {
+            ["github"] = McpServerConfig.CreateStdio(
+                command: "npx",
+                args: ["-y", "@github/mcp"],
+                env: new Dictionary<string, string> { ["TOKEN"] = "abc" }),
+        };
+        var client = new CopilotSdkClient(NewOptions(mcp));
+        var options = new CopilotBridgeInitOptions
+        {
+            Model = "m",
+            WorkingDirectory = "/tmp",
+            McpServers = mcp,
+        };
+
+        var parameters = InvokeBuildSessionNewParams(client, options);
+        var list = McpServerArray(parameters);
+
+        Assert.Single(list);
+        var entry = AsEntry(list[0]);
+        Assert.Equal("github", entry["name"]);
+        Assert.Equal("npx", entry["command"]);
+
+        var args = Assert.IsType<string[]>(entry["args"]);
+        Assert.Equal(["-y", "@github/mcp"], args);
+
+        // env is an array of {name, value} objects, not a plain map
+        var envList = Materialize(entry["env"]!);
+        Assert.Single(envList);
+        var envEntry = AsEntry(envList[0]);
+        Assert.Equal("TOKEN", envEntry["name"]);
+        Assert.Equal("abc", envEntry["value"]);
+
+        // No URL or explicit type field on stdio entries
+        Assert.False(entry.ContainsKey("url"));
+        Assert.False(entry.ContainsKey("type"));
+    }
+
+    [Fact]
+    public void Http_entry_is_projected_with_url_and_headers()
+    {
+        var mcp = new Dictionary<string, McpServerConfig>
+        {
+            ["remote"] = McpServerConfig.CreateHttp(
+                url: "https://example.com/mcp",
+                headers: new Dictionary<string, string> { ["X-Auth"] = "bearer" }),
+        };
+        var client = new CopilotSdkClient(NewOptions(mcp));
+        var options = new CopilotBridgeInitOptions
+        {
+            Model = "m",
+            WorkingDirectory = "/tmp",
+            McpServers = mcp,
+        };
+
+        var parameters = InvokeBuildSessionNewParams(client, options);
+        var list = McpServerArray(parameters);
+
+        Assert.Single(list);
+        var entry = AsEntry(list[0]);
+        Assert.Equal("remote", entry["name"]);
+        Assert.Equal("http", entry["type"]);
+        Assert.Equal("https://example.com/mcp", entry["url"]);
+
+        var headers = Materialize(entry["headers"]!);
+        Assert.Single(headers);
+        var headerEntry = AsEntry(headers[0]);
+        Assert.Equal("X-Auth", headerEntry["name"]);
+        Assert.Equal("bearer", headerEntry["value"]);
+    }
+
+    [Fact]
+    public void Bridge_options_McpServers_override_sdk_options()
+    {
+        // Per-call dictionary on CopilotBridgeInitOptions wins over the
+        // CopilotSdkClient's ctor-supplied McpServers (mirrors how Model,
+        // WorkingDirectory, etc. resolve). This guards the override path
+        // used by CopilotAgentLoop in OnBeforeRunAsync.
+        var ctorDict = new Dictionary<string, McpServerConfig>
+        {
+            ["ctor"] = McpServerConfig.CreateStdio("cmd-a", ["x"]),
+        };
+        var perCallDict = new Dictionary<string, McpServerConfig>
+        {
+            ["override"] = McpServerConfig.CreateStdio("cmd-b", ["y"]),
+        };
+        var client = new CopilotSdkClient(NewOptions(ctorDict));
+        var options = new CopilotBridgeInitOptions
+        {
+            Model = "m",
+            WorkingDirectory = "/tmp",
+            McpServers = perCallDict,
+        };
+
+        // Need to also run options through the private resolver since
+        // BuildSessionNewParams takes the resolved options. Re-invoke the
+        // same logic by calling ResolveEffectiveOptions reflectively.
+        var resolveMethod = typeof(CopilotSdkClient).GetMethod(
+            "ResolveEffectiveOptions",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(resolveMethod);
+        var resolved = (CopilotBridgeInitOptions)resolveMethod!.Invoke(client, [options])!;
+
+        var parameters = InvokeBuildSessionNewParams(client, resolved);
+        var list = McpServerArray(parameters);
+        Assert.Single(list);
+        var entry = AsEntry(list[0]);
+        Assert.Equal("override", entry["name"]);
+        Assert.Equal("cmd-b", entry["command"]);
+    }
+
+    [Fact]
+    public void Stdio_entry_without_command_is_skipped()
+    {
+        // Guards against shipping a malformed entry to Copilot — the Zod
+        // validator would reject the whole session/new request.
+        var mcp = new Dictionary<string, McpServerConfig>
+        {
+            ["broken"] = new McpServerConfig { Type = "stdio", Command = null },
+            ["good"] = McpServerConfig.CreateStdio("cmd", ["ok"]),
+        };
+        var client = new CopilotSdkClient(NewOptions(mcp));
+        var options = new CopilotBridgeInitOptions
+        {
+            Model = "m",
+            WorkingDirectory = "/tmp",
+            McpServers = mcp,
+        };
+
+        var parameters = InvokeBuildSessionNewParams(client, options);
+        var list = McpServerArray(parameters);
+        Assert.Single(list);
+        var entry = AsEntry(list[0]);
+        Assert.Equal("good", entry["name"]);
+    }
+}

--- a/tests/LmMultiTurn.Tests/CopilotAgentLoopProfileTests.cs
+++ b/tests/LmMultiTurn.Tests/CopilotAgentLoopProfileTests.cs
@@ -121,6 +121,34 @@ public class CopilotAgentLoopProfileTests : LoggingTestBase
     }
 
     [Fact]
+    public async Task SdkOptions_McpServers_PassedThroughToBridgeInitOptions()
+    {
+        // Pins the wiring at CopilotAgentLoop.OnBeforeRunAsync that forwards
+        // CopilotSdkOptions.McpServers into CopilotBridgeInitOptions.McpServers.
+        // A silent regression on this line would cause configured MCP servers
+        // to be quietly dropped from the session/new ACP request.
+        var fakeClient = new RecordingCopilotClient([PromptCompleted()]);
+        var mcp = new Dictionary<string, McpServerConfig>
+        {
+            ["github"] = McpServerConfig.CreateStdio("npx", ["-y", "@github/mcp"]),
+        };
+
+        await using var loop = new CopilotAgentLoop(
+            new CopilotSdkOptions
+            {
+                McpServers = mcp,
+            },
+            threadId: "thread-copilot-mcp-passthrough",
+            clientFactory: (_, _) => fakeClient,
+            logger: LoggerFactory.CreateLogger<CopilotAgentLoop>());
+
+        await RunOneTurnAsync(loop);
+
+        fakeClient.LastStartOptions.Should().NotBeNull();
+        fakeClient.LastStartOptions!.McpServers.Should().BeSameAs(mcp);
+    }
+
+    [Fact]
     public async Task Profile_WithUnsupportedInputs_DoesNotCrash()
     {
         var fakeClient = new RecordingCopilotClient([PromptCompleted()]);


### PR DESCRIPTION
## Summary

- **Recovery** — restores the MCP-server passthrough WIP that was lost during a stray `git reset --hard HEAD^`. Routes `CopilotSdkOptions.McpServers` (neutral `IReadOnlyDictionary<string, McpServerConfig>`) through `CopilotAgentLoop` → `CopilotBridgeInitOptions` → `CopilotSdkClient.BuildSessionNewParams` → ACP `session/new` wire array.
- **Packaging** — adds NuGet packaging metadata for `LmTestUtils`, `MockProviderHost`, and 5 more provider packages (rolled forward from 1.0.31).
- **Review fixes** — clarifies the `ResolveEffectiveOptions` fallback contract (empty per-call dict falls back to SDK options, matching the sibling `IsNullOrWhiteSpace` overrides) and pins the `CopilotAgentLoop` MCP passthrough with a new test.
- **Version** — `1.0.32` (1.0.31 was published; this is the corrected build).

## Commits

- `a2de0ad` Bump to 1.0.30 + include ProcessLauncher in publish script
- `13df117` Bump to 1.0.31 + package LmTestUtils, MockProviderHost, and 5 more providers
- `68ec2fc` feat(copilot): external MCP servers passthrough to Copilot CLI (recovery)
- `dc4c2b0` fix(copilot): clarify ResolveEffectiveOptions fallback + pin McpServers passthrough
- `fa08dd2` Bump to 1.0.32 for MCP passthrough recovery + review fixes

## Wire shape

ACP `session/new.mcpServers` is a Zod-validated array (NOT a map). Stdio entries: `{name, command, args, env: [{name, value}]}`. Http/sse: `{name, type, url, headers}`. Entries missing required fields are warn-and-skipped instead of failing the whole request. Empty `McpServers` emits `[]` (required-array contract).

## Known follow-ups (deferred from review, non-blocking)

- HTTP/SSE projection is currently un-gated against older Copilot CLI builds that validate stdio-only — revisit before any consumer ships HTTP/SSE MCP.
- The per-call `CopilotBridgeInitOptions.McpServers` override has no production consumer yet — speculative surface that could be collapsed if no caller emerges.
- The new wire-shape tests use reflection against private methods; a transport-level integration test would be more durable.

## Test plan

- [x] `dotnet build LmDotnetTools.sln` — 0 warnings, 0 errors
- [x] `tests/LmMultiTurn.Tests` — 234/234 (added `SdkOptions_McpServers_PassedThroughToBridgeInitOptions`)
- [x] `tests/CopilotSdkProvider.Tests` — 88/88 (5 new `CopilotSdkClientMcpServerShapeTests`)
- [ ] CI green
- [ ] Verify NuGet publish picks up 1.0.32