### PR TITLE
feat(copilot): project --disable-mcp-server / --disable-builtin-mcps from CopilotSdkOptions

### DIFF
--- a/src/CopilotSdkProvider/Configuration/CopilotSdkOptions.cs
+++ b/src/CopilotSdkProvider/Configuration/CopilotSdkOptions.cs
@@ -113,6 +113,20 @@ public record CopilotSdkOptions
         = ImmutableDictionary<string, McpServerConfig>.Empty;
 
     /// <summary>
+    ///     Names of MCP servers the Copilot CLI should be told to disable. Each
+    ///     non-empty entry projects to one <c>--disable-mcp-server &lt;name&gt;</c>
+    ///     argument on the spawned CLI process. Null or whitespace entries are
+    ///     skipped silently. Order is preserved.
+    /// </summary>
+    public IReadOnlyList<string> DisabledMcpServers { get; init; } = [];
+
+    /// <summary>
+    ///     When true, the Copilot CLI is launched with <c>--disable-builtin-mcps</c>,
+    ///     suppressing the CLI's bundled built-in MCP servers. Default <c>false</c>.
+    /// </summary>
+    public bool DisableBuiltinMcps { get; init; }
+
+    /// <summary>
     ///     Pluggable launcher used to spawn the Copilot CLI process. Defaults to
     ///     <see cref="DefaultProcessLauncher.Instance"/> which executes the CLI
     ///     directly on the host. Inject a custom <see cref="IProcessLauncher"/>

--- a/src/CopilotSdkProvider/Transport/CopilotAcpTransport.cs
+++ b/src/CopilotSdkProvider/Transport/CopilotAcpTransport.cs
@@ -102,7 +102,7 @@ internal sealed class CopilotAcpTransport : IAsyncDisposable
             {
                 Agent = CliAgentKind.Copilot,
                 ExecutableHint = _options.CopilotCliPath,
-                Arguments = ["--acp", "--stdio"],
+                Arguments = BuildCliArguments(_options),
                 WorkingDirectory = workingDirectory,
                 EnvironmentOverrides = envOverrides,
                 StandardOutputEncoding = Encoding.UTF8,
@@ -670,6 +670,33 @@ internal sealed class CopilotAcpTransport : IAsyncDisposable
                 pending.TrySetException(ex);
             }
         }
+    }
+
+    private static IReadOnlyList<string> BuildCliArguments(CopilotSdkOptions options)
+    {
+        var args = new List<string>(capacity: 4) { "--acp", "--stdio" };
+
+        var disabled = options.DisabledMcpServers;
+        if (disabled != null)
+        {
+            foreach (var name in disabled)
+            {
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    continue;
+                }
+
+                args.Add("--disable-mcp-server");
+                args.Add(name);
+            }
+        }
+
+        if (options.DisableBuiltinMcps)
+        {
+            args.Add("--disable-builtin-mcps");
+        }
+
+        return args;
     }
 
     private static void WriteArbitraryValue(Utf8JsonWriter writer, object value, JsonSerializerOptions jsonOptions)

--- a/src/CopilotSdkProvider/Transport/CopilotAcpTransport.cs
+++ b/src/CopilotSdkProvider/Transport/CopilotAcpTransport.cs
@@ -687,7 +687,7 @@ internal sealed class CopilotAcpTransport : IAsyncDisposable
                 }
 
                 args.Add("--disable-mcp-server");
-                args.Add(name);
+                args.Add(name.Trim());
             }
         }
 

--- a/tests/CopilotSdkProvider.Tests/Transport/CopilotAcpTransportLaunchContractTests.cs
+++ b/tests/CopilotSdkProvider.Tests/Transport/CopilotAcpTransportLaunchContractTests.cs
@@ -132,6 +132,24 @@ public class CopilotAcpTransportLaunchContractTests
     }
 
     [Fact]
