### PR TITLE
Add tool_schema Test (Mock) directive + agent-pool provider-override telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ node_modules/
 
 # OAuth refresh/access token store (FileOAuthTokenStore) — never commit secrets
 **/oauth-tokens/
+
+# Local git worktrees
+.worktrees/

--- a/samples/LmStreaming.Sample/Agents/MultiTurnAgentPool.cs
+++ b/samples/LmStreaming.Sample/Agents/MultiTurnAgentPool.cs
@@ -208,6 +208,23 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
         // first-creation calls for the same threadId still serialise on creation.
         var resolvedProviderId = ResolveProviderId(threadId, requestedProviderId);
 
+        // Surface silent provider overrides: a thread is locked to its first provider, so a
+        // later connection requesting a different provider is ignored. Without this warning the
+        // logs show the requested provider while a stale agent of a different provider serves
+        // the turn — which makes log-based debugging misleading.
+        if (
+            !string.IsNullOrWhiteSpace(requestedProviderId)
+            && !string.Equals(requestedProviderId, resolvedProviderId, StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            _logger.LogWarning(
+                "Thread {ThreadId} is locked to provider {EffectiveProviderId}; requested provider {RequestedProviderId} is ignored for this connection.",
+                threadId,
+                resolvedProviderId,
+                requestedProviderId
+            );
+        }
+
         // Use per-key lock to prevent concurrent factory invocations for the same threadId.
         // ConcurrentDictionary.GetOrAdd does not guarantee the factory runs at most once,
         // which would leak disposable resources (MCP clients) from the losing invocation.

--- a/samples/LmStreaming.Sample/WebSocket/ChatWebSocketManager.cs
+++ b/samples/LmStreaming.Sample/WebSocket/ChatWebSocketManager.cs
@@ -62,11 +62,16 @@ public sealed class ChatWebSocketManager
             : $"{threadId}-{Guid.NewGuid():N}";
         using var logScope = LogContext.PushProperty("codex_session_id", codexSessionId);
 
+        // Resolve the provider the pool will actually use (a thread is locked to its first
+        // provider) so the log reflects reality instead of just the client's request.
+        var effectiveProviderId = _agentPool.GetEffectiveProviderId(threadId, providerId);
+
         _logger.LogInformation(
-            "WebSocket connection started for thread {ThreadId} with mode {ModeId} provider {ProviderId} and session {CodexSessionId}",
+            "WebSocket connection started for thread {ThreadId} with mode {ModeId} requested provider {RequestedProviderId} effective provider {EffectiveProviderId} and session {CodexSessionId}",
             threadId,
             mode?.Id ?? "default",
             providerId ?? "(default)",
+            effectiveProviderId ?? "(default)",
             codexSessionId);
 
         var resolvedMode = mode ?? SystemChatModes.All[0];

--- a/src/LmTestUtils/TestMode/AnthropicTestSseMessageHandler.cs
+++ b/src/LmTestUtils/TestMode/AnthropicTestSseMessageHandler.cs
@@ -272,6 +272,14 @@ public sealed class AnthropicTestSseMessageHandler : HttpMessageHandler
                 _logger.LogDebug("Resolved __TOOLS_LIST__ placeholder to: {ToolsList}", toolsList);
                 message.ExplicitText = toolsList;
             }
+            else if (message.ExplicitText != null && message.ExplicitText.StartsWith("__TOOL_SCHEMA__"))
+            {
+                var toolName = message.ExplicitText.Contains(':')
+                    ? message.ExplicitText.Split(':', 2)[1]
+                    : null;
+                message.ExplicitText = ExtractToolSchema(requestRoot, toolName);
+                _logger.LogDebug("Resolved __TOOL_SCHEMA__ placeholder for {ToolName}", toolName);
+            }
             else if (message.ExplicitText == "__REQUEST_URL__")
             {
                 message.ExplicitText = request.RequestUri?.ToString() ?? "No request URL";
@@ -693,5 +701,47 @@ public sealed class AnthropicTestSseMessageHandler : HttpMessageHandler
         }
 
         return toolNames.Count == 0 ? "No tools available" : string.Join(", ", toolNames);
