### PR TITLE
[Gautam's Dev bot] fix(copilot): route MCP servers via --additional-mcp-config file (#59)

### DIFF
--- a/src/CopilotSdkProvider/Agents/CopilotSdkClient.cs
+++ b/src/CopilotSdkProvider/Agents/CopilotSdkClient.cs
@@ -5,7 +5,6 @@ using System.Threading.Channels;
 using AchieveAi.LmDotnetTools.CopilotSdkProvider.Configuration;
 using AchieveAi.LmDotnetTools.CopilotSdkProvider.Models;
 using AchieveAi.LmDotnetTools.CopilotSdkProvider.Transport;
-using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 using Microsoft.Extensions.Logging;
 
 namespace AchieveAi.LmDotnetTools.CopilotSdkProvider.Agents;
@@ -16,8 +15,10 @@ namespace AchieveAi.LmDotnetTools.CopilotSdkProvider.Agents;
 /// and per-turn <c>session/prompt</c> streaming. Intentionally leaner than the Codex
 /// client: no internal-tool span tracking and no feature-flag routing. External MCP
 /// servers (when supplied via <see cref="CopilotBridgeInitOptions.McpServers"/> or
-/// the equivalent <see cref="CopilotSdkOptions.McpServers"/>) are projected to the
-/// ACP <c>mcpServers</c> array on <c>session/new</c>.
+/// the equivalent <see cref="CopilotSdkOptions.McpServers"/>) are NOT routed through
+/// the ACP <c>session/new</c> <c>mcpServers</c> array (which rejects stdio entries);
+/// instead the transport writes them to a per-session temp file and passes
+/// <c>--additional-mcp-config=@&lt;path&gt;</c> on the CLI command line.
 /// </summary>
 public sealed class CopilotSdkClient : ICopilotSdkClient
 {
@@ -103,6 +104,7 @@ public sealed class CopilotSdkClient : ICopilotSdkClient
                 workingDirectory,
                 effectiveOptions.ApiKey,
                 effectiveOptions.BaseUrl,
+                effectiveOptions.McpServers,
                 HandleServerRequestAsync,
                 HandleServerNotification,
                 ct);
@@ -777,8 +779,11 @@ public sealed class CopilotSdkClient : ICopilotSdkClient
     {
         // Copilot CLI 1.0.x validates session/new params with Zod: `cwd` must be a non-null string
         // and `mcpServers` must be an array (even when empty). Default cwd to the current process
-        // directory when the caller did not specify one, and project any caller-provided
-        // McpServers dictionary to the ACP array shape (empty when unset).
+        // directory when the caller did not specify one. External MCP servers are NOT routed
+        // through this array — the ACP session/new schema rejects stdio entries and is
+        // unreliable for http/sse, so the provider projects them onto the CLI's
+        // `--additional-mcp-config=@<file>` flag (see CopilotAcpTransport). Always emit
+        // an empty array here so the Zod validator is satisfied.
         var cwd = !string.IsNullOrWhiteSpace(options.WorkingDirectory)
             ? options.WorkingDirectory
             : Environment.CurrentDirectory;
@@ -787,7 +792,7 @@ public sealed class CopilotSdkClient : ICopilotSdkClient
         {
             ["model"] = options.Model,
             ["cwd"] = cwd,
-            ["mcpServers"] = BuildMcpServerArray(options.McpServers),
+            ["mcpServers"] = Array.Empty<object>(),
         };
 
         if (!string.IsNullOrWhiteSpace(options.SessionId))
@@ -831,111 +836,6 @@ public sealed class CopilotSdkClient : ICopilotSdkClient
         }
 
         return parameters;
-    }
-
-    /// <summary>
-    /// Project a neutral <see cref="McpServerConfig"/> dictionary onto the ACP
-    /// <c>mcpServers</c> array shape Copilot's <c>session/new</c> Zod schema
-    /// validates. Each entry becomes <c>{ name, command, args, env: [{ name, value }] }</c>
-    /// for stdio transport. HTTP entries are forwarded best-effort with
-    /// <c>{ name, type: "http", url, headers: [{ name, value }] }</c>; older
-    /// Copilot CLI builds may reject these because raw ACP <c>session/new</c>
-    /// is stdio-centric. Entries missing required fields are skipped after a
-    /// warning so a single misconfigured server cannot block the whole session.
-    /// </summary>
-    private IReadOnlyList<object> BuildMcpServerArray(IReadOnlyDictionary<string, McpServerConfig>? mcpServers)
-    {
-        if (mcpServers is null || mcpServers.Count == 0)
-        {
-            return [];
-        }
-
-        var result = new List<object>(mcpServers.Count);
-        foreach (var (name, config) in mcpServers)
-        {
-            if (string.IsNullOrWhiteSpace(name) || config is null)
-            {
-                _logger?.LogWarning(
-                    "{event_type} {event_status} {server_name} {reason}",
-                    "copilot.mcp.server.skip",
-                    "skipped",
-                    name ?? "<null>",
-                    "name_or_config_null");
-                continue;
-            }
-
-            var entry = new Dictionary<string, object?> { ["name"] = name };
-
-            var transport = string.IsNullOrWhiteSpace(config.Type) ? "stdio" : config.Type;
-            if (string.Equals(transport, "http", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(transport, "sse", StringComparison.OrdinalIgnoreCase))
-            {
-                if (string.IsNullOrWhiteSpace(config.Url))
-                {
-                    _logger?.LogWarning(
-                        "{event_type} {event_status} {server_name} {reason}",
-                        "copilot.mcp.server.skip",
-                        "skipped",
-                        name,
-                        "http_missing_url");
-                    continue;
-                }
-
-                entry["type"] = transport;
-                entry["url"] = config.Url;
-                if (config.Headers is { Count: > 0 })
-                {
-                    entry["headers"] = ToAcpNameValuePairs(config.Headers);
-                }
-            }
-            else
-            {
-                if (string.IsNullOrWhiteSpace(config.Command))
-                {
-                    _logger?.LogWarning(
-                        "{event_type} {event_status} {server_name} {reason}",
-                        "copilot.mcp.server.skip",
-                        "skipped",
-                        name,
-                        "stdio_missing_command");
-                    continue;
-                }
-
-                entry["command"] = config.Command;
-                // ACP `args` is a required string array; emit `[]` rather than omit
-                // so the wire shape matches the Zod schema even for argument-less
-                // commands (e.g. `npx some-mcp`).
-                string[] args = config.Args is null ? [] : [.. config.Args];
-                entry["args"] = args;
-                if (config.Env is { Count: > 0 })
-                {
-                    entry["env"] = ToAcpNameValuePairs(config.Env);
-                }
-            }
-
-            result.Add(entry);
-        }
-
-        return result;
-    }
-
-    /// <summary>
-    /// ACP encodes env/headers as an array of <c>{ name, value }</c> objects rather
-    /// than a plain object so order and duplicate keys are preserved over the wire.
-    /// </summary>
-    private static IReadOnlyList<object> ToAcpNameValuePairs(IReadOnlyDictionary<string, string> source)
-    {
-        var pairs = new List<object>(source.Count);
-        foreach (var (key, value) in source)
-        {
-            pairs.Add(new Dictionary<string, object?>
-            {
-                ["name"] = key,
-                ["value"] = value,
-            });
-        }
-
-        return pairs;
     }
 
     private static object BuildSessionPromptParams(string sessionId, string input)

--- a/src/CopilotSdkProvider/Configuration/CopilotSdkOptions.cs
+++ b/src/CopilotSdkProvider/Configuration/CopilotSdkOptions.cs
@@ -101,13 +101,14 @@ public record CopilotSdkOptions
     public AgentRuntimeProfile? Profile { get; init; }
 
     /// <summary>
-    ///     External MCP servers to advertise to the Copilot CLI in the
-    ///     <c>session/new</c> ACP request, keyed by server name. Empty (the
-    ///     default) means the agent runs with no external MCP-served tools and
-    ///     the wire field is emitted as <c>[]</c>. Stdio-typed entries are
-    ///     forwarded in full; HTTP-typed entries are forwarded best-effort
-    ///     (raw ACP <c>session/new</c> is stdio-centric) and may be dropped or
-    ///     rejected by older Copilot CLI builds.
+    ///     External MCP servers to advertise to the Copilot CLI, keyed by server name.
+    ///     Empty (the default) means the agent runs with no external MCP-served tools.
+    ///     Non-empty values are written to a per-session JSON config file and passed
+    ///     via <c>--additional-mcp-config=@&lt;path&gt;</c> on the CLI command line so
+    ///     stdio entries are accepted (the ACP <c>session/new</c> <c>mcpServers</c>
+    ///     array is HTTP/SSE-only and silently rejects stdio servers). HTTP and SSE
+    ///     entries also flow through the same file. The temp file is created at
+    ///     transport startup and deleted on shutdown.
     /// </summary>
     public IReadOnlyDictionary<string, McpServerConfig> McpServers { get; init; }
         = ImmutableDictionary<string, McpServerConfig>.Empty;

--- a/src/CopilotSdkProvider/Models/CopilotBridgeProtocol.cs
+++ b/src/CopilotSdkProvider/Models/CopilotBridgeProtocol.cs
@@ -42,11 +42,11 @@ public sealed record CopilotBridgeInitOptions
     public string? SessionId { get; init; }
 
     /// <summary>
-    /// External MCP servers to advertise to the Copilot CLI on <c>session/new</c>.
-    /// The Copilot ACP server validates <c>mcpServers</c> as a required array, so
-    /// the SDK client always emits the field (empty when unset); non-null entries
-    /// here are projected to the ACP array shape with name + transport-specific
-    /// fields.
+    /// External MCP servers to advertise to the Copilot CLI. Non-null/non-empty
+    /// values are written to a per-session JSON config file and passed via
+    /// <c>--additional-mcp-config=@&lt;path&gt;</c> on the CLI command line. The
+    /// ACP <c>session/new</c> request always carries an empty <c>mcpServers</c>
+    /// array (it rejects stdio entries) — this dictionary fully replaces it.
     /// </summary>
     [JsonIgnore]
     public IReadOnlyDictionary<string, McpServerConfig>? McpServers { get; init; }

--- a/src/CopilotSdkProvider/Transport/CopilotAcpTransport.cs
+++ b/src/CopilotSdkProvider/Transport/CopilotAcpTransport.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Text;
 using System.Text.Json;
 using AchieveAi.LmDotnetTools.CopilotSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 using AchieveAi.LmDotnetTools.ProcessLauncher;
 using Microsoft.Extensions.Logging;
 
@@ -34,6 +35,7 @@ internal sealed class CopilotAcpTransport : IAsyncDisposable
     private Func<string, JsonElement?, CancellationToken, Task<JsonElement>>? _requestHandler;
     private Action<string, JsonElement?>? _notificationHandler;
     private CopilotRpcTraceWriter? _rpcTraceWriter;
+    private string? _mcpConfigTempFilePath;
     private long _nextRpcId;
     private int _closeSignalSent;
     private int _disposed;
@@ -48,10 +50,29 @@ internal sealed class CopilotAcpTransport : IAsyncDisposable
 
     public event Action<Exception?>? Closed;
 
+    public Task StartAsync(
+        string workingDirectory,
+        string? apiKey,
+        string? baseUrl,
+        Func<string, JsonElement?, CancellationToken, Task<JsonElement>> requestHandler,
+        Action<string, JsonElement?> notificationHandler,
+        CancellationToken ct)
+    {
+        return StartAsync(
+            workingDirectory,
+            apiKey,
+            baseUrl,
+            mcpServers: null,
+            requestHandler,
+            notificationHandler,
+            ct);
+    }
+
     public async Task StartAsync(
         string workingDirectory,
         string? apiKey,
         string? baseUrl,
+        IReadOnlyDictionary<string, McpServerConfig>? mcpServers,
         Func<string, JsonElement?, CancellationToken, Task<JsonElement>> requestHandler,
         Action<string, JsonElement?> notificationHandler,
         CancellationToken ct)
@@ -98,16 +119,34 @@ internal sealed class CopilotAcpTransport : IAsyncDisposable
                 envOverrides["COPILOT_BASE_URL"] = baseUrl;
             }
 
