### PR TITLE
feat: mid-session activation of sandbox-discovered subagents (#77)

### DIFF
--- a/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
@@ -1,34 +1,45 @@
 using System.Text.Json.Serialization;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Services.Auth;
+using LmStreaming.Sample.Services.Discovery;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LmStreaming.Sample.Controllers;
 
 /// <summary>
 /// Webhook endpoint the sandbox gateway calls when it discovers a new context file in the
-/// workspace (sub-agent, skill, …). This iteration is <b>log-only</b>: the controller verifies
-/// the shared secret in constant time, logs a structured event, and returns 200. There is no
-/// in-memory queue and no dynamic activation — those are tracked in #77 and land with their
-/// consumer (mid-session sub-agent catalog refresh / dynamic Agent tool reload).
+/// workspace (sub-agent, skill, …). For <c>kind == "subagent"</c> payloads this resolves the
+/// session, loads the markdown via <see cref="WorkspaceSubAgentLoader.LoadOneAsync"/>, and
+/// registers the resulting template into the session's
+/// <see cref="MutableSubAgentTemplateSource"/> so it surfaces in the Agent tool on the next turn.
+/// Other kinds are still log-only.
 /// </summary>
 /// <remarks>
 /// SECURITY: mirrors <see cref="AuthWebhookController"/>'s pattern: the gateway authenticates
 /// itself with a shared secret in the <c>Authorization</c> header, compared in constant time
 /// over fixed-width hashes. The controller NEVER logs the Authorization header value or the
-/// shared secret — only the discovery payload's kind/name/path and the allow decision.
+/// shared secret — only the discovery payload's kind/name/path and the activation decision.
 /// </remarks>
 [ApiController]
 [Route("api/discovery")]
 public sealed class ContextDiscoveryController(
     AuthSharedSecret sharedSecret,
+    SandboxSessionRegistry sessionRegistry,
+    WorkspaceSubAgentLoader subAgentLoader,
     ILogger<ContextDiscoveryController> logger) : ControllerBase
 {
+    private const string SubAgentKind = "subagent";
+
     /// <summary>
-    /// Gateway callback for one discovered context item. Returns 200 on success, 401 if the
-    /// shared secret doesn't match, 400 if the payload is malformed.
+    /// Gateway callback for one discovered context item. Returns 200 on success (including
+    /// best-effort no-ops), 401 if the shared secret doesn't match, 400 if the payload is
+    /// malformed.
     /// </summary>
     [HttpPost("context_discovery")]
-    public IActionResult Notify([FromBody] ContextDiscoveryPayload? body)
+    public async Task<IActionResult> NotifyAsync(
+        [FromBody] ContextDiscoveryPayload? body,
+        CancellationToken cancellationToken)
     {
         if (!sharedSecret.Matches(Request.Headers.Authorization.ToString()))
         {
@@ -43,18 +54,148 @@ public sealed class ContextDiscoveryController(
             return BadRequest();
         }
 
-        // Description is logged alongside kind/name/path so the field carries diagnostic value
-        // in this iteration even though dynamic activation (the consumer that mutates the catalog
-        // from these events) is deferred to #77.
         logger.LogInformation(
-            "ContextDiscovery: kind={Kind} name={Name} path={Path} description={Description}",
+            "ContextDiscovery: kind={Kind} name={Name} path={Path} description={Description} session={SessionId}",
             body.Kind,
             body.Name,
             body.Path,
-            body.Description);
+            body.Description,
+            body.SessionId);
+
+        if (string.Equals(body.Kind, SubAgentKind, StringComparison.Ordinal))
+        {
+            await TryActivateSubAgentAsync(body, cancellationToken).ConfigureAwait(false);
+        }
 
         return Ok();
     }
+
+    /// <summary>
+    /// Best-effort activation: resolves the session + binding, loads the markdown, and registers
+    /// the template. Every failure path is logged and swallowed — context discovery is an
+    /// enrichment, never blocking, so the gateway always sees a 200 for an authenticated payload.
+    /// </summary>
+    private async Task TryActivateSubAgentAsync(
+        ContextDiscoveryPayload body,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(body.SessionId))
+        {
+            logger.LogWarning(
+                "ContextDiscovery subagent {Name}: payload missing session_id; cannot resolve session for activation.",
+                body.Name);
+            return;
+        }
+
+        if (!sessionRegistry.TryGetSessionById(body.SessionId, out var session) || session is null)
+        {
+            logger.LogInformation(
+                "ContextDiscovery subagent {Name}: no session known for session_id {SessionId}; skipping activation.",
+                body.Name,
+                body.SessionId);
+            return;
+        }
+
+        if (!sessionRegistry.TryGetSubAgentBinding(body.SessionId, out var binding) || binding is null)
+        {
+            // The agent path hasn't been initialised for this session yet — built-ins/discovered
+            // entries are loaded the first time the loop is created. Once it is, subsequent
+            // discoveries land here and activate normally.
+            logger.LogInformation(
+                "ContextDiscovery subagent {Name}: session {SessionId} has no agent binding yet; skipping activation.",
+                body.Name,
+                body.SessionId);
+            return;
+        }
+
+        SubAgentSessionRegistryItem item;
+        try
+        {
+            item = new SubAgentSessionRegistryItem(
+                Kind: body.Kind!,
+                Name: body.Name!,
+                Description: body.Description,
+                Path: body.Path ?? string.Empty);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "ContextDiscovery subagent {Name}: failed to build discovery item.",
+                body.Name);
+            return;
+        }
+
+        // Fast-path: if a template with this name is already registered (built-in seed OR a
+        // previous discovery for this session), skip the disk read entirely. Gateways may retry
+        // the same discovery event after a transient failure; without this gate two near-
+        // simultaneous webhooks would both parse the markdown only for one to win the
+        // first-wins TryRegister. The race is still correct (TryRegister resolves it) — this
+        // just closes the retry-storm window before it hits the filesystem.
+        if (binding.Source.Templates.ContainsKey(body.Name!))
+        {
+            return;
+        }
+
+        SubAgentTemplate? template;
+        try
+        {
+            template = await subAgentLoader
+                .LoadOneAsync(session, item.ToDiscovered(), binding.AgentFactory, ct)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "ContextDiscovery subagent {Name}: loader threw while activating; skipping.",
+                body.Name);
+            return;
+        }
+
+        if (template is null || string.IsNullOrWhiteSpace(template.Name))
+        {
+            // LoadOneAsync already logged the specific reason (path traversal, missing file,
+            // malformed markdown, …); a non-null template with a blank Name would indicate a
+            // mapping bug, so it's also dropped here rather than registered as garbage.
+            return;
+        }
+
+        if (binding.Source.TryRegister(template.Name, template))
+        {
+            logger.LogInformation(
+                "ContextDiscovery subagent {Name}: activated for session {SessionId}.",
+                template.Name,
+                body.SessionId);
+        }
+        else
+        {
+            // First-wins collision with a built-in OR an earlier discovery on this same session.
+            // This matches WorkspaceSubAgentLoader.MergeBuiltInWins's trust boundary: discovered
+            // templates cannot shadow trusted built-ins, and a re-fire of the same discovery is a
+            // no-op rather than a re-register.
+            logger.LogInformation(
+                "ContextDiscovery subagent {Name}: session {SessionId} already has a template "
+                + "with that name; keeping the first.",
+                template.Name,
+                body.SessionId);
+        }
+    }
+}
+
+/// <summary>
+/// Internal helper that wraps the controller's payload fields in the shape
+/// <see cref="WorkspaceSubAgentLoader.LoadOneAsync"/> expects, without leaking the controller's
+/// public payload contract into the loader.
+/// </summary>
+internal readonly record struct SubAgentSessionRegistryItem(string Kind, string Name, string? Description, string Path)
+{
+    public SandboxSessionRegistry.DiscoveredItem ToDiscovered() =>
+        new(Kind, Name, Description, Path);
 }
 
 /// <summary>
@@ -65,6 +206,9 @@ public sealed class ContextDiscoveryController(
 /// </summary>
 public sealed record ContextDiscoveryPayload
 {
+    [JsonPropertyName("session_id")]
+    public string? SessionId { get; init; }
+
     [JsonPropertyName("kind")]
     public string? Kind { get; init; }
 

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -602,16 +602,33 @@ try
                     // pool-creation path (no ASP.NET SynchronizationContext) so a .Result here
                     // cannot deadlock. The blocking call is HTTP only when a sandbox session is
                     // active; otherwise BuildProductionSubAgentOptionsAsync returns synchronously.
+                    Func<IStreamingAgent> subAgentFactory = () => agentFactory(normalizedProviderId);
                     var subAgentOptions = isTestMode
                         ? sp.GetRequiredService<ITestAgentBuilder>()
-                            .CreateSubAgentOptions(loggerFactory, () => agentFactory(normalizedProviderId))
+                            .CreateSubAgentOptions(loggerFactory, subAgentFactory)
                         : BuildProductionSubAgentOptionsAsync(
-                                () => agentFactory(normalizedProviderId),
+                                subAgentFactory,
                                 sandboxSession,
                                 sp.GetRequiredService<WorkspaceSubAgentLoader>(),
                                 loggerFactory.CreateLogger("LmStreaming.Sample.SubAgentCatalog"))
                             .GetAwaiter()
                             .GetResult();
+
+                    // When a sandbox session is active, share the catalog with the session
+                    // registry so the context-discovery webhook can activate newly discovered
+                    // subagents into the same source the loop is reading. Without a session there
+                    // is no webhook path, so the loop falls back to wrapping the static templates
+                    // in a private source inside its ctor.
+                    MutableSubAgentTemplateSource? sharedSubAgentSource = null;
+                    if (sandboxSession is not null && subAgentOptions is not null)
+                    {
+                        var binding = sp.GetRequiredService<SandboxSessionRegistry>()
+                            .GetOrAddSubAgentBinding(
+                                sandboxSession.SessionId,
+                                subAgentOptions.Templates,
+                                subAgentFactory);
+                        sharedSubAgentSource = binding.Source;
+                    }
 
                     var agent = new MultiTurnAgentLoop(
                         providerAgent,
@@ -635,6 +652,7 @@ try
                         store: conversationStore,
                         logger: loggerFactory.CreateLogger<MultiTurnAgentLoop>(),
                         subAgentOptions: subAgentOptions,
+                        subAgentTemplateSource: sharedSubAgentSource,
                         loggerFactory: loggerFactory
                     );
 

--- a/samples/LmStreaming.Sample/Services/Discovery/WorkspaceSubAgentLoader.cs
+++ b/samples/LmStreaming.Sample/Services/Discovery/WorkspaceSubAgentLoader.cs
@@ -81,66 +81,108 @@ public sealed class WorkspaceSubAgentLoader
             return new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal);
         }
 
