### PR TITLE
feat(subagent): surface sandbox-discovered subagents as spawnable types

### DIFF
--- a/samples/LmStreaming.Sample/Controllers/AuthWebhookController.cs
+++ b/samples/LmStreaming.Sample/Controllers/AuthWebhookController.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json.Serialization;
 using LmStreaming.Sample.Services.Auth;
@@ -39,7 +38,7 @@ public sealed class AuthWebhookController(
         [FromBody] AuthWebhookRequest body,
         CancellationToken ct = default)
     {
-        if (!IsAuthorized())
+        if (!sharedSecret.Matches(Request.Headers.Authorization.ToString()))
         {
             // Do not reveal whether the header was missing, malformed, or simply wrong.
             logger.LogWarning("Rejected unauthorized auth-webhook call for provider {Provider}.", provider);
@@ -107,24 +106,6 @@ public sealed class AuthWebhookController(
                 body.DestinationHost);
             return Ok(AuthWebhookResponse.Deny($"token acquisition failed for provider '{tokenProvider.ProviderId}'"));
         }
-    }
-
-    /// <summary>
-    /// Constant-time comparison of the incoming <c>Authorization</c> header against the shared secret.
-    /// Both sides are hashed to a fixed-width SHA-256 digest first, so the comparison neither throws
-    /// on a length mismatch nor leaks the secret's length via an early-exit.
-    /// </summary>
-    private bool IsAuthorized()
-    {
-        var presented = Request.Headers.Authorization.ToString();
-        if (string.IsNullOrEmpty(presented))
-        {
-            return false;
-        }
-
-        var presentedHash = SHA256.HashData(Encoding.UTF8.GetBytes(presented));
-        var expectedHash = SHA256.HashData(Encoding.UTF8.GetBytes(sharedSecret.Value));
-        return CryptographicOperations.FixedTimeEquals(presentedHash, expectedHash);
     }
 
     /// <summary>Resolves a registered provider by the route id, matching <see cref="IOAuthTokenProvider.ProviderId"/> case-insensitively.</summary>

--- a/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json.Serialization;
 using LmStreaming.Sample.Services.Auth;
 using Microsoft.AspNetCore.Mvc;
@@ -32,7 +30,7 @@ public sealed class ContextDiscoveryController(
     [HttpPost("context_discovery")]
     public IActionResult Notify([FromBody] ContextDiscoveryPayload? body)
     {
-        if (!IsAuthorized())
+        if (!sharedSecret.Matches(Request.Headers.Authorization.ToString()))
         {
             // Do not reveal whether the header was missing, malformed, or simply wrong.
             logger.LogWarning("Rejected unauthorized context-discovery webhook call.");
@@ -45,26 +43,17 @@ public sealed class ContextDiscoveryController(
             return BadRequest();
         }
 
+        // Description is logged alongside kind/name/path so the field carries diagnostic value
+        // in this iteration even though dynamic activation (the consumer that mutates the catalog
+        // from these events) is deferred to #77.
         logger.LogInformation(
-            "ContextDiscovery: kind={Kind} name={Name} path={Path}",
+            "ContextDiscovery: kind={Kind} name={Name} path={Path} description={Description}",
             body.Kind,
             body.Name,
-            body.Path);
+            body.Path,
+            body.Description);
 
         return Ok();
-    }
-
-    private bool IsAuthorized()
-    {
-        var presented = Request.Headers.Authorization.ToString();
-        if (string.IsNullOrEmpty(presented))
-        {
-            return false;
-        }
-
-        var presentedHash = SHA256.HashData(Encoding.UTF8.GetBytes(presented));
-        var expectedHash = SHA256.HashData(Encoding.UTF8.GetBytes(sharedSecret.Value));
-        return CryptographicOperations.FixedTimeEquals(presentedHash, expectedHash);
     }
 }
 

--- a/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
@@ -1,0 +1,90 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Serialization;
+using LmStreaming.Sample.Services.Auth;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LmStreaming.Sample.Controllers;
+
+/// <summary>
+/// Webhook endpoint the sandbox gateway calls when it discovers a new context file in the
+/// workspace (sub-agent, skill, …). This iteration is <b>log-only</b>: the controller verifies
+/// the shared secret in constant time, logs a structured event, and returns 200. There is no
+/// in-memory queue and no dynamic activation — those are tracked in #77 and land with their
+/// consumer (mid-session sub-agent catalog refresh / dynamic Agent tool reload).
+/// </summary>
+/// <remarks>
+/// SECURITY: mirrors <see cref="AuthWebhookController"/>'s pattern: the gateway authenticates
+/// itself with a shared secret in the <c>Authorization</c> header, compared in constant time
+/// over fixed-width hashes. The controller NEVER logs the Authorization header value or the
+/// shared secret — only the discovery payload's kind/name/path and the allow decision.
+/// </remarks>
+[ApiController]
+[Route("api/discovery")]
+public sealed class ContextDiscoveryController(
+    AuthSharedSecret sharedSecret,
+    ILogger<ContextDiscoveryController> logger) : ControllerBase
+{
+    /// <summary>
+    /// Gateway callback for one discovered context item. Returns 200 on success, 401 if the
+    /// shared secret doesn't match, 400 if the payload is malformed.
+    /// </summary>
+    [HttpPost("context_discovery")]
+    public IActionResult Notify([FromBody] ContextDiscoveryPayload? body)
+    {
+        if (!IsAuthorized())
+        {
+            // Do not reveal whether the header was missing, malformed, or simply wrong.
+            logger.LogWarning("Rejected unauthorized context-discovery webhook call.");
+            return Unauthorized();
+        }
+
+        if (body is null || string.IsNullOrWhiteSpace(body.Kind) || string.IsNullOrWhiteSpace(body.Name))
+        {
+            logger.LogWarning("Rejected context-discovery webhook with malformed payload.");
+            return BadRequest();
+        }
+
+        logger.LogInformation(
+            "ContextDiscovery: kind={Kind} name={Name} path={Path}",
+            body.Kind,
+            body.Name,
+            body.Path);
+
+        return Ok();
+    }
+
+    private bool IsAuthorized()
+    {
+        var presented = Request.Headers.Authorization.ToString();
+        if (string.IsNullOrEmpty(presented))
+        {
+            return false;
+        }
+
+        var presentedHash = SHA256.HashData(Encoding.UTF8.GetBytes(presented));
+        var expectedHash = SHA256.HashData(Encoding.UTF8.GetBytes(sharedSecret.Value));
+        return CryptographicOperations.FixedTimeEquals(presentedHash, expectedHash);
+    }
+}
+
+/// <summary>
+/// Gateway → app payload for a single discovered context item. Field names are the gateway's
+/// wire contract (snake_case), pinned via <see cref="JsonPropertyNameAttribute"/> so they bind
+/// regardless of the app's JSON naming defaults. Unknown fields are tolerated by System.Text.Json
+/// by default so the gateway can add new fields without breaking older app builds.
+/// </summary>
+public sealed record ContextDiscoveryPayload
+{
+    [JsonPropertyName("kind")]
+    public string? Kind { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("path")]
+    public string? Path { get; init; }
+}

--- a/samples/LmStreaming.Sample/LmStreaming.Sample.csproj
+++ b/samples/LmStreaming.Sample/LmStreaming.Sample.csproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <!-- Expose internal auth-provider helpers (authorize-URL / scope builders) to the E2E test project. -->
     <InternalsVisibleTo Include="LmStreaming.Sample.E2E.Tests" />
+    <!-- Expose internal sub-agent merge helper + loader internals to the unit test project. -->
+    <InternalsVisibleTo Include="LmStreaming.Sample.Tests" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.84.1" />

--- a/samples/LmStreaming.Sample/LmStreaming.Sample.csproj
+++ b/samples/LmStreaming.Sample/LmStreaming.Sample.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Opt-in build of the Vue SPA during `dotnet build`. Disabled by default so everyday

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -597,6 +597,11 @@ try
                     var isTestMode =
                         string.Equals(normalizedProviderId, "test", StringComparison.Ordinal)
                         || string.Equals(normalizedProviderId, "test-anthropic", StringComparison.Ordinal);
+                    // Sync-over-async on the agent-creation factory delegate: there is no async
+                    // seam exposed by the pool's agent factory contract, and this runs on the
+                    // pool-creation path (no ASP.NET SynchronizationContext) so a .Result here
+                    // cannot deadlock. The blocking call is HTTP only when a sandbox session is
+                    // active; otherwise BuildProductionSubAgentOptionsAsync returns synchronously.
                     var subAgentOptions = isTestMode
                         ? sp.GetRequiredService<ITestAgentBuilder>()
                             .CreateSubAgentOptions(loggerFactory, () => agentFactory(normalizedProviderId))
@@ -1249,7 +1254,7 @@ public partial class Program
                     + "return a concise final answer that fully captures your findings — the parent only "
                     + "sees your final message, not your intermediate steps.",
                 AgentFactory = providerAgentFactory,
-                MaxTurnsPerRun = 25,
+                MaxTurnsPerRun = WorkspaceSubAgentLoader.DefaultMaxTurnsPerRun,
             },
             ["researcher"] = new SubAgentTemplate
             {
@@ -1263,7 +1268,7 @@ public partial class Program
                     + "tools available to you, cross-check what you find, and return a clear, well-structured "
                     + "summary. The parent only sees your final message, so make it self-contained.",
                 AgentFactory = providerAgentFactory,
-                MaxTurnsPerRun = 25,
+                MaxTurnsPerRun = WorkspaceSubAgentLoader.DefaultMaxTurnsPerRun,
             },
         };
 
@@ -1278,15 +1283,7 @@ public partial class Program
                 .LoadAsync(sandboxSession, providerAgentFactory)
                 .ConfigureAwait(false);
 