+    }
+
+    /// <summary>
+    ///     Extracts the description and parameter schema for a single named tool.
+    /// </summary>
+    private static string ExtractToolSchema(JsonElement root, string? toolName)
+    {
+        if (string.IsNullOrEmpty(toolName))
+        {
+            return "No tool name specified";
+        }
+
+        if (!root.TryGetProperty("tools", out var tools) || tools.ValueKind != JsonValueKind.Array)
+        {
+            return "No tools available";
+        }
+
+        foreach (var tool in tools.EnumerateArray())
+        {
+            if (tool.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            // Anthropic format: { "name", "description", "input_schema" }
+            if (
+                tool.TryGetProperty("name", out var name)
+                && name.ValueKind == JsonValueKind.String
+                && string.Equals(name.GetString(), toolName, StringComparison.Ordinal)
+            )
+            {
+                var description =
+                    tool.TryGetProperty("description", out var desc) && desc.ValueKind == JsonValueKind.String
+                        ? desc.GetString()
+                        : null;
+                JsonElement? schema =
+                    tool.TryGetProperty("input_schema", out var inputSchema) ? inputSchema : null;
+                return ToolSchemaFormatter.ToMarkdown(toolName, description, schema);
+            }
+        }
+
+        return $"Tool '{toolName}' not found";
     }
 }

--- a/src/LmTestUtils/TestMode/InstructionChainParser.cs
+++ b/src/LmTestUtils/TestMode/InstructionChainParser.cs
@@ -214,6 +214,22 @@ public sealed class InstructionChainParser(ILogger<InstructionChainParser> logge
                 continue;
             }
 
