### PR TITLE
chore: bump to 1.0.33 (Copilot MCP routing fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the LmDotnetTools project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.33] - 2026-05-23
+
+### Added
+
+- Copilot CLI: project `--disable-mcp-server` / `--disable-builtin-mcps` from `CopilotSdkOptions` (#60)
+
+### Fixed
+
+- Copilot CLI: route MCP servers via `--additional-mcp-config` file instead of inline args (#61)
+- Copilot CLI: trim disabled MCP server names in `BuildCliArguments`
+
+---
+
 ## [1.0.0] - 2025-08-01
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <!-- Centralized Versioning - UPDATE ONLY THIS SECTION FOR NEW RELEASES -->
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>32</PatchVersion>
+    <PatchVersion>33</PatchVersion>
     <PreReleaseLabel></PreReleaseLabel>
     <!-- Use values like 'alpha', 'beta', 'rc.1' or leave empty for stable -->
     <!-- Computed Version Properties (DO NOT MODIFY) -->


### PR DESCRIPTION
## Summary
- Bump version 1.0.32 -> 1.0.33
- CHANGELOG entry for the unreleased Copilot MCP work

## Included since 1.0.32
- feat(copilot): project `--disable-mcp-server` / `--disable-builtin-mcps` from `CopilotSdkOptions` (#60)
- fix(copilot): route MCP servers via `--additional-mcp-config` file (#61)
- fix(copilot): trim disabled MCP server names in `BuildCliArguments`

## Publish status
**1.0.33 was already published to NuGet.org** for all 18 packages prior to opening this PR. This PR records the version bump + changelog entry in source.

## Test plan
- [x] Solution builds clean in Release (0 warnings, 0 errors)
- [x] All 18 NuGet packages packed at 1.0.33
- [x] `dotnet nuget push` succeeded for every package on NuGet.org