-        var basePath = NormalizeBasePath(session.HostPath);
         var result = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal);
 
         foreach (var item in items)
         {
-            if (!string.Equals(item.Kind, SubAgentKind, StringComparison.Ordinal))
+            var loaded = await LoadOneAsync(session, item, agentFactory, ct).ConfigureAwait(false);
+            if (loaded is null || string.IsNullOrWhiteSpace(loaded.Name))
             {
                 continue;
             }
 
-            if (!TryResolveContainedPath(basePath, item.Path, out var fullPath))
-            {
-                _logger.LogWarning(
-                    "Skipping discovered sub-agent {Name}: path '{Path}' is outside workspace '{HostPath}'",
-                    item.Name,
-                    item.Path,
-                    session.HostPath);
-                continue;
-            }
-
-            string markdown;
-            try
-            {
-                markdown = await File.ReadAllTextAsync(fullPath, ct).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(
-                    ex,
-                    "Skipping discovered sub-agent {Name}: failed to read '{Path}'",
-                    item.Name,
-                    fullPath);
-                continue;
-            }
-
-            var stem = Path.GetFileNameWithoutExtension(fullPath);
-            var parsed = SubAgentMarkdownParser.Parse(markdown, stem);
-            if (parsed is null)
-            {
-                _logger.LogWarning(
-                    "Skipping discovered sub-agent {Name}: markdown at '{Path}' has no valid frontmatter or empty body",
-                    item.Name,
-                    fullPath);
-                continue;
-            }
-
-            var template = MapToTemplate(parsed, agentFactory);
-            if (!result.TryAdd(parsed.Name, template))
+            if (!result.TryAdd(loaded.Name, loaded))
             {
                 _logger.LogWarning(
                     "Discovered sub-agent {Name} collides with an earlier discovery; keeping the first occurrence",
-                    parsed.Name);
+                    loaded.Name);
             }
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Loads a single discovered item into a <see cref="SubAgentTemplate"/>, or returns null when
+    /// the item should be skipped (wrong kind, traversal attempt, missing/unreadable file,
+    /// malformed markdown). Cancellation propagates; all other failures are logged and become a
+    /// null result so the caller (batch loader OR the
+    /// <see cref="LmStreaming.Sample.Controllers.ContextDiscoveryController"/> webhook handler)
+    /// can treat them uniformly.
+    /// </summary>
+    /// <remarks>
+    /// Mid-session activation flow (issue #77): the context-discovery webhook fires once per newly
+    /// discovered item; for <c>kind == "subagent"</c> it calls this method and then registers the
+    /// result with the session's <c>MutableSubAgentTemplateSource</c>. Sharing this path with
+    /// <see cref="LoadAsync"/> keeps the boot-time scan and the live activation on a single
+    /// codepath so security/traversal guards and frontmatter rules cannot drift apart.
+    /// </remarks>
+    public async Task<SubAgentTemplate?> LoadOneAsync(
+        SandboxSession session,
+        SandboxSessionRegistry.DiscoveredItem item,
+        Func<IStreamingAgent> agentFactory,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(agentFactory);
+
+        if (!string.Equals(item.Kind, SubAgentKind, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(session.HostPath))
+        {
+            _logger.LogWarning(
+                "Skipping discovered sub-agent {Name}: session {SessionId} has no HostPath",
+                item.Name,
+                session.SessionId);
+            return null;
+        }
+
+        var basePath = NormalizeBasePath(session.HostPath);
+        if (!TryResolveContainedPath(basePath, item.Path, out var fullPath))
+        {
+            _logger.LogWarning(
+                "Skipping discovered sub-agent {Name}: path '{Path}' is outside workspace '{HostPath}'",
+                item.Name,
+                item.Path,
+                session.HostPath);
+            return null;
+        }
+
+        string markdown;
+        try
+        {
+            markdown = await File.ReadAllTextAsync(fullPath, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Skipping discovered sub-agent {Name}: failed to read '{Path}'",
+                item.Name,
+                fullPath);
+            return null;
+        }
+
+        var stem = Path.GetFileNameWithoutExtension(fullPath);
+        var parsed = SubAgentMarkdownParser.Parse(markdown, stem);
+        if (parsed is null)
+        {
+            _logger.LogWarning(
+                "Skipping discovered sub-agent {Name}: markdown at '{Path}' has no valid frontmatter or empty body",
+                item.Name,
+                fullPath);
+            return null;
+        }
+
+        return MapToTemplate(parsed, agentFactory);
     }
 
     /// <summary>

--- a/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
@@ -1,9 +1,22 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using LmStreaming.Sample.Services.Auth;
 
 namespace LmStreaming.Sample.Services;
+
+/// <summary>
+/// Per-session binding the context-discovery webhook needs to convert a discovered subagent into
+/// a live template: the catalog the loop reads (<see cref="Source"/>) plus the agent factory the
+/// template's spawn-time wiring will reuse (<see cref="AgentFactory"/>). The factory is provider-
+/// specific and only known at agent-creation time, so it must travel with the source rather than
+/// be re-derived inside the webhook handler.
+/// </summary>
+public sealed record SubAgentSessionBinding(
+    MutableSubAgentTemplateSource Source,
+    Func<IStreamingAgent> AgentFactory);
 
 /// <summary>
 /// A sandbox session created against the gateway and bound to a workspace directory.
@@ -46,6 +59,26 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
     };
 
     private readonly ConcurrentDictionary<string, Lazy<Task<SandboxSession>>> _sessions = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Per-session sub-agent binding (template source + agent factory) the loop uses to populate
+    /// the Agent tool's <c>subagent_type</c> enum and that the context-discovery webhook mutates
+    /// when the gateway reports a newly discovered subagent. Keyed by gateway session id (NOT
+    /// workspace id) so the webhook — which carries the session id, not the workspace id — can
+    /// look up the same instance the loop is reading from.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, SubAgentSessionBinding> _subAgentBindings =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Reverse map from gateway session id to the <see cref="SandboxSession"/> it represents.
+    /// Populated by <see cref="CreateSessionAsync"/> after a session is created so the
+    /// context-discovery webhook (which only knows the session id) can resolve back to the
+    /// session's <c>HostPath</c> for path-containment checks.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, SandboxSession> _sessionsById =
+        new(StringComparer.Ordinal);
+
     private readonly SandboxGatewayLifetime _gateway;
     private readonly SandboxGatewayOptions _options;
     private readonly ILogger<SandboxSessionRegistry> _logger;
@@ -222,6 +255,11 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
         var hostPath = StripLongPathPrefix(payload.Volumes?.Workspace?.ContainerPath ?? string.Empty);
         var session = new SandboxSession(workspaceId, payload.SessionId, workspaceRelPath, hostPath);
 
+        // Register the reverse session-id → session mapping so the context-discovery webhook can
+        // resolve back to the session. Last-write-wins is acceptable because session ids are
+        // gateway-allocated and unique per creation.
+        _sessionsById[session.SessionId] = session;
+
         _logger.LogInformation(
             "Created sandbox session {SessionId} for workspace {WorkspaceId} at host path {HostPath}",
             session.SessionId,
@@ -257,6 +295,8 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
         }
 
         _sessions.Clear();
+        _subAgentBindings.Clear();
+        _sessionsById.Clear();
         _httpClient.Dispose();
     }
 
@@ -303,6 +343,80 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
             .ConfigureAwait(false);
 
         return payload?.Items ?? [];
+    }
+
+    /// <summary>
+    /// Returns the <see cref="SubAgentSessionBinding"/> for <paramref name="sessionId"/>, creating
+    /// one on first access — seeded with <paramref name="seed"/> and remembering
+    /// <paramref name="agentFactory"/> for the discovery webhook's spawn-time wiring. Subsequent
+    /// calls return the existing binding unchanged; the binding is single-instance per session for
+    /// the registry's lifetime so the loop and the discovery webhook always share state.
+    /// </summary>
+    /// <remarks>
+    /// The seed lets the pool factory plant the built-in templates as the initial entries before
+    /// the loop wires the source into <see cref="SubAgentToolProvider"/>/<see cref="SubAgentManager"/>.
+    /// </remarks>
+    public SubAgentSessionBinding GetOrAddSubAgentBinding(
+        string sessionId,
+        IReadOnlyDictionary<string, SubAgentTemplate> seed,
+        Func<IStreamingAgent> agentFactory)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        ArgumentNullException.ThrowIfNull(seed);
+        ArgumentNullException.ThrowIfNull(agentFactory);
+
+        var binding = _subAgentBindings.GetOrAdd(
+            sessionId,
+            _ => new SubAgentSessionBinding(new MutableSubAgentTemplateSource(seed), agentFactory));
+
+        // Reconcile the seed every call: a later pool factory invocation for the same session may
+        // present additional built-in templates that weren't present on the first call. TryRegister
+        // is first-wins, so previously seeded entries (and any discovered templates registered by
+        // the webhook in between) are preserved — the trust boundary holds.
+        foreach (var kvp in seed)
+        {
+            _ = binding.Source.TryRegister(kvp.Key, kvp.Value);
+        }
+
+        return binding;
+    }
+
+    /// <summary>
+    /// Tries to look up the sub-agent binding previously registered for <paramref name="sessionId"/>
+    /// via <see cref="GetOrAddSubAgentBinding"/>. Returns false (with <paramref name="binding"/>
+    /// set to null) when no binding exists — the discovery webhook treats that as a best-effort
+    /// no-op rather than an error, since the session may not have routed through the agent path
+    /// yet.
+    /// </summary>
+    public bool TryGetSubAgentBinding(string sessionId, out SubAgentSessionBinding? binding)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            binding = null;
+            return false;
+        }
+
+        return _subAgentBindings.TryGetValue(sessionId, out binding);
+    }
+
+    /// <summary>
+    /// Tries to look up a created <see cref="SandboxSession"/> by its gateway-allocated session id.
+    /// Returns false (with <paramref name="session"/> set to null) when no session has been created
+    /// with that id yet — discovery callbacks that race ahead of session creation are treated as
+    /// best-effort no-ops by the caller.
+    /// </summary>
+    public bool TryGetSessionById(string sessionId, out SandboxSession? session)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            session = null;
+            return false;
+        }
+
+        return _sessionsById.TryGetValue(sessionId, out session);
     }
 
     private const int ErrorBodyMaxLength = 500;

--- a/src/LmCore/Middleware/FunctionRegistry.cs
+++ b/src/LmCore/Middleware/FunctionRegistry.cs
@@ -10,16 +10,22 @@ namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
 
 /// <summary>
 ///     Builder for combining functions from multiple sources with conflict resolution.
-///     IMPORTANT: This class is NOT thread-safe. It is designed to be used in a single-threaded
-///     context during application initialization. The registry should be built once during startup
-///     and the resulting function collections should be treated as read-only.
+///     IMPORTANT: Configuration (AddProvider, AddFunction, WithXxx) is NOT thread-safe and must
+///     run single-threaded at startup. Once configured, the registry is effectively frozen — at
+///     that point <see cref="Build"/> and <see cref="BuildContracts"/> may be called repeatedly
+///     and concurrently. Per-turn callers (e.g. <see cref="ToolCallInjectionMiddleware"/> via its
+///     factory delegate) rely on this contract so a mutating upstream catalog
+///     (e.g. <c>MutableSubAgentTemplateSource</c>, whose own thread-safety is provided by its
+///     internal <c>ConcurrentDictionary</c>) surfaces on the next turn without rebuilding the
+///     middleware stack.
 ///     Typical usage pattern:
