### PR TITLE
Sample: sandboxed workspace agent with GitHub/Azure DevOps token injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 **/TestResults/
 **/logs/
 .env
+.env.*
+!.env.example
 **/.env.test
 *.pyc
 *.pyo
@@ -51,3 +53,6 @@ node_modules/
 
 # Husky.Net auto-install scratch dir
 .husky/_/
+
+# OAuth refresh/access token store (FileOAuthTokenStore) — never commit secrets
+**/oauth-tokens/

--- a/samples/LmStreaming.Sample/AuthProviderGuide.md
+++ b/samples/LmStreaming.Sample/AuthProviderGuide.md
@@ -1,0 +1,353 @@
+# Auth Provider Guide — GitHub + Azure DevOps token injection
+
+This guide covers the **OAuth auth-provider** feature in the `LmStreaming.Sample` app: signing a
+user in to GitHub and Azure DevOps with the OAuth **device-code** flow, persisting their refresh
+tokens locally, and hosting an **auth webhook** that the sandbox gateway calls to inject a
+freshly-refreshed access token into sandbox→GitHub/ADO requests.
+
+It builds directly on the **Workspace Agent** sandbox — read
+[`SandboxWorkspaceGuide.md`](./SandboxWorkspaceGuide.md) first if you have not. This guide only
+adds the authenticated-egress layer on top of that sandbox.
+
+## Overview
+
+When the workspace agent runs `git` or `curl` against GitHub or Azure DevOps **inside the
+sandbox**, the gateway's egress proxy intercepts the outbound request and calls back to this app's
+webhook to obtain an `Authorization: Bearer <token>` header to inject. **The sandbox never sees the
+token** — it is added by the gateway proxy, outside the sandbox boundary, on the way out.
+
+Key properties:
+
+- **Default-deny egress.** Only the configured GitHub/ADO hosts are reachable from the sandbox, and
+  only when the matching provider is signed in. Everything else is blocked.
+- **One signed-in identity per provider, app-wide.** There is a single GitHub user and a single ADO
+  user for the whole app (not per chat / per session).
+- **Refresh tokens are persisted locally** under a gitignored `oauth-tokens/` directory and are
+  **never logged**. The app refreshes the short-lived access token on demand from the stored refresh
+  token.
+
+```
+                         ┌─────────────────────────────────────────────┐
+  Browser ── signin ───▶ │  LmStreaming.Sample app                     │
+  (device code UI)       │   • AuthController     (api/auth/*)          │
+                         │   • AuthWebhookController (api/auth/webhook) │
+                         │   • device-code providers + token store      │
+                         └───────────────▲─────────────────────────────┘
+                                         │ 3. POST /api/auth/webhook/{provider}
+                                         │    (shared secret) → Bearer token
+                ┌────────────────────────┴──────────────┐
+  sandbox ──1. git/curl──▶ │  Sandbox gateway (egress proxy)          │ ──2. allow? + token──▶ GitHub / ADO
+  (no token)               └──────────────────────────────────────────┘
+```
+
+---
+
+## Prerequisites — register the OAuth apps
+
+This is the part **only you (the developer) can do**: each provider needs an OAuth app registered
+on its side, and the app must be configured to issue **refresh tokens**.
+
+### GitHub — you need a GitHub *App*, not a classic OAuth App
+
+> Refresh tokens require a **GitHub App** with token expiry turned on. A *classic OAuth App* issues
+> a **non-expiring** `access_token` with **no** `refresh_token` — which mostly works, but you lose
+> automatic refresh and the "Expire user authorization tokens" lifecycle.
+
+1. Go to **Settings → Developer settings → GitHub Apps → New GitHub App**.
+2. Enable **"Device Flow"** (under the app's general settings).
+3. Under **Optional features** / the user-to-server token settings, enable
+   **"Expire user authorization tokens"**. This is what makes GitHub issue a `refresh_token` (and an
+   `expires_in`) when the user authorizes the device code.
+4. Set the user permissions / scopes you need (e.g. *Repository contents: Read-only*).
+5. Note the **Client ID** (looks like `Iv1.xxxxxxxxxxxx` or `Iv23xxxxxxxxxxxx`).
+
+Device flow does **not** need a client secret, so you do not have to store one.
+
+### Azure DevOps — register an app in Microsoft Entra ID
+
+1. Go to **Entra ID → App registrations → New registration**.
+2. Under **Authentication**, set **"Allow public client flows" = Yes**. This makes it a *public
+   client*, so the device-code flow works **without a client secret**.
+3. Note the **Application (client) ID** and your **tenant** (a tenant id/domain, or the literal
+   `organizations` for work/school accounts).
+
+The app requests the Azure DevOps resource scope `499b84ac-1321-427f-aa17-267ca6975798/.default`
+plus `offline_access` (the latter is what makes Entra issue a refresh token). These are already the
+defaults in config — you normally only need to supply the **client id** (and possibly the tenant).
+
+---
+
+## Configuration
+
+All settings live under the **`Auth`** configuration section (bound to
+`Services/Auth/AuthOptions.cs`). Put non-secret values in `appsettings.json` /
+`appsettings.Development.json`, and **secrets** (the gateway shared secret, any client secrets) in
+`.env` / user-secrets / environment variables — **never** in committed appsettings.
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `Auth:Github:ClientId` | *(empty)* | **Required to enable GitHub.** When empty, GitHub auth is disabled. |
+| `Auth:Github:Scopes` | `["repo", "read:org"]` | Scopes requested during the GitHub device-code flow. |
+| `Auth:Ado:ClientId` | *(empty)* | **Required to enable ADO.** When empty, ADO auth is disabled. |
+| `Auth:Ado:TenantId` | `organizations` | Entra tenant; `organizations` works for work/school accounts. |
+| `Auth:Ado:Scopes` | `["499b84ac-1321-427f-aa17-267ca6975798/.default", "offline_access"]` | ADO resource scope + `offline_access` for refresh tokens. |
+| `Auth:Webhook:PublicBaseUrl` | `http://127.0.0.1:5000` | The base URL the **gateway** calls back on to reach this app's webhook. |
+| `Auth:Webhook:GatewaySharedSecret` | *(empty)* | Shared secret the gateway sends as `Authorization`. If unset, a random 64-hex-char secret is generated at startup. |
+
+### appsettings.json example
+
+```json
+{
+  "Auth": {
+    "Github": {
+      "ClientId": "Iv23xxxxxxxxxxxxxxxx",
+      "Scopes": ["repo", "read:org"]
+    },
+    "Ado": {
+      "ClientId": "00000000-0000-0000-0000-000000000000",
+      "TenantId": "organizations"
+    },
+    "Webhook": {
+      "PublicBaseUrl": "http://127.0.0.1:5000"
+    }
+  }
+}
+```
+
+### Environment-variable override form
+
+ASP.NET Core maps nested keys with the double-underscore separator. This is the recommended way to
+supply the client ids and the shared secret (e.g. from `.env`):
+
+```bash
+Auth__Github__ClientId=Iv23xxxxxxxxxxxxxxxx
+Auth__Ado__ClientId=00000000-0000-0000-0000-000000000000
+Auth__Ado__TenantId=organizations
+Auth__Webhook__GatewaySharedSecret=<a long random string>
+```
+
+> **Provider disabled when `ClientId` is empty.** If a provider's client id is blank, that provider
+> is simply disabled: **no** `auth_providers`/`network.rules` for it are sent to the gateway, and
+> the plain Workspace Agent demo still works unchanged. You can enable just GitHub, just ADO, or
+> both.
+
+---
+
+## Sign-in flow (device code) — API
+
+The browser-facing endpoints are served by `Controllers/AuthController.cs` under the route
+`api/auth/{provider}` where `{provider}` is **`github`** or **`ado`** (case-insensitive). These
+endpoints never return token material — only the device-code challenge and a UI-safe status.
+
+### `POST /api/auth/{provider}/signin`
+
+Starts the device-code flow and returns the challenge to show the user. The app begins polling the
+provider's token endpoint **in the background**; once the user approves, the refresh token is stored
+automatically.
+
+Response body (`DeviceCodeChallenge`):
+
+```json
+{
+  "userCode": "WDJB-MJHT",
+  "verificationUri": "https://github.com/login/device",
+  "verificationUriComplete": "https://github.com/login/device?user_code=WDJB-MJHT",
+  "expiresInSeconds": 900,
+  "intervalSeconds": 5
+}
+```
+
+The user opens `verificationUri`, enters `userCode`, and approves. (`verificationUriComplete` is
+provided by GitHub but **not** by Entra/ADO, so it may be absent for `ado`.)
+
+> Returns **409 Conflict** if the provider is registered but not configured (e.g. missing
+> `ClientId`), and **404** for an unknown provider id.
+
+```bash
+curl -s -X POST http://127.0.0.1:5000/api/auth/github/signin | jq
+```
+
+### `GET /api/auth/{provider}/status`
+
+Returns the current (UI-safe, secret-free) sign-in status (`OAuthStatus`):
+
+```json
+{
+  "state": "SignedIn",
+  "account": "octocat",
+  "scopes": ["repo", "read:org"],
+  "expiresAtUtc": "2026-06-01T12:34:56+00:00",
+  "error": null
+}
+```
+
+`state` is one of `NotStarted` | `Pending` | `SignedIn` | `Failed`. Poll this while the user
+authorizes the device code; `Pending` → `SignedIn` once approval lands, or `Failed` (with `error`)
+if it expires / is declined. (`account` may be `null` for ADO — Entra access tokens are opaque and
+not parsed.)
+
+```bash
+curl -s http://127.0.0.1:5000/api/auth/github/status | jq
+```
+
+### `POST /api/auth/{provider}/signout`
+
+Clears the stored tokens and resets the provider to `NotStarted`. Returns **204 No Content**.
+
+```bash
+curl -s -X POST http://127.0.0.1:5000/api/auth/github/signout -o /dev/null -w "%{http_code}\n"
+```
+
+The same three endpoints exist for `ado` — just swap `github` for `ado` in the path.
+
+---
+
+## How injection works (the webhook)
+
+The webhook contract is implemented by `Controllers/AuthWebhookController.cs` on the route
+`api/auth/webhook/{provider}`.
+
+1. The gateway calls **`POST {PublicBaseUrl}/api/auth/webhook/{github|ado}`** whenever a sandboxed
+   outbound request matches a rule that requires that provider's credential.
+2. The request is **authenticated with the shared secret** carried in the `Authorization` header.
+   The controller compares it to the configured/generated secret in **constant time** (both sides
+   are SHA-256 hashed, then compared with `CryptographicOperations.FixedTimeEquals`), so neither the
+   length nor the value leaks via timing. A mismatch returns **401**.
+3. On success the app returns an **allow** decision with a freshly-valid bearer token and the
+   token's **real expiry**:
+
+   ```json
+   {
+     "decision": "allow",
+     "headers": [["Authorization", "Bearer <token>"]],
+     "expires_at": "2026-06-01T12:34:56+00:00"
+   }
+   ```
+
+   If the provider is not signed in (or a refresh fails), it returns a **deny** decision carrying a
+   token-free reason:
+
+   ```json
+   { "decision": "deny", "reason": "no valid token for provider 'github'; sign in required" }
+   ```
+
+   Both outcomes return **HTTP 200** — the decision lives in the body, not the status code.
+4. The gateway **caches the token by its `expires_at`** and re-calls the webhook when it lapses. On
+   the re-call the app transparently **refreshes** the access token using the stored refresh token
+   (the access token is renewed ~120s before its real expiry), persists the new value, and returns
+   it. The webhook never echoes token material into the gateway's logs.
+
+### What the sandbox is created with
+
+When at least one provider is configured, `Services/SandboxSessionRegistry.cs` adds two blocks to
+the sandbox-create request:
+
+- **`auth_providers`** — one `webhook`-type provider per configured OAuth provider, each pointing at
+  `{PublicBaseUrl}/api/auth/webhook/{provider}`, carrying the shared secret as `gateway_auth`, with
+  a 300-second cache TTL.
+- **`network.rules`** — default-deny by virtue of being an explicit allowlist; each rule has
+  `action: "allow"` and routes that provider's hosts (port 443) through the matching auth provider:
+  - **github** → `github.com`, `api.github.com`, `codeload.github.com`
+  - **ado** → `dev.azure.com`, `*.dev.azure.com`, `*.visualstudio.com`
+
+When **no** provider is configured, both blocks are omitted entirely and the plain workspace sandbox
+is created as before.
+
+### Loopback / SSRF allowlist
+
+The gateway refuses to call an HTTP loopback webhook by default (SSRF protection). The app
+**auto-spawns** the gateway with `AUTH_WEBHOOK_HTTP_LOOPBACK_HOSTS=127.0.0.1,localhost` set, which
+allowlists the loopback host so the `http://127.0.0.1:5000` callback is permitted. If you run your
+own gateway, you must set this yourself (or serve the webhook over HTTPS).
+
+---
+
+## Try it (live token-injection test)
+
+1. **Configure a client id.** Set `Auth__Github__ClientId` (and/or `Auth__Ado__ClientId`), e.g. in
+   `.env`. For ADO also set the tenant if it is not `organizations`.
+2. **Run the app** (this also auto-spawns the gateway with the loopback allowlist set):
+
+   ```bash
+   dotnet run --project samples/LmStreaming.Sample
+   ```
+
+3. **Start sign-in** and read back the challenge:
+
+   ```bash
+   curl -s -X POST http://127.0.0.1:5000/api/auth/github/signin | jq
+   ```
+
+4. **Approve in the browser** — open `verificationUri`, enter the `userCode`, approve.
+5. **Wait for `SignedIn`:**
+
+   ```bash
+   curl -s http://127.0.0.1:5000/api/auth/github/status | jq .state
+   # "Pending" ... then "SignedIn"
+   ```
+
+6. **Exercise injection from inside the sandbox.** In the Workspace Agent chat, ask the model to run
+   one of these via `Bash`:
+
+   - GitHub:
+
+     ```bash
+     curl -s https://api.github.com/user
+     ```
+
+   - Azure DevOps:
+
+     ```bash
+     curl -s "https://dev.azure.com/<org>/_apis/projects?api-version=7.1"
+     ```
+
+   The call **succeeds** because the gateway injected the bearer token on the way out — even though
+   the sandbox never received it.
+7. **Confirm the token is NOT visible inside the sandbox.** Ask the model to print the request
+   headers it sent, or to dump its environment — you will see **no** token. The `Authorization`
+   header is added by the gateway proxy *after* the request leaves the sandbox.
+8. **Force a refresh.** Wait past the access token's lifetime (or past the gateway's cache TTL) and
+   repeat step 6. The gateway re-calls the webhook, the app refreshes from the stored refresh token,
+   and the call still succeeds — no re-sign-in required.
+
+---
+
+## Security notes
+
+- **Refresh tokens and the shared secret are sensitive.** Refresh/access tokens are persisted as
+  one JSON file per provider under the gitignored `oauth-tokens/` directory (matched by
+  `**/oauth-tokens/` in `.gitignore`). Token material is **never** written to logs — only the
+  provider id, account, scopes, and expiry.
+- **Webhook authentication is constant-time.** The shared secret is validated with a fixed-time
+  comparison of SHA-256 digests; the controller never logs the token, the incoming `Authorization`
+  value, or the secret, and never echoes token material back to the gateway.
+- **Default-deny egress.** With auth configured, only the authenticated GitHub/ADO hosts are
+  reachable from the sandbox. Anything else is blocked by the absence of an `allow` rule.
+- **Keep the shared secret out of source control.** Supply
+  `Auth__Webhook__GatewaySharedSecret` via `.env`/user-secrets/environment. If you leave it unset, a
+  random secret is generated per process start (fine for local dev, but it changes on each restart).
+
+---
+
+## Troubleshooting
+
+**GitHub status never reaches `SignedIn`, or there is no refresh token.**
+You almost certainly registered a *classic OAuth App* instead of a **GitHub App** with **"Expire
+user authorization tokens"** enabled. Classic OAuth Apps do not issue a `refresh_token`. Re-register
+as a GitHub App with Device Flow + token expiry enabled (see Prerequisites).
+
+**The gateway rejects the webhook endpoint (SSRF / loopback refused).**
+The gateway will not call an HTTP loopback URL unless it is allowlisted. Make sure the gateway was
+**spawned by the app** (so `AUTH_WEBHOOK_HTTP_LOOPBACK_HOSTS=127.0.0.1,localhost` is set), or — if
+you run your own gateway — that the `PublicBaseUrl` host is in that env var, or serve the webhook
+over **HTTPS**.
+
+**401 from the webhook.**
+The shared secret the gateway sends does not match the app's. Ensure
+`Auth__Webhook__GatewaySharedSecret` is the same value the gateway uses — and remember that if you
+leave it unset, the app generates a **new random secret on every restart**, so a previously-spawned
+gateway will be out of sync. Set an explicit secret to pin it.
+
+**`deny` with "sign in required" in the webhook response.**
+The provider is not signed in (or its refresh failed). Re-run the sign-in flow and confirm
+`GET /api/auth/{provider}/status` returns `SignedIn` before exercising the sandbox.

--- a/samples/LmStreaming.Sample/Controllers/AuthController.cs
+++ b/samples/LmStreaming.Sample/Controllers/AuthController.cs
@@ -1,0 +1,78 @@
+using LmStreaming.Sample.Services.Auth;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LmStreaming.Sample.Controllers;
+
+/// <summary>
+/// UI-facing endpoints that drive the OAuth device-code sign-in lifecycle for each registered
+/// provider (e.g. "github", "ado"). The browser polls <see cref="Status"/> while the user
+/// authorizes the device code out-of-band.
+/// </summary>
+/// <remarks>
+/// SECURITY: these endpoints never surface token material — only the UI-safe
+/// <see cref="OAuthStatus"/> record and the device-code <see cref="DeviceCodeChallenge"/>.
+/// </remarks>
+[ApiController]
+[Route("api/auth")]
+public sealed class AuthController(
+    IEnumerable<IOAuthTokenProvider> providers,
+    ILogger<AuthController> logger) : ControllerBase
+{
+    /// <summary>
+    /// Starts the device-code flow for the named provider and returns the challenge to show the user.
+    /// </summary>
+    /// <param name="provider">Provider id, e.g. "github" or "ado".</param>
+    /// <param name="ct">Cancellation token.</param>
+    [HttpPost("{provider}/signin")]
+    public async Task<IActionResult> SignIn(string provider, CancellationToken ct = default)
+    {
+        var resolved = Resolve(provider);
+        if (resolved is null)
+        {
+            return NotFound();
+        }
+
+        try
+        {
+            var challenge = await resolved.BeginSignInAsync(ct);
+            logger.LogInformation("Started OAuth sign-in for provider {ProviderId}.", resolved.ProviderId);
+            return Ok(challenge);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Provider is registered but not configured (e.g. missing ClientId).
+            logger.LogInformation("OAuth sign-in unavailable for provider {ProviderId}.", resolved.ProviderId);
+            return Conflict(new { error = ex.Message });
+        }
+    }
+
+    /// <summary>Returns the current (UI-safe) sign-in status for the named provider.</summary>
+    /// <param name="provider">Provider id, e.g. "github" or "ado".</param>
+    [HttpGet("{provider}/status")]
+    public IActionResult Status(string provider)
+    {
+        var resolved = Resolve(provider);
+        return resolved is null ? NotFound() : Ok(resolved.Status);
+    }
+
+    /// <summary>Clears stored tokens and resets the named provider to its not-started state.</summary>
+    /// <param name="provider">Provider id, e.g. "github" or "ado".</param>
+    /// <param name="ct">Cancellation token.</param>
+    [HttpPost("{provider}/signout")]
+    public async Task<IActionResult> SignOut(string provider, CancellationToken ct = default)
+    {
+        var resolved = Resolve(provider);
+        if (resolved is null)
+        {
+            return NotFound();
+        }
+
+        await resolved.SignOutAsync(ct);
+        logger.LogInformation("Signed out OAuth provider {ProviderId}.", resolved.ProviderId);
+        return NoContent();
+    }
+
+    /// <summary>Resolves a registered provider by id, matching <see cref="IOAuthTokenProvider.ProviderId"/> case-insensitively.</summary>
+    private IOAuthTokenProvider? Resolve(string provider) =>
+        providers.FirstOrDefault(p => string.Equals(p.ProviderId, provider, StringComparison.OrdinalIgnoreCase));
+}

