### PR TITLE
fix: stop duplicate assistant bubbles for streamed text/reasoning finalization

### DIFF
--- a/samples/LmStreaming.Sample/CLAUDE.md
+++ b/samples/LmStreaming.Sample/CLAUDE.md
@@ -1,0 +1,68 @@
+# LmStreaming.Sample — Project Context
+
+A full-stack demo of the streaming chat pipeline: an ASP.NET Core backend (`Program.cs`,
+Kestrel on `http://localhost:5000`) that bridges `MultiTurnAgentLoop` to the browser over a
+WebSocket (`/ws`), plus a Vue 3 + Vite chat client in `ClientApp/` (dev server on
+`http://localhost:5173`, proxying `/api` and `/ws` to `:5000`).
+
+## Running locally
+```bash
+# Backend (Development env pairs with the Vite dev server)
+dotnet run --project samples/LmStreaming.Sample        # serves API + /ws on :5000
+# Frontend (separate terminal)
+npm --prefix samples/LmStreaming.Sample/ClientApp install
+npm --prefix samples/LmStreaming.Sample/ClientApp run dev   # http://localhost:5173
+```
+Provider is chosen in the UI (header dropdown, `GET /api/providers`). Copilot-backed providers
+("GPT-5.5 (Copilot)", "Sonnet/Haiku (Copilot)") need a resolvable Copilot/`gh` token, no API key.
+Add `?record=1` to the URL to dump the WebSocket stream + LLM request/response to `recordings/`.
+
+## UI / browser testing — READ THIS BEFORE WRITING BROWSER TESTS
+
+There are **two** Playwright surfaces. Keep them aligned; do not invent a third.
+
+1. **Authoritative automated regression — `tests/LmStreaming.Sample.Browser.E2E.Tests/`.**
+   Runs the real chat client under headless Chromium against a **scripted SSE backend (no real
+   LLM, deterministic, CI-safe)**. Look here FIRST for how to test UI behavior; copy an existing
+   scenario rather than starting from scratch.
+   - `Infrastructure/BrowserWebAppFactory.cs` — boots the app + scripted backend on an ephemeral port.
+   - `Infrastructure/UiHelpers.cs` — the **selector contract** (extension methods over `data-testid`).
+   - `Infrastructure/DomAssertions.cs` — await-don't-sleep helpers (`WaitForStreamIdleAsync`, …).
+   - `Scenarios/*.cs` — `MultiTurnConversationTests`, `ModeSwitchingTests`, `ClaudeMockProviderTests`,
+     `CancellationTests`, `ErrorHandlingTests`, … `dotnet test` runs them all (no exclusions).
+
+2. **Manual / exploratory (Claude MCP Playwright) — `PlaywrightTestingGuide.md`.**
+   Ready-to-run MCP scripts for ad-hoc checks. See its "Rationalization & fastest browser control"
+   section for the canonical fast patterns and the selector cross-reference.
+
+### Control the browser the FASTEST way possible
+- **Select by `data-testid`, never by brittle CSS classes.** The stable contract (see `UiHelpers.cs`):
+  `chat-input-textarea`, `send-button`, `stop-button`, `clear-button`, `error-banner`,
+  `message-list`, `user-message-group`, `assistant-message-group`, `assistant-text` (the answer
+  bubble — equals the `.text-bubble` element), `metadata-pill`, `thinking-pill`, `tool-call-pill`
+  (carries `data-tool-name`), `mode-selector-button` / `mode-option-{id}`,
+  `provider-selector-button` / `provider-option-{id}`.
+- **Bulk-extract DOM state in ONE `browser_evaluate` call** instead of many snapshot/locator
+  round-trips. e.g. count answer bubbles (the duplicate-bubble check):
+  ```js
+  () => [...document.querySelectorAll('[data-testid="assistant-text"]')].map(n => n.textContent.trim())
+  ```
+- **Wait on state, not time.** Stream finished = stop-button hidden + send-button visible
+  (`WaitForStreamIdleAsync`); MCP: `browser_wait_for` on `[data-testid=send-button]` enabled.
+  Never `Task.Delay`/fixed sleeps.
+- Select a provider: click `provider-selector-button`, then `provider-option-<id>` (e.g.
+  `provider-option-gpt-5.5`). A new chat resets the provider; pick it BEFORE the first send (the
+  thread locks to whatever provider is active when the first message is sent).
+
+## Message pipeline gotcha (why "duplicate bubble" regressions exist)
+Providers stream text as `TextUpdateMessage` deltas **and then** a finalizing `TextMessage`
+(same `generationId`). Two layers must treat that as ONE logical message:
+- `MessageTransformationMiddleware` gives the finalizing message the **same `messageOrderIdx`** as
+  its deltas (the client merge key is `kind-runId-generationId-messageOrderIdx`).
+- `MessageUpdateJoinerMiddleware` must **not** also emit a synthesized "built" copy beside the
+  provider's finalizing message (else history/persistence/reload store it twice).
+Regression coverage (all CI-runnable): `LmCore.Tests/Middleware/MessageTransformationMiddlewareTests`,
+`LmCore.Tests/Middleware/MessageUpdateJoinerMiddlewareTests`, and
+`OpenAiResponsesProvider.Tests/OpenAiResponsesAgentTests` (drives the real mock OpenAI `/responses`
+SSE stream through the pipeline). Add new duplicate-render checks at these levels first; a browser
+scenario in `Browser.E2E.Tests` is the optional top-of-pyramid.

--- a/samples/LmStreaming.Sample/PlaywrightTestingGuide.md
+++ b/samples/LmStreaming.Sample/PlaywrightTestingGuide.md
@@ -475,3 +475,82 @@ page.locator('.mode-name').textContent()    // Returns e.g. "General Assistant"
 | Thinking pills missing | Mode doesn't use thinking model | Switch to Medical Knowledge or test-anthropic mode |
 | Second turn fails with error | ReasoningMessage lost in history | Check MessageTransformationMiddleware fix is applied |
 | Recording files not created | Dump disabled for thread | Check `RequestResponseDumpFileName` in options |