+            // Default args; appended with --additional-mcp-config=@<file> when
+            // external MCP servers are configured (Copilot CLI's ACP session/new
+            // wire shape is stdio-hostile, so all MCP routing flows through the
+            // CLI's own config-file loader instead).
+            var arguments = new List<string> { "--acp", "--stdio" };
+            var hostPaths = new List<HostPathReference>
+            {
+                new(workingDirectory, HostPathKind.WorkingDirectory),
+            };
+
+            var mcpConfigPath = TryWriteMcpConfigFile(mcpServers);
+            if (mcpConfigPath != null)
+            {
+                _mcpConfigTempFilePath = mcpConfigPath;
+                arguments.Add($"--additional-mcp-config=@{mcpConfigPath}");
+                hostPaths.Add(new HostPathReference(mcpConfigPath, HostPathKind.McpConfigFile));
+            }
+
             var launchRequest = new ProcessLaunchRequest
             {
                 Agent = CliAgentKind.Copilot,
                 ExecutableHint = _options.CopilotCliPath,
-                Arguments = ["--acp", "--stdio"],
+                Arguments = arguments,
                 WorkingDirectory = workingDirectory,
                 EnvironmentOverrides = envOverrides,
                 StandardOutputEncoding = Encoding.UTF8,
                 StandardErrorEncoding = Encoding.UTF8,
-                HostPaths = [new HostPathReference(workingDirectory, HostPathKind.WorkingDirectory)],
+                HostPaths = hostPaths,
             };
 
             try
