### PR TITLE
feat: route OpenAI Responses and Anthropic providers through GitHub Copilot

### DIFF
--- a/samples/LmStreaming.Sample/LmStreaming.Sample.csproj
+++ b/samples/LmStreaming.Sample/LmStreaming.Sample.csproj
@@ -57,6 +57,7 @@
     <ProjectReference Include="..\..\src\LmMultiTurn\AchieveAi.LmDotnetTools.LmMultiTurn.csproj" />
     <ProjectReference Include="..\..\src\OpenAIProvider\AchieveAi.LmDotnetTools.OpenAIProvider.csproj" />
     <ProjectReference Include="..\..\src\AnthropicProvider\AchieveAi.LmDotnetTools.AnthropicProvider.csproj" />
+    <ProjectReference Include="..\..\src\OpenAiResponsesProvider\AchieveAi.LmDotnetTools.OpenAiResponsesProvider.csproj" />
     <ProjectReference Include="..\..\src\CodexSdkProvider\AchieveAi.LmDotnetTools.CodexSdkProvider.csproj" />
     <ProjectReference Include="..\..\src\ClaudeAgentSdkProvider\AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.csproj" />
     <ProjectReference Include="..\..\src\CopilotSdkProvider\AchieveAi.LmDotnetTools.CopilotSdkProvider.csproj" />

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -6,6 +6,8 @@ using AchieveAi.LmDotnetTools.AnthropicProvider.Agents;
 using AchieveAi.LmDotnetTools.AnthropicProvider.Models;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
 using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
+using AchieveAi.LmDotnetTools.LmCore.Auth;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
 using AchieveAi.LmDotnetTools.CodexSdkProvider.Configuration;
 using AchieveAi.LmDotnetTools.CodexSdkProvider.Models;
 using AchieveAi.LmDotnetTools.CopilotSdkProvider.Configuration;
@@ -184,6 +186,10 @@ try
             {
                 "openai" => CreateOpenAiAgent(loggerFactory),
                 "anthropic" => CreateAnthropicAgent(loggerFactory),
+                "sonnet" => CreateCopilotAnthropicAgent("Sonnet", loggerFactory),
+                "haiku" => CreateCopilotAnthropicAgent("Haiku", loggerFactory),
+                "gpt-5.5" => CreateCopilotResponsesAgent("GPT-5.5", loggerFactory),
+                "gpt-5.5-mini" => CreateCopilotResponsesAgent("GPT-5.5 mini", loggerFactory),
                 "test-anthropic" => CreateAnthropicTestAgent(loggerFactory, sp.GetRequiredService<ITestAgentBuilder>()),
                 "test" => CreateTestAgent(loggerFactory, sp.GetRequiredService<ITestAgentBuilder>()),
                 _ => throw new ProviderUnavailableException(
@@ -714,6 +720,44 @@ public partial class Program
         return new AnthropicAgent("Anthropic", anthropicClient, loggerFactory.CreateLogger<AnthropicAgent>());
     }
 
+    // Shared across the GitHub Copilot-backed agents: one token (resolved from the Copilot/gh CLI
+    // login) and one client-session id for the process lifetime.
+    private static readonly Lazy<ICopilotTokenProvider> s_copilotTokenProvider =
+        new(() => new CliCredentialCopilotTokenProvider());
+
+    private static readonly Lazy<CopilotSessionContext> s_copilotSession = new(() => new CopilotSessionContext());
+
+    /// <summary>
+    ///     Creates an Anthropic Messages agent (Sonnet/Haiku) routed through the GitHub Copilot
+    ///     backend. The model id is supplied per-thread by <see cref="GetModelIdForProvider"/>.
+    /// </summary>
+    private static IStreamingAgent CreateCopilotAnthropicAgent(string name, ILoggerFactory loggerFactory)
+    {
+        Log.Information("Creating Copilot-backed Anthropic agent: {Name}", name);
+        return CopilotAnthropicAgentFactory.Create(
+            name,
+            s_copilotTokenProvider.Value,
+            s_copilotSession.Value,
+            logger: loggerFactory.CreateLogger<AnthropicAgent>()
+        );
+    }
+
+    /// <summary>
+    ///     Creates an OpenAI Responses agent (GPT-5.5 / GPT-5.5 mini) routed through the GitHub Copilot
+    ///     backend over SSE (stateless per turn — the multi-turn loop resends full history each turn).
+    /// </summary>
+    private static IStreamingAgent CreateCopilotResponsesAgent(string name, ILoggerFactory loggerFactory)
+    {
+        Log.Information("Creating Copilot-backed OpenAI Responses agent: {Name}", name);
+        return CopilotResponsesAgentFactory.Create(
+            name,
+            s_copilotTokenProvider.Value,
+            CopilotResponsesTransport.Sse,
+            s_copilotSession.Value,
+            logger: loggerFactory.CreateLogger<OpenAiResponsesAgent>()
+        );
+    }
+
     /// <summary>
     ///     Gets the model ID based on the provider mode and env vars.
     /// </summary>
@@ -989,6 +1033,10 @@ public partial class Program
             "claude" or "claude-mock" => Environment.GetEnvironmentVariable("CLAUDE_MODEL") ?? "claude-sonnet-4-6",
             "codex" or "codex-mock" => Environment.GetEnvironmentVariable("CODEX_MODEL") ?? "gpt-5.3-codex",
             "copilot" or "copilot-mock" => Environment.GetEnvironmentVariable("COPILOT_MODEL") ?? "claude-sonnet-4.5",
+            "sonnet" => Environment.GetEnvironmentVariable("SONNET_MODEL") ?? "claude-sonnet-4.5",
+            "haiku" => Environment.GetEnvironmentVariable("HAIKU_MODEL") ?? "claude-haiku-4.5",
+            "gpt-5.5" => Environment.GetEnvironmentVariable("GPT55_MODEL") ?? "gpt-5.5",
+            "gpt-5.5-mini" => Environment.GetEnvironmentVariable("GPT55_MINI_MODEL") ?? "gpt-5-mini",
             _ => "test-model",
         };
     }

--- a/samples/LmStreaming.Sample/Services/ProviderRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/ProviderRegistry.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using AchieveAi.LmDotnetTools.LmCore.Auth;
 
 namespace LmStreaming.Sample.Services;
 
@@ -25,6 +26,10 @@ public sealed class ProviderRegistry
             new("claude", "Claude (CLI)"),
             new("codex", "Codex"),
             new("copilot", "Copilot (CLI)"),
+            new("sonnet", "Sonnet (Copilot)"),
+            new("haiku", "Haiku (Copilot)"),
+            new("gpt-5.5", "GPT-5.5 (Copilot)"),
+            new("gpt-5.5-mini", "GPT-5.5 mini (Copilot)"),
             new("claude-mock", "Claude (CLI, Mock)"),
             new("codex-mock", "Codex (Mock)"),
             new("copilot-mock", "Copilot (CLI, Mock)"),
@@ -63,6 +68,9 @@ public sealed class ProviderRegistry
         var hasCopilotCli = HasCliPath("COPILOT_CLI_PATH", "copilot", probe);
         var hasOpenAiKey = HasEnvVar("OPENAI_API_KEY");
         var hasAnthropicKey = HasEnvVar("ANTHROPIC_API_KEY");
+        // Copilot-backed providers route through the Copilot API using the developer's existing
+        // Copilot/gh login, so they are available whenever a token can be resolved.
+        var hasCopilotToken = new CliCredentialCopilotTokenProvider().ResolveToken() is not null;
 
         foreach (var entry in CatalogEntries)
         {
@@ -75,6 +83,7 @@ public sealed class ProviderRegistry
                 "anthropic" => hasAnthropicKey,
                 "claude" => hasClaudeCli,
                 "copilot" => hasCopilotCli,
+                "sonnet" or "haiku" or "gpt-5.5" or "gpt-5.5-mini" => hasCopilotToken,
                 // *-mock providers need both their CLI prerequisite and the running mock host;
                 // codex-mock has no CLI prerequisite (codex availability is unconditional).
                 "claude-mock" => hasClaudeCli,

--- a/src/AnthropicProvider/Agents/CopilotAnthropicAgentFactory.cs
+++ b/src/AnthropicProvider/Agents/CopilotAnthropicAgentFactory.cs
@@ -1,0 +1,79 @@
+using AchieveAi.LmDotnetTools.LmCore.Auth;
+using AchieveAi.LmDotnetTools.LmCore.Http;
+using AchieveAi.LmDotnetTools.LmCore.Performance;
+using Microsoft.Extensions.Logging;
+
+namespace AchieveAi.LmDotnetTools.AnthropicProvider.Agents;
+
+/// <summary>
+///     Builds an <see cref="AnthropicAgent"/> that talks the Anthropic Messages API through the
+///     GitHub Copilot backend (<c>POST {host}/v1/messages</c>) instead of api.anthropic.com.
+/// </summary>
+/// <remarks>
+///     The agent, client, request builder, and SSE parsing are reused unchanged — only the transport
+///     differs: a <see cref="CopilotHeadersHandler"/> supplies the bearer token and Copilot headers,
+///     and the base URL points at the Copilot host. The required <c>anthropic-version</c> header is
+///     injected via <see cref="CopilotOptions.ExtraHeaders"/>.
+/// </remarks>
+public static class CopilotAnthropicAgentFactory
+{
+    private const string AnthropicVersion = "2023-06-01";
+
+    /// <summary>
+    ///     Creates an <see cref="AnthropicAgent"/> routed through GitHub Copilot.
+    /// </summary>
+    /// <param name="name">Agent name.</param>
+    /// <param name="tokenProvider">Source of the GitHub OAuth bearer token.</param>
+    /// <param name="session">Optional shared tracking ids; a new context is created when omitted.</param>
+    /// <param name="options">Optional Copilot header options; defaults target the enterprise host.</param>
+    /// <param name="performanceTracker">Optional performance tracker.</param>
+    /// <param name="logger">Optional logger.</param>
+    /// <param name="retryOptions">Optional retry configuration.</param>
+    public static AnthropicAgent Create(
+        string name,
+        ICopilotTokenProvider tokenProvider,
+        CopilotSessionContext? session = null,
+        CopilotOptions? options = null,
+        IPerformanceTracker? performanceTracker = null,
+        ILogger<AnthropicAgent>? logger = null,
+        RetryOptions? retryOptions = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(tokenProvider);
+
+        var baseOptions = options ?? new CopilotOptions();
+        var copilotOptions = baseOptions with
+        {
+            DefaultInteractionType = baseOptions.DefaultInteractionType ?? "conversation-user",
+            ExtraHeaders = WithAnthropicVersion(baseOptions.ExtraHeaders),
+        };
+
+        var context = session ?? new CopilotSessionContext();
+        var host = copilotOptions.BaseUrl.TrimEnd('/');
+
+        var httpClient = CopilotHttpClientFactory.Create(host, tokenProvider, context, copilotOptions);
+
+        // The client appends "/messages", so the base URL must carry the "/v1" prefix to hit
+        // {host}/v1/messages.
+        var client = new AnthropicClient(httpClient, $"{host}/v1", performanceTracker, logger, retryOptions);
+
+        return new AnthropicAgent(name, client, logger);
+    }
+
+    private static IReadOnlyDictionary<string, string> WithAnthropicVersion(
+        IReadOnlyDictionary<string, string>? existing
+    )
+    {
+        var merged = existing is null
+            ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string>(existing, StringComparer.OrdinalIgnoreCase);
+
+        if (!merged.ContainsKey("anthropic-version"))
+        {
+            merged["anthropic-version"] = AnthropicVersion;
+        }
+
+        return merged;
+    }
+}

--- a/src/AnthropicProvider/Utils/AnthropicJsonSerializerOptionsFactory.cs
+++ b/src/AnthropicProvider/Utils/AnthropicJsonSerializerOptionsFactory.cs
@@ -37,6 +37,13 @@ public static class AnthropicJsonSerializerOptionsFactory
         // SSE streaming disposes the per-line JsonDocument after each event.
         options.Converters.Add(new StableJsonElementConverter());
 
+#if NET9_0_OR_GREATER
+        // Some Anthropic-compatible backends (e.g. GitHub Copilot's /v1/messages) emit the
+        // polymorphic "type" discriminator AFTER other properties, e.g. {"text":"hi","type":"text"}.
+        // System.Text.Json is order-sensitive about discriminators by default; allow them anywhere.
+        options.AllowOutOfOrderMetadataProperties = true;
+#endif
+
         return options;
     }
 

--- a/src/LmCore/Auth/CliCredentialCopilotTokenProvider.cs
+++ b/src/LmCore/Auth/CliCredentialCopilotTokenProvider.cs
@@ -96,7 +96,7 @@ public sealed partial class CliCredentialCopilotTokenProvider : ICopilotTokenPro
         var xdg = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
         if (!string.IsNullOrWhiteSpace(xdg))
         {
-            yield return xdg!;
+            yield return xdg;
         }
 
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
@@ -180,7 +180,7 @@ public sealed partial class CliCredentialCopilotTokenProvider : ICopilotTokenPro
                     var token = tokenEl.GetString();
                     if (!string.IsNullOrWhiteSpace(token))
                     {
-                        return token!.Trim();
+                        return token.Trim();
                     }
                 }
             }