+    public async Task StartAsync_DisabledServerName_IsTrimmed()
+    {
+        var request = await CaptureLaunchRequestAsync(new CopilotSdkOptions
+        {
+            CopilotCliPath = "copilot-cli-mock",
+            DisabledMcpServers = ["  playwright  ", "\tmemory\n"],
+        });
+
+        request.Arguments.Should().Equal(
+            "--acp",
+            "--stdio",
+            "--disable-mcp-server",
+            "playwright",
+            "--disable-mcp-server",
+            "memory");
+    }
+
+    [Fact]
     public async Task StartAsync_DisableBuiltinMcps_EmitsBuiltinFlag()
     {
         var request = await CaptureLaunchRequestAsync(new CopilotSdkOptions

--- a/tests/CopilotSdkProvider.Tests/Transport/CopilotAcpTransportLaunchContractTests.cs
+++ b/tests/CopilotSdkProvider.Tests/Transport/CopilotAcpTransportLaunchContractTests.cs
@@ -65,4 +65,131 @@ public class CopilotAcpTransportLaunchContractTests
         request.HostPaths.Should().ContainSingle()
             .Which.Should().BeEquivalentTo(new HostPathReference(workingDir, HostPathKind.WorkingDirectory));
     }
+
+    [Fact]
+    public async Task StartAsync_DefaultOptions_DoesNotEmitDisableMcpFlags()
+    {
+        var request = await CaptureLaunchRequestAsync(new CopilotSdkOptions
+        {
+            CopilotCliPath = "copilot-cli-mock",
+        });
+
+        request.Arguments.Should().Equal("--acp", "--stdio");
+    }
+
+    [Fact]
+    public async Task StartAsync_SingleDisabledMcpServer_EmitsOneDisableMcpServerFlag()
+    {
+        var request = await CaptureLaunchRequestAsync(new CopilotSdkOptions
+        {
+            CopilotCliPath = "copilot-cli-mock",
+            DisabledMcpServers = ["playwright"],
+        });
+
+        request.Arguments.Should().Equal(
+            "--acp",
+            "--stdio",
+            "--disable-mcp-server",
+            "playwright");
+    }
+
+    [Fact]
+    public async Task StartAsync_MultipleDisabledMcpServers_EmitsRepeatedFlagsInOrder()
+    {
+        var request = await CaptureLaunchRequestAsync(new CopilotSdkOptions
+        {
+            CopilotCliPath = "copilot-cli-mock",
+            DisabledMcpServers = ["playwright", "memory", "github"],
+        });
+
+        request.Arguments.Should().Equal(
+            "--acp",
+            "--stdio",
+            "--disable-mcp-server",
+            "playwright",
+            "--disable-mcp-server",
+            "memory",
+            "--disable-mcp-server",
+            "github");
+    }
+
+    [Fact]
+    public async Task StartAsync_NullOrWhitespaceServerName_IsSkipped()
+    {
+        var request = await CaptureLaunchRequestAsync(new CopilotSdkOptions
+        {
+            CopilotCliPath = "copilot-cli-mock",
+            DisabledMcpServers = ["playwright", "  ", null!, string.Empty, "memory"],
+        });
+
+        request.Arguments.Should().Equal(
+            "--acp",
+            "--stdio",
+            "--disable-mcp-server",
+            "playwright",
+            "--disable-mcp-server",
+            "memory");
+    }
+
+    [Fact]
+    public async Task StartAsync_DisableBuiltinMcps_EmitsBuiltinFlag()
+    {
+        var request = await CaptureLaunchRequestAsync(new CopilotSdkOptions
+        {
+            CopilotCliPath = "copilot-cli-mock",
+            DisableBuiltinMcps = true,
+        });
+
+        request.Arguments.Should().Equal("--acp", "--stdio", "--disable-builtin-mcps");
+    }
+
+    [Fact]
+    public async Task StartAsync_BothDisableFlags_EmitsDisabledServersBeforeBuiltinFlag()
+    {
+        var request = await CaptureLaunchRequestAsync(new CopilotSdkOptions
+        {
+            CopilotCliPath = "copilot-cli-mock",
+            DisabledMcpServers = ["playwright", "memory"],
+            DisableBuiltinMcps = true,
+        });
+
+        request.Arguments.Should().Equal(
+            "--acp",
+            "--stdio",
+            "--disable-mcp-server",
+            "playwright",
+            "--disable-mcp-server",
+            "memory",
+            "--disable-builtin-mcps");
+    }
+
+    private static async Task<ProcessLaunchRequest> CaptureLaunchRequestAsync(CopilotSdkOptions baseOptions)
+    {
+        var recorder = new RecordingLauncher();
+        var options = baseOptions with { ProcessLauncher = recorder };
+
+        await using var transport = new CopilotAcpTransport(options);
+
+        var workingDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(workingDir);
+        try
+        {
+            var act = async () => await transport.StartAsync(
+                workingDir,
+                apiKey: null,
+                baseUrl: null,
+                requestHandler: (_, _, _) => Task.FromResult(default(JsonElement)),
+                notificationHandler: (_, _) => { },
+                ct: CancellationToken.None);
+
+            await act.Should().ThrowAsync<InvalidOperationException>();
+        }
+        finally
+        {
+            Directory.Delete(workingDir, recursive: true);
+        }
+
+        recorder.LastRequest.Should().NotBeNull();
+        return recorder.LastRequest!;
+    }
 }


### PR DESCRIPTION
[Gautam's Dev bot]

## Summary
- Adds two init-only properties on `CopilotSdkOptions`:
  - `DisabledMcpServers` (`IReadOnlyList<string>`) — each non-empty entry projects to a repeated `--disable-mcp-server <name>` arg on the spawned Copilot CLI.
  - `DisableBuiltinMcps` (`bool`) — projects to a single `--disable-builtin-mcps` flag.
- `CopilotAcpTransport.StartAsync` now builds argv via a deterministic helper (base flags first, then disabled servers in insertion order, then the builtins flag) instead of the hardcoded `["--acp", "--stdio"]` list.
- Null / whitespace entries in `DisabledMcpServers` are skipped silently.
- Backward-compatible: defaults preserve the existing argv exactly.

## Test plan
- [x] New `CopilotAcpTransportLaunchContractTests` cases via the existing `RecordingLauncher` seam:
  - Default options emit only `--acp --stdio`.
  - Single disabled server emits one `--disable-mcp-server <name>` pair.
  - Multiple disabled servers emit repeated flags in insertion order.
  - Null / whitespace entries are skipped.
  - `DisableBuiltinMcps = true` emits `--disable-builtin-mcps`.
  - Both flags combined emit disabled servers before the builtins flag.
- [x] Full `CopilotSdkProvider.Tests` suite passes (104 / 104).

Closes #58