### PR TITLE
feat(claude-sdk): handle rate_limit_event advisories from claude-code 2.x

### DIFF
--- a/src/ClaudeAgentSdkProvider/Agents/ClaudeAgentSdkClient.cs
+++ b/src/ClaudeAgentSdkProvider/Agents/ClaudeAgentSdkClient.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -619,12 +620,63 @@ public class ClaudeAgentSdkClient : IClaudeAgentSdkClient
                 );
                 return [];
 
+            // Rate-limit advisories from claude-code 2.x. Surface them per-status so a throttled
+            // or denied request is visible, instead of falling through to the "Unhandled JSONL
+            // event type" warning below — the CLI emits one of these every turn, which otherwise
+            // floods the logs. Informational only, so no IMessage is produced.
+            case RateLimitEvent rateLimitEvent:
+                LogRateLimit(rateLimitEvent);
+                return [];
+
             default:
                 _logger?.LogWarning(
                     "Unhandled JSONL event type: {EventType}. Line was not processed.",
                     jsonlEvent.GetType().Name
                 );
                 return [];
+        }
+    }
+
+    /// <summary>
+    ///     Surface a rate-limit advisory from the CLI. Logs at INFO when the request was
+    ///     allowed (informational), at WARN when not — overage rejection or throttling are
+    ///     things the operator wants to know about. Falls back to DEBUG when the payload
+    ///     is missing the fields we'd need to make a better decision.
+    /// </summary>
+    private void LogRateLimit(RateLimitEvent ev)
+    {
+        var info = ev.RateLimitInfo;
+        if (info == null)
+        {
+            _logger?.LogDebug("[Agent:{SessionId}] rate_limit_event with no rate_limit_info payload", ev.SessionId);
+            return;
+        }
+
+        var allowed = string.Equals(info.Status, "allowed", StringComparison.Ordinal);
+        var resetsAtIso = info.ResetsAt is long resets
+            ? DateTimeOffset.FromUnixTimeSeconds(resets).ToString("O", CultureInfo.InvariantCulture)
+            : "(unknown)";
+
+        if (allowed)
+        {
+            _logger?.LogInformation(
+                "[Agent:{SessionId}] Rate-limit OK: window={Window}, resetsAt={ResetsAt}, usingOverage={UsingOverage}",
+                ev.SessionId,
+                info.RateLimitType,
+                resetsAtIso,
+                info.IsUsingOverage);
+        }
+        else
+        {
+            _logger?.LogWarning(
+                "[Agent:{SessionId}] Rate-limit NOT allowed: status={Status}, window={Window}, " +
+                "resetsAt={ResetsAt}, overageStatus={OverageStatus}, overageDisabledReason={OverageReason}",
+                ev.SessionId,
+                info.Status,
+                info.RateLimitType,
+                resetsAtIso,
+                info.OverageStatus,
+                info.OverageDisabledReason);
         }
     }
 

--- a/src/LmTestUtils/Logging/CapturingLogger.cs
+++ b/src/LmTestUtils/Logging/CapturingLogger.cs
@@ -23,4 +23,12 @@ public sealed class CapturingLogger<T> : ILogger<T>
     public int WarningCount(string substring)
         => _entries.Count(e => e.Level == LogLevel.Warning
             && e.Text.Contains(substring, StringComparison.Ordinal));
+
+    /// <summary>
+    ///     Number of captured entries logged at <paramref name="level"/> whose rendered
+    ///     message contains <paramref name="substring"/> (ordinal comparison).
+    /// </summary>
+    public int CountAtLevel(LogLevel level, string substring)
+        => _entries.Count(e => e.Level == level
+            && e.Text.Contains(substring, StringComparison.Ordinal));
 }

--- a/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.JsonlEventHandling.Tests.cs
+++ b/tests/ClaudeAgentSdkProvider.Tests/Agents/ClaudeAgentSdkClient.JsonlEventHandling.Tests.cs
@@ -3,6 +3,8 @@ using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Agents;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Models.JsonlEvents;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmTestUtils.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Tests.Agents;
 
@@ -42,4 +44,96 @@ public class ClaudeAgentSdkClientJsonlEventHandlingTests
         Assert.Equal("assistant survived stream event", text.Text);
     }
 