--- a/src/LmCore/Auth/CliCredentialCopilotTokenProvider.cs
+++ b/src/LmCore/Auth/CliCredentialCopilotTokenProvider.cs
@@ -1,0 +1,339 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Auth;
+
+/// <summary>
+///     Resolves a GitHub OAuth token from credentials already present on the machine, in priority order:
+///     <list type="number">
+///         <item>environment variables (<c>GITHUB_COPILOT_TOKEN</c>, <c>GH_COPILOT_TOKEN</c>, <c>GH_TOKEN</c>, <c>GITHUB_TOKEN</c>);</item>
+///         <item>the GitHub Copilot CLI config (<c>~/.copilot/config.json</c>), which stores its own GitHub token;</item>
+///         <item>the GitHub Copilot editor credential files (<c>apps.json</c> / <c>hosts.json</c>) under the user config dir;</item>
+///         <item>the <c>gh</c> CLI hosts file (<c>hosts.yml</c>);</item>
+///         <item>the <c>gh auth token</c> command.</item>
+///     </list>
+///     This is a zero-setup path for users already signed in to Copilot or the <c>gh</c> CLI.
+/// </summary>
+public sealed partial class CliCredentialCopilotTokenProvider : ICopilotTokenProvider
+{
+    private static readonly string[] EnvVarNames =
+    [
+        "GITHUB_COPILOT_TOKEN",
+        "GH_COPILOT_TOKEN",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+    ];
+
+    // The Copilot CLI's config.json is JSONC (leading // comments, possible trailing commas).
+    private static readonly JsonDocumentOptions LenientJsonOptions = new()
+    {
+        CommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+    };
+
+    /// <inheritdoc />
+    public Task<string> GetTokenAsync(CancellationToken cancellationToken = default)
+    {
+        var token = ResolveToken();
+        return token is not null
+            ? Task.FromResult(token)
+            : throw new InvalidOperationException(
+                "No GitHub Copilot token found. Set GITHUB_COPILOT_TOKEN (or GH_TOKEN), sign in with the "
+                    + "GitHub Copilot CLI / `gh auth login`, or use a device-flow token provider."
+            );
+    }
+
+    /// <summary>Attempts to resolve a token without throwing. Returns null when none is found.</summary>
+    public string? ResolveToken()
+    {
+        // 1. Environment variables.
+        foreach (var name in EnvVarNames)
+        {
+            var value = Environment.GetEnvironmentVariable(name);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value.Trim();
+            }
+        }
+
+        // 2. GitHub Copilot CLI config — holds the CLI's own (Copilot-entitled) GitHub token.
+        foreach (var path in CopilotCliConfigFiles())
+        {
+            var token = TryScanGitHubTokenFromJson(path);
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                return token;
+            }
+        }
+
+        // 3. GitHub Copilot editor credential files (apps.json / hosts.json).
+        foreach (var path in CopilotEditorCredentialFiles())
+        {
+            var token = TryReadOAuthTokenFromJson(path);
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                return token;
+            }
+        }
+
+        // 4. gh CLI hosts.yml (YAML).
+        foreach (var path in GhCliHostsYamlFiles())
+        {
+            var token = TryReadOAuthTokenFromYaml(path);
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                return token;
+            }
+        }
+
+        // 5. gh auth token (shell out, last resort).
+        return TryGetTokenFromGhCli();
+    }
+
+    private static IEnumerable<string> ConfigDirectories()
+    {
+        var xdg = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        if (!string.IsNullOrWhiteSpace(xdg))
+        {
+            yield return xdg!;
+        }
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(home))
+        {
+            yield return Path.Combine(home, ".config");
+        }
+
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (!string.IsNullOrWhiteSpace(localAppData))
+        {
+            yield return localAppData;
+        }
+
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        if (!string.IsNullOrWhiteSpace(appData))
+        {
+            yield return appData;
+        }
+    }
+
+    private static IEnumerable<string> CopilotCliConfigFiles()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(home))
+        {
+            yield return Path.Combine(home, ".copilot", "config.json");
+        }
+    }
+
+    private static IEnumerable<string> CopilotEditorCredentialFiles()
+    {
+        foreach (var dir in ConfigDirectories())
+        {
+            yield return Path.Combine(dir, "github-copilot", "apps.json");
+            yield return Path.Combine(dir, "github-copilot", "hosts.json");
+            yield return Path.Combine(dir, "gh", "hosts.json");
+        }
+    }
+
+    private static IEnumerable<string> GhCliHostsYamlFiles()
+    {
+        foreach (var dir in ConfigDirectories())
+        {
+            yield return Path.Combine(dir, "gh", "hosts.yml");
+            yield return Path.Combine(dir, "GitHub CLI", "hosts.yml");
+        }
+    }
+
+    /// <summary>
+    ///     Reads a GitHub OAuth token from a Copilot/gh JSON credential file. The files map a host
+    ///     key (e.g. <c>github.com</c> or <c>github.com:Iv1.xxxx</c>) to an object containing
+    ///     <c>oauth_token</c>.
+    /// </summary>
+    public static string? TryReadOAuthTokenFromJson(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+
+            using var doc = JsonDocument.Parse(File.ReadAllText(path), LenientJsonOptions);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            foreach (var entry in doc.RootElement.EnumerateObject())
+            {
+                if (!entry.Name.Contains("github.com", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (entry.Value.ValueKind == JsonValueKind.Object
+                    && entry.Value.TryGetProperty("oauth_token", out var tokenEl)
+                    && tokenEl.ValueKind == JsonValueKind.String)
+                {
+                    var token = tokenEl.GetString();
+                    if (!string.IsNullOrWhiteSpace(token))
+                    {
+                        return token!.Trim();
+                    }
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            // Ignore unreadable/malformed credential files and fall through to the next candidate.
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     Recursively scans a JSON file for the first string value that looks like a GitHub token
+    ///     (<c>gho_</c>/<c>ghu_</c>/<c>ghp_</c>/<c>ghs_</c>/<c>ghr_</c> prefix). Used for the Copilot
+    ///     CLI config, which embeds its token without a fixed, documented key path.
+    /// </summary>
+    public static string? TryScanGitHubTokenFromJson(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+
+            using var doc = JsonDocument.Parse(File.ReadAllText(path), LenientJsonOptions);
+            return FindGitHubToken(doc.RootElement);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? FindGitHubToken(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.String)
+        {
+            var value = element.GetString();
+            return value is not null && GitHubTokenRegex().IsMatch(value) ? value : null;
+        }
+
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                var found = FindGitHubToken(property.Value);
+                if (found is not null)
+                {
+                    return found;
+                }
+            }
+
+            return null;
+        }
+
+        if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in element.EnumerateArray())
+            {
+                var found = FindGitHubToken(item);
+                if (found is not null)
+                {
+                    return found;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     Reads the first <c>oauth_token:</c> value from a <c>gh</c> CLI <c>hosts.yml</c> file using a
+    ///     line-based parse (avoids taking a YAML dependency for one field).
+    /// </summary>
+    public static string? TryReadOAuthTokenFromYaml(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+
+            foreach (var line in File.ReadLines(path))
+            {
+                var trimmed = line.Trim();
+                if (trimmed.StartsWith("oauth_token:", StringComparison.OrdinalIgnoreCase))
+                {
+                    var value = trimmed["oauth_token:".Length..].Trim().Trim('"', '\'');
+                    if (!string.IsNullOrWhiteSpace(value))
+                    {
+                        return value;
+                    }
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Ignore unreadable files.
+        }
+
+        return null;
+    }
+
+    private static string? TryGetTokenFromGhCli()
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "gh",
+                    Arguments = "auth token",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                },
+            };
+
+            if (!process.Start())
+            {
+                return null;
+            }
+
+            var output = process.StandardOutput.ReadToEnd();
+            if (!process.WaitForExit(5000))
+            {
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch (InvalidOperationException)
+                {
+                    // Process already exited.
+                }
+
+                return null;
+            }
+
+            var token = output.Trim();
+            return process.ExitCode == 0 && !string.IsNullOrWhiteSpace(token) ? token : null;
+        }
+        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or InvalidOperationException or IOException)
+        {
+            // gh not installed / not on PATH.
+            return null;
+        }
+    }
+
+    [GeneratedRegex(@"^gh[oupsr]_[A-Za-z0-9]{20,}$", RegexOptions.CultureInvariant)]
+    private static partial Regex GitHubTokenRegex();
+}

--- a/src/LmCore/Auth/CompositeCopilotTokenProvider.cs
+++ b/src/LmCore/Auth/CompositeCopilotTokenProvider.cs
@@ -1,0 +1,83 @@
+namespace AchieveAi.LmDotnetTools.LmCore.Auth;
+
+/// <summary>
+///     Tries a sequence of <see cref="ICopilotTokenProvider"/>s in order and returns the first token
+///     that resolves, caching it in memory for the provider's lifetime. The default sequence reuses
+///     existing CLI credentials first, then falls back to the device flow.
+/// </summary>
+public sealed class CompositeCopilotTokenProvider : ICopilotTokenProvider
+{
+    private readonly IReadOnlyList<ICopilotTokenProvider> _providers;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private string? _cachedToken;
+
+    /// <summary>Creates a composite over the supplied providers (evaluated in order).</summary>
+    public CompositeCopilotTokenProvider(params ICopilotTokenProvider[] providers)
+    {
+        ArgumentNullException.ThrowIfNull(providers);
+        if (providers.Length == 0)
+        {
+            throw new ArgumentException("At least one token provider is required.", nameof(providers));
+        }
+
+        _providers = providers;
+    }
+
+    /// <summary>
+    ///     Builds the default chain: existing CLI/env credentials first, then GitHub device flow.
+    /// </summary>
+    public static CompositeCopilotTokenProvider CreateDefault(
+        DeviceFlowCopilotTokenProvider? deviceFlow = null
+    )
+    {
+        return new CompositeCopilotTokenProvider(
+            new CliCredentialCopilotTokenProvider(),
+            deviceFlow ?? new DeviceFlowCopilotTokenProvider()
+        );
+    }
+
+    /// <inheritdoc />
+    public async Task<string> GetTokenAsync(CancellationToken cancellationToken = default)
+    {
+        if (_cachedToken is not null)
+        {
+            return _cachedToken;
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_cachedToken is not null)
+            {
+                return _cachedToken;
+            }
+
+            Exception? last = null;
+            foreach (var provider in _providers)
+            {
+                try
+                {
+                    var token = await provider.GetTokenAsync(cancellationToken).ConfigureAwait(false);
+                    if (!string.IsNullOrWhiteSpace(token))
+                    {
+                        _cachedToken = token;
+                        return token;
+                    }
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    last = ex;
+                }
+            }
+
+            throw new InvalidOperationException(
+                "No GitHub Copilot token could be resolved from any configured provider.",
+                last
+            );
+        }
+        finally
+        {
+            _ = _gate.Release();
+        }
+    }
+}

--- a/src/LmCore/Auth/CompositeCopilotTokenProvider.cs
+++ b/src/LmCore/Auth/CompositeCopilotTokenProvider.cs
@@ -52,7 +52,7 @@ public sealed class CompositeCopilotTokenProvider : ICopilotTokenProvider
                 return _cachedToken;
             }
 
-            Exception? last = null;
+            var failures = new List<Exception>();
             foreach (var provider in _providers)
             {
                 try
@@ -66,13 +66,15 @@ public sealed class CompositeCopilotTokenProvider : ICopilotTokenProvider
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
-                    last = ex;
+                    // Preserve every failure — the first provider's error is often the most
+                    // informative, so don't let a later one overwrite it.
+                    failures.Add(ex);
                 }
             }
 
             throw new InvalidOperationException(
                 "No GitHub Copilot token could be resolved from any configured provider.",
-                last
+                failures.Count > 0 ? new AggregateException(failures) : null
             );
         }
         finally

--- a/src/LmCore/Auth/CopilotHttpClientFactory.cs
+++ b/src/LmCore/Auth/CopilotHttpClientFactory.cs
@@ -1,0 +1,41 @@
+using AchieveAi.LmDotnetTools.LmCore.Http;
+using AchieveAi.LmDotnetTools.LmCore.Utils;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Auth;
+
+/// <summary>
+///     Builds <see cref="HttpClient"/> instances that route through the GitHub Copilot API by
+///     wrapping a transport handler with <see cref="CopilotHeadersHandler"/> (auth + Copilot headers).
+/// </summary>
+public static class CopilotHttpClientFactory
+{
+    /// <summary>
+    ///     Creates an <see cref="HttpClient"/> whose every request is authenticated and decorated for
+    ///     the Copilot API.
+    /// </summary>
+    /// <param name="baseAddress">Base address for the client (e.g. the Copilot host root).</param>
+    /// <param name="tokenProvider">Bearer-token source.</param>
+    /// <param name="session">Shared client/machine tracking ids.</param>
+    /// <param name="options">Copilot header options (integration id, version, extra headers).</param>
+    /// <param name="timeout">Optional timeout (defaults to <see cref="HttpClientFactory.DefaultTimeout"/>).</param>
+    public static HttpClient Create(
+        string baseAddress,
+        ICopilotTokenProvider tokenProvider,
+        CopilotSessionContext session,
+        CopilotOptions? options = null,
+        TimeSpan? timeout = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(baseAddress);
+        ArgumentNullException.ThrowIfNull(tokenProvider);
+        ArgumentNullException.ThrowIfNull(session);
+
+        var handler = new CopilotHeadersHandler(tokenProvider, session, options, new HttpClientHandler());
+
+        return new HttpClient(handler)
+        {
+            BaseAddress = new Uri(baseAddress.TrimEnd('/')),
+            Timeout = timeout ?? HttpClientFactory.DefaultTimeout,
+        };
+    }
+}

--- a/src/LmCore/Auth/CopilotHttpClientFactory.cs
+++ b/src/LmCore/Auth/CopilotHttpClientFactory.cs
@@ -18,19 +18,24 @@ public static class CopilotHttpClientFactory
     /// <param name="session">Shared client/machine tracking ids.</param>
     /// <param name="options">Copilot header options (integration id, version, extra headers).</param>
     /// <param name="timeout">Optional timeout (defaults to <see cref="HttpClientFactory.DefaultTimeout"/>).</param>
