### PR TITLE
feat(subagent): bring Agent tool to parity with Claude Code's Agent tool

### DIFF
--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -17,6 +17,7 @@ using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmCore.Utils;
 using AchieveAi.LmDotnetTools.LmMultiTurn;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using AchieveAi.LmDotnetTools.LmStreaming.AspNetCore.Extensions;
 using AchieveAi.LmDotnetTools.LmTestUtils;
 using AchieveAi.LmDotnetTools.McpMiddleware.Extensions;
@@ -579,15 +580,20 @@ try
                         extraProperties = extraProperties.Add("Thinking", new AnthropicThinking(budgetTokens));
                     }
 
-                    // Test-mode DI seam: opt-in sub-agent orchestration. Real-provider modes
-                    // never resolve this service, so production wiring is unchanged.
+                    // Sub-agent orchestration options. Only the middleware providers reach this
+                    // path — the CLI providers (codex/claude/copilot and their *-mock variants)
+                    // returned earlier and have no sub-agent hook, so they are out of scope. Test
+                    // modes go through the ITestAgentBuilder DI seam (scripted templates for E2E);
+                    // the real providers get the production template catalog. In both cases the
+                    // template AgentFactory reuses agentFactory(normalizedProviderId) so each spawn
+                    // builds a FRESH provider agent on the same backend as the parent.
                     var isTestMode =
                         string.Equals(normalizedProviderId, "test", StringComparison.Ordinal)
                         || string.Equals(normalizedProviderId, "test-anthropic", StringComparison.Ordinal);
                     var subAgentOptions = isTestMode
                         ? sp.GetRequiredService<ITestAgentBuilder>()
                             .CreateSubAgentOptions(loggerFactory, () => agentFactory(normalizedProviderId))
-                        : null;
+                        : BuildProductionSubAgentOptions(() => agentFactory(normalizedProviderId));
 
                     var agent = new MultiTurnAgentLoop(
                         providerAgent,
@@ -1199,6 +1205,52 @@ public partial class Program
             "anthropic" or "test-anthropic" => [new AnthropicWebSearchTool()],
             _ => null,
         };
+    }
+
+    /// <summary>
+    ///     Builds the production sub-agent orchestration options for the real middleware
+    ///     providers (OpenAI / Anthropic / Copilot-backed). Each template reuses the parent's
+    ///     provider via <paramref name="providerAgentFactory"/> — invoked per spawn so every
+    ///     sub-agent gets a FRESH provider agent on the same backend — and carries its own
+    ///     system prompt and turn budget. The CLI providers (codex/claude/copilot) have no
+    ///     sub-agent hook and are out of scope, so this is only called from the middleware path.
+    /// </summary>
+    private static SubAgentOptions BuildProductionSubAgentOptions(Func<IStreamingAgent> providerAgentFactory)
+    {
+        var templates = new Dictionary<string, SubAgentTemplate>
+        {
+            ["general-purpose"] = new SubAgentTemplate
+            {
+                Name = "General-purpose agent",
+                Description = "Autonomous worker for multi-step tasks: research, search, and follow-through.",
+                WhenToUse =
+                    "Delegate self-contained tasks that need several tool calls or focused investigation "
+                    + "so the parent context stays clean. Not for trivial one-shot answers.",
+                SystemPrompt =
+                    "You are a general-purpose sub-agent working on behalf of a parent agent. "
+                    + "Complete the delegated task end to end using the tools available to you, then "
+                    + "return a concise final answer that fully captures your findings — the parent only "
+                    + "sees your final message, not your intermediate steps.",
+                AgentFactory = providerAgentFactory,
+                MaxTurnsPerRun = 25,
+            },
+            ["researcher"] = new SubAgentTemplate
+            {
+                Name = "Researcher",
+                Description = "Focused investigator that gathers information and summarizes findings.",
+                WhenToUse =
+                    "Delegate open-ended investigation across sources when you need a distilled summary "
+                    + "rather than raw results. Prefer general-purpose for tasks that also mutate state.",
+                SystemPrompt =
+                    "You are a research sub-agent. Investigate the delegated question thoroughly using the "
+                    + "tools available to you, cross-check what you find, and return a clear, well-structured "
+                    + "summary. The parent only sees your final message, so make it self-contained.",
+                AgentFactory = providerAgentFactory,
+                MaxTurnsPerRun = 25,
+            },
+        };
+
+        return new SubAgentOptions { Templates = templates, MaxConcurrentSubAgents = 5 };
     }
 
     private static int ResolveCodexMcpPort()

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -106,7 +106,7 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
 
             var toolProvider = new SubAgentToolProvider(
                 _subAgentManager,
-                [.. subAgentOptions.Templates.Keys]);
+                subAgentOptions.Templates);
 
             _ = functionRegistry.AddProvider(toolProvider);
         }

--- a/src/LmMultiTurn/SubAgents/SubAgentExecutionException.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentExecutionException.cs
@@ -1,0 +1,24 @@
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+
+/// <summary>
+/// Thrown when a synchronously-awaited sub-agent run completes with an error.
+/// Carries the failing agent's id and template so the parent tool handler can
+/// surface a clear failure result to the calling LLM.
+/// </summary>
+public sealed class SubAgentExecutionException : Exception
+{
+    public SubAgentExecutionException(string agentId, string templateName, string? errorMessage)
+        : base(
+            $"Sub-agent '{templateName}' ({agentId}) failed: " +
+            $"{errorMessage ?? "(no error message)"}")
+    {
+        AgentId = agentId;
+        TemplateName = templateName;
+    }
+
+    /// <summary>The id of the sub-agent whose run failed.</summary>
+    public string AgentId { get; }
+
+    /// <summary>The template the failing sub-agent was spawned from.</summary>
+    public string TemplateName { get; }
+}

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -672,7 +672,7 @@ public sealed class SubAgentManager : IAsyncDisposable
 
             // Fault the synchronous waiter (if any); a background spawn observes
             // this fault via ObserveCompletionFaults so it is never unobserved.
-            _ = state.Completion.TrySetException(
+            _ = state.TryCompleteWithException(
                 new SubAgentExecutionException(
                     state.AgentId, state.TemplateName, rcm.ErrorMessage));
 
@@ -694,7 +694,7 @@ public sealed class SubAgentManager : IAsyncDisposable
                 $"Result: {result}\n" +
                 $"</sub-agent>";
 
-            _ = state.Completion.TrySetResult(result);
+            _ = state.TryCompleteWithResult(result);
 
             if (state.NotifyParentOnCompletion)
             {
@@ -720,6 +720,9 @@ public sealed class SubAgentManager : IAsyncDisposable
     /// Awaits a synchronous sub-agent run's completion. If the parent abandons the wait
     /// (its cancellation token fires), the sub-agent is cancelled too so it stops promptly
     /// and frees its concurrency slot instead of running on, orphaned.
+    /// The wait has no independent timeout ceiling: it is bounded only by the caller's
+    /// <paramref name="ct"/> (the parent turn's lifetime), while runaway sub-agent runs are
+    /// independently bounded by the template's MaxTurnsPerRun.
     /// </summary>
     private static async Task<string> AwaitCompletionAsync(SubAgentState state, CancellationToken ct)
     {

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Channels;
 using AchieveAi.LmDotnetTools.LmCore.Core;
@@ -24,6 +25,7 @@ public sealed class SubAgentManager : IAsyncDisposable
     private readonly ILogger _logger;
 
     private readonly ConcurrentDictionary<string, SubAgentState> _agents = new();
+    private readonly ConcurrentDictionary<string, string> _namesToIds = new();
     private readonly SemaphoreSlim _concurrencyGate;
 
     public SubAgentManager(
@@ -50,10 +52,17 @@ public sealed class SubAgentManager : IAsyncDisposable
 
     /// <summary>
     /// Spawn a new sub-agent from a named template.
+    /// When <paramref name="runInBackground"/> is false (default), blocks until the
+    /// sub-agent's run completes and returns its final answer as the result. When true,
+    /// returns immediately with a JSON spawn receipt (agent id) and relays the eventual
+    /// result to the parent as an injected message.
     /// </summary>
     public async Task<string> SpawnAsync(
         string templateName,
         string task,
+        string? name = null,
+        string? model = null,
+        bool runInBackground = false,
         string[]? addTools = null,
         string[]? removeTools = null,
         CancellationToken ct = default)
@@ -74,21 +83,39 @@ public sealed class SubAgentManager : IAsyncDisposable
         }
 
         var agentId = Guid.NewGuid().ToString("N")[..12];
+        SubAgentState state;
 
         try
         {
-            var agent = CreateSubAgent(agentId, template, addTools, removeTools, out var store);
+            var agent = CreateSubAgent(agentId, template, model, addTools, removeTools, out var store);
 
-            var state = new SubAgentState
+            state = new SubAgentState
             {
                 AgentId = agentId,
                 TemplateName = templateName,
                 Task = task,
                 Agent = agent,
                 Store = store,
+                Name = name,
+                NotifyParentOnCompletion = runInBackground,
             };
 
             _agents[agentId] = state;
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                if (_namesToIds.TryGetValue(name, out var existingId)
+                    && existingId != agentId
+                    && _agents.ContainsKey(existingId))
+                {
+                    _logger.LogWarning(
+                        "Sub-agent name '{Name}' already maps to agent {ExistingId}; reassigning it "
+                            + "to the newly spawned agent {AgentId}. SendMessage by this name will now "
+                            + "address the new agent.",
+                        name, existingId, agentId);
+                }
+
+                _namesToIds[name] = agentId;
+            }
 
             // Start the agent loop in the background
             var cts = state.Cts;
@@ -104,57 +131,125 @@ public sealed class SubAgentManager : IAsyncDisposable
                 [new TextMessage { Role = Role.User, Text = task }], ct: ct);
 
             _logger.LogInformation(
-                "Spawned sub-agent {AgentId} from template {Template} with task: {Task}",
-                agentId, templateName, Truncate(task, 100));
+                "Spawned sub-agent {AgentId} from template {Template} (background={Background}) with task: {Task}",
+                agentId, templateName, runInBackground, Truncate(task, 100));
+        }
+        catch
+        {
+            // Release the gate on spawn-time failure (before the monitor takes ownership).
+            _ = _concurrencyGate.Release();
+            throw;
+        }
+
+        // Past this point the monitor owns the concurrency gate; do not release it here.
+        if (runInBackground)
+        {
+            // Nobody awaits the completion on the background path; observe any fault
+            // so it never surfaces as an UnobservedTaskException.
+            ObserveCompletionFaults(state);
 
             return JsonSerializer.Serialize(new
             {
                 agent_id = agentId,
+                name,
                 template = templateName,
                 status = "spawned",
             });
         }
-        catch
-        {
-            // Release the gate on failure
-            _ = _concurrencyGate.Release();
-            throw;
-        }
+
+        // Synchronous: block until the run completes and return its final answer.
+        // Parent relay is suppressed (NotifyParentOnCompletion=false) so the result
+        // flows back only as this tool result, in the same parent turn.
+        return await AwaitCompletionAsync(state, ct);
     }
 
     /// <summary>
-    /// Resume or send a new message to an existing sub-agent.
+    /// Continue an existing sub-agent identified by its id or caller-supplied name.
+    /// A running agent receives the message in its current run; a finished agent is
+    /// restarted. When <paramref name="runInBackground"/> is false (default), blocks
+    /// until the (re)started run completes and returns its final answer; when true,
+    /// returns a JSON receipt immediately and relays the result to the parent.
     /// </summary>