@@ -116,12 +155,14 @@ internal sealed class CopilotAcpTransport : IAsyncDisposable
             }
             catch (ProcessLauncherException ex)
             {
+                CleanupMcpConfigTempFile();
                 throw new InvalidOperationException(
                     $"Failed to start Copilot CLI (configured as '{_options.CopilotCliPath}'). Ensure Copilot CLI is installed and accessible.",
                     ex);
             }
             catch (Exception ex)
             {
+                CleanupMcpConfigTempFile();
                 throw new InvalidOperationException(
                     $"Failed to start Copilot CLI (configured as '{_options.CopilotCliPath}'). Ensure Copilot CLI is installed and accessible.",
                     ex);
@@ -302,6 +343,8 @@ internal sealed class CopilotAcpTransport : IAsyncDisposable
             {
                 await _rpcTraceWriter.DisposeAsync();
             }
+
+            CleanupMcpConfigTempFile();
 
             _processCts = null;
             _stdin = null;
@@ -669,6 +712,156 @@ internal sealed class CopilotAcpTransport : IAsyncDisposable
             {
                 pending.TrySetException(ex);
             }
+        }
+    }
+
+    /// <summary>
+    /// Serialise external MCP servers to a per-session JSON config file and return the
+    /// host-side path. The Copilot CLI consumes this via <c>--additional-mcp-config=@&lt;path&gt;</c>
+    /// and accepts stdio entries there (unlike the ACP <c>session/new</c> mcpServers
+    /// array, which is HTTP/SSE-only). Returns <c>null</c> when the map is empty or
+    /// every entry is invalid — callers should NOT emit the flag in that case so
+    /// session-startup behaviour is unchanged from before this feature.
+    /// </summary>
+    internal string? TryWriteMcpConfigFile(IReadOnlyDictionary<string, McpServerConfig>? mcpServers)
+    {
+        var json = BuildMcpConfigFileContent(mcpServers);
+        if (json == null)
+        {
+            return null;
+        }
+
+        var path = Path.Combine(Path.GetTempPath(), $"copilot-mcp-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        _logger?.LogInformation(
+            "{event_type} {event_status} {provider} {provider_mode} {server_count} {path}",
+            "copilot.mcp.config_file.write",
+            "completed",
+            _options.Provider,
+            _options.ProviderMode,
+            mcpServers?.Count ?? 0,
+            path);
+
+        return path;
+    }
+
+    /// <summary>
+    /// Build the JSON document Copilot CLI expects at <c>--additional-mcp-config</c>.
+    /// Schema: <c>{ "mcpServers": { "&lt;name&gt;": { "type", "command", "args", "env": { K: V } } } }</c>
+    /// for stdio entries, with <c>"type", "url", "headers": { K: V }</c> for http/sse.
+    /// Returns <c>null</c> when no valid entries remain (so callers can short-circuit
+    /// the flag/file emission).
+    /// </summary>
+    internal string? BuildMcpConfigFileContent(IReadOnlyDictionary<string, McpServerConfig>? mcpServers)
+    {
+        if (mcpServers is null || mcpServers.Count == 0)
+        {
+            return null;
+        }
+
+        var entries = new Dictionary<string, object>(StringComparer.Ordinal);
+        foreach (var (name, config) in mcpServers)
+        {
+            if (string.IsNullOrWhiteSpace(name) || config is null)
+            {
+                _logger?.LogWarning(
+                    "{event_type} {event_status} {server_name} {reason}",
+                    "copilot.mcp.server.skip",
+                    "skipped",
+                    name ?? "<null>",
+                    "name_or_config_null");
+                continue;
+            }
+
+            var transport = string.IsNullOrWhiteSpace(config.Type) ? "stdio" : config.Type;
+            var entry = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["type"] = transport,
+            };
+
+            if (string.Equals(transport, "http", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(transport, "sse", StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.IsNullOrWhiteSpace(config.Url))
+                {
+                    _logger?.LogWarning(
+                        "{event_type} {event_status} {server_name} {reason}",
+                        "copilot.mcp.server.skip",
+                        "skipped",
+                        name,
+                        "http_missing_url");
+                    continue;
+                }
+
+                entry["url"] = config.Url;
+                if (config.Headers is { Count: > 0 })
+                {
+                    entry["headers"] = config.Headers;
+                }
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(config.Command))
+                {
+                    _logger?.LogWarning(
+                        "{event_type} {event_status} {server_name} {reason}",
+                        "copilot.mcp.server.skip",
+                        "skipped",
+                        name,
+                        "stdio_missing_command");
+                    continue;
+                }
+
+                entry["command"] = config.Command;
+                entry["args"] = config.Args ?? [];
+                if (config.Env is { Count: > 0 })
+                {
+                    entry["env"] = config.Env;
+                }
+            }
+
+            entries[name] = entry;
+        }
+
+        if (entries.Count == 0)
+        {
+            return null;
+        }
+
+        var document = new Dictionary<string, object> { ["mcpServers"] = entries };
+        return JsonSerializer.Serialize(document, _json);
+    }
+
+    private void CleanupMcpConfigTempFile()
+    {
+        var path = _mcpConfigTempFilePath;
+        if (string.IsNullOrEmpty(path))
+        {
+            return;
+        }
+
+        _mcpConfigTempFilePath = null;
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Cleanup is best-effort: stale files in the OS temp directory are
+            // recovered by the OS on reboot/cleanup sweeps. Log and continue so
+            // shutdown isn't blocked by an I/O error.
+            _logger?.LogWarning(
+                ex,
+                "{event_type} {event_status} {provider} {provider_mode} {path}",
+                "copilot.mcp.config_file.cleanup",
+                "failed",
+                _options.Provider,
+                _options.ProviderMode,
+                path);
         }
     }
 