+    /// <param name="innerHandler">
+    ///     Optional transport handler to wrap (for tests, Polly resilience, or IHttpClientFactory
+    ///     integration). Defaults to a new <see cref="HttpClientHandler"/>.
+    /// </param>
     public static HttpClient Create(
         string baseAddress,
         ICopilotTokenProvider tokenProvider,
         CopilotSessionContext session,
         CopilotOptions? options = null,
-        TimeSpan? timeout = null
+        TimeSpan? timeout = null,
+        HttpMessageHandler? innerHandler = null
     )
     {
         ArgumentNullException.ThrowIfNull(baseAddress);
         ArgumentNullException.ThrowIfNull(tokenProvider);
         ArgumentNullException.ThrowIfNull(session);
 
-        var handler = new CopilotHeadersHandler(tokenProvider, session, options, new HttpClientHandler());
+        var handler = new CopilotHeadersHandler(tokenProvider, session, options, innerHandler ?? new HttpClientHandler());
 
         return new HttpClient(handler)
         {

--- a/src/LmCore/Auth/CopilotOptions.cs
+++ b/src/LmCore/Auth/CopilotOptions.cs
@@ -1,0 +1,52 @@
+namespace AchieveAi.LmDotnetTools.LmCore.Auth;
+
+/// <summary>
+///     Configuration for routing provider requests through the GitHub Copilot API
+///     (<c>https://api.enterprise.githubcopilot.com</c>). Controls the host plus the static
+///     headers the Copilot backend expects on every model call.
+/// </summary>
+/// <remarks>
+///     Defaults mimic the GitHub Copilot CLI so the backend treats requests as coming from a
+///     known integration. Callers that have their own approved integration id should override
+///     <see cref="IntegrationId"/>, <see cref="EditorVersion"/>, and <see cref="UserAgent"/>.
+/// </remarks>
+public sealed record CopilotOptions
+{
+    /// <summary>Default GitHub Copilot enterprise host (no trailing path).</summary>
+    public const string DefaultBaseUrl = "https://api.enterprise.githubcopilot.com";
+
+    /// <summary>The Copilot API host root, e.g. <c>https://api.enterprise.githubcopilot.com</c>.</summary>
+    public string BaseUrl { get; init; } = DefaultBaseUrl;
+
+    /// <summary><c>copilot-integration-id</c> header value. Identifies the calling integration.</summary>
+    public string IntegrationId { get; init; } = "copilot-developer-cli";
+
+    /// <summary><c>editor-version</c> header value.</summary>
+    public string EditorVersion { get; init; } = "copilot/1.0.57-3";
+
+    /// <summary><c>user-agent</c> header value.</summary>
+    public string UserAgent { get; init; } = "copilot/1.0.57-3 (client/github/cli win32 v24.16.0) term/unknown";
+
+    /// <summary><c>x-github-api-version</c> header value.</summary>
+    public string GitHubApiVersion { get; init; } = "2026-06-01";
+
+    /// <summary>
+    ///     Default <c>x-initiator</c> value (<c>user</c> or <c>agent</c>). Marks whether the
+    ///     originating action was user- or agent-initiated.
+    /// </summary>
+    public string DefaultInitiator { get; init; } = "user";
+
+    /// <summary>
+    ///     Optional default <c>x-interaction-type</c> value
+    ///     (<c>conversation-user</c> / <c>conversation-agent</c> / <c>conversation-background</c>).
+    ///     Omitted when null.
+    /// </summary>
+    public string? DefaultInteractionType { get; init; }
+
+    /// <summary>
+    ///     Static per-client headers added to every request (after the standard Copilot headers).
+    ///     Used for protocol-specific headers such as <c>anthropic-version</c> (Messages API) or
+    ///     <c>openai-intent</c> (Responses API). Existing headers on a request are not overwritten.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? ExtraHeaders { get; init; }
+}

--- a/src/LmCore/Auth/CopilotRequestHeaders.cs
+++ b/src/LmCore/Auth/CopilotRequestHeaders.cs
@@ -31,7 +31,7 @@ public static class CopilotRequestHeaders
 
         if (!string.IsNullOrEmpty(options.DefaultInteractionType))
         {
-            yield return new KeyValuePair<string, string>("x-interaction-type", options.DefaultInteractionType!);
+            yield return new KeyValuePair<string, string>("x-interaction-type", options.DefaultInteractionType);
         }
 
         if (options.ExtraHeaders is not null)

--- a/src/LmCore/Auth/CopilotRequestHeaders.cs
+++ b/src/LmCore/Auth/CopilotRequestHeaders.cs
@@ -1,0 +1,45 @@
+namespace AchieveAi.LmDotnetTools.LmCore.Auth;
+
+/// <summary>
+///     Produces the standard set of GitHub Copilot request headers (excluding <c>Authorization</c>)
+///     shared by the HTTP <see cref="AchieveAi.LmDotnetTools.LmCore.Http.CopilotHeadersHandler"/> and
+///     the WebSocket transport, so both decorate requests identically.
+/// </summary>
+public static class CopilotRequestHeaders
+{
+    /// <summary>
+    ///     Enumerates the Copilot headers for a single request. <paramref name="interactionId"/> is
+    ///     the per-request <c>x-interaction-id</c> the caller generates.
+    /// </summary>
+    public static IEnumerable<KeyValuePair<string, string>> Build(
+        CopilotOptions options,
+        CopilotSessionContext session,
+        string interactionId
+    )
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(session);
+
+        yield return new KeyValuePair<string, string>("copilot-integration-id", options.IntegrationId);
+        yield return new KeyValuePair<string, string>("editor-version", options.EditorVersion);
+        yield return new KeyValuePair<string, string>("x-github-api-version", options.GitHubApiVersion);
+        yield return new KeyValuePair<string, string>("User-Agent", options.UserAgent);
+        yield return new KeyValuePair<string, string>("x-client-machine-id", session.MachineId);
+        yield return new KeyValuePair<string, string>("x-client-session-id", session.ClientSessionId);
+        yield return new KeyValuePair<string, string>("x-interaction-id", interactionId);
+        yield return new KeyValuePair<string, string>("x-initiator", options.DefaultInitiator);
+
+        if (!string.IsNullOrEmpty(options.DefaultInteractionType))
+        {
+            yield return new KeyValuePair<string, string>("x-interaction-type", options.DefaultInteractionType!);
+        }
+
+        if (options.ExtraHeaders is not null)
+        {
+            foreach (var header in options.ExtraHeaders)
+            {
+                yield return header;
+            }
+        }
+    }
+}

--- a/src/LmCore/Auth/CopilotSessionContext.cs
+++ b/src/LmCore/Auth/CopilotSessionContext.cs
@@ -1,0 +1,72 @@
+namespace AchieveAi.LmDotnetTools.LmCore.Auth;
+
+/// <summary>
+///     Holds the client-tracking identifiers the GitHub Copilot backend correlates requests by.
+/// </summary>
+/// <remarks>
+///     <para>
+///     <see cref="MachineId"/> (<c>x-client-machine-id</c>) is stable across runs and is persisted
+///     under the user's local application data so the same machine reports a consistent id.
+///     </para>
+///     <para>
+///     <see cref="ClientSessionId"/> (<c>x-client-session-id</c>) is stable for the lifetime of a
+///     single provider/agent instance — one id per process session, generated on construction.
+///     </para>
+///     <para>
+///     The per-request <c>x-interaction-id</c> is generated fresh on each request by
+///     <see cref="AchieveAi.LmDotnetTools.LmCore.Http.CopilotHeadersHandler"/> and is therefore not
+///     stored here.
+///     </para>
+/// </remarks>
+public sealed class CopilotSessionContext
+{
+    private const string MachineIdFileName = "copilot-machine-id";
+
+    /// <summary>
+    ///     Creates a session context. When ids are omitted, the machine id is loaded from (or written
+    ///     to) local application data and the client session id is generated fresh.
+    /// </summary>
+    public CopilotSessionContext(string? machineId = null, string? clientSessionId = null)
+    {
+        MachineId = !string.IsNullOrWhiteSpace(machineId) ? machineId! : LoadOrCreateMachineId();
+        ClientSessionId = !string.IsNullOrWhiteSpace(clientSessionId) ? clientSessionId! : Guid.NewGuid().ToString();
+    }
+
+    /// <summary>Stable, machine-scoped identifier (<c>x-client-machine-id</c>).</summary>
+    public string MachineId { get; }
+
+    /// <summary>Per-instance session identifier (<c>x-client-session-id</c>).</summary>
+    public string ClientSessionId { get; }
+
+    private static string LoadOrCreateMachineId()
+    {
+        try
+        {
+            var dir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "LmDotnetTools"
+            );
+            var path = Path.Combine(dir, MachineIdFileName);
+
+            if (File.Exists(path))
+            {
+                var existing = File.ReadAllText(path).Trim();
+                if (Guid.TryParse(existing, out _))
+                {
+                    return existing;
+                }
+            }
+
+            var generated = Guid.NewGuid().ToString();
+            _ = Directory.CreateDirectory(dir);
+            File.WriteAllText(path, generated);
+            return generated;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+        {
+            // If the machine id can't be persisted (read-only/sandboxed FS), fall back to an
+            // ephemeral id so requests still carry a well-formed header.
+            return Guid.NewGuid().ToString();
+        }
+    }
+}

--- a/src/LmCore/Auth/CopilotSessionContext.cs
+++ b/src/LmCore/Auth/CopilotSessionContext.cs
@@ -28,8 +28,8 @@ public sealed class CopilotSessionContext
     /// </summary>
     public CopilotSessionContext(string? machineId = null, string? clientSessionId = null)
     {
-        MachineId = !string.IsNullOrWhiteSpace(machineId) ? machineId! : LoadOrCreateMachineId();
-        ClientSessionId = !string.IsNullOrWhiteSpace(clientSessionId) ? clientSessionId! : Guid.NewGuid().ToString();
+        MachineId = !string.IsNullOrWhiteSpace(machineId) ? machineId : LoadOrCreateMachineId();
+        ClientSessionId = !string.IsNullOrWhiteSpace(clientSessionId) ? clientSessionId : Guid.NewGuid().ToString();
     }
 
     /// <summary>Stable, machine-scoped identifier (<c>x-client-machine-id</c>).</summary>

--- a/src/LmCore/Auth/DeviceFlowCopilotTokenProvider.cs
+++ b/src/LmCore/Auth/DeviceFlowCopilotTokenProvider.cs
@@ -53,8 +53,8 @@ public sealed class DeviceFlowCopilotTokenProvider : ICopilotTokenProvider
     )
     {
         _http = httpClient ?? new HttpClient();
-        _clientId = string.IsNullOrWhiteSpace(clientId) ? DefaultClientId : clientId!;
-        _scope = string.IsNullOrWhiteSpace(scope) ? "read:user" : scope!;
+        _clientId = string.IsNullOrWhiteSpace(clientId) ? DefaultClientId : clientId;
+        _scope = string.IsNullOrWhiteSpace(scope) ? "read:user" : scope;
         _present = present ?? DefaultPresent;
         _logger = logger ?? NullLogger.Instance;
         _cacheFilePath = cacheToDisk ? ResolveCacheFilePath() : null;
@@ -80,7 +80,7 @@ public sealed class DeviceFlowCopilotTokenProvider : ICopilotTokenProvider
             if (!string.IsNullOrWhiteSpace(fromDisk))
             {
                 _cachedToken = fromDisk;
-                return fromDisk!;
+                return fromDisk;
             }
 
             var token = await RunDeviceFlowAsync(cancellationToken).ConfigureAwait(false);
@@ -110,7 +110,7 @@ public sealed class DeviceFlowCopilotTokenProvider : ICopilotTokenProvider
             var poll = await PollAccessTokenAsync(device.DeviceCode, cancellationToken).ConfigureAwait(false);
             if (!string.IsNullOrWhiteSpace(poll.AccessToken))
             {
-                return poll.AccessToken!;
+                return poll.AccessToken;
             }
 
             switch (poll.Error)

--- a/src/LmCore/Auth/DeviceFlowCopilotTokenProvider.cs
+++ b/src/LmCore/Auth/DeviceFlowCopilotTokenProvider.cs
@@ -1,0 +1,268 @@
+using System.Diagnostics;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Auth;
+
+/// <summary>
+///     Acquires a GitHub OAuth token via the GitHub OAuth <em>device flow</em> and caches it on disk
+///     for reuse on subsequent runs. Used as a fallback when no existing CLI credential is found.
+/// </summary>
+/// <remarks>
+///     The flow: request a device/user code, present the verification URL + code to the user, then
+///     poll the access-token endpoint until the user authorizes. The resulting token (<c>gho_…</c>)
+///     is sent directly to the Copilot API — no short-lived exchange is performed.
+/// </remarks>
+public sealed class DeviceFlowCopilotTokenProvider : ICopilotTokenProvider
+{
+    // Well-known GitHub Copilot OAuth client id (same one the editor plugins use).
+    private const string DefaultClientId = "Iv1.b507a08c87ecfe98";
+    private const string DeviceCodeUrl = "https://github.com/login/device/code";
+    private const string AccessTokenUrl = "https://github.com/login/oauth/access_token";
+    private const string TokenCacheFileName = "copilot-oauth-token";
+
+    private readonly HttpClient _http;
+    private readonly string _clientId;
+    private readonly string _scope;
+    private readonly Action<DeviceCodeInfo> _present;
+    private readonly ILogger _logger;
+    private readonly string? _cacheFilePath;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private string? _cachedToken;
+
+    /// <summary>
+    ///     Creates a device-flow token provider.
+    /// </summary>
+    /// <param name="httpClient">HTTP client used for the GitHub OAuth endpoints (injectable for tests).</param>
+    /// <param name="clientId">OAuth client id. Defaults to the well-known Copilot client id.</param>
+    /// <param name="scope">OAuth scope. Defaults to <c>read:user</c>.</param>
+    /// <param name="present">
+    ///     Callback that shows the verification URL + user code to the user. Defaults to writing to the console.
+    /// </param>
+    /// <param name="cacheToDisk">When true (default) the acquired token is cached under local app data.</param>
+    /// <param name="logger">Optional logger.</param>
+    public DeviceFlowCopilotTokenProvider(
+        HttpClient? httpClient = null,
+        string? clientId = null,
+        string? scope = null,
+        Action<DeviceCodeInfo>? present = null,
+        bool cacheToDisk = true,
+        ILogger? logger = null
+    )
+    {
+        _http = httpClient ?? new HttpClient();
+        _clientId = string.IsNullOrWhiteSpace(clientId) ? DefaultClientId : clientId!;
+        _scope = string.IsNullOrWhiteSpace(scope) ? "read:user" : scope!;
+        _present = present ?? DefaultPresent;
+        _logger = logger ?? NullLogger.Instance;
+        _cacheFilePath = cacheToDisk ? ResolveCacheFilePath() : null;
+    }
+
+    /// <inheritdoc />
+    public async Task<string> GetTokenAsync(CancellationToken cancellationToken = default)
+    {
+        if (_cachedToken is not null)
+        {
+            return _cachedToken;
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_cachedToken is not null)
+            {
+                return _cachedToken;
+            }
+
+            var fromDisk = ReadCachedToken();
+            if (!string.IsNullOrWhiteSpace(fromDisk))
+            {
+                _cachedToken = fromDisk;
+                return fromDisk!;
+            }
+
+            var token = await RunDeviceFlowAsync(cancellationToken).ConfigureAwait(false);
+            _cachedToken = token;
+            WriteCachedToken(token);
+            return token;
+        }
+        finally
+        {
+            _ = _gate.Release();
+        }
+    }
+
+    private async Task<string> RunDeviceFlowAsync(CancellationToken cancellationToken)
+    {
+        var device = await RequestDeviceCodeAsync(cancellationToken).ConfigureAwait(false);
+        _present(new DeviceCodeInfo(device.UserCode, device.VerificationUri, device.ExpiresIn));
+
+        var interval = TimeSpan.FromSeconds(Math.Max(1, device.Interval));
+        var deadline = Stopwatch.StartNew();
+        var expiry = TimeSpan.FromSeconds(device.ExpiresIn <= 0 ? 900 : device.ExpiresIn);
+
+        while (deadline.Elapsed < expiry)
+        {
+            await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+
+            var poll = await PollAccessTokenAsync(device.DeviceCode, cancellationToken).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(poll.AccessToken))
+            {
+                return poll.AccessToken!;
+            }
+
+            switch (poll.Error)
+            {
+                case "authorization_pending":
+                    break;
+                case "slow_down":
+                    interval += TimeSpan.FromSeconds(5);
+                    break;
+                case "expired_token":
+                case "access_denied":
+                    throw new InvalidOperationException(
+                        $"GitHub device-flow authorization failed: {poll.Error}."
+                    );
+                default:
+                    if (!string.IsNullOrEmpty(poll.Error))
+                    {
+                        throw new InvalidOperationException(
+                            $"GitHub device-flow authorization failed: {poll.Error}."
+                        );
+                    }
+
+                    break;
+            }
+        }
+
+        throw new InvalidOperationException("GitHub device-flow authorization timed out before the user approved it.");
+    }
+
+    private async Task<DeviceCodeResponse> RequestDeviceCodeAsync(CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, DeviceCodeUrl)
+        {
+            Content = new FormUrlEncodedContent(
+                new Dictionary<string, string> { ["client_id"] = _clientId, ["scope"] = _scope }
+            ),
+        };
+        request.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
+
+        using var response = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        _ = response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadFromJsonAsync<DeviceCodeResponse>(cancellationToken).ConfigureAwait(false);
+        return body
+            ?? throw new InvalidOperationException("GitHub device-code endpoint returned an empty response.");
+    }
+
+    private async Task<AccessTokenResponse> PollAccessTokenAsync(string deviceCode, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, AccessTokenUrl)
+        {
+            Content = new FormUrlEncodedContent(
+                new Dictionary<string, string>
+                {
+                    ["client_id"] = _clientId,
+                    ["device_code"] = deviceCode,
+                    ["grant_type"] = "urn:ietf:params:oauth:grant-type:device_code",
+                }
+            ),
+        };
+        request.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
+
+        using var response = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        var body = await response.Content.ReadFromJsonAsync<AccessTokenResponse>(cancellationToken).ConfigureAwait(false);
+        return body ?? new AccessTokenResponse();
+    }
+
+    private static void DefaultPresent(DeviceCodeInfo info)
+    {
+        Console.WriteLine();
+        Console.WriteLine($"To authorize GitHub Copilot access, open {info.VerificationUri} and enter code: {info.UserCode}");
+        Console.WriteLine();
+    }
+
+    private static string? ResolveCacheFilePath()
+    {
+        try
+        {
+            var dir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "LmDotnetTools"
+            );
+            return Path.Combine(dir, TokenCacheFileName);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+        {
+            return null;
+        }
+    }
+
+    private string? ReadCachedToken()
+    {
+        try
+        {
+            if (_cacheFilePath is not null && File.Exists(_cacheFilePath))
+            {
+                var token = File.ReadAllText(_cacheFilePath).Trim();
+                return string.IsNullOrWhiteSpace(token) ? null : token;
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogDebug(ex, "Could not read cached Copilot token");
+        }
+
+        return null;
+    }
+
+    private void WriteCachedToken(string token)
+    {
+        try
+        {
+            if (_cacheFilePath is null)
+            {
+                return;
+            }
+
+            _ = Directory.CreateDirectory(Path.GetDirectoryName(_cacheFilePath)!);
+            File.WriteAllText(_cacheFilePath, token);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogDebug(ex, "Could not persist Copilot token cache");
+        }
+    }
+
+    /// <summary>Details presented to the user to complete device-flow authorization.</summary>
+    public sealed record DeviceCodeInfo(string UserCode, string VerificationUri, int ExpiresIn);
+
+    private sealed record DeviceCodeResponse
+    {
+        [JsonPropertyName("device_code")]
+        public string DeviceCode { get; init; } = string.Empty;
+
+        [JsonPropertyName("user_code")]
+        public string UserCode { get; init; } = string.Empty;
+
+        [JsonPropertyName("verification_uri")]
+        public string VerificationUri { get; init; } = string.Empty;
+
+        [JsonPropertyName("expires_in")]
+        public int ExpiresIn { get; init; }
+
+        [JsonPropertyName("interval")]
+        public int Interval { get; init; }
+    }
+
+    private sealed record AccessTokenResponse
+    {
+        [JsonPropertyName("access_token")]
+        public string? AccessToken { get; init; }
+
+        [JsonPropertyName("error")]
+        public string? Error { get; init; }
+    }
+}

--- a/src/LmCore/Auth/ICopilotTokenProvider.cs
+++ b/src/LmCore/Auth/ICopilotTokenProvider.cs
@@ -1,0 +1,20 @@
+namespace AchieveAi.LmDotnetTools.LmCore.Auth;
+
+/// <summary>
+///     Supplies the GitHub OAuth bearer token used to authenticate against the GitHub Copilot API.
+/// </summary>
+/// <remarks>
+///     The captured Copilot CLI traffic shows the raw GitHub OAuth token (<c>gho_…</c>) sent
+///     directly as <c>Authorization: Bearer &lt;token&gt;</c> against the enterprise host — no
+///     short-lived token exchange is required. Implementations may read an existing CLI credential,
+///     run a device-flow login, or return a token supplied out-of-band.
+/// </remarks>
+public interface ICopilotTokenProvider
+{
+    /// <summary>
+    ///     Returns a GitHub OAuth bearer token (without the <c>Bearer </c> prefix).
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">No token could be resolved.</exception>
+    Task<string> GetTokenAsync(CancellationToken cancellationToken = default);
+}

--- a/src/LmCore/Http/CopilotHeadersHandler.cs
+++ b/src/LmCore/Http/CopilotHeadersHandler.cs
@@ -1,0 +1,68 @@
+using System.Net.Http.Headers;
+using AchieveAi.LmDotnetTools.LmCore.Auth;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Http;
+
+/// <summary>
+///     <see cref="DelegatingHandler"/> that authenticates and decorates outgoing requests for the
+///     GitHub Copilot API. On every request it resolves a bearer token from an
+///     <see cref="ICopilotTokenProvider"/>, sets <c>Authorization</c>, and adds the Copilot
+///     integration/tracking headers the backend expects.
+/// </summary>
+/// <remarks>
+///     Headers already present on a request are never overwritten, so a provider client that sets
+///     its own protocol header (for example the Anthropic client's <c>anthropic-version</c>) keeps
+///     control. A fresh <c>x-interaction-id</c> is generated per request; the machine and session
+///     ids come from the shared <see cref="CopilotSessionContext"/> and stay stable.
+/// </remarks>
+public sealed class CopilotHeadersHandler : DelegatingHandler
+{
+    private readonly ICopilotTokenProvider _tokenProvider;
+    private readonly CopilotSessionContext _session;
+    private readonly CopilotOptions _options;
+
+    /// <summary>
+    ///     Creates the handler. When <paramref name="innerHandler"/> is null a default
+    ///     <see cref="HttpClientHandler"/> is used, so the handler can drive an
+    ///     <see cref="HttpClient"/> on its own.
+    /// </summary>
+    public CopilotHeadersHandler(
+        ICopilotTokenProvider tokenProvider,
+        CopilotSessionContext session,
+        CopilotOptions? options = null,
+        HttpMessageHandler? innerHandler = null
+    )
+        : base(innerHandler ?? new HttpClientHandler())
+    {
+        _tokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+        _options = options ?? new CopilotOptions();
+    }
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken
+    )
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var token = await _tokenProvider.GetTokenAsync(cancellationToken).ConfigureAwait(false);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        foreach (var header in CopilotRequestHeaders.Build(_options, _session, Guid.NewGuid().ToString()))
+        {
+            AddIfMissing(request, header.Key, header.Value);
+        }
+
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void AddIfMissing(HttpRequestMessage request, string name, string value)
+    {
+        if (!request.Headers.Contains(name))
+        {
+            _ = request.Headers.TryAddWithoutValidation(name, value);
+        }
+    }
+}