-            foreach (var (key, template) in discovered)
-            {
-                if (!templates.TryAdd(key, template))
-                {
-                    logger.LogWarning(
-                        "Discovered sub-agent {Name} collides with a built-in template; keeping the built-in",
-                        key);
-                }
-            }
+            WorkspaceSubAgentLoader.MergeBuiltInWins(templates, discovered, logger);
         }
 
         return new SubAgentOptions { Templates = templates, MaxConcurrentSubAgents = 5 };

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -29,6 +29,7 @@ using LmStreaming.Sample.Models;
 using LmStreaming.Sample.Persistence;
 using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Services.Auth;
+using LmStreaming.Sample.Services.Discovery;
 using LmStreaming.Sample.Tools;
 using LmStreaming.Sample.WebSocket;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -188,6 +189,11 @@ try
         authOptions,
         sp.GetRequiredService<AuthSharedSecret>()
     ));
+
+    // Workspace sub-agent discovery. The loader asks the gateway what it has discovered in
+    // the session's workspace (sub-agent markdown files under .claude/agents/, etc.) and maps
+    // them into SubAgentTemplate so they show up as spawnable types in the Agent tool catalog.
+    _ = builder.Services.AddSingleton<WorkspaceSubAgentLoader>();
 
     // Codex MCP server: registered unconditionally but started lazily, so non-codex boots
     // don't pay the startup cost and so the codex provider stays selectable from the
@@ -594,7 +600,13 @@ try
                     var subAgentOptions = isTestMode
                         ? sp.GetRequiredService<ITestAgentBuilder>()
                             .CreateSubAgentOptions(loggerFactory, () => agentFactory(normalizedProviderId))
-                        : BuildProductionSubAgentOptions(() => agentFactory(normalizedProviderId));
+                        : BuildProductionSubAgentOptionsAsync(
+                                () => agentFactory(normalizedProviderId),
+                                sandboxSession,
+                                sp.GetRequiredService<WorkspaceSubAgentLoader>(),
+                                loggerFactory.CreateLogger("LmStreaming.Sample.SubAgentCatalog"))
+                            .GetAwaiter()
+                            .GetResult();
 
                     var agent = new MultiTurnAgentLoop(
                         providerAgent,
@@ -1216,9 +1228,13 @@ public partial class Program
     ///     system prompt and turn budget. The CLI providers (codex/claude/copilot) have no
     ///     sub-agent hook and are out of scope, so this is only called from the middleware path.
     /// </summary>
-    private static SubAgentOptions BuildProductionSubAgentOptions(Func<IStreamingAgent> providerAgentFactory)
+    private static async Task<SubAgentOptions> BuildProductionSubAgentOptionsAsync(
+        Func<IStreamingAgent> providerAgentFactory,
+        SandboxSession? sandboxSession,
+        WorkspaceSubAgentLoader workspaceLoader,
+        Microsoft.Extensions.Logging.ILogger logger)
     {
-        var templates = new Dictionary<string, SubAgentTemplate>
+        var templates = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal)
         {
             ["general-purpose"] = new SubAgentTemplate
             {
@@ -1250,6 +1266,28 @@ public partial class Program
                 MaxTurnsPerRun = 25,
             },
         };
+
+        // When a sandbox session is available, merge in any sub-agents the gateway has
+        // discovered in the workspace. Collision policy: BUILT-IN WINS — a discovered template
+        // cannot shadow one of the hardcoded entries above. Failures inside the loader are
+        // already logged and surfaced as an empty dictionary, so this call cannot throw and
+        // never aborts the agent-creation path.
+        if (sandboxSession is not null)
+        {
+            var discovered = await workspaceLoader
+                .LoadAsync(sandboxSession, providerAgentFactory)
+                .ConfigureAwait(false);
+
+            foreach (var (key, template) in discovered)
+            {
+                if (!templates.TryAdd(key, template))
+                {
+                    logger.LogWarning(
+                        "Discovered sub-agent {Name} collides with a built-in template; keeping the built-in",
+                        key);
+                }
+            }
+        }
 
         return new SubAgentOptions { Templates = templates, MaxConcurrentSubAgents = 5 };
     }

--- a/samples/LmStreaming.Sample/Services/Auth/AuthOptions.cs
+++ b/samples/LmStreaming.Sample/Services/Auth/AuthOptions.cs
@@ -69,4 +69,11 @@ public sealed class WebhookOptions
 
     /// <summary>Shared secret the gateway sends as Authorization when calling the webhook. When null, one is generated at startup.</summary>
     public string? GatewaySharedSecret { get; set; }
+
+    /// <summary>
+    /// Webhook public base URL with the trailing slash stripped — the canonical form callers
+    /// concatenate route segments to. Centralised so the gateway → app callback URLs all agree
+    /// even if a future operator misconfigures <see cref="PublicBaseUrl"/> with a trailing slash.
+    /// </summary>
+    public string CallbackBaseUrl => PublicBaseUrl.TrimEnd('/');
 }

--- a/samples/LmStreaming.Sample/Services/Auth/AuthSharedSecret.cs
+++ b/samples/LmStreaming.Sample/Services/Auth/AuthSharedSecret.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using System.Text;
 
 namespace LmStreaming.Sample.Services.Auth;
 
@@ -33,4 +34,23 @@ public sealed class AuthSharedSecret
     /// The resolved shared secret. SECRET — never log this value.
     /// </summary>
     public string Value { get; }
+
+    /// <summary>
+    /// Constant-time comparison of <paramref name="presented"/> against the shared secret. Both
+    /// sides are hashed to a fixed-width SHA-256 digest first, so the comparison neither throws
+    /// on a length mismatch nor leaks the secret's length via an early-exit. Returns false when
+    /// the presented value is null or empty (the "missing header" case).
+    /// </summary>
+    /// <param name="presented">The raw value from the inbound <c>Authorization</c> header.</param>
+    public bool Matches(string? presented)
+    {
+        if (string.IsNullOrEmpty(presented))
+        {
+            return false;
+        }
+
+        var presentedHash = SHA256.HashData(Encoding.UTF8.GetBytes(presented));
+        var expectedHash = SHA256.HashData(Encoding.UTF8.GetBytes(Value));
+        return CryptographicOperations.FixedTimeEquals(presentedHash, expectedHash);
+    }
 }

--- a/samples/LmStreaming.Sample/Services/Discovery/SubAgentMarkdownParser.cs
+++ b/samples/LmStreaming.Sample/Services/Discovery/SubAgentMarkdownParser.cs
@@ -1,0 +1,200 @@
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace LmStreaming.Sample.Services.Discovery;
+
+/// <summary>
+/// Result of parsing a sub-agent markdown file (the Claude-Code convention of a YAML
+/// frontmatter block fenced by <c>---</c> at the top of a markdown file, followed by the
+/// system-prompt body). Only the typed fields the loader actually maps to
+/// <see cref="AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents.SubAgentTemplate"/> are surfaced;
+/// unknown frontmatter keys are ignored at parse time.
+/// </summary>
+public sealed record ParsedSubAgent(
+    string Name,
+    string? Description,
+    string? Model,
+    IReadOnlyList<string>? Tools,
+    string SystemPrompt
+);
+
+/// <summary>
+/// Pure parser for a single sub-agent markdown document. Failures (missing fences,
+/// malformed YAML, empty body) return <c>null</c> so callers can log and skip the file
+/// rather than aborting a whole batch.
+/// </summary>
+/// <remarks>
+/// The expected document shape is the same one the workspace gateway uses when it walks
+/// <c>.claude/agents/*.md</c>:
+/// <code>
+/// ---
+/// name: echo-agent
+/// description: Echoes a marker for E2E discovery tests.
+/// model: claude-sonnet-4-5
+/// tools: [Read, Glob]
+/// ---
+/// You are the echo sub-agent. ...
+/// </code>
+/// </remarks>
+public static class SubAgentMarkdownParser
+{
+    private const string FenceMarker = "---";
+
+    private static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    /// <summary>
+    /// Parses <paramref name="markdown"/> into a <see cref="ParsedSubAgent"/>. Returns
+    /// <c>null</c> when the document is missing a frontmatter block, the YAML is malformed,
+    /// or the body is empty.
+    /// </summary>
+    /// <param name="markdown">Raw markdown content (frontmatter + body).</param>
+    /// <param name="filenameStem">
+    /// Filename without extension. Used as the <c>name</c> fallback when the frontmatter
+    /// omits it (mirrors Claude Code's behaviour). When also empty, parsing fails.
+    /// </param>
+    public static ParsedSubAgent? Parse(string markdown, string filenameStem)
+    {
+        if (string.IsNullOrEmpty(markdown))
+        {
+            return null;
+        }
+
+        if (!TrySplitFrontmatter(markdown, out var yaml, out var body))
+        {
+            return null;
+        }
+
+        FrontmatterDto? dto;
+        try
+        {
+            dto = YamlDeserializer.Deserialize<FrontmatterDto>(yaml);
+        }
+        catch (YamlDotNet.Core.YamlException)
+        {
+            return null;
+        }
+
+        var trimmedBody = body.Trim();
+        if (trimmedBody.Length == 0)
+        {
+            return null;
+        }
+
+        var name = !string.IsNullOrWhiteSpace(dto?.Name)
+            ? dto.Name.Trim()
+            : (string.IsNullOrWhiteSpace(filenameStem) ? null : filenameStem.Trim());
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return null;
+        }
+
+        var description = string.IsNullOrWhiteSpace(dto?.Description) ? null : dto.Description.Trim();
+        var model = string.IsNullOrWhiteSpace(dto?.Model) ? null : dto.Model.Trim();
+        var tools = NormalizeTools(dto?.Tools);
+
+        return new ParsedSubAgent(name, description, model, tools, trimmedBody);
+    }
+
+    private static bool TrySplitFrontmatter(string markdown, out string yaml, out string body)
+    {
+        yaml = string.Empty;
+        body = string.Empty;
+
+        // Tolerate UTF-8 BOM + leading whitespace before the opening fence.
+        var span = markdown.AsSpan().TrimStart('\uFEFF').TrimStart();
+        if (!StartsWithLine(span, FenceMarker, out var afterOpen))
+        {
+            return false;
+        }
+
+        var closeIndex = afterOpen.IndexOf("\n" + FenceMarker, StringComparison.Ordinal);
+        if (closeIndex < 0)
+        {
+            return false;
+        }
+
+        // Require the closing fence to terminate at a line boundary so that "----foo" mid-body
+        // doesn't accidentally close the block.
+        var afterFenceAt = closeIndex + 1 + FenceMarker.Length;
+        if (afterFenceAt < afterOpen.Length)
+        {
+            var trailing = afterOpen[afterFenceAt];
+            if (trailing != '\r' && trailing != '\n')
+            {
+                return false;
+            }
+        }
+
+        yaml = afterOpen[..closeIndex].ToString();
+        var bodySpan = afterOpen[afterFenceAt..];
+        body = bodySpan.ToString();
+        return true;
+    }
+
+    private static bool StartsWithLine(ReadOnlySpan<char> input, string marker, out ReadOnlySpan<char> rest)
+    {
+        rest = input;
+        if (input.Length < marker.Length || !input[..marker.Length].SequenceEqual(marker))
+        {
+            return false;
+        }
+
+        var after = input[marker.Length..];
+        if (after.Length == 0)
+        {
+            return false;
+        }
+
+        if (after[0] == '\r' && after.Length > 1 && after[1] == '\n')
+        {
+            rest = after[2..];
+            return true;
+        }
+
+        if (after[0] == '\n')
+        {
+            rest = after[1..];
+            return true;
+        }
+
+        return false;
+    }
+
+    private static IReadOnlyList<string>? NormalizeTools(IList<string>? raw)
+    {
+        if (raw is null)
+        {
+            return null;
+        }
+
+        var normalized = new List<string>(raw.Count);
+        foreach (var t in raw)
+        {
+            if (!string.IsNullOrWhiteSpace(t))
+            {
+                normalized.Add(t.Trim());
+            }
+        }
+
+        return normalized;
+    }
+
+    /// <summary>
+    /// Mutable DTO used only as the YAML deserialisation target. Public so YamlDotNet's
+    /// reflection can populate it; never exposed beyond <see cref="Parse"/>.
+    /// </summary>
+    public sealed class FrontmatterDto
+    {
+        public string? Name { get; set; }
+
+        public string? Description { get; set; }
+
+        public string? Model { get; set; }
+
+        public List<string>? Tools { get; set; }
+    }
+}