--- a/samples/LmStreaming.Sample/Controllers/AuthWebhookController.cs
+++ b/samples/LmStreaming.Sample/Controllers/AuthWebhookController.cs
@@ -1,0 +1,177 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Serialization;
+using LmStreaming.Sample.Services.Auth;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LmStreaming.Sample.Controllers;
+
+/// <summary>
+/// Implements the sandbox gateway's auth-webhook contract. The gateway calls this endpoint when an
+/// outbound request from a sandboxed app matches a rule that requires an OAuth-backed credential;
+/// this controller decides whether to <c>allow</c> (and injects the bearer token) or <c>deny</c>.
+/// </summary>
+/// <remarks>
+/// SECURITY: callers are authenticated by a shared secret carried in the <c>Authorization</c>
+/// header, compared in constant time. This controller never logs the token, the incoming
+/// Authorization header value, or the shared secret — only provider id, destination host, and the
+/// allow/deny decision.
+/// </remarks>
+[ApiController]
+[Route("api/auth/webhook")]
+public sealed class AuthWebhookController(
+    IEnumerable<IOAuthTokenProvider> providers,
+    AuthSharedSecret sharedSecret,
+    ILogger<AuthWebhookController> logger) : ControllerBase
+{
+    /// <summary>
+    /// Gateway callback: returns an allow decision (with a <c>Bearer</c> Authorization header and the
+    /// token's real expiry) when the named provider has a valid token, otherwise a deny decision.
+    /// Both outcomes return HTTP 200 — the decision lives in the response body, not the status code.
+    /// </summary>
+    /// <param name="provider">Route provider id, e.g. "github" or "ado".</param>
+    /// <param name="body">The gateway's webhook request describing the outbound call.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [HttpPost("{provider}")]
+    public async Task<IActionResult> Evaluate(
+        string provider,
+        [FromBody] AuthWebhookRequest body,
+        CancellationToken ct = default)
+    {
+        if (!IsAuthorized())
+        {
+            // Do not reveal whether the header was missing, malformed, or simply wrong.
+            logger.LogWarning("Rejected unauthorized auth-webhook call for provider {Provider}.", provider);
+            return Unauthorized();
+        }
+
+        ArgumentNullException.ThrowIfNull(body);
+
+        var tokenProvider = Resolve(provider);
+        if (tokenProvider is null)
+        {
+            logger.LogWarning(
+                "Auth-webhook deny for unknown provider {Provider} (host {DestinationHost}).",
+                provider,
+                body.DestinationHost);
+            return Ok(AuthWebhookResponse.Deny("unknown provider"));
+        }
+
+        try
+        {
+            var token = await tokenProvider.GetAccessTokenAsync(body.RequiredScopes, ct);
+            logger.LogInformation(
+                "Auth-webhook allow for provider {ProviderId} (host {DestinationHost}).",
+                tokenProvider.ProviderId,
+                body.DestinationHost);
+            return Ok(AuthWebhookResponse.Allow(token));
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Not signed in / refresh failed. Keep the provider's error detail in the server log
+            // ONLY — never echo it back to the gateway, where it could surface in aggregated logs.
+            logger.LogInformation(
+                ex,
+                "Auth-webhook deny for provider {ProviderId} (host {DestinationHost}).",
+                tokenProvider.ProviderId,
+                body.DestinationHost);
+            return Ok(AuthWebhookResponse.Deny($"no valid token for provider '{tokenProvider.ProviderId}'; sign in required"));
+        }
+    }
+
+    /// <summary>
+    /// Constant-time comparison of the incoming <c>Authorization</c> header against the shared secret.
+    /// Both sides are hashed to a fixed-width SHA-256 digest first, so the comparison neither throws
+    /// on a length mismatch nor leaks the secret's length via an early-exit.
+    /// </summary>
+    private bool IsAuthorized()
+    {
+        var presented = Request.Headers.Authorization.ToString();
+        if (string.IsNullOrEmpty(presented))
+        {
+            return false;
+        }
+
+        var presentedHash = SHA256.HashData(Encoding.UTF8.GetBytes(presented));
+        var expectedHash = SHA256.HashData(Encoding.UTF8.GetBytes(sharedSecret.Value));
+        return CryptographicOperations.FixedTimeEquals(presentedHash, expectedHash);
+    }
+
+    /// <summary>Resolves a registered provider by the route id, matching <see cref="IOAuthTokenProvider.ProviderId"/> case-insensitively.</summary>
+    private IOAuthTokenProvider? Resolve(string provider) =>
+        providers.FirstOrDefault(p => string.Equals(p.ProviderId, provider, StringComparison.OrdinalIgnoreCase));
+}
+
+/// <summary>
+/// The gateway → webhook request body. Field names are the gateway's wire contract (snake_case),
+/// pinned via <see cref="JsonPropertyNameAttribute"/> so they bind regardless of the app's JSON
+/// naming defaults.
+/// </summary>
+public sealed record AuthWebhookRequest
+{
+    [JsonPropertyName("session_id")]
+    public string? SessionId { get; init; }
+
+    [JsonPropertyName("app_id")]
+    public string? AppId { get; init; }
+
+    [JsonPropertyName("provider_id")]
+    public string? ProviderId { get; init; }
+
+    [JsonPropertyName("rule_id")]
+    public string? RuleId { get; init; }
+
+    [JsonPropertyName("destination_host")]
+    public string? DestinationHost { get; init; }
+
+    [JsonPropertyName("destination_port")]
+    public int DestinationPort { get; init; }
+
+    [JsonPropertyName("method")]
+    public string? Method { get; init; }
+
+    [JsonPropertyName("path")]
+    public string? Path { get; init; }
+
+    [JsonPropertyName("required_scopes")]
+    public string[]? RequiredScopes { get; init; }
+}
+
+/// <summary>
+/// The webhook → gateway response body. Serialized with snake_case property names (pinned via
+/// <see cref="JsonPropertyNameAttribute"/>) to match the gateway contract regardless of the app's
+/// camelCase JSON defaults. <see cref="Headers"/> and <see cref="ExpiresAt"/> are populated only on
+/// an allow; <see cref="Reason"/> only on a deny.
+/// </summary>
+public sealed record AuthWebhookResponse
+{
+    [JsonPropertyName("decision")]
+    public required string Decision { get; init; }
+
+    [JsonPropertyName("headers")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string[][]? Headers { get; init; }
+
+    [JsonPropertyName("expires_at")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    [JsonPropertyName("reason")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Reason { get; init; }
+
+    /// <summary>Builds an allow decision injecting the bearer token and the token's real expiry.</summary>
+    internal static AuthWebhookResponse Allow(OAuthAccessToken token) => new()
+    {
+        Decision = "allow",
+        Headers = [["Authorization", $"Bearer {token.Value}"]],
+        ExpiresAt = token.ExpiresAtUtc,
+    };
+
+    /// <summary>Builds a deny decision carrying a (token-free) reason.</summary>
+    internal static AuthWebhookResponse Deny(string reason) => new()
+    {
+        Decision = "deny",
+        Reason = reason,
+    };
+}

--- a/samples/LmStreaming.Sample/Persistence/SystemChatModes.cs
+++ b/samples/LmStreaming.Sample/Persistence/SystemChatModes.cs
@@ -18,6 +18,11 @@ public static class SystemChatModes
     public const string MedicalKnowledgeModeId = "medical-knowledge";
 
     /// <summary>
+    /// The workspace agent mode ID.
+    /// </summary>
+    public const string WorkspaceAgentModeId = "workspace-agent";
+
+    /// <summary>
     /// Gets all system-defined chat modes.
     /// </summary>
     public static IReadOnlyList<ChatMode> All { get; } =
@@ -27,7 +32,8 @@ public static class SystemChatModes
             Id = DefaultModeId,
             Name = "General Assistant",
             Description = "A helpful assistant with access to all available tools.",
-            SystemPrompt = "You are a helpful assistant with access to weather, calculator, and web search tools. Be concise and helpful in your responses.",
+            SystemPrompt =
+                "You are a helpful assistant with access to weather, calculator, and web search tools. Be concise and helpful in your responses.",
             EnabledTools = null, // All tools enabled
             IsSystemDefined = true,
             CreatedAt = 0,
@@ -38,7 +44,8 @@ public static class SystemChatModes
             Id = "math-helper",
             Name = "Math Helper",
             Description = "A focused assistant for mathematical calculations.",
-            SystemPrompt = "You are a math assistant. Help users with calculations and mathematical problems. Use the calculator tool when needed. Be precise and show your work.",
+            SystemPrompt =
+                "You are a math assistant. Help users with calculations and mathematical problems. Use the calculator tool when needed. Be precise and show your work.",
             EnabledTools = ["calculate"],
             IsSystemDefined = true,
             CreatedAt = 0,
@@ -49,7 +56,8 @@ public static class SystemChatModes
             Id = "weather-assistant",
             Name = "Weather Assistant",
             Description = "An assistant specialized in weather information.",
-            SystemPrompt = "You are a weather assistant. Help users get weather information for any location. Use the weather tool to provide accurate forecasts. Be friendly and informative.",
+            SystemPrompt =
+                "You are a weather assistant. Help users get weather information for any location. Use the weather tool to provide accurate forecasts. Be friendly and informative.",
             EnabledTools = ["get_weather"],
             IsSystemDefined = true,
             CreatedAt = 0,
@@ -59,8 +67,10 @@ public static class SystemChatModes
         {
             Id = "research-assistant",
             Name = "Research Assistant",
-            Description = "An assistant that can search the web for up-to-date information using server-side web search.",
-            SystemPrompt = "You are a research assistant with access to web search. When the user asks questions that require up-to-date information, current events, or facts you're unsure about, use your web search capability to find accurate answers. Cite your sources when providing information from web searches.",
+            Description =
+                "An assistant that can search the web for up-to-date information using server-side web search.",
+            SystemPrompt =
+                "You are a research assistant with access to web search. When the user asks questions that require up-to-date information, current events, or facts you're unsure about, use your web search capability to find accurate answers. Cite your sources when providing information from web searches.",
             EnabledTools = ["calculate", "get_weather", "web_search"],
             IsSystemDefined = true,
             CreatedAt = 0,
@@ -70,12 +80,35 @@ public static class SystemChatModes
         {
             Id = MedicalKnowledgeModeId,
             Name = "Medical Knowledge Assistant",
-            Description = "A medical knowledge assistant that can search textbooks and reference materials to answer clinical questions.",
-            SystemPrompt = "You are a medical knowledge assistant with access to textbook search tools. "
+            Description =
+                "A medical knowledge assistant that can search textbooks and reference materials to answer clinical questions.",
+            SystemPrompt =
+                "You are a medical knowledge assistant with access to textbook search tools. "
                 + "When answering questions, use the book search tools to find relevant passages from medical textbooks. "
                 + "Cite the source (book, chapter, page) for each fact you reference. "
                 + "Be precise, evidence-based, and acknowledge uncertainty when the literature is unclear.",
             EnabledTools = [], // No local/built-in tools; only MCP book search tools
+            IsSystemDefined = true,
+            CreatedAt = 0,
+            UpdatedAt = 0,
+        },
+        new ChatMode
+        {
+            Id = WorkspaceAgentModeId,
+            Name = "Workspace Agent",
+            Description =
+                "Operates on a sandboxed workspace — reads/edits files and runs commands through the isolated sandbox.",
+            SystemPrompt =
+                "You are a workspace agent operating on a sandboxed working directory (its absolute path is given to you below). "
+                + "You MUST use the sandbox tools (Read, Write, Edit, Glob, Grep, Bash, PowerShell) for ALL file and command operations in that workspace; never assume file contents or guess command output. "
+                + "Path rules: the shell tools (Bash, PowerShell) already start IN the workspace directory, so relative paths work there. "
+                + "The file tools (Read, Write, Edit, Glob, Grep) require ABSOLUTE paths under the workspace directory — pass the workspace's absolute path as the base (and use the 'path' argument to scope Glob/Grep). "
+                + "Always Read a file before you Write or Edit it; to create a NEW file, Read it first (it will report 'not found') and then Write — this satisfies the read-before-write safeguard. "
+                + "The workspace is shared and persists across the entire conversation, so be careful with destructive commands (deleting, overwriting, or force operations) and confirm intent before running them. "
+                + "When a relevant Skill is listed in the available tools (for example a repo-explorer skill), prefer invoking the Skill tool to follow its documented procedure rather than improvising your own steps. "
+                + "When using PowerShell, pass a distinct context_id per independent task so that parallel work does not share the same current directory or environment. "
+                + "Work step-by-step: explore the workspace before editing, always read a file before writing or editing it, and summarize what you changed when you are done.",
+            EnabledTools = [], // No local sample tools; tools come from the sandbox MCP server
             IsSystemDefined = true,
             CreatedAt = 0,
             UpdatedAt = 0,

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -26,6 +26,7 @@ using LmStreaming.Sample.Agents;
 using LmStreaming.Sample.Models;
 using LmStreaming.Sample.Persistence;
 using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Auth;
 using LmStreaming.Sample.Tools;
 using LmStreaming.Sample.WebSocket;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -134,6 +135,53 @@ try
         return registry;
     });
 
+    // Sandbox MCP gateway integration (Workspace Agent mode). The gateway lifetime boots eagerly
+    // as a hosted service but is non-fatal: when the gateway is not configured/available the app
+    // still starts for all other modes; the hard failure surfaces only when Workspace Agent mode
+    // actually tries to create a sandbox session.
+    var sandboxOptions =
+        builder.Configuration.GetSection(SandboxGatewayOptions.SectionName).Get<SandboxGatewayOptions>()
+        ?? new SandboxGatewayOptions();
+    _ = builder.Services.AddSingleton(sandboxOptions);
+    _ = builder.Services.AddSingleton(sp => new SandboxGatewayLifetime(
+        sandboxOptions,
+        sp.GetRequiredService<ILogger<SandboxGatewayLifetime>>(),
+        new HttpClient()
+    ));
+    _ = builder.Services.AddHostedService(sp => sp.GetRequiredService<SandboxGatewayLifetime>());
+
+    // OAuth auth-provider services (GitHub + Azure DevOps token injection for sandbox egress).
+    var authOptions =
+        builder.Configuration.GetSection(AuthOptions.SectionName).Get<AuthOptions>() ?? new AuthOptions();
+    _ = builder.Services.AddSingleton(authOptions);
+    _ = builder.Services.AddSingleton<AuthSharedSecret>();
+    var oauthTokenDir = Path.Combine(AppContext.BaseDirectory, "oauth-tokens");
+    _ = builder.Services.AddSingleton<IOAuthTokenStore>(sp => new FileOAuthTokenStore(
+        oauthTokenDir,
+        sp.GetRequiredService<ILogger<FileOAuthTokenStore>>()
+    ));
+    _ = builder.Services.AddSingleton<IOAuthTokenProvider>(sp => new GitHubDeviceFlowProvider(
+        authOptions.Github,
+        sp.GetRequiredService<IOAuthTokenStore>(),
+        new HttpClient(),
+        sp.GetRequiredService<ILogger<GitHubDeviceFlowProvider>>()
+    ));
+    _ = builder.Services.AddSingleton<IOAuthTokenProvider>(sp => new AdoDeviceFlowProvider(
+        authOptions.Ado,
+        sp.GetRequiredService<IOAuthTokenStore>(),
+        new HttpClient(),
+        sp.GetRequiredService<ILogger<AdoDeviceFlowProvider>>()
+    ));
+
+    _ = builder.Services.AddSingleton(sp => new SandboxSessionRegistry(
+        sp.GetRequiredService<SandboxGatewayLifetime>(),
+        sandboxOptions,
+        sp.GetRequiredService<ILogger<SandboxSessionRegistry>>(),
+        new HttpClient(),
+        authOptions,
+        sp.GetRequiredService<AuthSharedSecret>()
+    ));
+
     // Codex MCP server: registered unconditionally but started lazily, so non-codex boots
     // don't pay the startup cost and so the codex provider stays selectable from the
     // dropdown regardless of LM_PROVIDER_MODE.
@@ -221,6 +269,45 @@ try
                 var isMedicalMode = mode.Id == SystemChatModes.MedicalKnowledgeModeId;
                 var mcpBaseUrl = isMedicalMode ? llmQueryMcpBaseUrl : null;
                 var normalizedProviderId = providerId.ToLowerInvariant();
+
+                // Workspace Agent mode is backed by the sandbox MCP gateway. Resolve the sandbox
+                // session up front (sync-over-async, consistent with the books wiring) and augment
+                // the system prompt with the workspace's absolute host path — the local backend has
+                // no '/workspace' mount, so the model must use the absolute path for the file tools.
+                var isWorkspaceMode = mode.Id == SystemChatModes.WorkspaceAgentModeId;
+                var sandboxRegistry = sp.GetRequiredService<SandboxSessionRegistry>();
+                var sandboxLifetime = sp.GetRequiredService<SandboxGatewayLifetime>();
+                SandboxSession? sandboxSession = null;
+                var effectiveMode = mode;
+                if (isWorkspaceMode)
+                {
+                    // Only the middleware providers (OpenAI/Anthropic/test/...) and Copilot are wired
+                    // to route tool calls to the sandbox gateway. Reject the CLI-only providers and
+                    // mock variants up front instead of creating an unused sandbox session and an
+                    // agent with no sandbox tools.
+                    if (
+                        normalizedProviderId
+                        is "codex"
+                            or "claude"
+                            or "codex-mock"
+                            or "claude-mock"
+                            or "copilot-mock"
+                    )
+                    {
+                        throw new ProviderUnavailableException(
+                            normalizedProviderId,
+                            "Workspace Agent mode supports the OpenAI/Anthropic (and Copilot) providers; this provider is not wired for the sandbox."
+                        );
+                    }
+
+                    sandboxSession = sandboxRegistry.GetOrCreateSessionAsync("default").GetAwaiter().GetResult();
+                    var wsSuffix =
+                        "\n\nYour workspace directory is: "
+                        + sandboxSession.HostPath
+                        + "\nUse this absolute path as the base for the file tools (Read, Write, Edit, Glob, Grep). "
+                        + "The shell tools (Bash, PowerShell) already start in this directory.";
+                    effectiveMode = mode with { SystemPrompt = mode.SystemPrompt + wsSuffix };
+                }
 
                 // *-mock providers reuse the same agent-loop helpers as their real counterparts;
                 // the mock-host base URL is threaded into the SDK options as a per-spawn override
@@ -372,11 +459,19 @@ try
                     return new MultiTurnAgentPool.AgentCreationResult(
                         CreateCopilotAgentLoop(
                             threadId,
-                            mode,
+                            effectiveMode,
                             functionRegistry,
                             requestResponseDumpFileName,
                             conversationStore,
-                            loggerFactory
+                            loggerFactory,
+                            extraMcpServers: isWorkspaceMode
+                                ? BuildHttpMcpServer(
+                                    "sandbox",
+                                    $"{sandboxLifetime.GatewayBaseUrl}/mcp",
+                                    new Dictionary<string, string> { ["X-Session-ID"] = sandboxSession!.SessionId }
+                                )
+                                : null,
+                            workingDirectoryOverride: isWorkspaceMode ? sandboxSession!.HostPath : null
                         )
                     );
                 }
@@ -413,6 +508,22 @@ try
                     if (mcpClients.Count > 0)
                     {
                         ownedResources = [.. mcpClients.Cast<IAsyncDisposable>()];
+                    }
+                }
+                else if (isWorkspaceMode)
+                {
+                    // Workspace Agent mode: expose the sandbox file/shell tools via the gateway's
+                    // MCP endpoint, bound to this agent's sandbox session by the X-Session-ID header.
+                    var sandboxClients = ConnectHttpMcpClient(
+                        filteredRegistry,
+                        "sandbox",
+                        $"{sandboxLifetime.GatewayBaseUrl}/mcp",
+                        new Dictionary<string, string> { ["X-Session-ID"] = sandboxSession!.SessionId },
+                        loggerFactory
+                    );
+                    if (sandboxClients.Count > 0)
+                    {
+                        ownedResources = [.. sandboxClients.Cast<IAsyncDisposable>()];
                     }
                 }
 
@@ -454,7 +565,7 @@ try
                         providerAgent,
                         filteredRegistry,
                         threadId,
-                        systemPrompt: mode.SystemPrompt,
+                        systemPrompt: effectiveMode.SystemPrompt,
                         defaultOptions: new GenerateReplyOptions
                         {
                             ModelId = modelId,
@@ -723,8 +834,9 @@ public partial class Program
 
     // Shared across the GitHub Copilot-backed agents: one token (resolved from the Copilot/gh CLI
     // login) and one client-session id for the process lifetime.
-    private static readonly Lazy<ICopilotTokenProvider> s_copilotTokenProvider =
-        new(() => new CliCredentialCopilotTokenProvider());
+    private static readonly Lazy<ICopilotTokenProvider> s_copilotTokenProvider = new(() =>
+        new CliCredentialCopilotTokenProvider()
+    );
 
     private static readonly Lazy<CopilotSessionContext> s_copilotSession = new(() => new CopilotSessionContext());
 
@@ -1189,7 +1301,9 @@ public partial class Program
         IConversationStore conversationStore,
         ILoggerFactory loggerFactory,
         string? mockBaseUrlOverride = null,
-        string? mockApiKeyOverride = null
+        string? mockApiKeyOverride = null,
+        IReadOnlyDictionary<string, McpServerConfig>? extraMcpServers = null,
+        string? workingDirectoryOverride = null
     )
     {
         var copilotCliPath = Environment.GetEnvironmentVariable("COPILOT_CLI_PATH") ?? "copilot";
@@ -1237,6 +1351,13 @@ public partial class Program
         var effectiveModelAllowlistProbeEnabled =
             string.IsNullOrWhiteSpace(mockBaseUrlOverride) && modelAllowlistProbeEnabled;
 
+        // Workspace Agent mode supplies an explicit working directory (the sandbox host path);
+        // otherwise fall back to the env-configured value.
+        var effectiveWorkingDirectory =
+            !string.IsNullOrWhiteSpace(workingDirectoryOverride) ? workingDirectoryOverride
+            : string.IsNullOrWhiteSpace(workingDirectory) ? null
+            : workingDirectory;
+
         var copilotOptions = new CopilotSdkOptions
         {
             CopilotCliPath = copilotCliPath,
@@ -1244,7 +1365,8 @@ public partial class Program
             Model = model,
             ApiKey = string.IsNullOrWhiteSpace(effectiveApiKey) ? null : effectiveApiKey,
             BaseUrl = string.IsNullOrWhiteSpace(effectiveBaseUrl) ? null : effectiveBaseUrl,
-            WorkingDirectory = string.IsNullOrWhiteSpace(workingDirectory) ? null : workingDirectory,
+            WorkingDirectory = effectiveWorkingDirectory,
+            McpServers = extraMcpServers ?? ImmutableDictionary<string, McpServerConfig>.Empty,
             EnableRpcTrace = enableRpcTrace,
             RpcTraceFilePath = traceFilePath,
             CopilotSessionId = sessionId,
@@ -1352,6 +1474,74 @@ public partial class Program
         }
 
         return (registry, createdClients);
+    }
+
+    /// <summary>
+    ///     Builds a single-entry MCP server configuration for an HTTP endpoint.
+    ///     Used by CLI-driven providers (e.g. Copilot) which advertise MCP servers to the CLI
+    ///     rather than routing tool calls through the middleware pipeline.
+    /// </summary>
+    private static Dictionary<string, McpServerConfig> BuildHttpMcpServer(
+        string name,
+        string endpoint,
+        IReadOnlyDictionary<string, string> headers
+    )
+    {
+        return new Dictionary<string, McpServerConfig>
+        {
+            [name] = McpServerConfig.CreateHttp(endpoint, headers: headers),
+        };
+    }
+
+    /// <summary>
+    ///     Connects to an HTTP MCP server and adds its tools to the FunctionRegistry.
+    ///     Used by middleware-pipeline providers (Anthropic/OpenAI) which route tool calls through
+    ///     the registry. Returns the created McpClient instances for proper disposal by the caller.
+    ///     On failure the warning is logged and an empty list is returned so the agent still runs
+    ///     (without the MCP tools), mirroring <see cref="ConnectLlmQueryMcpClients"/>.
+    /// </summary>
+    private static List<McpClient> ConnectHttpMcpClient(
+        FunctionRegistry registry,
+        string name,
+        string endpoint,
+        IReadOnlyDictionary<string, string> headers,
+        ILoggerFactory loggerFactory
+    )
+    {
+        var createdClients = new List<McpClient>();
+        var logger = loggerFactory.CreateLogger<Program>();
+        try
+        {
+            var transport = new HttpClientTransport(
+                new HttpClientTransportOptions
+                {
+                    Name = name,
+                    Endpoint = new Uri(endpoint),
+                    // AdditionalHeaders is IDictionary; copy the read-only input into a mutable map.
+                    AdditionalHeaders = new Dictionary<string, string>(headers),
+                }
+            );
+
+            // Sync-over-async: acceptable in sample app (no SynchronizationContext)
+            var client = McpClient.CreateAsync(transport).GetAwaiter().GetResult();
+            createdClients.Add(client);
+
+            var mcpClients = new Dictionary<string, McpClient> { [name] = client };
+            _ = registry.AddMcpClientsAsync(mcpClients, name).GetAwaiter().GetResult();
+
+            logger.LogInformation("Connected to MCP server '{Name}' at {Endpoint}", name, endpoint);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Failed to connect to MCP server '{Name}' at {Endpoint} — continuing without its tools",
+                name,
+                endpoint
+            );
+        }
+
+        return createdClients;
     }
 
     /// <summary>