--- a/src/OpenAiResponsesProvider/Agents/CopilotResponsesAgentFactory.cs
+++ b/src/OpenAiResponsesProvider/Agents/CopilotResponsesAgentFactory.cs
@@ -1,0 +1,114 @@
+using AchieveAi.LmDotnetTools.LmCore.Auth;
+using Microsoft.Extensions.Logging;
+
+namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
+
+/// <summary>Transport choice for the GitHub Copilot Responses API.</summary>
+public enum CopilotResponsesTransport
+{
+    /// <summary>HTTP <c>POST /responses</c> with Server-Sent Events streaming.</summary>
+    Sse,
+
+    /// <summary>Persistent <c>GET /responses</c> WebSocket (the Copilot CLI's main conversation transport).</summary>
+    WebSocket,
+}
+
+/// <summary>
+///     Builds an <see cref="OpenAiResponsesAgent"/> that talks the OpenAI Responses API through the
+///     GitHub Copilot backend (<c>{host}/responses</c>) over either SSE or WebSocket. The agent and
+///     event→message mapping are reused unchanged; only the transport client differs.
+/// </summary>
+public static class CopilotResponsesAgentFactory
+{
+    private const string ResponsesPath = "/responses";
+
+    /// <summary>Creates an <see cref="OpenAiResponsesAgent"/> routed through GitHub Copilot.</summary>
+    /// <param name="name">Agent name.</param>
+    /// <param name="tokenProvider">Source of the GitHub OAuth bearer token.</param>
+    /// <param name="transport">SSE or WebSocket. Defaults to WebSocket (the CLI's primary transport).</param>
+    /// <param name="session">Optional shared tracking ids; a new context is created when omitted.</param>
+    /// <param name="options">Optional Copilot header options.</param>
+    /// <param name="logger">Optional logger.</param>
+    public static OpenAiResponsesAgent Create(
+        string name,
+        ICopilotTokenProvider tokenProvider,
+        CopilotResponsesTransport transport = CopilotResponsesTransport.WebSocket,
+        CopilotSessionContext? session = null,
+        CopilotOptions? options = null,
+        ILogger<OpenAiResponsesAgent>? logger = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(tokenProvider);
+
+        var baseOptions = options ?? new CopilotOptions();
+        var copilotOptions = baseOptions with
+        {
+            DefaultInteractionType = baseOptions.DefaultInteractionType ?? "conversation-user",
+            ExtraHeaders = WithOpenAiIntent(baseOptions.ExtraHeaders),
+        };
+
+        var context = session ?? new CopilotSessionContext();
+        var host = copilotOptions.BaseUrl.TrimEnd('/');
+
+        var client = transport == CopilotResponsesTransport.Sse
+            ? CreateSseClient(host, tokenProvider, context, copilotOptions)
+            : CreateWebSocketClient(host, tokenProvider, context, copilotOptions, logger);
+
+        return new OpenAiResponsesAgent(name, client, logger);
+    }
+
+    private static IOpenAiResponsesClient CreateSseClient(
+        string host,
+        ICopilotTokenProvider tokenProvider,
+        CopilotSessionContext context,
+        CopilotOptions options
+    )
+    {
+        var httpClient = CopilotHttpClientFactory.Create(host, tokenProvider, context, options);
+        return new OpenAiResponsesClient(httpClient, disposeClient: true, logger: null, responsesPath: ResponsesPath);
+    }
+
+    private static IOpenAiResponsesClient CreateWebSocketClient(
+        string host,
+        ICopilotTokenProvider tokenProvider,
+        CopilotSessionContext context,
+        CopilotOptions options,
+        ILogger? logger
+    )
+    {
+        var wsEndpoint = new Uri($"{ToWebSocketScheme(host)}{ResponsesPath}");
+        return new CopilotResponsesWebSocketClient(wsEndpoint, tokenProvider, context, options, logger);
+    }
+
+    private static string ToWebSocketScheme(string host)
+    {
+        if (host.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Concat("wss://", host.AsSpan("https://".Length));
+        }
+
+        if (host.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Concat("ws://", host.AsSpan("http://".Length));
+        }
+
+        return host;
+    }
+
+    private static IReadOnlyDictionary<string, string> WithOpenAiIntent(
+        IReadOnlyDictionary<string, string>? existing
+    )
+    {
+        var merged = existing is null
+            ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string>(existing, StringComparer.OrdinalIgnoreCase);
+
+        if (!merged.ContainsKey("openai-intent"))
+        {
+            merged["openai-intent"] = "conversation-agent";
+        }
+
+        return merged;
+    }
+}

--- a/src/OpenAiResponsesProvider/Agents/CopilotResponsesWebSocketClient.cs
+++ b/src/OpenAiResponsesProvider/Agents/CopilotResponsesWebSocketClient.cs
@@ -22,7 +22,7 @@ namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
 ///     <see cref="ResponseEventParser"/>, so the same <see cref="OpenAiResponsesAgent"/> mapping is
 ///     reused as for the SSE transport.
 /// </remarks>
-public sealed class CopilotResponsesWebSocketClient : IOpenAiResponsesClient
+public sealed class CopilotResponsesWebSocketClient : IOpenAiResponsesClient, IAsyncDisposable
 {
     private static readonly JsonSerializerOptions s_serializerOptions = new(JsonSerializerDefaults.Web)
     {
@@ -176,6 +176,28 @@ public sealed class CopilotResponsesWebSocketClient : IOpenAiResponsesClient
         return null;
     }
 
+    /// <summary>Asynchronously closes the socket and releases the turn gate. Preferred over <see cref="Dispose"/>.</summary>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        try
+        {
+            if (_socket is not null)
+            {
+                await _socket.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _turnGate.Dispose();
+        }
+    }
+
     /// <inheritdoc />
     public void Dispose()
     {
@@ -185,8 +207,20 @@ public sealed class CopilotResponsesWebSocketClient : IOpenAiResponsesClient
         }
 
         _disposed = true;
-        _socket?.DisposeAsync().AsTask().GetAwaiter().GetResult();
-        _turnGate.Dispose();
+        try
+        {
+            // Bounded best-effort close — never block the disposing thread indefinitely on the
+            // socket's network round-trip. The turn gate is always released in the finally.
+            _ = _socket?.DisposeAsync().AsTask().Wait(TimeSpan.FromSeconds(2));
+        }
+        catch (Exception ex) when (ex is AggregateException or WebSocketException or OperationCanceledException)
+        {
+            // Best-effort: the close raced, timed out, or the socket was already faulted.
+        }
+        finally
+        {
+            _turnGate.Dispose();
+        }
     }
 }
 

--- a/src/OpenAiResponsesProvider/Agents/CopilotResponsesWebSocketClient.cs
+++ b/src/OpenAiResponsesProvider/Agents/CopilotResponsesWebSocketClient.cs
@@ -1,0 +1,303 @@
+using System.Net.WebSockets;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Auth;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
+
+/// <summary>
+///     <see cref="IOpenAiResponsesClient"/> implementation that drives the GitHub Copilot Responses
+///     API over a persistent WebSocket (<c>GET /responses</c>, HTTP 101). Each
+///     <see cref="StreamResponseAsync"/> call sends one <c>response.create</c> text frame and yields
+///     the server's event frames until the turn's terminal lifecycle event.
+/// </summary>
+/// <remarks>
+///     Multi-turn chaining is automatic: the <c>response.completed.response.id</c> of one turn is
+///     fed as <c>previous_response_id</c> on the next, matching the Copilot CLI's behaviour. The
+///     socket stays open across turns. Server event frames are parsed with the shared
+///     <see cref="ResponseEventParser"/>, so the same <see cref="OpenAiResponsesAgent"/> mapping is
+///     reused as for the SSE transport.
+/// </remarks>
+public sealed class CopilotResponsesWebSocketClient : IOpenAiResponsesClient
+{
+    private static readonly JsonSerializerOptions s_serializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly Uri _endpoint;
+    private readonly ICopilotTokenProvider _tokenProvider;
+    private readonly CopilotSessionContext _session;
+    private readonly CopilotOptions _options;
+    private readonly Func<ICopilotResponsesSocket> _socketFactory;
+    private readonly ILogger _logger;
+    private readonly SemaphoreSlim _turnGate = new(1, 1);
+
+    private ICopilotResponsesSocket? _socket;
+    private string? _previousResponseId;
+    private bool _disposed;
+
+    /// <summary>Creates a WebSocket Responses client.</summary>
+    /// <param name="endpoint">
+    ///     WebSocket endpoint (e.g. <c>wss://api.enterprise.githubcopilot.com/responses</c>).
+    /// </param>
+    /// <param name="tokenProvider">Bearer-token source for the upgrade request.</param>
+    /// <param name="session">Shared client/machine tracking ids.</param>
+    /// <param name="options">Copilot header options.</param>
+    /// <param name="logger">Optional logger.</param>
+    /// <param name="socketFactory">
+    ///     Optional socket factory (override in tests). Defaults to a real <see cref="ClientWebSocket"/>.
+    /// </param>
+    public CopilotResponsesWebSocketClient(
+        Uri endpoint,
+        ICopilotTokenProvider tokenProvider,
+        CopilotSessionContext session,
+        CopilotOptions? options = null,
+        ILogger? logger = null,
+        Func<ICopilotResponsesSocket>? socketFactory = null
+    )
+    {
+        _endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
+        _tokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+        _options = options ?? new CopilotOptions();
+        _logger = logger ?? NullLogger.Instance;
+        _socketFactory = socketFactory ?? (() => new ClientWebSocketResponsesSocket());
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<ResponseEvent> StreamResponseAsync(
+        ResponseCreateRequest request,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        await _turnGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var socket = await EnsureConnectedAsync(cancellationToken).ConfigureAwait(false);
+
+            var frame = request with
+            {
+                Type = ResponseEventTypes.ClientResponseCreate,
+                Stream = null, // WebSocket frames are inherently streamed; omit the HTTP-only flag.
+                Initiator = request.Initiator ?? _options.DefaultInitiator,
+                Store = request.Store ?? false,
+                PreviousResponseId = request.PreviousResponseId ?? _previousResponseId,
+            };
+
+            var json = JsonSerializer.Serialize(frame, s_serializerOptions);
+            _logger.LogDebug(
+                "WS response.create model={Model} inputItems={Count} previousResponseId={Prev}",
+                frame.Model,
+                frame.Input.Count,
+                frame.PreviousResponseId is null ? "(none)" : "(set)"
+            );
+
+            await socket.SendTextAsync(json, cancellationToken).ConfigureAwait(false);
+
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var text = await socket.ReceiveTextAsync(cancellationToken).ConfigureAwait(false);
+                if (text is null)
+                {
+                    // Socket closed mid-turn.
+                    yield break;
+                }
+
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    continue;
+                }
+
+                var ev = ResponseEventParser.Parse(text);
+
+                if (ev is ResponseLifecycleEvent lifecycle
+                    && string.Equals(lifecycle.Type, ResponseEventTypes.ResponseCompleted, StringComparison.Ordinal))
+                {
+                    _previousResponseId = TryGetResponseId(lifecycle.Response) ?? _previousResponseId;
+                }
+
+                yield return ev;
+
+                if (ev.Type is ResponseEventTypes.ResponseCompleted or ResponseEventTypes.ResponseFailed)
+                {
+                    yield break;
+                }
+            }
+        }
+        finally
+        {
+            _ = _turnGate.Release();
+        }
+    }
+
+    private async Task<ICopilotResponsesSocket> EnsureConnectedAsync(CancellationToken cancellationToken)
+    {
+        if (_socket is { IsConnected: true })
+        {
+            return _socket;
+        }
+
+        var token = await _tokenProvider.GetTokenAsync(cancellationToken).ConfigureAwait(false);
+
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Authorization"] = $"Bearer {token}",
+        };
+        foreach (var header in CopilotRequestHeaders.Build(_options, _session, Guid.NewGuid().ToString()))
+        {
+            headers[header.Key] = header.Value;
+        }
+
+        var socket = _socketFactory();
+        await socket.ConnectAsync(_endpoint, headers, cancellationToken).ConfigureAwait(false);
+        _socket = socket;
+        return socket;
+    }
+
+    private static string? TryGetResponseId(JsonElement response)
+    {
+        if (response.ValueKind == JsonValueKind.Object
+            && response.TryGetProperty("id", out var idEl)
+            && idEl.ValueKind == JsonValueKind.String)
+        {
+            return idEl.GetString();
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _socket?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _turnGate.Dispose();
+    }
+}
+
+/// <summary>
+///     Minimal text-framed WebSocket abstraction used by <see cref="CopilotResponsesWebSocketClient"/>,
+///     allowing an in-memory fake to be substituted in tests.
+/// </summary>
+public interface ICopilotResponsesSocket : IAsyncDisposable
+{
+    /// <summary>True once the socket is open.</summary>
+    bool IsConnected { get; }
+
+    /// <summary>Opens the connection, applying <paramref name="headers"/> to the upgrade request.</summary>
+    Task ConnectAsync(Uri endpoint, IReadOnlyDictionary<string, string> headers, CancellationToken cancellationToken);
+
+    /// <summary>Sends a single UTF-8 text frame.</summary>
+    Task SendTextAsync(string text, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Receives the next complete text message (reassembling fragments). Returns null when the
+    ///     peer closes the connection.
+    /// </summary>
+    Task<string?> ReceiveTextAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+///     Default <see cref="ICopilotResponsesSocket"/> backed by a real <see cref="ClientWebSocket"/>.
+/// </summary>
+public sealed class ClientWebSocketResponsesSocket : ICopilotResponsesSocket
+{
+    private readonly ClientWebSocket _socket = new();
+
+    /// <inheritdoc />
+    public bool IsConnected => _socket.State == WebSocketState.Open;
+
+    /// <inheritdoc />
+    public async Task ConnectAsync(
+        Uri endpoint,
+        IReadOnlyDictionary<string, string> headers,
+        CancellationToken cancellationToken
+    )
+    {
+        ArgumentNullException.ThrowIfNull(headers);
+        foreach (var header in headers)
+        {
+            _socket.Options.SetRequestHeader(header.Key, header.Value);
+        }
+
+        await _socket.ConnectAsync(endpoint, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task SendTextAsync(string text, CancellationToken cancellationToken)
+    {
+        var bytes = Encoding.UTF8.GetBytes(text);
+        return _socket.SendAsync(bytes, WebSocketMessageType.Text, endOfMessage: true, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> ReceiveTextAsync(CancellationToken cancellationToken)
+    {
+        var buffer = new byte[16 * 1024];
+        using var message = new MemoryStream();
+
+        while (true)
+        {
+            WebSocketReceiveResult result;
+            try
+            {
+                result = await _socket.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
+            }
+            catch (WebSocketException)
+            {
+                return null;
+            }
+
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                return null;
+            }
+
+            message.Write(buffer, 0, result.Count);
+
+            if (result.EndOfMessage)
+            {
+                break;
+            }
+        }
+
+        return Encoding.UTF8.GetString(message.ToArray());
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (_socket.State == WebSocketState.Open)
+            {
+                await _socket
+                    .CloseAsync(WebSocketCloseStatus.NormalClosure, statusDescription: null, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+        }
+        catch (WebSocketException)
+        {
+            // Best-effort close.
+        }
+        finally
+        {
+            _socket.Dispose();
+        }
+    }
+}

--- a/src/OpenAiResponsesProvider/Agents/MessageMapper.cs
+++ b/src/OpenAiResponsesProvider/Agents/MessageMapper.cs
@@ -3,6 +3,8 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Models;
+using AchieveAi.LmDotnetTools.LmCore.Utils;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
 
 namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
@@ -24,72 +26,7 @@ internal static class MessageMapper
 
         foreach (var message in messages)
         {
-            switch (message)
-            {
-                case TextMessage text when text.Role == Role.System:
-                    if (instructionsBuilder.Length > 0)
-                    {
-                        _ = instructionsBuilder.Append('\n');
-                    }
-
-                    _ = instructionsBuilder.Append(text.Text);
-                    break;
-
-                case TextMessage text:
-                    inputItems.Add(
-                        new ResponseInputItem
-                        {
-                            Type = "message",
-                            Role = MapRole(text.Role),
-                            Content =
-                            [
-                                new ResponseInputContent
-                                {
-                                    Type = text.Role == Role.Assistant ? "output_text" : "input_text",
-                                    Text = text.Text,
-                                },
-                            ],
-                        }
-                    );
-                    break;
-
-                case ToolsCallMessage toolsCall:
-                    foreach (var call in toolsCall.ToolCalls)
-                    {
-                        inputItems.Add(
-                            new ResponseInputItem
-                            {
-                                Type = "function_call",
-                                CallId = call.ToolCallId,
-                                Content = null,
-                            }
-                        );
-                    }
-
-                    break;
-
-                case ToolsCallResultMessage results:
-                    foreach (var result in results.ToolCallResults)
-                    {
-                        inputItems.Add(
-                            new ResponseInputItem
-                            {
-                                Type = "function_call_output",
-                                CallId = result.ToolCallId,
-                                Output = result.Result,
-                            }
-                        );
-                    }
-
-                    break;
-
-                default:
-                    // Unsupported message types (e.g. UsageMessage on the input side, or
-                    // forwarded provider-specific frames) are dropped from the request — the
-                    // Responses API has no input-side analog and including them would cause a
-                    // 400.
-                    break;
-            }
+            MapMessage(message, instructionsBuilder, inputItems);
         }
 
         IReadOnlyList<ResponseToolSpec>? tools = null;
@@ -102,9 +39,7 @@ internal static class MessageMapper
                     Type = "function",
                     Name = fc.Name,
                     Description = fc.Description,
-                    Parameters = fc.Parameters is null
-                        ? null
-                        : JsonNode.Parse(JsonSerializer.Serialize(fc.Parameters)),
+                    Parameters = BuildParametersSchema(fc),
                 }),
             ];
         }
@@ -121,6 +56,172 @@ internal static class MessageMapper
             Tools = tools,
             ToolChoice = options?.ToolChoice is null ? null : JsonValue.Create(options.ToolChoice),
         };
+    }
+
+    // Options that know how to serialize JsonSchemaObject (notably its Union-typed "type" field).
+    private static readonly JsonSerializerOptions s_schemaSerializerOptions = JsonSerializerOptionsFactory.CreateBase(false);
+
+    /// <summary>
+    ///     Builds the JSON Schema object the Responses API expects for a function tool's
+    ///     <c>parameters</c> field: <c>{ "type": "object", "properties": { … }, "required": [ … ] }</c>.
+    ///     The contract's parameter <em>list</em> must not be serialized directly — that yields a JSON
+    ///     array, which the API rejects with "expected an object, but got an array".
+    /// </summary>
+    private static JsonNode? BuildParametersSchema(FunctionContract contract)
+    {
+        var properties = new Dictionary<string, JsonSchemaObject>(StringComparer.Ordinal);
+        var required = new List<string>();
+
+        if (contract.Parameters is not null)
+        {
+            foreach (var parameter in contract.Parameters)
+            {
+                if (string.IsNullOrEmpty(parameter.Name) || parameter.ParameterType is null)
+                {
+                    continue;
+                }
+
+                // Carry the parameter description onto the property schema when it has none of its own.
+                var propertySchema = parameter.ParameterType.Description is null && parameter.Description is not null
+                    ? parameter.ParameterType with { Description = parameter.Description }
+                    : parameter.ParameterType;
+
+                properties[parameter.Name] = propertySchema;
+                if (parameter.IsRequired)
+                {
+                    required.Add(parameter.Name);
+                }
+            }
+        }
+
+        var schema = new JsonSchemaObject
+        {
+            Type = JsonSchemaTypeHelper.ToType("object"),
+            Properties = properties,
+            Required = required.Count > 0 ? required : null,
+            AdditionalProperties = false,
+        };
+
+        return JsonSerializer.SerializeToNode(schema, s_schemaSerializerOptions);
+    }
+
+    /// <summary>
+    ///     Maps a single repo-native message onto Responses API input items (or instructions),
+    ///     appending to the supplied buffers. Recurses into container messages.
+    /// </summary>
+    /// <remarks>
+    ///     The multi-turn loop groups an assistant turn's parts into a <see cref="CompositeMessage"/>
+    ///     and bundles a tool call with its result into a <see cref="ToolsCallAggregateMessage"/>.
+    ///     Both must be unwrapped — dropping them (the original behaviour) hid the tool call + result
+    ///     from the model on continuation turns, so it re-issued the same call indefinitely.
+    /// </remarks>
+    private static void MapMessage(IMessage message, StringBuilder instructions, List<ResponseInputItem> inputItems)
+    {
+        switch (message)
+        {
+            case CompositeMessage composite:
+                foreach (var inner in composite.Messages)
+                {
+                    MapMessage(inner, instructions, inputItems);
+                }
+
+                break;
+
+            case ToolsCallAggregateMessage aggregate:
+                MapMessage(aggregate.ToolsCallMessage, instructions, inputItems);
+                MapMessage(aggregate.ToolsCallResult, instructions, inputItems);
+                break;
+
+            case TextMessage text when text.Role == Role.System:
+                if (instructions.Length > 0)
+                {
+                    _ = instructions.Append('\n');
+                }
+
+                _ = instructions.Append(text.Text);
+                break;
+
+            case TextMessage text:
+                inputItems.Add(
+                    new ResponseInputItem
+                    {
+                        Type = "message",
+                        Role = MapRole(text.Role),
+                        Content =
+                        [
+                            new ResponseInputContent
+                            {
+                                Type = text.Role == Role.Assistant ? "output_text" : "input_text",
+                                Text = text.Text,
+                            },
+                        ],
+                    }
+                );
+                break;
+
+            case ToolsCallMessage toolsCall:
+                foreach (var call in toolsCall.ToolCalls)
+                {
+                    // A replayed assistant tool call must carry name + arguments, not just call_id —
+                    // the Responses API rejects a function_call input item that omits them.
+                    inputItems.Add(
+                        new ResponseInputItem
+                        {
+                            Type = "function_call",
+                            CallId = call.ToolCallId,
+                            Name = call.FunctionName,
+                            Arguments = string.IsNullOrEmpty(call.FunctionArgs) ? "{}" : call.FunctionArgs,
+                            Content = null,
+                        }
+                    );
+                }
+
+                break;
+
+            case ToolsCallResultMessage results:
+                foreach (var result in results.ToolCallResults)
+                {
+                    inputItems.Add(
+                        new ResponseInputItem
+                        {
+                            Type = "function_call_output",
+                            CallId = result.ToolCallId,
+                            Output = result.Result,
+                        }
+                    );
+                }
+
+                break;
+
+            case ToolCallMessage singleCall:
+                inputItems.Add(
+                    new ResponseInputItem
+                    {
+                        Type = "function_call",
+                        CallId = singleCall.ToolCallId,
+                        Name = singleCall.FunctionName,
+                        Arguments = string.IsNullOrEmpty(singleCall.FunctionArgs) ? "{}" : singleCall.FunctionArgs,
+                        Content = null,
+                    }
+                );
+                break;
+
+            case ToolCallResultMessage singleResult:
+                inputItems.Add(
+                    new ResponseInputItem
+                    {
+                        Type = "function_call_output",
+                        CallId = singleResult.ToolCallId,
+                        Output = singleResult.Result,
+                    }
+                );
+                break;
+
+            default:
+                // Unsupported message types (e.g. UsageMessage on the input side) have no Responses
+                // input-side analog and are intentionally dropped.
+                break;
+        }
     }
 
     private static string MapRole(Role role)