--- a/tests/CopilotSdkProvider.Tests/Agents/CopilotSdkClientMcpServerShapeTests.cs
+++ b/tests/CopilotSdkProvider.Tests/Agents/CopilotSdkClientMcpServerShapeTests.cs
@@ -7,18 +7,15 @@ using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 namespace AchieveAi.LmDotnetTools.CopilotSdkProvider.Tests.Agents;
 
 /// <summary>
-/// Pins the ACP <c>session/new</c> <c>mcpServers</c> wire shape so the
-/// Copilot CLI's Zod validator keeps accepting it. The wire shape is an
-/// array (NOT a map) of <c>{ name, command, args, env: [{name,value}] }</c>
-/// entries for stdio transport, and <c>{ name, type, url, headers }</c> for
-/// http/sse transports. Reflection is used so the shape contract can be
-/// exercised without exposing <c>BuildSessionNewParams</c> publicly.
+/// Pins the ACP <c>session/new</c> <c>mcpServers</c> wire shape. The Copilot CLI's
+/// <c>session/new</c> Zod schema validates <c>mcpServers</c> as a required array and
+/// silently rejects stdio entries placed there — external MCP servers are routed
+/// through <c>--additional-mcp-config=@&lt;file&gt;</c> (see
+/// <c>CopilotAcpTransportLaunchContractTests</c> + <c>CopilotAcpTransportMcpConfigFileTests</c>)
+/// instead. <c>session/new</c> must therefore always carry an empty array.
 /// </summary>
 public sealed class CopilotSdkClientMcpServerShapeTests
 {
-    /// <summary>
-    /// Hand-rolled options for the unit (no real transport spun up).
-    /// </summary>
     private static CopilotSdkOptions NewOptions(
         IReadOnlyDictionary<string, McpServerConfig>? mcpServers = null)
     {
@@ -29,11 +26,6 @@ public sealed class CopilotSdkClientMcpServerShapeTests
         };
     }
 
-    /// <summary>
-    /// Invoke the private <c>BuildSessionNewParams</c> method through reflection
-    /// and return the resulting parameter dictionary so tests can assert on the
-    /// exact wire keys/values.
-    /// </summary>
     private static IDictionary<string, object?> InvokeBuildSessionNewParams(
         CopilotSdkClient client,
         CopilotBridgeInitOptions options)
@@ -42,10 +34,10 @@ public sealed class CopilotSdkClientMcpServerShapeTests
             "BuildSessionNewParams",
             BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(method);
-        var result = method!.Invoke(client, [options]);
+        var result = method.Invoke(client, [options]);
         Assert.NotNull(result);
         Assert.IsAssignableFrom<IDictionary<string, object?>>(result);
-        return (IDictionary<string, object?>)result!;
+        return (IDictionary<string, object?>)result;
     }
 
     private static IList<object> McpServerArray(IDictionary<string, object?> parameters)
@@ -53,16 +45,6 @@ public sealed class CopilotSdkClientMcpServerShapeTests
         Assert.True(parameters.ContainsKey("mcpServers"));
         var raw = parameters["mcpServers"];
         Assert.NotNull(raw);
-        return Materialize(raw!);
-    }
-
-    /// <summary>
-    /// Materialize a non-generic <see cref="System.Collections.IEnumerable"/> to a
-    /// <see cref="List{Object}"/> without using LINQ — analyzer IDE0305 fires on
-    /// <c>.Cast&lt;object&gt;().ToList()</c> in tests.
-    /// </summary>
-    private static IList<object> Materialize(object raw)
-    {
         var enumerable = Assert.IsAssignableFrom<System.Collections.IEnumerable>(raw);
         var list = new List<object>();
         foreach (var item in enumerable)
@@ -70,12 +52,6 @@ public sealed class CopilotSdkClientMcpServerShapeTests
             list.Add(item);
         }
         return list;