+
+---
+
+## Rationalization & Fastest Browser Control
+
+We have **two** Playwright surfaces. They must stay aligned on selectors and waiting strategy.
+
+| Surface | Where | Purpose | Backend |
+|---------|-------|---------|---------|
+| **Automated regression (authoritative)** | `tests/LmStreaming.Sample.Browser.E2E.Tests/` (.NET, `Microsoft.Playwright`, headless Chromium) | CI regression; the source of truth for "what the UI must do" | **Scripted SSE, no real LLM** (`BrowserWebAppFactory` + `OpenAiResponsesTestSseMessageHandler`) |
+| **Manual / exploratory (this guide)** | Claude MCP `mcp__playwright__browser_*` | Ad-hoc checks, new-scenario spikes, debugging a live provider | Whatever provider is selected (incl. real Copilot) |
+
+**Rule of thumb:** prototype a flow here with MCP, then promote the keeper checks into a
+`Scenarios/*.cs` test so they run in CI. Don't let the two drift.
+
+### Selector contract — prefer `data-testid` (used by the automated suite)
+
+The automated suite resolves everything via `data-testid` (see
+`tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs`). The older class-based
+selectors in the scripts above still work, but **new scripts should use the `data-testid` contract**
+so manual and automated tests target identical elements.
+
+| Element | `data-testid` (authoritative) | Legacy CSS class (this guide's older scripts) |
+|---------|-------------------------------|-----------------------------------------------|
+| Message textarea | `chat-input-textarea` | `.chat-input textarea` |
+| Send button | `send-button` | `.chat-input button` |
+| Stop button (stream active) | `stop-button` | — |
+| Assistant answer bubble | `assistant-text` | `.text-bubble` (same element) |
+| Assistant group | `assistant-message-group` | `.assistant-message-wrapper` |
+| User group | `user-message-group` | `.user-message-wrapper` |
+| Tool-call pill (`data-tool-name`) | `tool-call-pill` | `.pill-item` (tool) |
+| Thinking pill | `thinking-pill` | `.pill-item:has-text("Thinking:")` |
+| Mode selector / option | `mode-selector-button` / `mode-option-{id}` | `.selector-btn` / `.menu-item` |
+| Provider selector / option | `provider-selector-button` / `provider-option-{id}` | (none — newer control) |
+| Error banner | `error-banner` | — |
+| Message list | `message-list` | `.message-list` |
+
+### Fastest MCP browser-control patterns
+
+1. **Bulk-read the DOM in ONE `browser_evaluate`** instead of many snapshot/locator round-trips.
+   The canonical "duplicate bubble" check (count answer bubbles):
+   ```js
+   () => [...document.querySelectorAll('[data-testid="assistant-text"]')].map(n => n.textContent.trim())
+   ```
+   Each answer string should appear exactly once.
+2. **Wait on state, not time** — never sleep. Stream finished = `stop-button` hidden and
+   `send-button` visible/enabled (mirrors `DomAssertions.WaitForStreamIdleAsync`). MCP:
+   `browser_wait_for` on the `send-button` becoming enabled.
+3. **Select provider before the first send.** A new chat resets the provider, and the thread locks
+   to the provider active when the first message is sent. Click `provider-selector-button` →
+   `provider-option-<id>`, verify the header, THEN send.
+
+### Canonical exploratory script: GPT-5.5 (Copilot) duplicate-bubble check
+
+This is the exact MCP flow used to find/verify the duplicate-assistant-bubble bug — reuse it for
+any "does each answer render once?" spike (live **and** after reload):
+
+```
+Navigate http://localhost:5173/?record=1
+Click [data-testid=provider-selector-button]; click [data-testid=provider-option-gpt-5.5]; confirm header
+# Turn 1 (plain text)
+Fill [data-testid=chat-input-textarea] "What is the capital of France? Answer in one sentence."
+Click [data-testid=send-button]; wait until send-button enabled again
+Evaluate the bubble-count snippet  -> expect the answer exactly once
+# Turn 2 (tool call) — expect 1 [data-testid=tool-call-pill] and the answer once
+Fill "Use the calculator tool to compute 1234 * 5678, then tell me the result." ; Send ; wait idle ; evaluate
+# Turn 3 (multi-turn) — context retained, answer once
+Fill "What was the previous result divided by 2?" ; Send ; wait idle ; evaluate
+# CRITICAL: reload regression (persisted/reconciled render)
+Navigate http://localhost:5173/?record=1 (reopen the thread) ; wait ; evaluate
+  -> each of the 3 answers must still appear EXACTLY once
+```
+
+The automated equivalent (scripted SSE, CI-safe) belongs in
+`tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/` using `page.AssistantText().CountAsync()`
++ `WaitForStreamIdleAsync()`. Lower, faster regressions for this specific bug already live in
+`LmCore.Tests` (`MessageTransformationMiddlewareTests`, `MessageUpdateJoinerMiddlewareTests`) and
+`OpenAiResponsesProvider.Tests` (`OpenAiResponsesAgentTests` — drives the mock OpenAI `/responses`
+SSE through the real middleware pipeline).

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -465,7 +465,8 @@ try
                         },
                         store: conversationStore,
                         logger: loggerFactory.CreateLogger<MultiTurnAgentLoop>(),
-                        subAgentOptions: subAgentOptions
+                        subAgentOptions: subAgentOptions,
+                        loggerFactory: loggerFactory
                     );
 
                     return new MultiTurnAgentPool.AgentCreationResult(agent, ownedResources);

--- a/src/LmCore/Middleware/MessageTransformationMiddleware.cs
+++ b/src/LmCore/Middleware/MessageTransformationMiddleware.cs
@@ -65,7 +65,7 @@ public class MessageTransformationMiddleware : IStreamingMiddleware
         );
 
         // DOWNSTREAM: Assign message ordering to replies
-        var orderedReplies = AssignMessageOrdering(replies);
+        var orderedReplies = AssignMessageOrdering(replies, _logger);
 
         if (_logger.IsEnabled(LogLevel.Debug))
         {
@@ -113,7 +113,7 @@ public class MessageTransformationMiddleware : IStreamingMiddleware
         );
 
         // DOWNSTREAM: Assign message ordering to streaming replies
-        return AssignMessageOrderingStreaming(streamingResponse);
+        return AssignMessageOrderingStreaming(streamingResponse, _logger);
     }
 
     #region Downstream: Assign Message Ordering