--- a/samples/LmStreaming.Sample/Services/Discovery/WorkspaceSubAgentLoader.cs
+++ b/samples/LmStreaming.Sample/Services/Discovery/WorkspaceSubAgentLoader.cs
@@ -24,6 +24,14 @@ public sealed class WorkspaceSubAgentLoader
 {
     private const string SubAgentKind = "subagent";
 
+    /// <summary>
+    /// Per-spawn turn cap shared by every sample sub-agent template (built-in and discovered).
+    /// Centralised so the three call sites stay aligned and so a future bump is one edit, not
+    /// three drifting literals. Lower than <see cref="SubAgentTemplate"/>'s built-in default of
+    /// 50 because the sample's middleware path is single-provider and each turn is full-cost.
+    /// </summary>
+    internal const int DefaultMaxTurnsPerRun = 25;
+
     private readonly SandboxSessionRegistry _registry;
     private readonly ILogger<WorkspaceSubAgentLoader> _logger;
 
@@ -136,6 +144,36 @@ public sealed class WorkspaceSubAgentLoader
     }
 
     /// <summary>
+    /// Merges <paramref name="discovered"/> into <paramref name="builtIns"/> under built-in-wins
+    /// semantics: a discovered template whose key collides with an existing built-in entry is
+    /// skipped and logged. This pins a trust boundary — untrusted workspace markdown must NEVER
+    /// shadow a trusted hardcoded template — so any future change to the merge direction needs
+    /// the merge test to be updated explicitly.
+    /// </summary>
+    /// <param name="builtIns">The mutable built-in catalog. Receives discovered entries on no-collision.</param>
+    /// <param name="discovered">Discovered templates returned by <see cref="LoadAsync"/>.</param>
+    /// <param name="logger">Logger used to record collisions. Never null in production.</param>
+    internal static void MergeBuiltInWins(
+        IDictionary<string, SubAgentTemplate> builtIns,
+        IReadOnlyDictionary<string, SubAgentTemplate> discovered,
+        Microsoft.Extensions.Logging.ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(builtIns);
+        ArgumentNullException.ThrowIfNull(discovered);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        foreach (var (key, template) in discovered)
+        {
+            if (!builtIns.TryAdd(key, template))
+            {
+                logger.LogWarning(
+                    "Discovered sub-agent {Name} collides with a built-in template; keeping the built-in",
+                    key);
+            }
+        }
+    }
+
+    /// <summary>
     /// Maps a parsed markdown sub-agent into a <see cref="SubAgentTemplate"/>. Internal-static so
     /// the unit tests can pin the mapping table without needing a registry instance.
     /// </summary>
@@ -151,7 +189,7 @@ public sealed class WorkspaceSubAgentLoader
     ///     parent's runtime defaults (matching the built-in templates' shape).</item>
     ///   <item><c>tools</c> → <see cref="SubAgentTemplate.EnabledTools"/>. Absent (null) means
     ///     inherit every parent tool; an empty list means deny all tools (distinct case).</item>
-    ///   <item><c>MaxTurnsPerRun = 25</c> to match the existing production templates.</item>
+    ///   <item><see cref="DefaultMaxTurnsPerRun"/> to match the existing production templates.</item>
     /// </list>
     /// </remarks>
     internal static SubAgentTemplate MapToTemplate(
@@ -171,7 +209,7 @@ public sealed class WorkspaceSubAgentLoader
             AgentFactory = agentFactory,
             DefaultOptions = defaults,
             EnabledTools = parsed.Tools,
-            MaxTurnsPerRun = 25,
+            MaxTurnsPerRun = DefaultMaxTurnsPerRun,
         };
     }
 