--- a/src/OpenAiResponsesProvider/Agents/OpenAiResponsesAgent.cs
+++ b/src/OpenAiResponsesProvider/Agents/OpenAiResponsesAgent.cs
@@ -113,9 +113,10 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
 
         var request = MessageMapper.BuildRequest(messages, options);
         _logger.LogDebug(
-            "OpenAiResponsesAgent.GenerateReplyStreamingAsync model={Model} inputItems={Count} tools={ToolCount}",
+            "OpenAiResponsesAgent.GenerateReplyStreamingAsync model={Model} inputItems={Count} inputTypes=[{InputTypes}] tools={ToolCount}",
             request.Model,
             request.Input.Count,
+            string.Join(",", request.Input.Select(i => i.Type)),
             request.Tools?.Count ?? 0
         );
 
@@ -132,6 +133,9 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
         var generationId = Guid.NewGuid().ToString("N");
         var pendingFunctionCalls = new Dictionary<string, PendingFunctionCall>(StringComparer.Ordinal);
         var textBuffers = new Dictionary<int, StringBuilder>();
+        // Tool calls already surfaced, keyed by call_id, so the delta-correlated path and the
+        // output_item.done fallback don't double-emit the same call.
+        var emittedToolCallIds = new HashSet<string>(StringComparer.Ordinal);
 
         await foreach (var ev in events.ConfigureAwait(false))
         {
@@ -239,6 +243,8 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
                         var argsJson = string.IsNullOrEmpty(argsDone.Arguments)
                             ? completed.ArgsBuilder.ToString()
                             : argsDone.Arguments;
+                        var callId = completed.CallId ?? completed.ItemId;
+                        _ = emittedToolCallIds.Add(callId);
 
                         yield return new ToolsCallMessage
                         {
@@ -248,7 +254,7 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
                                 {
                                     FunctionName = completed.Name,
                                     FunctionArgs = argsJson,
-                                    ToolCallId = completed.CallId ?? completed.ItemId,
+                                    ToolCallId = callId,
                                     Index = completed.OutputIndex,
                                 },
                             ],
@@ -256,6 +262,42 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
                             FromAgent = fromAgent,
                             GenerationId = generationId,
                             MessageOrderIdx = completed.OutputIndex,
+                        };
+                    }
+
+                    break;
+
+                // Fallback / primary path for backends (e.g. GitHub Copilot) that rotate the
+                // per-event item_id so the delta-correlated path above can't match. The terminal
+                // output_item.done carries the complete function_call item (name, call_id, arguments),
+                // which is all we need. Deduped by call_id against the delta path.
+                case ResponseOutputItemEvent fnDone
+                    when fnDone.Type == ResponseEventTypes.OutputItemDone
+                        && TryReadString(fnDone.Item, "type", out var fnDoneType)
+                        && fnDoneType == "function_call":
+                    var doneCallId = TryReadString(fnDone.Item, "call_id", out var doneCid)
+                        ? doneCid
+                        : TryReadString(fnDone.Item, "id", out var doneIid)
+                            ? doneIid
+                            : null;
+                    if (doneCallId is not null && emittedToolCallIds.Add(doneCallId))
+                    {
+                        yield return new ToolsCallMessage
+                        {
+                            ToolCalls =
+                            [
+                                new ToolCall
+                                {
+                                    FunctionName = TryReadString(fnDone.Item, "name", out var doneName) ? doneName : string.Empty,
+                                    FunctionArgs = TryReadString(fnDone.Item, "arguments", out var doneArgs) ? doneArgs : "{}",
+                                    ToolCallId = doneCallId,
+                                    Index = fnDone.OutputIndex,
+                                },
+                            ],
+                            Role = Role.Assistant,
+                            FromAgent = fromAgent,
+                            GenerationId = generationId,
+                            MessageOrderIdx = fnDone.OutputIndex,
                         };
                     }
 

--- a/src/OpenAiResponsesProvider/Agents/OpenAiResponsesClient.cs
+++ b/src/OpenAiResponsesProvider/Agents/OpenAiResponsesClient.cs
@@ -21,7 +21,8 @@ namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
 /// </remarks>
 public sealed class OpenAiResponsesClient : IOpenAiResponsesClient
 {
-    private const string ResponsesPath = "/v1/responses";
+    /// <summary>Default Responses API path (OpenAI). The GitHub Copilot host uses <c>/responses</c>.</summary>
+    public const string DefaultResponsesPath = "/v1/responses";
 
     private static readonly JsonSerializerOptions s_serializerOptions = new(JsonSerializerDefaults.Web)
     {
@@ -30,16 +31,19 @@ public sealed class OpenAiResponsesClient : IOpenAiResponsesClient
 
     private readonly HttpClient _http;
     private readonly bool _disposeClient;
+    private readonly string _responsesPath;
     private readonly ILogger<OpenAiResponsesClient> _logger;
 
     public OpenAiResponsesClient(
         HttpClient httpClient,
         bool disposeClient = false,
-        ILogger<OpenAiResponsesClient>? logger = null
+        ILogger<OpenAiResponsesClient>? logger = null,
+        string? responsesPath = null
     )
     {
         _http = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _disposeClient = disposeClient;
+        _responsesPath = string.IsNullOrWhiteSpace(responsesPath) ? DefaultResponsesPath : responsesPath!;
         _logger = logger ?? NullLogger<OpenAiResponsesClient>.Instance;
     }
 
@@ -51,7 +55,8 @@ public sealed class OpenAiResponsesClient : IOpenAiResponsesClient
     public static OpenAiResponsesClient Create(
         Uri baseAddress,
         string? apiKey = null,
-        ILogger<OpenAiResponsesClient>? logger = null
+        ILogger<OpenAiResponsesClient>? logger = null,
+        string? responsesPath = null
     )
     {
         ArgumentNullException.ThrowIfNull(baseAddress);
@@ -61,7 +66,7 @@ public sealed class OpenAiResponsesClient : IOpenAiResponsesClient
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
         }
 
-        return new OpenAiResponsesClient(client, disposeClient: true, logger);
+        return new OpenAiResponsesClient(client, disposeClient: true, logger, responsesPath);
     }
 
     /// <inheritdoc />
@@ -77,7 +82,7 @@ public sealed class OpenAiResponsesClient : IOpenAiResponsesClient
         // diagnostic close to the call site.
         var streamingRequest = request.Stream is true ? request : request with { Stream = true };
 
-        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, ResponsesPath)
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, _responsesPath)
         {
             Content = JsonContent.Create(streamingRequest, options: s_serializerOptions),
         };
@@ -85,7 +90,7 @@ public sealed class OpenAiResponsesClient : IOpenAiResponsesClient
 
         _logger.LogDebug(
             "POST {Path} model={Model} inputItemCount={InputCount} stream=true",
-            ResponsesPath,
+            _responsesPath,
             streamingRequest.Model,
             streamingRequest.Input.Count
         );

--- a/src/OpenAiResponsesProvider/Models/ResponseCreateRequest.cs
+++ b/src/OpenAiResponsesProvider/Models/ResponseCreateRequest.cs
@@ -47,6 +47,42 @@ public sealed record ResponseCreateRequest
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IReadOnlyList<string>? Include { get; init; }
 