--- a/samples/LmStreaming.Sample/SandboxWorkspaceGuide.md
+++ b/samples/LmStreaming.Sample/SandboxWorkspaceGuide.md
@@ -1,0 +1,203 @@
+# Sandbox Workspace Guide — "Workspace Agent" mode
+
+This guide covers the **Workspace Agent** chat mode in the `LmStreaming.Sample` app. In this
+mode the LLM operates inside an isolated sandbox: its file/command tools are executed by an
+external Rust MCP gateway (the `SandboxedOstoolsMcpServer` project), scoped to one configured
+host directory.
+
+## Overview
+
+The sample can run an LLM that works inside a **sandboxed workspace**. The following tools are
+executed by the gateway, not by the host process:
+
+- **File operations** — `Read`, `Write`, `Edit`, `Glob`, `Grep`
+- **Shell** — `Bash`, `PowerShell`
+- **`Skill`** — runs a documented procedure from a configured skills directory
+
+Every tool runs scoped to a single configured host directory, with **default-deny network
+egress**.
+
+### Two provider paths
+
+There are two ways to drive this mode, with different isolation guarantees:
+
+- **Middleware providers (Anthropic / OpenAI) — the true-sandbox showcase.**
+  Every tool call goes through the gateway; no native tools compete for the same operations.
+  This path requires an API key (`ANTHROPIC_API_KEY` or `OPENAI_API_KEY`).
+  **Use this path when you want to demonstrate real, enforced isolation.**
+
+- **Copilot — the no-API-key convenience path.**
+  Uses a `gh`/Copilot token instead of an API key. Caveat: the Copilot CLI ships its **own**
+  native file/`Bash` tools that run on the host *outside* the gateway, so its isolation is
+  best-effort / prompt-steered, **not enforced**. Prefer the middleware path whenever you are
+  demonstrating isolation; use Copilot only for a quick, key-free try.
+
+## Prerequisites
+
+- **.NET 9 SDK** (the sample targets `net9.0`).
+- **Node 20** (for the Vite client in `ClientApp/`).
+- **The gateway, built once.** In `B:\sources\SandboxedOstoolsMcpServer` run:
+
+  ```bash
+  cargo build --release -p mcp-gateway -p agent-cli
+  ```
+
+  This produces:
+
+  ```text
+  target\release\mcp-gateway.exe
+  target\release\agent-cli.exe
+  ```
+
+### Optional hardening (not required)
+
+The gateway can additionally confine the `PowerShell` tool inside a Windows **AppContainer**.
+That is a one-time, admin-only setup via `scripts\install-windows-sandbox.ps1` in the gateway
+repo. **You do not need it for a first run:** the sample spawns the gateway with AppContainer
+confinement explicitly disabled (`LOCAL_SANDBOX_APPCONTAINER=false`) so the demo works
+frictionlessly out of the box.
+
+## Configuration
+
+Workspace Agent mode is configured through the **`SandboxGateway`** section of
+`appsettings.json` / `appsettings.Development.json`. The fields map to
+`Services/SandboxGatewayOptions.cs`:
+
+| Field | Default | Purpose |
+| --- | --- | --- |
+| `BaseUrl` | `http://localhost:3000` | Base URL of the gateway the app connects to. |
+| `Workspace` | — | Workspace path **relative to `WorkspaceBasePath`**, mounted as the sandbox workspace. |
+| `WorkspaceBasePath` | — | Host base directory the gateway resolves the workspace under (becomes `WORKSPACE_BASE_PATH` when the gateway is spawned). |
+| `AppId` | `lmstreaming-sample` | App id sent in the sandbox-create request. |
+| `AutoSpawn` | `true` | If a healthy gateway is already running at `BaseUrl`, adopt it; otherwise spawn `GatewayExePath`. |
+| `GatewayExePath` | — | Absolute path to the built `mcp-gateway.exe`, used for auto-spawn. |
+| `AgentCliPath` | — | Absolute path to the built `agent-cli.exe` (becomes `LOCAL_AGENT_CLI_PATH` when the gateway is spawned). |
+| `SkillsDir` | — | Directory whose `<skill>/SKILL.md` files become the gateway's `Skill` tool (becomes `SKILLS_DIRS`). The repo ships `sandbox-skills/repo-explorer`. |
+
+Example (`appsettings.Development.json`):
+
+```json
+{
+  "SandboxGateway": {
+    "BaseUrl": "http://localhost:3000",
+    "Workspace": "LmDotnetTools",
+    "WorkspaceBasePath": "B:\\sources",
+    "AppId": "lmstreaming-sample",
+    "AutoSpawn": true,
+    "GatewayExePath": "B:\\sources\\SandboxedOstoolsMcpServer\\target\\release\\mcp-gateway.exe",
+    "AgentCliPath": "B:\\sources\\SandboxedOstoolsMcpServer\\target\\release\\agent-cli.exe",
+    "SkillsDir": "B:\\sources\\LmDotnetTools\\samples\\LmStreaming.Sample\\sandbox-skills"
+  }
+}
+```
+
+With the example above, the mounted workspace is `WorkspaceBasePath` + `Workspace` =
+`B:\sources\LmDotnetTools`.
+
+> **Startup is non-fatal.** If the gateway is not configured or not reachable, the app still
+> boots and runs all other chat modes. The error only surfaces when **Workspace Agent mode is
+> actually used** (i.e. when the first sandbox session is created).
+
+## Running
+
+1. **Start the backend** (serves the API + `/ws` on `http://localhost:5000`):
+
+   ```bash
+   dotnet run --project samples/LmStreaming.Sample
+   ```
+
+   On boot the app adopts a healthy gateway already listening at `BaseUrl`, or spawns one
+   (local/Windows backend).
+
+2. **Start the client** (Vite dev server on `http://localhost:5173`):
+
+   ```bash
+   npm --prefix samples/LmStreaming.Sample/ClientApp install
+   npm --prefix samples/LmStreaming.Sample/ClientApp run dev
+   ```
+
+3. **In the UI:**
+   - Pick a **provider** — Anthropic or OpenAI for the true-sandbox demo, or Copilot for the
+     key-free path.
+   - Select the **Workspace Agent** mode.
+   - Start chatting.
+
+## How it works (brief)
+
+- On first use of Workspace Agent mode the app POSTs to
+  `{gateway}/api/v1/sandboxes` with a body like:
+
+  ```json
+  { "app": { "id": "lmstreaming-sample" }, "workspace": "LmDotnetTools" }
+  ```
+
+  and gets back a `session_id`.
+
+- Tool calls are sent to `{gateway}/mcp` (JSON-RPC) with an `X-Session-ID` header. The gateway
+  runs each tool inside the sandbox bound to that session.
+
+### Important path model (local/Windows backend)
+
+There is **no `/workspace` path** in the local backend. Instead:
+
+- The **shell tools** (`Bash`, `PowerShell`) **start in the workspace directory**, so relative
+  paths work there.
+- The **file tools** (`Read`, `Write`, `Edit`, `Glob`, `Grep`) require **absolute host paths**
+  under the workspace.
+
+To make the model use the right base path, the app injects the workspace's **absolute host
+path** into the system prompt at runtime (the gateway reports it when the session is created).
+
+### Session lifetime
+
+The sandbox session is **app-wide** — shared across all tabs and conversations — and is
+**deleted when the app shuts down**.
+
+## Try it (manual test prompts)
+
+Paste these into the chat after selecting a provider and the **Workspace Agent** mode:
+
+1. **List + summarize**
+   > List the files in the workspace and summarize the README.
+
+   *Expect:* `Glob`/`Read`/`Bash` tool-call pills and a real file listing of the workspace.
+
+2. **Write + read back**
+   > Create `notes.md` containing "hello" and read it back.
+
+   *Expect:* a `Write` followed by a `Read`; the file actually appears in the host workspace
+   directory.
+
+3. **Run a skill**
+   > Use the repo-explorer skill to map this project.
+
+   *Expect:* a `Skill` tool call that produces a structured JSON manifest (languages, entry
+   points, build/test commands, and a one-line purpose per top-level directory).
+
+4. **Isolation — refused egress / path escape** *(middleware path)*
+   > Read `C:\Windows\win.ini`.
+
+   *Expect:* the tool refuses with "path is outside the sandbox" — the file is outside the
+   mounted workspace.
+
+5. **Shell in the workspace**
+   > Run `ls` (or `Get-ChildItem`) and tell me how many files are in the workspace root.
+
+   *Expect:* a `Bash`/`PowerShell` pill; relative paths resolve because the shell starts in the
+   workspace directory.
+
+## Troubleshooting
+
+- **Gateway won't start.**
+  Ensure `cargo build --release` ran successfully and that `GatewayExePath` / `AgentCliPath`
+  point at the built executables. Check the app logs for the spawn error (the gateway's
+  stdout/stderr is mirrored into the app log).
+
+- **"Workspace Agent mode supports the OpenAI/Anthropic (and Copilot) providers…"**
+  You selected Workspace Agent mode with a provider that is not wired for the sandbox (e.g.
+  codex, claude, or a mock provider). Switch to Anthropic, OpenAI, or Copilot.
+
+- **Tools say "path is outside the sandbox" for relative file-tool paths.**
+  This is **expected** for the file tools in the local backend. Use the **absolute workspace
+  path** that the system prompt gives you as the base for `Read`/`Write`/`Edit`/`Glob`/`Grep`.
+  (The shell tools, by contrast, already start in the workspace and accept relative paths.)

--- a/samples/LmStreaming.Sample/Services/Auth/AdoDeviceFlowProvider.cs
+++ b/samples/LmStreaming.Sample/Services/Auth/AdoDeviceFlowProvider.cs
@@ -1,0 +1,64 @@
+namespace LmStreaming.Sample.Services.Auth;
+
+/// <summary>
+/// Azure DevOps device-code OAuth provider backed by the Microsoft Entra (Azure AD) v2.0 endpoints.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Entra's device-code and token endpoints accept <c>application/x-www-form-urlencoded</c> requests
+/// and return JSON, so no <c>Accept</c> override is needed. A <c>refresh_token</c> is only issued
+/// when the requested scopes include <c>offline_access</c> (carried in <see cref="AdoAuthOptions.Scopes"/>),
+/// and the refresh grant must repeat the <c>scope</c> parameter — see <see cref="AddRefreshScope"/>.
+/// </para>
+/// <para>
+/// Entra does not return <c>verification_uri_complete</c> for the device-code flow, so the challenge
+/// surfaces only the <c>verification_uri</c> + <c>user_code</c>.
+/// </para>
+/// </remarks>
+public sealed class AdoDeviceFlowProvider : DeviceFlowOAuthProviderBase
+{
+    private readonly AdoAuthOptions _options;
+
+    /// <summary>Creates the Azure DevOps (Entra) device-code provider.</summary>
+    /// <param name="options">Entra client id, tenant + scopes (include <c>offline_access</c>).</param>
+    /// <param name="store">Token persistence.</param>
+    /// <param name="http">HTTP client for the OAuth calls.</param>
+    /// <param name="logger">Logger; token material is never written to it.</param>
+    public AdoDeviceFlowProvider(
+        AdoAuthOptions options,
+        IOAuthTokenStore store,
+        HttpClient http,
+        ILogger<AdoDeviceFlowProvider> logger)
+        : base(store, http, logger)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <inheritdoc />
+    public override string ProviderId => "ado";
+
+    /// <inheritdoc />
+    protected override string? ClientId => _options.ClientId;
+
+    /// <inheritdoc />
+    protected override IReadOnlyList<string> Scopes => _options.Scopes;
+
+    /// <inheritdoc />
+    protected override string DeviceCodeEndpoint =>
+        $"https://login.microsoftonline.com/{_options.TenantId}/oauth2/v2.0/devicecode";
+
+    /// <inheritdoc />
+    protected override string TokenEndpoint =>
+        $"https://login.microsoftonline.com/{_options.TenantId}/oauth2/v2.0/token";
+
+    /// <summary>Entra's refresh grant requires the original space-joined scopes.</summary>
+    protected override void AddRefreshScope(Dictionary<string, string> form) =>
+        form["scope"] = string.Join(' ', Scopes);
+
+    /// <summary>
+    /// Account resolution is best-effort and not required for Azure DevOps; the access token is an
+    /// opaque Entra token that must not be parsed by clients, so we return <c>null</c>.
+    /// </summary>
+    protected override Task<string?> ResolveAccountAsync(string accessToken, CancellationToken ct) =>
+        Task.FromResult<string?>(null);
+}

--- a/samples/LmStreaming.Sample/Services/Auth/AuthOptions.cs
+++ b/samples/LmStreaming.Sample/Services/Auth/AuthOptions.cs
@@ -1,0 +1,53 @@
+namespace LmStreaming.Sample.Services.Auth;
+
+/// <summary>
+/// Strongly-typed configuration for the OAuth auth-provider feature.
+/// Bound from the <c>Auth</c> configuration section.
+/// </summary>
+public sealed class AuthOptions
+{
+    /// <summary>Configuration section name these options are bound from.</summary>
+    public const string SectionName = "Auth";
+
+    /// <summary>GitHub device-code sign-in settings.</summary>
+    public GitHubAuthOptions Github { get; set; } = new();
+
+    /// <summary>Azure DevOps (Entra) device-code sign-in settings.</summary>
+    public AdoAuthOptions Ado { get; set; } = new();
+
+    /// <summary>Gateway↔webhook callback settings.</summary>
+    public WebhookOptions Webhook { get; set; } = new();
+}
+
+/// <summary>GitHub OAuth/device-code settings.</summary>
+public sealed class GitHubAuthOptions
+{
+    /// <summary>GitHub App (or OAuth App) client id. When null/empty, GitHub auth is disabled.</summary>
+    public string? ClientId { get; set; }
+
+    /// <summary>Scopes requested during the GitHub device-code flow.</summary>
+    public string[] Scopes { get; set; } = ["repo", "read:org"];
+}
+
+/// <summary>Azure DevOps (Entra) OAuth/device-code settings.</summary>
+public sealed class AdoAuthOptions
+{
+    /// <summary>Entra app (public client) id. When null/empty, ADO auth is disabled.</summary>
+    public string? ClientId { get; set; }
+
+    /// <summary>Entra tenant; "organizations" works for multi-tenant work/school accounts.</summary>
+    public string TenantId { get; set; } = "organizations";
+
+    /// <summary>Azure DevOps resource scope + offline_access for refresh tokens.</summary>
+    public string[] Scopes { get; set; } = ["499b84ac-1321-427f-aa17-267ca6975798/.default", "offline_access"];
+}
+
+/// <summary>Gateway↔webhook callback settings.</summary>
+public sealed class WebhookOptions
+{
+    /// <summary>Externally-reachable base URL the gateway calls back on (loopback for local dev).</summary>
+    public string PublicBaseUrl { get; set; } = "http://127.0.0.1:5000";
+
+    /// <summary>Shared secret the gateway sends as Authorization when calling the webhook. When null, one is generated at startup.</summary>
+    public string? GatewaySharedSecret { get; set; }
+}

--- a/samples/LmStreaming.Sample/Services/Auth/AuthSharedSecret.cs
+++ b/samples/LmStreaming.Sample/Services/Auth/AuthSharedSecret.cs
@@ -1,0 +1,36 @@
+using System.Security.Cryptography;
+
+namespace LmStreaming.Sample.Services.Auth;
+
+/// <summary>
+/// Resolves the gateway↔webhook shared secret exactly once for the process lifetime.
+/// Registered as a singleton so the webhook controller and the sandbox registry observe
+/// the same value: it comes from <see cref="WebhookOptions.GatewaySharedSecret"/> when
+/// configured, otherwise a cryptographically-random value generated at startup.
+/// </summary>
+/// <remarks>
+/// SECRET — the resolved <see cref="Value"/> authenticates gateway callbacks and must never
+/// be logged.
+/// </remarks>
+public sealed class AuthSharedSecret
+{
+    /// <summary>
+    /// Resolves the shared secret from the supplied <paramref name="options"/>, falling back
+    /// to a freshly generated cryptographically-random value when none is configured.
+    /// </summary>
+    /// <param name="options">Auth options carrying the optional configured secret.</param>
+    public AuthSharedSecret(AuthOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var configured = options.Webhook.GatewaySharedSecret;
+        Value = string.IsNullOrWhiteSpace(configured)
+            ? RandomNumberGenerator.GetHexString(64)
+            : configured;
+    }
+
+    /// <summary>
+    /// The resolved shared secret. SECRET — never log this value.
+    /// </summary>
+    public string Value { get; }
+}