-    }
-
-    private static IDictionary<string, object?> AsEntry(object entry)
-    {
-        Assert.IsAssignableFrom<IDictionary<string, object?>>(entry);
-        return (IDictionary<string, object?>)entry;
     }
 
     [Fact]
@@ -90,8 +66,12 @@ public sealed class CopilotSdkClientMcpServerShapeTests
     }
 
     [Fact]
-    public void Stdio_entry_is_projected_to_acp_shape()
+    public void Stdio_entries_are_NOT_projected_into_session_new()
     {
+        // External MCP servers flow through --additional-mcp-config=@<file>, not
+        // through session/new. The wire array must remain empty regardless of the
+        // configured McpServers dictionary so the Copilot CLI Zod validator does
+        // not see (and reject) a stdio entry on the ACP request.
         var mcp = new Dictionary<string, McpServerConfig>
         {
             ["github"] = McpServerConfig.CreateStdio(
@@ -108,31 +88,16 @@ public sealed class CopilotSdkClientMcpServerShapeTests
         };
 
         var parameters = InvokeBuildSessionNewParams(client, options);
-        var list = McpServerArray(parameters);
 
-        Assert.Single(list);
-        var entry = AsEntry(list[0]);
-        Assert.Equal("github", entry["name"]);
-        Assert.Equal("npx", entry["command"]);
-
-        var args = Assert.IsType<string[]>(entry["args"]);
-        Assert.Equal(["-y", "@github/mcp"], args);
-
-        // env is an array of {name, value} objects, not a plain map
-        var envList = Materialize(entry["env"]!);
-        Assert.Single(envList);
-        var envEntry = AsEntry(envList[0]);
-        Assert.Equal("TOKEN", envEntry["name"]);
-        Assert.Equal("abc", envEntry["value"]);
-
-        // No URL or explicit type field on stdio entries
-        Assert.False(entry.ContainsKey("url"));
-        Assert.False(entry.ContainsKey("type"));
+        Assert.Empty(McpServerArray(parameters));
     }
 
     [Fact]
-    public void Http_entry_is_projected_with_url_and_headers()
+    public void Http_entries_are_NOT_projected_into_session_new()
     {
+        // Same as stdio: even though the ACP schema historically accepted http
+        // entries, the consolidated routing (single source of truth) is the
+        // --additional-mcp-config file.
         var mcp = new Dictionary<string, McpServerConfig>
         {
             ["remote"] = McpServerConfig.CreateHttp(
@@ -148,28 +113,20 @@ public sealed class CopilotSdkClientMcpServerShapeTests
         };
 
         var parameters = InvokeBuildSessionNewParams(client, options);
-        var list = McpServerArray(parameters);
 
-        Assert.Single(list);
-        var entry = AsEntry(list[0]);
-        Assert.Equal("remote", entry["name"]);
-        Assert.Equal("http", entry["type"]);
-        Assert.Equal("https://example.com/mcp", entry["url"]);
-
-        var headers = Materialize(entry["headers"]!);
-        Assert.Single(headers);
-        var headerEntry = AsEntry(headers[0]);
-        Assert.Equal("X-Auth", headerEntry["name"]);
-        Assert.Equal("bearer", headerEntry["value"]);
+        Assert.Empty(McpServerArray(parameters));
     }
 
     [Fact]
-    public void Bridge_options_McpServers_override_sdk_options()
+    public void Bridge_options_McpServers_override_sdk_options_via_resolver()
     {
         // Per-call dictionary on CopilotBridgeInitOptions wins over the
         // CopilotSdkClient's ctor-supplied McpServers (mirrors how Model,
-        // WorkingDirectory, etc. resolve). This guards the override path
-        // used by CopilotAgentLoop in OnBeforeRunAsync.
+        // WorkingDirectory, etc. resolve). This guards the override path used by
+        // CopilotAgentLoop in OnBeforeRunAsync — even though McpServers no longer
+        // appears in session/new, the resolver still needs to surface the
+        // per-call value so the transport's --additional-mcp-config file picks
+        // up the override.
         var ctorDict = new Dictionary<string, McpServerConfig>
         {
             ["ctor"] = McpServerConfig.CreateStdio("cmd-a", ["x"]),
@@ -186,45 +143,15 @@ public sealed class CopilotSdkClientMcpServerShapeTests
             McpServers = perCallDict,
         };
 
-        // Need to also run options through the private resolver since
-        // BuildSessionNewParams takes the resolved options. Re-invoke the
-        // same logic by calling ResolveEffectiveOptions reflectively.
         var resolveMethod = typeof(CopilotSdkClient).GetMethod(
             "ResolveEffectiveOptions",
             BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(resolveMethod);
-        var resolved = (CopilotBridgeInitOptions)resolveMethod!.Invoke(client, [options])!;
+        var resolved = (CopilotBridgeInitOptions)resolveMethod.Invoke(client, [options])!;
 
-        var parameters = InvokeBuildSessionNewParams(client, resolved);
-        var list = McpServerArray(parameters);
-        Assert.Single(list);
-        var entry = AsEntry(list[0]);
-        Assert.Equal("override", entry["name"]);
-        Assert.Equal("cmd-b", entry["command"]);
-    }
-
-    [Fact]
-    public void Stdio_entry_without_command_is_skipped()
-    {
-        // Guards against shipping a malformed entry to Copilot — the Zod
-        // validator would reject the whole session/new request.
-        var mcp = new Dictionary<string, McpServerConfig>
-        {
-            ["broken"] = new McpServerConfig { Type = "stdio", Command = null },
-            ["good"] = McpServerConfig.CreateStdio("cmd", ["ok"]),
-        };
-        var client = new CopilotSdkClient(NewOptions(mcp));
-        var options = new CopilotBridgeInitOptions
-        {
-            Model = "m",
-            WorkingDirectory = "/tmp",
-            McpServers = mcp,
-        };
-
-        var parameters = InvokeBuildSessionNewParams(client, options);
-        var list = McpServerArray(parameters);
-        Assert.Single(list);
-        var entry = AsEntry(list[0]);
-        Assert.Equal("good", entry["name"]);
+        Assert.NotNull(resolved.McpServers);
+        Assert.Single(resolved.McpServers);
+        Assert.True(resolved.McpServers.ContainsKey("override"));
+        Assert.Equal("cmd-b", resolved.McpServers["override"].Command);
     }
 }

--- a/tests/CopilotSdkProvider.Tests/Transport/CopilotAcpTransportMcpConfigFileTests.cs
+++ b/tests/CopilotSdkProvider.Tests/Transport/CopilotAcpTransportMcpConfigFileTests.cs
@@ -1,0 +1,333 @@
+using System.Reflection;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.CopilotSdkProvider.Configuration;
+using AchieveAi.LmDotnetTools.CopilotSdkProvider.Transport;
+using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+using AchieveAi.LmDotnetTools.ProcessLauncher;
+
+namespace AchieveAi.LmDotnetTools.CopilotSdkProvider.Tests.Transport;
+
+/// <summary>
+/// Verifies that <see cref="CopilotAcpTransport"/> projects
+/// <c>CopilotSdkOptions.McpServers</c> (and per-session overrides) onto the Copilot
+/// CLI's <c>--additional-mcp-config=@&lt;file&gt;</c> flag instead of the ACP
+/// <c>session/new</c> wire shape. Drives two surfaces:
+///   1. The internal <c>BuildMcpConfigFileContent</c> producer (schema + filter rules).
+///   2. The end-to-end launch contract (flag appears in arguments, file exists,
+///      <c>HostPathReference</c> declared, temp file cleaned up on Dispose).
+/// </summary>
+public sealed class CopilotAcpTransportMcpConfigFileTests
+{
+    private sealed class RecordingLauncher : IProcessLauncher
+    {
+        public ProcessLaunchRequest? LastRequest { get; private set; }
+
+        public string? CapturedMcpConfigFileContents { get; private set; }
+
+        public string? CapturedMcpConfigFilePath { get; private set; }
+
+        public Task<IProcessHandle> LaunchAsync(ProcessLaunchRequest request, CancellationToken cancellationToken = default)
+        {
+            LastRequest = request;
+
+            // The temp file must exist at launch time; capture its contents
+            // before the transport's StartAsync error path cleans it up.
+            foreach (var arg in request.Arguments)
+            {
+                if (arg.StartsWith("--additional-mcp-config=@", StringComparison.Ordinal))
+                {
+                    var path = arg["--additional-mcp-config=@".Length..];
+                    CapturedMcpConfigFilePath = path;
+                    if (File.Exists(path))
+                    {
+                        CapturedMcpConfigFileContents = File.ReadAllText(path);
+                    }
+                    break;
+                }
+            }
+
+            throw new ProcessLauncherException("recording launcher: never spawns");
+        }
+    }
+
+    private static string? InvokeBuildMcpConfigFileContent(
+        CopilotAcpTransport transport,
+        IReadOnlyDictionary<string, McpServerConfig>? mcpServers)
+    {
+        var method = typeof(CopilotAcpTransport).GetMethod(
+            "BuildMcpConfigFileContent",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (string?)method.Invoke(transport, [mcpServers]);
+    }
+
+    private static async Task RunStartAsync(CopilotAcpTransport transport, string workingDir, IReadOnlyDictionary<string, McpServerConfig>? mcp)
+    {
+        var startMethod = typeof(CopilotAcpTransport).GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .First(m => m.Name == "StartAsync" && m.GetParameters().Length == 7);
+
+        var task = (Task)startMethod.Invoke(transport,
+        [
+            workingDir,
+            "ghp_test",
+            "https://example.test",
+            mcp,
+            (Func<string, JsonElement?, CancellationToken, Task<JsonElement>>)((_, _, _) => Task.FromResult(default(JsonElement))),
+            (Action<string, JsonElement?>)((_, _) => { }),
+            CancellationToken.None,
+        ])!;
+        await task;
+    }
+
+    [Fact]
+    public void Empty_mcpServers_produces_no_config_file_content()
+    {
+        var transport = new CopilotAcpTransport(new CopilotSdkOptions());
+        var content = InvokeBuildMcpConfigFileContent(transport, null);
+        Assert.Null(content);
+
+        var empty = InvokeBuildMcpConfigFileContent(transport, new Dictionary<string, McpServerConfig>());
+        Assert.Null(empty);
+    }
+
+    [Fact]
+    public void Single_stdio_server_uses_config_file_schema_with_object_env()
+    {
+        var transport = new CopilotAcpTransport(new CopilotSdkOptions());
+        var mcp = new Dictionary<string, McpServerConfig>
+        {
+            ["github"] = McpServerConfig.CreateStdio(
+                command: "npx",
+                args: ["-y", "@github/mcp"],
+                env: new Dictionary<string, string> { ["TOKEN"] = "abc", ["EXTRA"] = "1" }),
+        };
+
+        var content = InvokeBuildMcpConfigFileContent(transport, mcp);
+        Assert.NotNull(content);
+
+        using var doc = JsonDocument.Parse(content!);
+        var servers = doc.RootElement.GetProperty("mcpServers");
+        Assert.Equal(JsonValueKind.Object, servers.ValueKind);
+        var entry = servers.GetProperty("github");
+        Assert.Equal("stdio", entry.GetProperty("type").GetString());
+        Assert.Equal("npx", entry.GetProperty("command").GetString());
+
+        var args = entry.GetProperty("args");
+        Assert.Equal(JsonValueKind.Array, args.ValueKind);
+        Assert.Equal(2, args.GetArrayLength());
+        Assert.Equal("-y", args[0].GetString());
+        Assert.Equal("@github/mcp", args[1].GetString());
+
+        // env must be a plain object map, NOT the ACP {name,value} array shape.
+        var env = entry.GetProperty("env");
+        Assert.Equal(JsonValueKind.Object, env.ValueKind);
+        Assert.Equal("abc", env.GetProperty("TOKEN").GetString());
+        Assert.Equal("1", env.GetProperty("EXTRA").GetString());
+    }
+
+    [Fact]
+    public void Http_server_uses_config_file_schema_with_object_headers()
+    {
+        var transport = new CopilotAcpTransport(new CopilotSdkOptions());
+        var mcp = new Dictionary<string, McpServerConfig>
+        {
+            ["remote"] = McpServerConfig.CreateHttp(
+                url: "https://example.com/mcp",
+                headers: new Dictionary<string, string> { ["X-Auth"] = "bearer" }),
+        };
+
+        var content = InvokeBuildMcpConfigFileContent(transport, mcp);
+        Assert.NotNull(content);
+
+        using var doc = JsonDocument.Parse(content!);
+        var entry = doc.RootElement.GetProperty("mcpServers").GetProperty("remote");
+        Assert.Equal("http", entry.GetProperty("type").GetString());
+        Assert.Equal("https://example.com/mcp", entry.GetProperty("url").GetString());
+        Assert.False(entry.TryGetProperty("command", out _));
+
+        var headers = entry.GetProperty("headers");
+        Assert.Equal(JsonValueKind.Object, headers.ValueKind);
+        Assert.Equal("bearer", headers.GetProperty("X-Auth").GetString());
+    }
+
+    [Fact]
+    public void Mixed_server_types_appear_in_one_file()
+    {
+        var transport = new CopilotAcpTransport(new CopilotSdkOptions());
+        var mcp = new Dictionary<string, McpServerConfig>
+        {
+            ["stdio-srv"] = McpServerConfig.CreateStdio("npx", ["-y", "thing"]),
+            ["http-srv"] = McpServerConfig.CreateHttp("https://h.example/mcp"),
+        };
+
+        var content = InvokeBuildMcpConfigFileContent(transport, mcp);
+        Assert.NotNull(content);
+
+        using var doc = JsonDocument.Parse(content!);
+        var servers = doc.RootElement.GetProperty("mcpServers");
+        Assert.Equal("stdio", servers.GetProperty("stdio-srv").GetProperty("type").GetString());
+        Assert.Equal("http", servers.GetProperty("http-srv").GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void Stdio_server_without_command_is_skipped()
+    {
+        var transport = new CopilotAcpTransport(new CopilotSdkOptions());
+        var mcp = new Dictionary<string, McpServerConfig>
+        {
+            ["broken"] = new McpServerConfig { Type = "stdio", Command = null },
+            ["good"] = McpServerConfig.CreateStdio("cmd", ["ok"]),
+        };
+
+        var content = InvokeBuildMcpConfigFileContent(transport, mcp);
+        Assert.NotNull(content);
+
+        using var doc = JsonDocument.Parse(content!);
+        var servers = doc.RootElement.GetProperty("mcpServers");
+        Assert.False(servers.TryGetProperty("broken", out _));
+        Assert.True(servers.TryGetProperty("good", out _));
+    }
+
+    [Fact]
+    public void Only_invalid_entries_yields_no_file_content()
+    {
+        var transport = new CopilotAcpTransport(new CopilotSdkOptions());
+        var mcp = new Dictionary<string, McpServerConfig>
+        {
+            ["broken"] = new McpServerConfig { Type = "stdio", Command = null },
+        };
+
+        var content = InvokeBuildMcpConfigFileContent(transport, mcp);
+        Assert.Null(content);
+    }
+
+    [Fact]
+    public void Args_default_to_empty_array_when_omitted()
+    {
+        // Some commands (e.g. `npx some-mcp`) carry no extra args; ensure
+        // `args` is emitted as `[]` rather than missing so the CLI schema
+        // sees the expected key.
+        var transport = new CopilotAcpTransport(new CopilotSdkOptions());
+        var mcp = new Dictionary<string, McpServerConfig>
+        {
+            ["noargs"] = new McpServerConfig { Type = "stdio", Command = "cmd", Args = null },
+        };
+
+        var content = InvokeBuildMcpConfigFileContent(transport, mcp);
+        Assert.NotNull(content);
+
+        using var doc = JsonDocument.Parse(content!);
+        var args = doc.RootElement.GetProperty("mcpServers").GetProperty("noargs").GetProperty("args");
+        Assert.Equal(JsonValueKind.Array, args.ValueKind);
+        Assert.Equal(0, args.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task StartAsync_without_mcp_servers_omits_flag_and_creates_no_file()
+    {
+        var recorder = new RecordingLauncher();
+        var options = new CopilotSdkOptions
+        {
+            CopilotCliPath = "copilot-cli-mock",
+            ProcessLauncher = recorder,
+        };
+
+        await using var transport = new CopilotAcpTransport(options);
+
+        var workingDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(workingDir);
+        try
+        {
+            var act = async () => await RunStartAsync(transport, workingDir, mcp: null);
+            await act.Should().ThrowAsync<InvalidOperationException>();
+        }
+        finally
+        {
+            Directory.Delete(workingDir, recursive: true);
+        }
+
+        recorder.LastRequest.Should().NotBeNull();
+        recorder.LastRequest!.Arguments.Should().Equal("--acp", "--stdio");
+        recorder.CapturedMcpConfigFilePath.Should().BeNull();
+        recorder.LastRequest.HostPaths.Should().NotContain(p => p.Kind == HostPathKind.McpConfigFile);
+    }
+
+    [Fact]
+    public async Task StartAsync_with_stdio_server_injects_flag_writes_file_and_declares_host_path()
+    {
+        var recorder = new RecordingLauncher();
+        var options = new CopilotSdkOptions
+        {
+            CopilotCliPath = "copilot-cli-mock",
+            ProcessLauncher = recorder,
+        };
+        var mcp = new Dictionary<string, McpServerConfig>
+        {
+            ["github"] = McpServerConfig.CreateStdio("npx", ["-y", "@github/mcp"]),
+        };
+
+        await using var transport = new CopilotAcpTransport(options);
+
+        var workingDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(workingDir);
+        try
+        {
+            var act = async () => await RunStartAsync(transport, workingDir, mcp);
+            await act.Should().ThrowAsync<InvalidOperationException>();
+        }
+        finally
+        {
+            Directory.Delete(workingDir, recursive: true);
+        }
+
+        recorder.LastRequest.Should().NotBeNull();
+        recorder.LastRequest!.Arguments.Should().StartWith(["--acp", "--stdio"]);
+        var flagArg = recorder.LastRequest.Arguments.Single(a => a.StartsWith("--additional-mcp-config=@", StringComparison.Ordinal));
+        flagArg.Should().StartWith("--additional-mcp-config=@");
+
+        recorder.CapturedMcpConfigFilePath.Should().NotBeNull();
+        recorder.CapturedMcpConfigFileContents.Should().NotBeNullOrWhiteSpace();
+        using var doc = JsonDocument.Parse(recorder.CapturedMcpConfigFileContents!);
+        var entry = doc.RootElement.GetProperty("mcpServers").GetProperty("github");
+        entry.GetProperty("command").GetString().Should().Be("npx");
+
+        recorder.LastRequest.HostPaths.Should().Contain(p =>
+            p.Kind == HostPathKind.McpConfigFile && p.Path == recorder.CapturedMcpConfigFilePath);
+    }
+
+    [Fact]
+    public async Task StartAsync_cleans_up_temp_file_after_launch_failure()
+    {
+        var recorder = new RecordingLauncher();
+        var options = new CopilotSdkOptions
+        {
+            CopilotCliPath = "copilot-cli-mock",
+            ProcessLauncher = recorder,
+        };
+        var mcp = new Dictionary<string, McpServerConfig>
+        {
+            ["github"] = McpServerConfig.CreateStdio("npx", ["-y", "@github/mcp"]),
+        };
+
+        var transport = new CopilotAcpTransport(options);
+
+        var workingDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(workingDir);
+        try
+        {
+            var act = async () => await RunStartAsync(transport, workingDir, mcp);
+            await act.Should().ThrowAsync<InvalidOperationException>();
+        }
+        finally
+        {
+            Directory.Delete(workingDir, recursive: true);
+            await transport.DisposeAsync();
+        }
+
+        // The recording launcher captured the path BEFORE the failure-path
+        // cleanup ran, so the file existed at launch time. The transport must
+        // delete it before returning control to the caller.
+        recorder.CapturedMcpConfigFilePath.Should().NotBeNull();
+        File.Exists(recorder.CapturedMcpConfigFilePath!).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
[Gautam's Dev bot]

## Summary

Copilot CLI's ACP `session/new` Zod schema validates `mcpServers` as an array and silently rejects stdio entries (only http/sse are permitted there). As a result, stdio MCP servers configured via `CopilotSdkOptions.McpServers` were never actually registered with the agent — the user only discovered this because their `github` MCP tools were silently missing from sessions.

This PR routes **every** external MCP server (stdio + http) through the CLI's own `--additional-mcp-config=@<file>` loader, which is the single source of truth the CLI uses to register MCP servers internally.

## Changes

- **`CopilotAcpTransport.StartAsync`** now writes the resolved `McpServers` dictionary to a per-session JSON file in the OS temp dir and appends `--additional-mcp-config=@<path>` to the CLI args. The temp file is also registered as a `HostPathReference` so containerised launchers can mount it.
- The temp file is deleted on `StopAsync`, launch failure, and `Dispose` — lifecycle owned by the transport.
- `session/new` always emits an empty `mcpServers` array, matching the validator's expectation.
- Empty/null `McpServers` is a no-op (no file, no flag) — preserves prior behaviour for users that don't configure external MCP.

## Wire format

The written file matches the CLI's expected schema:

```json
{
  "mcpServers": {
    "github": {
      "type": "stdio",
      "command": "npx",
      "args": ["-y", "@github/mcp"],
      "env": { "TOKEN": "abc" }
    },
    "remote": {
      "type": "http",
      "url": "https://example.com/mcp",
      "headers": { "X-Auth": "bearer" }
    }
  }
}
```

Note `env`/`headers` are object maps (CLI shape), not the ACP name/value-pair arrays that used to flow through `session/new`.

## Tests

- New `CopilotAcpTransportMcpConfigFileTests` (10 tests) cover: empty -> no file, stdio object-env schema, http object-headers, mixed types, missing-command skipping, only-invalid -> null, args default `[]`, `StartAsync` omits flag when null, injects flag + host path on the launch command, cleanup on launch failure.
- Rewrote `CopilotSdkClientMcpServerShapeTests` to assert the wire array is always empty regardless of configured stdio/http entries; the per-call override path still flows through the resolver so the new temp-file routing picks it up.
- All 107 tests in `CopilotSdkProvider.Tests` pass.

## Test plan

- [x] `dotnet test tests/CopilotSdkProvider.Tests/CopilotSdkProvider.Tests.csproj`
- [x] Manually verified empty/null `McpServers` is a no-op (no flag, no file written)
- [x] Manually verified stdio + http entries serialise into the CLI's expected schema
- [ ] CI green

Closes #59