+    [Fact]
+    public void ConvertNonTerminalJsonlEventToMessages_AllowedRateLimit_LogsInformation_AndEmitsNoMessages()
+    {
+        var logger = new CapturingLogger<ClaudeAgentSdkClient>();
+        var client = new ClaudeAgentSdkClient(new ClaudeAgentSdkOptions(), logger);
+
+        var rateLimit = new RateLimitEvent
+        {
+            SessionId = "session-1",
+            RateLimitInfo = new RateLimitInfo
+            {
+                Status = "allowed",
+                RateLimitType = "five_hour",
+                ResetsAt = 1777410000,
+                IsUsingOverage = false,
+            },
+        };
+
+        var messages = client.ConvertNonTerminalJsonlEventToMessages(rateLimit, emitSystemInit: false);
+
+        Assert.Empty(messages);
+        Assert.Equal(1, logger.CountAtLevel(LogLevel.Information, "Rate-limit OK"));
+        Assert.Equal(0, logger.CountAtLevel(LogLevel.Warning, "Rate-limit NOT allowed"));
+        // Regression: rate_limit_event must NOT fall through to the "Unhandled" warning.
+        Assert.Equal(0, logger.WarningCount("Unhandled JSONL event type"));
+    }
+
+    [Theory]
+    [InlineData("throttled")]
+    [InlineData("denied")]
+    [InlineData("warning")]
+    public void ConvertNonTerminalJsonlEventToMessages_NonAllowedRateLimit_LogsWarning(string status)
+    {
+        var logger = new CapturingLogger<ClaudeAgentSdkClient>();
+        var client = new ClaudeAgentSdkClient(new ClaudeAgentSdkOptions(), logger);
+
+        var rateLimit = new RateLimitEvent
+        {
+            SessionId = "session-1",
+            RateLimitInfo = new RateLimitInfo
+            {
+                Status = status,
+                RateLimitType = "five_hour",
+                ResetsAt = 1777410000,
+                OverageStatus = "rejected",
+                OverageDisabledReason = "org_level_disabled",
+            },
+        };
+
+        var messages = client.ConvertNonTerminalJsonlEventToMessages(rateLimit, emitSystemInit: false);
+
+        Assert.Empty(messages);
+        Assert.Equal(1, logger.CountAtLevel(LogLevel.Warning, "Rate-limit NOT allowed"));
+        Assert.Equal(0, logger.CountAtLevel(LogLevel.Information, "Rate-limit OK"));
+        Assert.Equal(0, logger.WarningCount("Unhandled JSONL event type"));
+    }
+
+    [Fact]
+    public void ConvertNonTerminalJsonlEventToMessages_RateLimitWithNoInfo_LogsDebug()
+    {
+        var logger = new CapturingLogger<ClaudeAgentSdkClient>();
+        var client = new ClaudeAgentSdkClient(new ClaudeAgentSdkOptions(), logger);
+
+        var rateLimit = new RateLimitEvent { SessionId = "session-1", RateLimitInfo = null };
+
+        var messages = client.ConvertNonTerminalJsonlEventToMessages(rateLimit, emitSystemInit: false);
+
+        Assert.Empty(messages);
+        Assert.Equal(1, logger.CountAtLevel(LogLevel.Debug, "no rate_limit_info payload"));
+        Assert.Equal(0, logger.WarningCount("Unhandled JSONL event type"));
+    }
+
+    [Fact]
+    public void ConvertNonTerminalJsonlEventToMessages_RateLimitEvent_ParsedFromJsonlLine_IsHandled()
+    {
+        // Guards the end-to-end path: a real rate_limit_event JSONL line must parse to a
+        // RateLimitEvent (registered discriminator) and be handled, not warned as "Unhandled".
+        var logger = new CapturingLogger<ClaudeAgentSdkClient>();
+        var client = new ClaudeAgentSdkClient(new ClaudeAgentSdkOptions(), logger);
+
+        const string line = """
+            {"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1777410000,"rateLimitType":"five_hour","isUsingOverage":false},"uuid":"u1","session_id":"session-1"}
+            """;
+        var parsed = JsonSerializer.Deserialize<JsonlEventBase>(line);
+
+        var rateLimit = Assert.IsType<RateLimitEvent>(parsed);
+        var messages = client.ConvertNonTerminalJsonlEventToMessages(rateLimit, emitSystemInit: false);
+
+        Assert.Empty(messages);
+        Assert.Equal(1, logger.CountAtLevel(LogLevel.Information, "Rate-limit OK"));
+        Assert.Equal(0, logger.WarningCount("Unhandled JSONL event type"));
+    }
 }


### PR DESCRIPTION
## Summary

Forward-ports the **rate-limit-events client wiring** from Azure DevOps commit `1818f42` ("Enhance ClaudeAgentSdkClient to support rate limit events and improve error handling") onto `main`'s refactored `ClaudeAgentSdkClient`.

During the recent ADO↔GitHub reconciliation merge (`29c08ed`), `ClaudeAgentSdkClient.cs` was resolved by **keeping main's version** — ADO's `1818f42` had reworked the same regions main independently refactored (token-arg builder + extracted dispatch + pluggable launcher, #54), so a mechanical merge would have been fragile. The *additive scaffolding* was retained in that merge:
- `RateLimitEvent` / `RateLimitInfo` types
- `[JsonDerivedType(typeof(RateLimitEvent), "rate_limit_event")]` registration on `JsonlEventBase`
- the extra `ResultEvent` / `ResultEventMessage` fields

Only the **client handling** was deferred. This PR re-applies it.

## Bug it fixes

`claude-code` 2.x emits a `rate_limit_event` before **every turn**. On `main` these parsed to a registered `RateLimitEvent` but then fell through `ConvertNonTerminalJsonlEventToMessages` to the `default:` branch — `LogWarning("Unhandled JSONL event type: {EventType}...")` — which flooded the logs once per turn.

## Changes

- **`ConvertNonTerminalJsonlEventToMessages`**: add a `RateLimitEvent` case (covers *both* stdout loops via the shared dispatch) that calls `LogRateLimit` and emits no `IMessage` — the advisory is informational.
- **`LogRateLimit`**: `INFO` when `status == "allowed"`; `WARN` otherwise (throttled / denied / overage rejection); `DEBUG` when `rate_limit_info` is absent. Logs the reset window in round-trip ISO-8601.
- **`CapturingLogger<T>`** (test util): add `CountAtLevel(level, substring)` for level-specific log assertions.
- **Tests** (`ClaudeAgentSdkClient.JsonlEventHandling.Tests`): allowed / non-allowed (throttled, denied, warning) / null-info / parsed-JSONL-line — each asserts the event no longer triggers the "Unhandled JSONL event type" warning.

## Verification

- `dotnet build` — 0 warnings, 0 errors (zero-warning gate).
- `ClaudeAgentSdkProvider.Tests` — **107 passed** (101 prior + 6 new), 0 failed.

## Out of scope (separate follow-up)

`1818f42` also reworked `ResultEvent` error handling (`IsSuccessSubtype` / `LogResultFailure` + subtype-based failure detection & retry). That is entangled with main's existing `ResultEvent` control flow and is intentionally **not** included here — it warrants its own focused change.