--- a/samples/LmStreaming.Sample/Services/Auth/DeviceFlowOAuthProviderBase.cs
+++ b/samples/LmStreaming.Sample/Services/Auth/DeviceFlowOAuthProviderBase.cs
@@ -1,0 +1,558 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace LmStreaming.Sample.Services.Auth;
+
+/// <summary>
+/// Shared implementation of the OAuth 2.0 <em>device authorization grant</em>
+/// (<see href="https://www.rfc-editor.org/rfc/rfc8628">RFC 8628</see>) plus the refresh-token
+/// grant. Concrete providers (GitHub, Entra/ADO) supply only the endpoints, client id, scopes and
+/// the best-effort account-resolution hook; this base owns the device-code request, the background
+/// polling loop, token persistence and on-demand refresh.
+/// </summary>
+/// <remarks>
+/// SECURITY: access tokens and refresh tokens are secrets. This type never logs token material —
+/// only provider id, sign-in state, expiry, HTTP status and OAuth error codes.
+/// </remarks>
+public abstract partial class DeviceFlowOAuthProviderBase : IOAuthTokenProvider
+{
+    /// <summary>The device-code grant type used when polling the token endpoint.</summary>
+    private const string DeviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code";
+
+    /// <summary>The refresh-token grant type used to renew an access token.</summary>
+    private const string RefreshTokenGrantType = "refresh_token";
+
+    /// <summary>Refresh the access token this many seconds before it actually expires.</summary>
+    private static readonly TimeSpan ExpirySkew = TimeSpan.FromSeconds(120);
+
+    /// <summary>Fallback device-code lifetime when the server omits <c>expires_in</c>.</summary>
+    private static readonly TimeSpan DefaultDeviceCodeLifetime = TimeSpan.FromSeconds(900);
+
+    /// <summary>Used as the stored expiry for non-expiring tokens (e.g. classic GitHub OAuth Apps). Computed at use so it is always ~100 years from issuance, not from process start.</summary>
+    private static DateTimeOffset NonExpiringSentinel => DateTimeOffset.UtcNow.AddYears(100);
+
+    private readonly IOAuthTokenStore _store;
+    private readonly object _statusGate = new();
+    private readonly SemaphoreSlim _refreshGate = new(1, 1);
+
+    private OAuthStatus _status = new(OAuthSignInState.NotStarted, Account: null, Scopes: [], ExpiresAtUtc: null, Error: null);
+    private CancellationTokenSource? _pollCts;
+    private Task? _pollTask;
+
+    /// <summary>The HTTP client used for every OAuth call (injected for testability).</summary>
+    protected HttpClient Http { get; }
+
+    /// <summary>Logger scoped to the concrete provider.</summary>
+    protected ILogger Logger { get; }
+
+    /// <summary>Creates the base provider.</summary>
+    /// <param name="store">Persistence for the refresh/access token record.</param>
+    /// <param name="http">HTTP client used for all OAuth endpoints.</param>
+    /// <param name="logger">Logger; token material is never written to it.</param>
+    protected DeviceFlowOAuthProviderBase(IOAuthTokenStore store, HttpClient http, ILogger logger)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        Http = http ?? throw new ArgumentNullException(nameof(http));
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public abstract string ProviderId { get; }
+
+    /// <summary>Client id of the registered app, or null/empty when the provider is disabled.</summary>
+    protected abstract string? ClientId { get; }
+
+    /// <summary>Scopes requested during sign-in. Space-joined when sent to the server.</summary>
+    protected abstract IReadOnlyList<string> Scopes { get; }
+
+    /// <summary>Absolute URL of the device-authorization (<c>device/code</c>) endpoint.</summary>
+    protected abstract string DeviceCodeEndpoint { get; }
+
+    /// <summary>Absolute URL of the token endpoint (device-code + refresh grants).</summary>
+    protected abstract string TokenEndpoint { get; }
+
+    /// <summary>
+    /// When true the request carries <c>Accept: application/json</c> so the server returns a JSON
+    /// body (GitHub defaults to form-encoded responses without it). Entra always returns JSON.
+    /// </summary>
+    protected virtual bool SendJsonAcceptHeader => false;
+
+    /// <summary>
+    /// Best-effort resolution of a human-readable account/display name from a freshly issued access
+    /// token. Implementations must swallow failures and return <c>null</c> rather than throw.
+    /// </summary>
+    /// <param name="accessToken">The newly issued access token (secret — do not log).</param>
+    /// <param name="ct">Cancellation token.</param>
+    protected abstract Task<string?> ResolveAccountAsync(string accessToken, CancellationToken ct);
+
+    /// <inheritdoc />
+    public OAuthStatus Status
+    {
+        get
+        {
+            lock (_statusGate)
+            {
+                return _status;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<DeviceCodeChallenge> BeginSignInAsync(CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(ClientId))
+        {
+            throw new InvalidOperationException($"OAuth provider '{ProviderId}' is not configured (missing ClientId).");
+        }
+
+        // Cancel any in-flight poll from a previous BeginSignIn before starting a new one.
+        await CancelPollAsync().ConfigureAwait(false);
+
+        var device = await RequestDeviceCodeAsync(ct).ConfigureAwait(false);
+
+        SetStatus(new OAuthStatus(OAuthSignInState.Pending, Account: null, Scopes, ExpiresAtUtc: null, Error: null));
+        Logger.LogInformation("OAuth device-code flow started for provider {ProviderId} (expires in {ExpiresIn}s).", ProviderId, device.ExpiresIn);
+
+        // Fire-and-forget background polling; BeginSignIn must not block on user authorization.
+        var cts = new CancellationTokenSource();
+        _pollCts = cts;
+        _pollTask = Task.Run(() => PollForTokenAsync(device, cts.Token), CancellationToken.None);
+
+        return new DeviceCodeChallenge(
+            device.UserCode,
+            device.VerificationUri,
+            device.VerificationUriComplete,
+            device.ExpiresIn,
+            Math.Max(1, device.Interval));
+    }
+
+    /// <inheritdoc />
+    public async Task SignOutAsync(CancellationToken ct = default)
+    {
+        await CancelPollAsync().ConfigureAwait(false);
+        await _store.RemoveAsync(ProviderId, ct).ConfigureAwait(false);
+        SetStatus(new OAuthStatus(OAuthSignInState.NotStarted, Account: null, Scopes: [], ExpiresAtUtc: null, Error: null));
+        Logger.LogInformation("Signed out of OAuth provider {ProviderId}.", ProviderId);
+    }
+
+    /// <inheritdoc />
+    public async Task<OAuthAccessToken> GetAccessTokenAsync(IReadOnlyList<string>? scopes = null, CancellationToken ct = default)
+    {
+        var record = await _store.GetAsync(ProviderId, ct).ConfigureAwait(false)
+            ?? throw new InvalidOperationException($"OAuth provider '{ProviderId}' is not signed in.");
+
+        if (TryGetValidAccessToken(record, out var current))
+        {
+            return current;
+        }
+
+        return await RefreshAccessTokenAsync(record, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the stored access token when it is present and either non-refreshable (so the stored
+    /// value is the only option) or comfortably outside the expiry skew.
+    /// </summary>
+    private static bool TryGetValidAccessToken(OAuthTokenRecord record, out OAuthAccessToken token)
+    {
+        token = default!;
+        if (string.IsNullOrEmpty(record.AccessToken))
+        {
+            return false;
+        }
+
+        var expiry = record.AccessTokenExpiresAtUtc ?? NonExpiringSentinel;
+        var canRefresh = !string.IsNullOrEmpty(record.RefreshToken);
+
+        // A still-valid token, or a token we have no way to refresh (return what we have).
+        if (!canRefresh || expiry - ExpirySkew > DateTimeOffset.UtcNow)
+        {
+            token = new OAuthAccessToken(record.AccessToken, expiry);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Refreshes the access token via the refresh-token grant. Serialized by a semaphore so
+    /// concurrent callers don't stampede the token endpoint; the first to acquire performs the
+    /// refresh and the rest observe the freshly persisted token.
+    /// </summary>
+    private async Task<OAuthAccessToken> RefreshAccessTokenAsync(OAuthTokenRecord record, CancellationToken ct)
+    {
+        await _refreshGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            // Re-read after acquiring the gate: another caller may have already refreshed.
+            var latest = await _store.GetAsync(ProviderId, ct).ConfigureAwait(false) ?? record;
+            if (TryGetValidAccessToken(latest, out var fresh))
+            {
+                return fresh;
+            }
+
+            if (string.IsNullOrEmpty(latest.RefreshToken))
+            {
+                SetFailed("no refresh token available");
+                throw new InvalidOperationException($"OAuth provider '{ProviderId}' has no refresh token; sign in again.");
+            }
+
+            var form = new Dictionary<string, string>
+            {
+                ["grant_type"] = RefreshTokenGrantType,
+                ["client_id"] = ClientId!,
+                ["refresh_token"] = latest.RefreshToken,
+            };
+            AddRefreshScope(form);
+
+            var response = await PostTokenAsync(form, ct).ConfigureAwait(false);
+            if (string.IsNullOrEmpty(response.AccessToken))
+            {
+                SetFailed(response.Error ?? "refresh failed");
+                throw new InvalidOperationException(
+                    $"OAuth provider '{ProviderId}' token refresh failed: {response.Error ?? "no access_token returned"}.");
+            }
+
+            var updated = ApplyTokenResponse(latest, response);
+            await _store.SaveAsync(updated, ct).ConfigureAwait(false);
+            SetStatus(new OAuthStatus(OAuthSignInState.SignedIn, updated.Account, updated.Scopes, updated.AccessTokenExpiresAtUtc, Error: null));
+            Logger.LogInformation("Refreshed access token for provider {ProviderId} (expires {ExpiresAt:o}).", ProviderId, updated.AccessTokenExpiresAtUtc);
+
+            return new OAuthAccessToken(updated.AccessToken!, updated.AccessTokenExpiresAtUtc ?? NonExpiringSentinel);
+        }
+        finally
+        {
+            _ = _refreshGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Background loop that polls the token endpoint until the user authorizes, the device code
+    /// expires, the user denies, or the flow is cancelled. Never throws into the runtime: terminal
+    /// problems are surfaced as a <see cref="OAuthSignInState.Failed"/> status.
+    /// </summary>
+    private async Task PollForTokenAsync(DeviceCodeResult device, CancellationToken ct)
+    {
+        var interval = TimeSpan.FromSeconds(Math.Max(1, device.Interval));
+        var lifetime = TimeSpan.FromSeconds(device.ExpiresIn <= 0 ? (int)DefaultDeviceCodeLifetime.TotalSeconds : device.ExpiresIn);
+        var elapsed = Stopwatch.StartNew();
+
+        try
+        {
+            while (elapsed.Elapsed < lifetime)
+            {
+                await Task.Delay(interval, ct).ConfigureAwait(false);
+
+                var form = new Dictionary<string, string>
+                {
+                    ["grant_type"] = DeviceCodeGrantType,
+                    ["client_id"] = ClientId!,
+                    ["device_code"] = device.DeviceCode,
+                };
+
+                var response = await PostTokenAsync(form, ct).ConfigureAwait(false);
+                if (!string.IsNullOrEmpty(response.AccessToken))
+                {
+                    await PersistNewSignInAsync(response, ct).ConfigureAwait(false);
+                    return;
+                }
+
+                switch (response.Error)
+                {
+                    case "authorization_pending":
+                        break;
+                    case "slow_down":
+                        interval += TimeSpan.FromSeconds(5);
+                        Logger.LogDebug("Provider {ProviderId} device-code polling backing off to {Interval}s.", ProviderId, interval.TotalSeconds);
+                        break;
+                    case "access_denied":
+                    case "authorization_declined":
+                    case "expired_token":
+                    case "bad_verification_code":
+                        SetFailed(response.Error);
+                        Logger.LogWarning("Provider {ProviderId} device-code flow failed: {Error}.", ProviderId, response.Error);
+                        return;
+                    default:
+                        if (!string.IsNullOrEmpty(response.Error))
+                        {
+                            SetFailed(response.Error);
+                            Logger.LogWarning("Provider {ProviderId} device-code flow failed: {Error}.", ProviderId, response.Error);
+                            return;
+                        }
+
+                        break;
+                }
+            }
+
+            SetFailed("timed_out");
+            Logger.LogWarning("Provider {ProviderId} device-code flow timed out before authorization.", ProviderId);
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancelled by SignOut / a subsequent BeginSignIn — leave the new status alone.
+            Logger.LogDebug("Provider {ProviderId} device-code polling cancelled.", ProviderId);
+        }
+        catch (Exception ex)
+        {
+            SetFailed("polling_error");
+            Logger.LogError(ex, "Provider {ProviderId} device-code polling errored.", ProviderId);
+        }
+    }
+
+    /// <summary>Persists a brand-new sign-in (token + best-effort account) and marks the provider signed in.</summary>
+    private async Task PersistNewSignInAsync(TokenResponse response, CancellationToken ct)
+    {
+        var account = await SafeResolveAccountAsync(response.AccessToken!, ct).ConfigureAwait(false);
+        var record = new OAuthTokenRecord(
+            ProviderId,
+            account,
+            response.RefreshToken ?? string.Empty,
+            response.AccessToken,
+            ComputeExpiry(response),
+            Scopes);
+
+        await _store.SaveAsync(record, ct).ConfigureAwait(false);
+        SetStatus(new OAuthStatus(OAuthSignInState.SignedIn, account, Scopes, record.AccessTokenExpiresAtUtc, Error: null));
+        Logger.LogInformation("Signed in to provider {ProviderId} as {Account} (expires {ExpiresAt:o}).", ProviderId, account ?? "<unknown>", record.AccessTokenExpiresAtUtc);
+    }
+
+    /// <summary>Wraps <see cref="ResolveAccountAsync"/> so a faulty implementation cannot break sign-in.</summary>
+    private async Task<string?> SafeResolveAccountAsync(string accessToken, CancellationToken ct)
+    {
+        try
+        {
+            return await ResolveAccountAsync(accessToken, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Provider {ProviderId} could not resolve account name (best-effort).", ProviderId);
+            return null;
+        }
+    }
+
+    /// <summary>Merges a refresh-grant response onto the existing record, preserving the old refresh token when not rotated.</summary>
+    private OAuthTokenRecord ApplyTokenResponse(OAuthTokenRecord existing, TokenResponse response) =>
+        existing with
+        {
+            AccessToken = response.AccessToken,
+            AccessTokenExpiresAtUtc = ComputeExpiry(response),
+            // Entra/GitHub may rotate the refresh token; keep the previous one when none is returned.
+            RefreshToken = string.IsNullOrEmpty(response.RefreshToken) ? existing.RefreshToken : response.RefreshToken,
+        };
+
+    /// <summary>Computes the absolute access-token expiry; non-expiring tokens use a far-future sentinel.</summary>
+    private static DateTimeOffset ComputeExpiry(TokenResponse response) =>
+        response.ExpiresIn > 0 ? DateTimeOffset.UtcNow.AddSeconds(response.ExpiresIn) : NonExpiringSentinel;
+
+    /// <summary>POSTs the device-authorization request and parses the challenge.</summary>
+    private async Task<DeviceCodeResult> RequestDeviceCodeAsync(CancellationToken ct)
+    {
+        var form = new Dictionary<string, string>
+        {
+            ["client_id"] = ClientId!,
+            ["scope"] = string.Join(' ', Scopes),
+        };
+
+        using var request = BuildFormRequest(DeviceCodeEndpoint, form);
+        using var response = await Http.SendAsync(request, ct).ConfigureAwait(false);
+        var json = await ReadJsonOrThrowAsync(response, "device-code", ct).ConfigureAwait(false);
+
+        var result = json.Deserialize(DeviceFlowJson.Default.DeviceCodeResult);
+        if (result is null || string.IsNullOrEmpty(result.DeviceCode))
+        {
+            throw new InvalidOperationException($"OAuth provider '{ProviderId}' device-code endpoint returned an unusable response.");
+        }
+
+        return result;
+    }
+
+    /// <summary>POSTs to the token endpoint and parses the (possibly error) token response.</summary>
+    private async Task<TokenResponse> PostTokenAsync(Dictionary<string, string> form, CancellationToken ct)
+    {
+        using var request = BuildFormRequest(TokenEndpoint, form);
+        using var response = await Http.SendAsync(request, ct).ConfigureAwait(false);
+
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            Logger.LogWarning("Provider {ProviderId} token endpoint returned empty body (HTTP {Status}).", ProviderId, (int)response.StatusCode);
+            return new TokenResponse { Error = "empty_response" };
+        }
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize(body, DeviceFlowJson.Default.TokenResponse);
+            return parsed ?? new TokenResponse { Error = "empty_response" };
+        }
+        catch (JsonException ex)
+        {
+            // The token endpoint always speaks JSON for our providers; a parse failure is unexpected.
+            Logger.LogWarning(ex, "Provider {ProviderId} token endpoint returned unparseable body (HTTP {Status}).", ProviderId, (int)response.StatusCode);
+            return new TokenResponse { Error = "unparseable_response" };
+        }
+    }
+
+    /// <summary>Builds a form-urlencoded POST, adding the JSON Accept header for providers that need it.</summary>
+    private HttpRequestMessage BuildFormRequest(string endpoint, Dictionary<string, string> form)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = new FormUrlEncodedContent(form),
+        };
+        if (SendJsonAcceptHeader)
+        {
+            request.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
+        }
+
+        return request;
+    }
+
+    /// <summary>Ensures a successful HTTP status and returns the parsed JSON document, logging (without secrets) on failure.</summary>
+    private async Task<JsonElement> ReadJsonOrThrowAsync(HttpResponseMessage response, string what, CancellationToken ct)
+    {
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = TryExtractError(body);
+            Logger.LogWarning("Provider {ProviderId} {What} request failed: HTTP {Status} {Error}.", ProviderId, what, (int)response.StatusCode, error ?? "<no error>");
+            throw new InvalidOperationException($"OAuth provider '{ProviderId}' {what} request failed (HTTP {(int)response.StatusCode}{(error is null ? "" : $": {error}")}).");
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            return doc.RootElement.Clone();
+        }
+        catch (JsonException ex)
+        {
+            Logger.LogWarning(ex, "Provider {ProviderId} {What} response was not valid JSON.", ProviderId, what);
+            throw new InvalidOperationException($"OAuth provider '{ProviderId}' {what} response was not valid JSON.", ex);
+        }
+    }
+
+    /// <summary>Best-effort extraction of the OAuth <c>error</c> field from an error body for logging.</summary>
+    private static string? TryExtractError(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            return doc.RootElement.TryGetProperty("error", out var error) ? error.GetString() : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Hook for providers whose refresh grant requires a <c>scope</c> field (Entra). No-op by default.</summary>
+    protected virtual void AddRefreshScope(Dictionary<string, string> form)
+    {
+    }
+
+    /// <summary>Atomically swaps the current status.</summary>
+    private void SetStatus(OAuthStatus status)
+    {
+        lock (_statusGate)
+        {
+            _status = status;
+        }
+    }
+
+    /// <summary>Marks the provider failed, preserving the current account/expiry for context.</summary>
+    private void SetFailed(string error)
+    {
+        lock (_statusGate)
+        {
+            _status = _status with { State = OAuthSignInState.Failed, Error = error };
+        }
+    }
+
+    /// <summary>Cancels and disposes the current polling task/CTS, awaiting clean shutdown.</summary>
+    private async Task CancelPollAsync()
+    {
+        var cts = _pollCts;
+        var task = _pollTask;
+        _pollCts = null;
+        _pollTask = null;
+
+        if (cts is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await cts.CancelAsync().ConfigureAwait(false);
+            if (task is not null)
+            {
+                await task.ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when the poll loop observes cancellation.
+        }
+        finally
+        {
+            cts.Dispose();
+        }
+    }
+
+    /// <summary>The device-authorization response (RFC 8628 §3.2).</summary>
+    private sealed record DeviceCodeResult
+    {
+        [JsonPropertyName("device_code")]
+        public string DeviceCode { get; init; } = string.Empty;
+
+        [JsonPropertyName("user_code")]
+        public string UserCode { get; init; } = string.Empty;
+
+        [JsonPropertyName("verification_uri")]
+        public string VerificationUri { get; init; } = string.Empty;
+
+        [JsonPropertyName("verification_uri_complete")]
+        public string? VerificationUriComplete { get; init; }
+
+        [JsonPropertyName("expires_in")]
+        public int ExpiresIn { get; init; }
+
+        [JsonPropertyName("interval")]
+        public int Interval { get; init; }
+    }
+
+    /// <summary>The token-endpoint response (device-code success/error and refresh success/error).</summary>
+    private sealed record TokenResponse
+    {
+        [JsonPropertyName("access_token")]
+        public string? AccessToken { get; init; }
+
+        [JsonPropertyName("refresh_token")]
+        public string? RefreshToken { get; init; }
+
+        [JsonPropertyName("expires_in")]
+        public int ExpiresIn { get; init; }
+
+        [JsonPropertyName("token_type")]
+        public string? TokenType { get; init; }
+
+        [JsonPropertyName("scope")]
+        public string? Scope { get; init; }
+
+        [JsonPropertyName("error")]
+        public string? Error { get; init; }
+    }
+
+    /// <summary>Source-generated JSON context for the private DTOs (trim/AOT friendly, zero reflection warnings).</summary>
+    [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+    [JsonSerializable(typeof(DeviceCodeResult))]
+    [JsonSerializable(typeof(TokenResponse))]
+    private sealed partial class DeviceFlowJson : JsonSerializerContext
+    {
+    }
+}

--- a/samples/LmStreaming.Sample/Services/Auth/FileOAuthTokenStore.cs
+++ b/samples/LmStreaming.Sample/Services/Auth/FileOAuthTokenStore.cs
@@ -1,0 +1,183 @@
+using System.Text;
+using System.Text.Json;
+
+namespace LmStreaming.Sample.Services.Auth;
+
+/// <summary>
+/// File-backed implementation of <see cref="IOAuthTokenStore"/>. Persists one JSON file per
+/// provider (<c>&lt;baseDir&gt;/&lt;sanitized-provider&gt;.json</c>) for local development use.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Writes are atomic (temp-file + <see cref="File.Move(string, string, bool)"/>) and all operations
+/// are serialized by a single per-store <see cref="SemaphoreSlim"/>, making concurrent
+/// Get/Save/Remove calls (even across different providers) safe.
+/// </para>
+/// <para>
+/// SECURITY: the persisted JSON contains secret token material. <see cref="OAuthTokenRecord.RefreshToken"/>
+/// and <see cref="OAuthTokenRecord.AccessToken"/> values are NEVER written to logs — only the
+/// provider id, account, and access-token expiry are logged. Callers should point the base
+/// directory at a git-ignored location (e.g. <c>oauth-tokens/</c>).
+/// </para>
+/// </remarks>
+public sealed class FileOAuthTokenStore : IOAuthTokenStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    private readonly string _baseDirectory;
+    private readonly ILogger<FileOAuthTokenStore> _logger;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    /// <summary>
+    /// Creates a new <see cref="FileOAuthTokenStore"/>, ensuring the base directory exists.
+    /// </summary>
+    /// <param name="baseDirectory">
+    /// Directory under which per-provider token files are stored. Created if missing. Callers
+    /// typically pass something like <c>Path.Combine(AppContext.BaseDirectory, "oauth-tokens")</c>.
+    /// </param>
+    /// <param name="logger">Logger for structured diagnostics (never receives token values).</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="baseDirectory"/> is null or whitespace.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="logger"/> is null.</exception>
+    public FileOAuthTokenStore(string baseDirectory, ILogger<FileOAuthTokenStore> logger)
+    {
+        if (string.IsNullOrWhiteSpace(baseDirectory))
+        {
+            throw new ArgumentException("Base directory cannot be null or whitespace.", nameof(baseDirectory));
+        }
+
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _baseDirectory = Path.GetFullPath(baseDirectory);
+        _logger = logger;
+        _ = Directory.CreateDirectory(_baseDirectory);
+    }
+
+    /// <inheritdoc />
+    public async Task<OAuthTokenRecord?> GetAsync(string provider, CancellationToken ct = default)
+    {
+        var filePath = GetFilePath(provider);
+
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (!File.Exists(filePath))
+            {
+                return null;
+            }
+
+            var json = await File.ReadAllTextAsync(filePath, Encoding.UTF8, ct).ConfigureAwait(false);
+            return JsonSerializer.Deserialize<OAuthTokenRecord>(json, JsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            // Corrupt/unparseable file: surface a warning but never throw — the caller treats a
+            // missing/invalid token the same as "not stored" and re-authenticates. Token values
+            // are intentionally excluded from the log.
+            _logger.LogWarning(ex, "Failed to parse OAuth token file for provider {Provider}", provider);
+            return null;
+        }
+        finally
+        {
+            _ = _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task SaveAsync(OAuthTokenRecord record, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        var filePath = GetFilePath(record.Provider);
+        var json = JsonSerializer.Serialize(record, JsonOptions);
+
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            // Ensure the directory still exists (it may have been removed out-of-band).
+            _ = Directory.CreateDirectory(_baseDirectory);
+
+            // Atomic write: stage to a temp file, then move over the target so a reader never
+            // observes a partially written file.
+            var tempFilePath = filePath + ".tmp";
+            await File.WriteAllTextAsync(tempFilePath, json, Encoding.UTF8, ct).ConfigureAwait(false);
+            File.Move(tempFilePath, filePath, overwrite: true);
+        }
+        finally
+        {
+            _ = _gate.Release();
+        }
+
+        // SECURITY: log only non-secret metadata (provider + expiry). Never the token values.
+        _logger.LogInformation(
+            "Saved OAuth token for provider {Provider} (expires {ExpiresAt})",
+            record.Provider,
+            record.AccessTokenExpiresAtUtc);
+    }
+
+    /// <inheritdoc />
+    public async Task RemoveAsync(string provider, CancellationToken ct = default)
+    {
+        var filePath = GetFilePath(provider);
+
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+                _logger.LogInformation("Removed OAuth token for provider {Provider}", provider);
+            }
+        }
+        finally
+        {
+            _ = _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Maps a provider id to its on-disk file path, sanitizing the id into a safe file name.
+    /// </summary>
+    /// <param name="provider">Provider id (e.g. <c>"anthropic"</c>).</param>
+    /// <returns>Absolute path to the provider's token file inside the base directory.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="provider"/> is null/whitespace or contains no characters that
+    /// survive sanitization (which prevents path traversal via separators or <c>..</c>).
+    /// </exception>
+    private string GetFilePath(string provider)
+    {
+        var fileName = SanitizeProvider(provider);
+        return Path.Combine(_baseDirectory, fileName + ".json");
+    }
+
+    /// <summary>
+    /// Reduces a provider id to a safe file-name stem. Only <c>[a-z0-9_-]</c> survive (lowercased);
+    /// every other character — including path separators and <c>.</c> — is dropped, which makes
+    /// path traversal (e.g. <c>..</c> or <c>../etc</c>) impossible.
+    /// </summary>
+    private static string SanitizeProvider(string provider)
+    {
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            throw new ArgumentException("Provider cannot be null or whitespace.", nameof(provider));
+        }
+
+        var builder = new StringBuilder(provider.Length);
+        foreach (var ch in provider)
+        {
+            var lower = char.ToLowerInvariant(ch);
+            if (lower is (>= 'a' and <= 'z') or (>= '0' and <= '9') or '_' or '-')
+            {
+                _ = builder.Append(lower);
+            }
+        }
+
+        if (builder.Length == 0)
+        {
+            throw new ArgumentException(
+                $"Provider '{provider}' did not yield a valid file name after sanitization.",
+                nameof(provider));
+        }
+
+        return builder.ToString();
+    }
+}

--- a/samples/LmStreaming.Sample/Services/Auth/GitHubDeviceFlowProvider.cs
+++ b/samples/LmStreaming.Sample/Services/Auth/GitHubDeviceFlowProvider.cs
@@ -1,0 +1,84 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace LmStreaming.Sample.Services.Auth;
+
+/// <summary>
+/// GitHub device-code OAuth provider.
+/// </summary>
+/// <remarks>
+/// <para>
+/// GitHub's device-flow endpoints respond with form-encoded bodies by default; this provider sends
+/// <c>Accept: application/json</c> so the base class can parse JSON.
+/// </para>
+/// <para>
+/// Refresh tokens are only issued by a <em>GitHub App</em> with "Expire user authorization tokens"
+/// enabled. Classic OAuth Apps issue a non-expiring <c>access_token</c> with no <c>refresh_token</c>
+/// and no <c>expires_in</c>. Both are handled: when no refresh token is returned the base stores an
+/// empty refresh token with a far-future expiry, and <c>GetAccessTokenAsync</c> simply returns the
+/// stored access token (there is nothing to refresh).
+/// </para>
+/// </remarks>
+public sealed class GitHubDeviceFlowProvider : DeviceFlowOAuthProviderBase
+{
+    /// <summary>GitHub requires a User-Agent on API calls; identify this sample app.</summary>
+    private const string UserAgent = "LmStreaming.Sample";
+
+    private readonly GitHubAuthOptions _options;
+
+    /// <summary>Creates the GitHub device-code provider.</summary>
+    /// <param name="options">GitHub client id + scopes.</param>
+    /// <param name="store">Token persistence.</param>
+    /// <param name="http">HTTP client for the OAuth + API calls.</param>
+    /// <param name="logger">Logger; token material is never written to it.</param>
+    public GitHubDeviceFlowProvider(
+        GitHubAuthOptions options,
+        IOAuthTokenStore store,
+        HttpClient http,
+        ILogger<GitHubDeviceFlowProvider> logger)
+        : base(store, http, logger)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <inheritdoc />
+    public override string ProviderId => "github";
+
+    /// <inheritdoc />
+    protected override string? ClientId => _options.ClientId;
+
+    /// <inheritdoc />
+    protected override IReadOnlyList<string> Scopes => _options.Scopes;
+
+    /// <inheritdoc />
+    protected override string DeviceCodeEndpoint => "https://github.com/login/device/code";
+
+    /// <inheritdoc />
+    protected override string TokenEndpoint => "https://github.com/login/oauth/access_token";
+
+    /// <summary>GitHub returns form-encoded bodies unless we ask for JSON.</summary>
+    protected override bool SendJsonAcceptHeader => true;
+
+    /// <summary>
+    /// Best-effort resolution of the GitHub login via <c>GET https://api.github.com/user</c>.
+    /// Returns the <c>login</c> field, or <c>null</c> on any failure (the base treats this as optional).
+    /// </summary>
+    protected override async Task<string?> ResolveAccountAsync(string accessToken, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.github.com/user");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        request.Headers.UserAgent.ParseAdd(UserAgent);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+
+        using var response = await Http.SendAsync(request, ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            Logger.LogDebug("GitHub /user lookup returned HTTP {Status}; account name unavailable.", (int)response.StatusCode);
+            return null;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+        return doc.RootElement.TryGetProperty("login", out var login) ? login.GetString() : null;
+    }
+}

--- a/samples/LmStreaming.Sample/Services/Auth/IOAuthTokenProvider.cs
+++ b/samples/LmStreaming.Sample/Services/Auth/IOAuthTokenProvider.cs
@@ -1,0 +1,56 @@
+namespace LmStreaming.Sample.Services.Auth;
+
+/// <summary>Sign-in lifecycle state for an OAuth provider.</summary>
+public enum OAuthSignInState
+{
+    NotStarted,
+    Pending,
+    SignedIn,
+    Failed
+}
+
+/// <summary>A short-lived access token with its absolute UTC expiry.</summary>
+public sealed record OAuthAccessToken(string Value, DateTimeOffset ExpiresAtUtc);
+
+/// <summary>The device-code challenge to show the user during sign-in.</summary>
+public sealed record DeviceCodeChallenge(
+    string UserCode,
+    string VerificationUri,
+    string? VerificationUriComplete,
+    int ExpiresInSeconds,
+    int IntervalSeconds);
+
+/// <summary>Current sign-in status (safe to expose to the UI; contains no secrets).</summary>
+public sealed record OAuthStatus(
+    OAuthSignInState State,
+    string? Account,
+    IReadOnlyList<string> Scopes,
+    DateTimeOffset? ExpiresAtUtc,
+    string? Error);
+
+/// <summary>
+/// Owns the OAuth device-code sign-in + refresh-token lifecycle for one provider
+/// (e.g. "github" or "ado"). Implementations persist the refresh token and refresh
+/// the access token on demand.
+/// </summary>
+public interface IOAuthTokenProvider
+{
+    /// <summary>Stable provider id, e.g. "github" or "ado".</summary>
+    string ProviderId { get; }
+
+    /// <summary>Current sign-in status (no secrets).</summary>
+    OAuthStatus Status { get; }
+
+    /// <summary>Starts the device-code flow and begins background polling; returns the challenge to show the user.</summary>
+    Task<DeviceCodeChallenge> BeginSignInAsync(CancellationToken ct = default);
+
+    /// <summary>Clears stored tokens and resets to NotStarted.</summary>
+    Task SignOutAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns a valid access token, transparently refreshing via the stored refresh token when
+    /// the current one is missing or within the expiry skew. Throws InvalidOperationException
+    /// when not signed in / refresh fails.
+    /// </summary>
+    Task<OAuthAccessToken> GetAccessTokenAsync(IReadOnlyList<string>? scopes = null, CancellationToken ct = default);
+}

--- a/samples/LmStreaming.Sample/Services/Auth/IOAuthTokenStore.cs
+++ b/samples/LmStreaming.Sample/Services/Auth/IOAuthTokenStore.cs
@@ -1,0 +1,20 @@
+namespace LmStreaming.Sample.Services.Auth;
+
+/// <summary>Persisted token material for one provider. SECRET — never log RefreshToken/AccessToken.</summary>
+public sealed record OAuthTokenRecord(
+    string Provider,
+    string? Account,
+    string RefreshToken,
+    string? AccessToken,
+    DateTimeOffset? AccessTokenExpiresAtUtc,
+    IReadOnlyList<string> Scopes);
+
+/// <summary>File-backed store for OAuth refresh/access tokens, keyed by provider id.</summary>
+public interface IOAuthTokenStore
+{
+    Task<OAuthTokenRecord?> GetAsync(string provider, CancellationToken ct = default);
+
+    Task SaveAsync(OAuthTokenRecord record, CancellationToken ct = default);
+
+    Task RemoveAsync(string provider, CancellationToken ct = default);
+}

--- a/samples/LmStreaming.Sample/Services/SandboxGatewayLifetime.cs
+++ b/samples/LmStreaming.Sample/Services/SandboxGatewayLifetime.cs
@@ -1,0 +1,456 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+/// Owns the lifecycle of the Rust sandbox MCP gateway process for the sample app.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered as a singleton <see cref="IHostedService"/> so it boots eagerly during
+/// <c>Host.StartAsync</c>. On startup it either <em>adopts</em> an already-running gateway
+/// (detected via the health endpoint) or <em>spawns</em> one when
+/// <see cref="SandboxGatewayOptions.AutoSpawn"/> is enabled, then polls until the gateway
+/// reports healthy.
+/// </para>
+/// <para>
+/// This type owns ONLY the gateway process and the base URL. Sandbox sessions are owned by
+/// <see cref="SandboxSessionRegistry"/>, which depends on this type for
+/// <see cref="GatewayBaseUrl"/>.
+/// </para>
+/// <para>
+/// When the gateway was spawned by us we kill it on shutdown; when it was adopted we leave it
+/// running (we did not start it, so it is not ours to stop).
+/// </para>
+/// </remarks>
+public sealed class SandboxGatewayLifetime : IHostedService, IAsyncDisposable
+{
+    private const int DefaultGatewayPort = 3000;
+    private static readonly TimeSpan HealthProbeTimeout = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan SpawnReadyTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan SpawnPollInterval = TimeSpan.FromMilliseconds(500);
+
+    private readonly SandboxGatewayOptions _options;
+    private readonly ILogger<SandboxGatewayLifetime> _logger;
+    private readonly HttpClient _httpClient;
+
+    // Serialises adopt-or-spawn so concurrent EnsureReadyAsync callers never spawn twice.
+    private readonly SemaphoreSlim _readyGate = new(1, 1);
+
+    // True only when this process spawned the gateway; gates whether StopAsync kills it.
+    private bool _ownsProcess;
+    private Process? _process;
+    private bool _disposed;
+
+    // True once the gateway has been observed healthy (adopted or spawned); lets EnsureReadyAsync
+    // short-circuit without re-probing on the hot path.
+    private bool _ready;
+
+    /// <summary>
+    /// Initialises the lifetime with the gateway options, a logger, and the
+    /// <see cref="HttpClient"/> used for health probes during startup.
+    /// </summary>
+    /// <param name="options">Strongly-typed gateway configuration.</param>
+    /// <param name="logger">Logger for lifecycle diagnostics.</param>
+    /// <param name="httpClient">Client used to probe the gateway health endpoint.</param>
+    public SandboxGatewayLifetime(
+        SandboxGatewayOptions options,
+        ILogger<SandboxGatewayLifetime> logger,
+        HttpClient httpClient
+    )
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+    /// <summary>
+    /// Base URL of the gateway (trailing slash trimmed). Consumers append paths such as
+    /// <c>/api/v1/sandboxes</c> to this value.
+    /// </summary>
+    public string GatewayBaseUrl => _options.BaseUrl.TrimEnd('/');
+
+    /// <summary>
+    /// True when this process spawned (and therefore owns) the gateway, as opposed to having
+    /// adopted an already-running one.
+    /// </summary>
+    public bool OwnsProcess => _ownsProcess;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Startup is best-effort and NON-fatal: the app must boot for non-workspace modes even when
+    /// the gateway is not configured or not reachable. Any adopt/spawn failure is logged as a
+    /// warning here; the hard, actionable error is deferred to <see cref="EnsureReadyAsync"/>,
+    /// which Workspace Agent mode calls when it actually needs the gateway.
+    /// </remarks>
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        try
+        {
+            await EnsureReadyAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Host shutdown during startup — propagate cancellation, don't swallow it.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal at boot: other modes don't need the gateway. The clear error resurfaces
+            // from EnsureReadyAsync when Workspace Agent mode is first used.
+            _logger.LogWarning(
+                ex,
+                "Sandbox gateway is not ready at startup ({GatewayBaseUrl}); Workspace Agent mode "
+                    + "will retry on first use. Other modes are unaffected.",
+                GatewayBaseUrl
+            );
+        }
+    }
+
+    /// <summary>
+    /// Ensures the gateway is healthy, adopting an already-running one or spawning it on demand.
+    /// Idempotent and safe to call concurrently. Throws a clear, actionable
+    /// <see cref="InvalidOperationException"/> only if a healthy gateway still cannot be reached.
+    /// </summary>
+    /// <param name="ct">Cancellation token observed while probing/spawning.</param>
+    public async Task EnsureReadyAsync(CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (_ready)
+        {
+            return;
+        }
+
+        await _readyGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_ready)
+            {
+                return;
+            }
+
+            // 1. Adopt an already-running gateway when one answers the health endpoint.
+            if (await IsHealthyAsync(HealthProbeTimeout, ct).ConfigureAwait(false))
+            {
+                _logger.LogInformation("Adopted existing sandbox gateway at {GatewayBaseUrl}", GatewayBaseUrl);
+                _ready = true;
+                return;
+            }
+
+            // 2. No gateway is running and auto-spawn is disabled — fail with actionable guidance.
+            if (!_options.AutoSpawn)
+            {
+                throw new InvalidOperationException(
+                    $"No sandbox gateway is reachable at {GatewayBaseUrl} and AutoSpawn is disabled. "
+                        + "Build the gateway with 'cargo build --release', then run it with "
+                        + "SANDBOX_BACKEND=local, LOCAL_AGENT_CLI_PATH=<agent-cli>, BIND_ADDRESS=127.0.0.1, "
+                        + $"PORT={ResolvePort()} and LOCAL_SANDBOX_APPCONTAINER=false — or set "
+                        + $"{SandboxGatewayOptions.SectionName}:AutoSpawn=true to have the app spawn it."
+                );
+            }
+
+            // 3. Spawn the gateway ourselves and wait until it is healthy.
+            await SpawnAndWaitAsync(ct).ConfigureAwait(false);
+            _ready = true;
+        }
+        finally
+        {
+            _ = _readyGate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        // Adopted gateways are left running; only kill what we spawned.
+        if (!_ownsProcess || _process is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        TryKillProcess();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        _disposed = true;
+
+        if (_ownsProcess)
+        {
+            TryKillProcess();
+        }
+
+        _process?.Dispose();
+        _process = null;
+        _readyGate.Dispose();
+        _httpClient.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Spawns the gateway process with the required environment and polls the health endpoint
+    /// until it reports healthy or the ready timeout elapses.
+    /// </summary>
+    private async Task SpawnAndWaitAsync(CancellationToken cancellationToken)
+    {
+        var exePath = RequireFile(
+            _options.GatewayExePath,
+            nameof(SandboxGatewayOptions.GatewayExePath),
+            "gateway executable"
+        );
+        var agentCliPath = RequireFile(_options.AgentCliPath, nameof(SandboxGatewayOptions.AgentCliPath), "agent CLI");
+
+        // Dispose any process object left over from a prior failed spawn attempt before replacing it.
+        _process?.Dispose();
+        _process = null;
+
+        var psi = BuildStartInfo(exePath, agentCliPath);
+        var process =
+            Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to start sandbox gateway process '{exePath}'.");
+
+        _process = process;
+        _ownsProcess = true;
+
+        // Drain stdout/stderr asynchronously so the child never blocks on a full pipe; mirror
+        // both streams into the app log so gateway startup failures are diagnosable.
+        process.OutputDataReceived += (_, e) => LogGatewayLine("stdout", e.Data);
+        process.ErrorDataReceived += (_, e) => LogGatewayLine("stderr", e.Data);
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        _logger.LogInformation(
+            "Spawned sandbox gateway (pid {Pid}) at {GatewayBaseUrl}; waiting for healthy",
+            process.Id,
+            GatewayBaseUrl
+        );
+
+        if (await WaitForHealthyAsync(cancellationToken).ConfigureAwait(false))
+        {
+            _logger.LogInformation("Sandbox gateway is healthy at {GatewayBaseUrl}", GatewayBaseUrl);
+            return;
+        }
+
+        // Never went healthy in time. Surface whether the process already died and tear it down.
+        var exited = process.HasExited;
+        TryKillProcess();
+        throw new InvalidOperationException(
+            $"Sandbox gateway at {GatewayBaseUrl} did not become healthy within "
+                + $"{SpawnReadyTimeout.TotalSeconds:0}s"
+                + (exited ? $" (process exited with code {SafeExitCode(process)})." : ".")
+                + " Check the application log for the gateway's stdout/stderr output."
+        );
+    }
+
+    /// <summary>
+    /// Builds the <see cref="ProcessStartInfo"/> for the gateway, including the exact environment
+    /// the gateway requires for the local backend.
+    /// </summary>
+    private ProcessStartInfo BuildStartInfo(string exePath, string agentCliPath)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = exePath,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
+            WorkingDirectory = Path.GetDirectoryName(exePath) ?? AppContext.BaseDirectory,
+        };
+
+        psi.Environment["SANDBOX_BACKEND"] = "local";
+        psi.Environment["LOCAL_AGENT_CLI_PATH"] = agentCliPath;
+        psi.Environment["BIND_ADDRESS"] = "127.0.0.1";
+        psi.Environment["PORT"] = ResolvePort().ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        // The gateway defaults LOCAL_SANDBOX_APPCONTAINER to TRUE on Windows; we MUST opt out
+        // explicitly because the sample runs unsandboxed against the developer's workspace.
+        psi.Environment["LOCAL_SANDBOX_APPCONTAINER"] = "false";
+
+        // SSRF loopback allowlist: lets the gateway call our http loopback auth webhook. Harmless
+        // when auth providers are not configured; required when they are.
+        psi.Environment["AUTH_WEBHOOK_HTTP_LOOPBACK_HOSTS"] = "127.0.0.1,localhost";
+
+        if (!string.IsNullOrWhiteSpace(_options.WorkspaceBasePath))
+        {
+            psi.Environment["WORKSPACE_BASE_PATH"] = _options.WorkspaceBasePath;
+        }
+
+        if (!string.IsNullOrWhiteSpace(_options.SkillsDir))
+        {
+            psi.Environment["SKILLS_DIRS"] = _options.SkillsDir;
+        }
+
+        return psi;
+    }
+
+    /// <summary>
+    /// Polls the health endpoint until healthy, the ready timeout elapses, the spawned process
+    /// exits, or cancellation is requested.
+    /// </summary>
+    private async Task<bool> WaitForHealthyAsync(CancellationToken cancellationToken)
+    {
+        var deadline = DateTime.UtcNow + SpawnReadyTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Bail early if the process already died — no point polling a dead gateway.
+            if (_process is { HasExited: true })
+            {
+                return false;
+            }
+
+            if (await IsHealthyAsync(HealthProbeTimeout, cancellationToken).ConfigureAwait(false))
+            {
+                return true;
+            }
+
+            try
+            {
+                await Task.Delay(SpawnPollInterval, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Probes <c>GET {BaseUrl}/health</c> and returns true only on a success status code.
+    /// Transient connection failures (e.g. refusals during startup) are treated as "not healthy"
+    /// rather than propagated, so they never crash the host.
+    /// </summary>
+    private async Task<bool> IsHealthyAsync(TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(timeout);
+
+        try
+        {
+            using var response = await _httpClient
+                .GetAsync($"{GatewayBaseUrl}/health", timeoutCts.Token)
+                .ConfigureAwait(false);
+            return response.IsSuccessStatusCode;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Host shutdown requested — let the caller observe cancellation.
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException)
+        {
+            // Connection refused / per-probe timeout during startup: not healthy yet.
+            return false;
+        }
+    }
+
+    private void LogGatewayLine(string stream, string? line)
+    {
+        if (!string.IsNullOrEmpty(line))
+        {
+            _logger.LogDebug("[sandbox-gateway {Stream}] {Line}", stream, line);
+        }
+    }
+
+    /// <summary>Resolves the gateway port from the configured base URL, defaulting to 3000.</summary>
+    private int ResolvePort()
+    {
+        return Uri.TryCreate(GatewayBaseUrl, UriKind.Absolute, out var uri) && uri.Port > 0
+            ? uri.Port
+            : DefaultGatewayPort;
+    }
+
+    private static string RequireFile(string? path, string optionName, string description)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new InvalidOperationException(
+                $"Cannot spawn the sandbox gateway: {SandboxGatewayOptions.SectionName}:{optionName} "
+                    + $"(the {description}) is not configured."
+            );
+        }
+
+        if (!File.Exists(path))
+        {
+            throw new InvalidOperationException(
+                $"Cannot spawn the sandbox gateway: the {description} was not found at '{path}' "
+                    + $"(from {SandboxGatewayOptions.SectionName}:{optionName})."
+            );
+        }
+
+        return path;
+    }
+
+    private void TryKillProcess()
+    {
+        var process = _process;
+        if (process is null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!process.HasExited)
+            {
+                // Kill the whole tree: the gateway may have spawned the agent CLI as a child.
+                process.Kill(entireProcessTree: true);
+                process.WaitForExit(5000);
+                _logger.LogInformation("Stopped spawned sandbox gateway (pid {Pid})", SafePid(process));
+            }
+        }
+        catch (Exception ex)
+        {
+            // Shutdown best-effort: a kill failure must not throw out of StopAsync/DisposeAsync.
+            _logger.LogWarning(ex, "Failed to stop spawned sandbox gateway");
+        }
+        finally
+        {
+            _ownsProcess = false;
+        }
+    }
+
+    private static int SafeExitCode(Process process)
+    {
+        try
+        {
+            return process.ExitCode;
+        }
+        catch
+        {
+            return -1;
+        }
+    }
+
+    private static int SafePid(Process process)
+    {
+        try
+        {
+            return process.Id;
+        }
+        catch
+        {
+            return -1;
+        }
+    }
+}

--- a/samples/LmStreaming.Sample/Services/SandboxGatewayOptions.cs
+++ b/samples/LmStreaming.Sample/Services/SandboxGatewayOptions.cs
@@ -1,0 +1,59 @@
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+/// Strongly-typed configuration for the Rust sandbox MCP gateway integration.
+/// Bound from the <c>SandboxGateway</c> configuration section.
+/// </summary>
+public sealed class SandboxGatewayOptions
+{
+    /// <summary>
+    /// Configuration section name these options are bound from.
+    /// </summary>
+    public const string SectionName = "SandboxGateway";
+
+    /// <summary>
+    /// Base URL of the gateway the app connects to.
+    /// </summary>
+    public string BaseUrl { get; set; } = "http://localhost:3000";
+
+    /// <summary>
+    /// Workspace path relative to <see cref="WorkspaceBasePath"/>, mounted as the sandbox
+    /// workspace. On the Docker backend this is <c>/workspace</c>; on the local/Windows
+    /// backend the workspace is the resolved host directory itself (no <c>/workspace</c> mount).
+    /// </summary>
+    public string? Workspace { get; set; }
+
+    /// <summary>
+    /// Host base directory the gateway resolves the workspace under.
+    /// Becomes <c>WORKSPACE_BASE_PATH</c> when the gateway is spawned.
+    /// </summary>
+    public string? WorkspaceBasePath { get; set; }
+
+    /// <summary>
+    /// App id sent in the sandbox-create request.
+    /// </summary>
+    public string AppId { get; set; } = "lmstreaming-sample";
+
+    /// <summary>
+    /// When <c>true</c> and the gateway is not already healthy, spawn it.
+    /// </summary>
+    public bool AutoSpawn { get; set; } = true;
+
+    /// <summary>
+    /// Absolute path to <c>mcp-gateway.exe</c>, used for auto-spawn.
+    /// </summary>
+    public string? GatewayExePath { get; set; }
+
+    /// <summary>
+    /// Absolute path to <c>agent-cli.exe</c>.
+    /// Becomes <c>LOCAL_AGENT_CLI_PATH</c> when the gateway is spawned.
+    /// </summary>
+    public string? AgentCliPath { get; set; }
+
+    /// <summary>
+    /// Directory of sandbox skills.
+    /// Becomes <c>SKILLS_DIRS</c> when the gateway is spawned (the gateway uses
+    /// <c>';'</c>-separated values on Windows).
+    /// </summary>
+    public string? SkillsDir { get; set; }
+}

--- a/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
@@ -1,0 +1,410 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LmStreaming.Sample.Services.Auth;
+
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+/// A sandbox session created against the gateway and bound to a workspace directory.
+/// </summary>
+/// <param name="WorkspaceId">Logical workspace key the session was created for (v1 always
+/// <c>"default"</c>).</param>
+/// <param name="SessionId">Gateway session id; sent as the <c>X-Session-ID</c> header on tool
+/// calls.</param>
+/// <param name="WorkspaceRelPath">Workspace path relative to the gateway's workspace base, as
+/// requested at creation time.</param>
+/// <param name="HostPath">Absolute host path of the mounted workspace (long-path <c>\\?\</c>
+/// prefix stripped) — the path the model uses for absolute-path file tools.</param>
+public sealed record SandboxSession(string WorkspaceId, string SessionId, string WorkspaceRelPath, string HostPath);
+
+/// <summary>
+/// Owns sandbox sessions for the sample app. Sessions are created lazily and exactly once per
+/// workspace id, then destroyed on application shutdown when the DI container disposes this
+/// singleton.
+/// </summary>
+/// <remarks>
+/// <para>
+/// v1 only ever requests the <c>"default"</c> workspace, which maps to the configured
+/// <see cref="SandboxGatewayOptions.Workspace"/>. The <c>workspaceId</c> parameter is kept as the
+/// seam for future per-request workspace switching.
+/// </para>
+/// <para>
+/// Creation is single-flight: concurrent first-callers for the same workspace id share one
+/// in-flight POST via a cached <see cref="Lazy{T}"/>. A failed creation is evicted so a later
+/// call can retry.
+/// </para>
+/// </remarks>
+public sealed class SandboxSessionRegistry : IAsyncDisposable
+{
+    private const string DefaultWorkspaceId = "default";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly ConcurrentDictionary<string, Lazy<Task<SandboxSession>>> _sessions = new(StringComparer.Ordinal);
+    private readonly SandboxGatewayLifetime _gateway;
+    private readonly SandboxGatewayOptions _options;
+    private readonly ILogger<SandboxSessionRegistry> _logger;
+    private readonly HttpClient _httpClient;
+    private readonly AuthOptions _authOptions;
+    private readonly AuthSharedSecret _sharedSecret;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initialises the registry.
+    /// </summary>
+    /// <param name="gateway">Gateway lifetime, used for the base URL.</param>
+    /// <param name="options">Strongly-typed gateway configuration.</param>
+    /// <param name="logger">Logger for session diagnostics.</param>
+    /// <param name="httpClient">Client used to create and destroy sandbox sessions.</param>
+    /// <param name="authOptions">OAuth auth-provider configuration; drives the optional
+    /// <c>auth_providers</c>/<c>network</c> blocks sent on sandbox creation.</param>
+    /// <param name="sharedSecret">Gateway↔webhook shared secret attached to each auth provider.
+    /// SECRET — never logged.</param>
+    public SandboxSessionRegistry(
+        SandboxGatewayLifetime gateway,
+        SandboxGatewayOptions options,
+        ILogger<SandboxSessionRegistry> logger,
+        HttpClient httpClient,
+        AuthOptions authOptions,
+        AuthSharedSecret sharedSecret
+    )
+    {
+        _gateway = gateway ?? throw new ArgumentNullException(nameof(gateway));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _authOptions = authOptions ?? throw new ArgumentNullException(nameof(authOptions));
+        _sharedSecret = sharedSecret ?? throw new ArgumentNullException(nameof(sharedSecret));
+    }
+
+    /// <summary>
+    /// Returns the sandbox session for <paramref name="workspaceId"/>, creating it on first use.
+    /// Concurrent first-callers share a single creation; subsequent callers get the cached session.
+    /// </summary>
+    /// <param name="workspaceId">Logical workspace key. v1 only passes <c>"default"</c>.</param>
+    /// <param name="ct">Cancellation token observed by the creating call.</param>
+    public Task<SandboxSession> GetOrCreateSessionAsync(
+        string workspaceId = DefaultWorkspaceId,
+        CancellationToken ct = default
+    )
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (string.IsNullOrWhiteSpace(workspaceId))
+        {
+            workspaceId = DefaultWorkspaceId;
+        }
+
+        // Use CancellationToken.None inside the single-flight Lazy factory: the shared creation task
+        // must not be poisoned by the first caller's request-scoped token being cancelled (e.g. that
+        // caller disconnecting), which would otherwise fail it for all concurrent waiters.
+        var lazy = _sessions.GetOrAdd(
+            workspaceId,
+            key => new Lazy<Task<SandboxSession>>(
+                () => CreateSessionAsync(key, CancellationToken.None),
+                LazyThreadSafetyMode.ExecutionAndPublication
+            )
+        );
+
+        return AwaitAndEvictOnFailureAsync(workspaceId, lazy);
+    }
+
+    /// <summary>
+    /// Awaits the cached creation task. On failure the cached <see cref="Lazy{T}"/> is evicted so a
+    /// later call retries instead of replaying the cached fault.
+    /// </summary>
+    private async Task<SandboxSession> AwaitAndEvictOnFailureAsync(string workspaceId, Lazy<Task<SandboxSession>> lazy)
+    {
+        try
+        {
+            return await lazy.Value.ConfigureAwait(false);
+        }
+        catch
+        {
+            // Only evict the entry we own, in case another creation has since replaced it.
+            _ = ((ICollection<KeyValuePair<string, Lazy<Task<SandboxSession>>>>)_sessions).Remove(
+                new KeyValuePair<string, Lazy<Task<SandboxSession>>>(workspaceId, lazy)
+            );
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// POSTs a sandbox-create request to the gateway and maps the response to a
+    /// <see cref="SandboxSession"/>.
+    /// </summary>
+    private async Task<SandboxSession> CreateSessionAsync(string workspaceId, CancellationToken ct)
+    {
+        // Surface the clear, actionable gateway error here (not at app startup) — this is the
+        // first point at which Workspace Agent mode actually requires a healthy gateway.
+        await _gateway.EnsureReadyAsync(ct).ConfigureAwait(false);
+
+        var workspaceRelPath = _options.Workspace ?? string.Empty;
+        var requestUri = $"{_gateway.GatewayBaseUrl}/api/v1/sandboxes";
+        var (authProviders, network) = BuildAuthProviders();
+        var request = new CreateSandboxRequest(
+            new AppRef(_options.AppId),
+            workspaceRelPath,
+            authProviders,
+            network
+        );
+
+        _logger.LogInformation(
+            "Creating sandbox session for workspace {WorkspaceId} (app {AppId}, path '{WorkspaceRelPath}')",
+            workspaceId,
+            _options.AppId,
+            workspaceRelPath
+        );
+
+        if (authProviders is { Count: > 0 })
+        {
+            // Log only which providers were attached — never the shared secret.
+            _logger.LogInformation(
+                "Sandbox session created with auth providers: {Providers}",
+                string.Join(", ", authProviders.Select(p => p.Id))
+            );
+        }
+
+        using var response = await _httpClient
+            .PostAsJsonAsync(requestUri, request, JsonOptions, ct)
+            .ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            _logger.LogError(
+                "Sandbox create failed for workspace {WorkspaceId}: {StatusCode} {Body}",
+                workspaceId,
+                (int)response.StatusCode,
+                body
+            );
+            throw new InvalidOperationException(
+                $"Sandbox gateway returned {(int)response.StatusCode} creating a session for "
+                    + $"workspace '{workspaceId}': {body}"
+            );
+        }
+
+        var payload = await response
+            .Content.ReadFromJsonAsync<CreateSandboxResponse>(JsonOptions, ct)
+            .ConfigureAwait(false);
+
+        if (payload is null || string.IsNullOrWhiteSpace(payload.SessionId))
+        {
+            throw new InvalidOperationException(
+                $"Sandbox gateway returned a success status but no session id for workspace '{workspaceId}'."
+            );
+        }
+
+        var hostPath = StripLongPathPrefix(payload.Volumes?.Workspace?.ContainerPath ?? string.Empty);
+        var session = new SandboxSession(workspaceId, payload.SessionId, workspaceRelPath, hostPath);
+
+        _logger.LogInformation(
+            "Created sandbox session {SessionId} for workspace {WorkspaceId} at host path {HostPath}",
+            session.SessionId,
+            workspaceId,
+            session.HostPath
+        );
+
+        return session;
+    }
+
+    /// <summary>
+    /// Best-effort destroys every successfully-created session on shutdown. Errors are logged and
+    /// swallowed so disposal never throws.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        foreach (var entry in _sessions.Values)
+        {
+            // Only destroy sessions that were actually created and completed successfully.
+            if (!entry.IsValueCreated || !entry.Value.IsCompletedSuccessfully)
+            {
+                continue;
+            }
+
+            await DestroySessionAsync(entry.Value.Result).ConfigureAwait(false);
+        }
+
+        _sessions.Clear();
+        _httpClient.Dispose();
+    }
+
+    private async Task DestroySessionAsync(SandboxSession session)
+    {
+        try
+        {
+            using var response = await _httpClient
+                .DeleteAsync($"{_gateway.GatewayBaseUrl}/api/v1/sandboxes/{session.SessionId}")
+                .ConfigureAwait(false);
+
+            if (response.IsSuccessStatusCode)
+            {
+                _logger.LogInformation("Destroyed sandbox session {SessionId}", session.SessionId);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Sandbox destroy returned {StatusCode} for session {SessionId}",
+                    (int)response.StatusCode,
+                    session.SessionId
+                );
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to destroy sandbox session {SessionId}", session.SessionId);
+        }
+    }
+
+    /// <summary>
+    /// Strips a leading Windows long-path prefix (<c>\\?\</c>, including the <c>\\?\UNC\</c> form)
+    /// so the stored host path reads as a normal absolute path the model can pass to file tools.
+    /// </summary>
+    internal static string StripLongPathPrefix(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+
+        const string UncPrefix = @"\\?\UNC\";
+        const string Prefix = @"\\?\";
+
+        if (path.StartsWith(UncPrefix, StringComparison.Ordinal))
+        {
+            // \\?\UNC\server\share -> \\server\share
+            return @"\\" + path[UncPrefix.Length..];
+        }
+
+        return path.StartsWith(Prefix, StringComparison.Ordinal) ? path[Prefix.Length..] : path;
+    }
+
+    /// <summary>
+    /// Builds the optional <c>auth_providers</c> + <c>network</c> blocks for the sandbox-create
+    /// request from the configured OAuth providers. Each configured provider (one with a non-empty
+    /// client id) contributes a webhook auth-provider plus an allow rule scoping it to that
+    /// provider's hosts. Returns <c>(null, null)</c> when no provider is configured so both blocks
+    /// are omitted from the JSON.
+    /// </summary>
+    private (IReadOnlyList<AuthProviderDto>? Providers, NetworkDto? Network) BuildAuthProviders()
+    {
+        var providers = new List<AuthProviderDto>();
+        var rules = new List<NetworkRuleDto>();
+        var baseUrl = _authOptions.Webhook.PublicBaseUrl.TrimEnd('/');
+
+        if (!string.IsNullOrWhiteSpace(_authOptions.Github.ClientId))
+        {
+            providers.Add(
+                new AuthProviderDto(
+                    Id: "github-auth",
+                    Type: "webhook",
+                    Endpoint: $"{baseUrl}/api/auth/webhook/github",
+                    GatewayAuth: _sharedSecret.Value,
+                    CacheTtlSeconds: 300,
+                    RequiredScopes: []
+                )
+            );
+            rules.Add(
+                new NetworkRuleDto(
+                    Id: "github",
+                    Action: "allow",
+                    Hosts: ["github.com", "api.github.com", "codeload.github.com"],
+                    Ports: [443],
+                    Methods: [],
+                    Paths: [],
+                    AuthProvider: "github-auth",
+                    RequiredScopes: [],
+                    Priority: 100
+                )
+            );
+        }
+
+        if (!string.IsNullOrWhiteSpace(_authOptions.Ado.ClientId))
+        {
+            providers.Add(
+                new AuthProviderDto(
+                    Id: "ado-auth",
+                    Type: "webhook",
+                    Endpoint: $"{baseUrl}/api/auth/webhook/ado",
+                    GatewayAuth: _sharedSecret.Value,
+                    CacheTtlSeconds: 300,
+                    RequiredScopes: []
+                )
+            );
+            rules.Add(
+                new NetworkRuleDto(
+                    Id: "ado",
+                    Action: "allow",
+                    Hosts: ["dev.azure.com", "*.dev.azure.com", "*.visualstudio.com"],
+                    Ports: [443],
+                    Methods: [],
+                    Paths: [],
+                    AuthProvider: "ado-auth",
+                    RequiredScopes: [],
+                    Priority: 100
+                )
+            );
+        }
+
+        return providers.Count > 0 ? (providers, new NetworkDto(rules)) : (null, null);
+    }
+
+    // --- Gateway JSON contract (snake_case via JsonOptions) ---
+
+    private sealed record CreateSandboxRequest(
+        [property: JsonPropertyName("app")] AppRef App,
+        [property: JsonPropertyName("workspace")] string Workspace,
+        [property: JsonPropertyName("auth_providers")] IReadOnlyList<AuthProviderDto>? AuthProviders,
+        [property: JsonPropertyName("network")] NetworkDto? Network
+    );
+
+    private sealed record AppRef([property: JsonPropertyName("id")] string Id);
+
+    private sealed record AuthProviderDto(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("type")] string Type,
+        [property: JsonPropertyName("endpoint")] string Endpoint,
+        [property: JsonPropertyName("gateway_auth")] string GatewayAuth,
+        [property: JsonPropertyName("cache_ttl_seconds")] int CacheTtlSeconds,
+        [property: JsonPropertyName("required_scopes")] IReadOnlyList<string> RequiredScopes
+    );
+
+    private sealed record NetworkDto([property: JsonPropertyName("rules")] IReadOnlyList<NetworkRuleDto> Rules);
+
+    private sealed record NetworkRuleDto(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("action")] string Action,
+        [property: JsonPropertyName("hosts")] IReadOnlyList<string> Hosts,
+        [property: JsonPropertyName("ports")] IReadOnlyList<int> Ports,
+        [property: JsonPropertyName("methods")] IReadOnlyList<string> Methods,
+        [property: JsonPropertyName("paths")] IReadOnlyList<string> Paths,
+        [property: JsonPropertyName("auth_provider")] string AuthProvider,
+        [property: JsonPropertyName("required_scopes")] IReadOnlyList<string> RequiredScopes,
+        [property: JsonPropertyName("priority")] int Priority
+    );
+
+    private sealed record CreateSandboxResponse(
+        [property: JsonPropertyName("session_id")] string SessionId,
+        [property: JsonPropertyName("container_id")] string? ContainerId,
+        [property: JsonPropertyName("volumes")] VolumesDto? Volumes
+    );
+
+    private sealed record VolumesDto([property: JsonPropertyName("workspace")] WorkspaceVolumeDto? Workspace);
+
+    private sealed record WorkspaceVolumeDto(
+        [property: JsonPropertyName("container_path")] string? ContainerPath,
+        [property: JsonPropertyName("read_only")] bool ReadOnly
+    );
+}

--- a/samples/LmStreaming.Sample/appsettings.Development.json
+++ b/samples/LmStreaming.Sample/appsettings.Development.json
@@ -13,5 +13,27 @@
   "LlmQueryMcp": {
     "BaseUrl": "http://localhost:5173",
     "ExamType": "NeetPG"
+  },
+  "SandboxGateway": {
+    "BaseUrl": "http://localhost:3000",
+    "Workspace": "LmDotnetTools",
+    "WorkspaceBasePath": "B:\\sources",
+    "AppId": "lmstreaming-sample",
+    "AutoSpawn": true,
+    "GatewayExePath": "B:\\sources\\SandboxedOstoolsMcpServer\\target\\release\\mcp-gateway.exe",
+    "AgentCliPath": "B:\\sources\\SandboxedOstoolsMcpServer\\target\\release\\agent-cli.exe",
+    "SkillsDir": "B:\\sources\\LmDotnetTools\\samples\\LmStreaming.Sample\\sandbox-skills"
+  },
+  "Auth": {
+    "_comment": "Fill in Github.ClientId / Ado.ClientId with your own app registration ids to enable OAuth sign-in locally. Leaving a ClientId empty disables that provider.",
+    "Github": {
+      "ClientId": ""
+    },
+    "Ado": {
+      "ClientId": ""
+    },
+    "Webhook": {
+      "PublicBaseUrl": "http://127.0.0.1:5000"
+    }
   }
 }

--- a/samples/LmStreaming.Sample/appsettings.json
+++ b/samples/LmStreaming.Sample/appsettings.json
@@ -33,5 +33,20 @@
       "WithExceptionDetails"
     ]
   },