-///     1. Create a FunctionRegistry instance during initialization
-///     2. Configure it with providers and settings
-///     3. Call Build() once to generate the final function collections
-///     4. Use the built collections (which are immutable) throughout the application lifetime
-///     Do not modify the registry after calling Build(), and do not share a FunctionRegistry
-///     instance across multiple threads during configuration.
+///     1. Create a FunctionRegistry instance during initialization.
+///     2. Configure it with providers and settings.
+///     3. Stop configuring (freeze).
+///     4. Call Build() / BuildContracts() per request. Provider-internal state may evolve as long
+///        as the provider documents its own thread-safety; the registry's own member collections
+///        are read-only after step 3.
+///     Do not call configuration methods after step 3.
 /// </summary>
 public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithProviders, IConfiguredFunctionRegistry
 {
@@ -86,6 +92,24 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
         }
 
         return issues;
+    }
+
+    /// <summary>
+    ///     Re-materializes only the function contracts from the registered providers and
+    ///     explicit functions. Side-effect free and repeatable — callers may invoke this
+    ///     per request (e.g. <see cref="ToolCallInjectionMiddleware"/>'s factory delegate)
+    ///     so a mutating upstream catalog (such as <c>MutableSubAgentTemplateSource</c>)
+    ///     surfaces on the next turn without rebuilding the middleware stack.
+    /// </summary>
+    /// <remarks>
+    ///     This shares the contract-materialization path with <see cref="Build"/>; the
+    ///     handler dictionary it produces is discarded. Provider handlers are method
+    ///     references, so re-running the path is cheap.
+    /// </remarks>
+    public IEnumerable<FunctionContract> BuildContracts()
+    {
+        var (contracts, _) = Build();
+        return contracts;
     }
 
     /// <summary>
@@ -179,7 +203,10 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
             finalHandlers[registeredName] = resolved.Handler;
         }
 
-        logger.LogInformation(
+        // Debug rather than Information because Build() is now re-run per turn via
+        // BuildContracts() to surface mutable upstream catalogs (e.g. MutableSubAgentTemplateSource);
+        // emitting an Information record every turn would spam logs.
+        logger.LogDebug(
             "Function registry built: {ContractCount} functions registered",
             finalContracts.Count
         );
@@ -221,8 +248,11 @@ public class FunctionRegistry : IFunctionRegistryBuilder, IFunctionRegistryWithP
         ILogger<ToolCallInjectionMiddleware>? logger = null
     )
     {
-        var (contracts, handlers) = Build();
-        var middleware = new ToolCallInjectionMiddleware(contracts, name, logger);
+        var (_, handlers) = Build();
+        var middleware = new ToolCallInjectionMiddleware(
+            BuildContracts,
+            name,
+            logger);
         return (middleware, handlers);
     }
 

--- a/src/LmCore/Middleware/ToolCallInjectionMiddleware.cs
+++ b/src/LmCore/Middleware/ToolCallInjectionMiddleware.cs
@@ -11,26 +11,50 @@ namespace AchieveAi.LmDotnetTools.LmCore.Middleware;
 ///     This middleware does NOT execute tools - it only makes them available to the LLM.
 ///     Use with ToolCallExecutor for explicit tool execution in application code.
 /// </summary>
+/// <remarks>
+///     The middleware always reads the current function set through a factory delegate so a
+///     mutating upstream catalog (e.g. mid-session sub-agent template discovery) surfaces in
+///     the next call's request options without needing to rebuild the middleware stack.
+/// </remarks>
 public class ToolCallInjectionMiddleware : IStreamingMiddleware
 {
-    private readonly IEnumerable<FunctionContract> _functions;
+    private readonly Func<IEnumerable<FunctionContract>> _functionsFactory;
     private readonly ILogger<ToolCallInjectionMiddleware> _logger;
 
     /// <summary>
-    ///     Creates a new instance of ToolCallInjectionMiddleware
+    ///     Creates a new instance of ToolCallInjectionMiddleware.
     /// </summary>
-    /// <param name="functions">The function contracts to inject into requests</param>
-    /// <param name="name">Optional name for this middleware instance</param>
-    /// <param name="logger">Optional logger</param>
+    /// <param name="functionsFactory">
+    ///     Factory returning the current function contracts for each request. Invoked once per
+    ///     <see cref="InvokeAsync"/> / <see cref="InvokeStreamingAsync"/> call so a mutable
+    ///     upstream source (e.g. <c>MutableSubAgentTemplateSource</c>) is reflected on the
+    ///     next call without rebuilding middleware.
+    /// </param>
+    /// <param name="name">Optional name for this middleware instance.</param>
+    /// <param name="logger">Optional logger.</param>
+    public ToolCallInjectionMiddleware(
+        Func<IEnumerable<FunctionContract>> functionsFactory,
+        string? name = null,
+        ILogger<ToolCallInjectionMiddleware>? logger = null
+    )
+    {
+        _functionsFactory = functionsFactory ?? throw new ArgumentNullException(nameof(functionsFactory));
+        _logger = logger ?? NullLogger<ToolCallInjectionMiddleware>.Instance;
+        Name = name ?? nameof(ToolCallInjectionMiddleware);
+    }
+
+    /// <summary>
+    ///     Convenience overload for callers with a fixed function set. Captures
+    ///     <paramref name="functions"/> in a no-op factory.
+    /// </summary>
     public ToolCallInjectionMiddleware(
         IEnumerable<FunctionContract> functions,
         string? name = null,
         ILogger<ToolCallInjectionMiddleware>? logger = null
     )
+        : this(() => functions, name, logger)
     {
-        _functions = functions ?? throw new ArgumentNullException(nameof(functions));
-        _logger = logger ?? NullLogger<ToolCallInjectionMiddleware>.Instance;
-        Name = name ?? nameof(ToolCallInjectionMiddleware);
+        ArgumentNullException.ThrowIfNull(functions);
     }
 
     public string? Name { get; }
@@ -41,13 +65,17 @@ public class ToolCallInjectionMiddleware : IStreamingMiddleware
         CancellationToken cancellationToken = default
     )
     {
+        // Materialize once: the factory may iterate a thread-safe dictionary, and PrepareOptions +
+        // the optional Debug log would otherwise re-enumerate it.
+        var functions = _functionsFactory().ToList();
+
         if (_logger.IsEnabled(LogLevel.Debug))
         {
-            _logger.LogDebug("Injecting {FunctionCount} functions into request options", _functions.Count());
+            _logger.LogDebug("Injecting {FunctionCount} functions into request options", functions.Count);
         }
 
         // Clone options and add functions
-        var modifiedOptions = PrepareOptions(context.Options);
+        var modifiedOptions = PrepareOptions(context.Options, functions);
 
         // Generate reply with the modified options
         ArgumentNullException.ThrowIfNull(agent);
@@ -62,13 +90,15 @@ public class ToolCallInjectionMiddleware : IStreamingMiddleware
         CancellationToken cancellationToken = default
     )
     {
+        var functions = _functionsFactory().ToList();
+
         if (_logger.IsEnabled(LogLevel.Debug))
         {
-            _logger.LogDebug("Injecting {FunctionCount} functions into streaming request options", _functions.Count());
+            _logger.LogDebug("Injecting {FunctionCount} functions into streaming request options", functions.Count);
         }
 
         // Clone options and add functions
-        var modifiedOptions = PrepareOptions(context.Options);
+        var modifiedOptions = PrepareOptions(context.Options, functions);
 
         // Get the streaming response from the agent
         ArgumentNullException.ThrowIfNull(agent);
@@ -82,23 +112,27 @@ public class ToolCallInjectionMiddleware : IStreamingMiddleware
     }
 
     /// <summary>
-    ///     Prepares the options by combining middleware functions with context options functions
+    ///     Prepares the options by combining middleware functions with context options functions.
     /// </summary>
-    private GenerateReplyOptions PrepareOptions(GenerateReplyOptions? contextOptions)
+    private static GenerateReplyOptions PrepareOptions(
+        GenerateReplyOptions? contextOptions,
+        IEnumerable<FunctionContract> functions)
     {
         var options = contextOptions ?? new GenerateReplyOptions();
-        var combinedFunctions = CombineFunctions(options.Functions);
+        var combinedFunctions = CombineFunctions(functions, options.Functions);
         return options with { Functions = combinedFunctions?.ToArray() };
     }
 
     /// <summary>
-    ///     Combines middleware functions with option functions
+    ///     Combines middleware functions with option functions.
     /// </summary>
-    private IEnumerable<FunctionContract>? CombineFunctions(IEnumerable<FunctionContract>? optionFunctions)
+    private static IEnumerable<FunctionContract>? CombineFunctions(
+        IEnumerable<FunctionContract>? middlewareFunctions,
+        IEnumerable<FunctionContract>? optionFunctions)
     {
-        return _functions == null && optionFunctions == null ? null
-            : _functions == null ? optionFunctions
-            : optionFunctions == null ? _functions
-            : _functions.Concat(optionFunctions);
+        return middlewareFunctions == null && optionFunctions == null ? null
+            : middlewareFunctions == null ? optionFunctions
+            : optionFunctions == null ? middlewareFunctions
+            : middlewareFunctions.Concat(optionFunctions);
     }
 }

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -65,6 +65,12 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
     /// <param name="store">Optional persistence store for conversation state</param>
     /// <param name="logger">Optional logger</param>
     /// <param name="subAgentOptions">Optional sub-agent orchestration configuration</param>
+    /// <param name="subAgentTemplateSource">
+    ///     Optional mutable template catalog shared with an outer owner (e.g. a sandbox
+    ///     session registry that activates discovered subagents mid-session). When null
+    ///     and <paramref name="subAgentOptions"/> is provided, the loop wraps
+    ///     <c>subAgentOptions.Templates</c> in a fresh, private source.
+    /// </param>
     /// <param name="loggerFactory">
     ///     Optional logger factory used to give the internal message pipeline middlewares
     ///     (MessageTransformation, MessageUpdateJoiner) their own category loggers so their
@@ -82,6 +88,7 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         IConversationStore? store = null,
         ILogger<MultiTurnAgentLoop>? logger = null,
         SubAgentOptions? subAgentOptions = null,