+            // Check for tool_schema - returns description + parameter schema for a single named tool
+            if (item.TryGetProperty("tool_schema", out var toolSchemaEl) && toolSchemaEl.ValueKind == JsonValueKind.Object)
+            {
+                var toolName =
+                    toolSchemaEl.TryGetProperty("name", out var toolNameEl)
+                    && toolNameEl.ValueKind == JsonValueKind.String
+                        ? toolNameEl.GetString()
+                        : null;
+
+                var placeholder = string.IsNullOrEmpty(toolName)
+                    ? "__TOOL_SCHEMA__"
+                    : $"__TOOL_SCHEMA__:{toolName}";
+                messages.Add(InstructionMessage.ForExplicitText(placeholder));
+                continue;
+            }
+
             // Check for request_url_echo - returns the request URL as text
             if (item.TryGetProperty("request_url_echo", out _))
             {

--- a/src/LmTestUtils/TestMode/SseStreamHttpContent.cs
+++ b/src/LmTestUtils/TestMode/SseStreamHttpContent.cs
@@ -520,6 +520,14 @@ public sealed class SseStreamHttpContent : HttpContent
         for (var i = 0; i < tokens.Length; i += wordsPerChunk)
         {
             var chunkTokens = string.Join(' ', tokens.Skip(i).Take(Math.Min(wordsPerChunk, tokens.Length - i)));
+
+            // Re-attach the boundary space consumed by Split(' ') so concatenated reasoning deltas
+            // reconstruct the original text (see ChunkTextMessage for the rationale).
+            if (i > 0)
+            {
+                chunkTokens = " " + chunkTokens;
+            }
+
             yield return useReasoning
                 ? new Choice
                 {
@@ -571,13 +579,20 @@ public sealed class SseStreamHttpContent : HttpContent
         for (var i = 0; i < tokens.Length; i += wordsPerChunk)
         {
             var chunkTokens = string.Join(' ', tokens.Skip(i).Take(Math.Min(wordsPerChunk, tokens.Length - i)));
+
+            // Split(' ') consumes the single space that separated this chunk from the previous one.
+            // Re-attach it on every chunk after the first so the client reconstructs the original
+            // text verbatim when it concatenates the streamed deltas (otherwise boundary spaces are
+            // lost, e.g. "a file" + "from" -> "filefrom").
+            var chunkContent = i == 0 ? chunkTokens : " " + chunkTokens;
+
             yield return new Choice
             {
                 Index = index,
                 Delta = new ChatMessage
                 {
                     Role = RoleEnum.Assistant,
-                    Content = new Union<string, Union<TextContent, ImageContent>[]>(chunkTokens),
+                    Content = new Union<string, Union<TextContent, ImageContent>[]>(chunkContent),
                 },
             };
         }

--- a/src/LmTestUtils/TestMode/TestSseMessageHandler.cs
+++ b/src/LmTestUtils/TestMode/TestSseMessageHandler.cs
@@ -220,6 +220,13 @@ public sealed class TestSseMessageHandler : HttpMessageHandler
             {
                 message.ExplicitText = ExtractToolsList(requestRoot);
             }
+            else if (message.ExplicitText != null && message.ExplicitText.StartsWith("__TOOL_SCHEMA__"))
+            {
+                var toolName = message.ExplicitText.Contains(':')
+                    ? message.ExplicitText.Split(':', 2)[1]
+                    : null;
+                message.ExplicitText = ExtractToolSchema(requestRoot, toolName);
+            }
             else if (message.ExplicitText == "__REQUEST_URL__")
             {
                 message.ExplicitText = request.RequestUri?.ToString() ?? "No request URL";
@@ -322,6 +329,49 @@ public sealed class TestSseMessageHandler : HttpMessageHandler
     }
 
     /// <summary>
+    ///     Extracts the description and parameter schema for a single named tool.
+    /// </summary>
+    private static string ExtractToolSchema(JsonElement root, string? toolName)
+    {
+        if (string.IsNullOrEmpty(toolName))
+        {
+            return "No tool name specified";
+        }
+
+        if (!root.TryGetProperty("tools", out var tools) || tools.ValueKind != JsonValueKind.Array)
+        {
+            return "No tools available";
+        }
+
+        foreach (var tool in tools.EnumerateArray())
+        {
+            if (tool.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            // OpenAI format: { "type": "function", "function": { "name", "description", "parameters" } }
+            if (
+                tool.TryGetProperty("function", out var fn)
+                && fn.ValueKind == JsonValueKind.Object
+                && fn.TryGetProperty("name", out var name)
+                && name.ValueKind == JsonValueKind.String
+                && string.Equals(name.GetString(), toolName, StringComparison.Ordinal)
+            )
+            {
+                var description =
+                    fn.TryGetProperty("description", out var desc) && desc.ValueKind == JsonValueKind.String
+                        ? desc.GetString()
+                        : null;
+                JsonElement? schema = fn.TryGetProperty("parameters", out var pars) ? pars : null;
+                return ToolSchemaFormatter.ToMarkdown(toolName, description, schema);
+            }
+        }
+
+        return $"Tool '{toolName}' not found";
+    }
+
+    /// <summary>
     ///     Extracts request headers as a newline-separated string.
     /// </summary>
     private static string ExtractRequestHeaders(HttpRequestMessage request)
@@ -353,12 +403,12 @@ public sealed class TestSseMessageHandler : HttpMessageHandler
             return root.GetRawText();
         }
 
-        var result = new Dictionary<string, string>();
+        var result = new Dictionary<string, JsonElement>();
         foreach (var field in fields)
         {
             if (root.TryGetProperty(field, out var value))
             {
-                result[field] = value.ToString();
+                result[field] = value;
             }
         }
 

--- a/src/LmTestUtils/TestMode/ToolSchemaFormatter.cs
+++ b/src/LmTestUtils/TestMode/ToolSchemaFormatter.cs
@@ -1,0 +1,31 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+namespace AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+
+/// <summary>
+///     Formats a single tool's description and parameter schema as Markdown,
+///     with the schema rendered as an indented JSON code block for easy reading.
+/// </summary>
+internal static class ToolSchemaFormatter
+{
+    private static readonly JsonSerializerOptions PrettyOptions = new()
+    {
+        WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    /// <summary>
+    ///     Builds a Markdown document describing a single tool.
+    /// </summary>
+    /// <param name="name">The tool name.</param>
+    /// <param name="description">The tool description (may be null/empty).</param>
+    /// <param name="schema">The parameter/input schema element (may be null).</param>
+    public static string ToMarkdown(string name, string? description, JsonElement? schema)
+    {
+        var desc = string.IsNullOrWhiteSpace(description) ? "_No description provided._" : description;
+        var schemaJson = schema.HasValue ? JsonSerializer.Serialize(schema.Value, PrettyOptions) : "{}";
+
+        return $"# {name}\n\n## Description\n\n{desc}\n\n## Schema\n\n```json\n{schemaJson}\n```";
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Agents/MultiTurnAgentPoolTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Agents/MultiTurnAgentPoolTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Tests.TestDoubles;
+using Microsoft.Extensions.Logging;
 
 namespace LmStreaming.Sample.Tests.Agents;
 
@@ -115,6 +116,75 @@ public class MultiTurnAgentPoolTests
         _ = pool.GetOrCreateAgent("thread-y", mode, requestedProviderId: "openai", requestResponseDumpFileName: null);
 
         providerSeen.Should().ContainSingle().Which.Should().Be("anthropic");
+    }
+
+    [Fact]
+    public async Task GetOrCreateAgent_LogsWarning_WhenRequestedProviderOverriddenByPersisted()
+    {
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test", "openai", "anthropic"]);
+        var store = new InMemoryConversationStore();
+        await store.SaveMetadataAsync(
+            "thread-override",
+            new ThreadMetadata
+            {
+                ThreadId = "thread-override",
+                LastUpdated = 1,
+                Properties = ImmutableDictionary<string, object>.Empty.SetItem(
+                    MultiTurnAgentPool.ProviderPropertyKey,
+                    "anthropic"
+                ),
+            }
+        );
+
+        var logger = new CapturingLogger<MultiTurnAgentPool>();
+        await using var pool = new MultiTurnAgentPool(
+            (threadId, _, _, _) => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId)),
+            registry.ToReal(),
+            store,
+            logger
+        );
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        _ = pool.GetOrCreateAgent("thread-override", mode, requestedProviderId: "test", requestResponseDumpFileName: null);
+
+        var warning = logger
+            .Entries.Where(e => e.Level == LogLevel.Warning)
+            .Should()
+            .ContainSingle(e => e.Message.Contains("anthropic") && e.Message.Contains("test"))
+            .Subject;
+        warning.Message.Should().Contain("locked");
+    }
+
+    [Fact]
+    public async Task GetOrCreateAgent_DoesNotWarn_WhenRequestedProviderMatchesPersisted()
+    {
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test", "anthropic"]);
+        var store = new InMemoryConversationStore();
+        await store.SaveMetadataAsync(
+            "thread-match",
+            new ThreadMetadata
+            {
+                ThreadId = "thread-match",
+                LastUpdated = 1,
+                Properties = ImmutableDictionary<string, object>.Empty.SetItem(
+                    MultiTurnAgentPool.ProviderPropertyKey,
+                    "anthropic"
+                ),
+            }
+        );
+
+        var logger = new CapturingLogger<MultiTurnAgentPool>();
+        await using var pool = new MultiTurnAgentPool(
+            (threadId, _, _, _) => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId)),
+            registry.ToReal(),
+            store,
+            logger
+        );
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        _ = pool.GetOrCreateAgent("thread-match", mode, requestedProviderId: "anthropic", requestResponseDumpFileName: null);
+
+        logger.Entries.Where(e => e.Level == LogLevel.Warning).Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/TestDoubles/CapturingLogger.cs
+++ b/tests/LmStreaming.Sample.Tests/TestDoubles/CapturingLogger.cs
@@ -1,0 +1,41 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace LmStreaming.Sample.Tests.TestDoubles;
+
+/// <summary>
+/// Minimal <see cref="ILogger{TCategoryName}"/> test double that captures emitted log
+/// entries so tests can assert on level and rendered message. Thread-safe for the
+/// concurrent code paths exercised by <c>MultiTurnAgentPool</c>.
+/// </summary>
+internal sealed class CapturingLogger<T> : ILogger<T>
+{
+    public readonly record struct Entry(LogLevel Level, string Message);
+
+    private readonly ConcurrentQueue<Entry> _entries = new();
+
+    public IReadOnlyList<Entry> Entries => [.. _entries];
+
+    public IDisposable BeginScope<TState>(TState state)
+        where TState : notnull => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter
+    )
+    {
+        _entries.Enqueue(new Entry(logLevel, formatter(state, exception)));
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose() { }
+    }
+}

--- a/tests/LmTestUtils.Tests/TestMode/SseStreamHttpContentTests.cs
+++ b/tests/LmTestUtils.Tests/TestMode/SseStreamHttpContentTests.cs
@@ -1,0 +1,92 @@
+using System.Text;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+
+namespace AchieveAi.LmDotnetTools.LmTestUtils.Tests.TestMode;
+
+public class SseStreamHttpContentTests
+{
+    [Fact]
+    public async Task OpenAiStream_ExplicitText_ReassemblesWithSpacesAcrossChunkBoundaries()
+    {
+        // Six words force two 3-word chunks; the space between word 3 and word 4 lands on a
+        // chunk boundary, which previously vanished when the client concatenated the deltas.
+        const string OriginalText = "alpha beta gamma delta epsilon zeta";
+
+        var plan = new InstructionPlan(
+            "chunk-space-test",
+            reasoningLength: null,
+            messages: [InstructionMessage.ForExplicitText(OriginalText)]
+        );
+
+        var assembled = await StreamAndReassembleContentAsync(plan, wordsPerChunk: 3);
+
+        Assert.Equal(OriginalText, assembled);
+    }
+
+    [Fact]
+    public async Task OpenAiStream_ExplicitText_PreservesInteriorSpacingInJsonPayload()
+    {
+        // Mirrors the request_params_echo:tools use case: a compact JSON blob streamed through
+        // the word-chunker must survive reassembly byte-for-byte.
+        const string OriginalText =
+            "{\"tools\":[{\"name\":\"sandbox-Read\",\"description\":\"Reads a file from the filesystem.\"}]}";
+
+        var plan = new InstructionPlan(
+            "chunk-space-json-test",
+            reasoningLength: null,
+            messages: [InstructionMessage.ForExplicitText(OriginalText)]
+        );
+
+        var assembled = await StreamAndReassembleContentAsync(plan, wordsPerChunk: 3);
+
+        Assert.Equal(OriginalText, assembled);
+    }
+
+    private static async Task<string> StreamAndReassembleContentAsync(InstructionPlan plan, int wordsPerChunk)
+    {
+        var content = new SseStreamHttpContent(
+            plan,
+            model: "test-model",
+            wordsPerChunk: wordsPerChunk,
+            chunkDelayMs: 0
+        );
+
+        using var stream = new MemoryStream();
+        await content.CopyToAsync(stream);
+        var sse = Encoding.UTF8.GetString(stream.ToArray());
+
+        var builder = new StringBuilder();
+        foreach (var line in sse.Split('\n'))
+        {
+            var trimmed = line.TrimEnd('\r');
+            if (!trimmed.StartsWith("data: ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var payload = trimmed["data: ".Length..];
+            if (payload == "[DONE]")
+            {
+                break;
+            }
+
+            using var doc = JsonDocument.Parse(payload);
+            if (!doc.RootElement.TryGetProperty("choices", out var choices)
+                || choices.ValueKind != JsonValueKind.Array
+                || choices.GetArrayLength() == 0)
+            {
+                continue;
+            }
+
+            var delta = choices[0].GetProperty("delta");
+            if (delta.TryGetProperty("content", out var contentEl)
+                && contentEl.ValueKind == JsonValueKind.String)
+            {
+                builder.Append(contentEl.GetString());
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/tests/LmTestUtils.Tests/TestMode/ToolSchemaPlaceholderTests.cs
+++ b/tests/LmTestUtils.Tests/TestMode/ToolSchemaPlaceholderTests.cs
@@ -1,0 +1,263 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AchieveAi.LmDotnetTools.LmTestUtils.Tests.TestMode;
+
+public class ToolSchemaPlaceholderTests
+{
+    private readonly InstructionChainParser _parser;
+
+    public ToolSchemaPlaceholderTests()
+    {
+        var logger = NullLoggerFactory.Instance.CreateLogger<InstructionChainParser>();
+        _parser = new InstructionChainParser(logger);
+    }
+
+    // ─── Parser tests ────────────────────────────────────────────────
+
+    [Fact]
+    public void Parser_ToolSchema_WithName_ShouldEncodeNameInPlaceholder()
+    {
+        var content = """
+            <|instruction_start|>
+            {"instruction_chain": [
+                {"messages":[{"tool_schema":{"name":"get_weather"}}]}
+            ]}
+            <|instruction_end|>
+            """;
+
+        var result = _parser.ExtractInstructionChain(content);
+
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Single(result[0].Messages);
+        Assert.Equal("__TOOL_SCHEMA__:get_weather", result[0].Messages[0].ExplicitText);
+    }
+
+    [Fact]
+    public void Parser_ToolSchema_WithoutName_ShouldUseGenericPlaceholder()
+    {
+        var content = """
+            <|instruction_start|>
+            {"instruction_chain": [
+                {"messages":[{"tool_schema":{}}]}
+            ]}
+            <|instruction_end|>
+            """;
+
+        var result = _parser.ExtractInstructionChain(content);
+
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Single(result[0].Messages);
+        Assert.Equal("__TOOL_SCHEMA__", result[0].Messages[0].ExplicitText);
+    }
+
+    // ─── End-to-end handler tests (OpenAI) ───────────────────────────
+
+    [Fact]
+    public async Task OpenAI_ToolSchema_ShouldReturnSingleToolDescriptionAndSchema()
+    {
+        using var client = TestModeHttpClientFactory.CreateOpenAiTestClient(chunkDelayMs: 0);
+
+        var content = await SendOpenAiAsync(client, "get_weather");
+
+        // Markdown structure.
+        Assert.Contains("# get_weather", content);
+        Assert.Contains("## Description", content);
+        Assert.Contains("## Schema", content);
+        Assert.Contains("```json", content);
+
+        // Targeted tool's description is present.
+        Assert.Contains("Get current weather conditions for a specific location", content);
+
+        // The JSON schema block is valid, indented JSON describing the tool's parameters.
+        var schemaJson = ExtractJsonBlock(content);
+        using var schema = JsonDocument.Parse(schemaJson);
+        Assert.True(schema.RootElement.GetProperty("properties").TryGetProperty("location", out _));
+        Assert.Contains("\n  ", schemaJson); // indentation proves it is pretty-printed
+
+        // The other tool is NOT included (single-tool focus).
+        Assert.DoesNotContain("calculate", content);
+        Assert.DoesNotContain("Perform basic arithmetic", content);
+    }
+
+    [Fact]
+    public async Task OpenAI_ToolSchema_UnknownTool_ShouldReturnNotFound()
+    {
+        using var client = TestModeHttpClientFactory.CreateOpenAiTestClient(chunkDelayMs: 0);
+
+        var content = await SendOpenAiAsync(client, "does_not_exist");
+
+        Assert.Contains("not found", content);
+    }
+
+    // ─── End-to-end handler tests (Anthropic) ────────────────────────
+
+    [Fact]
+    public async Task Anthropic_ToolSchema_ShouldReturnSingleToolDescriptionAndSchema()
+    {
+        using var client = TestModeHttpClientFactory.CreateAnthropicTestClient(chunkDelayMs: 0);
+
+        var text = await SendAnthropicAsync(client, "get_weather");
+
+        Assert.Contains("# get_weather", text);
+        Assert.Contains("## Description", text);
+        Assert.Contains("## Schema", text);
+        Assert.Contains("```json", text);
+        Assert.Contains("Get current weather conditions for a specific location", text);
+
+        var schemaJson = ExtractJsonBlock(text);
+        using var schema = JsonDocument.Parse(schemaJson);
+        Assert.True(schema.RootElement.GetProperty("properties").TryGetProperty("location", out _));
+
+        Assert.DoesNotContain("calculate", text);
+        Assert.DoesNotContain("Perform basic arithmetic", text);
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────
+
+    private static string ExtractJsonBlock(string markdown)
+    {
+        const string fence = "```json\n";
+        var start = markdown.IndexOf(fence, StringComparison.Ordinal);
+        Assert.True(start >= 0, "Expected a ```json code block.");
+        start += fence.Length;
+        var end = markdown.IndexOf("\n```", start, StringComparison.Ordinal);
+        Assert.True(end > start, "Expected a closing code fence.");
+        return markdown[start..end];
+    }
+
+    private static string BuildUserContent(string toolName)
+    {
+        var instruction = new
+        {
+            instruction_chain = new[]
+            {
+                new { messages = new[] { new { tool_schema = new { name = toolName } } } },
+            },
+        };
+
+        var instructionJson = JsonSerializer.Serialize(instruction);
+        return $"test\n<|instruction_start|>{instructionJson}<|instruction_end|>";
+    }
+
+    private static async Task<string> SendOpenAiAsync(HttpClient client, string toolName)
+    {
+        var requestObj = new
+        {
+            model = "gpt-4o",
+            stream = false,
+            tools = new object[]
+            {
+                new
+                {
+                    type = "function",
+                    function = new
+                    {
+                        name = "get_weather",
+                        description = "Get current weather conditions for a specific location",
+                        parameters = new
+                        {
+                            type = "object",
+                            properties = new { location = new { type = "string" } },
+                            required = new[] { "location" },
+                        },
+                    },
+                },
+                new
+                {
+                    type = "function",
+                    function = new
+                    {
+                        name = "calculate",
+                        description = "Perform basic arithmetic",
+                        parameters = new
+                        {
+                            type = "object",
+                            properties = new { expression = new { type = "string" } },
+                            required = new[] { "expression" },
+                        },
+                    },
+                },
+            },
+            messages = new[] { new { role = "user", content = BuildUserContent(toolName) } },
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "http://test-mode/v1/chat/completions")
+        {
+            Content = new StringContent(JsonSerializer.Serialize(requestObj), Encoding.UTF8, "application/json"),
+        };
+
+        using var response = await client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var json = JsonDocument.Parse(body);
+        var content = json.RootElement
+            .GetProperty("choices")[0]
+            .GetProperty("message")
+            .GetProperty("content")
+            .GetString();
+
+        Assert.NotNull(content);
+        return content;
+    }
+
+    private static async Task<string> SendAnthropicAsync(HttpClient client, string toolName)
+    {
+        var requestObj = new
+        {
+            model = "claude-sonnet-4-5-20250929",
+            stream = false,
+            max_tokens = 1024,
+            tools = new object[]
+            {
+                new
+                {
+                    name = "get_weather",
+                    description = "Get current weather conditions for a specific location",
+                    input_schema = new
+                    {
+                        type = "object",
+                        properties = new { location = new { type = "string" } },
+                        required = new[] { "location" },
+                    },
+                },
+                new
+                {
+                    name = "calculate",
+                    description = "Perform basic arithmetic",
+                    input_schema = new
+                    {
+                        type = "object",
+                        properties = new { expression = new { type = "string" } },
+                        required = new[] { "expression" },
+                    },
+                },
+            },
+            messages = new[] { new { role = "user", content = BuildUserContent(toolName) } },
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "http://test-mode/v1/messages")
+        {
+            Content = new StringContent(JsonSerializer.Serialize(requestObj), Encoding.UTF8, "application/json"),
+        };
+
+        using var response = await client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var json = JsonDocument.Parse(body);
+        var contentArray = json.RootElement.GetProperty("content");
+        Assert.True(contentArray.GetArrayLength() > 0);
+
+        var text = contentArray[0].GetProperty("text").GetString();
+        Assert.NotNull(text);
+        return text;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `tool_schema` directive to the **Test (Mock)** provider's InstructionChain DSL that returns a single named tool's description and parameter schema as Markdown (with a pretty-printed JSON block). Previously the DSL could only list *all* tools; this enables inspecting one tool's schema in mock-mode tests and demos. Also adds provider-override telemetry to the agent pool so silent provider overrides on locked threads are visible in logs.

## Changes

- **`InstructionChainParser`** — parse  + '{"tool_schema":{"name":"..."}}' +  into a `__TOOL_SCHEMA__:<name>` placeholder.
- **`TestSseMessageHandler` / `AnthropicTestSseMessageHandler`** — resolve the placeholder by locating the tool in the request payload and formatting it.
- **`ToolSchemaFormatter`** (new) — shared Markdown formatter (indented JSON, relaxed escaping).
- **`SseStreamHttpContent`** — preserve newline/indentation when word-chunking so the pretty-printed JSON survives streaming intact.
- **`MultiTurnAgentPool` / `ChatWebSocketManager`** — warn/log when a thread locked to a provider receives a request for a different provider (effective provider id).
- **`.gitignore`** — ignore `.worktrees/`.

## Testing

- `dotnet build LmDotnetTools.sln` — 0 warnings, 0 errors.
- `LmTestUtils.Tests` — 83 passed (parser, OpenAI/Anthropic end-to-end Markdown output, not-found, chunking regression).
- `LmStreaming.Sample.Tests` — 181 passed (pool provider-override telemetry).
- Live-verified the Markdown `tool_schema` output over WebSocket against the running sample.

## Related Issues

Fixes #84