+  "SandboxGateway": {
+    "BaseUrl": "http://localhost:3000",
+    "AutoSpawn": true
+  },
+  "Auth": {
+    "Github": {
+      "ClientId": ""
+    },
+    "Ado": {
+      "ClientId": ""
+    },
+    "Webhook": {
+      "PublicBaseUrl": "http://127.0.0.1:5000"
+    }
+  },
   "AllowedHosts": "*"
 }

--- a/samples/LmStreaming.Sample/sandbox-skills/repo-explorer/SKILL.md
+++ b/samples/LmStreaming.Sample/sandbox-skills/repo-explorer/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: repo-explorer
+description: Map an unfamiliar code repository into a structured manifest — languages, entry points, build/test commands, and a one-line purpose for each top-level directory. Use when asked to "explore", "map", "summarize the structure of", or "get oriented in" a repo/workspace.
+---
+
+# Repo Explorer
+
+Turn an unfamiliar repository into a deterministic, structured manifest. Follow these steps in order, then emit the JSON exactly as specified.
+
+## Procedure
+
+1. **List the tree.** Run `Bash: ls` at the workspace root, then `Glob **/*` (cap depth ~3). Ignore `node_modules`, `target`, `.git`, `bin`, `obj`, `dist`, and `.venv`. Note the top-level directories.
+
+2. **Detect languages & manifests.** Look for `package.json` (JS/TS), `*.csproj`/`*.sln` (C#), `Cargo.toml` (Rust), `pyproject.toml`/`requirements.txt` (Python), `go.mod` (Go), `pom.xml`/`build.gradle` (JVM). Each manifest implies a language and a toolchain.
+
+3. **Find entry points & commands.** Locate `Program.cs`, `main.rs`, `index.ts`/`index.js`, `__main__.py`/`main.py`, `cmd/*/main.go`, etc. Derive the build + test commands from the manifests (e.g. `dotnet build`/`dotnet test`, `npm run build`/`npm test`, `cargo build`/`cargo test`, `pytest`, `go build`/`go test ./...`).
+
+4. **Confirm purpose.** `Read` the top-level `README*` (if present) and the primary manifest(s) to confirm what the project does and to label each top-level directory.
+
+5. **Emit the manifest.** Output one fenced ```json block matching this exact schema (no extra keys):
+
+```json
+{
+  "languages": ["..."],
+  "entryPoints": ["..."],
+  "build": ["..."],
+  "test": ["..."],
+  "topLevelDirs": [{ "path": "...", "purpose": "..." }],
+  "summary": "one-paragraph overview"
+}
+```
+
+Notes: Always `Read` a file before editing it, and keep every command read-only (list/read/inspect only) during exploration — do not build, install, or modify anything.

--- a/tests/LmStreaming.Sample.E2E.Tests/Infrastructure/SandboxGatewayPrerequisites.cs
+++ b/tests/LmStreaming.Sample.E2E.Tests/Infrastructure/SandboxGatewayPrerequisites.cs
@@ -1,0 +1,216 @@
+using LmStreaming.Sample.Services;
+
+namespace LmStreaming.Sample.E2E.Tests.Infrastructure;
+
+/// <summary>
+/// Detects whether a real sandbox MCP gateway is available for the gated workspace E2E test and,
+/// when it is, applies the matching <c>SandboxGateway:*</c> configuration via environment variables.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The test is skipped unless ONE of the following is true:
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <c>SANDBOX_GATEWAY_EXE</c> points at an existing <c>mcp-gateway.exe</c> (with <c>agent-cli.exe</c>
+/// beside it, or at <c>SANDBOX_AGENT_CLI</c>) — the host spawns the gateway (adopt-or-spawn).
+/// </description></item>
+/// <item><description>
+/// A gateway already responds <c>200</c> at <c>{SANDBOX_GATEWAY_URL ?? http://localhost:3000}/health</c>
+/// — the host adopts it.
+/// </description></item>
+/// </list>
+/// <para>
+/// This keeps the test green-by-skip in CI (which has no Rust gateway) while exercising the full
+/// stack on any machine "configured with the path to the gateway".
+/// </para>
+/// </remarks>
+public sealed class SandboxGatewayPrerequisites
+{
+    private const string DefaultBaseUrl = "http://localhost:3000";
+
+    private SandboxGatewayPrerequisites(
+        bool available,
+        string skipReason,
+        bool spawnMode,
+        string? gatewayExePath,
+        string? agentCliPath,
+        string baseUrl)
+    {
+        Available = available;
+        SkipReason = skipReason;
+        SpawnMode = spawnMode;
+        GatewayExePath = gatewayExePath;
+        AgentCliPath = agentCliPath;
+        BaseUrl = baseUrl;
+    }
+
+    /// <summary>True when a gateway is configured/reachable and the gated test may run.</summary>
+    public bool Available { get; }
+
+    /// <summary>Human-readable reason shown when the test is skipped.</summary>
+    public string SkipReason { get; }
+
+    /// <summary>True when the host should spawn the gateway from <see cref="GatewayExePath"/>; false when adopting a running one.</summary>
+    public bool SpawnMode { get; }
+
+    /// <summary>Resolved path to <c>mcp-gateway.exe</c> (spawn mode only).</summary>
+    public string? GatewayExePath { get; }
+
+    /// <summary>Resolved path to <c>agent-cli.exe</c> (spawn mode only).</summary>
+    public string? AgentCliPath { get; }
+
+    /// <summary>Base URL the app talks to (spawned or adopted).</summary>
+    public string BaseUrl { get; }
+
+    /// <summary>Probes the environment and returns the resolved availability + skip reason.</summary>
+    public static SandboxGatewayPrerequisites Detect()
+    {
+        var baseUrl = NonEmpty(Environment.GetEnvironmentVariable("SANDBOX_GATEWAY_URL")) ?? DefaultBaseUrl;
+
+        var exe = NonEmpty(Environment.GetEnvironmentVariable("SANDBOX_GATEWAY_EXE"));
+        if (exe is not null)
+        {
+            if (!File.Exists(exe))
+            {
+                return Unavailable(
+                    $"SANDBOX_GATEWAY_EXE is set to '{exe}' but no file exists there.");
+            }
+
+            var agentCli =
+                NonEmpty(Environment.GetEnvironmentVariable("SANDBOX_AGENT_CLI"))
+                ?? Path.Combine(Path.GetDirectoryName(exe)!, "agent-cli.exe");
+            if (!File.Exists(agentCli))
+            {
+                return Unavailable(
+                    $"agent-cli.exe was not found at '{agentCli}'. Place it beside the gateway exe "
+                        + "or set SANDBOX_AGENT_CLI.");
+            }
+
+            return new SandboxGatewayPrerequisites(
+                available: true,
+                skipReason: string.Empty,
+                spawnMode: true,
+                gatewayExePath: exe,
+                agentCliPath: agentCli,
+                baseUrl: baseUrl);
+        }
+
+        // No exe configured — adopt a gateway only if one is already healthy.
+        if (IsHealthy(baseUrl))
+        {
+            return new SandboxGatewayPrerequisites(
+                available: true,
+                skipReason: string.Empty,
+                spawnMode: false,
+                gatewayExePath: null,
+                agentCliPath: null,
+                baseUrl: baseUrl);
+        }
+
+        return Unavailable(
+            "No sandbox gateway is configured. Set SANDBOX_GATEWAY_EXE to mcp-gateway.exe "
+                + "(with agent-cli.exe beside it) or run a gateway reachable at "
+                + $"{baseUrl}/health to enable this test.");
+    }
+
+    /// <summary>
+    /// Creates a temp host workspace, applies the resolved <c>SandboxGateway:*</c> settings as
+    /// environment variables (so the in-memory host binds them), and returns a scope that restores
+    /// the prior environment and deletes the temp workspace on dispose.
+    /// </summary>
+    public GatewayConfigScope CreateConfigScope()
+    {
+        if (!Available)
+        {
+            throw new InvalidOperationException("CreateConfigScope must not be called when the gateway is unavailable.");
+        }
+
+        var workspaceBase = Path.Combine(Path.GetTempPath(), "lmstreaming-sandbox-e2e");
+        const string workspaceLeaf = "workspace";
+        _ = Directory.CreateDirectory(Path.Combine(workspaceBase, workspaceLeaf));
+
+        var vars = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [$"{SandboxGatewayOptions.SectionName}__BaseUrl"] = BaseUrl,
+            [$"{SandboxGatewayOptions.SectionName}__WorkspaceBasePath"] = workspaceBase,
+            [$"{SandboxGatewayOptions.SectionName}__Workspace"] = workspaceLeaf,
+            [$"{SandboxGatewayOptions.SectionName}__AutoSpawn"] = SpawnMode ? "true" : "false",
+            [$"{SandboxGatewayOptions.SectionName}__GatewayExePath"] = GatewayExePath,
+            [$"{SandboxGatewayOptions.SectionName}__AgentCliPath"] = AgentCliPath,
+        };
+
+        return new GatewayConfigScope(vars, Path.Combine(workspaceBase, workspaceLeaf));
+    }
+
+    private static SandboxGatewayPrerequisites Unavailable(string reason) =>
+        new(false, reason, false, null, null, DefaultBaseUrl);
+
+    private static string? NonEmpty(string? value) => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    private static bool IsHealthy(string baseUrl)
+    {
+        try
+        {
+            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+            using var response = http.GetAsync($"{baseUrl.TrimEnd('/')}/health").GetAwaiter().GetResult();
+            return response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            // Any failure (connection refused, timeout, DNS) means "no gateway to adopt".
+            return false;
+        }
+    }
+}
+
+/// <summary>
+/// Applies a set of environment variables for the duration of a test and restores their prior
+/// values (and removes the temp workspace) on dispose.
+/// </summary>
+public sealed class GatewayConfigScope : IDisposable
+{
+    private readonly Dictionary<string, string?> _previous = new(StringComparer.Ordinal);
+    private readonly string _workspacePath;
+    private bool _disposed;
+
+    internal GatewayConfigScope(Dictionary<string, string?> vars, string workspacePath)
+    {
+        _workspacePath = workspacePath;
+        foreach (var (key, value) in vars)
+        {
+            _previous[key] = Environment.GetEnvironmentVariable(key);
+            Environment.SetEnvironmentVariable(key, value);
+        }
+    }
+
+    /// <summary>Absolute path to the host workspace directory configured for this scope.</summary>
+    public string WorkspacePath => _workspacePath;
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        foreach (var (key, value) in _previous)
+        {
+            Environment.SetEnvironmentVariable(key, value);
+        }
+
+        try
+        {
+            if (Directory.Exists(_workspacePath))
+            {
+                Directory.Delete(_workspacePath, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort temp cleanup
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.E2E.Tests/LmStreaming.Sample.E2E.Tests.csproj
+++ b/tests/LmStreaming.Sample.E2E.Tests/LmStreaming.Sample.E2E.Tests.csproj
@@ -21,6 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="7.1.0" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\samples\LmStreaming.Sample\LmStreaming.Sample.csproj" />

--- a/tests/LmStreaming.Sample.E2E.Tests/Scenarios/AuthWebhookControllerTests.cs
+++ b/tests/LmStreaming.Sample.E2E.Tests/Scenarios/AuthWebhookControllerTests.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmTestUtils.Logging;
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using FluentAssertions;
+using LmStreaming.Sample.E2E.Tests.Infrastructure;
+using LmStreaming.Sample.Services.Auth;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace LmStreaming.Sample.E2E.Tests.Scenarios;
+
+/// <summary>
+/// Verifies the sandbox gateway's auth-webhook contract (<c>POST /api/auth/webhook/{provider}</c>)
+/// end-to-end through the real ASP.NET pipeline. These checks need NO gateway and run in CI always:
+/// they cover the security-critical authorization (constant-time shared-secret check) and the
+/// token-free deny path taken when the provider is not signed in. Progress is logged via
+/// <see cref="LoggingTestBase"/> to the shared <c>.logs/tests/tests.jsonl</c> file.
+/// </summary>
+public sealed class AuthWebhookControllerTests : LoggingTestBase
+{
+    private const string WebhookBody = """
+        {
+          "session_id": "s-test",
+          "app_id": "lmstreaming-sample",
+          "provider_id": "github",
+          "rule_id": "github",
+          "destination_host": "api.github.com",
+          "destination_port": 443,
+          "method": "GET",
+          "path": "/user",
+          "required_scopes": []
+        }
+        """;
+
+    public AuthWebhookControllerTests(ITestOutputHelper output)
+        : base(output)
+    {
+    }
+
+    private E2EWebAppFactory NewFactory()
+    {
+        // Any scripted handler works — these tests hit the HTTP API, never create an agent.
+        var responder = ScriptedSseResponder.New()
+            .ForRole("noop", _ => true)
+                .Turn(t => t.Text("ok"))
+            .Build();
+        Logger.LogInformation("Booting in-process sample host (provider mode 'test') for auth-webhook checks");
+        return new E2EWebAppFactory("test", new ScriptedBuilder(responder.AsAnthropicHandler()));
+    }
+
+    private static StringContent JsonBody() => new(WebhookBody, Encoding.UTF8, "application/json");
+
+    [Fact]
+    public async Task Missing_authorization_is_rejected_401()
+    {
+        LogTestStart();
+        using var factory = NewFactory();
+        using var client = factory.CreateClient();
+
+        Logger.LogInformation("POST /api/auth/webhook/github with NO Authorization header (expect 401)");
+        using var response = await client.PostAsync("/api/auth/webhook/github", JsonBody());
+
+        Logger.LogInformation("Response status {StatusCode}", (int)response.StatusCode);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        LogTestEnd();
+    }
+
+    [Fact]
+    public async Task Wrong_shared_secret_is_rejected_401()
+    {
+        LogTestStart();
+        using var factory = NewFactory();
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/auth/webhook/github")
+        {
+            Content = JsonBody(),
+        };
+        request.Headers.TryAddWithoutValidation("Authorization", "definitely-not-the-secret");
+
+        Logger.LogInformation("POST /api/auth/webhook/github with WRONG shared secret (expect 401)");
+        using var response = await client.SendAsync(request);
+
+        Logger.LogInformation("Response status {StatusCode}", (int)response.StatusCode);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        LogTestEnd();
+    }
+
+    [Fact]
+    public async Task Correct_secret_but_not_signed_in_returns_200_deny()
+    {
+        LogTestStart();
+        using var factory = NewFactory();
+        using var client = factory.CreateClient();
+
+        // The real shared secret is resolved by the host (configured or random-at-startup).
+        var sharedSecret = factory.Services.GetRequiredService<AuthSharedSecret>().Value;
+        Logger.LogInformation("Resolved AuthSharedSecret from DI (length {Length}); value NOT logged", sharedSecret.Length);
+
+        // Ensure the github provider has no persisted token so the deny path is deterministic.
+        await factory.Services.GetRequiredService<IOAuthTokenStore>().RemoveAsync("github");
+        Logger.LogInformation("Cleared any persisted github token to force the not-signed-in deny path");
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/auth/webhook/github")
+        {
+            Content = JsonBody(),
+        };
+        request.Headers.TryAddWithoutValidation("Authorization", sharedSecret);
+
+        Logger.LogInformation("POST /api/auth/webhook/github with CORRECT shared secret, not signed in (expect 200 deny)");
+        using var response = await client.SendAsync(request);
+
+        // The decision lives in the body, not the status code — both allow and deny are HTTP 200.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await response.Content.ReadAsStringAsync();
+        Logger.LogInformation("Webhook decision body: {Body}", json);
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("decision").GetString().Should().Be("deny");
+
+        // The deny reason must NOT leak token material or the provider's internal error text.
+        var reason = doc.RootElement.TryGetProperty("reason", out var r) ? r.GetString() : null;
+        reason.Should().NotBeNullOrEmpty();
+        LogTestEnd();
+    }
+}

--- a/tests/LmStreaming.Sample.E2E.Tests/Scenarios/FileOAuthTokenStoreTests.cs
+++ b/tests/LmStreaming.Sample.E2E.Tests/Scenarios/FileOAuthTokenStoreTests.cs
@@ -1,0 +1,137 @@
+using AchieveAi.LmDotnetTools.LmTestUtils.Logging;
+using FluentAssertions;
+using LmStreaming.Sample.Services.Auth;
+using Xunit.Abstractions;
+
+namespace LmStreaming.Sample.E2E.Tests.Scenarios;
+
+/// <summary>
+/// Unit tests for <see cref="FileOAuthTokenStore"/> — the gitignored, file-per-provider refresh-token
+/// store. Ungated (no gateway, no network), so they run in CI always. Progress is logged via
+/// <see cref="LoggingTestBase"/> to the shared <c>.logs/tests/tests.jsonl</c> file. SECURITY: tests
+/// never log token values — only field names / lengths / non-secret metadata.
+/// </summary>
+public sealed class FileOAuthTokenStoreTests : LoggingTestBase
+{
+    public FileOAuthTokenStoreTests(ITestOutputHelper output)
+        : base(output)
+    {
+    }
+
+    private FileOAuthTokenStore NewStore(string dir)
+    {
+        Logger.LogInformation("Creating FileOAuthTokenStore rooted at {Dir}", dir);
+        return new FileOAuthTokenStore(dir, LoggerFactory.CreateLogger<FileOAuthTokenStore>());
+    }
+
+    private static OAuthTokenRecord SampleRecord(
+        string provider = "github",
+        string refresh = "refresh-abc",
+        string? access = "access-xyz") =>
+        new(
+            Provider: provider,
+            Account: "octocat",
+            RefreshToken: refresh,
+            AccessToken: access,
+            AccessTokenExpiresAtUtc: new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            Scopes: ["repo", "read:org"]);
+
+    [Fact]
+    public async Task Save_then_Get_round_trips_all_fields()
+    {
+        LogTestStart();
+        using var temp = new TempDir();
+        var store = NewStore(temp.Path);
+        var record = SampleRecord();
+
+        await store.SaveAsync(record);
+        var loaded = await store.GetAsync("github");
+        Logger.LogInformation(
+            "Round-trip loaded provider={Provider}, account={Account}, scopes=[{Scopes}] (token values not logged)",
+            loaded?.Provider,
+            loaded?.Account,
+            loaded is null ? string.Empty : string.Join(", ", loaded.Scopes));
+
+        loaded.Should().NotBeNull();
+        loaded!.Provider.Should().Be(record.Provider);
+        loaded.Account.Should().Be(record.Account);
+        loaded.RefreshToken.Should().Be(record.RefreshToken);
+        loaded.AccessToken.Should().Be(record.AccessToken);
+        loaded.AccessTokenExpiresAtUtc.Should().Be(record.AccessTokenExpiresAtUtc);
+        loaded.Scopes.Should().BeEquivalentTo(record.Scopes);
+        LogTestEnd();
+    }
+
+    [Fact]
+    public async Task Get_missing_provider_returns_null()
+    {
+        LogTestStart();
+        using var temp = new TempDir();
+        var store = NewStore(temp.Path);
+
+        var loaded = await store.GetAsync("never-saved");
+        Logger.LogInformation("Get for unsaved provider returned null={IsNull}", loaded is null);
+        loaded.Should().BeNull();
+        LogTestEnd();
+    }
+
+    [Fact]
+    public async Task Save_overwrites_existing_record()
+    {
+        LogTestStart();
+        using var temp = new TempDir();
+        var store = NewStore(temp.Path);
+
+        await store.SaveAsync(SampleRecord(refresh: "first", access: "first-access"));
+        await store.SaveAsync(SampleRecord(refresh: "second", access: "second-access"));
+
+        var loaded = await store.GetAsync("github");
+        Logger.LogInformation("After overwrite, refresh/access token updated (values not logged)");
+        loaded!.RefreshToken.Should().Be("second");
+        loaded.AccessToken.Should().Be("second-access");
+        LogTestEnd();
+    }
+
+    [Fact]
+    public async Task Remove_deletes_the_record()
+    {
+        LogTestStart();
+        using var temp = new TempDir();
+        var store = NewStore(temp.Path);
+        await store.SaveAsync(SampleRecord());
+
+        await store.RemoveAsync("github");
+        var loaded = await store.GetAsync("github");
+        Logger.LogInformation("After remove, Get returned null={IsNull}", loaded is null);
+
+        loaded.Should().BeNull();
+        LogTestEnd();
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public TempDir()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "oauth-store-test-" + Guid.NewGuid().ToString("N"));
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(Path))
+                {
+                    Directory.Delete(Path, recursive: true);
+                }
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.E2E.Tests/Scenarios/SandboxWorkspaceGatewayE2ETests.cs
+++ b/tests/LmStreaming.Sample.E2E.Tests/Scenarios/SandboxWorkspaceGatewayE2ETests.cs
@@ -1,0 +1,148 @@
+using AchieveAi.LmDotnetTools.LmTestUtils.Logging;
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using FluentAssertions;
+using LmStreaming.Sample.E2E.Tests.Infrastructure;
+using LmStreaming.Sample.Persistence;
+using LmStreaming.Sample.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace LmStreaming.Sample.E2E.Tests.Scenarios;
+
+/// <summary>
+/// End-to-end proof that the <c>Workspace Agent</c> mode drives the REAL sandbox MCP gateway:
+/// a mock-Anthropic provider returns a scripted instruction chain (one <c>sandbox-Bash</c> tool
+/// call, then a final text), the middleware executes that tool call against the gateway, and we
+/// assert both the tool-result round-trip and the write-through to the host workspace directory.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Why <c>test-anthropic</c>: it is NOT one of the providers the Workspace-Agent guard rejects, so
+/// it flows through the same middleware path as the real Anthropic/OpenAI providers — the path that
+/// folds the gateway's MCP tools into the per-agent function registry. Tool names are registered as
+/// <c>{clientId}-{tool}</c>, i.e. <c>sandbox-Bash</c>.
+/// </para>
+/// <para>
+/// Gated: the test runs only when a gateway is configured/reachable
+/// (see <see cref="SandboxGatewayPrerequisites"/>); otherwise it is skipped so CI stays green
+/// without the Rust gateway. All progress is logged via <see cref="LoggingTestBase"/> to the shared
+/// <c>.logs/tests/tests.jsonl</c> file with test correlation.
+/// </para>
+/// </remarks>
+public sealed class SandboxWorkspaceGatewayE2ETests : LoggingTestBase
+{
+    public SandboxWorkspaceGatewayE2ETests(ITestOutputHelper output)
+        : base(output)
+    {
+    }
+
+    [SkippableFact]
+    public async Task Workspace_agent_runs_sandbox_tool_through_gateway_and_writes_to_host()
+    {
+        LogTestStart();
+
+        var prereq = SandboxGatewayPrerequisites.Detect();
+        Logger.LogInformation(
+            "Sandbox gateway prerequisites resolved: Available={Available}, SpawnMode={SpawnMode}, "
+                + "BaseUrl={BaseUrl}, GatewayExe={GatewayExe}, SkipReason={SkipReason}",
+            prereq.Available,
+            prereq.SpawnMode,
+            prereq.BaseUrl,
+            prereq.GatewayExePath ?? "(adopt running gateway)",
+            string.IsNullOrEmpty(prereq.SkipReason) ? "(none)" : prereq.SkipReason);
+        Skip.IfNot(prereq.Available, prereq.SkipReason);
+
+        using var config = prereq.CreateConfigScope();
+        Logger.LogInformation(
+            "Applied SandboxGateway config: WorkspacePath={WorkspacePath}, AutoSpawn={AutoSpawn}",
+            config.WorkspacePath,
+            prereq.SpawnMode);
+
+        // Unique marker + file so reruns (and a shared adopted gateway) never collide.
+        var marker = "e2e_marker_" + Guid.NewGuid().ToString("N")[..8];
+        var fileName = "sandbox-e2e-" + Guid.NewGuid().ToString("N")[..8] + ".txt";
+
+        // Bash starts in the workspace directory on the local backend, so a relative path lands
+        // inside the host workspace. echo+cat writes the marker AND returns it as the tool result.
+        var command = $"echo {marker} > {fileName} && cat {fileName}";
+        Logger.LogInformation(
+            "Scripted instruction chain: turn 1 -> tool_use sandbox-Bash (command={Command}); turn 2 -> final text",
+            command);
+
+        var responder = ScriptedSseResponder.New()
+            .ForRole("workspace-agent", _ => true)
+                .Turn(t => t.ToolCall("sandbox-Bash", new { command }))
+                .Turn(t => t.Text("Wrote and read the marker file."))
+            .Build();
+
+        using var factory = new E2EWebAppFactory(
+            "test-anthropic",
+            new ScriptedBuilder(responder.AsAnthropicHandler()));
+
+        var threadId = "sandbox-ws-" + Guid.NewGuid().ToString("N");
+        Logger.LogInformation(
+            "Connecting WebSocket thread {ThreadId} in mode {ModeId} (provider test-anthropic, middleware path)",
+            threadId,
+            SystemChatModes.WorkspaceAgentModeId);
+        var socket = await factory.ConnectWebSocketAsync(threadId, SystemChatModes.WorkspaceAgentModeId);
+        await using var client = new WebSocketTestClient(socket);
+
+        await client.SendUserMessageAsync("Create the marker file in the workspace and read it back.");
+        Logger.LogInformation("Sent user message; collecting streamed frames (timeout 120s)...");
+        using var frames = await client.CollectUntilDoneAsync(TimeSpan.FromSeconds(120));
+        Logger.LogInformation("Collected {FrameCount} WebSocket frame(s)", frames.Count);
+
+        var toolNames = frames.ToolCallNames();
+        var toolResults = frames.ToolCallResults();
+        Logger.LogInformation(
+            "Observed {ToolCount} tool call(s): [{ToolNames}]",
+            toolNames.Count,
+            string.Join(", ", toolNames));
+        LogData("toolResults", toolResults);
+
+        // (1) The model's tool call reached the registry under the prefixed sandbox tool name.
+        toolNames.Should().Contain(
+            "sandbox-Bash",
+            "the gateway's Bash tool is folded into the registry as 'sandbox-Bash'");
+
+        // (2) Round-trip through the gateway: executing Bash returned the marker it just wrote.
+        string.Concat(toolResults).Should().Contain(
+            marker,
+            "the sandbox Bash tool executed echo+cat through the gateway and returned the marker");
+
+        // (3) Write-through: the file the model created exists on the REAL host workspace.
+        //     HostPath is gateway-reported, so read it from the (single-flight) live session.
+        var session = await factory.Services
+            .GetRequiredService<SandboxSessionRegistry>()
+            .GetOrCreateSessionAsync("default");
+        Logger.LogInformation(
+            "Resolved live sandbox session {SessionId}; host workspace path {HostPath}",
+            session.SessionId,
+            session.HostPath);
+
+        var hostFile = Path.Combine(session.HostPath, fileName);
+        Logger.LogInformation("Asserting host write-through at {HostFile}", hostFile);
+        File.Exists(hostFile).Should().BeTrue(
+            $"the model wrote {fileName} via the sandbox gateway into the host workspace {session.HostPath}");
+        var hostContent = await File.ReadAllTextAsync(hostFile);
+        Logger.LogInformation("Host file content length {Length}; contains marker={ContainsMarker}",
+            hostContent.Length,
+            hostContent.Contains(marker, StringComparison.Ordinal));
+        hostContent.Should().Contain(marker);
+
+        // (4) The agent finished with its scripted closing text.
+        frames.ConcatText().Should().Contain("Wrote and read the marker file.");
+
+        try
+        {
+            File.Delete(hostFile);
+            Logger.LogInformation("Cleaned up probe file {HostFile}", hostFile);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Best-effort cleanup of probe file {HostFile} failed", hostFile);
+        }
+
+        LogTestEnd();
+    }
+}

--- a/tests/LmStreaming.Sample.E2E.Tests/Scenarios/SandboxWorkspaceGatewayE2ETests.cs
+++ b/tests/LmStreaming.Sample.E2E.Tests/Scenarios/SandboxWorkspaceGatewayE2ETests.cs
@@ -1,6 +1,7 @@
 using AchieveAi.LmDotnetTools.LmTestUtils.Logging;
 using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using LmStreaming.Sample.E2E.Tests.Infrastructure;
 using LmStreaming.Sample.Persistence;
 using LmStreaming.Sample.Services;
@@ -145,4 +146,191 @@ public sealed class SandboxWorkspaceGatewayE2ETests : LoggingTestBase
 
         LogTestEnd();
     }
+
+    /// <summary>
+    /// Validates the CORE sandbox MCP tool set end-to-end through the real gateway by driving a
+    /// scripted instruction chain that exercises, in sequence,
+    /// <c>sandbox-Write → sandbox-Read → sandbox-Bash → sandbox-Glob → sandbox-Grep</c>, then asserts
+    /// each tool produced its expected result. Per-tool validation outcomes are logged as structured
+    /// <c>SandboxToolCheck</c> events to <c>.logs/tests/tests.jsonl</c> so they can be queried with DuckDB.
+    /// </summary>
+    [SkippableFact]
+    public async Task Workspace_agent_runs_core_sandbox_tool_chain_through_gateway()
+    {
+        LogTestStart();
+
+        var prereq = SandboxGatewayPrerequisites.Detect();
+        Logger.LogInformation(
+            "Sandbox gateway prerequisites: Available={Available}, SpawnMode={SpawnMode}, BaseUrl={BaseUrl}, SkipReason={SkipReason}",
+            prereq.Available,
+            prereq.SpawnMode,
+            prereq.BaseUrl,
+            string.IsNullOrEmpty(prereq.SkipReason) ? "(none)" : prereq.SkipReason);
+        Skip.IfNot(prereq.Available, prereq.SkipReason);
+
+        using var config = prereq.CreateConfigScope();
+        var ws = Path.GetFullPath(config.WorkspacePath);
+
+        var id = Guid.NewGuid().ToString("N")[..8];
+        var marker = "marker_" + id;          // appears in file content -> surfaced ONLY by Read
+        var needle = "NEEDLE_" + id;          // appears in file content -> surfaced by Read AND Grep
+        var bashMarker = "bashok_" + id;      // surfaced ONLY by Bash echo
+        var probeName = "probe-" + id + ".txt";
+        var probeAbs = Path.Combine(ws, probeName);
+        var fileContent = $"line-one {marker}\nline-two {needle}\n";
+
+        Logger.LogInformation(
+            "Scripted chain over workspace {Ws}: Read(register) -> Write -> Read -> Bash -> Glob -> Grep "
+                + "(probe={Probe}, marker={Marker}, needle={Needle}, bashMarker={BashMarker})",
+            ws,
+            probeName,
+            marker,
+            needle,
+            bashMarker);
+
+        // The gateway enforces Claude-Code read-before-write semantics: a path must be Read (even a
+        // not-yet-existing one — a failed Read still registers it) before Write/Edit is permitted.
+        // The chain therefore opens with a Read of the (missing) probe path, mirroring what the
+        // Workspace Agent system prompt instructs the real LLM to do.
+        var responder = ScriptedSseResponder.New()
+            .ForRole("workspace-agent", _ => true)
+                .Turn(t => t.ToolCall("sandbox-Read", new { file_path = probeAbs }))
+                .Turn(t => t.ToolCall("sandbox-Write", new { file_path = probeAbs, content = fileContent }))
+                .Turn(t => t.ToolCall("sandbox-Read", new { file_path = probeAbs }))
+                .Turn(t => t.ToolCall("sandbox-Bash", new { command = $"echo {bashMarker}" }))
+                .Turn(t => t.ToolCall("sandbox-Glob", new { pattern = "*.txt", path = ws }))
+                .Turn(t => t.ToolCall("sandbox-Grep", new { pattern = needle, path = ws, output_mode = "content" }))
+                .Turn(t => t.Text("Completed sandbox tool chain."))
+            .Build();
+
+        using var factory = new E2EWebAppFactory(
+            "test-anthropic",
+            new ScriptedBuilder(responder.AsAnthropicHandler()));
+
+        var threadId = "sandbox-chain-" + Guid.NewGuid().ToString("N");
+        Logger.LogInformation("Connecting WebSocket thread {ThreadId} in mode {ModeId}", threadId, SystemChatModes.WorkspaceAgentModeId);
+        var socket = await factory.ConnectWebSocketAsync(threadId, SystemChatModes.WorkspaceAgentModeId);
+        await using var client = new WebSocketTestClient(socket);
+
+        await client.SendUserMessageAsync("Run the workspace tool chain: write, read, bash, glob, grep.");
+        using var frames = await client.CollectUntilDoneAsync(TimeSpan.FromSeconds(180));
+
+        var toolNames = frames.ToolCallNames();
+        var toolResults = frames.ToolCallResults();
+        var combinedResults = string.Concat(toolResults);
+        var needleHits = CountOccurrences(combinedResults, needle);
+        Logger.LogInformation(
+            "Observed {ToolCount} tool-call frame(s); distinct tools=[{Tools}]; combined result chars={Len}; needleHits={NeedleHits}",
+            toolNames.Count,
+            string.Join(", ", toolNames.Distinct()),
+            combinedResults.Length,
+            needleHits);
+        LogData("toolCallNames", toolNames);
+        LogData("toolCallResults", toolResults);
+
+        var session = await factory.Services
+            .GetRequiredService<SandboxSessionRegistry>()
+            .GetOrCreateSessionAsync("default");
+        Logger.LogInformation(
+            "Live session {SessionId}; hostPath={HostPath}; configuredWorkspace={Ws}; pathsMatch={Match}",
+            session.SessionId,
+            session.HostPath,
+            ws,
+            string.Equals(Path.GetFullPath(session.HostPath), ws, StringComparison.OrdinalIgnoreCase));
+
+        var hostExists = File.Exists(probeAbs);
+        var hostContent = hostExists ? await File.ReadAllTextAsync(probeAbs) : string.Empty;
+        Logger.LogInformation(
+            "Host probe file: path={ProbeAbs} exists={Exists} contentLength={Length} containsMarker={HasMarker} containsNeedle={HasNeedle}",
+            probeAbs,
+            hostExists,
+            hostContent.Length,
+            hostContent.Contains(marker, StringComparison.Ordinal),
+            hostContent.Contains(needle, StringComparison.Ordinal));
+
+        // Per-tool validation: each tool gets a distinct signal so a single failing tool is isolable.
+        var checks = new[]
+        {
+            new ToolCheck(
+                "sandbox-Write",
+                toolNames.Contains("sandbox-Write"),
+                File.Exists(probeAbs) && hostContent.Contains(marker, StringComparison.Ordinal),
+                $"host file {probeName} written with marker"),
+            new ToolCheck(
+                "sandbox-Read",
+                toolNames.Contains("sandbox-Read"),
+                combinedResults.Contains(marker, StringComparison.Ordinal),
+                "Read returned file content (marker)"),
+            new ToolCheck(
+                "sandbox-Bash",
+                toolNames.Contains("sandbox-Bash"),
+                combinedResults.Contains(bashMarker, StringComparison.Ordinal),
+                "Bash echoed its marker"),
+            new ToolCheck(
+                "sandbox-Glob",
+                toolNames.Contains("sandbox-Glob"),
+                combinedResults.Contains(probeName, StringComparison.Ordinal),
+                "Glob listed the probe file"),
+            new ToolCheck(
+                "sandbox-Grep",
+                toolNames.Contains("sandbox-Grep"),
+                needleHits >= 2,
+                "Grep matched the needle (Read + Grep => >=2 hits)"),
+        };
+
+        foreach (var c in checks)
+        {
+            Logger.LogInformation(
+                "SandboxToolCheck: tool={SandboxTool} invoked={Invoked} validated={Validated} detail={Detail}",
+                c.Tool,
+                c.Invoked,
+                c.Validated,
+                c.Detail);
+        }
+
+        using (new AssertionScope())
+        {
+            foreach (var c in checks)
+            {
+                c.Invoked.Should().BeTrue($"{c.Tool} should have been invoked through the gateway-backed registry");
+                c.Validated.Should().BeTrue($"{c.Tool} should have produced its expected result — {c.Detail}");
+            }
+        }
+
+        frames.ConcatText().Should().Contain(
+            "Completed sandbox tool chain.",
+            "the agent loop should run all five tool turns then the closing text");
+
+        try
+        {
+            File.Delete(probeAbs);
+            Logger.LogInformation("Cleaned up probe file {ProbeAbs}", probeAbs);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Best-effort cleanup of probe file {ProbeAbs} failed", probeAbs);
+        }
+
+        LogTestEnd();
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        if (string.IsNullOrEmpty(haystack) || string.IsNullOrEmpty(needle))
+        {
+            return 0;
+        }
+
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+
+    private sealed record ToolCheck(string Tool, bool Invoked, bool Validated, string Detail);
 }


### PR DESCRIPTION
## Summary

Extends the existing `samples/LmStreaming.Sample` chat app into a runnable demonstration of the **SandboxedOstools MCP gateway**. An LLM operates inside an isolated, policy‑enforced *workspace* sandbox, and its outbound calls to **GitHub** / **Azure DevOps** are transparently authenticated by injecting freshly‑refreshed OAuth tokens that the sandbox itself never sees. The sample app is modified in place — no new app, no `*-v2` files.

## Changes

**Phase 1 — Sandboxed workspace agent**
- Adopt‑or‑spawn lifecycle for `mcp-gateway.exe` (`SandboxGatewayLifetime`) with correct local‑backend env; **non‑fatal startup**, lazy session creation.
- `SandboxSessionRegistry` — single‑flight, app‑wide workspace session with teardown on shutdown (keyed by workspace id → `?workspace=` seam for later).
- New **Workspace Agent** chat mode; tools come entirely from the sandbox. Middleware path (Anthropic/OpenAI) = true isolation; Copilot path = best‑effort, prompt‑steered. Both wired via one shared `BuildHttpMcpServer` / `ConnectHttpMcpClient` helper.
- `repo-explorer` **Skill** demonstrating the gateway's skill mechanism.

**Phase 2 — GitHub + Azure DevOps auth provider**
- Device‑code OAuth sign‑in (single app‑wide user) + refresh, for GitHub and Azure DevOps (Entra).
- File‑backed refresh‑token store — atomic writes, gitignored, token values never logged.
- `AuthWebhookController` hosts the gateway's auth‑webhook: returns a freshly‑refreshed bearer + real expiry to inject, or a token‑free `deny`. Constant‑time shared‑secret check; generic deny reasons.
- Sandbox‑create now sends `auth_providers` + default‑deny `network.rules (action:"allow")` scoped to GitHub/ADO hosts; gateway spawned with the `AUTH_WEBHOOK_HTTP_LOOPBACK_HOSTS` SSRF allowlist.

**Config / docs**
- `SandboxGateway` + `Auth` blocks in `appsettings*.json` (empty placeholder client ids — no secrets).
- `.gitignore`: ignore `**/oauth-tokens/` and `.env.*`.
- New guides: `SandboxWorkspaceGuide.md`, `AuthProviderGuide.md`.

## Testing

- `dotnet build LmDotnetTools.sln` → **0 warnings / 0 errors**; sample unit tests **69/69 pass**.
- **Phase 1 (live, real Anthropic LLM):** created a session, ran `Bash → Read → Write → Read` through the gateway; a model‑written file landed on the host workspace with exact content; an out‑of‑workspace path was refused.
- **Phase 2 (credential‑free):** auth endpoints 200; unconfigured‑provider sign‑in → 409; webhook authz → 401 (missing) / 401 (wrong secret) / 200‑`deny` (correct secret, not signed in); the auth‑wired sandbox‑create was **accepted** by the gateway (SSRF allowlist + network‑rule contract verified).
- Two security review passes (2 blocking + 2 should‑fix) all addressed.

> **Live token‑injection demo** is not exercised here — it needs the maintainer to register a GitHub App (Device Flow, *expire user tokens* on) and an Entra public client, then set `Auth:Github:ClientId` / `Auth:Ado:ClientId`. Steps are in `AuthProviderGuide.md`.

## Security

- Tokens never enter the sandbox — injected at the egress proxy after policy evaluation.
- Refresh/access tokens stored gitignored, written atomically, never logged.
- Webhook secret compared in constant time (SHA‑256 both sides → `FixedTimeEquals`); deny reasons carry no provider error text.
- Default‑deny egress; only GitHub/ADO hosts allowed; `http://` webhook host restricted via `AUTH_WEBHOOK_HTTP_LOOPBACK_HOSTS`.

## Related Issues

Fixes #68