+        MutableSubAgentTemplateSource? subAgentTemplateSource = null,
         ILoggerFactory? loggerFactory = null)
         : base(threadId, systemPrompt, defaultOptions, maxTurnsPerRun, inputChannelCapacity, outputChannelCapacity, store, logger)
     {
@@ -97,16 +104,24 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
             // Agent/CheckAgent tools, preventing unbounded recursive delegation.
             var (contracts, handlers) = functionRegistry.Build();
 
+            // Use the caller-supplied source when present (so an outer owner — typically
+            // a sandbox session registry — can activate discovered subagents mid-session
+            // by calling TryRegister on it). Otherwise wrap the static template dictionary
+            // in a fresh source so behavior matches the previous immutable contract.
+            var source = subAgentTemplateSource
+                ?? new MutableSubAgentTemplateSource(subAgentOptions.Templates);
+
             _subAgentManager = new SubAgentManager(
                 parentAgent: this,
                 parentContracts: [.. contracts],
                 parentHandlers: handlers,
                 options: subAgentOptions,
+                source: source,
                 logger: logger);
 
             var toolProvider = new SubAgentToolProvider(
                 _subAgentManager,
-                subAgentOptions.Templates);
+                source);
 
             _ = functionRegistry.AddProvider(toolProvider);
         }