--- a/samples/LmStreaming.Sample/Services/Discovery/WorkspaceSubAgentLoader.cs
+++ b/samples/LmStreaming.Sample/Services/Discovery/WorkspaceSubAgentLoader.cs
@@ -1,0 +1,235 @@
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+
+namespace LmStreaming.Sample.Services.Discovery;
+
+/// <summary>
+/// Loads workspace-discovered sub-agent templates for a sandbox session: asks the gateway what
+/// it has discovered, then for each <c>kind == "subagent"</c> item reads the markdown file from
+/// the workspace host directory and maps it to a <see cref="SubAgentTemplate"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Per-file errors (missing file, parse failure, traversal attempt, I/O failure) are logged and
+/// skipped; they never abort the whole batch. A complete gateway failure also returns an empty
+/// dictionary after logging — discovery is a non-essential enrichment of the built-in catalog.
+/// </para>
+/// <para>
+/// Collision policy: this loader returns ONLY the discovered templates. The caller (Program.cs)
+/// is responsible for merging into its own template catalog under built-in-wins semantics.
+/// </para>
+/// </remarks>
+public sealed class WorkspaceSubAgentLoader
+{
+    private const string SubAgentKind = "subagent";
+
+    private readonly SandboxSessionRegistry _registry;
+    private readonly ILogger<WorkspaceSubAgentLoader> _logger;
+
+    public WorkspaceSubAgentLoader(
+        SandboxSessionRegistry registry,
+        ILogger<WorkspaceSubAgentLoader> logger)
+    {
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Discovers and loads sub-agent templates for <paramref name="session"/>. Returns an empty
+    /// dictionary when nothing is discovered or when the gateway lookup fails.
+    /// </summary>
+    /// <param name="session">The sandbox session whose <c>HostPath</c> contains the files.</param>
+    /// <param name="agentFactory">Provider-agent factory reused by every discovered template.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task<IReadOnlyDictionary<string, SubAgentTemplate>> LoadAsync(
+        SandboxSession session,
+        Func<IStreamingAgent> agentFactory,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(agentFactory);
+
+        IReadOnlyList<SandboxSessionRegistry.DiscoveredItem> items;
+        try
+        {
+            items = await _registry.ListDiscoveredAsync(session.SessionId, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to list discovered items for session {SessionId}; continuing without workspace sub-agents",
+                session.SessionId);
+            return new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal);
+        }
+
+        if (items.Count == 0 || string.IsNullOrWhiteSpace(session.HostPath))
+        {
+            return new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal);
+        }
+
+        var basePath = NormalizeBasePath(session.HostPath);
+        var result = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal);
+
+        foreach (var item in items)
+        {
+            if (!string.Equals(item.Kind, SubAgentKind, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!TryResolveContainedPath(basePath, item.Path, out var fullPath))
+            {
+                _logger.LogWarning(
+                    "Skipping discovered sub-agent {Name}: path '{Path}' is outside workspace '{HostPath}'",
+                    item.Name,
+                    item.Path,
+                    session.HostPath);
+                continue;
+            }
+
+            string markdown;
+            try
+            {
+                markdown = await File.ReadAllTextAsync(fullPath, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Skipping discovered sub-agent {Name}: failed to read '{Path}'",
+                    item.Name,
+                    fullPath);
+                continue;
+            }
+
+            var stem = Path.GetFileNameWithoutExtension(fullPath);
+            var parsed = SubAgentMarkdownParser.Parse(markdown, stem);
+            if (parsed is null)
+            {
+                _logger.LogWarning(
+                    "Skipping discovered sub-agent {Name}: markdown at '{Path}' has no valid frontmatter or empty body",
+                    item.Name,
+                    fullPath);
+                continue;
+            }
+
+            var template = MapToTemplate(parsed, agentFactory);
+            if (!result.TryAdd(parsed.Name, template))
+            {
+                _logger.LogWarning(
+                    "Discovered sub-agent {Name} collides with an earlier discovery; keeping the first occurrence",
+                    parsed.Name);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Maps a parsed markdown sub-agent into a <see cref="SubAgentTemplate"/>. Internal-static so
+    /// the unit tests can pin the mapping table without needing a registry instance.
+    /// </summary>
+    /// <remarks>
+    /// Mapping rules:
+    /// <list type="bullet">
+    ///   <item><c>description</c> → both <see cref="SubAgentTemplate.Description"/> AND
+    ///     <see cref="SubAgentTemplate.WhenToUse"/>, so the Agent-tool catalog isn't blank
+    ///     for discovered templates (which don't carry a separate <c>when_to_use</c> field).</item>
+    ///   <item><c>model</c> → <see cref="SubAgentTemplate.DefaultOptions"/> with only
+    ///     <see cref="GenerateReplyOptions.ModelId"/> set; absent leaves
+    ///     <see cref="SubAgentTemplate.DefaultOptions"/> null so the sub-agent inherits the
+    ///     parent's runtime defaults (matching the built-in templates' shape).</item>
+    ///   <item><c>tools</c> → <see cref="SubAgentTemplate.EnabledTools"/>. Absent (null) means
+    ///     inherit every parent tool; an empty list means deny all tools (distinct case).</item>
+    ///   <item><c>MaxTurnsPerRun = 25</c> to match the existing production templates.</item>
+    /// </list>
+    /// </remarks>
+    internal static SubAgentTemplate MapToTemplate(
+        ParsedSubAgent parsed,
+        Func<IStreamingAgent> agentFactory)
+    {
+        var defaults = !string.IsNullOrWhiteSpace(parsed.Model)
+            ? new GenerateReplyOptions { ModelId = parsed.Model.Trim() }
+            : null;
+
+        return new SubAgentTemplate
+        {
+            Name = parsed.Name,
+            Description = parsed.Description,
+            WhenToUse = parsed.Description,
+            SystemPrompt = parsed.SystemPrompt,
+            AgentFactory = agentFactory,
+            DefaultOptions = defaults,
+            EnabledTools = parsed.Tools,
+            MaxTurnsPerRun = 25,
+        };
+    }
+
+    /// <summary>
+    /// Normalises <paramref name="hostPath"/> to a full path with a trailing directory separator
+    /// so a <see cref="string.StartsWith(string, StringComparison)"/> containment check rejects
+    /// sibling-prefix attacks (e.g. <c>C:\work-evil</c> against base <c>C:\work</c>).
+    /// </summary>
+    internal static string NormalizeBasePath(string hostPath)
+    {
+        var full = Path.GetFullPath(hostPath);
+        return full.EndsWith(Path.DirectorySeparatorChar)
+            ? full
+            : full + Path.DirectorySeparatorChar;
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="relativeOrAbsolute"/> against <paramref name="basePath"/> and
+    /// asserts the result stays inside <paramref name="basePath"/>. Guards path-injection
+    /// (<c>"../etc/passwd"</c>); does NOT prevent symlink-escape, which would need
+    /// <see cref="File.ResolveLinkTarget(string, bool)"/>/junction resolution and is out of
+    /// scope for this loader. Comparison is case-insensitive on Windows and case-sensitive
+    /// elsewhere, matching the underlying filesystem's behaviour.
+    /// </summary>
+    internal static bool TryResolveContainedPath(string basePath, string relativeOrAbsolute, out string fullPath)
+    {
+        fullPath = string.Empty;
+        if (string.IsNullOrWhiteSpace(relativeOrAbsolute))
+        {
+            return false;
+        }
+
+        string combined;
+        try
+        {
+            combined = Path.IsPathRooted(relativeOrAbsolute)
+                ? Path.GetFullPath(relativeOrAbsolute)
+                : Path.GetFullPath(Path.Combine(basePath, relativeOrAbsolute));
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return false;
+        }
+
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        // basePath always carries a trailing separator (NormalizeBasePath); combined therefore
+        // must START WITH that separator-terminated prefix to be "inside" basePath. Equality with
+        // the bare basePath (i.e. the workspace root itself) is rejected because a sub-agent
+        // markdown file MUST be a file under that root, not the root directory.
+        if (!combined.StartsWith(basePath, comparison))
+        {
+            return false;
+        }
+
+        fullPath = combined;
+        return true;
+    }
+}

--- a/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
@@ -164,11 +164,13 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
 
         var requestUri = $"{_gateway.GatewayBaseUrl}/api/v1/sandboxes";
         var (authProviders, network) = BuildAuthProviders();
+        var discovery = BuildDiscovery();
         var request = new CreateSandboxRequest(
             new AppRef(_options.AppId),
             workspaceRelPath,
             authProviders,
-            network
+            network,
+            discovery
         );
 
         _logger.LogInformation(
@@ -256,6 +258,41 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
 
         _sessions.Clear();
         _httpClient.Dispose();
+    }
+
+    /// <summary>
+    /// Lists items the gateway has discovered for the session's workspace (the result of its
+    /// background sweep of context files — sub-agents, skills, etc). Callers filter by
+    /// <see cref="DiscoveredItem.Kind"/> for the kinds they care about.
+    /// </summary>
+    /// <param name="sessionId">Gateway session id returned by <see cref="GetOrCreateSessionAsync"/>.</param>
+    /// <param name="ct">Cancellation token observed by the HTTP call.</param>
+    /// <returns>The discovered items. Empty when the gateway reports no discoveries; never null.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the gateway returns a non-success status. The body (truncated) is included so
+    /// callers can correlate against gateway logs. Caller is expected to catch + log + degrade.
+    /// </exception>
+    public async Task<IReadOnlyList<DiscoveredItem>> ListDiscoveredAsync(string sessionId, CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+
+        var requestUri = $"{_gateway.GatewayBaseUrl}/api/v1/sandboxes/{sessionId}/discovered";
+        using var response = await _httpClient.GetAsync(requestUri, ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            throw new InvalidOperationException(
+                $"Sandbox gateway returned {(int)response.StatusCode} listing discovered items for "
+                    + $"session '{sessionId}': {body}"
+            );
+        }
+
+        var payload = await response
+            .Content.ReadFromJsonAsync<DiscoveredItemsResponse>(JsonOptions, ct)
+            .ConfigureAwait(false);
+
+        return payload?.Items ?? [];
     }
 
     private async Task DestroySessionAsync(SandboxSession session)
@@ -378,13 +415,59 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
         return providers.Count > 0 ? (providers, new NetworkDto(rules)) : (null, null);
     }
 
+    /// <summary>
+    /// Builds the outbound <c>discovery</c> block telling the gateway where to deliver
+    /// context-discovery events. The URL is the public webhook base (the same one the gateway
+    /// already uses for auth callbacks) plus the discovery route; the auth value is the
+    /// gateway↔webhook shared secret. SECRET — never logged.
+    /// </summary>
+    private DiscoveryDto BuildDiscovery()
+    {
+        var baseUrl = _authOptions.Webhook.PublicBaseUrl.TrimEnd('/');
+        return new DiscoveryDto(
+            new DiscoveryWebhookDto(
+                Url: $"{baseUrl}/api/discovery/context_discovery",
+                Auth: _sharedSecret.Value
+            )
+        );
+    }
+
     // --- Gateway JSON contract (snake_case via JsonOptions) ---
 
     private sealed record CreateSandboxRequest(
         [property: JsonPropertyName("app")] AppRef App,
         [property: JsonPropertyName("workspace")] string Workspace,
         [property: JsonPropertyName("auth_providers")] IReadOnlyList<AuthProviderDto>? AuthProviders,
-        [property: JsonPropertyName("network")] NetworkDto? Network
+        [property: JsonPropertyName("network")] NetworkDto? Network,
+        [property: JsonPropertyName("discovery")] DiscoveryDto? Discovery = null
+    );
+
+    /// <summary>Outbound <c>discovery</c> block telling the gateway where to deliver
+    /// context-discovery events. Omitted from the request JSON when null.</summary>
+    internal sealed record DiscoveryDto(
+        [property: JsonPropertyName("webhook")] DiscoveryWebhookDto Webhook
+    );
+
+    /// <summary>Webhook descriptor inside the outbound <c>discovery</c> block. <c>auth</c>
+    /// matches the value the gateway later presents in the <c>Authorization</c> header on its
+    /// callbacks — same convention as the auth-provider <c>gateway_auth</c> field.</summary>
+    internal sealed record DiscoveryWebhookDto(
+        [property: JsonPropertyName("url")] string Url,
+        [property: JsonPropertyName("auth")] string Auth
+    );
+
+    /// <summary>One item the gateway has discovered for the workspace (a sub-agent file,
+    /// a skill descriptor, …). <see cref="Kind"/> is the discriminator the caller filters by;
+    /// <see cref="Path"/> is workspace-relative.</summary>
+    public sealed record DiscoveredItem(
+        [property: JsonPropertyName("kind")] string Kind,
+        [property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("description")] string? Description,
+        [property: JsonPropertyName("path")] string Path
+    );
+
+    private sealed record DiscoveredItemsResponse(
+        [property: JsonPropertyName("items")] IReadOnlyList<DiscoveredItem> Items
     );
 
     private sealed record AppRef([property: JsonPropertyName("id")] string Id);

--- a/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
@@ -282,9 +282,19 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
         if (!response.IsSuccessStatusCode)
         {
             var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var bodySnippet = TruncateBody(body);
+            // Log + throw, matching CreateSessionAsync's policy: the caller is expected to catch
+            // and degrade, but we still want a server-log breadcrumb correlating the failure with
+            // gateway logs by session id.
+            _logger.LogError(
+                "Sandbox discovered-items list failed for session {SessionId}: {StatusCode} {Body}",
+                sessionId,
+                (int)response.StatusCode,
+                bodySnippet
+            );
             throw new InvalidOperationException(
                 $"Sandbox gateway returned {(int)response.StatusCode} listing discovered items for "
-                    + $"session '{sessionId}': {body}"
+                    + $"session '{sessionId}': {bodySnippet}"
             );
         }
 
@@ -294,6 +304,18 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
 
         return payload?.Items ?? [];
     }
+
+    private const int ErrorBodyMaxLength = 500;
+
+    /// <summary>
+    /// Caps a gateway error body so a large HTML error page (e.g. a 502 from a reverse proxy) can
+    /// not blow up server logs or the exception message. Mirrors the doc-claim on
+    /// <see cref="ListDiscoveredAsync"/>.
+    /// </summary>
+    private static string TruncateBody(string body) =>
+        string.IsNullOrEmpty(body) || body.Length <= ErrorBodyMaxLength
+            ? body
+            : body[..ErrorBodyMaxLength] + "...(truncated)";
 
     private async Task DestroySessionAsync(SandboxSession session)
     {
@@ -356,7 +378,7 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
     {
         var providers = new List<AuthProviderDto>();
         var rules = new List<NetworkRuleDto>();
-        var baseUrl = _authOptions.Webhook.PublicBaseUrl.TrimEnd('/');
+        var baseUrl = _authOptions.Webhook.CallbackBaseUrl;
 
         if (!string.IsNullOrWhiteSpace(_authOptions.Github.ClientId))
         {
@@ -423,7 +445,7 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
     /// </summary>
     private DiscoveryDto BuildDiscovery()
     {
-        var baseUrl = _authOptions.Webhook.PublicBaseUrl.TrimEnd('/');
+        var baseUrl = _authOptions.Webhook.CallbackBaseUrl;
         return new DiscoveryDto(
             new DiscoveryWebhookDto(
                 Url: $"{baseUrl}/api/discovery/context_discovery",

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
@@ -1,0 +1,105 @@
+using LmStreaming.Sample.Services.Auth;
+using Microsoft.AspNetCore.Http;
+
+namespace LmStreaming.Sample.Tests.Controllers;
+
+/// <summary>
+/// Tests for <see cref="ContextDiscoveryController.Notify"/>: 401 on missing/wrong shared
+/// secret, 400 on malformed payload, 200 on the happy path. The handler is intentionally
+/// thin (log-only), so the contract under test is the auth + payload validation it pins.
+/// </summary>
+public class ContextDiscoveryControllerTests
+{
+    private const string Secret = "test-shared-secret-1234";
+
+    private static ContextDiscoveryController CreateController(string? authorizationHeader)
+    {
+        var sharedSecret = new AuthSharedSecret(new AuthOptions
+        {
+            Webhook = new WebhookOptions { GatewaySharedSecret = Secret },
+        });
+        var controller = new ContextDiscoveryController(
+            sharedSecret,
+            NullLogger<ContextDiscoveryController>.Instance);
+
+        var httpContext = new DefaultHttpContext();
+        if (authorizationHeader is not null)
+        {
+            httpContext.Request.Headers.Authorization = authorizationHeader;
+        }
+
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        return controller;
+    }
+
+    [Fact]
+    public void Notify_NoAuthorizationHeader_ReturnsUnauthorized()
+    {
+        var controller = CreateController(authorizationHeader: null);
+        var body = new ContextDiscoveryPayload { Kind = "subagent", Name = "echo" };
+
+        var result = controller.Notify(body);
+
+        result.Should().BeOfType<UnauthorizedResult>();
+    }
+
+    [Fact]
+    public void Notify_WrongSecret_ReturnsUnauthorized()
+    {
+        var controller = CreateController(authorizationHeader: "wrong-secret");
+        var body = new ContextDiscoveryPayload { Kind = "subagent", Name = "echo" };
+
+        var result = controller.Notify(body);
+
+        result.Should().BeOfType<UnauthorizedResult>();
+    }
+
+    [Fact]
+    public void Notify_CorrectSecret_NullBody_ReturnsBadRequest()
+    {
+        var controller = CreateController(authorizationHeader: Secret);
+
+        var result = controller.Notify(null);
+
+        result.Should().BeOfType<BadRequestResult>();
+    }
+
+    [Fact]
+    public void Notify_CorrectSecret_MissingKind_ReturnsBadRequest()
+    {
+        var controller = CreateController(authorizationHeader: Secret);
+        var body = new ContextDiscoveryPayload { Name = "echo" };
+
+        var result = controller.Notify(body);
+
+        result.Should().BeOfType<BadRequestResult>();
+    }
+
+    [Fact]
+    public void Notify_CorrectSecret_MissingName_ReturnsBadRequest()
+    {
+        var controller = CreateController(authorizationHeader: Secret);
+        var body = new ContextDiscoveryPayload { Kind = "subagent" };
+
+        var result = controller.Notify(body);
+
+        result.Should().BeOfType<BadRequestResult>();
+    }
+
+    [Fact]
+    public void Notify_CorrectSecret_WellFormedPayload_ReturnsOk()
+    {
+        var controller = CreateController(authorizationHeader: Secret);
+        var body = new ContextDiscoveryPayload
+        {
+            Kind = "subagent",
+            Name = "echo",
+            Description = "Echoes a marker.",
+            Path = ".claude/agents/echo.md",
+        };
+
+        var result = controller.Notify(body);
+
+        result.Should().BeOfType<OkResult>();
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentMarkdownParserTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentMarkdownParserTests.cs
@@ -1,0 +1,149 @@
+using LmStreaming.Sample.Services.Discovery;
+
+namespace LmStreaming.Sample.Tests.Services.Discovery;
+
+/// <summary>
+/// Unit tests for <see cref="SubAgentMarkdownParser.Parse"/>. The parser is pure: it returns a
+/// <see cref="ParsedSubAgent"/> or <c>null</c> for malformed input. These tests pin the
+/// frontmatter contract, the unknown-key tolerance, and the fallback name resolution.
+/// </summary>
+public class SubAgentMarkdownParserTests
+{
+    [Fact]
+    public void Parse_WellFormed_ExposesAllFields()
+    {
+        var md = "---\nname: echo-agent\ndescription: Echo discovered marker.\nmodel: claude-sonnet-4-5\ntools:\n  - Read\n  - Glob\n---\nYou are the echo sub-agent.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "fallback");
+
+        parsed.Should().NotBeNull();
+        parsed!.Name.Should().Be("echo-agent");
+        parsed.Description.Should().Be("Echo discovered marker.");
+        parsed.Model.Should().Be("claude-sonnet-4-5");
+        parsed.Tools.Should().Equal("Read", "Glob");
+        parsed.SystemPrompt.Should().Be("You are the echo sub-agent.");
+    }
+
+    [Fact]
+    public void Parse_NoFrontmatterFence_ReturnsNull()
+    {
+        var md = "name: echo-agent\nYou are the echo sub-agent.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
+
+        parsed.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_MissingClosingFence_ReturnsNull()
+    {
+        var md = "---\nname: echo-agent\nYou are the echo sub-agent.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
+
+        parsed.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_EmptyBody_ReturnsNull()
+    {
+        var md = "---\nname: echo-agent\n---\n";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
+
+        parsed.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_MissingName_FallsBackToFilenameStem()
+    {
+        var md = "---\ndescription: No name in YAML.\n---\nSystem prompt.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "stem-name");
+
+        parsed.Should().NotBeNull();
+        parsed!.Name.Should().Be("stem-name");
+        parsed.Description.Should().Be("No name in YAML.");
+    }
+
+    [Fact]
+    public void Parse_MissingNameAndStem_ReturnsNull()
+    {
+        var md = "---\ndescription: Nothing.\n---\nBody.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, string.Empty);
+
+        parsed.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_UnknownFrontmatterKeys_AreIgnored()
+    {
+        // Verifies IgnoreUnmatchedProperties — additions in the gateway's frontmatter contract
+        // must not break older builds.
+        var md = "---\nname: echo-agent\ndescription: Echo.\ntags: [demo, test]\nfuture_field: 42\n---\nBody.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
+
+        parsed.Should().NotBeNull();
+        parsed!.Name.Should().Be("echo-agent");
+    }
+
+    [Fact]
+    public void Parse_MalformedYaml_ReturnsNull()
+    {
+        var md = "---\nname: [unterminated\n---\nBody.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
+
+        parsed.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_EmptyToolsList_IsEmpty_NotNull()
+    {
+        // Distinct from "absent" — empty means "no tools at all".
+        var md = "---\nname: echo-agent\ntools: []\n---\nBody.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
+
+        parsed.Should().NotBeNull();
+        parsed!.Tools.Should().NotBeNull();
+        parsed.Tools.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_ToolsAbsent_IsNull()
+    {
+        // Absent means "inherit all parent tools".
+        var md = "---\nname: echo-agent\n---\nBody.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
+
+        parsed.Should().NotBeNull();
+        parsed!.Tools.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_CrlfLineEndings_AreHandled()
+    {
+        var md = "---\r\nname: echo-agent\r\ndescription: With CRLF.\r\n---\r\nBody.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
+
+        parsed.Should().NotBeNull();
+        parsed!.Name.Should().Be("echo-agent");
+        parsed.SystemPrompt.Should().Be("Body.");
+    }
+
+    [Fact]
+    public void Parse_LeadingBomAndWhitespace_AreTolerated()
+    {
+        var md = "\uFEFF\n---\nname: echo-agent\n---\nBody.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
+
+        parsed.Should().NotBeNull();
+        parsed!.Name.Should().Be("echo-agent");
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentMergeTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentMergeTests.cs
@@ -1,0 +1,132 @@
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using LmStreaming.Sample.Services.Discovery;
+using Microsoft.Extensions.Logging;
+
+namespace LmStreaming.Sample.Tests.Services.Discovery;
+
+/// <summary>
+/// Pins the built-in-wins merge contract that gates the sub-agent catalog from being shadowed
+/// by workspace-discovered markdown. A one-line flip to <c>discovered</c>-wins is exactly the
+/// kind of trust-boundary regression this test exists to catch.
+/// </summary>
+public class SubAgentMergeTests
+{
+    private static readonly Mock<IStreamingAgent> AgentStub = new();
+    private static readonly Func<IStreamingAgent> AgentFactory = () => AgentStub.Object;
+
+    private static SubAgentTemplate Make(string name, string systemPrompt) => new()
+    {
+        Name = name,
+        Description = name,
+        WhenToUse = name,
+        SystemPrompt = systemPrompt,
+        AgentFactory = AgentFactory,
+        MaxTurnsPerRun = WorkspaceSubAgentLoader.DefaultMaxTurnsPerRun,
+    };
+
+    [Fact]
+    public void MergeBuiltInWins_DiscoveredWithoutCollision_AddsToBuiltIns()
+    {
+        var builtIns = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal)
+        {
+            ["general-purpose"] = Make("built-in", "BUILT-IN"),
+        };
+        var discovered = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal)
+        {
+            ["echo"] = Make("echo", "DISCOVERED"),
+        };
+
+        WorkspaceSubAgentLoader.MergeBuiltInWins(
+            builtIns,
+            discovered,
+            NullLogger<SubAgentMergeTests>.Instance);
+
+        builtIns.Should().ContainKey("echo");
+        builtIns["echo"].SystemPrompt.Should().Be("DISCOVERED");
+        builtIns["general-purpose"].SystemPrompt.Should().Be("BUILT-IN");
+    }
+
+    [Fact]
+    public void MergeBuiltInWins_CollisionWithBuiltIn_BuiltInIsKept()
+    {
+        // Trust-boundary guard: an untrusted workspace markdown file MUST NOT shadow the
+        // hardcoded built-in template under the same key. If this test fails, the merge
+        // direction has been inverted somewhere.
+        var builtIns = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal)
+        {
+            ["general-purpose"] = Make("built-in", "BUILT-IN"),
+        };
+        var discovered = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal)
+        {
+            ["general-purpose"] = Make("general-purpose", "SHOULD-NOT-WIN"),
+        };
+
+        WorkspaceSubAgentLoader.MergeBuiltInWins(
+            builtIns,
+            discovered,
+            NullLogger<SubAgentMergeTests>.Instance);
+
+        builtIns["general-purpose"].SystemPrompt.Should().Be("BUILT-IN");
+    }
+
+    [Fact]
+    public void MergeBuiltInWins_CollisionWithBuiltIn_LogsWarning()
+    {
+        var builtIns = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal)
+        {
+            ["general-purpose"] = Make("built-in", "BUILT-IN"),
+        };
+        var discovered = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal)
+        {
+            ["general-purpose"] = Make("general-purpose", "SHOULD-NOT-WIN"),
+        };
+        var logger = new CollectingLogger();
+
+        WorkspaceSubAgentLoader.MergeBuiltInWins(builtIns, discovered, logger);
+
+        logger.Entries.Should().ContainSingle().Which.Level.Should().Be(LogLevel.Warning);
+        logger.Entries[0].Message.Should().Contain("collides with a built-in template");
+    }
+
+    [Fact]
+    public void MergeBuiltInWins_EmptyDiscovered_NoOp()
+    {
+        var builtIns = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal)
+        {
+            ["general-purpose"] = Make("built-in", "BUILT-IN"),
+        };
+
+        WorkspaceSubAgentLoader.MergeBuiltInWins(
+            builtIns,
+            new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal),
+            NullLogger<SubAgentMergeTests>.Instance);
+
+        builtIns.Should().HaveCount(1);
+    }
+
+    private sealed class CollectingLogger : ILogger
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/WorkspaceSubAgentLoaderLoadAsyncTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/WorkspaceSubAgentLoaderLoadAsyncTests.cs
@@ -1,0 +1,283 @@
+using System.Net;
+using System.Text;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Auth;
+using LmStreaming.Sample.Services.Discovery;
+
+namespace LmStreaming.Sample.Tests.Services.Discovery;
+
+/// <summary>
+/// End-to-end tests for <see cref="WorkspaceSubAgentLoader.LoadAsync"/>, driving the registry's
+/// HTTP path through a stub handler so the loader's full pipeline (gateway → kind-filter →
+/// path-resolve → read → parse → map) is exercised against a real on-disk workspace. These
+/// pin the contract the unit tests on the static helpers don't cover: that a wrong-kind item
+/// is skipped, a gateway failure surfaces as an empty dict (not a throw), a malformed markdown
+/// file is skipped without aborting the batch, and two discovered files with the same parsed
+/// name collide loader-side under first-wins.
+/// </summary>
+public class WorkspaceSubAgentLoaderLoadAsyncTests : IDisposable
+{
+    private const string SessionId = "session-load-test";
+    private const string GatewayBaseUrl = "http://localhost:3000";
+
+    private static readonly Mock<IStreamingAgent> AgentStub = new();
+    private static readonly Func<IStreamingAgent> AgentFactory = () => AgentStub.Object;
+
+    private readonly string _hostPath;
+
+    public WorkspaceSubAgentLoaderLoadAsyncTests()
+    {
+        _hostPath = Path.Combine(Path.GetTempPath(), "wi76-loader-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(_hostPath, ".claude", "agents"));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_hostPath))
+            {
+                Directory.Delete(_hostPath, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+
+    private static readonly string WellFormedMarkdown =
+        """
+        ---
+        name: echo
+        description: Echoes a marker.
+        ---
+        You are the echo sub-agent. Respond with the marker the user supplies.
+        """;
+
+    private SandboxSession CreateSession() => new(
+        WorkspaceId: "default",
+        SessionId: SessionId,
+        WorkspaceRelPath: "default",
+        HostPath: _hostPath);
+
+    private (SandboxSessionRegistry Registry, WorkspaceSubAgentLoader Loader) CreateLoader(
+        Func<HttpRequestMessage, HttpResponseMessage> respond)
+    {
+        var handler = new StubHandler(respond);
+        var gatewayLifetimeClient = new HttpClient(new StubHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)));
+        var gateway = new SandboxGatewayLifetime(
+            new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl },
+            NullLogger<SandboxGatewayLifetime>.Instance,
+            gatewayLifetimeClient);
+
+        var registry = new SandboxSessionRegistry(
+            gateway,
+            new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl },
+            NullLogger<SandboxSessionRegistry>.Instance,
+            new HttpClient(handler),
+            new AuthOptions(),
+            new AuthSharedSecret(new AuthOptions()));
+
+        var loader = new WorkspaceSubAgentLoader(
+            registry,
+            NullLogger<WorkspaceSubAgentLoader>.Instance);
+
+        return (registry, loader);
+    }
+
+    private static HttpResponseMessage JsonOk(string body) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    [Fact]
+    public async Task LoadAsync_WellFormedSubAgent_ReturnsMappedTemplate()
+    {
+        var path = Path.Combine(".claude", "agents", "echo.md");
+        await File.WriteAllTextAsync(Path.Combine(_hostPath, path), WellFormedMarkdown);
+        var (_, loader) = CreateLoader(_ => JsonOk($$"""
+            { "items": [ { "kind": "subagent", "name": "echo", "description": "Echoes a marker.", "path": "{{path.Replace("\\", "\\\\")}}" } ] }
+            """));
+
+        var result = await loader.LoadAsync(CreateSession(), AgentFactory);
+
+        result.Should().ContainKey("echo");
+        var template = result["echo"];
+        template.Description.Should().Be("Echoes a marker.");
+        template.WhenToUse.Should().Be("Echoes a marker.");
+        template.SystemPrompt.Should().Contain("echo sub-agent");
+        template.MaxTurnsPerRun.Should().Be(WorkspaceSubAgentLoader.DefaultMaxTurnsPerRun);
+    }
+
+    [Fact]
+    public async Task LoadAsync_NonSubAgentKind_IsSkipped()
+    {
+        // Kind-filter pin: skills and unknown kinds must not be mapped as sub-agents even when
+        // their path resolves to a parseable file. The filter happens before the read.
+        var (_, loader) = CreateLoader(_ => JsonOk("""
+            { "items": [ { "kind": "skill", "name": "review", "description": "x", "path": ".claude/skills/review.md" } ] }
+            """));
+
+        var result = await loader.LoadAsync(CreateSession(), AgentFactory);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LoadAsync_GatewayFailure_ReturnsEmptyDictionary()
+    {
+        // BLOCKER policy: a non-2xx from /discovered must NOT abort agent creation. The loader
+        // swallows the throw, logs, and returns an empty dict so the catalog falls back to
+        // built-ins only.
+        var (_, loader) = CreateLoader(_ => new HttpResponseMessage(HttpStatusCode.BadGateway)
+        {
+            Content = new StringContent("upstream went away"),
+        });
+
+        var result = await loader.LoadAsync(CreateSession(), AgentFactory);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LoadAsync_FileMissingOnDisk_SkipsButContinuesBatch()
+    {
+        // Per-file resilience: a discovered item whose path doesn't exist on disk must be
+        // logged + skipped without aborting the rest of the batch. Pair an existing file with
+        // a missing one and prove only the existing one comes through.
+        var goodPath = Path.Combine(".claude", "agents", "echo.md");
+        await File.WriteAllTextAsync(Path.Combine(_hostPath, goodPath), WellFormedMarkdown);
+        var (_, loader) = CreateLoader(_ => JsonOk($$"""
+            {
+              "items": [
+                { "kind": "subagent", "name": "missing", "description": "Missing file.", "path": ".claude/agents/missing.md" },
+                { "kind": "subagent", "name": "echo",    "description": "Echoes.",       "path": "{{goodPath.Replace("\\", "\\\\")}}" }
+              ]
+            }
+            """));
+
+        var result = await loader.LoadAsync(CreateSession(), AgentFactory);
+
+        result.Should().HaveCount(1);
+        result.Should().ContainKey("echo");
+    }
+
+    [Fact]
+    public async Task LoadAsync_MalformedMarkdown_IsSkipped()
+    {
+        // Parser returns null on malformed input → loader logs + skips that file, keeps others.
+        var goodPath = Path.Combine(".claude", "agents", "echo.md");
+        var badPath = Path.Combine(".claude", "agents", "bad.md");
+        await File.WriteAllTextAsync(Path.Combine(_hostPath, goodPath), WellFormedMarkdown);
+        await File.WriteAllTextAsync(Path.Combine(_hostPath, badPath), "no frontmatter at all\n");
+        var (_, loader) = CreateLoader(_ => JsonOk($$"""
+            {
+              "items": [
+                { "kind": "subagent", "name": "bad",  "description": "x", "path": "{{badPath.Replace("\\", "\\\\")}}" },
+                { "kind": "subagent", "name": "echo", "description": "x", "path": "{{goodPath.Replace("\\", "\\\\")}}" }
+              ]
+            }
+            """));
+
+        var result = await loader.LoadAsync(CreateSession(), AgentFactory);
+
+        result.Should().ContainKey("echo");
+        result.Should().NotContainKey("bad");
+    }
+
+    [Fact]
+    public async Task LoadAsync_PathTraversalAttempt_IsSkipped()
+    {
+        // Path-injection guard at the loader boundary: a "../" item must never be read.
+        var (_, loader) = CreateLoader(_ => JsonOk("""
+            { "items": [ { "kind": "subagent", "name": "escape", "description": "x", "path": "../outside.md" } ] }
+            """));
+
+        var result = await loader.LoadAsync(CreateSession(), AgentFactory);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LoadAsync_TwoDiscoveriesSameParsedName_FirstWins()
+    {
+        // Loader-level collision (distinct from the built-in collision in MergeBuiltInWins):
+        // two discovered markdown files whose frontmatter declares the same `name` must
+        // collapse to the first occurrence so the dict insert can't throw.
+        var firstPath = Path.Combine(".claude", "agents", "echo-a.md");
+        var secondPath = Path.Combine(".claude", "agents", "echo-b.md");
+        await File.WriteAllTextAsync(
+            Path.Combine(_hostPath, firstPath),
+            """
+            ---
+            name: echo
+            description: First.
+            ---
+            FIRST body.
+            """);
+        await File.WriteAllTextAsync(
+            Path.Combine(_hostPath, secondPath),
+            """
+            ---
+            name: echo
+            description: Second.
+            ---
+            SECOND body.
+            """);
+        var (_, loader) = CreateLoader(_ => JsonOk($$"""
+            {
+              "items": [
+                { "kind": "subagent", "name": "echo-a", "description": "x", "path": "{{firstPath.Replace("\\", "\\\\")}}" },
+                { "kind": "subagent", "name": "echo-b", "description": "x", "path": "{{secondPath.Replace("\\", "\\\\")}}" }
+              ]
+            }
+            """));
+
+        var result = await loader.LoadAsync(CreateSession(), AgentFactory);
+
+        result.Should().HaveCount(1);
+        result["echo"].SystemPrompt.Should().Contain("FIRST");
+    }
+
+    [Fact]
+    public async Task LoadAsync_EmptyHostPath_ReturnsEmpty()
+    {
+        // A session without a resolved host workspace (e.g. gateway never mounted one) is a
+        // valid mode for non-workspace providers — the loader must short-circuit, not throw.
+        var session = new SandboxSession("default", SessionId, "default", HostPath: "");
+        var (_, loader) = CreateLoader(_ => JsonOk("""
+            { "items": [ { "kind": "subagent", "name": "echo", "description": "x", "path": "echo.md" } ] }
+            """));
+
+        var result = await loader.LoadAsync(session, AgentFactory);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LoadAsync_NullArguments_Throw()
+    {
+        var (_, loader) = CreateLoader(_ => JsonOk("""{ "items": [] }"""));
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => loader.LoadAsync(null!, AgentFactory));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => loader.LoadAsync(CreateSession(), null!));
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond)
+        {
+            _respond = respond;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_respond(request));
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/WorkspaceSubAgentLoaderTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/WorkspaceSubAgentLoaderTests.cs
@@ -104,7 +104,7 @@ public class WorkspaceSubAgentLoaderTests
 
         var template = WorkspaceSubAgentLoader.MapToTemplate(parsed, AgentFactory);
 
-        template.MaxTurnsPerRun.Should().Be(25);
+        template.MaxTurnsPerRun.Should().Be(WorkspaceSubAgentLoader.DefaultMaxTurnsPerRun);
     }
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/WorkspaceSubAgentLoaderTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/WorkspaceSubAgentLoaderTests.cs
@@ -1,0 +1,189 @@
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using LmStreaming.Sample.Services.Discovery;
+
+namespace LmStreaming.Sample.Tests.Services.Discovery;
+
+/// <summary>
+/// Unit tests for <see cref="WorkspaceSubAgentLoader"/>'s pure helpers:
+/// <see cref="WorkspaceSubAgentLoader.MapToTemplate"/> (mapping table),
+/// <see cref="WorkspaceSubAgentLoader.TryResolveContainedPath"/> (path-injection guard) and
+/// <see cref="WorkspaceSubAgentLoader.NormalizeBasePath"/> (trailing-separator pin).
+/// The HTTP-driven <c>LoadAsync</c> orchestration is thin (registry → filter → resolve →
+/// read → parse → map) and is exercised end-to-end by the live workspace mode; the risky
+/// surface (mapping table + traversal guard + parser) is pinned here.
+/// </summary>
+public class WorkspaceSubAgentLoaderTests
+{
+    private static readonly Mock<IStreamingAgent> AgentStub = new();
+    private static readonly Func<IStreamingAgent> AgentFactory = () => AgentStub.Object;
+
+    [Fact]
+    public void MapToTemplate_DescriptionMapsToBothDescriptionAndWhenToUse()
+    {
+        var parsed = new ParsedSubAgent(
+            Name: "echo",
+            Description: "Echoes a discovered marker.",
+            Model: null,
+            Tools: null,
+            SystemPrompt: "You are echo.");
+
+        var template = WorkspaceSubAgentLoader.MapToTemplate(parsed, AgentFactory);
+
+        template.Name.Should().Be("echo");
+        template.Description.Should().Be("Echoes a discovered marker.");
+        template.WhenToUse.Should().Be("Echoes a discovered marker.");
+        template.SystemPrompt.Should().Be("You are echo.");
+    }
+
+    [Fact]
+    public void MapToTemplate_ModelOverride_SetsDefaultOptionsModelId()
+    {
+        var parsed = new ParsedSubAgent(
+            Name: "echo",
+            Description: null,
+            Model: "claude-sonnet-4-5",
+            Tools: null,
+            SystemPrompt: "Body.");
+
+        var template = WorkspaceSubAgentLoader.MapToTemplate(parsed, AgentFactory);
+
+        template.DefaultOptions.Should().NotBeNull();
+        template.DefaultOptions!.ModelId.Should().Be("claude-sonnet-4-5");
+    }
+
+    [Fact]
+    public void MapToTemplate_NoModelOverride_LeavesDefaultOptionsNull()
+    {
+        var parsed = new ParsedSubAgent(
+            Name: "echo",
+            Description: null,
+            Model: null,
+            Tools: null,
+            SystemPrompt: "Body.");
+
+        var template = WorkspaceSubAgentLoader.MapToTemplate(parsed, AgentFactory);
+
+        template.DefaultOptions.Should().BeNull();
+    }
+
+    [Fact]
+    public void MapToTemplate_ToolsAbsent_NullEnabledTools_InheritsAllParentTools()
+    {
+        var parsed = new ParsedSubAgent("echo", null, null, Tools: null, SystemPrompt: "Body.");
+
+        var template = WorkspaceSubAgentLoader.MapToTemplate(parsed, AgentFactory);
+
+        template.EnabledTools.Should().BeNull();
+    }
+
+    [Fact]
+    public void MapToTemplate_EmptyTools_EmptyEnabledTools_DistinctFromNull()
+    {
+        var parsed = new ParsedSubAgent("echo", null, null, Tools: [], SystemPrompt: "Body.");
+
+        var template = WorkspaceSubAgentLoader.MapToTemplate(parsed, AgentFactory);
+
+        template.EnabledTools.Should().NotBeNull();
+        template.EnabledTools.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MapToTemplate_ToolsList_PreservedAsEnabledTools()
+    {
+        var parsed = new ParsedSubAgent("echo", null, null, Tools: ["Read", "Glob"], SystemPrompt: "Body.");
+
+        var template = WorkspaceSubAgentLoader.MapToTemplate(parsed, AgentFactory);
+
+        template.EnabledTools.Should().Equal("Read", "Glob");
+    }
+
+    [Fact]
+    public void MapToTemplate_MaxTurnsPerRun_MatchesProductionTemplates()
+    {
+        var parsed = new ParsedSubAgent("echo", null, null, null, "Body.");
+
+        var template = WorkspaceSubAgentLoader.MapToTemplate(parsed, AgentFactory);
+
+        template.MaxTurnsPerRun.Should().Be(25);
+    }
+
+    [Fact]
+    public void TryResolveContainedPath_DotDotEscape_Rejected()
+    {
+        var basePath = WorkspaceSubAgentLoader.NormalizeBasePath(Path.Combine(Path.GetTempPath(), "wi76-base"));
+
+        var contained = WorkspaceSubAgentLoader.TryResolveContainedPath(
+            basePath,
+            relativeOrAbsolute: Path.Combine("..", "outside.md"),
+            out var resolved);
+
+        contained.Should().BeFalse();
+        resolved.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TryResolveContainedPath_SiblingPrefixAttack_Rejected()
+    {
+        // Pin the trailing-separator normalisation: a sibling whose path begins with the bare
+        // base ("C:\\work") plus extra characters must NOT be considered contained in "C:\\work".
+        var root = Path.Combine(Path.GetTempPath(), "wi76-work");
+        var basePath = WorkspaceSubAgentLoader.NormalizeBasePath(root);
+        var sibling = root + "-evil";
+
+        var contained = WorkspaceSubAgentLoader.TryResolveContainedPath(
+            basePath,
+            relativeOrAbsolute: Path.Combine(sibling, "agent.md"),
+            out _);
+
+        contained.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryResolveContainedPath_RelativeUnderBase_Accepted()
+    {
+        var basePath = WorkspaceSubAgentLoader.NormalizeBasePath(Path.Combine(Path.GetTempPath(), "wi76-base"));
+
+        var contained = WorkspaceSubAgentLoader.TryResolveContainedPath(
+            basePath,
+            relativeOrAbsolute: Path.Combine(".claude", "agents", "echo.md"),
+            out var resolved);
+
+        contained.Should().BeTrue();
+        resolved.Should().StartWith(basePath);
+        resolved.Should().EndWith("echo.md");
+    }
+
+    [Fact]
+    public void TryResolveContainedPath_AbsoluteUnderBase_Accepted()
+    {
+        var basePath = WorkspaceSubAgentLoader.NormalizeBasePath(Path.Combine(Path.GetTempPath(), "wi76-base"));
+        var absolute = Path.Combine(basePath, ".claude", "agents", "echo.md");
+
+        var contained = WorkspaceSubAgentLoader.TryResolveContainedPath(
+            basePath,
+            relativeOrAbsolute: absolute,
+            out var resolved);
+
+        contained.Should().BeTrue();
+        resolved.Should().EndWith("echo.md");
+    }
+
+    [Fact]
+    public void TryResolveContainedPath_EmptyInput_Rejected()
+    {
+        var basePath = WorkspaceSubAgentLoader.NormalizeBasePath(Path.GetTempPath());
+
+        WorkspaceSubAgentLoader.TryResolveContainedPath(basePath, string.Empty, out _).Should().BeFalse();
+        WorkspaceSubAgentLoader.TryResolveContainedPath(basePath, "   ", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NormalizeBasePath_AlwaysEndsWithSeparator()
+    {
+        var input = Path.Combine(Path.GetTempPath(), "wi76-trailing");
+
+        var normalized = WorkspaceSubAgentLoader.NormalizeBasePath(input);
+
+        normalized.Should().EndWith(Path.DirectorySeparatorChar.ToString());
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryListDiscoveredTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryListDiscoveredTests.cs
@@ -1,0 +1,169 @@
+using System.Net;
+using System.Text;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Auth;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// HTTP-level tests for <see cref="SandboxSessionRegistry.ListDiscoveredAsync"/>: the success path
+/// (well-formed JSON → strongly-typed items) and the failure path (non-2xx → thrown
+/// <see cref="InvalidOperationException"/> carrying the truncated body). Both were promised in
+/// plan v2 and remained ungated until this pin.
+/// </summary>
+public class SandboxSessionRegistryListDiscoveredTests
+{
+    private const string SessionId = "session-abc";
+    private const string GatewayBaseUrl = "http://localhost:3000";
+
+    private static (SandboxSessionRegistry Registry, StubHandler Handler) CreateRegistry(
+        Func<HttpRequestMessage, HttpResponseMessage> respond)
+    {
+        var handler = new StubHandler(respond);
+        // SandboxGatewayLifetime needs an HttpClient too; give it the same stub since this test
+        // only exercises ListDiscoveredAsync and never calls EnsureReadyAsync.
+        var gatewayLifetimeClient = new HttpClient(new StubHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)));
+        var gateway = new SandboxGatewayLifetime(
+            new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl },
+            NullLogger<SandboxGatewayLifetime>.Instance,
+            gatewayLifetimeClient);
+
+        var registry = new SandboxSessionRegistry(
+            gateway,
+            new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl },
+            NullLogger<SandboxSessionRegistry>.Instance,
+            new HttpClient(handler),
+            new AuthOptions(),
+            new AuthSharedSecret(new AuthOptions()));
+
+        return (registry, handler);
+    }
+
+    [Fact]
+    public async Task ListDiscoveredAsync_Success_ReturnsItems()
+    {
+        var json = """
+            {
+              "items": [
+                { "kind": "subagent", "name": "echo", "description": "echo agent", "path": ".claude/agents/echo.md" },
+                { "kind": "skill",    "name": "review", "description": null,      "path": ".claude/skills/review.md" }
+              ]
+            }
+            """;
+        var (registry, handler) = CreateRegistry(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        });
+
+        var items = await registry.ListDiscoveredAsync(SessionId);
+
+        items.Should().HaveCount(2);
+        items[0].Kind.Should().Be("subagent");
+        items[0].Name.Should().Be("echo");
+        items[0].Description.Should().Be("echo agent");
+        items[0].Path.Should().Be(".claude/agents/echo.md");
+        items[1].Kind.Should().Be("skill");
+        items[1].Description.Should().BeNull();
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.RequestUri!.ToString().Should().Be($"{GatewayBaseUrl}/api/v1/sandboxes/{SessionId}/discovered");
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Get);
+    }
+
+    [Fact]
+    public async Task ListDiscoveredAsync_EmptyItems_ReturnsEmptyList()
+    {
+        var (registry, _) = CreateRegistry(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"items\":[]}", Encoding.UTF8, "application/json"),
+        });
+
+        var items = await registry.ListDiscoveredAsync(SessionId);
+
+        items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListDiscoveredAsync_NonSuccess_ThrowsWithTruncatedBody()
+    {
+        // Reviewer flagged the doc claim "(truncated)" vs zero-truncation in code as a
+        // doc/code mismatch. Pin both halves: large body is actually truncated AND the
+        // marker appears in the thrown message.
+        var largeBody = new string('x', 1200);
+        var (registry, _) = CreateRegistry(_ => new HttpResponseMessage(HttpStatusCode.BadGateway)
+        {
+            Content = new StringContent(largeBody, Encoding.UTF8, "text/html"),
+        });
+
+        var act = async () => await registry.ListDiscoveredAsync(SessionId);
+
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("502");
+        ex.Which.Message.Should().Contain("...(truncated)");
+        ex.Which.Message.Length.Should().BeLessThan(1200 + 200);
+    }
+
+    [Fact]
+    public async Task ListDiscoveredAsync_NotFound_Throws()
+    {
+        var (registry, _) = CreateRegistry(_ => new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent("session not found"),
+        });
+
+        var act = async () => await registry.ListDiscoveredAsync(SessionId);
+
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("404");
+        ex.Which.Message.Should().Contain("session not found");
+    }
+
+    [Fact]
+    public async Task ListDiscoveredAsync_NullPayload_ReturnsEmptyList()
+    {
+        // Gateway returning a JSON null body is structurally allowed by the wire contract;
+        // map that to an empty list rather than NRE.
+        var (registry, _) = CreateRegistry(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        });
+
+        var items = await registry.ListDiscoveredAsync(SessionId);
+
+        items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListDiscoveredAsync_NullOrWhitespaceSessionId_Throws()
+    {
+        var (registry, _) = CreateRegistry(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        await Assert.ThrowsAsync<ArgumentException>(() => registry.ListDiscoveredAsync(""));
+        await Assert.ThrowsAsync<ArgumentException>(() => registry.ListDiscoveredAsync("   "));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => registry.ListDiscoveredAsync(null!));
+    }
+
+    /// <summary>
+    /// Minimal HttpMessageHandler that delegates the response to a lambda and records the last
+    /// request. Captures the request for URL/method assertions.
+    /// </summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond)
+        {
+            _respond = respond;
+        }
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(_respond(request));
+        }
+    }
+}


### PR DESCRIPTION
**[Gautam's Dev bot]** Phase 2 of WI-76 — surface sandbox-discovered subagents as spawnable Agent-tool types.

## Summary
- **`SubAgentMarkdownParser`** — pure parser for `.claude/agents/*.md` (YAML frontmatter + body). Tolerates BOM, CRLF, unknown frontmatter keys; returns null on malformed input so the loader can log + skip per file.
- **`WorkspaceSubAgentLoader`** — for each `kind == "subagent"` item the gateway reports, resolves the file inside the workspace host directory (containment guard rejects `..` traversal and sibling-prefix attacks like `C:\work` vs `C:\work-evil`), parses, and maps to `SubAgentTemplate`. Per-file failures log + skip; a complete gateway failure returns an empty dictionary after warning.
- **`SandboxSessionRegistry`** — new `ListDiscoveredAsync` GET against `/api/v1/sandboxes/{id}/discovered` + an outbound `discovery` block on `CreateSandboxRequest` that hands the gateway the webhook URL + shared secret.
- **`ContextDiscoveryController`** — log-only webhook for gateway-pushed discovery events. Constant-time SHA256 auth mirroring `AuthWebhookController`; the dynamic-activation queue is deferred to #77.
- **`Program.cs`** — async-ifies `BuildProductionSubAgentOptions` and merges discovered templates under **built-in wins** collision semantics.

## Reviewer findings applied
1. Dropped `IContextDiscoveryQueue` — controller is log-only this iteration.
2. Discovery GET folded into `SandboxSessionRegistry` (reuses the same auth-aware `HttpClient`).
3. `SubAgentTemplateFactory` folded into the loader as `internal static MapToTemplate`.
4. Dropped `ParsedSubAgent.Frontmatter` dict — only the fields we actually map are surfaced.
5. Dropped the 256 KB read cap.
6. Path guard pinned: `NormalizeBasePath` always carries a trailing separator + Ordinal/OrdinalIgnoreCase selected by `OperatingSystem.IsWindows()`.
7. `description` → both `Description` AND `WhenToUse` (the Agent-tool catalog is never blank for discovered templates).
8. All gateway DTOs pinned with explicit `[JsonPropertyName]`.

## Test plan
- [x] `dotnet build samples/LmStreaming.Sample/LmStreaming.Sample.csproj` → 0 warnings, 0 errors
- [x] `dotnet test tests/LmStreaming.Sample.Tests/LmStreaming.Sample.Tests.csproj` → **107 / 107 passed** (31 new)
  - `SubAgentMarkdownParserTests` (12): well-formed/malformed/BOM/CRLF/fallback-name/unknown-keys/empty-tools vs absent
  - `WorkspaceSubAgentLoaderTests` (13): mapping table + traversal guard (`../` rejected, sibling-prefix rejected, relative/absolute under base accepted) + `NormalizeBasePath` trailing-separator pin
  - `ContextDiscoveryControllerTests` (6): 401 missing/wrong secret, 400 null/missing kind/missing name, 200 happy path
- [ ] Manual gateway smoke once the matching gateway build lands (gateway-side discovery emission is the other half of the contract).

Refs #76