@@ -138,7 +138,8 @@ public class MessageTransformationMiddleware : IStreamingMiddleware
     /// </summary>
     private static IEnumerable<IMessage> ProcessMessageForOrdering(
         IMessage message,
-        OrderingState state
+        OrderingState state,
+        ILogger logger
     )
     {
         // Only assign ordering to messages with a GenerationId
@@ -203,9 +204,31 @@ public class MessageTransformationMiddleware : IStreamingMiddleware
                 break;
 
             case TextMessage m:
-                StartNewMessage();
-                var (textOrderIdx, _) = GetCurrentIndices();
-                yield return m with { MessageOrderIdx = textOrderIdx };
+                // A finalizing TextMessage consolidates the immediately-preceding TextUpdateMessage
+                // stream for this generation, so it must reuse that stream's messageOrderIdx — same
+                // as the TextWithCitationsMessage case above. Otherwise a consumer that merges by
+                // (generationId, messageOrderIdx) cannot merge it onto the streamed message and
+                // renders a duplicate text bubble. A standalone complete TextMessage (no open
+                // text_update stream) still starts a new message.
+                if (state.CurrentMessageIdentity[generationId] == "text_update")
+                {
+                    var (finalizedTextOrderIdx, _) = GetCurrentIndices();
+                    // Close the stream so a subsequent message (even another TextMessage) starts fresh.
+                    state.CurrentMessageIdentity[generationId] = null;
+                    logger.LogDebug(
+                        "Finalizing TextMessage reuses streamed messageOrderIdx {MessageOrderIdx} for generation {GenerationId} (merged with its text_update stream rather than creating a duplicate)",
+                        finalizedTextOrderIdx,
+                        generationId
+                    );
+                    yield return m with { MessageOrderIdx = finalizedTextOrderIdx };
+                }
+                else
+                {
+                    StartNewMessage();
+                    var (textOrderIdx, _) = GetCurrentIndices();
+                    yield return m with { MessageOrderIdx = textOrderIdx };
+                }
+
                 break;
 
             case TextUpdateMessage m:
@@ -217,9 +240,27 @@ public class MessageTransformationMiddleware : IStreamingMiddleware
                 break;
 
             case ReasoningMessage m:
-                StartNewMessage();
-                var (reasoningOrderIdx, _) = GetCurrentIndices();
-                yield return m with { MessageOrderIdx = reasoningOrderIdx };
+                // Mirror the TextMessage rule: a finalizing ReasoningMessage consolidates its
+                // preceding ReasoningUpdateMessage stream and must share that stream's
+                // messageOrderIdx so consumers merge instead of duplicating.
+                if (state.CurrentMessageIdentity[generationId] == "reasoning_update")
+                {
+                    var (finalizedReasoningOrderIdx, _) = GetCurrentIndices();
+                    state.CurrentMessageIdentity[generationId] = null;
+                    logger.LogDebug(
+                        "Finalizing ReasoningMessage reuses streamed messageOrderIdx {MessageOrderIdx} for generation {GenerationId} (merged with its reasoning_update stream rather than creating a duplicate)",
+                        finalizedReasoningOrderIdx,
+                        generationId
+                    );
+                    yield return m with { MessageOrderIdx = finalizedReasoningOrderIdx };
+                }
+                else
+                {
+                    StartNewMessage();
+                    var (reasoningOrderIdx, _) = GetCurrentIndices();
+                    yield return m with { MessageOrderIdx = reasoningOrderIdx };
+                }
+
                 break;
 
             case ReasoningUpdateMessage m:
@@ -386,13 +427,13 @@ public class MessageTransformationMiddleware : IStreamingMiddleware
     /// <summary>
     /// Assigns messageOrderIdx and chunkIdx to messages with the same GenerationId
     /// </summary>
-    private static IEnumerable<IMessage> AssignMessageOrdering(IEnumerable<IMessage> messages)
+    private static IEnumerable<IMessage> AssignMessageOrdering(IEnumerable<IMessage> messages, ILogger logger)
     {
         var state = new OrderingState();
 
         foreach (var message in messages)
         {
-            foreach (var processedMessage in ProcessMessageForOrdering(message, state))
+            foreach (var processedMessage in ProcessMessageForOrdering(message, state, logger))
             {
                 yield return processedMessage;
             }
@@ -403,14 +444,15 @@ public class MessageTransformationMiddleware : IStreamingMiddleware
     /// Assigns messageOrderIdx and chunkIdx to streaming messages on the fly
     /// </summary>
     private static async IAsyncEnumerable<IMessage> AssignMessageOrderingStreaming(
-        IAsyncEnumerable<IMessage> messages
+        IAsyncEnumerable<IMessage> messages,
+        ILogger logger
     )
     {
         var state = new OrderingState();
 
         await foreach (var message in messages)
         {
-            foreach (var processedMessage in ProcessMessageForOrdering(message, state))
+            foreach (var processedMessage in ProcessMessageForOrdering(message, state, logger))
             {
                 yield return processedMessage;
             }

--- a/src/LmCore/Middleware/MessageTransformationMiddleware.cs
+++ b/src/LmCore/Middleware/MessageTransformationMiddleware.cs
@@ -240,27 +240,14 @@ public class MessageTransformationMiddleware : IStreamingMiddleware
                 break;
 
             case ReasoningMessage m:
-                // Mirror the TextMessage rule: a finalizing ReasoningMessage consolidates its
-                // preceding ReasoningUpdateMessage stream and must share that stream's
-                // messageOrderIdx so consumers merge instead of duplicating.
-                if (state.CurrentMessageIdentity[generationId] == "reasoning_update")
-                {
-                    var (finalizedReasoningOrderIdx, _) = GetCurrentIndices();
-                    state.CurrentMessageIdentity[generationId] = null;
-                    logger.LogDebug(
-                        "Finalizing ReasoningMessage reuses streamed messageOrderIdx {MessageOrderIdx} for generation {GenerationId} (merged with its reasoning_update stream rather than creating a duplicate)",
-                        finalizedReasoningOrderIdx,
-                        generationId
-                    );
-                    yield return m with { MessageOrderIdx = finalizedReasoningOrderIdx };
-                }
-                else
-                {
-                    StartNewMessage();
-                    var (reasoningOrderIdx, _) = GetCurrentIndices();
-                    yield return m with { MessageOrderIdx = reasoningOrderIdx };
-                }
-
+                // Reasoning finalization is intentionally NOT merged onto its update stream here.
+                // The OpenAI Responses reasoning item carries its content differently from the
+                // streamed deltas, and merging caused thinking blocks to stop rendering. Reasoning
+                // duplicate-display is already handled client-side, so a finalizing ReasoningMessage
+                // starts its own message (original behavior).
+                StartNewMessage();
+                var (reasoningOrderIdx, _) = GetCurrentIndices();
+                yield return m with { MessageOrderIdx = reasoningOrderIdx };
                 break;
 
             case ReasoningUpdateMessage m:

--- a/src/LmCore/Middleware/MessageTransformationMiddleware.cs
+++ b/src/LmCore/Middleware/MessageTransformationMiddleware.cs
@@ -13,6 +13,13 @@ namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
 ///     This enables the new simplified message flow while maintaining backward compatibility
 ///     with provider transformations that expect aggregated messages.
 /// </summary>
+/// <remarks>
+///     Composition order matters on the response path: this middleware MUST run before
+///     <see cref="MessageUpdateJoinerMiddleware" /> (Transformation → Joiner). Transformation assigns
+///     the messageOrderIdx that lets a finalizing TextMessage merge onto its streamed deltas; the
+///     Joiner then suppresses the synthesized duplicate for history. Omitting or reordering these
+///     two middlewares reintroduces duplicate assistant messages.
+/// </remarks>
 public class MessageTransformationMiddleware : IStreamingMiddleware
 {
     private readonly ILogger<MessageTransformationMiddleware> _logger;
@@ -215,11 +222,15 @@ public class MessageTransformationMiddleware : IStreamingMiddleware
                     var (finalizedTextOrderIdx, _) = GetCurrentIndices();
                     // Close the stream so a subsequent message (even another TextMessage) starts fresh.
                     state.CurrentMessageIdentity[generationId] = null;
-                    logger.LogDebug(
-                        "Finalizing TextMessage reuses streamed messageOrderIdx {MessageOrderIdx} for generation {GenerationId} (merged with its text_update stream rather than creating a duplicate)",
-                        finalizedTextOrderIdx,
-                        generationId
-                    );
+                    if (logger.IsEnabled(LogLevel.Debug))
+                    {
+                        logger.LogDebug(
+                            "Finalizing TextMessage reuses streamed messageOrderIdx {MessageOrderIdx} for generation {GenerationId} (merged with its text_update stream rather than creating a duplicate)",
+                            finalizedTextOrderIdx,
+                            generationId
+                        );
+                    }
+
                     yield return m with { MessageOrderIdx = finalizedTextOrderIdx };
                 }
                 else

--- a/src/LmCore/Middleware/MessageUpdateJoinerMiddleware.cs
+++ b/src/LmCore/Middleware/MessageUpdateJoinerMiddleware.cs
@@ -2,6 +2,8 @@ using System.Runtime.CompilerServices;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Utils;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
 
@@ -10,13 +12,17 @@ namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
 /// </summary>
 public class MessageUpdateJoinerMiddleware : IStreamingMiddleware
 {
+    private readonly ILogger _logger;
+
     /// <summary>
     ///     Initializes a new instance of the <see cref="MessageUpdateJoinerMiddleware" /> class.
     /// </summary>
     /// <param name="name">Optional name for the middleware.</param>
-    public MessageUpdateJoinerMiddleware(string? name = null)
+    /// <param name="logger">Optional logger; de-dup decisions are logged at Debug level.</param>
+    public MessageUpdateJoinerMiddleware(string? name = null, ILogger<MessageUpdateJoinerMiddleware>? logger = null)
     {
         Name = name ?? nameof(MessageUpdateJoinerMiddleware);
+        _logger = logger ?? NullLogger<MessageUpdateJoinerMiddleware>.Instance;
     }
 
     /// <summary>
@@ -53,11 +59,12 @@ public class MessageUpdateJoinerMiddleware : IStreamingMiddleware
             context.Options,
             cancellationToken
         );
-        return TransformStreamWithBuilder(sourceStream, cancellationToken);
+        return TransformStreamWithBuilder(sourceStream, _logger, cancellationToken);
     }
 
     private static async IAsyncEnumerable<IMessage> TransformStreamWithBuilder(
         IAsyncEnumerable<IMessage> sourceStream,
+        ILogger logger,
         [EnumeratorCancellation] CancellationToken cancellationToken = default
     )
     {
@@ -90,17 +97,41 @@ public class MessageUpdateJoinerMiddleware : IStreamingMiddleware
             // Check if we're switching message types and need to complete current builder
             if (lastMessageType != null && lastMessageType != message.GetType() && activeBuilder != null)
             {
-                // Track if we're completing a tool call builder
-                if (activeBuilder is ToolCallMessageBuilder)
-                {
-                    completedToolCallCount++;
-                }
+                // When the provider follows a streamed delta sequence with its OWN finalized complete
+                // message of the same kind (TextUpdateMessage… → TextMessage, or
+                // ReasoningUpdateMessage… → ReasoningMessage), that finalized message already IS the
+                // joined result. Emitting the builder's synthesized copy as well would forward/persist
+                // the same logical message twice (duplicate assistant bubble + duplicate history that
+                // also bloats the next turn's prompt). Discard the synthesized copy and let the
+                // incoming finalized message be the single representation.
+                var incomingFinalizesActiveBuilder =
+                    (message is TextMessage && activeBuilder is TextMessageBuilder)
+                    || (message is ReasoningMessage && activeBuilder is ReasoningMessageBuilder);
 
-                // Complete the previous builder before processing the new message
-                var builtMessage = activeBuilder.Build();
-                activeBuilder = null;
-                activeBuilderType = null;
-                yield return builtMessage;
+                if (incomingFinalizesActiveBuilder)
+                {
+                    logger.LogDebug(
+                        "Joiner suppressed synthesized {MessageType} duplicate for generation {GenerationId}; provider supplied a finalizing complete message",
+                        message.GetType().Name,
+                        message.GenerationId
+                    );
+                    activeBuilder = null;
+                    activeBuilderType = null;
+                }
+                else
+                {
+                    // Track if we're completing a tool call builder
+                    if (activeBuilder is ToolCallMessageBuilder)
+                    {
+                        completedToolCallCount++;
+                    }
+
+                    // Complete the previous builder before processing the new message
+                    var builtMessage = activeBuilder.Build();
+                    activeBuilder = null;
+                    activeBuilderType = null;
+                    yield return builtMessage;
+                }
             }
 
             // Check if tool call ID/Index changed for singular ToolCallUpdateMessage

--- a/src/LmCore/Middleware/MessageUpdateJoinerMiddleware.cs
+++ b/src/LmCore/Middleware/MessageUpdateJoinerMiddleware.cs
@@ -97,16 +97,18 @@ public class MessageUpdateJoinerMiddleware : IStreamingMiddleware
             // Check if we're switching message types and need to complete current builder
             if (lastMessageType != null && lastMessageType != message.GetType() && activeBuilder != null)
             {
-                // When the provider follows a streamed delta sequence with its OWN finalized complete
-                // message of the same kind (TextUpdateMessage… → TextMessage, or
-                // ReasoningUpdateMessage… → ReasoningMessage), that finalized message already IS the
-                // joined result. Emitting the builder's synthesized copy as well would forward/persist
-                // the same logical message twice (duplicate assistant bubble + duplicate history that
-                // also bloats the next turn's prompt). Discard the synthesized copy and let the
-                // incoming finalized message be the single representation.
+                // When the provider follows a streamed text-delta sequence with its OWN finalized
+                // TextMessage, that finalized message already IS the joined result. Emitting the
+                // builder's synthesized copy as well would forward/persist the same logical message
+                // twice (duplicate assistant bubble + duplicate history that also bloats the next
+                // turn's prompt). Discard the synthesized copy and let the incoming finalized message
+                // be the single representation.
+                //
+                // NOTE: This applies to text only. Reasoning is intentionally excluded — the OpenAI
+                // Responses reasoning item carries its content differently from the streamed reasoning
+                // deltas, so suppressing the built reasoning here stops thinking blocks from rendering.
                 var incomingFinalizesActiveBuilder =
-                    (message is TextMessage && activeBuilder is TextMessageBuilder)
-                    || (message is ReasoningMessage && activeBuilder is ReasoningMessageBuilder);
+                    message is TextMessage && activeBuilder is TextMessageBuilder;
 
                 if (incomingFinalizesActiveBuilder)
                 {

--- a/src/LmCore/Middleware/MessageUpdateJoinerMiddleware.cs
+++ b/src/LmCore/Middleware/MessageUpdateJoinerMiddleware.cs
@@ -10,6 +10,12 @@ namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
 /// <summary>
 ///     Middleware that joins update messages into larger messages for more efficient processing.
 /// </summary>
+/// <remarks>
+///     Composition order matters on the response path: this middleware MUST run after
+///     <see cref="MessageTransformationMiddleware" /> (Transformation → Joiner) so that finalizing
+///     text messages already carry their assigned messageOrderIdx. Reordering or omitting either
+///     middleware reintroduces duplicate assistant messages.
+/// </remarks>
 public class MessageUpdateJoinerMiddleware : IStreamingMiddleware
 {
     private readonly ILogger _logger;
@@ -107,16 +113,25 @@ public class MessageUpdateJoinerMiddleware : IStreamingMiddleware
                 // NOTE: This applies to text only. Reasoning is intentionally excluded — the OpenAI
                 // Responses reasoning item carries its content differently from the streamed reasoning
                 // deltas, so suppressing the built reasoning here stops thinking blocks from rendering.
+                // Also require a matching GenerationId: a finalizing TextMessage may only supersede
+                // the builder it actually finalizes. Without this, an interleaved generation
+                // (gen1: TextUpdate…, gen2: TextMessage) could silently drop gen1's accumulated text.
                 var incomingFinalizesActiveBuilder =
-                    message is TextMessage && activeBuilder is TextMessageBuilder;
+                    message is TextMessage
+                    && activeBuilder is TextMessageBuilder textBuilder
+                    && textBuilder.GenerationId == message.GenerationId;
 
                 if (incomingFinalizesActiveBuilder)
                 {
-                    logger.LogDebug(
-                        "Joiner suppressed synthesized {MessageType} duplicate for generation {GenerationId}; provider supplied a finalizing complete message",
-                        message.GetType().Name,
-                        message.GenerationId
-                    );
+                    if (logger.IsEnabled(LogLevel.Debug))
+                    {
+                        logger.LogDebug(
+                            "Joiner suppressed synthesized {MessageType} duplicate for generation {GenerationId}; provider supplied a finalizing complete message",
+                            message.GetType().Name,
+                            message.GenerationId
+                        );
+                    }
+
                     activeBuilder = null;
                     activeBuilderType = null;
                 }

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -65,6 +65,11 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
     /// <param name="store">Optional persistence store for conversation state</param>
     /// <param name="logger">Optional logger</param>
     /// <param name="subAgentOptions">Optional sub-agent orchestration configuration</param>
+    /// <param name="loggerFactory">
+    ///     Optional logger factory used to give the internal message pipeline middlewares
+    ///     (MessageTransformation, MessageUpdateJoiner) their own category loggers so their
+    ///     ordering/de-dup decisions are visible in structured logs. When null they stay silent.
+    /// </param>
     public MultiTurnAgentLoop(
         IStreamingAgent providerAgent,
         FunctionRegistry functionRegistry,
@@ -76,7 +81,8 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         int outputChannelCapacity = 1000,
         IConversationStore? store = null,
         ILogger<MultiTurnAgentLoop>? logger = null,
-        SubAgentOptions? subAgentOptions = null)
+        SubAgentOptions? subAgentOptions = null,
+        ILoggerFactory? loggerFactory = null)
         : base(threadId, systemPrompt, defaultOptions, maxTurnsPerRun, inputChannelCapacity, outputChannelCapacity, store, logger)
     {
         ArgumentNullException.ThrowIfNull(providerAgent);
@@ -116,10 +122,12 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         // Build the complete middleware stack (loop owns the pipeline)
         // Response path order: Provider -> MessageTransformation -> JsonFragment -> Publishing -> Joiner -> ToolCall
         _agent = providerAgent
-            .WithMessageTransformation()
+            .WithMessageTransformation(loggerFactory?.CreateLogger<MessageTransformationMiddleware>())
             .WithMiddleware(new JsonFragmentUpdateMiddleware())
             .WithMiddleware(publishingMiddleware)
-            .WithMiddleware(new MessageUpdateJoinerMiddleware(name: "MessageJoiner"))
+            .WithMiddleware(new MessageUpdateJoinerMiddleware(
+                name: "MessageJoiner",
+                logger: loggerFactory?.CreateLogger<MessageUpdateJoinerMiddleware>()))
             .WithMiddleware(toolCallMiddleware);
     }
 

--- a/tests/LmCore.Tests/Middleware/MessageTransformationMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/MessageTransformationMiddlewareTests.cs
@@ -399,32 +399,6 @@ public class MessageTransformationMiddlewareTests
         Assert.Equal(0, textUpdate3.ChunkIdx);
     }
 
-    [Fact]
-    public async Task Downstream_FinalizingReasoningMessage_SharesOrderIdx_WithPrecedingReasoningUpdateStream()
-    {
-        // Same rule as text: a finalizing ReasoningMessage consolidates its ReasoningUpdateMessage
-        // deltas and must share their messageOrderIdx so consumers merge instead of duplicating.
-        // Arrange
-        var middleware = new MessageTransformationMiddleware();
-        var agent = new MockAgent(
-            new ReasoningUpdateMessage { Reasoning = "Think", GenerationId = "gen1" },
-            new ReasoningUpdateMessage { Reasoning = "ing", GenerationId = "gen1" },
-            new ReasoningMessage { Reasoning = "Thinking", GenerationId = "gen1" }
-        );
-        var context = new MiddlewareContext(Messages: [], Options: null);
-        // Act
-        var result = await middleware.InvokeAsync(context, agent);
-        var messages = result.ToList();
-        // Assert
-        Assert.Equal(3, messages.Count);
-        var reasoningUpdate1 = Assert.IsType<ReasoningUpdateMessage>(messages[0]);
-        var reasoningUpdate2 = Assert.IsType<ReasoningUpdateMessage>(messages[1]);
-        var reasoningMessage = Assert.IsType<ReasoningMessage>(messages[2]);
-        Assert.Equal(0, reasoningUpdate1.MessageOrderIdx);
-        Assert.Equal(0, reasoningUpdate2.MessageOrderIdx);
-        // The finalizing ReasoningMessage shares the stream's orderIdx (0), not a bumped one.
-        Assert.Equal(0, reasoningMessage.MessageOrderIdx);
-    }
     #endregion
     #region Plural to Singular Conversion Tests
     [Fact]
@@ -748,26 +722,25 @@ public class MessageTransformationMiddlewareTests
         Assert.Equal(0, reasoningUpdate1.ChunkIdx);
         Assert.Equal(0, reasoningUpdate2.MessageOrderIdx);
         Assert.Equal(1, reasoningUpdate2.ChunkIdx);
-        // Complete reasoning shares its reasoning_update stream's orderIdx (0), not a bumped one,
-        // so consumers merge it onto the streamed reasoning instead of duplicating it.
+        // Complete reasoning: orderIdx=1 (reasoning finalization starts its own message)
         var reasoning = Assert.IsType<ReasoningMessage>(messages[2]);
-        Assert.Equal(0, reasoning.MessageOrderIdx);
-        // Tool call: orderIdx=1
+        Assert.Equal(1, reasoning.MessageOrderIdx);
+        // Tool call: orderIdx=2
         var toolCall = Assert.IsType<ToolCallMessage>(messages[3]);
-        Assert.Equal(1, toolCall.MessageOrderIdx);
-        // Tool result: orderIdx=2
+        Assert.Equal(2, toolCall.MessageOrderIdx);
+        // Tool result: orderIdx=3
         var toolResult = Assert.IsType<ToolCallResultMessage>(messages[4]);
-        Assert.Equal(2, toolResult.MessageOrderIdx);
-        // Text updates: orderIdx=3, chunkIdx increments
+        Assert.Equal(3, toolResult.MessageOrderIdx);
+        // Text updates: orderIdx=4, chunkIdx increments
         var textUpdate1 = Assert.IsType<TextUpdateMessage>(messages[5]);
         var textUpdate2 = Assert.IsType<TextUpdateMessage>(messages[6]);
-        Assert.Equal(3, textUpdate1.MessageOrderIdx);
+        Assert.Equal(4, textUpdate1.MessageOrderIdx);
         Assert.Equal(0, textUpdate1.ChunkIdx);
-        Assert.Equal(3, textUpdate2.MessageOrderIdx);
+        Assert.Equal(4, textUpdate2.MessageOrderIdx);
         Assert.Equal(1, textUpdate2.ChunkIdx);
-        // Usage: orderIdx=4
+        // Usage: orderIdx=5
         var usage = Assert.IsType<UsageMessage>(messages[7]);
-        Assert.Equal(4, usage.MessageOrderIdx);
+        Assert.Equal(5, usage.MessageOrderIdx);
     }
     [Fact]
     public async Task Downstream_HandlesMultipleGenerations_Independently()

--- a/tests/LmCore.Tests/Middleware/MessageTransformationMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/MessageTransformationMiddlewareTests.cs
@@ -335,14 +335,47 @@ public class MessageTransformationMiddlewareTests
         Assert.Equal(1, reasoningUpdate2.ChunkIdx);
     }
     [Fact]
-    public async Task Downstream_ResetsChunkIdx_WhenCompleteMessageInterrupts()
+    public async Task Downstream_FinalizingTextMessage_SharesOrderIdx_WithPrecedingTextUpdateStream()
     {
+        // A finalizing TextMessage consolidates the just-streamed TextUpdateMessage deltas for the
+        // same generation, so it MUST share that stream's messageOrderIdx. Otherwise a consumer that
+        // merges by (generationId, messageOrderIdx) cannot merge it onto the streamed message and
+        // renders a duplicate text bubble (regression: GPT-5.5/Copilot Responses double-render).
         // Arrange
         var middleware = new MessageTransformationMiddleware();
         var agent = new MockAgent(
             new TextUpdateMessage { Text = "Hello", GenerationId = "gen1" },
             new TextUpdateMessage { Text = " ", GenerationId = "gen1" },
-            new TextMessage { Text = "Complete message", GenerationId = "gen1" },
+            new TextMessage { Text = "Hello World", GenerationId = "gen1" }
+        );
+        var context = new MiddlewareContext(Messages: [], Options: null);
+        // Act
+        var result = await middleware.InvokeAsync(context, agent);
+        var messages = result.ToList();
+        // Assert
+        Assert.Equal(3, messages.Count);
+        var textUpdate1 = Assert.IsType<TextUpdateMessage>(messages[0]);
+        var textUpdate2 = Assert.IsType<TextUpdateMessage>(messages[1]);
+        var textMessage = Assert.IsType<TextMessage>(messages[2]);
+        Assert.Equal(0, textUpdate1.MessageOrderIdx);
+        Assert.Equal(0, textUpdate1.ChunkIdx);
+        Assert.Equal(0, textUpdate2.MessageOrderIdx);
+        Assert.Equal(1, textUpdate2.ChunkIdx);
+        // The finalizing TextMessage shares the stream's orderIdx (0), not a bumped one.
+        Assert.Equal(0, textMessage.MessageOrderIdx);
+    }
+
+    [Fact]
+    public async Task Downstream_TextUpdateStreamAfterFinalization_StartsNewMessage()
+    {
+        // Once a finalizing TextMessage closes a text stream, a subsequent TextUpdate stream for the
+        // same generation is a NEW logical message and must get the next orderIdx with chunkIdx reset.
+        // Arrange
+        var middleware = new MessageTransformationMiddleware();
+        var agent = new MockAgent(
+            new TextUpdateMessage { Text = "Hello", GenerationId = "gen1" },
+            new TextUpdateMessage { Text = " ", GenerationId = "gen1" },
+            new TextMessage { Text = "Hello ", GenerationId = "gen1" },
             new TextUpdateMessage { Text = "World", GenerationId = "gen1" }
         );
         var context = new MiddlewareContext(Messages: [], Options: null);
@@ -351,20 +384,46 @@ public class MessageTransformationMiddlewareTests
         var messages = result.ToList();
         // Assert
         Assert.Equal(4, messages.Count);
-        // First two TextUpdateMessages
         var textUpdate1 = Assert.IsType<TextUpdateMessage>(messages[0]);
         var textUpdate2 = Assert.IsType<TextUpdateMessage>(messages[1]);
+        var textMessage = Assert.IsType<TextMessage>(messages[2]);
+        var textUpdate3 = Assert.IsType<TextUpdateMessage>(messages[3]);
         Assert.Equal(0, textUpdate1.MessageOrderIdx);
         Assert.Equal(0, textUpdate1.ChunkIdx);
         Assert.Equal(0, textUpdate2.MessageOrderIdx);
         Assert.Equal(1, textUpdate2.ChunkIdx);
-        // Complete message gets new orderIdx
-        var textMessage = Assert.IsType<TextMessage>(messages[2]);
-        Assert.Equal(1, textMessage.MessageOrderIdx);
-        // Next TextUpdateMessage starts new message with reset chunkIdx
-        var textUpdate3 = Assert.IsType<TextUpdateMessage>(messages[3]);
-        Assert.Equal(2, textUpdate3.MessageOrderIdx);
-        Assert.Equal(0, textUpdate3.ChunkIdx); // Reset to 0
+        // Finalizing TextMessage shares the first stream's orderIdx (0)...
+        Assert.Equal(0, textMessage.MessageOrderIdx);
+        // ...and the next delta stream starts a new message (orderIdx 1, chunkIdx reset to 0).
+        Assert.Equal(1, textUpdate3.MessageOrderIdx);
+        Assert.Equal(0, textUpdate3.ChunkIdx);
+    }
+
+    [Fact]
+    public async Task Downstream_FinalizingReasoningMessage_SharesOrderIdx_WithPrecedingReasoningUpdateStream()
+    {
+        // Same rule as text: a finalizing ReasoningMessage consolidates its ReasoningUpdateMessage
+        // deltas and must share their messageOrderIdx so consumers merge instead of duplicating.
+        // Arrange
+        var middleware = new MessageTransformationMiddleware();
+        var agent = new MockAgent(
+            new ReasoningUpdateMessage { Reasoning = "Think", GenerationId = "gen1" },
+            new ReasoningUpdateMessage { Reasoning = "ing", GenerationId = "gen1" },
+            new ReasoningMessage { Reasoning = "Thinking", GenerationId = "gen1" }
+        );
+        var context = new MiddlewareContext(Messages: [], Options: null);
+        // Act
+        var result = await middleware.InvokeAsync(context, agent);
+        var messages = result.ToList();
+        // Assert
+        Assert.Equal(3, messages.Count);
+        var reasoningUpdate1 = Assert.IsType<ReasoningUpdateMessage>(messages[0]);
+        var reasoningUpdate2 = Assert.IsType<ReasoningUpdateMessage>(messages[1]);
+        var reasoningMessage = Assert.IsType<ReasoningMessage>(messages[2]);
+        Assert.Equal(0, reasoningUpdate1.MessageOrderIdx);
+        Assert.Equal(0, reasoningUpdate2.MessageOrderIdx);
+        // The finalizing ReasoningMessage shares the stream's orderIdx (0), not a bumped one.
+        Assert.Equal(0, reasoningMessage.MessageOrderIdx);
     }
     #endregion
     #region Plural to Singular Conversion Tests
@@ -689,25 +748,26 @@ public class MessageTransformationMiddlewareTests
         Assert.Equal(0, reasoningUpdate1.ChunkIdx);
         Assert.Equal(0, reasoningUpdate2.MessageOrderIdx);
         Assert.Equal(1, reasoningUpdate2.ChunkIdx);
-        // Complete reasoning: orderIdx=1
+        // Complete reasoning shares its reasoning_update stream's orderIdx (0), not a bumped one,
+        // so consumers merge it onto the streamed reasoning instead of duplicating it.
         var reasoning = Assert.IsType<ReasoningMessage>(messages[2]);
-        Assert.Equal(1, reasoning.MessageOrderIdx);
-        // Tool call: orderIdx=2
+        Assert.Equal(0, reasoning.MessageOrderIdx);
+        // Tool call: orderIdx=1
         var toolCall = Assert.IsType<ToolCallMessage>(messages[3]);
-        Assert.Equal(2, toolCall.MessageOrderIdx);
-        // Tool result: orderIdx=3
+        Assert.Equal(1, toolCall.MessageOrderIdx);
+        // Tool result: orderIdx=2
         var toolResult = Assert.IsType<ToolCallResultMessage>(messages[4]);
-        Assert.Equal(3, toolResult.MessageOrderIdx);
-        // Text updates: orderIdx=4, chunkIdx increments
+        Assert.Equal(2, toolResult.MessageOrderIdx);
+        // Text updates: orderIdx=3, chunkIdx increments
         var textUpdate1 = Assert.IsType<TextUpdateMessage>(messages[5]);
         var textUpdate2 = Assert.IsType<TextUpdateMessage>(messages[6]);
-        Assert.Equal(4, textUpdate1.MessageOrderIdx);
+        Assert.Equal(3, textUpdate1.MessageOrderIdx);
         Assert.Equal(0, textUpdate1.ChunkIdx);
-        Assert.Equal(4, textUpdate2.MessageOrderIdx);
+        Assert.Equal(3, textUpdate2.MessageOrderIdx);
         Assert.Equal(1, textUpdate2.ChunkIdx);
-        // Usage: orderIdx=5
+        // Usage: orderIdx=4
         var usage = Assert.IsType<UsageMessage>(messages[7]);
-        Assert.Equal(5, usage.MessageOrderIdx);
+        Assert.Equal(4, usage.MessageOrderIdx);
     }
     [Fact]
     public async Task Downstream_HandlesMultipleGenerations_Independently()

--- a/tests/LmCore.Tests/Middleware/MessageUpdateJoinerMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/MessageUpdateJoinerMiddlewareTests.cs
@@ -387,6 +387,47 @@ public class MessageUpdateJoinerMiddlewareTests
         Assert.Contains("Finalizing TextMessage reuses streamed messageOrderIdx", logText);
     }
 
+    [Fact]
+    public async Task InvokeStreamingAsync_FinalizingTextFromDifferentGeneration_DoesNotSuppressBuiltText()
+    {
+        // Guard for the generationId match: a finalizing TextMessage from a DIFFERENT generation must
+        // NOT suppress the active builder's accumulated text (otherwise interleaved generations cause
+        // silent data loss). Both texts must survive.
+        // Arrange
+        var middleware = new MessageUpdateJoinerMiddleware();
+        var stream = new List<IMessage>
+        {
+            new TextUpdateMessage { Text = "gen1 ", Role = Role.Assistant, GenerationId = "gen1" },
+            new TextUpdateMessage { Text = "text", Role = Role.Assistant, GenerationId = "gen1" },
+            new TextMessage { Text = "gen2 complete", Role = Role.Assistant, GenerationId = "gen2" },
+        };
+        var mockStreamingAgent = new Mock<IStreamingAgent>();
+        _ = mockStreamingAgent
+            .Setup(a =>
+                a.GenerateReplyStreamingAsync(
+                    It.IsAny<IEnumerable<IMessage>>(),
+                    It.IsAny<GenerateReplyOptions>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(stream.ToAsyncEnumerable());
+        var context = new MiddlewareContext([], new GenerateReplyOptions());
+
+        // Act
+        var resultStream = await middleware.InvokeStreamingAsync(context, mockStreamingAgent.Object);
+        var results = new List<IMessage>();
+        await foreach (var message in resultStream)
+        {
+            results.Add(message);
+        }
+
+        // Assert — gen1's built accumulation AND gen2's finalizing message both survive.
+        var textMessages = results.OfType<TextMessage>().ToList();
+        Assert.Equal(2, textMessages.Count);
+        Assert.Contains(textMessages, t => ((ICanGetText)t).GetText() == "gen1 text");
+        Assert.Contains(textMessages, t => ((ICanGetText)t).GetText() == "gen2 complete");
+    }
+
     #region Helper Methods
 
     // Helper method to split string on spaces while including spaces in the parts

--- a/tests/LmCore.Tests/Middleware/MessageUpdateJoinerMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/MessageUpdateJoinerMiddlewareTests.cs
@@ -1,5 +1,7 @@
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Models;
+using Microsoft.Extensions.Logging;
+using Serilog;
 namespace AchieveAi.LmDotnetTools.LmCore.Tests.Middleware;
 
 public class MessageUpdateJoinerMiddlewareTests
@@ -193,6 +195,235 @@ public class MessageUpdateJoinerMiddlewareTests
                 ),
             Times.Once
         );
+    }
+
+    [Fact]
+    public async Task InvokeStreamingAsync_TextDeltasFollowedByFinalizingTextMessage_YieldsSingleTextMessage()
+    {
+        // Regression (GPT-5.5 / Copilot Responses duplicate bubble): a provider streams text deltas and
+        // then emits its OWN finalizing complete TextMessage. The joiner must NOT also emit the
+        // synthesized "built" copy — otherwise the same answer is persisted/forwarded twice, which
+        // renders as two identical assistant bubbles and bloats the next turn's prompt.
+        // Arrange
+        var middleware = new MessageUpdateJoinerMiddleware();
+        var stream = new List<IMessage>
+        {
+            new TextUpdateMessage { Text = "Hello", Role = Role.Assistant, GenerationId = "gen1" },
+            new TextUpdateMessage { Text = " World", Role = Role.Assistant, GenerationId = "gen1" },
+            new TextMessage { Text = "Hello World", Role = Role.Assistant, GenerationId = "gen1" },
+        };
+        var mockStreamingAgent = new Mock<IStreamingAgent>();
+        _ = mockStreamingAgent
+            .Setup(a =>
+                a.GenerateReplyStreamingAsync(
+                    It.IsAny<IEnumerable<IMessage>>(),
+                    It.IsAny<GenerateReplyOptions>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(stream.ToAsyncEnumerable());
+        var context = new MiddlewareContext([], new GenerateReplyOptions());
+
+        // Act
+        var resultStream = await middleware.InvokeStreamingAsync(context, mockStreamingAgent.Object);
+        var results = new List<IMessage>();
+        await foreach (var message in resultStream)
+        {
+            results.Add(message);
+        }
+
+        // Assert — exactly ONE text message (the provider's finalizing message), not two.
+        var textMessages = results.OfType<TextMessage>().ToList();
+        _ = Assert.Single(textMessages);
+        Assert.Equal("Hello World", ((ICanGetText)textMessages[0]).GetText());
+    }
+
+    [Fact]
+    public async Task InvokeStreamingAsync_ReasoningDeltasFollowedByFinalizingReasoningMessage_YieldsSingleReasoningMessage()
+    {
+        // Same dedup rule for reasoning: streamed ReasoningUpdateMessage deltas followed by the
+        // provider's finalizing ReasoningMessage must collapse to a single ReasoningMessage.
+        // Arrange
+        var middleware = new MessageUpdateJoinerMiddleware();
+        var stream = new List<IMessage>
+        {
+            new ReasoningUpdateMessage { Reasoning = "Think", Role = Role.Assistant, GenerationId = "gen1" },
+            new ReasoningUpdateMessage { Reasoning = "ing", Role = Role.Assistant, GenerationId = "gen1" },
+            new ReasoningMessage { Reasoning = "Thinking", Role = Role.Assistant, GenerationId = "gen1" },
+        };
+        var mockStreamingAgent = new Mock<IStreamingAgent>();
+        _ = mockStreamingAgent
+            .Setup(a =>
+                a.GenerateReplyStreamingAsync(
+                    It.IsAny<IEnumerable<IMessage>>(),
+                    It.IsAny<GenerateReplyOptions>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(stream.ToAsyncEnumerable());
+        var context = new MiddlewareContext([], new GenerateReplyOptions());
+
+        // Act
+        var resultStream = await middleware.InvokeStreamingAsync(context, mockStreamingAgent.Object);
+        var results = new List<IMessage>();
+        await foreach (var message in resultStream)
+        {
+            results.Add(message);
+        }
+
+        // Assert — exactly ONE reasoning message.
+        var reasoningMessages = results.OfType<ReasoningMessage>().ToList();
+        _ = Assert.Single(reasoningMessages);
+        Assert.Equal("Thinking", reasoningMessages[0].Reasoning);
+    }
+
+    [Fact]
+    public async Task InvokeStreamingAsync_TextDeltasFollowedByDifferentKindComplete_StillEmitsBuiltText()
+    {
+        // Guard against over-suppression: when text deltas are followed by a complete message of a
+        // DIFFERENT kind, the joiner must still emit the built TextMessage — the deltas were not
+        // superseded by a same-kind finalizer, so dropping them would lose the streamed text.
+        // Arrange
+        var middleware = new MessageUpdateJoinerMiddleware();
+        var stream = new List<IMessage>
+        {
+            new TextUpdateMessage { Text = "Hello", Role = Role.Assistant, GenerationId = "gen1" },
+            new TextUpdateMessage { Text = " World", Role = Role.Assistant, GenerationId = "gen1" },
+            new ReasoningMessage { Reasoning = "afterthought", Role = Role.Assistant, GenerationId = "gen1" },
+        };
+        var mockStreamingAgent = new Mock<IStreamingAgent>();
+        _ = mockStreamingAgent
+            .Setup(a =>
+                a.GenerateReplyStreamingAsync(
+                    It.IsAny<IEnumerable<IMessage>>(),
+                    It.IsAny<GenerateReplyOptions>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(stream.ToAsyncEnumerable());
+        var context = new MiddlewareContext([], new GenerateReplyOptions());
+
+        // Act
+        var resultStream = await middleware.InvokeStreamingAsync(context, mockStreamingAgent.Object);
+        var results = new List<IMessage>();
+        await foreach (var message in resultStream)
+        {
+            results.Add(message);
+        }
+
+        // Assert — the built text message is preserved, alongside the reasoning message.
+        var textMessages = results.OfType<TextMessage>().ToList();
+        _ = Assert.Single(textMessages);
+        Assert.Equal("Hello World", ((ICanGetText)textMessages[0]).GetText());
+        _ = Assert.Single(results.OfType<ReasoningMessage>());
+    }
+
+    [Fact]
+    public async Task DuplicateBubbleRegression_DeltasPlusFinalizingText_ThroughTransformationAndJoiner_YieldsSingleMergedText()
+    {
+        // Simplest end-to-end-at-unit-level reproduction of the GPT-5.5 / Copilot "duplicate assistant
+        // bubble" bug. A provider streams text deltas and then its OWN finalizing TextMessage (same
+        // generationId). Run that through the real downstream "for history" pipeline the app assembles
+        // — MessageTransformation (assigns messageOrderIdx) then MessageUpdateJoiner — and the result
+        // MUST be exactly ONE TextMessage whose messageOrderIdx equals the deltas' (so the live UI
+        // merges them by generationId+messageOrderIdx, and history persists the answer once).
+        //
+        // Before the fix this produced TWO TextMessages: a joiner-built copy AND the finalizing copy,
+        // with mismatched messageOrderIdx (0 vs 1). The single assertion below catches both fixes:
+        //   - Assert.Single  -> guards MessageUpdateJoinerMiddleware (no synthesized duplicate)
+        //   - MessageOrderIdx -> guards MessageTransformationMiddleware (finalizer shares deltas' idx)
+        // Arrange
+        var agentMessages = new List<IMessage>
+        {
+            new TextUpdateMessage { Text = "The capital of France ", Role = Role.Assistant, GenerationId = "gen1" },
+            new TextUpdateMessage { Text = "is Paris.", Role = Role.Assistant, GenerationId = "gen1" },
+            new TextMessage { Text = "The capital of France is Paris.", Role = Role.Assistant, GenerationId = "gen1" },
+        };
+        var mockStreamingAgent = new Mock<IStreamingAgent>();
+        _ = mockStreamingAgent
+            .Setup(a =>
+                a.GenerateReplyStreamingAsync(
+                    It.IsAny<IEnumerable<IMessage>>(),
+                    It.IsAny<GenerateReplyOptions>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(agentMessages.ToAsyncEnumerable());
+
+        // The same downstream history pipeline MultiTurnAgentLoop assembles.
+        var pipeline = mockStreamingAgent.Object
+            .WithMessageTransformation()
+            .WithMiddleware(new MessageUpdateJoinerMiddleware());
+
+        // Act
+        var resultStream = await pipeline.GenerateReplyStreamingAsync([], new GenerateReplyOptions());
+        var results = new List<IMessage>();
+        await foreach (var message in resultStream)
+        {
+            results.Add(message);
+        }
+
+        // Assert — exactly one assistant text representation, carrying the deltas' messageOrderIdx (0).
+        var textMessages = results.OfType<TextMessage>().ToList();
+        _ = Assert.Single(textMessages);
+        Assert.Equal("The capital of France is Paris.", ((ICanGetText)textMessages[0]).GetText());
+        Assert.Equal(0, textMessages[0].MessageOrderIdx);
+    }
+
+    [Fact]
+    public async Task DuplicateBubbleRegression_PipelineEmitsServerSideDedupDecisionLogs()
+    {
+        // Closes the server-side log-visibility gap: the middleware that prevents the duplicate now
+        // LOGS its decision. Drive the repro through the pipeline with real loggers writing
+        // DuckDB-queryable CompactJson JSONL, then assert (a) the behavior (one TextMessage) and
+        // (b) that both decision logs are present — so a future regression is debuggable from logs,
+        // not just from code-reading.
+        // Arrange
+        var logPath = Path.Combine(AppContext.BaseDirectory, "logs", $"dup-bubble-decisions-{Guid.NewGuid():N}.jsonl");
+        _ = Directory.CreateDirectory(Path.GetDirectoryName(logPath)!);
+        var serilog = new Serilog.LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .WriteTo.File(new Serilog.Formatting.Compact.CompactJsonFormatter(), logPath)
+            .CreateLogger();
+        using var loggerFactory = new Serilog.Extensions.Logging.SerilogLoggerFactory(serilog, dispose: false);
+
+        var agentMessages = new List<IMessage>
+        {
+            new TextUpdateMessage { Text = "The capital of France ", Role = Role.Assistant, GenerationId = "gen1" },
+            new TextUpdateMessage { Text = "is Paris.", Role = Role.Assistant, GenerationId = "gen1" },
+            new TextMessage { Text = "The capital of France is Paris.", Role = Role.Assistant, GenerationId = "gen1" },
+        };
+        var mockStreamingAgent = new Mock<IStreamingAgent>();
+        _ = mockStreamingAgent
+            .Setup(a =>
+                a.GenerateReplyStreamingAsync(
+                    It.IsAny<IEnumerable<IMessage>>(),
+                    It.IsAny<GenerateReplyOptions>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(agentMessages.ToAsyncEnumerable());
+
+        var pipeline = mockStreamingAgent.Object
+            .WithMessageTransformation(loggerFactory.CreateLogger<MessageTransformationMiddleware>())
+            .WithMiddleware(new MessageUpdateJoinerMiddleware(logger: loggerFactory.CreateLogger<MessageUpdateJoinerMiddleware>()));
+
+        // Act
+        var resultStream = await pipeline.GenerateReplyStreamingAsync([], new GenerateReplyOptions());
+        var results = new List<IMessage>();
+        await foreach (var message in resultStream)
+        {
+            results.Add(message);
+        }
+        serilog.Dispose(); // flush the JSONL to disk
+
+        // Assert — behavior: a single merged text message.
+        _ = Assert.Single(results.OfType<TextMessage>());
+
+        // Assert — the de-dup decisions are now visible in the structured logs (DuckDB-queryable).
+        var logText = await File.ReadAllTextAsync(logPath);
+        Assert.Contains("Joiner suppressed synthesized", logText);
+        Assert.Contains("Finalizing TextMessage reuses streamed messageOrderIdx", logText);
     }
 
     #region Helper Methods

--- a/tests/LmCore.Tests/Middleware/MessageUpdateJoinerMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/MessageUpdateJoinerMiddlewareTests.cs
@@ -239,45 +239,6 @@ public class MessageUpdateJoinerMiddlewareTests
     }
 
     [Fact]
-    public async Task InvokeStreamingAsync_ReasoningDeltasFollowedByFinalizingReasoningMessage_YieldsSingleReasoningMessage()
-    {
-        // Same dedup rule for reasoning: streamed ReasoningUpdateMessage deltas followed by the
-        // provider's finalizing ReasoningMessage must collapse to a single ReasoningMessage.
-        // Arrange
-        var middleware = new MessageUpdateJoinerMiddleware();
-        var stream = new List<IMessage>
-        {
-            new ReasoningUpdateMessage { Reasoning = "Think", Role = Role.Assistant, GenerationId = "gen1" },
-            new ReasoningUpdateMessage { Reasoning = "ing", Role = Role.Assistant, GenerationId = "gen1" },
-            new ReasoningMessage { Reasoning = "Thinking", Role = Role.Assistant, GenerationId = "gen1" },
-        };
-        var mockStreamingAgent = new Mock<IStreamingAgent>();
-        _ = mockStreamingAgent
-            .Setup(a =>
-                a.GenerateReplyStreamingAsync(
-                    It.IsAny<IEnumerable<IMessage>>(),
-                    It.IsAny<GenerateReplyOptions>(),
-                    It.IsAny<CancellationToken>()
-                )
-            )
-            .ReturnsAsync(stream.ToAsyncEnumerable());
-        var context = new MiddlewareContext([], new GenerateReplyOptions());
-
-        // Act
-        var resultStream = await middleware.InvokeStreamingAsync(context, mockStreamingAgent.Object);
-        var results = new List<IMessage>();
-        await foreach (var message in resultStream)
-        {
-            results.Add(message);
-        }
-
-        // Assert — exactly ONE reasoning message.
-        var reasoningMessages = results.OfType<ReasoningMessage>().ToList();
-        _ = Assert.Single(reasoningMessages);
-        Assert.Equal("Thinking", reasoningMessages[0].Reasoning);
-    }
-
-    [Fact]
     public async Task InvokeStreamingAsync_TextDeltasFollowedByDifferentKindComplete_StillEmitsBuiltText()
     {
         // Guard against over-suppression: when text deltas are followed by a complete message of a

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentTests.cs
@@ -1,4 +1,5 @@
 using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
 using FluentAssertions;
@@ -152,6 +153,82 @@ public sealed class OpenAiResponsesAgentTests
         var result = await rig.Agent.GenerateReplyAsync(messages);
 
         result.OfType<TextMessage>().Should().NotBeEmpty();
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Regression: GPT-5.5 / Copilot Responses "duplicate assistant bubble" bug.
+    // The provider emits text deltas followed by its OWN finalizing TextMessage. Two layers must
+    // treat that as ONE logical message:
+    //   1) MessageTransformationMiddleware must give the finalizing TextMessage the SAME
+    //      messageOrderIdx as the deltas (so the live UI merges them by generationId+messageOrderIdx).
+    //   2) MessageUpdateJoinerMiddleware must not ALSO emit a synthesized "built" copy alongside the
+    //      provider's finalizing message (so history/persistence/reload store it once).
+    // Both are driven here through the real mock OpenAI /responses SSE stream.
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Agent_throughMessageTransformation_finalizedText_sharesOrderIdx_withTextDeltas()
+    {
+        await using var rig = TestRig.Create();
+        const string prompt = """
+            <|instruction_start|>
+            {"instruction_chain":[
+                {"messages":[{"text_message":{"length":5}}]}
+            ]}
+            <|instruction_end|>
+            """;
+        var messages = new IMessage[] { new TextMessage { Role = Role.User, Text = prompt } };
+
+        var pipeline = rig.Agent.WithMessageTransformation();
+
+        var collected = new List<IMessage>();
+        await foreach (var m in await pipeline.GenerateReplyStreamingAsync(messages))
+        {
+            collected.Add(m);
+        }
+
+        var deltas = collected.OfType<TextUpdateMessage>().ToList();
+        var finalText = collected.OfType<TextMessage>().Single();
+        deltas.Should().NotBeEmpty();
+        var deltaOrderIdxs = deltas.Select(d => d.MessageOrderIdx).Distinct().ToList();
+        deltaOrderIdxs.Should().ContainSingle("all text deltas of one answer share one messageOrderIdx");
+        finalText.MessageOrderIdx.Should().Be(
+            deltaOrderIdxs[0],
+            "the finalizing TextMessage must reuse the delta stream's messageOrderIdx so the client merges them into one bubble"
+        );
+    }
+
+    [Fact]
+    public async Task Agent_throughTransformationAndJoiner_yields_single_finalized_text_message()
+    {
+        await using var rig = TestRig.Create();
+        const string prompt = """
+            <|instruction_start|>
+            {"instruction_chain":[
+                {"messages":[{"text_message":{"length":6}}]}
+            ]}
+            <|instruction_end|>
+            """;
+        var messages = new IMessage[] { new TextMessage { Role = Role.User, Text = prompt } };
+
+        // The same downstream "for history" pipeline the MultiTurnAgentLoop assembles:
+        //   provider -> MessageTransformation (assigns messageOrderIdx) -> MessageUpdateJoiner.
+        var pipeline = rig.Agent
+            .WithMessageTransformation()
+            .WithMiddleware(new MessageUpdateJoinerMiddleware());
+
+        var collected = new List<IMessage>();
+        await foreach (var m in await pipeline.GenerateReplyStreamingAsync(messages))
+        {
+            collected.Add(m);
+        }
+
+        var textMessages = collected.OfType<TextMessage>().ToList();
+        textMessages.Should().ContainSingle(
+            "the joiner must not emit both a synthesized built copy and the provider's finalizing TextMessage"
+        );
+        textMessages[0].Role.Should().Be(Role.Assistant);
+        textMessages[0].Text.Trim().Split(' ').Should().HaveCount(6);
     }
 
     private sealed class TestRig : IAsyncDisposable


### PR DESCRIPTION
## Summary
Streaming providers (notably the new **GPT-5.5 / Copilot Responses** path) emit text as `TextUpdateMessage` deltas followed by a finalizing `TextMessage` carrying the same `generationId`. Two pipeline layers each turned that single logical message into a duplicate, so every assistant answer rendered as **two identical bubbles** — both live and after reload/persistence.

## Changes
- **`MessageTransformationMiddleware`** — the finalizing `TextMessage`/`ReasoningMessage` now reuses the `messageOrderIdx` of the update stream it consolidates (mirrors the existing `TextWithCitationsMessage` handling), then closes the stream so genuinely separate messages still increment. The client merge key (`kind-runId-generationId-messageOrderIdx`) then merges the finalizer onto the streamed bubble instead of creating a second one.
- **`MessageUpdateJoinerMiddleware`** — suppresses the synthesized "built" copy when the provider supplies its own finalizing complete message of the same kind as the active builder, so history/persistence stores the answer once (and the next turn's prompt isn't bloated with a duplicate).
- **Observability** — decision-point Debug logging in both middlewares; `MultiTurnAgentLoop` gained an optional `ILoggerFactory` (the sample wires it) so the de-dup decisions are visible in structured logs (DuckDB-queryable).
- **Docs** — new `samples/LmStreaming.Sample/CLAUDE.md` and a "Rationalization & Fastest Browser Control" section appended to `PlaywrightTestingGuide.md`.

## Testing
- Unit (CI-runnable, TDD red→green): `MessageTransformationMiddlewareTests`, `MessageUpdateJoinerMiddlewareTests` (incl. a combined-pipeline regression and a server-side logging assertion), `OpenAiResponsesAgentTests` (drives the mock OpenAI `/responses` SSE stream through the real middleware pipeline).
- Regression gate: **LmCore 753, LmMultiTurn 245, OpenAiResponses 58, AnthropicProvider 166 — all green.**
- End-to-end (Playwright, real Copilot): each answer renders exactly once, **live and after reload**.

## Related Issues
Fixes #65