--- a/src/LmMultiTurn/SubAgents/MutableSubAgentTemplateSource.cs
+++ b/src/LmMultiTurn/SubAgents/MutableSubAgentTemplateSource.cs
@@ -1,0 +1,62 @@
+using System.Collections.Concurrent;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+
+/// <summary>
+/// Thread-safe, mutable catalog of sub-agent templates. Crosses the boundary between
+/// webhook threads that register newly-discovered templates mid-session and the agent
+/// loop that reads them when building each turn's tool descriptors.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Collision policy is <b>first-wins</b>: <see cref="TryRegister"/> only adds new entries
+/// and returns false on conflict. This matches the trust-boundary semantics established
+/// by <c>WorkspaceSubAgentLoader.MergeBuiltInWins</c> — built-in (trusted) seeds enter
+/// the source first, and discovered (untrusted) entries cannot shadow them.
+/// </para>
+/// <para>
+/// <see cref="Templates"/> returns the live <see cref="ConcurrentDictionary{TKey,TValue}"/>
+/// view. Enumerating it during a concurrent <see cref="TryRegister"/> is safe — the
+/// snapshot may include or exclude the new entry depending on timing, but never throws
+/// and never tears.
+/// </para>
+/// </remarks>
+public sealed class MutableSubAgentTemplateSource
+{
+    private readonly ConcurrentDictionary<string, SubAgentTemplate> _templates;
+
+    /// <summary>
+    /// Creates an empty source.
+    /// </summary>
+    public MutableSubAgentTemplateSource()
+    {
+        _templates = new ConcurrentDictionary<string, SubAgentTemplate>(StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Creates a source pre-seeded with <paramref name="initial"/>. Entries are copied; the
+    /// source does not retain a reference to the supplied dictionary.
+    /// </summary>
+    public MutableSubAgentTemplateSource(IReadOnlyDictionary<string, SubAgentTemplate> initial)
+    {
+        ArgumentNullException.ThrowIfNull(initial);
+        _templates = new ConcurrentDictionary<string, SubAgentTemplate>(initial, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Live snapshot of the current templates. Reads are lock-free; consumers should treat
+    /// the returned view as read-only.
+    /// </summary>
+    public IReadOnlyDictionary<string, SubAgentTemplate> Templates => _templates;
+
+    /// <summary>
+    /// Atomically registers <paramref name="template"/> under <paramref name="name"/>. Returns
+    /// true on first registration and false when an entry already exists for that name.
+    /// </summary>
+    public bool TryRegister(string name, SubAgentTemplate template)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(template);
+        return _templates.TryAdd(name, template);
+    }
+}

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -22,6 +22,7 @@ public sealed class SubAgentManager : IAsyncDisposable
     private readonly IReadOnlyList<FunctionContract> _parentContracts;
     private readonly IDictionary<string, ToolHandler> _parentHandlers;
     private readonly SubAgentOptions _options;
+    private readonly MutableSubAgentTemplateSource _source;
     private readonly ILogger _logger;
 
     private readonly ConcurrentDictionary<string, SubAgentState> _agents = new();
@@ -33,17 +34,20 @@ public sealed class SubAgentManager : IAsyncDisposable
         IReadOnlyList<FunctionContract> parentContracts,
         IDictionary<string, ToolHandler> parentHandlers,
         SubAgentOptions options,
+        MutableSubAgentTemplateSource source,
         ILogger? logger = null)
     {
         ArgumentNullException.ThrowIfNull(parentAgent);
         ArgumentNullException.ThrowIfNull(parentContracts);
         ArgumentNullException.ThrowIfNull(parentHandlers);
         ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(source);
 
         _parentAgent = parentAgent;
         _parentContracts = parentContracts;
         _parentHandlers = parentHandlers;
         _options = options;
+        _source = source;
         _logger = logger ?? NullLogger.Instance;
         _concurrencyGate = new SemaphoreSlim(
             options.MaxConcurrentSubAgents,
@@ -67,11 +71,14 @@ public sealed class SubAgentManager : IAsyncDisposable
         string[]? removeTools = null,
         CancellationToken ct = default)
     {
-        if (!_options.Templates.TryGetValue(templateName, out var template))
+        // Snapshot the live source view so a concurrent TryRegister cannot make the
+        // diagnostic Available list inconsistent with the lookup that produced template.
+        var templates = _source.Templates;
+        if (!templates.TryGetValue(templateName, out var template))
         {
             throw new ArgumentException(
                 $"Unknown template '{templateName}'. " +
-                $"Available: {string.Join(", ", _options.Templates.Keys)}",
+                $"Available: {string.Join(", ", templates.Keys)}",
                 nameof(templateName));
         }
 
@@ -359,7 +366,7 @@ public sealed class SubAgentManager : IAsyncDisposable
     /// </summary>
     public IReadOnlyList<string> GetTemplateNames()
     {
-        return _options.Templates.Keys.ToList().AsReadOnly();
+        return _source.Templates.Keys.ToList().AsReadOnly();
     }
 
     public async ValueTask DisposeAsync()

--- a/src/LmMultiTurn/SubAgents/SubAgentToolProvider.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentToolProvider.cs
@@ -15,16 +15,16 @@ namespace AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 public class SubAgentToolProvider : IFunctionProvider
 {
     private readonly SubAgentManager _manager;
-    private readonly IReadOnlyDictionary<string, SubAgentTemplate> _templates;
+    private readonly MutableSubAgentTemplateSource _source;
 
     public SubAgentToolProvider(
         SubAgentManager manager,
-        IReadOnlyDictionary<string, SubAgentTemplate> templates)
+        MutableSubAgentTemplateSource source)
     {
         ArgumentNullException.ThrowIfNull(manager);
-        ArgumentNullException.ThrowIfNull(templates);
+        ArgumentNullException.ThrowIfNull(source);
         _manager = manager;
-        _templates = templates;
+        _source = source;
     }
 
     public string ProviderName => "SubAgentTools";
@@ -43,7 +43,11 @@ public class SubAgentToolProvider : IFunctionProvider
 
     private FunctionDescriptor CreateAgentDescriptor()
     {
-        var typeList = string.Join(", ", _templates.Keys);
+        // Snapshot the live templates view once per descriptor build so the catalog text
+        // and the subagent_type enum list are consistent within this descriptor even when
+        // TryRegister lands concurrently.
+        var templates = _source.Templates;
+        var typeList = string.Join(", ", templates.Keys);
 
         var contract = new FunctionContract
         {
@@ -60,7 +64,7 @@ public class SubAgentToolProvider : IFunctionProvider
                 + "Each sub-agent starts fresh and does NOT see your conversation history, "
                 + "so make the prompt self-contained. Use SendMessage to continue an "
                 + "existing sub-agent with a follow-up.\n\n"
-                + BuildTemplateCatalog(),
+                + BuildTemplateCatalog(templates),
             Parameters =
             [
                 new FunctionParameterContract
@@ -226,12 +230,12 @@ public class SubAgentToolProvider : IFunctionProvider
     /// Builds the per-template catalog embedded in the Agent tool description so the
     /// parent LLM can pick the right sub-agent type.
     /// </summary>
-    private string BuildTemplateCatalog()
+    private static string BuildTemplateCatalog(IReadOnlyDictionary<string, SubAgentTemplate> templates)
     {
         var sb = new StringBuilder();
         _ = sb.Append("Available sub-agent types (subagent_type):");
 
-        foreach (var (key, template) in _templates)
+        foreach (var (key, template) in templates)
         {
             var description = string.IsNullOrWhiteSpace(template.Description)
                 ? "(no description provided)"

--- a/tests/LmCore.Tests/Middleware/FunctionRegistryTests.cs
+++ b/tests/LmCore.Tests/Middleware/FunctionRegistryTests.cs
@@ -207,6 +207,65 @@ public class FunctionRegistryTests
     }
 
     [Fact]
+    public void BuildContracts_ReturnsSameContractsAsBuild()
+    {
+        // BuildContracts is the per-call hook ToolCallInjectionMiddleware uses; it must produce
+        // the same contracts as Build() (the canonical materialization path) so the catalog the
+        // LLM sees is identical to the one whose handlers are registered.
+        string[] funcs = ["func1", "func2"];
+        var registry = new FunctionRegistry();
+        var provider = CreateTestProvider("test", funcs);
+        _ = registry.AddProvider(provider);
+
+        var (buildContracts, _) = registry.Build();
+        var standaloneContracts = registry.BuildContracts();
+
+        Assert.Equal(
+            buildContracts.Select(c => c.Name).OrderBy(n => n),
+            standaloneContracts.Select(c => c.Name).OrderBy(n => n));
+    }
+
+    [Fact]
+    public void BuildContracts_Repeatable_SideEffectFree()
+    {
+        // The middleware calls BuildContracts() on every request; mutating internal registry
+        // state per-call would (a) break repeatability and (b) leak handler dictionaries.
+        // This test pins that calling BuildContracts twice returns the same contracts and that
+        // a subsequent Build() still works correctly.
+        string[] funcs = ["alpha", "beta"];
+        var registry = new FunctionRegistry();
+        _ = registry.AddProvider(CreateTestProvider("p", funcs));
+
+        var first = registry.BuildContracts().Select(c => c.Name).OrderBy(n => n).ToArray();
+        var second = registry.BuildContracts().Select(c => c.Name).OrderBy(n => n).ToArray();
+        var (afterBuild, handlersAfter) = registry.Build();
+
+        var third = afterBuild.Select(c => c.Name).OrderBy(n => n).ToArray();
+        Assert.Equal(first, second);
+        Assert.Equal(first, third);
+        Assert.Equal(2, handlersAfter.Count);
+    }
+
+    [Fact]
+    public void BuildContracts_ObservesNewlyAddedProvider()
+    {
+        // The mid-session activation flow registers a new template into a MutableSubAgentTemplateSource
+        // and relies on the registry-equivalent surface (BuildContracts) to expose it. Mirror the
+        // same dynamic-add behaviour here directly against the FunctionRegistry path.
+        var registry = new FunctionRegistry();
+        _ = registry.AddProvider(CreateTestProvider("p1", ["one"]));
+
+        var before = registry.BuildContracts().Select(c => c.Name).ToArray();
+        _ = registry.AddProvider(CreateTestProvider("p2", ["two"]));
+        var after = registry.BuildContracts().Select(c => c.Name).OrderBy(n => n).ToArray();
+
+        string[] expectedBefore = ["one"];
+        string[] expectedAfter = ["one", "two"];
+        Assert.Equal(expectedBefore, before);
+        Assert.Equal(expectedAfter, after);
+    }
+
+    [Fact]
     public void BuildMiddleware_CreatesWorkingMiddleware()
     {
         // Arrange

--- a/tests/LmCore.Tests/Middleware/ToolCallInjectionMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/ToolCallInjectionMiddlewareTests.cs
@@ -1,0 +1,130 @@
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.Middleware;
+
+/// <summary>
+/// Pins the factory-delegate contract of <see cref="ToolCallInjectionMiddleware"/>: the delegate
+/// must be invoked once per Invoke/InvokeStreaming call so a mutating upstream catalog (e.g.
+/// <c>MutableSubAgentTemplateSource</c>) surfaces on the next turn without rebuilding the
+/// middleware stack — this is the mechanism that enables mid-session sub-agent activation.
+/// </summary>
+public class ToolCallInjectionMiddlewareTests
+{
+    private static FunctionContract Contract(string name) => new()
+    {
+        Name = name,
+        Description = $"Test function {name}",
+        Parameters = [],
+    };
+
+    [Fact]
+    public async Task InvokeAsync_InvokesFactoryEachCall_ReflectsMutationOnNextCall()
+    {
+        // The whole point of the factory delegate is that a later mutation of the underlying
+        // function set surfaces on the next call. If the middleware cached the first snapshot
+        // it would defeat mid-session sub-agent activation.
+        var functions = new List<FunctionContract> { Contract("first") };
+        var middleware = new ToolCallInjectionMiddleware(() => functions);
+
+        var capturedOptions = new List<GenerateReplyOptions?>();
+        var mockAgent = new Mock<IAgent>();
+        mockAgent
+            .Setup(a => a.GenerateReplyAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>(
+                (_, opts, _) => capturedOptions.Add(opts))
+            .ReturnsAsync([new TextMessage { Text = "ok", Role = Role.Assistant }]);
+
+        var context = new MiddlewareContext([new TextMessage { Text = "hi", Role = Role.User }]);
+        _ = await middleware.InvokeAsync(context, mockAgent.Object);
+
+        functions.Add(Contract("second"));
+        _ = await middleware.InvokeAsync(context, mockAgent.Object);
+
+        capturedOptions.Should().HaveCount(2);
+        capturedOptions[0]!.Functions!.Select(f => f.Name).Should().BeEquivalentTo(["first"]);
+        capturedOptions[1]!.Functions!.Select(f => f.Name).Should().BeEquivalentTo(["first", "second"]);
+    }
+
+    [Fact]
+    public async Task InvokeStreamingAsync_InvokesFactoryEachCall_ReflectsMutationOnNextCall()
+    {
+        // Parity with the non-streaming path — the streaming surface is what the multi-turn loop
+        // actually uses, so the mid-session activation path must work here too.
+        var functions = new List<FunctionContract> { Contract("first") };
+        var middleware = new ToolCallInjectionMiddleware(() => functions);
+
+        var capturedOptions = new List<GenerateReplyOptions?>();
+        var mockAgent = new Mock<IStreamingAgent>();
+        mockAgent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>(
+                (_, opts, _) => capturedOptions.Add(opts))
+            .ReturnsAsync(EmptyStream());
+
+        var context = new MiddlewareContext([new TextMessage { Text = "hi", Role = Role.User }]);
+        _ = await middleware.InvokeStreamingAsync(context, mockAgent.Object);
+
+        functions.Add(Contract("second"));
+        _ = await middleware.InvokeStreamingAsync(context, mockAgent.Object);
+
+        capturedOptions.Should().HaveCount(2);
+        capturedOptions[0]!.Functions!.Select(f => f.Name).Should().BeEquivalentTo(["first"]);
+        capturedOptions[1]!.Functions!.Select(f => f.Name).Should().BeEquivalentTo(["first", "second"]);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_MergesFactoryFunctions_WithExistingOptionsFunctions()
+    {
+        // Caller-supplied request functions (e.g. set by a higher middleware) must not be
+        // dropped just because the injection middleware also has its own catalog.
+        FunctionContract[] mwFns = [Contract("middleware")];
+        var middleware = new ToolCallInjectionMiddleware(() => mwFns);
+        var existingOptions = new GenerateReplyOptions { Functions = [Contract("existing")] };
+        var context = new MiddlewareContext([new TextMessage { Text = "hi", Role = Role.User }], existingOptions);
+
+        GenerateReplyOptions? captured = null;
+        var mockAgent = new Mock<IAgent>();
+        mockAgent
+            .Setup(a => a.GenerateReplyAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>(
+                (_, opts, _) => captured = opts)
+            .ReturnsAsync([new TextMessage { Text = "ok", Role = Role.Assistant }]);
+
+        _ = await middleware.InvokeAsync(context, mockAgent.Object);
+
+        captured!.Functions!.Select(f => f.Name)
+            .Should().BeEquivalentTo(["middleware", "existing"]);
+    }
+
+    [Fact]
+    public void Constructor_NullFactory_Throws()
+    {
+        var act = () => new ToolCallInjectionMiddleware((Func<IEnumerable<FunctionContract>>)null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_FixedFunctionsOverload_NullFunctions_Throws()
+    {
+        var act = () => new ToolCallInjectionMiddleware((IEnumerable<FunctionContract>)null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    private static async IAsyncEnumerable<IMessage> EmptyStream()
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+}

--- a/tests/LmMultiTurn.Tests/MidSessionTemplateActivationTests.cs
+++ b/tests/LmMultiTurn.Tests/MidSessionTemplateActivationTests.cs
@@ -1,0 +1,275 @@
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+/// <summary>
+/// End-to-end integration test for issue #77: a template registered into the shared
+/// <see cref="MutableSubAgentTemplateSource"/> mid-session must surface in the request options
+/// that <see cref="ToolCallInjectionMiddleware"/> passes to the underlying agent on the NEXT
+/// turn — without rebuilding the middleware stack. This pins the full chain
+/// <c>MutableSubAgentTemplateSource → SubAgentToolProvider → FunctionRegistry.BuildContracts →
+/// ToolCallInjectionMiddleware</c> as one wired path, so a regression in any link breaks here.
+/// </summary>
+public class MidSessionTemplateActivationTests : IAsyncLifetime
+{
+    private readonly Mock<IMultiTurnAgent> _parentMock = new();
+    private readonly Mock<IStreamingAgent> _subAgentMock = new();
+    private SubAgentManager? _manager;
+    private MutableSubAgentTemplateSource? _source;
+    private ToolCallInjectionMiddleware? _middleware;
+
+    public Task InitializeAsync()
+    {
+        _parentMock
+            .Setup(p => p.SendAsync(
+                It.IsAny<List<IMessage>>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SendReceipt("receipt-1", null, DateTimeOffset.UtcNow));
+
+        var seed = new SubAgentTemplate
+        {
+            Name = "researcher",
+            SystemPrompt = "You are a researcher.",
+            Description = "Researches topics.",
+            WhenToUse = "Use for investigation.",
+            AgentFactory = () => _subAgentMock.Object,
+        };
+
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate> { ["researcher"] = seed },
+            MaxConcurrentSubAgents = 5,
+        };
+
+        _source = new MutableSubAgentTemplateSource(options.Templates);
+
+        _manager = new SubAgentManager(
+            parentAgent: _parentMock.Object,
+            parentContracts: [],
+            parentHandlers: new Dictionary<string, ToolHandler>(),
+            options: options,
+            source: _source);
+
+        var provider = new SubAgentToolProvider(_manager, _source);
+        var registry = new FunctionRegistry().AddProvider(provider);
+
+        var (middleware, _) = registry.BuildToolCallComponents();
+        _middleware = middleware;
+
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_manager != null)
+        {
+            await _manager.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task TryRegister_MidSession_SurfacesInNextTurnRequestOptions()
+    {
+        // Pin the end-to-end mid-session activation flow. Turn 1: only the seeded template is
+        // visible in the Agent tool description. Webhook fires (simulated by a TryRegister call
+        // on the same source). Turn 2: the new template surfaces in the request options that
+        // hit the agent — without recreating any middleware.
+        var capturedOptions = new List<GenerateReplyOptions?>();
+        var agentMock = new Mock<IAgent>();
+        agentMock
+            .Setup(a => a.GenerateReplyAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>(
+                (_, opts, _) => capturedOptions.Add(opts))
+            .ReturnsAsync([new TextMessage { Text = "ok", Role = Role.Assistant }]);
+
+        var ctx = new MiddlewareContext([new TextMessage { Text = "hi", Role = Role.User }]);
+
+        _ = await _middleware!.InvokeAsync(ctx, agentMock.Object);
+
+        var turnOneAgent = capturedOptions[0]!.Functions!.First(f => f.Name == "Agent");
+        turnOneAgent.Description.Should().Contain("researcher");
+        turnOneAgent.Description.Should().NotContain("reviewer");
+
+        // Discovery webhook arrives mid-session.
+        _source!.TryRegister("reviewer", new SubAgentTemplate
+        {
+            Name = "reviewer",
+            SystemPrompt = "You are a reviewer.",
+            Description = "Reviews PRs.",
+            WhenToUse = "Use after coder lands a change.",
+            AgentFactory = () => _subAgentMock.Object,
+        }).Should().BeTrue();
+
+        _ = await _middleware!.InvokeAsync(ctx, agentMock.Object);
+
+        var turnTwoAgent = capturedOptions[1]!.Functions!.First(f => f.Name == "Agent");
+        turnTwoAgent.Description.Should().Contain("researcher");
+        turnTwoAgent.Description.Should().Contain("reviewer");
+        turnTwoAgent.Description.Should().Contain("Reviews PRs.");
+    }
+
+    [Fact]
+    public async Task MultiTurnAgentLoop_ConstructedWithSharedSource_NextTurnSeesActivatedTemplate()
+    {
+        // Pin the Program.cs wiring decision: passing a `subAgentTemplateSource` to the loop ctor
+        // must route through SubAgentToolProvider so a later TryRegister surfaces on the next turn
+        // hitting the provider agent. If a future refactor drops the `?? new MutableSubAgentTemplateSource`
+        // fallback OR ignores `subAgentTemplateSource` and constructs its own private source, the
+        // unit-level provider tests still pass but this test fails — pinning the chain at the seam
+        // the production sample actually uses.
+        var capturedOptions = new List<GenerateReplyOptions?>();
+        var providerAgent = new Mock<IStreamingAgent>();
+        providerAgent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>(
+                (_, opts, _) => capturedOptions.Add(opts))
+            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>(
+                (_, _, _) => Task.FromResult(SingleTextReply($"turn-{capturedOptions.Count}")));
+
+        var sharedSource = new MutableSubAgentTemplateSource(
+            new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal)
+            {
+                ["researcher"] = new SubAgentTemplate
+                {
+                    Name = "researcher",
+                    SystemPrompt = "You are a researcher.",
+                    Description = "Researches topics.",
+                    WhenToUse = "Use for investigation.",
+                    AgentFactory = () => _subAgentMock.Object,
+                },
+            });
+
+        var loopOptions = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal),
+            MaxConcurrentSubAgents = 5,
+        };
+
+        var registry = new FunctionRegistry();
+        await using var loop = new MultiTurnAgentLoop(
+            providerAgent.Object,
+            registry,
+            threadId: "wi77-loop-wiring",
+            subAgentOptions: loopOptions,
+            subAgentTemplateSource: sharedSource);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = loop.RunAsync(cts.Token);
+
+        try
+        {
+            await DrainSingleTurnAsync(loop, "turn one", cts.Token);
+
+            capturedOptions.Should().NotBeEmpty(
+                "the loop's parent agent must have been invoked at least once on turn 1");
+            var turnOne = capturedOptions[^1]!.Functions!.First(f => f.Name == "Agent");
+            turnOne.Description.Should().Contain("researcher");
+            turnOne.Description.Should().NotContain("reviewer");
+
+            // Webhook arrives mid-session.
+            sharedSource.TryRegister("reviewer", new SubAgentTemplate
+            {
+                Name = "reviewer",
+                SystemPrompt = "You are a reviewer.",
+                Description = "Reviews PRs.",
+                WhenToUse = "Use after coder lands a change.",
+                AgentFactory = () => _subAgentMock.Object,
+            }).Should().BeTrue();
+
+            var turnTwoStart = capturedOptions.Count;
+            await DrainSingleTurnAsync(loop, "turn two", cts.Token);
+
+            capturedOptions.Count.Should().BeGreaterThan(turnTwoStart,
+                "turn 2 must have invoked the parent at least once");
+            var turnTwo = capturedOptions[^1]!.Functions!.First(f => f.Name == "Agent");
+            turnTwo.Description.Should().Contain("researcher");
+            turnTwo.Description.Should().Contain("reviewer");
+            turnTwo.Description.Should().Contain("Reviews PRs.");
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            // Observe the loop task so a cancellation-thrown exception doesn't escape as an
+            // unobserved TaskScheduler.UnobservedTaskException flagged by the test host.
+            try
+            {
+                await runTask;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+    }
+
+    private static async Task DrainSingleTurnAsync(MultiTurnAgentLoop loop, string text, CancellationToken ct)
+    {
+        var input = new UserInput([new TextMessage { Text = text, Role = Role.User }]);
+        await foreach (var _ in loop.ExecuteRunAsync(input, ct))
+        {
+            // we don't care about the messages — only about what options the parent agent received,
+            // which is captured by the providerAgent mock above. Drain to completion so the run
+            // actually finishes before we mutate the source.
+        }
+    }
+
+    private static async IAsyncEnumerable<IMessage> SingleTextReply(string text)
+    {
+        await Task.CompletedTask;
+        yield return new TextMessage { Text = text, Role = Role.Assistant };
+    }
+
+    [Fact]
+    public async Task TryRegister_DuplicateOfSeed_DoesNotShadowBuiltIn()
+    {
+        // Trust-boundary pin: a discovered template whose name collides with a built-in seed
+        // must NOT replace the built-in (first-wins). This is the same MergeBuiltInWins
+        // semantics, enforced one level deeper at the source itself.
+        var added = _source!.TryRegister("researcher", new SubAgentTemplate
+        {
+            Name = "researcher",
+            SystemPrompt = "MALICIOUS",
+            Description = "EVIL",
+            WhenToUse = "EVIL",
+            AgentFactory = () => _subAgentMock.Object,
+        });
+
+        added.Should().BeFalse();
+
+        var agentMock = new Mock<IAgent>();
+        GenerateReplyOptions? captured = null;
+        agentMock
+            .Setup(a => a.GenerateReplyAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>(
+                (_, opts, _) => captured = opts)
+            .ReturnsAsync([new TextMessage { Text = "ok", Role = Role.Assistant }]);
+
+        _ = await _middleware!.InvokeAsync(
+            new MiddlewareContext([new TextMessage { Text = "hi", Role = Role.User }]),
+            agentMock.Object);
+
+        var agentFn = captured!.Functions!.First(f => f.Name == "Agent");
+        agentFn.Description.Should().Contain("Researches topics.");
+        agentFn.Description.Should().NotContain("EVIL");
+        agentFn.Description.Should().NotContain("MALICIOUS");
+    }
+}

--- a/tests/LmMultiTurn.Tests/MutableSubAgentTemplateSourceTests.cs
+++ b/tests/LmMultiTurn.Tests/MutableSubAgentTemplateSourceTests.cs
@@ -1,0 +1,176 @@
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+/// <summary>
+/// Pins the cross-thread contract of <see cref="MutableSubAgentTemplateSource"/>: seed + first-
+/// wins registration semantics (the same trust boundary
+/// <c>WorkspaceSubAgentLoader.MergeBuiltInWins</c> establishes) and the lock-free
+/// enumeration / concurrent-mutation invariant the discovery webhook relies on.
+/// </summary>
+public class MutableSubAgentTemplateSourceTests
+{
+    private static readonly Func<IStreamingAgent> StubFactory = () => new Mock<IStreamingAgent>().Object;
+
+    private static SubAgentTemplate Template(string name) =>
+        new()
+        {
+            Name = name,
+            Description = $"{name} description",
+            WhenToUse = $"use {name}",
+            SystemPrompt = $"You are {name}.",
+            AgentFactory = StubFactory,
+        };
+
+    [Fact]
+    public void EmptyCtor_StartsWithNoTemplates()
+    {
+        var source = new MutableSubAgentTemplateSource();
+
+        source.Templates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SeededCtor_ExposesSeedEntries()
+    {
+        var seed = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal)
+        {
+            ["researcher"] = Template("researcher"),
+        };
+
+        var source = new MutableSubAgentTemplateSource(seed);
+
+        source.Templates.Should().ContainKey("researcher");
+        source.Templates["researcher"].Name.Should().Be("researcher");
+    }
+
+    [Fact]
+    public void SeededCtor_CopiesEntries_DoesNotShareSeedDictionary()
+    {
+        // The source must not retain a reference to the seed dictionary: a later mutation of the
+        // seed by an unrelated caller cannot retroactively change the catalog the loop is reading.
+        var seed = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal)
+        {
+            ["researcher"] = Template("researcher"),
+        };
+
+        var source = new MutableSubAgentTemplateSource(seed);
+        seed.Remove("researcher");
+
+        source.Templates.Should().ContainKey("researcher");
+    }
+
+    [Fact]
+    public void TryRegister_FirstCall_AddsAndReturnsTrue()
+    {
+        var source = new MutableSubAgentTemplateSource();
+
+        var added = source.TryRegister("echo", Template("echo"));
+
+        added.Should().BeTrue();
+        source.Templates.Should().ContainKey("echo");
+    }
+
+    [Fact]
+    public void TryRegister_DuplicateName_KeepsFirstAndReturnsFalse()
+    {
+        // First-wins matches WorkspaceSubAgentLoader.MergeBuiltInWins's trust boundary: a
+        // discovered template (untrusted) cannot shadow a built-in (trusted) seed.
+        var seed = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal)
+        {
+            ["echo"] = Template("echo"),
+        };
+        var source = new MutableSubAgentTemplateSource(seed);
+        var replacement = Template("echo") with { Description = "replacement" };
+
+        var added = source.TryRegister("echo", replacement);
+
+        added.Should().BeFalse();
+        source.Templates["echo"].Description.Should().Be("echo description");
+    }
+
+    [Fact]
+    public void TryRegister_NullOrBlankName_Throws()
+    {
+        var source = new MutableSubAgentTemplateSource();
+
+        var blankCall = () => source.TryRegister("   ", Template("x"));
+        var nullCall = () => source.TryRegister(null!, Template("x"));
+
+        blankCall.Should().Throw<ArgumentException>();
+        nullCall.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void TryRegister_NullTemplate_Throws()
+    {
+        var source = new MutableSubAgentTemplateSource();
+
+        var act = () => source.TryRegister("echo", null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task ConcurrentTryRegister_NeverThrows_FinalCountMatches()
+    {
+        // ConcurrentDictionary guarantees TryAdd's atomicity; this test pins the surface contract
+        // and ensures no race in our wrapper causes a torn read or lost write under high contention.
+        var source = new MutableSubAgentTemplateSource();
+        const int writerCount = 32;
+        const int writesPerWriter = 100;
+
+        var tasks = Enumerable.Range(0, writerCount).Select(writerIdx => Task.Run(() =>
+        {
+            for (var i = 0; i < writesPerWriter; i++)
+            {
+                // Each writer uses its own keyspace so the only valid race outcome is "everything
+                // landed"; collisions across writers would mask races as a false-success.
+                source.TryRegister($"w{writerIdx}-{i}", Template($"w{writerIdx}-{i}"));
+            }
+        }));
+
+        await Task.WhenAll(tasks);
+
+        source.Templates.Count.Should().Be(writerCount * writesPerWriter);
+    }
+
+    [Fact]
+    public async Task EnumerationDuringConcurrentRegistration_NeverThrows()
+    {
+        // SubAgentToolProvider.CreateAgentDescriptor enumerates Templates while building the
+        // Agent-tool descriptor; a concurrent TryRegister from the discovery webhook must not
+        // throw an InvalidOperationException through that enumeration.
+        var source = new MutableSubAgentTemplateSource();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        var writer = Task.Run(() =>
+        {
+            var i = 0;
+            while (!cts.IsCancellationRequested)
+            {
+                source.TryRegister($"key-{i++}", Template($"k{i}"));
+            }
+        }, cts.Token);
+
+        var reader = Task.Run(() =>
+        {
+            while (!cts.IsCancellationRequested)
+            {
+                // Force enumeration of both keys and values; ConcurrentDictionary's snapshot
+                // semantics make this safe but the test makes the invariant explicit.
+                foreach (var kvp in source.Templates)
+                {
+                    _ = kvp.Key.Length;
+                    _ = kvp.Value.Name;
+                }
+            }
+        }, cts.Token);
+
+        await Task.WhenAll(writer, reader);
+    }
+}

--- a/tests/LmMultiTurn.Tests/SubAgentManagerTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentManagerTests.cs
@@ -646,7 +646,8 @@ public class SubAgentManagerTests : IAsyncLifetime
             parentAgent: _parentMock.Object,
             parentContracts: [],
             parentHandlers: new Dictionary<string, ToolHandler>(),
-            options: options);
+            options: options,
+            source: new MutableSubAgentTemplateSource(options.Templates));
     }
 
     /// <summary>

--- a/tests/LmMultiTurn.Tests/SubAgentToolProviderTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentToolProviderTests.cs
@@ -22,6 +22,7 @@ public class SubAgentToolProviderTests : IAsyncLifetime
     private readonly Mock<IStreamingAgent> _subAgentMock = new();
     private SubAgentManager? _manager;
     private SubAgentToolProvider? _provider;
+    private MutableSubAgentTemplateSource? _source;
 
     public Task InitializeAsync()
     {
@@ -59,13 +60,16 @@ public class SubAgentToolProviderTests : IAsyncLifetime
             MaxConcurrentSubAgents = 5,
         };
 
+        _source = new MutableSubAgentTemplateSource(options.Templates);
+
         _manager = new SubAgentManager(
             parentAgent: _parentMock.Object,
             parentContracts: [],
             parentHandlers: new Dictionary<string, ToolHandler>(),
-            options: options);
+            options: options,
+            source: _source);
 
-        _provider = new SubAgentToolProvider(_manager, options.Templates);
+        _provider = new SubAgentToolProvider(_manager, _source);
 
         return Task.CompletedTask;
     }
@@ -196,6 +200,59 @@ public class SubAgentToolProviderTests : IAsyncLifetime
         // Assert
         await act.Should().ThrowAsync<ArgumentException>()
             .WithMessage("*agent_id*required*");
+    }
+
+    [Fact]
+    public void GetFunctions_AfterTryRegister_ReflectsNewTemplate()
+    {
+        // Mid-session activation contract (#77): when the discovery webhook registers a new
+        // template into the shared source, the next GetFunctions() call must surface it in the
+        // Agent tool's catalog. The ToolCallInjectionMiddleware re-invokes the function-set
+        // factory each request, so this provider must NOT cache its descriptor list.
+        var beforeRegister = _provider!.GetFunctions()
+            .First(f => f.Contract.Name == "Agent").Contract.Description!;
+        beforeRegister.Should().NotContain("reviewer");
+
+        _source!.TryRegister("reviewer", new SubAgentTemplate
+        {
+            Name = "reviewer",
+            SystemPrompt = "You are a reviewer.",
+            Description = "Reviews pull requests for correctness.",
+            WhenToUse = "Use after coder completes a change.",
+            AgentFactory = () => _subAgentMock.Object,
+        }).Should().BeTrue();
+
+        var afterRegister = _provider!.GetFunctions()
+            .First(f => f.Contract.Name == "Agent").Contract.Description!;
+        afterRegister.Should().Contain("reviewer");
+        afterRegister.Should().Contain("Reviews pull requests for correctness.");
+        afterRegister.Should().Contain("Use after coder completes a change.");
+    }
+
+    [Fact]
+    public void AgentDescriptor_SubagentTypeEnumList_IncludesNewlyRegistered()
+    {
+        // The subagent_type parameter description carries a comma-separated enum list of
+        // available template keys; this must also reflect a TryRegister-added template so the
+        // parent LLM knows it can pick the new type.
+        _source!.TryRegister("reviewer", new SubAgentTemplate
+        {
+            Name = "reviewer",
+            SystemPrompt = "You are a reviewer.",
+            Description = "Reviews PRs.",
+            WhenToUse = "After coder.",
+            AgentFactory = () => _subAgentMock.Object,
+        });
+
+        var subagentTypeDesc = _provider!.GetFunctions()
+            .First(f => f.Contract.Name == "Agent")
+            .Contract.Parameters!
+            .First(p => p.Name == "subagent_type")
+            .Description!;
+
+        subagentTypeDesc.Should().Contain("researcher");
+        subagentTypeDesc.Should().Contain("coder");
+        subagentTypeDesc.Should().Contain("reviewer");
     }
 
     private ToolHandler GetHandler(string name)

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
@@ -1,25 +1,37 @@
+using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Services.Auth;
+using LmStreaming.Sample.Services.Discovery;
 using Microsoft.AspNetCore.Http;
 
 namespace LmStreaming.Sample.Tests.Controllers;
 
 /// <summary>
-/// Tests for <see cref="ContextDiscoveryController.Notify"/>: 401 on missing/wrong shared
-/// secret, 400 on malformed payload, 200 on the happy path. The handler is intentionally
-/// thin (log-only), so the contract under test is the auth + payload validation it pins.
+/// Tests for <see cref="ContextDiscoveryController.NotifyAsync"/>: 401 on missing/wrong shared
+/// secret, 400 on malformed payload, 200 on the happy path (including best-effort no-ops when
+/// the session/binding aren't known yet — discovery is an enrichment, not a precondition).
 /// </summary>
 public class ContextDiscoveryControllerTests
 {
     private const string Secret = "test-shared-secret-1234";
+    private const string GatewayBaseUrl = "http://localhost:3000";
 
-    private static ContextDiscoveryController CreateController(string? authorizationHeader)
+    private static ContextDiscoveryController CreateController(
+        string? authorizationHeader,
+        SandboxSessionRegistry? registry = null,
+        WorkspaceSubAgentLoader? loader = null)
     {
         var sharedSecret = new AuthSharedSecret(new AuthOptions
         {
             Webhook = new WebhookOptions { GatewaySharedSecret = Secret },
         });
+
+        registry ??= CreateEmptyRegistry();
+        loader ??= new WorkspaceSubAgentLoader(registry, NullLogger<WorkspaceSubAgentLoader>.Instance);
+
         var controller = new ContextDiscoveryController(
             sharedSecret,
+            registry,
+            loader,
             NullLogger<ContextDiscoveryController>.Instance);
 
         var httpContext = new DefaultHttpContext();
@@ -32,62 +44,84 @@ public class ContextDiscoveryControllerTests
         return controller;
     }
 
+    private static SandboxSessionRegistry CreateEmptyRegistry()
+    {
+        // No HTTP traffic occurs in these tests — the controller's session/binding lookups go
+        // through the in-memory dictionaries only — so a stub handler that throws on use is the
+        // safest contract.
+        static HttpResponseMessage UnusedRespond(HttpRequestMessage _) =>
+            throw new InvalidOperationException("HTTP not expected in ContextDiscoveryControllerTests");
+
+        var gateway = new SandboxGatewayLifetime(
+            new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl },
+            NullLogger<SandboxGatewayLifetime>.Instance,
+            new HttpClient(new StubHandler(UnusedRespond)));
+
+        return new SandboxSessionRegistry(
+            gateway,
+            new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl },
+            NullLogger<SandboxSessionRegistry>.Instance,
+            new HttpClient(new StubHandler(UnusedRespond)),
+            new AuthOptions(),
+            new AuthSharedSecret(new AuthOptions()));
+    }
+
     [Fact]
-    public void Notify_NoAuthorizationHeader_ReturnsUnauthorized()
+    public async Task NotifyAsync_NoAuthorizationHeader_ReturnsUnauthorized()
     {
         var controller = CreateController(authorizationHeader: null);
         var body = new ContextDiscoveryPayload { Kind = "subagent", Name = "echo" };
 
-        var result = controller.Notify(body);
+        var result = await controller.NotifyAsync(body, CancellationToken.None);
 
         result.Should().BeOfType<UnauthorizedResult>();
     }
 
     [Fact]
-    public void Notify_WrongSecret_ReturnsUnauthorized()
+    public async Task NotifyAsync_WrongSecret_ReturnsUnauthorized()
     {
         var controller = CreateController(authorizationHeader: "wrong-secret");
         var body = new ContextDiscoveryPayload { Kind = "subagent", Name = "echo" };
 
-        var result = controller.Notify(body);
+        var result = await controller.NotifyAsync(body, CancellationToken.None);
 
         result.Should().BeOfType<UnauthorizedResult>();
     }
 
     [Fact]
-    public void Notify_CorrectSecret_NullBody_ReturnsBadRequest()
+    public async Task NotifyAsync_CorrectSecret_NullBody_ReturnsBadRequest()
     {
         var controller = CreateController(authorizationHeader: Secret);
 
-        var result = controller.Notify(null);
+        var result = await controller.NotifyAsync(null, CancellationToken.None);
 
         result.Should().BeOfType<BadRequestResult>();
     }
 
     [Fact]
-    public void Notify_CorrectSecret_MissingKind_ReturnsBadRequest()
+    public async Task NotifyAsync_CorrectSecret_MissingKind_ReturnsBadRequest()
     {
         var controller = CreateController(authorizationHeader: Secret);
         var body = new ContextDiscoveryPayload { Name = "echo" };
 
-        var result = controller.Notify(body);
+        var result = await controller.NotifyAsync(body, CancellationToken.None);
 
         result.Should().BeOfType<BadRequestResult>();
     }
 
     [Fact]
-    public void Notify_CorrectSecret_MissingName_ReturnsBadRequest()
+    public async Task NotifyAsync_CorrectSecret_MissingName_ReturnsBadRequest()
     {
         var controller = CreateController(authorizationHeader: Secret);
         var body = new ContextDiscoveryPayload { Kind = "subagent" };
 
-        var result = controller.Notify(body);
+        var result = await controller.NotifyAsync(body, CancellationToken.None);
 
         result.Should().BeOfType<BadRequestResult>();
     }
 
     [Fact]
-    public void Notify_CorrectSecret_WellFormedPayload_ReturnsOk()
+    public async Task NotifyAsync_CorrectSecret_WellFormedPayload_ReturnsOk()
     {
         var controller = CreateController(authorizationHeader: Secret);
         var body = new ContextDiscoveryPayload
@@ -98,8 +132,68 @@ public class ContextDiscoveryControllerTests
             Path = ".claude/agents/echo.md",
         };
 
-        var result = controller.Notify(body);
+        var result = await controller.NotifyAsync(body, CancellationToken.None);
 
         result.Should().BeOfType<OkResult>();
+    }
+
+    [Fact]
+    public async Task NotifyAsync_NonSubAgentKind_NoSession_ReturnsOk()
+    {
+        // Non-subagent kinds are still logged as discoveries but never activate — the controller
+        // must NOT try to resolve a session for them. Verifies that path stays a no-op even when
+        // session_id is absent from the payload.
+        var controller = CreateController(authorizationHeader: Secret);
+        var body = new ContextDiscoveryPayload
+        {
+            Kind = "skill",
+            Name = "review-skill",
+            Path = ".claude/skills/review.md",
+        };
+
+        var result = await controller.NotifyAsync(body, CancellationToken.None);
+
+        result.Should().BeOfType<OkResult>();
+    }
+
+    [Fact]
+    public async Task NotifyAsync_SubAgentPayload_UnknownSession_ReturnsOkWithoutActivation()
+    {
+        // Discovery firing before the agent path has initialised the session must NOT fail —
+        // the gateway shouldn't see a 5xx for an enrichment event. Best-effort no-op + 200 is
+        // the contract.
+        var registry = CreateEmptyRegistry();
+        var controller = CreateController(
+            authorizationHeader: Secret,
+            registry: registry);
+
+        var body = new ContextDiscoveryPayload
+        {
+            SessionId = "session-not-in-registry",
+            Kind = "subagent",
+            Name = "ghost",
+            Path = ".claude/agents/ghost.md",
+        };
+
+        var result = await controller.NotifyAsync(body, CancellationToken.None);
+
+        result.Should().BeOfType<OkResult>();
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond)
+        {
+            _respond = respond;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_respond(request));
+        }
     }
 }

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/WorkspaceSubAgentLoaderLoadOneAsyncTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/WorkspaceSubAgentLoaderLoadOneAsyncTests.cs
@@ -1,0 +1,232 @@
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Auth;
+using LmStreaming.Sample.Services.Discovery;
+
+namespace LmStreaming.Sample.Tests.Services.Discovery;
+
+/// <summary>
+/// Pins the direct <see cref="WorkspaceSubAgentLoader.LoadOneAsync"/> contract used by the
+/// <see cref="LmStreaming.Sample.Controllers.ContextDiscoveryController"/> webhook handler:
+/// a single discovered item resolves to either a fully-mapped template (happy path) or null
+/// (anything skippable — wrong kind, traversal, missing file, malformed markdown). Cancellation
+/// propagates; null args throw. The webhook handler relies on uniform null-on-failure so it can
+/// log + 200 without branching on each failure mode.
+/// </summary>
+public class WorkspaceSubAgentLoaderLoadOneAsyncTests : IDisposable
+{
+    private const string SessionId = "session-load-one-test";
+    private const string GatewayBaseUrl = "http://localhost:3000";
+
+    private static readonly Mock<IStreamingAgent> AgentStub = new();
+    private static readonly Func<IStreamingAgent> AgentFactory = () => AgentStub.Object;
+
+    private readonly string _hostPath;
+
+    public WorkspaceSubAgentLoaderLoadOneAsyncTests()
+    {
+        _hostPath = Path.Combine(Path.GetTempPath(), "wi77-loadone-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(_hostPath, ".claude", "agents"));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_hostPath))
+            {
+                Directory.Delete(_hostPath, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+
+    private static readonly string WellFormedMarkdown =
+        """
+        ---
+        name: echo
+        description: Echoes a marker.
+        ---
+        You are the echo sub-agent. Respond with the marker the user supplies.
+        """;
+
+    private SandboxSession CreateSession(string? hostPathOverride = null) => new(
+        WorkspaceId: "default",
+        SessionId: SessionId,
+        WorkspaceRelPath: "default",
+        HostPath: hostPathOverride ?? _hostPath);
+
+    private WorkspaceSubAgentLoader CreateLoader()
+    {
+        // Registry is not exercised by LoadOneAsync — pass a stub HttpClient that throws if used.
+        static HttpResponseMessage UnusedRespond(HttpRequestMessage _) =>
+            throw new InvalidOperationException("HTTP not expected in LoadOneAsync tests");
+
+        var gateway = new SandboxGatewayLifetime(
+            new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl },
+            NullLogger<SandboxGatewayLifetime>.Instance,
+            new HttpClient(new StubHandler(UnusedRespond)));
+
+        var registry = new SandboxSessionRegistry(
+            gateway,
+            new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl },
+            NullLogger<SandboxSessionRegistry>.Instance,
+            new HttpClient(new StubHandler(UnusedRespond)),
+            new AuthOptions(),
+            new AuthSharedSecret(new AuthOptions()));
+
+        return new WorkspaceSubAgentLoader(registry, NullLogger<WorkspaceSubAgentLoader>.Instance);
+    }
+
+    private static SandboxSessionRegistry.DiscoveredItem Item(
+        string kind,
+        string name,
+        string path) => new(kind, name, $"{name} description", path);
+
+    [Fact]
+    public async Task LoadOneAsync_HappyPath_ReturnsMappedTemplate()
+    {
+        var relPath = Path.Combine(".claude", "agents", "echo.md");
+        await File.WriteAllTextAsync(Path.Combine(_hostPath, relPath), WellFormedMarkdown);
+        var loader = CreateLoader();
+
+        var template = await loader.LoadOneAsync(
+            CreateSession(),
+            Item("subagent", "echo", relPath),
+            AgentFactory);
+
+        template.Should().NotBeNull();
+        template!.Name.Should().Be("echo");
+        template.Description.Should().Be("Echoes a marker.");
+        template.WhenToUse.Should().Be("Echoes a marker.");
+        template.SystemPrompt.Should().Contain("echo sub-agent");
+        template.MaxTurnsPerRun.Should().Be(WorkspaceSubAgentLoader.DefaultMaxTurnsPerRun);
+    }
+
+    [Fact]
+    public async Task LoadOneAsync_NonSubAgentKind_ReturnsNull()
+    {
+        // Skills (and any other non-subagent kind) must short-circuit BEFORE the file read — the
+        // webhook handler relies on this to keep its 200-OK no-op path cheap.
+        var loader = CreateLoader();
+
+        var template = await loader.LoadOneAsync(
+            CreateSession(),
+            Item("skill", "review", ".claude/skills/review.md"),
+            AgentFactory);
+
+        template.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task LoadOneAsync_PathTraversal_ReturnsNull()
+    {
+        // Webhook receives this from an UNTRUSTED gateway payload. The traversal guard MUST sit
+        // at LoadOneAsync's boundary, otherwise a malicious "../../etc/passwd" path could be read.
+        var loader = CreateLoader();
+
+        var template = await loader.LoadOneAsync(
+            CreateSession(),
+            Item("subagent", "escape", "../outside.md"),
+            AgentFactory);
+
+        template.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task LoadOneAsync_MissingFile_ReturnsNull()
+    {
+        var loader = CreateLoader();
+
+        var template = await loader.LoadOneAsync(
+            CreateSession(),
+            Item("subagent", "ghost", ".claude/agents/ghost.md"),
+            AgentFactory);
+
+        template.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task LoadOneAsync_MalformedMarkdown_ReturnsNull()
+    {
+        var relPath = Path.Combine(".claude", "agents", "bad.md");
+        await File.WriteAllTextAsync(Path.Combine(_hostPath, relPath), "no frontmatter at all\n");
+        var loader = CreateLoader();
+
+        var template = await loader.LoadOneAsync(
+            CreateSession(),
+            Item("subagent", "bad", relPath),
+            AgentFactory);
+
+        template.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task LoadOneAsync_EmptyHostPath_ReturnsNull()
+    {
+        // A session without a resolved workspace (e.g. a provider that never mounted one) is a
+        // valid state — the webhook must not throw or attempt to combine "" + path.
+        var loader = CreateLoader();
+
+        var template = await loader.LoadOneAsync(
+            CreateSession(hostPathOverride: ""),
+            Item("subagent", "echo", ".claude/agents/echo.md"),
+            AgentFactory);
+
+        template.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task LoadOneAsync_NullArgs_Throw()
+    {
+        var loader = CreateLoader();
+        var item = Item("subagent", "echo", ".claude/agents/echo.md");
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => loader.LoadOneAsync(null!, item, AgentFactory));
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => loader.LoadOneAsync(CreateSession(), null!, AgentFactory));
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => loader.LoadOneAsync(CreateSession(), item, null!));
+    }
+
+    [Fact]
+    public async Task LoadOneAsync_CancellationDuringRead_Propagates()
+    {
+        // Cancellation MUST propagate (the only exception not absorbed into null) so a webhook
+        // tied to an aborted request can bail rather than continue mapping a half-read file.
+        var relPath = Path.Combine(".claude", "agents", "echo.md");
+        await File.WriteAllTextAsync(Path.Combine(_hostPath, relPath), WellFormedMarkdown);
+        var loader = CreateLoader();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = () => loader.LoadOneAsync(
+            CreateSession(),
+            Item("subagent", "echo", relPath),
+            AgentFactory,
+            cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond)
+        {
+            _respond = respond;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_respond(request));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Wires the chain `MutableSubAgentTemplateSource` → `SubAgentToolProvider` / `SubAgentManager` → `FunctionRegistry.BuildContracts` → `ToolCallInjectionMiddleware` factory delegate so a sub-agent template registered into the shared source mid-session surfaces in the Agent tool's request options on the **next turn** — without rebuilding the middleware stack.

The webhook entrypoint (`ContextDiscoveryController`) resolves the session, gates on `binding.Source.Templates.ContainsKey` to short-circuit retry storms, loads the markdown via `WorkspaceSubAgentLoader.LoadOneAsync`, and calls `TryRegister`. The trust boundary is preserved at the source: `MutableSubAgentTemplateSource.TryRegister` is **first-wins**, so discovered templates can never shadow built-in seeds, and a re-fired discovery is a no-op.

## Key changes

- **`MutableSubAgentTemplateSource`** (new): thread-safe first-wins template registry.
- **`ToolCallInjectionMiddleware`**: factory-delegate ctor — current function set is read per call so a mutating upstream catalog is reflected on the next invocation. Functions materialized once per call.
- **`FunctionRegistry`**: `Build()` / `BuildContracts()` callable per turn; per-turn build log lowered to `Debug`. Class docs rewritten to describe the new contract (configuration must be single-threaded and frozen before per-turn builds).
- **`MultiTurnAgentLoop`**: optional `subAgentTemplateSource` ctor argument routes both `SubAgentManager` and `SubAgentToolProvider` through the same source so a webhook-driven `TryRegister` is visible on the next turn hitting the provider agent.
- **`SandboxSessionRegistry.GetOrAddSubAgentBinding`**: reconciles the seed every call so a later pool factory invocation cannot drop new built-in templates; previously seeded + discovered templates are preserved by `TryRegister`'s first-wins semantics.
- **`ContextDiscoveryController`**: handles `kind == "subagent"`, resolves the session binding, fast-paths on `ContainsKey` before the disk read, calls the loader, and registers the template. Best-effort with structured logs; webhook always `200`s for authenticated payloads.

## Test plan

- [x] `MutableSubAgentTemplateSourceTests` — registry semantics + concurrent `TryRegister` resolves to one winner.
- [x] `ToolCallInjectionMiddlewareTests` — factory delegate invoked per call; mid-session contract change visible on next request.
- [x] `WorkspaceSubAgentLoaderLoadOneAsyncTests` — single-template parse path used by the webhook (incl. path-traversal and malformed-markdown drops).
- [x] `MidSessionTemplateActivationTests` — end-to-end pin across the full chain AND across the production `MultiTurnAgentLoop` wiring seam (real loop, real registry, real middleware; only the provider agent is mocked to capture `GenerateReplyOptions`).
- [x] `ContextDiscoveryControllerTests` — extended for `kind == "subagent"`: session resolution, binding gate, fast-path no-op, first-wins collision with a built-in seed.
- [x] `FunctionRegistry` / `SubAgentManager` / `SubAgentToolProvider` tests — extended for the new mutable source / factory-delegate contracts.
- [x] `dotnet build LmDotnetTools.sln` — 0 warnings, 0 errors.
- [x] `LmMultiTurn.Tests` (267) / `LmCore.Tests` (744) / `LmStreaming.Sample.Tests` (136) all pass.

Closes #77

[Gautam's Dev bot]