+    /// <summary>
+    ///     Reasoning configuration (e.g. <c>{ "effort": "high" }</c>). Used by reasoning-capable
+    ///     models surfaced through the Copilot Responses transport.
+    /// </summary>
+    [JsonPropertyName("reasoning")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ResponseReasoningOptions? Reasoning { get; init; }
+
+    /// <summary>
+    ///     Text output configuration (e.g. <c>{ "verbosity": "low" }</c>).
+    /// </summary>
+    [JsonPropertyName("text")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ResponseTextOptions? Text { get; init; }
+
+    /// <summary>
+    ///     Whether the server should persist response state. The Copilot CLI sends <c>false</c> and
+    ///     carries reasoning across turns via <c>include: ["reasoning.encrypted_content"]</c>.
+    /// </summary>
+    [JsonPropertyName("store")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Store { get; init; }
+
+    /// <summary>Whether the model may emit tool calls in parallel.</summary>
+    [JsonPropertyName("parallel_tool_calls")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? ParallelToolCalls { get; init; }
+
+    /// <summary>
+    ///     Who initiated this turn (<c>user</c> or <c>agent</c>). Carried in the WebSocket
+    ///     <c>response.create</c> frame.
+    /// </summary>
+    [JsonPropertyName("initiator")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Initiator { get; init; }
+
     [JsonPropertyName("metadata")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public JsonNode? Metadata { get; init; }
@@ -74,6 +110,30 @@ public sealed record ResponseCreateRequest
 }
 
 /// <summary>
+///     Reasoning configuration for a <c>response.create</c> request.
+/// </summary>
+public sealed record ResponseReasoningOptions
+{
+    [JsonPropertyName("effort")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Effort { get; init; }
+
+    [JsonPropertyName("summary")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Summary { get; init; }
+}
+
+/// <summary>
+///     Text output configuration for a <c>response.create</c> request.
+/// </summary>
+public sealed record ResponseTextOptions
+{
+    [JsonPropertyName("verbosity")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Verbosity { get; init; }
+}
+
+/// <summary>
 ///     Item in the <c>input</c> array of a <c>response.create</c> request.
 ///     Models user/assistant message inputs and function-call outputs that come back
 ///     in subsequent turns.
@@ -92,12 +152,29 @@ public sealed record ResponseInputItem
     public IReadOnlyList<ResponseInputContent>? Content { get; init; }
 
     /// <summary>
-    ///     For <c>type = "function_call_output"</c>: the call ID returned by a prior
+    ///     For <c>type = "function_call"</c> and <c>type = "function_call_output"</c>: the call ID
+    ///     correlating the model's tool call with its result. Echoed verbatim from the
     ///     <c>response.output_item.added</c> function_call event.
     /// </summary>
     [JsonPropertyName("call_id")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? CallId { get; init; }
+
+    /// <summary>
+    ///     For <c>type = "function_call"</c>: the tool name. Required by the Responses API when a
+    ///     prior assistant turn's tool call is replayed as conversation history.
+    /// </summary>
+    [JsonPropertyName("name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Name { get; init; }
+
+    /// <summary>
+    ///     For <c>type = "function_call"</c>: the JSON-encoded arguments string the model produced.
+    ///     Required alongside <see cref="Name"/> — omitting it makes the API reject the input item.
+    /// </summary>
+    [JsonPropertyName("arguments")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Arguments { get; init; }
 
     /// <summary>
     ///     For <c>type = "function_call_output"</c>: the textual result of the local tool

--- a/tests/CopilotLive.Tests/CopilotAnthropicLiveTests.cs
+++ b/tests/CopilotLive.Tests/CopilotAnthropicLiveTests.cs
@@ -1,0 +1,109 @@
+using System.Text;
+using AchieveAi.LmDotnetTools.AnthropicProvider.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using FluentAssertions;
+using Xunit.Abstractions;
+
+namespace AchieveAi.LmDotnetTools.CopilotLive.Tests;
+
+/// <summary>
+///     Live tests for the Anthropic Messages API (<c>POST /v1/messages</c>) routed through GitHub
+///     Copilot. Skipped automatically when no Copilot credential is present.
+/// </summary>
+[Collection(CopilotLiveCollection.Name)]
+public sealed class CopilotAnthropicLiveTests
+{
+    private readonly CopilotLiveFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public CopilotAnthropicLiveTests(CopilotLiveFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    [SkippableFact]
+    public async Task Messages_non_streaming_returns_assistant_text()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+        var cancellationToken = cts.Token;
+
+        var model = await _fixture.ResolveAnthropicModelAsync(cancellationToken);
+        _output.WriteLine($"Anthropic model: {model}");
+
+        var agent = CopilotAnthropicAgentFactory.Create(
+            "copilot-anthropic-live",
+            _fixture.TokenProvider,
+            _fixture.Session,
+            _fixture.Options
+        );
+
+        var reply = await agent.GenerateReplyAsync(
+            [new TextMessage { Role = Role.User, Text = "Reply with the single word: READY" }],
+            new GenerateReplyOptions { ModelId = model, MaxToken = 64, Temperature = 0 },
+            cancellationToken
+        );
+
+        var text = ExtractText(reply);
+        _output.WriteLine($"Reply: {text}");
+        text.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [SkippableFact]
+    public async Task Messages_streaming_yields_text()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+        var cancellationToken = cts.Token;
+
+        var model = await _fixture.ResolveAnthropicModelAsync(cancellationToken);
+
+        var agent = CopilotAnthropicAgentFactory.Create(
+            "copilot-anthropic-live-stream",
+            _fixture.TokenProvider,
+            _fixture.Session,
+            _fixture.Options
+        );
+
+        var stream = await agent.GenerateReplyStreamingAsync(
+            [new TextMessage { Role = Role.User, Text = "Count from 1 to 5, separated by spaces." }],
+            new GenerateReplyOptions { ModelId = model, MaxToken = 128, Temperature = 0 },
+            cancellationToken
+        );
+
+        var builder = new StringBuilder();
+        var sawUpdate = false;
+        await foreach (var message in stream.WithCancellation(cancellationToken))
+        {
+            if (message is TextUpdateMessage update)
+            {
+                sawUpdate = true;
+                _ = builder.Append(update.Text);
+            }
+            else if (message is TextMessage final && builder.Length == 0)
+            {
+                _ = builder.Append(final.Text);
+            }
+        }
+
+        _output.WriteLine($"Streamed text: {builder}");
+        sawUpdate.Should().BeTrue("the streaming endpoint should emit incremental text updates");
+        builder.ToString().Should().NotBeNullOrWhiteSpace();
+    }
+
+    private static string ExtractText(IEnumerable<IMessage> messages)
+    {
+        var builder = new StringBuilder();
+        foreach (var message in messages)
+        {
+            if (message is TextMessage text)
+            {
+                _ = builder.Append(text.Text);
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/tests/CopilotLive.Tests/CopilotLive.Tests.csproj
+++ b/tests/CopilotLive.Tests/CopilotLive.Tests.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    Manual / on-demand live test suite that calls the REAL GitHub Copilot API using whatever
+    credentials the developer is already logged in with (Copilot CLI / gh / env var).
+
+    This project is intentionally NOT part of LmDotnetTools.sln and NOT listed in
+    scripts/ci-test.ps1, so CI never builds or runs it. Run it explicitly:
+
+        dotnet test tests/CopilotLive.Tests
+
+    Tests skip themselves (rather than fail) when no Copilot credential is found.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>AchieveAi.LmDotnetTools.CopilotLive.Tests</RootNamespace>
+    <AssemblyName>AchieveAi.LmDotnetTools.CopilotLive.Tests</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="FluentAssertions" Version="7.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\LmCore\AchieveAi.LmDotnetTools.LmCore.csproj" />
+    <ProjectReference Include="..\..\src\AnthropicProvider\AchieveAi.LmDotnetTools.AnthropicProvider.csproj" />
+    <ProjectReference Include="..\..\src\OpenAiResponsesProvider\AchieveAi.LmDotnetTools.OpenAiResponsesProvider.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/tests/CopilotLive.Tests/CopilotLiveFixture.cs
+++ b/tests/CopilotLive.Tests/CopilotLiveFixture.cs
@@ -1,0 +1,163 @@
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Auth;
+
+namespace AchieveAi.LmDotnetTools.CopilotLive.Tests;
+
+/// <summary>
+///     Shared state for the live Copilot suite: resolves the developer's existing GitHub Copilot
+///     credential once, holds a single <see cref="CopilotSessionContext"/> (so every test in the run
+///     shares one client-session id, like a real CLI session), and lazily lists the available models
+///     so chat tests can pick valid model ids without hard-coding names that drift over time.
+/// </summary>
+public sealed class CopilotLiveFixture
+{
+    private readonly SemaphoreSlim _modelsGate = new(1, 1);
+    private IReadOnlyList<string>? _models;
+
+    public CopilotLiveFixture()
+    {
+        var cli = new CliCredentialCopilotTokenProvider();
+        var token = cli.ResolveToken();
+
+        Available = token is not null;
+        SkipReason = Available
+            ? string.Empty
+            : "No GitHub Copilot credential found. Log in with the GitHub Copilot CLI or `gh auth login`, "
+                + "or set GITHUB_COPILOT_TOKEN / GH_TOKEN, then re-run.";
+
+        TokenProvider = cli;
+        Session = new CopilotSessionContext();
+        Options = new CopilotOptions();
+    }
+
+    /// <summary>True when a Copilot credential was found and live tests should run.</summary>
+    public bool Available { get; }
+
+    /// <summary>Human-readable reason shown when <see cref="Available"/> is false.</summary>
+    public string SkipReason { get; }
+
+    public ICopilotTokenProvider TokenProvider { get; }
+
+    public CopilotSessionContext Session { get; }
+
+    public CopilotOptions Options { get; }
+
+    /// <summary>Lists model ids from <c>GET {host}/models</c> (cached for the run).</summary>
+    public async Task<IReadOnlyList<string>> GetModelsAsync(CancellationToken cancellationToken)
+    {
+        if (_models is not null)
+        {
+            return _models;
+        }
+
+        await _modelsGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_models is not null)
+            {
+                return _models;
+            }
+
+            using var http = CopilotHttpClientFactory.Create(Options.BaseUrl, TokenProvider, Session, Options);
+            using var response = await http.GetAsync("/models", cancellationToken).ConfigureAwait(false);
+            _ = response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            _models = ParseModelIds(json);
+            return _models;
+        }
+        finally
+        {
+            _ = _modelsGate.Release();
+        }
+    }
+
+    /// <summary>
+    ///     Resolves the Anthropic model id to use: the <c>COPILOT_ANTHROPIC_MODEL</c> env override, else
+    ///     the cheapest-looking Claude model exposed by <c>/models</c>, else a sensible default.
+    /// </summary>
+    public async Task<string> ResolveAnthropicModelAsync(CancellationToken cancellationToken)
+    {
+        var env = Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_MODEL");
+        if (!string.IsNullOrWhiteSpace(env))
+        {
+            return env!;
+        }
+
+        var models = await GetModelsAsync(cancellationToken).ConfigureAwait(false);
+        return PickPreferred(models, "claude", ["haiku", "sonnet"]) ?? "claude-sonnet-4.5";
+    }
+
+    /// <summary>
+    ///     Resolves the OpenAI model id to use: the <c>COPILOT_OPENAI_MODEL</c> env override, else the
+    ///     cheapest-looking GPT model exposed by <c>/models</c>, else a sensible default.
+    /// </summary>
+    public async Task<string> ResolveOpenAiModelAsync(CancellationToken cancellationToken)
+    {
+        var env = Environment.GetEnvironmentVariable("COPILOT_OPENAI_MODEL");
+        if (!string.IsNullOrWhiteSpace(env))
+        {
+            return env!;
+        }
+
+        var models = await GetModelsAsync(cancellationToken).ConfigureAwait(false);
+        return PickPreferred(models, "gpt", ["nano", "mini"]) ?? "gpt-4.1";
+    }
+
+    private static string? PickPreferred(IReadOnlyList<string> models, string family, string[] cheapHints)
+    {
+        var candidates = models.Where(m => m.Contains(family, StringComparison.OrdinalIgnoreCase)).ToList();
+        if (candidates.Count == 0)
+        {
+            return null;
+        }
+
+        foreach (var hint in cheapHints)
+        {
+            var match = candidates.FirstOrDefault(m => m.Contains(hint, StringComparison.OrdinalIgnoreCase));
+            if (match is not null)
+            {
+                return match;
+            }
+        }
+
+        return candidates[0];
+    }
+
+    private static IReadOnlyList<string> ParseModelIds(string json)
+    {
+        var ids = new List<string>();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        var list = root.ValueKind == JsonValueKind.Object && root.TryGetProperty("data", out var data)
+            ? data
+            : root;
+
+        if (list.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in list.EnumerateArray())
+            {
+                if (item.ValueKind == JsonValueKind.Object
+                    && item.TryGetProperty("id", out var idEl)
+                    && idEl.ValueKind == JsonValueKind.String)
+                {
+                    var id = idEl.GetString();
+                    if (!string.IsNullOrWhiteSpace(id))
+                    {
+                        ids.Add(id!);
+                    }
+                }
+            }
+        }
+
+        return ids;
+    }
+}
+
+/// <summary>xUnit collection so the fixture (token + session + model list) is shared across tests.</summary>
+[CollectionDefinition(Name)]
+public sealed class CopilotLiveCollection : ICollectionFixture<CopilotLiveFixture>
+{
+    public const string Name = "copilot-live";
+}

--- a/tests/CopilotLive.Tests/CopilotResponsesLiveTests.cs
+++ b/tests/CopilotLive.Tests/CopilotResponsesLiveTests.cs
@@ -1,0 +1,138 @@
+using System.Text;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
+using FluentAssertions;
+using Xunit.Abstractions;
+
+namespace AchieveAi.LmDotnetTools.CopilotLive.Tests;
+
+/// <summary>
+///     Live tests for the OpenAI Responses API (<c>/responses</c>) routed through GitHub Copilot,
+///     over both the SSE (HTTP POST) and WebSocket transports. Skipped automatically when no Copilot
+///     credential is present.
+/// </summary>
+[Collection(CopilotLiveCollection.Name)]
+public sealed class CopilotResponsesLiveTests
+{
+    private readonly CopilotLiveFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public CopilotResponsesLiveTests(CopilotLiveFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    [SkippableFact]
+    public async Task Lists_available_models()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        var models = await _fixture.GetModelsAsync(cts.Token);
+        foreach (var id in models)
+        {
+            _output.WriteLine(id);
+        }
+
+        models.Should().NotBeEmpty("GET /models should return the catalog the account can access");
+    }
+
+    [SkippableFact]
+    public async Task Responses_sse_returns_text()
+    {
+        await RunSingleTurnAsync(CopilotResponsesTransport.Sse);
+    }
+
+    [SkippableFact]
+    public async Task Responses_websocket_returns_text()
+    {
+        await RunSingleTurnAsync(CopilotResponsesTransport.WebSocket);
+    }
+
+    [SkippableFact]
+    public async Task Responses_websocket_multi_turn_chains_previous_response()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(180));
+        var cancellationToken = cts.Token;
+
+        var model = await _fixture.ResolveOpenAiModelAsync(cancellationToken);
+        _output.WriteLine($"OpenAI model: {model}");
+
+        using var agent = CopilotResponsesAgentFactory.Create(
+            "copilot-responses-live-ws-multi",
+            _fixture.TokenProvider,
+            CopilotResponsesTransport.WebSocket,
+            _fixture.Session,
+            _fixture.Options
+        );
+
+        var options = new GenerateReplyOptions { ModelId = model, MaxToken = 128 };
+
+        var first = ExtractText(
+            await agent.GenerateReplyAsync(
+                [new TextMessage { Role = Role.User, Text = "My favourite colour is teal. Acknowledge in one short sentence." }],
+                options,
+                cancellationToken
+            )
+        );
+        _output.WriteLine($"Turn 1: {first}");
+        first.Should().NotBeNullOrWhiteSpace();
+
+        // Second turn reuses the same open socket; the client chains previous_response_id automatically.
+        var second = ExtractText(
+            await agent.GenerateReplyAsync(
+                [new TextMessage { Role = Role.User, Text = "What colour did I say was my favourite? Answer with one word." }],
+                options,
+                cancellationToken
+            )
+        );
+        _output.WriteLine($"Turn 2: {second}");
+        second.Should().NotBeNullOrWhiteSpace();
+        second.Should().ContainEquivalentOf("teal", "server-side state should carry context from the prior turn");
+    }
+
+    private async Task RunSingleTurnAsync(CopilotResponsesTransport transport)
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+        var cancellationToken = cts.Token;
+
+        var model = await _fixture.ResolveOpenAiModelAsync(cancellationToken);
+        _output.WriteLine($"OpenAI model: {model} ({transport})");
+
+        using var agent = CopilotResponsesAgentFactory.Create(
+            $"copilot-responses-live-{transport}",
+            _fixture.TokenProvider,
+            transport,
+            _fixture.Session,
+            _fixture.Options
+        );
+
+        var reply = await agent.GenerateReplyAsync(
+            [new TextMessage { Role = Role.User, Text = "Reply with the single word: READY" }],
+            new GenerateReplyOptions { ModelId = model, MaxToken = 64 },
+            cancellationToken
+        );
+
+        var text = ExtractText(reply);
+        _output.WriteLine($"Reply: {text}");
+        text.Should().NotBeNullOrWhiteSpace();
+    }
+
+    private static string ExtractText(IEnumerable<IMessage> messages)
+    {
+        var builder = new StringBuilder();
+        foreach (var message in messages)
+        {
+            if (message is TextMessage text)
+            {
+                _ = builder.Append(text.Text);
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/tests/CopilotLive.Tests/README.md
+++ b/tests/CopilotLive.Tests/README.md
@@ -1,0 +1,70 @@
+# CopilotLive.Tests — manual live suite (NOT run by CI)
+
+Smoke tests that call the **real** GitHub Copilot API
+(`https://api.enterprise.githubcopilot.com`) through `CopilotAnthropicAgentFactory` and
+`CopilotResponsesAgentFactory`, using whatever GitHub Copilot credential you are already logged in
+with.
+
+## Why it isn't in CI
+
+This project is deliberately **excluded from `LmDotnetTools.sln`** and **not listed in
+`scripts/ci-test.ps1`**, so the CI build never restores, compiles, or runs it. Each test is also a
+`[SkippableFact]` that **skips itself** (rather than failing) when no Copilot credential is found —
+so even if it were ever added to a run, it stays green without credentials.
+
+## Prerequisites
+
+Be logged in to GitHub Copilot via any one of these (checked in this order):
+
+1. Env var: `GITHUB_COPILOT_TOKEN`, `GH_COPILOT_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`
+2. GitHub Copilot CLI / editor login (`github-copilot/apps.json` or `hosts.json`)
+3. `gh auth login` (`gh/hosts.json`)
+
+## Run it
+
+```bash
+# from the repo root
+dotnet test tests/CopilotLive.Tests
+
+# a single test
+dotnet test tests/CopilotLive.Tests --filter "FullyQualifiedName~Responses_websocket_returns_text"
+```
+
+See model ids and replies (xUnit captures `ITestOutputHelper`):
+
+```bash
+dotnet test tests/CopilotLive.Tests --logger "console;verbosity=detailed"
+```
+
+## What it covers
+
+| Test | Endpoint / transport |
+|------|----------------------|
+| `Lists_available_models` | `GET /models` |
+| `Messages_non_streaming_returns_assistant_text` | `POST /v1/messages` |
+| `Messages_streaming_yields_text` | `POST /v1/messages` (SSE) |
+| `Responses_sse_returns_text` | `POST /responses` (SSE) |
+| `Responses_websocket_returns_text` | `GET /responses` (WebSocket) |
+| `Responses_websocket_multi_turn_chains_previous_response` | WebSocket multi-turn (`previous_response_id`) |
+
+## Model selection
+
+By default the suite reads `GET /models` and picks a cheap model per family (prefers
+`haiku`/`sonnet` for Claude, `nano`/`mini` for GPT). Override explicitly with:
+
+```bash
+COPILOT_ANTHROPIC_MODEL=claude-sonnet-4.5 COPILOT_OPENAI_MODEL=gpt-4.1 dotnet test tests/CopilotLive.Tests
+```
+
+## Troubleshooting
+
+- **All tests skip** → no credential found. Confirm `gh auth token` prints a token, or that the
+  Copilot CLI is logged in (`~/.copilot/config.json` exists).
+- **`421 Misdirected Request`** → the resolved token isn't entitled for the enterprise host
+  (`api.enterprise.githubcopilot.com`). The token-provider prefers the Copilot CLI's own token for
+  this reason; a plain `gh` token may only work against the individual host. Set
+  `GITHUB_COPILOT_TOKEN` to a Copilot-entitled token to force it.
+
+> Note: these tests consume real Copilot quota and mimic the Copilot CLI's request headers. The token
+> provider reads the Copilot CLI config (`~/.copilot/config.json`, which is JSONC), Copilot editor
+> credential files, `gh`'s `hosts.yml`, and finally `gh auth token`.

--- a/tests/LmCore.Tests/Auth/CliCredentialCopilotTokenProviderTests.cs
+++ b/tests/LmCore.Tests/Auth/CliCredentialCopilotTokenProviderTests.cs
@@ -1,0 +1,116 @@
+using AchieveAi.LmDotnetTools.LmCore.Auth;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.Auth;
+
+public sealed class CliCredentialCopilotTokenProviderTests
+{
+    [Fact]
+    public void TryReadOAuthTokenFromJson_reads_copilot_hosts_shape()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"copilot-hosts-{Guid.NewGuid():N}.json");
+        File.WriteAllText(
+            path,
+            """{ "github.com": { "user": "octocat", "oauth_token": "gho_from_hosts" } }"""
+        );
+
+        try
+        {
+            CliCredentialCopilotTokenProvider.TryReadOAuthTokenFromJson(path).Should().Be("gho_from_hosts");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void TryReadOAuthTokenFromJson_reads_apps_shape_with_composite_key()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"copilot-apps-{Guid.NewGuid():N}.json");
+        File.WriteAllText(
+            path,
+            """{ "github.com:Iv1.b507a08c87ecfe98": { "oauth_token": "gho_from_apps" } }"""
+        );
+
+        try
+        {
+            CliCredentialCopilotTokenProvider.TryReadOAuthTokenFromJson(path).Should().Be("gho_from_apps");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void TryReadOAuthTokenFromJson_returns_null_for_missing_file()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}.json");
+        CliCredentialCopilotTokenProvider.TryReadOAuthTokenFromJson(path).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryScanGitHubTokenFromJson_reads_token_from_jsonc_with_comments()
+    {
+        // The GitHub Copilot CLI's config.json is JSONC: leading // comments + the token nested
+        // somewhere in the document, with other properties before it.
+        var path = Path.Combine(Path.GetTempPath(), $"copilot-config-{Guid.NewGuid():N}.json");
+        File.WriteAllText(
+            path,
+            "// User settings belong in settings.json.\n"
+                + "// This file is managed automatically.\n"
+                + "{\n  \"trustedFolders\": [\"a\", \"b\"],\n"
+                + "  \"auth\": { \"host\": \"github.com\", \"token\": \"gho_jsoncTokenAAAAAAAAAAAAAAAAAAAAAA\" }\n}\n"
+        );
+
+        try
+        {
+            CliCredentialCopilotTokenProvider
+                .TryScanGitHubTokenFromJson(path)
+                .Should()
+                .Be("gho_jsoncTokenAAAAAAAAAAAAAAAAAAAAAA");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void TryReadOAuthTokenFromYaml_reads_gh_hosts_yml()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"gh-hosts-{Guid.NewGuid():N}.yml");
+        File.WriteAllText(
+            path,
+            "github.com:\n    user: octocat\n    oauth_token: gho_from_yaml_bbbbbbbbbbbbbbbbbbbbbb\n    git_protocol: https\n"
+        );
+
+        try
+        {
+            CliCredentialCopilotTokenProvider
+                .TryReadOAuthTokenFromYaml(path)
+                .Should()
+                .Be("gho_from_yaml_bbbbbbbbbbbbbbbbbbbbbb");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ResolveToken_prefers_environment_variable()
+    {
+        var original = Environment.GetEnvironmentVariable("GITHUB_COPILOT_TOKEN");
+        try
+        {
+            Environment.SetEnvironmentVariable("GITHUB_COPILOT_TOKEN", "gho_from_env");
+            new CliCredentialCopilotTokenProvider().ResolveToken().Should().Be("gho_from_env");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GITHUB_COPILOT_TOKEN", original);
+        }
+    }
+}

--- a/tests/LmCore.Tests/Auth/CompositeCopilotTokenProviderTests.cs
+++ b/tests/LmCore.Tests/Auth/CompositeCopilotTokenProviderTests.cs
@@ -1,0 +1,91 @@
+using AchieveAi.LmDotnetTools.LmCore.Auth;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.Auth;
+
+public sealed class CompositeCopilotTokenProviderTests
+{
+    private sealed class StubProvider(Func<CancellationToken, Task<string>> behavior) : ICopilotTokenProvider
+    {
+        public int CallCount { get; private set; }
+
+        public Task<string> GetTokenAsync(CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return behavior(cancellationToken);
+        }
+    }
+
+    private static StubProvider Returns(string token) => new(_ => Task.FromResult(token));
+
+    private static StubProvider Throws(Exception ex) => new(_ => Task.FromException<string>(ex));
+
+    [Fact]
+    public async Task First_provider_wins_and_later_providers_are_not_called()
+    {
+        var first = Returns("gho_first");
+        var second = Returns("gho_second");
+        var composite = new CompositeCopilotTokenProvider(first, second);
+
+        (await composite.GetTokenAsync()).Should().Be("gho_first");
+        first.CallCount.Should().Be(1);
+        second.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Falls_back_to_next_provider_when_earlier_one_fails()
+    {
+        var first = Throws(new InvalidOperationException("no creds"));
+        var second = Returns("gho_fallback");
+        var composite = new CompositeCopilotTokenProvider(first, second);
+
+        (await composite.GetTokenAsync()).Should().Be("gho_fallback");
+        first.CallCount.Should().Be(1);
+        second.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Resolved_token_is_cached_in_memory()
+    {
+        var first = Returns("gho_cached");
+        var composite = new CompositeCopilotTokenProvider(first);
+
+        (await composite.GetTokenAsync()).Should().Be("gho_cached");
+        (await composite.GetTokenAsync()).Should().Be("gho_cached");
+
+        first.CallCount.Should().Be(1, "the cached token should be reused without re-invoking the provider");
+    }
+
+    [Fact]
+    public async Task Cancellation_propagates_and_is_not_swallowed_as_a_provider_failure()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var provider = new StubProvider(ct =>
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult("unreachable");
+        });
+        var composite = new CompositeCopilotTokenProvider(provider);
+
+        var act = async () => await composite.GetTokenAsync(cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task When_all_providers_fail_all_failures_are_preserved()
+    {
+        var first = Throws(new InvalidOperationException("first failure"));
+        var second = Throws(new IOException("second failure"));
+        var composite = new CompositeCopilotTokenProvider(first, second);
+
+        var act = async () => await composite.GetTokenAsync();
+
+        var ex = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        ex.InnerException.Should().BeOfType<AggregateException>();
+        var aggregate = (AggregateException)ex.InnerException!;
+        aggregate.InnerExceptions.Should().HaveCount(2);
+        aggregate.InnerExceptions.Select(e => e.Message).Should().Contain(["first failure", "second failure"]);
+    }
+}

--- a/tests/LmCore.Tests/Auth/CopilotHeadersHandlerTests.cs
+++ b/tests/LmCore.Tests/Auth/CopilotHeadersHandlerTests.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using System.Net.Http.Headers;
+using AchieveAi.LmDotnetTools.LmCore.Auth;
+using AchieveAi.LmDotnetTools.LmCore.Http;
+using AchieveAi.LmDotnetTools.LmTestUtils;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.Auth;
+
+public sealed class CopilotHeadersHandlerTests
+{
+    private sealed class StubTokenProvider(string token) : ICopilotTokenProvider
+    {
+        public int CallCount { get; private set; }
+
+        public Task<string> GetTokenAsync(CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(token);
+        }
+    }
+
+    private static (HttpClient client, List<HttpRequestMessage> captured, StubTokenProvider tokens) BuildClient(
+        CopilotOptions? options = null,
+        CopilotSessionContext? session = null
+    )
+    {
+        var captured = new List<HttpRequestMessage>();
+        var inner = new FakeHttpMessageHandler(
+            (request, _) =>
+            {
+                captured.Add(request);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+        );
+
+        var tokens = new StubTokenProvider("gho_test_token");
+        var handler = new CopilotHeadersHandler(
+            tokens,
+            session ?? new CopilotSessionContext("machine-1", "session-1"),
+            options,
+            inner
+        );
+
+        return (new HttpClient(handler) { BaseAddress = new Uri("https://api.enterprise.githubcopilot.com") }, captured, tokens);
+    }
+
+    [Fact]
+    public async Task Adds_auth_and_copilot_headers()
+    {
+        var (client, captured, tokens) = BuildClient(
+            new CopilotOptions { ExtraHeaders = new Dictionary<string, string> { ["anthropic-version"] = "2023-06-01" } }
+        );
+
+        _ = await client.PostAsync("/v1/messages", new StringContent("{}"));
+
+        var req = captured.Single();
+        req.Headers.Authorization.Should().BeEquivalentTo(new AuthenticationHeaderValue("Bearer", "gho_test_token"));
+        HeaderValue(req, "copilot-integration-id").Should().Be("copilot-developer-cli");
+        HeaderValue(req, "editor-version").Should().StartWith("copilot/");
+        HeaderValue(req, "x-github-api-version").Should().Be("2026-06-01");
+        HeaderValue(req, "x-client-machine-id").Should().Be("machine-1");
+        HeaderValue(req, "x-client-session-id").Should().Be("session-1");
+        HeaderValue(req, "x-interaction-id").Should().NotBeNullOrWhiteSpace();
+        HeaderValue(req, "anthropic-version").Should().Be("2023-06-01");
+        tokens.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Interaction_id_is_fresh_per_request_but_session_ids_are_stable()
+    {
+        var (client, captured, _) = BuildClient();
+
+        _ = await client.PostAsync("/responses", new StringContent("{}"));
+        _ = await client.PostAsync("/responses", new StringContent("{}"));
+
+        var first = captured[0];
+        var second = captured[1];
+
+        HeaderValue(first, "x-interaction-id").Should().NotBe(HeaderValue(second, "x-interaction-id"));
+        HeaderValue(first, "x-client-session-id").Should().Be(HeaderValue(second, "x-client-session-id"));
+        HeaderValue(first, "x-client-machine-id").Should().Be(HeaderValue(second, "x-client-machine-id"));
+    }
+
+    [Fact]
+    public async Task Does_not_overwrite_a_header_the_caller_already_set()
+    {
+        var (client, captured, _) = BuildClient(
+            new CopilotOptions { ExtraHeaders = new Dictionary<string, string> { ["anthropic-version"] = "2023-06-01" } }
+        );
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/v1/messages")
+        {
+            Content = new StringContent("{}"),
+        };
+        _ = request.Headers.TryAddWithoutValidation("anthropic-version", "custom-version");
+
+        _ = await client.SendAsync(request);
+
+        HeaderValue(captured.Single(), "anthropic-version").Should().Be("custom-version");
+    }
+
+    private static string? HeaderValue(HttpRequestMessage request, string name)
+    {
+        return request.Headers.TryGetValues(name, out var values) ? values.FirstOrDefault() : null;
+    }
+}

--- a/tests/LmCore.Tests/Auth/DeviceFlowCopilotTokenProviderTests.cs
+++ b/tests/LmCore.Tests/Auth/DeviceFlowCopilotTokenProviderTests.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using System.Text;
+using AchieveAi.LmDotnetTools.LmCore.Auth;
+using AchieveAi.LmDotnetTools.LmTestUtils;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.Auth;
+
+public sealed class DeviceFlowCopilotTokenProviderTests
+{
+    [Fact]
+    public async Task Completes_device_flow_and_caches_token_in_memory()
+    {
+        var deviceCodeRequests = 0;
+        var tokenRequests = 0;
+
+        var handler = new FakeHttpMessageHandler(
+            (request, _) =>
+            {
+                var url = request.RequestUri!.AbsoluteUri;
+                if (url.Contains("login/device/code", StringComparison.Ordinal))
+                {
+                    deviceCodeRequests++;
+                    return Task.FromResult(
+                        Json(
+                            """{"device_code":"dc","user_code":"ABCD-1234","verification_uri":"https://github.com/login/device","expires_in":900,"interval":0}"""
+                        )
+                    );
+                }
+
+                if (url.Contains("login/oauth/access_token", StringComparison.Ordinal))
+                {
+                    tokenRequests++;
+                    // Pending on the first poll, success on the second — exercises the poll loop.
+                    return Task.FromResult(
+                        tokenRequests == 1
+                            ? Json("""{"error":"authorization_pending"}""")
+                            : Json("""{"access_token":"gho_device"}""")
+                    );
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+        );
+
+        var presented = 0;
+        var provider = new DeviceFlowCopilotTokenProvider(
+            httpClient: new HttpClient(handler),
+            present: _ => presented++,
+            cacheToDisk: false
+        );
+
+        var token = await provider.GetTokenAsync();
+        token.Should().Be("gho_device");
+        presented.Should().Be(1);
+        deviceCodeRequests.Should().Be(1);
+        tokenRequests.Should().Be(2);
+
+        // Second call is served from the in-memory cache (no further HTTP).
+        var again = await provider.GetTokenAsync();
+        again.Should().Be("gho_device");
+        deviceCodeRequests.Should().Be(1);
+        tokenRequests.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Throws_on_access_denied()
+    {
+        var handler = new FakeHttpMessageHandler(
+            (request, _) =>
+            {
+                var url = request.RequestUri!.AbsoluteUri;
+                return Task.FromResult(
+                    url.Contains("login/device/code", StringComparison.Ordinal)
+                        ? Json(
+                            """{"device_code":"dc","user_code":"X","verification_uri":"https://github.com/login/device","expires_in":900,"interval":0}"""
+                        )
+                        : Json("""{"error":"access_denied"}""")
+                );
+            }
+        );
+
+        var provider = new DeviceFlowCopilotTokenProvider(
+            httpClient: new HttpClient(handler),
+            present: _ => { },
+            cacheToDisk: false
+        );
+
+        var act = async () => await provider.GetTokenAsync();
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    private static HttpResponseMessage Json(string body) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+}

--- a/tests/LmStreaming.Sample.Tests/Services/ProviderRegistryTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ProviderRegistryTests.cs
@@ -183,7 +183,8 @@ public class ProviderRegistryTests
         catalog.Select(p => p.Id).Should().BeEquivalentTo(
             [
                 "anthropic", "claude", "claude-mock", "codex", "codex-mock",
-                "copilot", "copilot-mock", "openai", "test", "test-anthropic",
+                "copilot", "copilot-mock", "gpt-5.5", "gpt-5.5-mini", "haiku",
+                "openai", "sonnet", "test", "test-anthropic",
             ],
             options => options.WithStrictOrdering());
     }

--- a/tests/OpenAiResponsesProvider.Tests/CopilotResponsesWebSocketClientTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/CopilotResponsesWebSocketClientTests.cs
@@ -1,0 +1,156 @@
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Auth;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Tests;
+
+/// <summary>
+///     Verifies the WebSocket Responses transport: <c>response.create</c> framing, event parsing
+///     via the shared <see cref="ResponseEventParser"/>, and automatic <c>previous_response_id</c>
+///     chaining across turns over a single socket.
+/// </summary>
+public sealed class CopilotResponsesWebSocketClientTests
+{
+    private sealed class StubTokenProvider : ICopilotTokenProvider
+    {
+        public Task<string> GetTokenAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult("gho_test");
+    }
+
+    private sealed class FakeSocket : ICopilotResponsesSocket
+    {
+        private readonly Func<string, IEnumerable<string>> _respond;
+        private readonly Queue<string> _incoming = new();
+
+        public FakeSocket(Func<string, IEnumerable<string>> respond) => _respond = respond;
+
+        public List<string> Sent { get; } = [];
+        public List<IReadOnlyDictionary<string, string>> Connects { get; } = [];
+        public bool IsConnected { get; private set; }
+
+        public Task ConnectAsync(Uri endpoint, IReadOnlyDictionary<string, string> headers, CancellationToken ct)
+        {
+            Connects.Add(headers);
+            IsConnected = true;
+            return Task.CompletedTask;
+        }
+
+        public Task SendTextAsync(string text, CancellationToken ct)
+        {
+            Sent.Add(text);
+            foreach (var frame in _respond(text))
+            {
+                _incoming.Enqueue(frame);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> ReceiveTextAsync(CancellationToken ct) =>
+            Task.FromResult(_incoming.Count > 0 ? _incoming.Dequeue() : null);
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private static IEnumerable<string> ScriptedTurn(string sentFrame, int turnIndex)
+    {
+        var responseId = "resp-" + turnIndex;
+        yield return "{\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"" + responseId + "\"}}";
+        yield return "{\"type\":\"response.output_text.delta\",\"sequence_number\":1,\"item_id\":\"i\",\"output_index\":0,\"content_index\":0,\"delta\":\"hello\"}";
+        yield return "{\"type\":\"response.completed\",\"sequence_number\":2,\"response\":{\"id\":\"" + responseId + "\"}}";
+    }
+
+    private static ResponseCreateRequest Request() =>
+        new()
+        {
+            Model = "gpt-5.5",
+            Input = [new ResponseInputItem { Role = "user", Content = [new ResponseInputContent { Text = "hi" }] }],
+        };
+
+    [Fact]
+    public async Task Sends_response_create_frame_with_copilot_headers_on_connect()
+    {
+        var turn = 0;
+        var fake = new FakeSocket(sent => ScriptedTurn(sent, turn++));
+        using var client = new CopilotResponsesWebSocketClient(
+            new Uri("wss://api.enterprise.githubcopilot.com/responses"),
+            new StubTokenProvider(),
+            new CopilotSessionContext("machine-1", "session-1"),
+            options: null,
+            logger: null,
+            socketFactory: () => fake
+        );
+
+        _ = await CollectAsync(client.StreamResponseAsync(Request()));
+
+        var sentFrame = JsonDocument.Parse(fake.Sent.Single()).RootElement;
+        sentFrame.GetProperty("type").GetString().Should().Be(ResponseEventTypes.ClientResponseCreate);
+        sentFrame.GetProperty("model").GetString().Should().Be("gpt-5.5");
+
+        var headers = fake.Connects.Single();
+        headers["Authorization"].Should().Be("Bearer gho_test");
+        headers["copilot-integration-id"].Should().Be("copilot-developer-cli");
+        headers["x-client-session-id"].Should().Be("session-1");
+    }
+
+    [Fact]
+    public async Task Yields_parsed_events_until_completed()
+    {
+        var turn = 0;
+        var fake = new FakeSocket(sent => ScriptedTurn(sent, turn++));
+        using var client = new CopilotResponsesWebSocketClient(
+            new Uri("wss://host/responses"),
+            new StubTokenProvider(),
+            new CopilotSessionContext("m", "s"),
+            socketFactory: () => fake
+        );
+
+        var events = await CollectAsync(client.StreamResponseAsync(Request()));
+
+        events.Select(e => e.Type).Should().ContainInOrder(
+            ResponseEventTypes.ResponseCreated,
+            ResponseEventTypes.OutputTextDelta,
+            ResponseEventTypes.ResponseCompleted
+        );
+        events.Last().Should().BeOfType<ResponseLifecycleEvent>();
+    }
+
+    [Fact]
+    public async Task Chains_previous_response_id_across_turns()
+    {
+        var turn = 0;
+        var fake = new FakeSocket(sent => ScriptedTurn(sent, turn++));
+        using var client = new CopilotResponsesWebSocketClient(
+            new Uri("wss://host/responses"),
+            new StubTokenProvider(),
+            new CopilotSessionContext("m", "s"),
+            socketFactory: () => fake
+        );
+
+        _ = await CollectAsync(client.StreamResponseAsync(Request()));
+        _ = await CollectAsync(client.StreamResponseAsync(Request()));
+
+        // First frame has no previous_response_id; second chains off the first turn's completed id.
+        var firstFrame = JsonDocument.Parse(fake.Sent[0]).RootElement;
+        firstFrame.TryGetProperty("previous_response_id", out _).Should().BeFalse();
+
+        var secondFrame = JsonDocument.Parse(fake.Sent[1]).RootElement;
+        secondFrame.GetProperty("previous_response_id").GetString().Should().Be("resp-0");
+
+        // The socket is reused across turns (connected once).
+        fake.Connects.Should().ContainSingle();
+    }
+
+    private static async Task<List<ResponseEvent>> CollectAsync(IAsyncEnumerable<ResponseEvent> stream)
+    {
+        var list = new List<ResponseEvent>();
+        await foreach (var ev in stream)
+        {
+            list.Add(ev);
+        }
+
+        return list;
+    }
+}

--- a/tests/OpenAiResponsesProvider.Tests/MessageMapperTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/MessageMapperTests.cs
@@ -79,8 +79,8 @@ public sealed class MessageMapperTests
             {
                 ToolCalls =
                 [
-                    new ToolCall { FunctionName = "lookup", FunctionArgs = "{}", ToolCallId = "call-1" },
-                    new ToolCall { FunctionName = "fetch", FunctionArgs = "{}", ToolCallId = "call-2" },
+                    new ToolCall { FunctionName = "lookup", FunctionArgs = "{\"q\":\"x\"}", ToolCallId = "call-1" },
+                    new ToolCall { FunctionName = "fetch", FunctionArgs = "", ToolCallId = "call-2" },
                 ],
                 Role = Role.Assistant,
             },
@@ -91,6 +91,9 @@ public sealed class MessageMapperTests
         request.Input.Should().HaveCount(2);
         request.Input.Select(i => i.Type).Should().AllBe("function_call");
         request.Input.Select(i => i.CallId).Should().Equal("call-1", "call-2");
+        // A replayed function_call MUST carry name + arguments or the API 400s. Empty args default to "{}".
+        request.Input.Select(i => i.Name).Should().Equal("lookup", "fetch");
+        request.Input.Select(i => i.Arguments).Should().Equal("{\"q\":\"x\"}", "{}");
         request.Input.Should().OnlyContain(i => i.Content == null);
     }
 
@@ -145,7 +148,84 @@ public sealed class MessageMapperTests
         tool.Type.Should().Be("function");
         tool.Name.Should().Be("search");
         tool.Description.Should().Be("search the web");
+
+        // parameters MUST be a JSON Schema object, not the raw parameter list (which serializes to an
+        // array). The Responses API rejects an array with "expected an object, but got an array".
         tool.Parameters.Should().NotBeNull();
+        tool.Parameters.Should().BeOfType<System.Text.Json.Nodes.JsonObject>();
+        var parameters = tool.Parameters!.AsObject();
+        parameters["type"]!.GetValue<string>().Should().Be("object");
+        parameters["properties"].Should().NotBeNull();
+        parameters["properties"]!.AsObject().Should().ContainKey("q");
+        parameters["properties"]!["q"]!["description"]!.GetValue<string>().Should().Be("query");
+        parameters["required"]!.AsArray().Select(n => n!.GetValue<string>()).Should().Contain("q");
+    }
+
+    [Fact]
+    public void Singular_ToolCallMessage_and_result_round_trip_as_function_call_items()
+    {
+        // The multi-turn loop replays history as SINGULAR ToolCallMessage / ToolCallResultMessage.
+        // These must map to function_call + function_call_output (with matching call_id) or the model
+        // never sees the tool result and loops, re-calling the tool forever.
+        var messages = new IMessage[]
+        {
+            new TextMessage { Role = Role.User, Text = "add 17 and 25" },
+            new ToolCallMessage
+            {
+                FunctionName = "add",
+                FunctionArgs = "{\"a\":17,\"b\":25}",
+                ToolCallId = "call_abc",
+                Role = Role.Assistant,
+            },
+            new ToolCallResultMessage { ToolCallId = "call_abc", Result = "42", Role = Role.Tool },
+        };
+
+        var request = MessageMapper.BuildRequest(messages, options: null);
+
+        request.Input.Should().HaveCount(3);
+        request.Input[1].Type.Should().Be("function_call");
+        request.Input[1].CallId.Should().Be("call_abc");
+        request.Input[1].Name.Should().Be("add");
+        request.Input[1].Arguments.Should().Be("{\"a\":17,\"b\":25}");
+        request.Input[2].Type.Should().Be("function_call_output");
+        request.Input[2].CallId.Should().Be("call_abc");
+        request.Input[2].Output.Should().Be("42");
+    }
+
+    [Fact]
+    public void CompositeMessage_wrapping_aggregate_tool_call_round_trips()
+    {
+        // This is the ACTUAL shape the multi-turn loop replays: an assistant turn grouped into a
+        // CompositeMessage that contains a ToolsCallAggregateMessage (tool call + its result).
+        // The mapper must unwrap both, or the model never sees the result and loops forever.
+        var toolCall = new ToolsCallMessage
+        {
+            ToolCalls = [new ToolCall { FunctionName = "calculate", FunctionArgs = "{\"a\":17,\"b\":25}", ToolCallId = "call_xyz" }],
+            Role = Role.Assistant,
+        };
+        var toolResult = new ToolsCallResultMessage
+        {
+            ToolCallResults = [new ToolCallResult("call_xyz", "42")],
+            Role = Role.Tool,
+        };
+        var composite = new CompositeMessage
+        {
+            Messages = [new ToolsCallAggregateMessage(toolCall, toolResult)],
+            Role = Role.Assistant,
+        };
+
+        var messages = new IMessage[] { new TextMessage { Role = Role.User, Text = "add 17 and 25" }, composite };
+
+        var request = MessageMapper.BuildRequest(messages, options: null);
+
+        request.Input.Select(i => i.Type).Should().Equal("message", "function_call", "function_call_output");
+        var call = request.Input[1];
+        call.CallId.Should().Be("call_xyz");
+        call.Name.Should().Be("calculate");
+        call.Arguments.Should().Be("{\"a\":17,\"b\":25}");
+        var output = request.Input[2];
+        output.CallId.Should().Be("call_xyz");
+        output.Output.Should().Be("42");
     }
 
     [Fact]

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentToolCallTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentToolCallTests.cs
@@ -1,0 +1,118 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Tests;
+
+/// <summary>
+///     Targeted tests for <see cref="OpenAiResponsesAgent"/>'s function-call emission, driven by a
+///     hand-scripted event stream so individual event fields (notably the per-event
+///     <c>item_id</c>) can be controlled precisely.
+/// </summary>
+public sealed class OpenAiResponsesAgentToolCallTests
+{
+    private sealed class ScriptedClient(IReadOnlyList<ResponseEvent> events) : IOpenAiResponsesClient
+    {
+        public async IAsyncEnumerable<ResponseEvent> StreamResponseAsync(
+            ResponseCreateRequest request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            foreach (var ev in events)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return ev;
+                await Task.Yield();
+            }
+        }
+
+        public void Dispose() { }
+    }
+
+    private static JsonElement El(string json) => JsonSerializer.Deserialize<JsonElement>(json);
+
+    private static async Task<List<ToolsCallMessage>> RunAsync(IReadOnlyList<ResponseEvent> events)
+    {
+        using var agent = new OpenAiResponsesAgent("test", new ScriptedClient(events));
+        var stream = await agent.GenerateReplyStreamingAsync(
+            [new TextMessage { Role = Role.User, Text = "go" }]
+        );
+
+        var calls = new List<ToolsCallMessage>();
+        await foreach (var message in stream)
+        {
+            if (message is ToolsCallMessage tc)
+            {
+                calls.Add(tc);
+            }
+        }
+
+        return calls;
+    }
+
+    [Fact]
+    public async Task Tool_call_emitted_from_output_item_done_when_delta_item_ids_rotate()
+    {
+        // The GitHub Copilot stream rotates (encrypts) the per-event item_id, so the
+        // delta-correlation path can never match. The terminal output_item.done carries the
+        // complete function_call — exactly one ToolsCallMessage must result (not zero, not two).
+        var events = new ResponseEvent[]
+        {
+            new ResponseLifecycleEvent { Type = ResponseEventTypes.ResponseCreated, Response = El("{\"id\":\"resp_1\"}") },
+            new ResponseOutputItemEvent
+            {
+                Type = ResponseEventTypes.OutputItemAdded,
+                OutputIndex = 0,
+                Item = El("{\"type\":\"function_call\",\"id\":\"item-A\",\"call_id\":\"call_1\",\"name\":\"add\"}"),
+            },
+            new ResponseFunctionCallArgumentsDeltaEvent { Type = ResponseEventTypes.FunctionCallArgumentsDelta, ItemId = "rotated-1", Delta = "{\"a\":1" },
+            new ResponseFunctionCallArgumentsDoneEvent { Type = ResponseEventTypes.FunctionCallArgumentsDone, ItemId = "rotated-2", Arguments = "{\"a\":1,\"b\":2}" },
+            new ResponseOutputItemEvent
+            {
+                Type = ResponseEventTypes.OutputItemDone,
+                OutputIndex = 0,
+                Item = El("{\"type\":\"function_call\",\"id\":\"item-Z\",\"call_id\":\"call_1\",\"name\":\"add\",\"arguments\":\"{\\\"a\\\":1,\\\"b\\\":2}\"}"),
+            },
+            new ResponseLifecycleEvent { Type = ResponseEventTypes.ResponseCompleted, Response = El("{\"id\":\"resp_1\"}") },
+        };
+
+        var calls = await RunAsync(events);
+
+        calls.Should().ContainSingle("rotated delta item_ids must yield exactly one tool call via output_item.done");
+        var call = calls[0].ToolCalls.Should().ContainSingle().Subject;
+        call.FunctionName.Should().Be("add");
+        call.ToolCallId.Should().Be("call_1");
+        call.FunctionArgs.Should().Contain("\"b\":2");
+    }
+
+    [Fact]
+    public async Task Tool_call_not_duplicated_when_delta_path_and_output_item_done_both_resolve()
+    {
+        // Standard OpenAI stream: item_ids match, so the delta path emits first. The subsequent
+        // output_item.done for the same call_id must be deduped (one tool call, not two).
+        var events = new ResponseEvent[]
+        {
+            new ResponseOutputItemEvent
+            {
+                Type = ResponseEventTypes.OutputItemAdded,
+                OutputIndex = 0,
+                Item = El("{\"type\":\"function_call\",\"id\":\"item-1\",\"call_id\":\"call_9\",\"name\":\"mul\"}"),
+            },
+            new ResponseFunctionCallArgumentsDoneEvent { Type = ResponseEventTypes.FunctionCallArgumentsDone, ItemId = "item-1", Arguments = "{\"x\":3}" },
+            new ResponseOutputItemEvent
+            {
+                Type = ResponseEventTypes.OutputItemDone,
+                OutputIndex = 0,
+                Item = El("{\"type\":\"function_call\",\"id\":\"item-1\",\"call_id\":\"call_9\",\"name\":\"mul\",\"arguments\":\"{\\\"x\\\":3}\"}"),
+            },
+        };
+
+        var calls = await RunAsync(events);
+
+        calls.Should().ContainSingle("the delta path and output_item.done must not both emit the same call_id");
+        calls[0].ToolCalls.Should().ContainSingle().Which.ToolCallId.Should().Be("call_9");
+    }
+}


### PR DESCRIPTION
## Summary
Adds a shared GitHub Copilot transport so the existing **OpenAI Responses** and **Anthropic** providers can use a GitHub Copilot subscription as their backend (`api.enterprise.githubcopilot.com`), reusing a Copilot login instead of separate OpenAI/Anthropic keys. Along the way it fixes the Responses-API tool-calling path, which was broken end-to-end (a 400 on `tools[].parameters`, then an infinite tool-call loop).

The protocol was reverse-engineered from captured GitHub Copilot CLI traffic; the raw `gho_` token is used directly (no token exchange).

## Changes
**Shared transport (LmCore)**
- `ICopilotTokenProvider` with a CLI-credential reader (env vars, Copilot CLI `config.json` (JSONC), `gh` `hosts.yml`, `gh auth token`) and a device-flow fallback.
- `CopilotHeadersHandler` (bearer auth + `copilot-integration-id`/`editor-version`/`x-github-api-version`/`user-agent`, fresh `x-interaction-id` per request, stable machine/session ids), `CopilotSessionContext`, `CopilotOptions`, `CopilotRequestHeaders`, `CopilotHttpClientFactory`.

**Providers**
- Anthropic `/v1/messages` via Copilot — `CopilotAnthropicAgentFactory` (reuses `AnthropicAgent` unchanged).
- OpenAI `/responses` via Copilot over **SSE and WebSocket** — `CopilotResponsesAgentFactory`, `CopilotResponsesWebSocketClient` (multi-turn `previous_response_id` chaining); configurable responses path; new `reasoning`/`text`/`store`/`parallel_tool_calls`/`initiator` request fields.
- `LmStreaming.Sample`: four new selectable providers — Sonnet, Haiku, GPT-5.5, GPT-5.5 mini.

**Bug fixes (pre-existing, surfaced by real Copilot traffic)**
- `tools[].parameters` is now a JSON Schema object, not an array (fixes a 400).
- Tool round-trip: `function_call` carries `name`+`arguments`; `MessageMapper` recurses `CompositeMessage` and unpacks `ToolsCallAggregateMessage` so the replayed tool result actually reaches the model (fixes an infinite tool-call loop).
- Agent emits tool calls from `output_item.done` (Copilot rotates the per-event `item_id`), deduped by `call_id`.
- Anthropic deserializer tolerates an out-of-order `type` discriminator (net9 `AllowOutOfOrderMetadataProperties`).

## Testing
- Unit/integration: full solution green — incl. `OpenAiResponsesProvider.Tests`, `AnthropicProvider.Tests` (166), `LmCore.Tests` (741, incl. new Copilot auth tests). New tests cover token providers, header injection, mapper tool round-trip (composite/aggregate), and WebSocket framing/chaining. (~2,460 passing, 0 real failures.)
- E2E: `LmStreaming.Sample.E2E.Tests` 10/10; `LmStreaming.Sample.Browser.E2E.Tests` 13 passed / 4 skipped (CLI-gated).
- Live (manual `CopilotLive.Tests`, excluded from CI, gated on a Copilot login): 6/6 against the real API — Anthropic stream + non-stream, Responses SSE + WebSocket, multi-turn chaining.
- Verified in the sample app: Sonnet/Haiku/GPT-5.5/GPT-5.5 mini answer; calculator tool round-trip completes ("17 plus 25 equals 42.") with no loop.

Note: `CopilotLive.Tests` is intentionally **not** in the solution / CI; run it on demand with `dotnet test tests/CopilotLive.Tests`. Defaults mimic the Copilot CLI's integration headers (a ToS consideration).

## Related Issues
Fixes #63