-    public async Task<string> ResumeAsync(
-        string agentId,
-        string newMessage,
+    public async Task<string> SendMessageAsync(
+        string target,
+        string prompt,
+        bool runInBackground = false,
         CancellationToken ct = default)
     {
-        if (!_agents.TryGetValue(agentId, out var state))
+        var agentId = ResolveAgentId(target);
+        var state = _agents[agentId];
+
+        var wasRunning = state.Status == SubAgentStatus.Running;
+        state.NotifyParentOnCompletion = runInBackground;
+
+        // A finished completion is replaced so this run can be awaited fresh; a pending
+        // one (running agent) is kept so existing waiters observe the next resolution.
+        state.ResetCompletionIfFinished();
+
+        if (wasRunning)
         {
-            throw new ArgumentException(
-                $"Unknown agent ID '{agentId}'.", nameof(agentId));
+            // Inject the message into the currently running agent.
+            _ = await state.Agent.SendAsync(
+                [new TextMessage { Role = Role.User, Text = prompt }], ct: ct);
+
+            _logger.LogInformation(
+                "Sent message to running sub-agent {AgentId}: {Message}",
+                agentId, Truncate(prompt, 100));
+        }
+        else
+        {
+            await RestartRunAsync(state, prompt, ct);
         }
 
-        if (state.Status == SubAgentStatus.Running)
+        if (runInBackground)
         {
-            // Inject message into the currently running agent
-            _ = await state.Agent.SendAsync(
-                [new TextMessage { Role = Role.User, Text = newMessage }], ct: ct);
+            ObserveCompletionFaults(state);
 
             return JsonSerializer.Serialize(new
             {
                 agent_id = agentId,
-                status = "message_sent",
+                name = state.Name,
+                status = wasRunning ? "message_sent" : "resumed",
             });
         }
 
-        // Agent is completed/error/stopped - need to resume
+        return await AwaitCompletionAsync(state, ct);
+    }
+
+    /// <summary>
+    /// Resolves a caller-supplied target (agent id or name) to a concrete agent id.
+    /// </summary>
+    private string ResolveAgentId(string target)
+    {
+        if (_agents.ContainsKey(target))
+        {
+            return target;
+        }
+
+        if (_namesToIds.TryGetValue(target, out var id) && _agents.ContainsKey(id))
+        {
+            return id;
+        }
+
+        throw new ArgumentException(
+            $"Unknown sub-agent '{target}'. Provide a valid agent id or name.",
+            nameof(target));
+    }
+
+    /// <summary>
+    /// Restarts a finished (completed/error/stopped) sub-agent's run with a new message.
+    /// On success the new monitor owns the concurrency gate; on failure the gate is released.
+    /// </summary>
+    private async Task RestartRunAsync(
+        SubAgentState state,
+        string prompt,
+        CancellationToken ct)
+    {
         if (!await _concurrencyGate.WaitAsync(TimeSpan.FromSeconds(5), ct))
         {
             throw new InvalidOperationException(
                 $"Max concurrent sub-agents ({_options.MaxConcurrentSubAgents}) " +
-                $"reached. Cannot resume agent '{agentId}'.");
+                $"reached. Cannot resume agent '{state.AgentId}'.");
         }
 
         try
@@ -205,19 +300,13 @@ public sealed class SubAgentManager : IAsyncDisposable
             state.MonitorTask = MonitorSubAgentAsync(state, cts.Token);
 
             _ = await state.Agent.SendAsync(
-                [new TextMessage { Role = Role.User, Text = newMessage }], ct: ct);
+                [new TextMessage { Role = Role.User, Text = prompt }], ct: ct);
 
             state.Status = SubAgentStatus.Running;
 
             _logger.LogInformation(
                 "Resumed sub-agent {AgentId} with message: {Message}",
-                agentId, Truncate(newMessage, 100));
-
-            return JsonSerializer.Serialize(new
-            {
-                agent_id = agentId,
-                status = "resumed",
-            });
+                state.AgentId, Truncate(prompt, 100));
         }
         catch
         {
@@ -254,6 +343,7 @@ public sealed class SubAgentManager : IAsyncDisposable
         return JsonSerializer.Serialize(new
         {
             agent_id = agentId,
+            name = state.Name,
             status = state.Status.ToString().ToLowerInvariant(),
             template = state.TemplateName,
             task = state.Task,
@@ -334,6 +424,7 @@ public sealed class SubAgentManager : IAsyncDisposable
         }
 
         _agents.Clear();
+        _namesToIds.Clear();
         _concurrencyGate.Dispose();
     }
 
@@ -343,11 +434,17 @@ public sealed class SubAgentManager : IAsyncDisposable
     private IMultiTurnAgent CreateSubAgent(
         string agentId,
         SubAgentTemplate template,
+        string? modelOverride,
         string[]? addTools,
         string[]? removeTools,
         out IConversationStore? store)
     {
         var providerAgent = template.AgentFactory();
+
+        // Apply the per-spawn model override (if any) on top of the template defaults.
+        var defaultOptions = string.IsNullOrWhiteSpace(modelOverride)
+            ? template.DefaultOptions
+            : (template.DefaultOptions ?? new GenerateReplyOptions()) with { ModelId = modelOverride };
 
         // Determine conversation store
         var storeFactory =
@@ -380,7 +477,7 @@ public sealed class SubAgentManager : IAsyncDisposable
             registry,
             threadId: $"subagent-{agentId}",
             systemPrompt: template.SystemPrompt,
-            defaultOptions: template.DefaultOptions,
+            defaultOptions: defaultOptions,
             maxTurnsPerRun: template.MaxTurnsPerRun,
             store: store,
             logger: _logger is NullLogger ? null : new SubAgentLoopLoggerAdapter(_logger));
@@ -447,7 +544,29 @@ public sealed class SubAgentManager : IAsyncDisposable
         CancellationToken ct)
     {
         string? lastTextContent = null;
-        var completionHandled = false;
+        var gateReleased = false;
+
+        // Release the concurrency slot exactly once per monitor. A single monitor can
+        // observe multiple RunCompletedMessages — a background sub-agent continued in
+        // place via SendMessage runs again under the same monitor — but the slot was
+        // acquired once (at spawn/restart), so it must be released once: on the first
+        // completion, and never again. Releasing per-completion would over-release the
+        // semaphore (eventually SemaphoreFullException) and break the concurrency limit.
+        void ReleaseGateOnce()
+        {
+            if (!gateReleased)
+            {
+                gateReleased = true;
+                _ = _concurrencyGate.Release();
+            }
+        }
+
+        // Subscribers receive raw streaming deltas: the publishing middleware runs
+        // upstream of the joiner, so the consolidated TextMessage never reaches here —
+        // only TextUpdateMessage deltas do. Reconstruct the sub-agent's final answer by
+        // accumulating deltas per generation and keeping the latest generation's text.
+        var textBuilder = new StringBuilder();
+        string? textGenerationId = null;
 
         try
         {
@@ -463,11 +582,30 @@ public sealed class SubAgentManager : IAsyncDisposable
                     }
                 }
 
-                // Track last assistant text for completion result
-                if (msg is TextMessage tm
+                // Track the last assistant text for the completion result. Subscribers
+                // receive raw deltas, so accumulate TextUpdateMessage deltas per
+                // generation; a consolidated TextMessage (non-streaming mock) is taken as-is.
+                if (msg is TextUpdateMessage tu
+                    && tu.Role == Role.Assistant
+                    && !tu.IsThinking)
+                {
+                    // A new generation resets the accumulator so we keep only the most
+                    // recent assistant message, not earlier turns' text.
+                    if (!string.Equals(textGenerationId, tu.GenerationId, StringComparison.Ordinal))
+                    {
+                        textGenerationId = tu.GenerationId;
+                        _ = textBuilder.Clear();
+                    }
+
+                    _ = textBuilder.Append(tu.Text);
+                    lastTextContent = textBuilder.ToString();
+                }
+                else if (msg is TextMessage tm
                     && tm.Role == Role.Assistant
                     && !tm.IsThinking)
                 {
+                    textGenerationId = tm.GenerationId;
+                    _ = textBuilder.Clear().Append(tm.Text);
                     lastTextContent = tm.Text;
                 }
 
@@ -475,8 +613,10 @@ public sealed class SubAgentManager : IAsyncDisposable
                 {
                     state.LastResult = lastTextContent;
                     await HandleRunCompletionAsync(state, rcm, lastTextContent);
-                    completionHandled = true;
+                    ReleaseGateOnce();
                     lastTextContent = null;
+                    textGenerationId = null;
+                    _ = textBuilder.Clear();
                 }
             }
         }
@@ -499,56 +639,106 @@ public sealed class SubAgentManager : IAsyncDisposable
         }
         finally
         {
-            // Guard against semaphore slot leaks: if HandleRunCompletionAsync
-            // was never called (stream ended without RunCompletedMessage,
-            // cancellation, or exception), release the semaphore here.
-            if (!completionHandled)
-            {
-                _ = _concurrencyGate.Release();
-            }
+            // Fallback: if no completion was ever handled (the stream ended, was
+            // cancelled, or faulted before any RunCompletedMessage), the slot still
+            // needs releasing. ReleaseGateOnce is idempotent, so this is a no-op when
+            // a completion already released it.
+            ReleaseGateOnce();
         }
     }
 
     /// <summary>
-    /// Handles a sub-agent run completion by updating state and notifying the parent.
+    /// Handles a sub-agent run completion: resolves the synchronous completion signal
+    /// and, for background spawns/continuations, relays the result to the parent.
     /// </summary>
     private async Task HandleRunCompletionAsync(
         SubAgentState state,
         RunCompletedMessage rcm,
         string? lastTextContent)
     {
-        try
+        // The concurrency slot is released by the monitor (ReleaseGateOnce), exactly once
+        // per monitor lifetime — not here, because a single monitor may handle several
+        // completions when a background sub-agent is continued in place via SendMessage.
+        if (rcm.IsError)
         {
-            if (rcm.IsError)
+            state.Status = SubAgentStatus.Error;
+
+            var errorText =
+                $"<sub-agent name=\"{state.TemplateName}\" " +
+                $"id=\"{state.AgentId}\">\n" +
+                $"[Error] Task: {state.Task}\n" +
+                $"Error: {rcm.ErrorMessage}\n" +
+                $"</sub-agent>";
+
+            // Fault the synchronous waiter (if any); a background spawn observes
+            // this fault via ObserveCompletionFaults so it is never unobserved.
+            _ = state.Completion.TrySetException(
+                new SubAgentExecutionException(
+                    state.AgentId, state.TemplateName, rcm.ErrorMessage));
+
+            if (state.NotifyParentOnCompletion)
             {
-                state.Status = SubAgentStatus.Error;
-
-                var errorText =
-                    $"<sub-agent name=\"{state.TemplateName}\" " +
-                    $"id=\"{state.AgentId}\">\n" +
-                    $"[Error] Task: {state.Task}\n" +
-                    $"Error: {rcm.ErrorMessage}\n" +
-                    $"</sub-agent>";
-
                 await SendToParentAsync(state, errorText);
             }
-            else
+        }
+        else
+        {
+            state.Status = SubAgentStatus.Completed;
+
+            var result = lastTextContent ?? "(no text response)";
+
+            var resultText =
+                $"<sub-agent name=\"{state.TemplateName}\" " +
+                $"id=\"{state.AgentId}\">\n" +
+                $"[Completed] Task: {state.Task}\n" +
+                $"Result: {result}\n" +
+                $"</sub-agent>";
+
+            _ = state.Completion.TrySetResult(result);
+
+            if (state.NotifyParentOnCompletion)
             {
-                state.Status = SubAgentStatus.Completed;
-
-                var resultText =
-                    $"<sub-agent name=\"{state.TemplateName}\" " +
-                    $"id=\"{state.AgentId}\">\n" +
-                    $"[Completed] Task: {state.Task}\n" +
-                    $"Result: {lastTextContent ?? "(no text response)"}\n" +
-                    $"</sub-agent>";
-
                 await SendToParentAsync(state, resultText);
             }
         }
-        finally
+    }
+
+    /// <summary>
+    /// Observes faults on a completion the caller will not await (background path),
+    /// so a faulted run never surfaces as an UnobservedTaskException during GC.
+    /// </summary>
+    private static void ObserveCompletionFaults(SubAgentState state)
+    {
+        _ = state.Completion.Task.ContinueWith(
+            static t => { _ = t.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    /// <summary>
+    /// Awaits a synchronous sub-agent run's completion. If the parent abandons the wait
+    /// (its cancellation token fires), the sub-agent is cancelled too so it stops promptly
+    /// and frees its concurrency slot instead of running on, orphaned.
+    /// </summary>
+    private static async Task<string> AwaitCompletionAsync(SubAgentState state, CancellationToken ct)
+    {
+        try
         {
-            _ = _concurrencyGate.Release();
+            return await state.Completion.Task.WaitAsync(ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            try
+            {
+                await state.Cts.CancelAsync();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The sub-agent was already torn down (e.g. concurrent disposal); nothing to cancel.
+            }
+
+            throw;
         }
     }
 

--- a/src/LmMultiTurn/SubAgents/SubAgentState.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentState.cs
@@ -38,6 +38,18 @@ internal class SubAgentState
     public required string Task { get; init; }
     public required IMultiTurnAgent Agent { get; init; }
 
+    /// <summary>
+    /// Optional caller-supplied handle so SendMessage can address this agent by name.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// When true (background spawn/continuation), run completion is relayed to the
+    /// parent as an injected user message. When false (synchronous call), the tool
+    /// handler awaiting <see cref="Completion"/> returns the result directly instead.
+    /// </summary>
+    public bool NotifyParentOnCompletion { get; set; }
+
     public Task? RunTask { get; set; }
     public Task? MonitorTask { get; set; }
     public CancellationTokenSource Cts { get; set; } = new();
@@ -63,4 +75,33 @@ internal class SubAgentState
     /// Populated from the last assistant TextMessage before RunCompletedMessage.
     /// </summary>
     public string? LastResult { get; set; }
+
+    /// <summary>
+    /// Signal resolved when the current run completes: the final assistant text on
+    /// success, faulted on error, cancelled when the run ends without completing.
+    /// Synchronous Agent/SendMessage calls await this to return the result as the
+    /// tool result.
+    /// </summary>
+    public TaskCompletionSource<string> Completion { get; private set; } = CreateCompletionSource();
+
+    /// <summary>
+    /// Replaces an already-resolved completion with a fresh one so a follow-up
+    /// run (SendMessage continuation) can be awaited. A pending (unresolved)
+    /// completion is kept — existing waiters observe the next resolution.
+    /// </summary>
+    public void ResetCompletionIfFinished()
+    {
+        if (Completion.Task.IsCompleted)
+        {
+            Completion = CreateCompletionSource();
+        }
+    }
+
+    private static TaskCompletionSource<string> CreateCompletionSource()
+    {
+        // RunContinuationsAsynchronously: the monitor task resolves this signal;
+        // running waiter continuations inline would execute tool-handler code on
+        // the monitor's subscription thread.
+        return new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
 }

--- a/src/LmMultiTurn/SubAgents/SubAgentState.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentState.cs
@@ -48,7 +48,8 @@ internal class SubAgentState
     /// parent as an injected user message. When false (synchronous call), the tool
     /// handler awaiting <see cref="Completion"/> returns the result directly instead.
     /// </summary>
-    public bool NotifyParentOnCompletion { get; set; }
+    private volatile bool _notifyParentOnCompletion;
+    public bool NotifyParentOnCompletion { get => _notifyParentOnCompletion; set => _notifyParentOnCompletion = value; }
 
     public Task? RunTask { get; set; }
     public Task? MonitorTask { get; set; }
@@ -85,15 +86,48 @@ internal class SubAgentState
     public TaskCompletionSource<string> Completion { get; private set; } = CreateCompletionSource();
 
     /// <summary>
+    /// Guards the read-check-replace of <see cref="Completion"/> against the monitor
+    /// thread resolving the same source, so reset and resolution never race.
+    /// </summary>
+    private readonly object _completionLock = new();
+
+    /// <summary>
     /// Replaces an already-resolved completion with a fresh one so a follow-up
     /// run (SendMessage continuation) can be awaited. A pending (unresolved)
     /// completion is kept — existing waiters observe the next resolution.
     /// </summary>
     public void ResetCompletionIfFinished()
     {
-        if (Completion.Task.IsCompleted)
+        lock (_completionLock)
         {
-            Completion = CreateCompletionSource();
+            if (Completion.Task.IsCompleted)
+            {
+                Completion = CreateCompletionSource();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resolves the current completion with a successful result under the completion
+    /// lock, so it cannot race a concurrent <see cref="ResetCompletionIfFinished"/>.
+    /// </summary>
+    public bool TryCompleteWithResult(string result)
+    {
+        lock (_completionLock)
+        {
+            return Completion.TrySetResult(result);
+        }
+    }
+
+    /// <summary>
+    /// Faults the current completion under the completion lock, so it cannot race a
+    /// concurrent <see cref="ResetCompletionIfFinished"/>.
+    /// </summary>
+    public bool TryCompleteWithException(Exception exception)
+    {
+        lock (_completionLock)
+        {
+            return Completion.TrySetException(exception);
         }
     }
 

--- a/src/LmMultiTurn/SubAgents/SubAgentTemplate.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentTemplate.cs
@@ -17,6 +17,18 @@ public record SubAgentTemplate
     public string? Name { get; init; }
 
     /// <summary>
+    /// One-line summary of what this sub-agent does. Embedded in the Agent tool
+    /// description's template catalog so the parent LLM can pick the right type.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Delegation guidance: when the parent should (and should not) delegate to
+    /// this sub-agent. Embedded in the Agent tool description's template catalog.
+    /// </summary>
+    public string? WhenToUse { get; init; }
+
+    /// <summary>
     /// Independent system prompt for the sub-agent.
     /// </summary>
     public required string SystemPrompt { get; init; }

--- a/src/LmMultiTurn/SubAgents/SubAgentToolProvider.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentToolProvider.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
@@ -7,23 +8,23 @@ using AchieveAi.LmDotnetTools.LmCore.Models;
 namespace AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 
 /// <summary>
-/// Provides Agent and CheckAgent tool definitions for sub-agent orchestration.
-/// Registered as an IFunctionProvider so these tools are included in the
-/// parent agent's function registry alongside all other tools.
+/// Provides the Agent, SendMessage, and CheckAgent tool definitions for sub-agent
+/// orchestration. Registered as an IFunctionProvider so these tools are included in
+/// the parent agent's function registry alongside all other tools.
 /// </summary>
 public class SubAgentToolProvider : IFunctionProvider
 {
     private readonly SubAgentManager _manager;
-    private readonly IReadOnlyList<string> _templateNames;
+    private readonly IReadOnlyDictionary<string, SubAgentTemplate> _templates;
 
     public SubAgentToolProvider(
         SubAgentManager manager,
-        IReadOnlyList<string> templateNames)
+        IReadOnlyDictionary<string, SubAgentTemplate> templates)
     {
         ArgumentNullException.ThrowIfNull(manager);
-        ArgumentNullException.ThrowIfNull(templateNames);
+        ArgumentNullException.ThrowIfNull(templates);
         _manager = manager;
-        _templateNames = templateNames;
+        _templates = templates;
     }
 
     public string ProviderName => "SubAgentTools";
@@ -36,68 +37,91 @@ public class SubAgentToolProvider : IFunctionProvider
     public IEnumerable<FunctionDescriptor> GetFunctions()
     {
         yield return CreateAgentDescriptor();
+        yield return CreateSendMessageDescriptor();
         yield return CreateCheckAgentDescriptor();
     }
 
     private FunctionDescriptor CreateAgentDescriptor()
     {
-        var templateList = string.Join(", ", _templateNames);
+        var typeList = string.Join(", ", _templates.Keys);
 
         var contract = new FunctionContract
         {
             Name = "Agent",
             Description =
-                "Spawn a new sub-agent from a named template to work on a task, " +
-                "or send a new message to an existing sub-agent by ID. " +
-                "Returns immediately with the agent ID.",
+                "Delegate a task to a specialized sub-agent. By default this BLOCKS "
+                + "until the sub-agent finishes and returns its final answer as the "
+                + "tool result — use it when you need the answer before continuing.\n\n"
+                + "Set run_in_background: true to spawn asynchronously instead: the tool "
+                + "returns an agent id immediately, you poll progress with CheckAgent, "
+                + "and the final result is also delivered back to you as a follow-up "
+                + "message. Use background mode for long-running work you want to run "
+                + "while you keep working, or to fan out several sub-agents at once.\n\n"
+                + "Each sub-agent starts fresh and does NOT see your conversation history, "
+                + "so make the prompt self-contained. Use SendMessage to continue an "
+                + "existing sub-agent with a follow-up.\n\n"
+                + BuildTemplateCatalog(),
             Parameters =
             [
                 new FunctionParameterContract
                 {
-                    Name = "template_name",
+                    Name = "subagent_type",
                     Description =
-                        "Name of the sub-agent template. Available: " +
-                        $"{templateList}. Required for new agents.",
-                    ParameterType = new JsonSchemaObject
-                    {
-                        Type = new("string"),
-                    },
-                    IsRequired = false,
-                },
-                new FunctionParameterContract
-                {
-                    Name = "task",
-                    Description =
-                        "The task description or message to send to " +
-                        "the sub-agent.",
-                    ParameterType = new JsonSchemaObject
-                    {
-                        Type = new("string"),
-                    },
+                        $"Which sub-agent to spawn. One of: {typeList}.",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
                     IsRequired = true,
                 },
                 new FunctionParameterContract
                 {
-                    Name = "agent_id",
+                    Name = "prompt",
                     Description =
-                        "If provided, resumes or sends to an existing " +
-                        "sub-agent instead of spawning new.",
-                    ParameterType = new JsonSchemaObject
-                    {
-                        Type = new("string"),
-                    },
+                        "The task or instruction for the sub-agent. Be specific and "
+                        + "self-contained; the sub-agent does not share your context.",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
+                    IsRequired = true,
+                },
+                new FunctionParameterContract
+                {
+                    Name = "description",
+                    Description =
+                        "Optional short 3-5 word label for this delegation "
+                        + "(used for telemetry/UI).",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
+                    IsRequired = false,
+                },
+                new FunctionParameterContract
+                {
+                    Name = "name",
+                    Description =
+                        "Optional handle to address this sub-agent later via "
+                        + "SendMessage instead of using its generated id.",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
+                    IsRequired = false,
+                },
+                new FunctionParameterContract
+                {
+                    Name = "model",
+                    Description =
+                        "Optional model id override for this sub-agent "
+                        + "(defaults to the template's configured model).",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
+                    IsRequired = false,
+                },
+                new FunctionParameterContract
+                {
+                    Name = "run_in_background",
+                    Description =
+                        "When true, return immediately with an agent id instead of "
+                        + "blocking for the result. Poll progress with CheckAgent.",
+                    ParameterType = new JsonSchemaObject { Type = new("boolean") },
                     IsRequired = false,
                 },
                 new FunctionParameterContract
                 {
                     Name = "add_tools",
                     Description =
-                        "Comma-separated list of additional tool names " +
-                        "to enable.",
-                    ParameterType = new JsonSchemaObject
-                    {
-                        Type = new("string"),
-                    },
+                        "Comma-separated list of additional tool names to enable.",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
                     IsRequired = false,
                 },
                 new FunctionParameterContract
@@ -105,10 +129,7 @@ public class SubAgentToolProvider : IFunctionProvider
                     Name = "remove_tools",
                     Description =
                         "Comma-separated list of tool names to disable.",
-                    ParameterType = new JsonSchemaObject
-                    {
-                        Type = new("string"),
-                    },
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
                     IsRequired = false,
                 },
             ],
@@ -122,23 +143,72 @@ public class SubAgentToolProvider : IFunctionProvider
         };
     }
 
+    private FunctionDescriptor CreateSendMessageDescriptor()
+    {
+        var contract = new FunctionContract
+        {
+            Name = "SendMessage",
+            Description =
+                "Continue an existing sub-agent with a follow-up message. Address it "
+                + "by the id returned from Agent, or by the name you gave it when "
+                + "spawning. By default BLOCKS until the continued run finishes and "
+                + "returns its final answer; set run_in_background: true to return "
+                + "immediately and poll with CheckAgent.",
+            Parameters =
+            [
+                new FunctionParameterContract
+                {
+                    Name = "target",
+                    Description =
+                        "The sub-agent's id (from Agent) or the name you assigned it.",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
+                    IsRequired = true,
+                },
+                new FunctionParameterContract
+                {
+                    Name = "prompt",
+                    Description = "The follow-up message or instruction to send.",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
+                    IsRequired = true,
+                },
+                new FunctionParameterContract
+                {
+                    Name = "run_in_background",
+                    Description =
+                        "When true, return immediately instead of blocking for the "
+                        + "result. Poll progress with CheckAgent.",
+                    ParameterType = new JsonSchemaObject { Type = new("boolean") },
+                    IsRequired = false,
+                },
+            ],
+        };
+
+        return new FunctionDescriptor
+        {
+            Contract = contract,
+            Handler = HandleSendMessageToolAsync,
+            ProviderName = ProviderName,
+        };
+    }
+
     private FunctionDescriptor CreateCheckAgentDescriptor()
     {
         var contract = new FunctionContract
         {
             Name = "CheckAgent",
             Description =
-                "Check the status and recent activity of a sub-agent.",
+                "Check the status and recent activity of a background sub-agent (one "
+                + "spawned with run_in_background: true). Returns its status, recent "
+                + "turns, and final result once completed. Synchronous Agent/SendMessage "
+                + "calls already return the result directly and do not need CheckAgent.",
             Parameters =
             [
                 new FunctionParameterContract
                 {
                     Name = "agent_id",
-                    Description = "The ID of the sub-agent to check.",
-                    ParameterType = new JsonSchemaObject
-                    {
-                        Type = new("string"),
-                    },
+                    Description =
+                        "The id of the sub-agent to check (from Agent or SendMessage).",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
                     IsRequired = true,
                 },
             ],
@@ -152,6 +222,32 @@ public class SubAgentToolProvider : IFunctionProvider
         };
     }
 
+    /// <summary>
+    /// Builds the per-template catalog embedded in the Agent tool description so the
+    /// parent LLM can pick the right sub-agent type.
+    /// </summary>
+    private string BuildTemplateCatalog()
+    {
+        var sb = new StringBuilder();
+        _ = sb.Append("Available sub-agent types (subagent_type):");
+
+        foreach (var (key, template) in _templates)
+        {
+            var description = string.IsNullOrWhiteSpace(template.Description)
+                ? "(no description provided)"
+                : template.Description.Trim();
+
+            _ = sb.Append("\n- ").Append(key).Append(": ").Append(description);
+
+            if (!string.IsNullOrWhiteSpace(template.WhenToUse))
+            {
+                _ = sb.Append("\n  When to use: ").Append(template.WhenToUse.Trim());
+            }
+        }
+
+        return sb.ToString();
+    }
+
     private async Task<ToolHandlerResult> HandleAgentToolAsync(
         string argsJson,
         ToolCallContext context,
@@ -160,30 +256,67 @@ public class SubAgentToolProvider : IFunctionProvider
         using var doc = JsonDocument.Parse(argsJson);
         var root = doc.RootElement;
 
-        var agentId = GetOptionalString(root, "agent_id");
-        var task = GetOptionalString(root, "task")
+        var prompt = GetOptionalString(root, "prompt")
+            ?? throw new ArgumentException("The 'prompt' parameter is required.");
+        var subagentType = GetOptionalString(root, "subagent_type")
             ?? throw new ArgumentException(
-                "The 'task' parameter is required.");
+                "The 'subagent_type' parameter is required.");
 
-        if (agentId != null)
+        var name = GetOptionalString(root, "name");
+        var model = GetOptionalString(root, "model");
+        var runInBackground = GetOptionalBool(root, "run_in_background") ?? false;
+
+        // 'description' is intentionally accepted but not read here: it is a short
+        // human-facing delegation label exposed for parity with Claude Code's Agent tool.
+        // It has no server-side effect, so it is not threaded into SpawnAsync.
+        var addTools = ParseCommaSeparated(GetOptionalString(root, "add_tools"));
+        var removeTools = ParseCommaSeparated(GetOptionalString(root, "remove_tools"));
+
+        try
         {
-            // Resume or send to existing agent
-            return ToolHandlerResult.FromText(await _manager.ResumeAsync(agentId, task));
+            var result = await _manager.SpawnAsync(
+                subagentType,
+                prompt,
+                name,
+                model,
+                runInBackground,
+                addTools,
+                removeTools,
+                cancellationToken);
+
+            return ToolHandlerResult.FromText(result);
         }
+        catch (SubAgentExecutionException ex)
+        {
+            return ToolHandlerResult.FromError(ex.Message, "subagent_failed");
+        }
+    }
 
-        // Spawn new agent
-        var templateName = GetOptionalString(root, "template_name")
-            ?? throw new ArgumentException(
-                "The 'template_name' parameter is required " +
-                "when spawning a new agent.");
+    private async Task<ToolHandlerResult> HandleSendMessageToolAsync(
+        string argsJson,
+        ToolCallContext context,
+        CancellationToken cancellationToken)
+    {
+        using var doc = JsonDocument.Parse(argsJson);
+        var root = doc.RootElement;
 
-        var addTools = ParseCommaSeparated(
-            GetOptionalString(root, "add_tools"));
-        var removeTools = ParseCommaSeparated(
-            GetOptionalString(root, "remove_tools"));
+        var target = GetOptionalString(root, "target")
+            ?? throw new ArgumentException("The 'target' parameter is required.");
+        var prompt = GetOptionalString(root, "prompt")
+            ?? throw new ArgumentException("The 'prompt' parameter is required.");
+        var runInBackground = GetOptionalBool(root, "run_in_background") ?? false;
 
-        return ToolHandlerResult.FromText(
-            await _manager.SpawnAsync(templateName, task, addTools, removeTools));
+        try
+        {
+            var result = await _manager.SendMessageAsync(
+                target, prompt, runInBackground, cancellationToken);
+
+            return ToolHandlerResult.FromText(result);
+        }
+        catch (SubAgentExecutionException ex)
+        {
+            return ToolHandlerResult.FromError(ex.Message, "subagent_failed");
+        }
     }
 
     private Task<ToolHandlerResult> HandleCheckAgentToolAsync(
@@ -209,6 +342,23 @@ public class SubAgentToolProvider : IFunctionProvider
             && prop.ValueKind == JsonValueKind.String
             ? prop.GetString()
             : null;
+    }
+
+    private static bool? GetOptionalBool(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var prop))
+        {
+            return null;
+        }
+
+        return prop.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            // Some models emit booleans as strings ("true"/"false").
+            JsonValueKind.String when bool.TryParse(prop.GetString(), out var parsed) => parsed,
+            _ => null,
+        };
     }
 
     private static string[]? ParseCommaSeparated(string? value)

--- a/tests/LmMultiTurn.Tests/SubAgentIntegrationTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentIntegrationTests.cs
@@ -15,15 +15,16 @@ namespace LmMultiTurn.Tests;
 
 /// <summary>
 /// Integration tests verifying the full sub-agent orchestration flow:
-/// parent agent spawns sub-agent via tool call, sub-agent completes,
-/// and result is relayed back to the parent.
+/// parent agent spawns a sub-agent via tool call, the sub-agent completes,
+/// and the result flows back to the parent — synchronously as the tool result
+/// (default) or via a background receipt polled with CheckAgent.
 /// </summary>
 public class SubAgentIntegrationTests
 {
     /// <summary>
-    /// End-to-end test: parent calls the Agent tool to spawn a sub-agent,
-    /// the tool handler returns a JSON result with agent_id, and the
-    /// sub-agent's mock responds with a text message.
+    /// End-to-end test: parent calls the Agent tool to spawn a sub-agent. By
+    /// default the call is synchronous, so the tool result IS the sub-agent's
+    /// final answer (not a JSON receipt) and there is no second parent relay turn.
     /// </summary>
     [Fact]
     public async Task ParentSpawnsSubAgent_SubAgentCompletes_ParentReceivesResult()
@@ -62,8 +63,8 @@ public class SubAgentIntegrationTests
                                 FunctionName = "Agent",
                                 FunctionArgs = JsonSerializer.Serialize(new
                                 {
-                                    template_name = "researcher",
-                                    task = "Research the topic",
+                                    subagent_type = "researcher",
+                                    prompt = "Research the topic",
                                 }),
                                 ToolCallId = "call_agent_1",
                                 Role = Role.Assistant,
@@ -128,21 +129,15 @@ public class SubAgentIntegrationTests
             tc => tc.FunctionName == "Agent",
             "the parent should have called the Agent tool");
 
-        // The tool call result should contain a valid agent_id
+        // Synchronous Agent: the tool result IS the sub-agent's final answer,
+        // not a JSON spawn receipt.
         var toolCallResults = messages.OfType<ToolCallResultMessage>().ToList();
         toolCallResults.Should().NotBeEmpty(
             "the Agent tool should have returned a result");
 
-        var agentToolResult = toolCallResults
-            .FirstOrDefault(r => r.ToolName == "Agent" || r.Result.Contains("agent_id"));
-        agentToolResult.Should().NotBeNull(
-            "the Agent tool result should be present");
-
-        using var resultDoc = JsonDocument.Parse(agentToolResult!.Result);
-        resultDoc.RootElement.GetProperty("agent_id").GetString()
-            .Should().NotBeNullOrEmpty("spawn should return an agent_id");
-        resultDoc.RootElement.GetProperty("status").GetString()
-            .Should().Be("spawned");
+        toolCallResults.Should().Contain(
+            r => r.Result.Contains("Sub-agent analysis complete"),
+            "synchronous Agent returns the sub-agent's final text as the tool result");
 
         // The parent should have generated a final text response
         messages.OfType<TextMessage>()
@@ -158,8 +153,9 @@ public class SubAgentIntegrationTests
     }
 
     /// <summary>
-    /// Verifies that the CheckAgent tool is registered and callable
-    /// alongside the Agent tool when sub-agent options are configured.
+    /// Verifies the background spawn + CheckAgent flow: a sub-agent spawned with
+    /// run_in_background: true returns a JSON receipt with an agent id, which the
+    /// parent then polls with the CheckAgent tool.
     /// </summary>
     [Fact]
     public async Task SubAgentTools_AreRegisteredAndCallable()
@@ -190,15 +186,17 @@ public class SubAgentIntegrationTests
                     parentCallCount++;
                     if (parentCallCount == 1)
                     {
-                        // Spawn a sub-agent
+                        // Spawn a sub-agent in the background so the tool returns a
+                        // receipt (agent_id) immediately for CheckAgent to poll.
                         return Task.FromResult(ToAsyncEnumerable([
                             new ToolCallMessage
                             {
                                 FunctionName = "Agent",
                                 FunctionArgs = JsonSerializer.Serialize(new
                                 {
-                                    template_name = "worker",
-                                    task = "Do some work",
+                                    subagent_type = "worker",
+                                    prompt = "Do some work",
+                                    run_in_background = true,
                                 }),
                                 ToolCallId = "call_spawn",
                                 Role = Role.Assistant,

--- a/tests/LmMultiTurn.Tests/SubAgentManagerTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentManagerTests.cs
@@ -14,8 +14,9 @@ using Xunit;
 namespace LmMultiTurn.Tests;
 
 /// <summary>
-/// Unit tests for SubAgentManager lifecycle operations:
-/// spawning, peeking, completion relay, concurrency enforcement, and disposal.
+/// Unit tests for SubAgentManager lifecycle operations: synchronous and background
+/// spawning, peeking, completion relay, continuation via SendMessageAsync,
+/// concurrency enforcement, and disposal.
 /// </summary>
 public class SubAgentManagerTests : IAsyncLifetime
 {
@@ -46,7 +47,64 @@ public class SubAgentManagerTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task SpawnAsync_CreatesAgentAndReturnsId()
+    public async Task SpawnAsync_Synchronous_ReturnsFinalTextWithoutParentRelay()
+    {
+        // Arrange: sub-agent returns a single text response then the run completes
+        SetupSubAgentResponse([
+            new TextMessage { Text = "Sub-agent result", Role = Role.Assistant },
+        ]);
+
+        _manager = CreateManager();
+
+        // Act: synchronous spawn (default) blocks and returns the final answer directly
+        var result = await _manager.SpawnAsync("test-agent", "Do some work");
+
+        // Assert: the tool result is the sub-agent's final text, not a JSON receipt
+        result.Should().Be("Sub-agent result");
+
+        // The synchronous path must NOT relay the result to the parent — the result
+        // flows back only as this tool result, in the same parent turn.
+        _parentMock.Verify(
+            p => p.SendAsync(
+                It.IsAny<List<IMessage>>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SpawnAsync_Synchronous_Error_ThrowsAndDoesNotRelayToParent()
+    {
+        // Arrange: sub-agent throws -> MultiTurnAgentLoop completes the run with IsError=true
+        _subAgentMock
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("API call failed"));
+
+        _manager = CreateManager();
+
+        // Act: synchronous spawn surfaces the failure as a typed exception
+        var act = () => _manager.SpawnAsync("test-agent", "error-prone task");
+
+        // Assert
+        await act.Should().ThrowAsync<SubAgentExecutionException>()
+            .WithMessage("*test-agent*failed*");
+
+        // No parent relay on the synchronous path.
+        _parentMock.Verify(
+            p => p.SendAsync(
+                It.IsAny<List<IMessage>>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SpawnAsync_Background_ReturnsSpawnReceipt()
     {
         // Arrange
         SetupSubAgentResponse([
@@ -55,8 +113,9 @@ public class SubAgentManagerTests : IAsyncLifetime
 
         _manager = CreateManager(maxConcurrent: 5);
 
-        // Act
-        var resultJson = await _manager.SpawnAsync("test-agent", "Do some work");
+        // Act: background spawn returns immediately with a JSON receipt
+        var resultJson = await _manager.SpawnAsync(
+            "test-agent", "Do some work", runInBackground: true);
 
         // Assert
         using var doc = JsonDocument.Parse(resultJson);
@@ -86,29 +145,17 @@ public class SubAgentManagerTests : IAsyncLifetime
     {
         // Arrange: sub-agent that never completes (blocks indefinitely)
         var blockingTcs = new TaskCompletionSource<bool>();
-        _subAgentMock
-            .Setup(a => a.GenerateReplyStreamingAsync(
-                It.IsAny<IEnumerable<IMessage>>(),
-                It.IsAny<GenerateReplyOptions>(),
-                It.IsAny<CancellationToken>()))
-            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>(
-                async (_, _, ct) =>
-                {
-                    // Wait until cancelled or test completes
-                    await blockingTcs.Task.WaitAsync(ct);
-                    return ToAsyncEnumerable([
-                        new TextMessage { Text = "done", Role = Role.Assistant },
-                    ]);
-                });
+        SetupBlockingSubAgent(blockingTcs);
 
         _manager = CreateManager(maxConcurrent: 1);
 
-        // Act: first spawn should succeed
-        await _manager.SpawnAsync("test-agent", "first task");
+        // Act: first (background) spawn acquires the only concurrency slot
+        await _manager.SpawnAsync("test-agent", "first task", runInBackground: true);
 
-        // Second spawn should fail because concurrency limit is 1
-        // and first agent is still running (semaphore wait times out after 5s)
-        var act = () => _manager.SpawnAsync("test-agent", "second task");
+        // Second spawn should fail because concurrency limit is 1 and the first agent
+        // is still running (semaphore wait times out after 5s).
+        var act = () => _manager.SpawnAsync(
+            "test-agent", "second task", runInBackground: true);
 
         // Assert
         await act.Should().ThrowAsync<InvalidOperationException>()
@@ -141,7 +188,8 @@ public class SubAgentManagerTests : IAsyncLifetime
         ]);
 
         _manager = CreateManager();
-        var resultJson = await _manager.SpawnAsync("test-agent", "Do analysis");
+        var resultJson = await _manager.SpawnAsync(
+            "test-agent", "Do analysis", runInBackground: true);
 
         using var spawnDoc = JsonDocument.Parse(resultJson);
         var agentId = spawnDoc.RootElement.GetProperty("agent_id").GetString()!;
@@ -176,7 +224,7 @@ public class SubAgentManagerTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Completion_SendsWrappedResultToParent()
+    public async Task Completion_Background_SendsWrappedResultToParent()
     {
         // Arrange: sub-agent returns a text response then the run completes
         SetupSubAgentResponse([
@@ -184,7 +232,8 @@ public class SubAgentManagerTests : IAsyncLifetime
         ]);
 
         _manager = CreateManager();
-        await _manager.SpawnAsync("test-agent", "Analyze the codebase");
+        await _manager.SpawnAsync(
+            "test-agent", "Analyze the codebase", runInBackground: true);
 
         // Poll until the sub-agent completion is relayed to parent
         var parentCalled = false;
@@ -229,24 +278,13 @@ public class SubAgentManagerTests : IAsyncLifetime
     [Fact]
     public async Task DisposeAsync_StopsAllAgents()
     {
-        // Arrange: create a sub-agent with a delayed response
+        // Arrange: create a background sub-agent with a delayed response
         var blockingTcs = new TaskCompletionSource<bool>();
-        _subAgentMock
-            .Setup(a => a.GenerateReplyStreamingAsync(
-                It.IsAny<IEnumerable<IMessage>>(),
-                It.IsAny<GenerateReplyOptions>(),
-                It.IsAny<CancellationToken>()))
-            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>(
-                async (_, _, ct) =>
-                {
-                    await blockingTcs.Task.WaitAsync(ct);
-                    return ToAsyncEnumerable([
-                        new TextMessage { Text = "done", Role = Role.Assistant },
-                    ]);
-                });
+        SetupBlockingSubAgent(blockingTcs);
 
         _manager = CreateManager(maxConcurrent: 5);
-        await _manager.SpawnAsync("test-agent", "long-running task 1");
+        await _manager.SpawnAsync(
+            "test-agent", "long-running task 1", runInBackground: true);
 
         // Act & Assert: dispose should not throw even with running agents
         blockingTcs.SetResult(true);
@@ -258,32 +296,22 @@ public class SubAgentManagerTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task ResumeAsync_RunningAgent_SendsMessage()
+    public async Task SendMessageAsync_RunningAgent_SendsMessage()
     {
         // Arrange: sub-agent that blocks so it stays in Running state
         var blockingTcs = new TaskCompletionSource<bool>();
-        _subAgentMock
-            .Setup(a => a.GenerateReplyStreamingAsync(
-                It.IsAny<IEnumerable<IMessage>>(),
-                It.IsAny<GenerateReplyOptions>(),
-                It.IsAny<CancellationToken>()))
-            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>(
-                async (_, _, ct) =>
-                {
-                    await blockingTcs.Task.WaitAsync(ct);
-                    return ToAsyncEnumerable([
-                        new TextMessage { Text = "done", Role = Role.Assistant },
-                    ]);
-                });
+        SetupBlockingSubAgent(blockingTcs);
 
         _manager = CreateManager();
-        var spawnJson = await _manager.SpawnAsync("test-agent", "initial task");
+        var spawnJson = await _manager.SpawnAsync(
+            "test-agent", "initial task", runInBackground: true);
 
         using var spawnDoc = JsonDocument.Parse(spawnJson);
         var agentId = spawnDoc.RootElement.GetProperty("agent_id").GetString()!;
 
-        // Act: resume with a new message while agent is running
-        var resumeJson = await _manager.ResumeAsync(agentId, "follow-up message");
+        // Act: continue with a new message (background) while the agent is running
+        var resumeJson = await _manager.SendMessageAsync(
+            agentId, "follow-up message", runInBackground: true);
 
         // Assert
         using var resumeDoc = JsonDocument.Parse(resumeJson);
@@ -295,7 +323,7 @@ public class SubAgentManagerTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task ResumeAsync_CompletedAgent_RestartsRun()
+    public async Task SendMessageAsync_CompletedAgent_RestartsRun()
     {
         // Arrange: sub-agent completes quickly
         SetupSubAgentResponse([
@@ -303,7 +331,8 @@ public class SubAgentManagerTests : IAsyncLifetime
         ]);
 
         _manager = CreateManager();
-        var spawnJson = await _manager.SpawnAsync("test-agent", "initial task");
+        var spawnJson = await _manager.SpawnAsync(
+            "test-agent", "initial task", runInBackground: true);
 
         using var spawnDoc = JsonDocument.Parse(spawnJson);
         var agentId = spawnDoc.RootElement.GetProperty("agent_id").GetString()!;
@@ -330,13 +359,14 @@ public class SubAgentManagerTests : IAsyncLifetime
         peekDoc.RootElement.GetProperty("status").GetString()
             .Should().Be("completed");
 
-        // Act: resume the completed agent - this should restart a new run
-        // Need to set up the mock to respond again for the restart
+        // Act: continue the completed agent - this restarts a new run.
+        // Set up the mock to respond again for the restart.
         SetupSubAgentResponse([
             new TextMessage { Text = "Second result", Role = Role.Assistant },
         ]);
 
-        var resumeJson = await _manager.ResumeAsync(agentId, "continue work");
+        var resumeJson = await _manager.SendMessageAsync(
+            agentId, "continue work", runInBackground: true);
 
         // Assert
         using var resumeDoc = JsonDocument.Parse(resumeJson);
@@ -345,21 +375,123 @@ public class SubAgentManagerTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task ResumeAsync_UnknownAgentId_Throws()
+    public async Task SendMessageAsync_ResolvesAgentByName()
+    {
+        // Arrange: blocking agent stays Running so it can receive a follow-up message
+        var blockingTcs = new TaskCompletionSource<bool>();
+        SetupBlockingSubAgent(blockingTcs);
+
+        _manager = CreateManager();
+
+        // Spawn with a caller-supplied name in the background
+        await _manager.SpawnAsync(
+            "test-agent", "initial task", name: "researcher", runInBackground: true);
+
+        // Act: address the agent by its name instead of its generated id
+        var resumeJson = await _manager.SendMessageAsync(
+            "researcher", "follow-up message", runInBackground: true);
+
+        // Assert
+        using var resumeDoc = JsonDocument.Parse(resumeJson);
+        var root = resumeDoc.RootElement;
+        root.GetProperty("name").GetString().Should().Be("researcher");
+        root.GetProperty("status").GetString().Should().Be("message_sent");
+
+        // Cleanup
+        blockingTcs.SetResult(true);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_InjectIntoRunningBackgroundAgent_DoesNotOverReleaseConcurrencyGate()
+    {
+        // Regression guard for the gate single-release invariant. A background sub-agent
+        // continued in place via SendMessage (while still Running) feeds a SECOND run
+        // under the SAME monitor, so that one monitor observes two RunCompletedMessages.
+        // The concurrency slot is acquired once (at spawn), so it must be released exactly
+        // once. Releasing per completion (the original bug) over-releases the SemaphoreSlim,
+        // which throws SemaphoreFullException inside the monitor and flips the agent to
+        // Error status. The fix releases once per monitor, so the agent settles 'completed'.
+        var entered = new TaskCompletionSource<bool>();
+        var release = new TaskCompletionSource<bool>();
+        _subAgentMock
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>(
+                async (_, _, ct) =>
+                {
+                    // Signal the first turn is in-flight, then block so the task input is
+                    // already consumed before the follow-up is injected (forcing two runs).
+                    _ = entered.TrySetResult(true);
+                    await release.Task.WaitAsync(ct);
+                    return ToAsyncEnumerable([
+                        new TextMessage { Text = "done", Role = Role.Assistant },
+                    ]);
+                });
+
+        _manager = CreateManager(maxConcurrent: 1);
+
+        var spawnJson = await _manager.SpawnAsync(
+            "test-agent", "initial task", runInBackground: true);
+        using var spawnDoc = JsonDocument.Parse(spawnJson);
+        var agentId = spawnDoc.RootElement.GetProperty("agent_id").GetString()!;
+
+        // Wait until the first run has consumed the task and is blocked, so the follow-up
+        // becomes a distinct second run rather than collapsing into the first batch.
+        (await entered.Task.WaitAsync(TimeSpan.FromSeconds(10))).Should().BeTrue();
+
+        // Inject the follow-up while the first run is still Running -> same-monitor path.
+        var resumeJson = await _manager.SendMessageAsync(
+            agentId, "follow-up", runInBackground: true);
+        using var resumeDoc = JsonDocument.Parse(resumeJson);
+        resumeDoc.RootElement.GetProperty("status").GetString()
+            .Should().Be("message_sent");
+
+        // Release the block: the first run completes, then the queued follow-up drives a
+        // second run — both completions are observed by the one monitor.
+        release.SetResult(true);
+
+        // The agent must settle in 'completed', NOT 'error'. Under the over-release bug the
+        // monitor faults on the second completion (SemaphoreFullException) -> Error status.
+        await WaitForConditionAsync(
+            () =>
+            {
+                try
+                {
+                    return _manager!.Peek(agentId).Contains("\"completed\"");
+                }
+                catch
+                {
+                    return false;
+                }
+            },
+            TimeSpan.FromSeconds(10));
+
+        var peekJson = _manager.Peek(agentId);
+        using var peekDoc = JsonDocument.Parse(peekJson);
+        peekDoc.RootElement.GetProperty("status").GetString()
+            .Should().Be(
+                "completed",
+                "the monitor must release the concurrency slot exactly once across both runs");
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_UnknownTarget_Throws()
     {
         // Arrange
         _manager = CreateManager();
 
         // Act
-        var act = () => _manager.ResumeAsync("non-existent-id", "some message");
+        var act = () => _manager.SendMessageAsync("non-existent-id", "some message");
 
         // Assert
         await act.Should().ThrowAsync<ArgumentException>()
-            .WithMessage("*Unknown agent ID*non-existent-id*");
+            .WithMessage("*Unknown sub-agent*non-existent-id*");
     }
 
     [Fact]
-    public async Task Completion_Error_SendsWrappedErrorToParent()
+    public async Task Completion_Background_Error_SendsWrappedErrorToParent()
     {
         // Arrange: sub-agent throws on first call to trigger error run completion.
         // MultiTurnAgentLoop catches this and calls CompleteRunAsync(isError: true),
@@ -372,7 +504,8 @@ public class SubAgentManagerTests : IAsyncLifetime
             .ThrowsAsync(new InvalidOperationException("API call failed"));
 
         _manager = CreateManager();
-        await _manager.SpawnAsync("test-agent", "error-prone task");
+        await _manager.SpawnAsync(
+            "test-agent", "error-prone task", runInBackground: true);
 
         // Poll until parent receives error notification
         await WaitForConditionAsync(
@@ -486,23 +619,6 @@ public class SubAgentManagerTests : IAsyncLifetime
     }
 
     /// <summary>
-    /// Checks if a message is a TextMessage containing sub-agent XML tags.
-    /// Extracted as a static method to avoid pattern matching in Moq expression trees.
-    /// </summary>
-    private static bool ContainsSubAgentTag(
-        IMessage message,
-        string templateName)
-    {
-        if (message is not TextMessage tm)
-        {
-            return false;
-        }
-
-        return tm.Text.Contains($"<sub-agent name=\"{templateName}\"")
-            && tm.Text.Contains("</sub-agent>");
-    }
-
-    /// <summary>
     /// Checks if a message is a TextMessage containing sub-agent error markers.
     /// Verifies the [Error] tag specifically to distinguish from [Completed].
     /// </summary>
@@ -567,6 +683,28 @@ public class SubAgentManagerTests : IAsyncLifetime
                 It.IsAny<GenerateReplyOptions>(),
                 It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult(ToAsyncEnumerable(messages)));
+    }
+
+    /// <summary>
+    /// Configures the mock sub-agent to block until <paramref name="release"/> is
+    /// completed (or the run is cancelled), keeping it in the Running state. Used by
+    /// concurrency, disposal, and continuation tests that need a long-running agent.
+    /// </summary>
+    private void SetupBlockingSubAgent(TaskCompletionSource<bool> release)
+    {
+        _subAgentMock
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>(
+                async (_, _, ct) =>
+                {
+                    await release.Task.WaitAsync(ct);
+                    return ToAsyncEnumerable([
+                        new TextMessage { Text = "done", Role = Role.Assistant },
+                    ]);
+                });
     }
 
     /// <summary>

--- a/tests/LmMultiTurn.Tests/SubAgentToolProviderTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentToolProviderTests.cs
@@ -12,8 +12,9 @@ using Xunit;
 namespace LmMultiTurn.Tests;
 
 /// <summary>
-/// Unit tests for SubAgentToolProvider: verifies that the Agent and CheckAgent
-/// tool descriptors are correctly generated and that handler argument validation works.
+/// Unit tests for SubAgentToolProvider: verifies the Agent, SendMessage, and
+/// CheckAgent tool descriptors are generated correctly (including the embedded
+/// template catalog) and that handler argument validation works.
 /// </summary>
 public class SubAgentToolProviderTests : IAsyncLifetime
 {
@@ -32,9 +33,19 @@ public class SubAgentToolProviderTests : IAsyncLifetime
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SendReceipt("receipt-1", null, DateTimeOffset.UtcNow));
 
-        var template = new SubAgentTemplate
+        var researcher = new SubAgentTemplate
         {
-            SystemPrompt = "You are a test agent.",
+            SystemPrompt = "You are a researcher.",
+            Description = "Researches topics and summarizes findings.",
+            WhenToUse = "Use for open-ended investigation across many sources.",
+            AgentFactory = () => _subAgentMock.Object,
+        };
+
+        var coder = new SubAgentTemplate
+        {
+            SystemPrompt = "You are a coder.",
+            Description = "Writes and edits code.",
+            WhenToUse = "Use for focused implementation tasks.",
             AgentFactory = () => _subAgentMock.Object,
         };
 
@@ -42,8 +53,8 @@ public class SubAgentToolProviderTests : IAsyncLifetime
         {
             Templates = new Dictionary<string, SubAgentTemplate>
             {
-                ["researcher"] = template,
-                ["coder"] = template,
+                ["researcher"] = researcher,
+                ["coder"] = coder,
             },
             MaxConcurrentSubAgents = 5,
         };
@@ -54,8 +65,7 @@ public class SubAgentToolProviderTests : IAsyncLifetime
             parentHandlers: new Dictionary<string, ToolHandler>(),
             options: options);
 
-        _provider = new SubAgentToolProvider(
-            _manager, ["researcher", "coder"]);
+        _provider = new SubAgentToolProvider(_manager, options.Templates);
 
         return Task.CompletedTask;
     }
@@ -69,62 +79,127 @@ public class SubAgentToolProviderTests : IAsyncLifetime
     }
 
     [Fact]
-    public void GetFunctions_ReturnsTwoFunctions()
+    public void GetFunctions_ReturnsThreeFunctions()
     {
         // Act
         var functions = _provider!.GetFunctions().ToList();
 
         // Assert
-        functions.Should().HaveCount(2);
+        functions.Should().HaveCount(3);
         functions.Select(f => f.Contract.Name)
-            .Should().BeEquivalentTo(["Agent", "CheckAgent"]);
+            .Should().BeEquivalentTo(["Agent", "SendMessage", "CheckAgent"]);
     }
 
     [Fact]
-    public async Task HandleAgentToolAsync_MissingTask_ThrowsArgumentException()
+    public void AgentDescriptor_EmbedsTemplateCatalog()
+    {
+        // Act
+        var agent = _provider!.GetFunctions()
+            .First(f => f.Contract.Name == "Agent");
+
+        // Assert: each template's key, Description, and WhenToUse appear in the
+        // tool description so the parent LLM can pick the right sub-agent type.
+        var description = agent.Contract.Description!;
+        description.Should().Contain("researcher");
+        description.Should().Contain("Researches topics and summarizes findings.");
+        description.Should().Contain("Use for open-ended investigation across many sources.");
+        description.Should().Contain("coder");
+        description.Should().Contain("Writes and edits code.");
+    }
+
+    [Fact]
+    public void AgentDescriptor_HasParityParameters()
+    {
+        // Act
+        var agent = _provider!.GetFunctions()
+            .First(f => f.Contract.Name == "Agent");
+        var paramNames = agent.Contract.Parameters!.Select(p => p.Name).ToList();
+
+        // Assert: Claude Code parity parameters present; legacy ones gone.
+        paramNames.Should().Contain(
+            ["subagent_type", "prompt", "description", "name", "model", "run_in_background", "add_tools", "remove_tools"]);
+        paramNames.Should().NotContain("template_name");
+        paramNames.Should().NotContain("task");
+        paramNames.Should().NotContain("agent_id");
+    }
+
+    [Fact]
+    public async Task HandleAgentToolAsync_MissingPrompt_ThrowsArgumentException()
     {
         // Arrange
-        var functions = _provider!.GetFunctions().ToList();
-        var agentHandler = functions.First(f => f.Contract.Name == "Agent").Handler;
-        var args = JsonSerializer.Serialize(new { template_name = "researcher" });
+        var agentHandler = GetHandler("Agent");
+        var args = JsonSerializer.Serialize(new { subagent_type = "researcher" });
 
         // Act
         var act = () => agentHandler(args, new ToolCallContext(), CancellationToken.None);
 
         // Assert
         await act.Should().ThrowAsync<ArgumentException>()
-            .WithMessage("*task*required*");
+            .WithMessage("*prompt*required*");
     }
 
     [Fact]
-    public async Task HandleAgentToolAsync_MissingTemplateAndAgentId_ThrowsArgumentException()
+    public async Task HandleAgentToolAsync_MissingSubagentType_ThrowsArgumentException()
     {
         // Arrange
-        var functions = _provider!.GetFunctions().ToList();
-        var agentHandler = functions.First(f => f.Contract.Name == "Agent").Handler;
-        var args = JsonSerializer.Serialize(new { task = "do something" });
+        var agentHandler = GetHandler("Agent");
+        var args = JsonSerializer.Serialize(new { prompt = "do something" });
 
         // Act
         var act = () => agentHandler(args, new ToolCallContext(), CancellationToken.None);
 
         // Assert
         await act.Should().ThrowAsync<ArgumentException>()
-            .WithMessage("*template_name*required*");
+            .WithMessage("*subagent_type*required*");
+    }
+
+    [Fact]
+    public async Task HandleSendMessageToolAsync_MissingTarget_ThrowsArgumentException()
+    {
+        // Arrange
+        var handler = GetHandler("SendMessage");
+        var args = JsonSerializer.Serialize(new { prompt = "follow up" });
+
+        // Act
+        var act = () => handler(args, new ToolCallContext(), CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*target*required*");
+    }
+
+    [Fact]
+    public async Task HandleSendMessageToolAsync_MissingPrompt_ThrowsArgumentException()
+    {
+        // Arrange
+        var handler = GetHandler("SendMessage");
+        var args = JsonSerializer.Serialize(new { target = "abc123" });
+
+        // Act
+        var act = () => handler(args, new ToolCallContext(), CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*prompt*required*");
     }
 
     [Fact]
     public async Task HandleCheckAgentToolAsync_MissingAgentId_ThrowsArgumentException()
     {
         // Arrange
-        var functions = _provider!.GetFunctions().ToList();
-        var checkHandler = functions.First(f => f.Contract.Name == "CheckAgent").Handler;
+        var handler = GetHandler("CheckAgent");
         var args = JsonSerializer.Serialize(new { });
 
         // Act
-        var act = () => checkHandler(args, new ToolCallContext(), CancellationToken.None);
+        var act = () => handler(args, new ToolCallContext(), CancellationToken.None);
 
         // Assert
         await act.Should().ThrowAsync<ArgumentException>()
             .WithMessage("*agent_id*required*");
+    }
+
+    private ToolHandler GetHandler(string name)
+    {
+        return _provider!.GetFunctions().First(f => f.Contract.Name == name).Handler;
     }
 }

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/RecursiveInstructionChainTests.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/RecursiveInstructionChainTests.cs
@@ -43,7 +43,7 @@ public sealed class RecursiveInstructionChainTests
             .Turn(t => t.Text("Sub-agent summary: Seattle is rainy."))
             .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
             // Parent instruction chain: spawn sub-agent -> summarize.
-            .Turn(t => t.ToolCall("Agent", new { template_name = "weather_sub", task = "check Seattle weather" }))
+            .Turn(t => t.ToolCall("Agent", new { subagent_type = "weather_sub", prompt = "check Seattle weather" }))
             .Turn(t => t.Text("Parent final: sub-agent confirmed Seattle is rainy."))
             .Build();
 
@@ -83,13 +83,14 @@ public sealed class RecursiveInstructionChainTests
         string.Join(" ", assistantTexts).Should().Contain("Parent final");
         string.Join(" ", assistantTexts).Should().Contain("Seattle is rainy");
 
-        // Sub-agent's tool-call turn must be consumed; later sub-agent turns may be
-        // short-circuited by the Agent-relay termination policy (see SubAgentToolUseTests
-        // in the transport suite for the exact invariant).
+        // Under the synchronous Agent model a sub-agent run ends at its first text-only turn
+        // (no tool calls). The sub-agent consumes its tool-call turn (1) and the follow-up text
+        // turn (2) that terminates the run; the third scripted summary turn is never reached, so
+        // exactly one turn remains queued.
         responder
             .RemainingTurns["weather-sub"]
             .Should()
-            .BeLessThan(3, "sub-agent should have consumed at least its tool-call turn");
+            .Be(1, "the run ends at the first text-only turn, leaving the third scripted turn unconsumed");
 
         responder.RemainingTurns["parent"].Should().Be(0);
         await session.SaveSuccessScreenshotAsync($"RecursiveChain.Parent_and_sub_agent_instruction_chains_render_end_to_end_{providerMode}");

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/SubAgentLifecycleTests.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/SubAgentLifecycleTests.cs
@@ -7,8 +7,9 @@ namespace LmStreaming.Sample.Browser.E2E.Tests.Scenarios;
 
 /// <summary>
 /// AC3 — Sub-agent spawn / progress / result rendering. Parent emits an <c>Agent</c>
-/// tool call; sub-agent returns text; parent summarizes. Verifies the UI renders both
-/// a tool-call pill (the <c>Agent</c> relay) and the parent's final text.
+/// tool call; the synchronous call blocks until the sub-agent returns its text, which
+/// becomes the tool result; the parent then summarizes. Verifies the UI renders both the
+/// <c>Agent</c> tool-call pill and the parent's final text.
 /// </summary>
 [Collection(PlaywrightCollection.Name)]
 public sealed class SubAgentLifecycleTests
@@ -32,7 +33,7 @@ public sealed class SubAgentLifecycleTests
             .ForRole("researcher", ctx => ctx.SystemPromptContains(ResearcherMarker))
             .Turn(t => t.Text("Found three fresh AI papers today."))
             .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
-            .Turn(t => t.ToolCall("Agent", new { template_name = "researcher", task = "Find AI papers" }))
+            .Turn(t => t.ToolCall("Agent", new { subagent_type = "researcher", prompt = "Find AI papers" }))
             .Turn(t => t.Text("Summary: researcher surfaced three AI papers."))
             .Build();
 
@@ -58,17 +59,17 @@ public sealed class SubAgentLifecycleTests
         var page = session.Page;
 
         await page.SendMessageAsync("research AI papers for me");
-        // Sub-agent flow is slower than plain streams — allow more time for the second
-        // parent turn to surface after the Agent relay completes.
+        // Sub-agent flow is slower than plain streams — the synchronous Agent call blocks until
+        // the sub-agent returns its text, so allow more time for the second parent turn to surface.
         await page.WaitForStreamIdleAsync(timeoutMs: 30_000);
 
-        // A tool-call pill for the Agent relay should be visible.
+        // A tool-call pill for the synchronous Agent call should be visible.
         await page.ToolCallPills().WaitForCountAtLeastAsync(1, timeoutMs: 20_000);
         var toolNames = await page.ToolCallPills()
             .EvaluateAllAsync<string[]>("nodes => nodes.map(n => n.getAttribute('data-tool-name') ?? '')");
         toolNames.Should().Contain("Agent");
 
-        // The parent's final text should be rendered after the relay.
+        // The parent's final text should be rendered after the sub-agent's text becomes the tool result.
         await page.AssistantText().WaitForCountAtLeastAsync(1);
         var assistantTexts = await page.AssistantText().AllInnerTextsAsync();
         string.Join(" ", assistantTexts).Should().Contain("researcher surfaced three AI papers");

--- a/tests/LmStreaming.Sample.E2E.Tests/Scenarios/ConcurrentSubAgentsTests.cs
+++ b/tests/LmStreaming.Sample.E2E.Tests/Scenarios/ConcurrentSubAgentsTests.cs
@@ -7,9 +7,10 @@ namespace LmStreaming.Sample.E2E.Tests.Scenarios;
 
 /// <summary>
 /// Parent emits two <c>Agent</c> tool calls in a single turn. Two sub-agents should
-/// spawn, complete independently, and both results relay back before the parent produces
-/// its final summary. The two sub-agents share a system-prompt marker but differ on a
-/// tag (A/B) so each one picks from its own plan queue.
+/// spawn, complete independently, and both final answers come back as the two synchronous
+/// <c>Agent</c> tool results before the parent produces its final summary. The two
+/// sub-agents differ on a system-prompt marker (A/B) so each one picks from its own plan
+/// queue.
 /// </summary>
 public sealed class ConcurrentSubAgentsTests
 {
@@ -28,8 +29,8 @@ public sealed class ConcurrentSubAgentsTests
                 .Turn(t => t.Text("worker-B done"))
             .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
                 .Turn(t => t.ToolCalls(
-                    ("Agent", new { template_name = "worker_a", task = "do A" }),
-                    ("Agent", new { template_name = "worker_b", task = "do B" })))
+                    ("Agent", new { subagent_type = "worker_a", prompt = "do A" }),
+                    ("Agent", new { subagent_type = "worker_b", prompt = "do B" })))
                 .Turn(t => t.Text("Both workers finished."))
             .Build();
 

--- a/tests/LmStreaming.Sample.E2E.Tests/Scenarios/SendMessageTests.cs
+++ b/tests/LmStreaming.Sample.E2E.Tests/Scenarios/SendMessageTests.cs
@@ -1,0 +1,107 @@
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using FluentAssertions;
+using LmStreaming.Sample.E2E.Tests.Infrastructure;
+
+namespace LmStreaming.Sample.E2E.Tests.Scenarios;
+
+/// <summary>
+/// Exercises the <c>SendMessage</c> tool: the parent first spawns a named sub-agent with
+/// <c>Agent</c>, then continues that same sub-agent with a follow-up via <c>SendMessage</c>,
+/// addressing it by the caller-chosen <c>name</c> rather than its generated id. Because both
+/// calls are synchronous, each one's tool result is the sub-agent's final answer for that
+/// round, and the sub-agent is restarted for the continuation (its first run had already
+/// completed before the parent's follow-up turn).
+/// </summary>
+/// <remarks>
+/// Addressing by <c>name</c> (a caller-supplied, static value) is what makes this scenario
+/// scriptable: the generated <c>agent_id</c> is a runtime GUID that a static responder cannot
+/// feed back into a follow-up call, but the <c>name</c> is known at scripting time. The
+/// researcher role's two queued turns are consumed across the two synchronous runs (spawn +
+/// continuation), so both drain deterministically — no background relay, no race.
+/// </remarks>
+public sealed class SendMessageTests
+{
+    [Theory]
+    [InlineData("test")]
+    [InlineData("test-anthropic")]
+    public async Task Parent_continues_named_subagent_via_send_message(string providerMode)
+    {
+        const string ResearcherMarker = "You are the research sub-agent";
+        const string FirstAnswer = "Initial research done.";
+        const string SecondAnswer = "Follow-up research done.";
+
+        var responder = ScriptedSseResponder.New()
+            .ForRole("researcher", ctx => ctx.SystemPromptContains(ResearcherMarker))
+                .Turn(t => t.Text(FirstAnswer))
+                .Turn(t => t.Text(SecondAnswer))
+            .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
+                .Turn(t => t.ToolCall(
+                    "Agent",
+                    new
+                    {
+                        subagent_type = "researcher",
+                        prompt = "initial research",
+                        name = "researcher",
+                    }))
+                .Turn(t => t.ToolCall(
+                    "SendMessage",
+                    new { target = "researcher", prompt = "dig deeper" }))
+                .Turn(t => t.Text("Done: both rounds complete."))
+            .Build();
+
+        var handler = providerMode == "test-anthropic"
+            ? responder.AsAnthropicHandler()
+            : responder.AsOpenAiHandler();
+
+        var builder = new ScriptedBuilder(
+            handler,
+            subAgentFactory: (_, providerAgentFactory) => new SubAgentOptions
+            {
+                Templates = new Dictionary<string, SubAgentTemplate>
+                {
+                    ["researcher"] = new SubAgentTemplate
+                    {
+                        Name = "Researcher",
+                        SystemPrompt = ResearcherMarker,
+                        AgentFactory = providerAgentFactory,
+                        MaxTurnsPerRun = 5,
+                    },
+                },
+                MaxConcurrentSubAgents = 5,
+            });
+
+        using var factory = new E2EWebAppFactory(providerMode, builder);
+
+        var threadId = $"sendmessage-{providerMode}-{Guid.NewGuid():N}";
+        var socket = await factory.ConnectWebSocketAsync(threadId);
+        await using var client = new WebSocketTestClient(socket);
+
+        await client.SendUserMessageAsync("research then dig deeper");
+        using var frames = await client.CollectUntilDoneAsync(TimeSpan.FromSeconds(30));
+
+        var toolCalls = frames.ToolCallNames();
+        toolCalls.Should().Contain("Agent");
+        toolCalls.Should().Contain("SendMessage");
+
+        // Each synchronous call returns the sub-agent's final answer for that round: the
+        // spawn returns the first run's text, the SendMessage continuation returns the
+        // restarted run's text. Both surface as Agent/SendMessage tool results.
+        var toolResults = frames.ToolCallResults();
+        toolResults.Should().Contain(
+            r => r.Contains(FirstAnswer, StringComparison.Ordinal),
+            "the Agent spawn result is the sub-agent's first-round answer");
+        toolResults.Should().Contain(
+            r => r.Contains(SecondAnswer, StringComparison.Ordinal),
+            "the SendMessage continuation result is the restarted run's answer");
+
+        var streamedText = frames.ConcatText();
+        streamedText.Should().Contain("Done: both rounds complete");
+
+        // Both parent turns (Agent + SendMessage + final text) and both researcher runs
+        // (spawn + continuation) drained their queues — proving the continuation actually
+        // restarted the same sub-agent and ran its second scripted turn.
+        responder.RemainingTurns["parent"].Should().Be(0);
+        responder.RemainingTurns["researcher"].Should().Be(0);
+    }
+}

--- a/tests/LmStreaming.Sample.E2E.Tests/Scenarios/SubAgentBackgroundTests.cs
+++ b/tests/LmStreaming.Sample.E2E.Tests/Scenarios/SubAgentBackgroundTests.cs
@@ -1,0 +1,103 @@
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using FluentAssertions;
+using LmStreaming.Sample.E2E.Tests.Infrastructure;
+
+namespace LmStreaming.Sample.E2E.Tests.Scenarios;
+
+/// <summary>
+/// Exercises the <c>run_in_background: true</c> path of the <c>Agent</c> tool. Unlike the
+/// default synchronous spawn (which blocks and returns the sub-agent's final text), a
+/// background spawn returns a JSON receipt — <c>{ agent_id, name, template, status:"spawned" }</c>
+/// — immediately, before the sub-agent has produced any answer. The parent then continues
+/// without waiting. This is the receipt shape a parent would later poll with <c>CheckAgent</c>.
+/// </summary>
+/// <remarks>
+/// The runtime <c>agent_id</c> is a GUID minted at spawn time, so a static scripted responder
+/// cannot feed it back into a follow-up <c>CheckAgent</c> call — that dynamic poll loop is
+/// covered by the in-process integration test (<c>SubAgentIntegrationTests</c>). Here we assert
+/// the deterministic fact: the background spawn's tool result is the receipt, NOT the answer.
+/// </remarks>
+public sealed class SubAgentBackgroundTests
+{
+    [Theory]
+    [InlineData("test")]
+    [InlineData("test-anthropic")]
+    public async Task Background_spawn_returns_receipt_not_answer(string providerMode)
+    {
+        const string WorkerMarker = "You are the background worker sub-agent";
+        const string SubAgentAnswer = "Background work finished with secret payload.";
+
+        var responder = ScriptedSseResponder.New()
+            .ForRole("bg-worker", ctx => ctx.SystemPromptContains(WorkerMarker))
+                .Turn(t => t.Text(SubAgentAnswer))
+            .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
+                .Turn(t => t.ToolCall(
+                    "Agent",
+                    new
+                    {
+                        subagent_type = "bg_worker",
+                        prompt = "do background work",
+                        name = "bg1",
+                        run_in_background = true,
+                    }))
+                .Turn(t => t.Text("Kicked off the background worker."))
+            .Build();
+
+        var handler = providerMode == "test-anthropic"
+            ? responder.AsAnthropicHandler()
+            : responder.AsOpenAiHandler();
+
+        var builder = new ScriptedBuilder(
+            handler,
+            subAgentFactory: (_, providerAgentFactory) => new SubAgentOptions
+            {
+                Templates = new Dictionary<string, SubAgentTemplate>
+                {
+                    ["bg_worker"] = new SubAgentTemplate
+                    {
+                        Name = "BackgroundWorker",
+                        SystemPrompt = WorkerMarker,
+                        AgentFactory = providerAgentFactory,
+                        MaxTurnsPerRun = 5,
+                    },
+                },
+                MaxConcurrentSubAgents = 5,
+            });
+
+        using var factory = new E2EWebAppFactory(providerMode, builder);
+
+        var threadId = $"subagent-bg-{providerMode}-{Guid.NewGuid():N}";
+        var socket = await factory.ConnectWebSocketAsync(threadId);
+        await using var client = new WebSocketTestClient(socket);
+
+        await client.SendUserMessageAsync("spawn a background worker");
+        using var frames = await client.CollectUntilDoneAsync(TimeSpan.FromSeconds(30));
+
+        var toolCalls = frames.ToolCallNames();
+        toolCalls.Should().Contain("Agent");
+
+        // The background spawn's tool result is a JSON receipt, returned synchronously before
+        // the sub-agent finishes — so it carries the spawn metadata, NOT the sub-agent's answer.
+        var receipt = frames.ToolCallResults()
+            .FirstOrDefault(r => r.Contains("agent_id", StringComparison.Ordinal));
+        receipt.Should().NotBeNull("background spawn returns a JSON receipt with an agent id");
+
+        using (var doc = JsonDocument.Parse(receipt!))
+        {
+            var root = doc.RootElement;
+            root.GetProperty("agent_id").GetString().Should().NotBeNullOrWhiteSpace();
+            root.GetProperty("name").GetString().Should().Be("bg1");
+            root.GetProperty("template").GetString().Should().Be("bg_worker");
+            root.GetProperty("status").GetString().Should().Be("spawned");
+        }
+
+        // The receipt must NOT contain the sub-agent's eventual answer — that only flows back
+        // later (relayed to the parent for background spawns), never as the spawn tool result.
+        receipt!.Should().NotContain(SubAgentAnswer);
+
+        var streamedText = frames.ConcatText();
+        streamedText.Should().Contain("Kicked off the background worker");
+    }
+}

--- a/tests/LmStreaming.Sample.E2E.Tests/Scenarios/SubAgentSpawnTests.cs
+++ b/tests/LmStreaming.Sample.E2E.Tests/Scenarios/SubAgentSpawnTests.cs
@@ -9,15 +9,15 @@ namespace LmStreaming.Sample.E2E.Tests.Scenarios;
 /// <summary>
 /// Exercises the parent → <c>SubAgentManager</c> → sub-agent fan-out path under scripted
 /// SSE. The parent's first turn emits an <c>Agent</c> tool call that spawns a sub-agent;
-/// the sub-agent returns a plain-text result which <c>SubAgentManager</c> relays back into
-/// the parent as a user message; the parent's second turn summarizes the relayed result.
+/// the call is synchronous, so the sub-agent's plain-text answer comes back as the
+/// <c>Agent</c> tool result (no parent relay) and the parent's second turn summarizes it.
 /// </summary>
 public sealed class SubAgentSpawnTests
 {
     [Theory]
     [InlineData("test")]
     [InlineData("test-anthropic")]
-    public async Task Parent_spawns_subagent_and_relays_result(string providerMode)
+    public async Task Parent_spawns_subagent_and_receives_result(string providerMode)
     {
         const string ResearcherPromptMarker = "You are the research sub-agent";
 
@@ -27,7 +27,7 @@ public sealed class SubAgentSpawnTests
             .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
                 .Turn(t => t.ToolCall(
                     "Agent",
-                    new { template_name = "researcher", task = "Find AI papers" }))
+                    new { subagent_type = "researcher", prompt = "Find AI papers" }))
                 .Turn(t => t.Text("Summary: researcher surfaced three AI papers."))
             .Build();
 
@@ -52,6 +52,13 @@ public sealed class SubAgentSpawnTests
 
         var toolCalls = frames.ToolCallNames();
         toolCalls.Should().Contain("Agent");
+
+        // Synchronous Agent: the sub-agent's final text comes back as the tool result
+        // (not a JSON spawn receipt), proving the parent blocked on completion.
+        var toolResults = frames.ToolCallResults();
+        toolResults.Should().Contain(
+            r => r.Contains("Found three fresh AI papers today.", StringComparison.Ordinal),
+            "the Agent tool result is the sub-agent's final answer");
 
         var streamedText = frames.ConcatText();
         streamedText.Should().Contain("Summary: researcher surfaced three AI papers");

--- a/tests/LmStreaming.Sample.E2E.Tests/Scenarios/SubAgentToolUseTests.cs
+++ b/tests/LmStreaming.Sample.E2E.Tests/Scenarios/SubAgentToolUseTests.cs
@@ -34,7 +34,7 @@ public sealed class SubAgentToolUseTests
             .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
                 .Turn(t => t.ToolCall(
                     "Agent",
-                    new { template_name = "weather_sub", task = "check Seattle weather" }))
+                    new { subagent_type = "weather_sub", prompt = "check Seattle weather" }))
                 .Turn(t => t.Text("Parent: sub-agent completed the weather check."))
             .Build();
 
@@ -74,13 +74,12 @@ public sealed class SubAgentToolUseTests
         var toolResults = frames.ToolCallResults();
         toolResults.Should().NotBeEmpty();
 
-        // Sub-agent must consume at least its first (tool-call) turn. Whether the second
-        // (final-text) turn is also consumed depends on how the parent's Agent-tool relay
-        // finalizes the sub-agent's loop — some paths terminate the sub-agent as soon as its
-        // first useful action (the tool call) is surfaced back up to the parent. We assert the
-        // weaker invariant rather than couple this E2E test to that relay-termination policy.
+        // Synchronous Agent: the parent blocks until the sub-agent's run COMPLETES, so by the
+        // time the parent produces its summary the sub-agent has deterministically consumed
+        // BOTH of its turns (the get_weather tool call AND the final text). No background relay,
+        // no race — the queue is fully drained.
         responder.RemainingTurns["weather-sub"].Should()
-            .BeLessThan(2, "sub-agent should have consumed at least its tool-call turn");
+            .Be(0, "the parent awaits the sub-agent's full run, draining both of its turns");
 
         var streamedText = frames.ConcatText();
         streamedText.Should().Contain("sub-agent completed the weather check");


### PR DESCRIPTION
## Summary

Brings the `LmMultiTurn` sub-agent tool surface (`SubAgentToolProvider`) to full
parity with Claude Code's `Agent` tool — same interaction model, parameter names,
and description richness — and wires sub-agent templates into `LmStreaming.Sample`
for real providers (previously test-mode only).

**Back-compat: clean break** — parameters renamed outright and all consumers
updated in this change. No aliases.

## What changed

1. **Sync return model.** `Agent` now blocks and returns the sub-agent's final
   answer as the tool result. `run_in_background: true` opts into async: the tool
   returns a JSON spawn receipt (agent id) immediately, `CheckAgent` polls, and the
   final result is also relayed back to the parent as a follow-up message.
2. **Rich tool description.** `SubAgentTemplate` gains `Description`/`WhenToUse`;
   the `Agent` description embeds a per-template catalog plus delegation guidance so
   the parent LLM picks the right `subagent_type`.
3. **Parameter parity.** `prompt` (was `task`), `subagent_type` (was
   `template_name`), `description` (short UI label), `name`, `model`. `add_tools`/
   `remove_tools` kept as extensions.
4. **`SendMessage` tool.** New separate tool (`target`, `prompt`,
   `run_in_background`) continues an existing sub-agent by id or name; the `agent_id`
   overload is removed from `Agent`.
5. **Sample production wiring.** `general-purpose` + `researcher` templates wired
   into the real middleware providers (OpenAI/Anthropic/Copilot) in
   `LmStreaming.Sample`. CLI providers (codex/claude/copilot) have no sub-agent hook
   and stay out of scope.

## Concurrency hardening (self-review)

The monitor releases each sub-agent's concurrency slot **exactly once per monitor**,
even when a background agent is continued in place via `SendMessage` and a single
long-lived monitor observes multiple run completions (previously this over-released
the semaphore). A synchronous caller that abandons the wait (its cancellation token
fires) now cancels the sub-agent so it stops promptly and frees its slot instead of
orphaning. Covered by a regression test that fails (agent ends `error`) if the
single-release guard is removed.

## Acceptance criteria

- [x] `Agent` returns the final answer synchronously; `run_in_background: true`
      returns the agent id immediately
- [x] `Agent` description embeds the template catalog (name, description,
      when-to-use) and delegation guidance
- [x] Parameters renamed: `prompt`, `subagent_type`, `description`, `name`,
      `model`; `SubAgentTemplate` gains `Description`/`WhenToUse`
- [x] New `SendMessage` tool continues an existing sub-agent; `agent_id` removed
      from `Agent`
- [x] `CheckAgent` documents the background/polling workflow
- [x] `LmStreaming.Sample` exposes useful sub-agent templates on real providers;
      sub-agent tool calls render in the chat UI
- [x] All unit + E2E tests updated and green

## Testing

- Solution build: 0 warnings / 0 errors (zero-warning gate)
- `LmMultiTurn.Tests`: 253 passed
- `LmStreaming.Sample.E2E.Tests`: 33 passed, 2 skipped (sandbox-gateway)
- `LmStreaming.Sample.Browser.E2E.Tests`: 13 passed, 5 skipped (CLI mock providers)

Fixes #70
