### PR TITLE
Per-conversation sandbox isolation, multi-turn history recovery, Copilot keychain auth

### DIFF
--- a/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
@@ -137,11 +137,16 @@ public sealed class ContextDiscoveryController(
             return;
         }
 
-        if (!sessionRegistry.TryGetSubAgentBinding(body.SessionId, out var binding) || binding is null)
+        // Fan the discovery out to every conversation currently live on this session. Each
+        // conversation owns its own catalog source (so a NEW conversation starting later does not
+        // inherit another conversation's discoveries); a discovery that arrives while one or more
+        // conversations are live activates into each of them.
+        var bindings = sessionRegistry.GetSubAgentBindingsForSession(body.SessionId);
+        if (bindings.Count == 0)
         {
-            // The agent path hasn't been initialised for this session yet — built-ins/discovered
-            // entries are loaded the first time the loop is created. Once it is, subsequent
-            // discoveries land here and activate normally.
+            // No conversation has initialised the agent path for this session yet — built-ins/
+            // discovered entries are loaded the first time a loop is created. Once one is,
+            // subsequent discoveries land here and activate normally.
             logger.LogInformation(
                 "ContextDiscovery subagent {Name}: session {SessionId} has no agent binding yet; skipping activation.",
                 body.Name,
@@ -167,63 +172,74 @@ public sealed class ContextDiscoveryController(
             return;
         }
 
-        // Fast-path: if a template with this name is already registered (built-in seed OR a
-        // previous discovery for this session), skip the disk read entirely. Gateways may retry
-        // the same discovery event after a transient failure; without this gate two near-
-        // simultaneous webhooks would both parse the markdown only for one to win the
-        // first-wins TryRegister. The race is still correct (TryRegister resolves it) — this
-        // just closes the retry-storm window before it hits the filesystem.
-        if (binding.Source.Templates.ContainsKey(body.Name!))
-        {
-            return;
-        }
+        // Load the markdown at most once and register the resulting template into every live
+        // conversation's catalog. The loader is keyed by the session + path, not the conversation,
+        // so a single read is reused; the per-conversation step is only the first-wins TryRegister.
+        SubAgentTemplate? template = null;
+        var loaded = false;
 
-        SubAgentTemplate? template;
-        try
+        foreach (var binding in bindings)
         {
-            template = await subAgentLoader
-                .LoadOneAsync(session, item.ToDiscovered(), binding.AgentFactory, ct)
-                .ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(
-                ex,
-                "ContextDiscovery subagent {Name}: loader threw while activating; skipping.",
-                body.Name);
-            return;
-        }
+            // Fast-path: if this conversation already has a template with this name (built-in seed
+            // OR a previous discovery on this conversation), skip it entirely.
+            if (binding.Source.Templates.ContainsKey(body.Name!))
+            {
+                continue;
+            }
 
-        if (template is null || string.IsNullOrWhiteSpace(template.Name))
-        {
-            // LoadOneAsync already logged the specific reason (path traversal, missing file,
-            // malformed markdown, …); a non-null template with a blank Name would indicate a
-            // mapping bug, so it's also dropped here rather than registered as garbage.
-            return;
-        }
+            if (!loaded)
+            {
+                loaded = true;
+                try
+                {
+                    template = await subAgentLoader
+                        .LoadOneAsync(session, item.ToDiscovered(), binding.AgentFactory, ct)
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(
+                        ex,
+                        "ContextDiscovery subagent {Name}: loader threw while activating; skipping.",
+                        body.Name);
+                    return;
+                }
+            }
 
-        if (binding.Source.TryRegister(template.Name, template))
-        {
-            logger.LogInformation(
-                "ContextDiscovery subagent {Name}: activated for session {SessionId}.",
-                template.Name,
-                body.SessionId);
-        }
-        else
-        {
-            // First-wins collision with a built-in OR an earlier discovery on this same session.
-            // This matches WorkspaceSubAgentLoader.MergeBuiltInWins's trust boundary: discovered
-            // templates cannot shadow trusted built-ins, and a re-fire of the same discovery is a
-            // no-op rather than a re-register.
-            logger.LogInformation(
-                "ContextDiscovery subagent {Name}: session {SessionId} already has a template "
-                + "with that name; keeping the first.",
-                template.Name,
-                body.SessionId);
+            if (template is null || string.IsNullOrWhiteSpace(template.Name))
+            {
+                // LoadOneAsync already logged the specific reason (path traversal, missing file,
+                // malformed markdown, …); a non-null template with a blank Name would indicate a
+                // mapping bug, so it's also dropped here rather than registered as garbage.
+                return;
+            }
+
+            // Rebind the template to THIS conversation's agent factory. The template is loaded once
+            // (with the first conversation's factory), but each conversation must spawn the
+            // discovered sub-agent with its OWN provider — otherwise a sub-agent fanned into
+            // conversation B would run on conversation A's provider.
+            var conversationTemplate = template with { AgentFactory = binding.AgentFactory };
+
+            if (binding.Source.TryRegister(conversationTemplate.Name!, conversationTemplate))
+            {
+                logger.LogInformation(
+                    "ContextDiscovery subagent {Name}: activated for session {SessionId}.",
+                    conversationTemplate.Name,
+                    body.SessionId);
+            }
+            else
+            {
+                // First-wins collision with a built-in OR an earlier discovery on this conversation.
+                logger.LogInformation(
+                    "ContextDiscovery subagent {Name}: session {SessionId} already has a template "
+                    + "with that name; keeping the first.",
+                    template.Name,
+                    body.SessionId);
+            }
         }
     }
 }

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -669,6 +669,7 @@ try
                         var binding = sp.GetRequiredService<SandboxSessionRegistry>()
                             .GetOrAddSubAgentBinding(
                                 sandboxSession.SessionId,
+                                threadId,
                                 subAgentOptions.Templates,
                                 subAgentFactory);
                         sharedSubAgentSource = binding.Source;

--- a/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
@@ -61,13 +61,19 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
     private readonly ConcurrentDictionary<string, Lazy<Task<SandboxSession>>> _sessions = new(StringComparer.Ordinal);
 
     /// <summary>
-    /// Per-session sub-agent binding (template source + agent factory) the loop uses to populate
-    /// the Agent tool's <c>subagent_type</c> enum and that the context-discovery webhook mutates
-    /// when the gateway reports a newly discovered subagent. Keyed by gateway session id (NOT
-    /// workspace id) so the webhook — which carries the session id, not the workspace id — can
-    /// look up the same instance the loop is reading from.
+    /// Sub-agent binding (template source + agent factory) the loop uses to populate the Agent
+    /// tool's <c>subagent_type</c> enum and that the context-discovery webhook mutates when the
+    /// gateway reports a newly discovered subagent.
     /// </summary>
-    private readonly ConcurrentDictionary<string, SubAgentSessionBinding> _subAgentBindings =
+    /// <remarks>
+    /// Keyed by gateway session id and THEN by conversation (agent-pool thread) id. All
+    /// conversations share ONE sandbox session (v1 always uses the <c>"default"</c> workspace),
+    /// but each conversation owns its OWN catalog source so a sub-agent discovered/registered
+    /// while one conversation is live does not bleed into a NEW conversation that starts later.
+    /// The outer key is the session id (what the webhook carries) so it can fan a discovery out to
+    /// every conversation currently live on that session.
+    /// </remarks>
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, SubAgentSessionBinding>> _subAgentBindings =
         new(StringComparer.Ordinal);
 
     /// <summary>
@@ -369,34 +375,49 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
     }
 
     /// <summary>
-    /// Returns the <see cref="SubAgentSessionBinding"/> for <paramref name="sessionId"/>, creating
-    /// one on first access — seeded with <paramref name="seed"/> and remembering
+    /// Returns the <see cref="SubAgentSessionBinding"/> for the
+    /// (<paramref name="sessionId"/>, <paramref name="conversationId"/>) pair, creating one on
+    /// first access — seeded with <paramref name="seed"/> and remembering
     /// <paramref name="agentFactory"/> for the discovery webhook's spawn-time wiring. Subsequent
-    /// calls return the existing binding unchanged; the binding is single-instance per session for
-    /// the registry's lifetime so the loop and the discovery webhook always share state.
+    /// calls for the same pair return the existing binding unchanged.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// Bindings are scoped per CONVERSATION, not per session: all conversations share one sandbox
+    /// session, but each gets its own catalog source seeded only with the static built-ins, so a
+    /// sub-agent discovered/registered while one conversation is live does NOT leak into a new
+    /// conversation that starts later. The webhook fans live discoveries out via
+    /// <see cref="GetSubAgentBindingsForSession"/>.
+    /// </para>
+    /// <para>
     /// The seed lets the pool factory plant the built-in templates as the initial entries before
     /// the loop wires the source into <see cref="SubAgentToolProvider"/>/<see cref="SubAgentManager"/>.
+    /// </para>
     /// </remarks>
     public SubAgentSessionBinding GetOrAddSubAgentBinding(
         string sessionId,
+        string conversationId,
         IReadOnlyDictionary<string, SubAgentTemplate> seed,
         Func<IStreamingAgent> agentFactory)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
         ArgumentNullException.ThrowIfNull(seed);
         ArgumentNullException.ThrowIfNull(agentFactory);
 
-        var binding = _subAgentBindings.GetOrAdd(
+        var conversations = _subAgentBindings.GetOrAdd(
             sessionId,
+            _ => new ConcurrentDictionary<string, SubAgentSessionBinding>(StringComparer.Ordinal));
+
+        var binding = conversations.GetOrAdd(
+            conversationId,
             _ => new SubAgentSessionBinding(new MutableSubAgentTemplateSource(seed), agentFactory));
 
-        // Reconcile the seed every call: a later pool factory invocation for the same session may
-        // present additional built-in templates that weren't present on the first call. TryRegister
-        // is first-wins, so previously seeded entries (and any discovered templates registered by
-        // the webhook in between) are preserved — the trust boundary holds.
+        // Reconcile the seed every call: a later pool factory invocation for the same conversation
+        // may present additional built-in templates that weren't present on the first call.
+        // TryRegister is first-wins, so previously seeded entries (and any discovered templates
+        // registered by the webhook in between) are preserved — the trust boundary holds.
         foreach (var kvp in seed)
         {
             _ = binding.Source.TryRegister(kvp.Key, kvp.Value);
@@ -406,22 +427,47 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
     }
 
     /// <summary>
-    /// Tries to look up the sub-agent binding previously registered for <paramref name="sessionId"/>
-    /// via <see cref="GetOrAddSubAgentBinding"/>. Returns false (with <paramref name="binding"/>
-    /// set to null) when no binding exists — the discovery webhook treats that as a best-effort
-    /// no-op rather than an error, since the session may not have routed through the agent path
-    /// yet.
+    /// Tries to look up the sub-agent binding previously registered for the
+    /// (<paramref name="sessionId"/>, <paramref name="conversationId"/>) pair via
+    /// <see cref="GetOrAddSubAgentBinding"/>. Returns false (with <paramref name="binding"/> set to
+    /// null) when no binding exists — the discovery webhook treats that as a best-effort no-op
+    /// rather than an error, since the conversation may not have routed through the agent path yet.
     /// </summary>
-    public bool TryGetSubAgentBinding(string sessionId, out SubAgentSessionBinding? binding)
+    public bool TryGetSubAgentBinding(string sessionId, string conversationId, out SubAgentSessionBinding? binding)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        if (string.IsNullOrWhiteSpace(sessionId))
+        if (string.IsNullOrWhiteSpace(sessionId) || string.IsNullOrWhiteSpace(conversationId))
         {
             binding = null;
             return false;
         }
 
-        return _subAgentBindings.TryGetValue(sessionId, out binding);
+        if (_subAgentBindings.TryGetValue(sessionId, out var conversations))
+        {
+            return conversations.TryGetValue(conversationId, out binding);
+        }
+
+        binding = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Returns every conversation's sub-agent binding currently registered for
+    /// <paramref name="sessionId"/>. Used by the context-discovery webhook to fan a discovered
+    /// sub-agent out to every conversation that is live on the shared session. Empty when no
+    /// conversation has initialised the agent path for the session yet.
+    /// </summary>
+    public IReadOnlyList<SubAgentSessionBinding> GetSubAgentBindingsForSession(string sessionId)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            return [];
+        }
+
+        return _subAgentBindings.TryGetValue(sessionId, out var conversations)
+            ? [.. conversations.Values]
+            : [];
     }
 
     /// <summary>
@@ -500,6 +546,14 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
         foreach (var set in _sessionThreads.Values)
         {
             _ = set.TryRemove(threadId, out _);
+        }
+
+        // Release the conversation's per-conversation sub-agent binding (keyed by conversation ==
+        // thread id). One is created per chat, so without this they accumulate unbounded for the
+        // process lifetime.
+        foreach (var conversations in _subAgentBindings.Values)
+        {
+            _ = conversations.TryRemove(threadId, out _);
         }
     }
 

--- a/src/GithubCopilotProvider/Auth/CliCredentialCopilotTokenProvider.cs
+++ b/src/GithubCopilotProvider/Auth/CliCredentialCopilotTokenProvider.cs
@@ -9,6 +9,7 @@ namespace AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
 ///     <list type="number">
 ///         <item>environment variables (<c>GITHUB_COPILOT_TOKEN</c>, <c>GH_COPILOT_TOKEN</c>, <c>GH_TOKEN</c>, <c>GITHUB_TOKEN</c>);</item>
 ///         <item>the GitHub Copilot CLI config (<c>~/.copilot/config.json</c>), which stores its own GitHub token;</item>
+///         <item>the macOS login keychain (service <c>copilot-cli</c>), where the Copilot CLI stores its token on macOS;</item>
 ///         <item>the GitHub Copilot editor credential files (<c>apps.json</c> / <c>hosts.json</c>) under the user config dir;</item>
 ///         <item>the <c>gh</c> CLI hosts file (<c>hosts.yml</c>);</item>
 ///         <item>the <c>gh auth token</c> command.</item>
@@ -67,7 +68,15 @@ public sealed partial class CliCredentialCopilotTokenProvider : ICopilotTokenPro
             }
         }
 
-        // 3. GitHub Copilot editor credential files (apps.json / hosts.json).
+        // 3. macOS login keychain — the Copilot CLI stores its token here (service "copilot-cli"),
+        //    not in any file, so this is the only zero-setup source for a keychain-authenticated user.
+        var keychainToken = TryGetTokenFromMacKeychain();
+        if (!string.IsNullOrWhiteSpace(keychainToken))
+        {
+            return keychainToken;
+        }
+
+        // 4. GitHub Copilot editor credential files (apps.json / hosts.json).
         foreach (var path in CopilotEditorCredentialFiles())
         {
             var token = TryReadOAuthTokenFromJson(path);
@@ -77,7 +86,7 @@ public sealed partial class CliCredentialCopilotTokenProvider : ICopilotTokenPro
             }
         }
 
-        // 4. gh CLI hosts.yml (YAML).
+        // 5. gh CLI hosts.yml (YAML).
         foreach (var path in GhCliHostsYamlFiles())
         {
             var token = TryReadOAuthTokenFromYaml(path);
@@ -87,7 +96,7 @@ public sealed partial class CliCredentialCopilotTokenProvider : ICopilotTokenPro
             }
         }
 
-        // 5. gh auth token (shell out, last resort).
+        // 6. gh auth token (shell out, last resort).
         return TryGetTokenFromGhCli();
     }
 
@@ -287,6 +296,65 @@ public sealed partial class CliCredentialCopilotTokenProvider : ICopilotTokenPro
         }
 
         return null;
+    }
+
+    /// <summary>
+    ///     Reads the Copilot CLI's GitHub token from the macOS login keychain (generic-password
+    ///     service <c>copilot-cli</c>) via <c>security find-generic-password -s copilot-cli -w</c>.
+    ///     No-ops on non-macOS platforms. Only returns a value that looks like a GitHub token so a
+    ///     foreign/legacy keychain entry can never poison resolution.
+    /// </summary>
+    private static string? TryGetTokenFromMacKeychain()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return null;
+        }
+
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "security",
+                    ArgumentList = { "find-generic-password", "-s", "copilot-cli", "-w" },
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                },
+            };
+
+            if (!process.Start())
+            {
+                return null;
+            }
+
+            var output = process.StandardOutput.ReadToEnd();
+            if (!process.WaitForExit(5000))
+            {
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch (InvalidOperationException)
+                {
+                    // Process already exited.
+                }
+
+                return null;
+            }
+
+            var token = output.Trim();
+            return process.ExitCode == 0 && GitHubTokenRegex().IsMatch(token) ? token : null;
+        }
+        catch (Exception ex)
+            when (ex is System.ComponentModel.Win32Exception or InvalidOperationException or IOException)
+        {
+            // `security` missing / not on PATH (non-macOS or stripped image).
+            return null;
+        }
     }
 
     private static string? TryGetTokenFromGhCli()

--- a/src/LmMultiTurn/MultiTurnAgentBase.cs
+++ b/src/LmMultiTurn/MultiTurnAgentBase.cs
@@ -35,6 +35,11 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     // Lifecycle
     private Task? _runTask;
     private CancellationTokenSource? _internalCts;
+
+    // Set once history has been (attempted to be) recovered from the store, so RunAsync's
+    // startup recovery and any explicit RecoverAsync call never double-restore (RestoreHistory
+    // appends). Guards the "recover persisted history on (re)create" path used by the agent pool.
+    private bool _historyRecovered;
     private volatile bool _isDisposed;
 
     #endregion
@@ -484,6 +489,10 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
             throw new InvalidOperationException("No persistence store configured");
         }
 
+        // Mark recovery as attempted up front so RunAsync's startup recovery does not run it a
+        // second time (RestoreHistory appends, so a double-recover would duplicate history).
+        _historyRecovered = true;
+
         // Load metadata first
         var metadata = await Store.LoadMetadataAsync(ThreadId, ct);
         if (metadata == null)
@@ -857,6 +866,17 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
 
         // Ensure channel exists (recreate if it was completed by previous stop)
         EnsureChannelExists();
+
+        // Rehydrate persisted conversation history before the loop processes any input. The agent
+        // pool creates a loop and starts it via RunAsync without ever calling RecoverAsync, so
+        // without this an agent recreated after a restart (or a mode/provider switch, which also
+        // rebuilds the agent) begins with empty history and the LLM loses all prior context even
+        // though every message is still in the store. Idempotent via _historyRecovered, so callers
+        // that already recovered explicitly are not double-restored.
+        if (Store != null && !_historyRecovered)
+        {
+            await RecoverAsync(ct);
+        }
 
         await OnBeforeRunAsync();
 

--- a/src/LmMultiTurn/MultiTurnAgentBase.cs
+++ b/src/LmMultiTurn/MultiTurnAgentBase.cs
@@ -39,7 +39,7 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     // Set once history has been (attempted to be) recovered from the store, so RunAsync's
     // startup recovery and any explicit RecoverAsync call never double-restore (RestoreHistory
     // appends). Guards the "recover persisted history on (re)create" path used by the agent pool.
-    private bool _historyRecovered;
+    private volatile bool _historyRecovered;
     private volatile bool _isDisposed;
 
     #endregion
@@ -489,15 +489,19 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
             throw new InvalidOperationException("No persistence store configured");
         }
 
-        // Mark recovery as attempted up front so RunAsync's startup recovery does not run it a
-        // second time (RestoreHistory appends, so a double-recover would duplicate history).
-        _historyRecovered = true;
+        // NOTE: _historyRecovered is set ONLY on non-throwing completion (after RestoreHistory, and
+        // on the early "nothing to restore" returns). Setting it before I/O would mean a transient
+        // failure in LoadMetadataAsync/LoadMessagesAsync permanently blocks retry — RunAsync's
+        // startup recovery (gated on !_historyRecovered) would skip forever and the agent would run
+        // with empty history even after the store recovers. The double-recover guard is specifically
+        // about RestoreHistory appending, so the flag belongs right after a successful restore.
 
         // Load metadata first
         var metadata = await Store.LoadMetadataAsync(ThreadId, ct);
         if (metadata == null)
         {
             Logger.LogDebug("No stored metadata found for thread {ThreadId}", ThreadId);
+            _historyRecovered = true;
             return false;
         }
 
@@ -506,14 +510,17 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
         if (persistedMessages.Count == 0)
         {
             Logger.LogDebug("No stored messages found for thread {ThreadId}", ThreadId);
+            _historyRecovered = true;
             return false;
         }
 
         // Convert persisted messages back to IMessages
         var messages = MessagePersistenceConverter.FromPersistedMessages(persistedMessages);
 
-        // Restore history
+        // Restore history. Mark recovered immediately after the append succeeds so RunAsync's
+        // startup recovery and any later explicit RecoverAsync never double-restore.
         RestoreHistory(messages);
+        _historyRecovered = true;
 
         // Restore state
         lock (_stateLock)

--- a/src/LmTestUtils/TestMode/AnthropicTestSseMessageHandler.cs
+++ b/src/LmTestUtils/TestMode/AnthropicTestSseMessageHandler.cs
@@ -266,6 +266,12 @@ public sealed class AnthropicTestSseMessageHandler : HttpMessageHandler
                 );
                 message.ExplicitText = systemPrompt;
             }
+            else if (message.ExplicitText == "__TOOLS_ECHO__")
+            {
+                var toolsEcho = ExtractToolsEcho(requestRoot);
+                _logger.LogDebug("Resolved __TOOLS_ECHO__ placeholder to: {ToolsEcho}", toolsEcho);
+                message.ExplicitText = toolsEcho;
+            }
             else if (message.ExplicitText == "__TOOLS_LIST__")
             {
                 var toolsList = ExtractToolsList(requestRoot);
@@ -743,5 +749,43 @@ public sealed class AnthropicTestSseMessageHandler : HttpMessageHandler
         }
 
         return $"Tool '{toolName}' not found";
+    }
+
+    /// <summary>
+    ///     Extracts each visible tool as <c>name: description</c>, newline-separated. Unlike
+    ///     <see cref="ExtractToolsList"/> (names only), this surfaces descriptions so a probe can
+    ///     inspect content embedded there — e.g. the sub-agent catalog baked into the "Agent" tool
+    ///     description. Anthropic wire format: <c>{ "name", "description", "input_schema" }</c>.
+    /// </summary>
+    private static string ExtractToolsEcho(JsonElement root)
+    {
+        if (!root.TryGetProperty("tools", out var tools) || tools.ValueKind != JsonValueKind.Array)
+        {
+            return "No tools available";
+        }
+
+        var lines = new List<string>();
+        foreach (var tool in tools.EnumerateArray())
+        {
+            if (tool.ValueKind != JsonValueKind.Object
+                || !tool.TryGetProperty("name", out var name)
+                || name.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var toolName = name.GetString();
+            if (string.IsNullOrEmpty(toolName))
+            {
+                continue;
+            }
+
+            var description = tool.TryGetProperty("description", out var desc) && desc.ValueKind == JsonValueKind.String
+                ? desc.GetString() ?? string.Empty
+                : string.Empty;
+            lines.Add($"{toolName}: {description}");
+        }
+
+        return lines.Count == 0 ? "No tools available" : string.Join("\n", lines);
     }
 }

--- a/src/LmTestUtils/TestMode/InstructionChainParser.cs
+++ b/src/LmTestUtils/TestMode/InstructionChainParser.cs
@@ -230,6 +230,15 @@ public sealed class InstructionChainParser(ILogger<InstructionChainParser> logge
                 continue;
             }
 
+            // Check for tools_echo - returns names AND descriptions of all visible tools. Lets a
+            // probe inspect content carried in a tool's description (e.g. the sub-agent catalog
+            // embedded in the "Agent" tool description), which tools_list (names only) cannot see.
+            if (item.TryGetProperty("tools_echo", out _))
+            {
+                messages.Add(InstructionMessage.ForExplicitText("__TOOLS_ECHO__"));
+                continue;
+            }
+
             // Check for request_url_echo - returns the request URL as text
             if (item.TryGetProperty("request_url_echo", out _))
             {

--- a/src/LmTestUtils/TestMode/TestSseMessageHandler.cs
+++ b/src/LmTestUtils/TestMode/TestSseMessageHandler.cs
@@ -216,6 +216,10 @@ public sealed class TestSseMessageHandler : HttpMessageHandler
             {
                 message.ExplicitText = ExtractSystemPrompt(requestRoot);
             }
+            else if (message.ExplicitText == "__TOOLS_ECHO__")
+            {
+                message.ExplicitText = ExtractToolsEcho(requestRoot);
+            }
             else if (message.ExplicitText == "__TOOLS_LIST__")
             {
                 message.ExplicitText = ExtractToolsList(requestRoot);
@@ -369,6 +373,46 @@ public sealed class TestSseMessageHandler : HttpMessageHandler
         }
 
         return $"Tool '{toolName}' not found";
+    }
+
+    /// <summary>
+    ///     Extracts each visible tool as <c>name: description</c>, newline-separated. Unlike
+    ///     <see cref="ExtractToolsList"/> (names only), this surfaces descriptions so a probe can
+    ///     inspect content embedded there — e.g. the sub-agent catalog baked into the "Agent" tool
+    ///     description. OpenAI wire format: <c>{ "function": { "name", "description" } }</c>.
+    /// </summary>
+    private static string ExtractToolsEcho(JsonElement root)
+    {
+        if (!root.TryGetProperty("tools", out var tools) || tools.ValueKind != JsonValueKind.Array)
+        {
+            return "No tools available";
+        }
+
+        var lines = new List<string>();
+        foreach (var tool in tools.EnumerateArray())
+        {
+            if (tool.ValueKind != JsonValueKind.Object
+                || !tool.TryGetProperty("function", out var fn)
+                || fn.ValueKind != JsonValueKind.Object
+                || !fn.TryGetProperty("name", out var name)
+                || name.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var toolName = name.GetString();
+            if (string.IsNullOrEmpty(toolName))
+            {
+                continue;
+            }
+
+            var description = fn.TryGetProperty("description", out var desc) && desc.ValueKind == JsonValueKind.String
+                ? desc.GetString() ?? string.Empty
+                : string.Empty;
+            lines.Add($"{toolName}: {description}");
+        }
+
+        return lines.Count == 0 ? "No tools available" : string.Join("\n", lines);
     }
 
     /// <summary>

--- a/tests/LmMultiTurn.Tests/MultiTurnAgentBaseTests.cs
+++ b/tests/LmMultiTurn.Tests/MultiTurnAgentBaseTests.cs
@@ -30,6 +30,9 @@ public class MultiTurnAgentBaseTests
         public string? LastRunId { get; private set; }
         public string? LastGenerationId { get; private set; }
 
+        /// <summary>Test-only window into the protected conversation history, used to assert recovery.</summary>
+        public IReadOnlyList<IMessage> SnapshotHistoryForTest() => GetHistorySnapshot();
+
         public TestMultiTurnAgent(
             string threadId,
             List<IMessage>? messagesToReturn = null,
@@ -649,6 +652,69 @@ public class MultiTurnAgentBaseTests
         receipt.QueuedAt.Should().BeOnOrBefore(afterSend);
 
         // Cleanup
+        await agent.DisposeAsync();
+    }
+
+    #endregion
+
+    #region History Recovery Tests
+
+    [Fact]
+    public async Task RunAsync_RecoversPersistedHistory_FromStore_WithoutExplicitRecoverCall()
+    {
+        // Regression: the agent pool builds a loop and starts it via RunAsync — it never calls
+        // RecoverAsync explicitly. After an app restart the in-memory history is empty, so unless
+        // RunAsync rehydrates the persisted conversation, the LLM loses ALL prior context even
+        // though every message is still on disk (symptom: "the model doesn't have older messages").
+        var store = new InMemoryConversationStore();
+        var threadId = "test-thread-history-recovery";
+        const string runId = "prior-run";
+
+        var priorMessages = new List<IMessage>
+        {
+            new TextMessage { Text = "My name is Alice.", Role = Role.User, GenerationId = "g1", RunId = runId },
+            new TextMessage
+            {
+                Text = "Nice to meet you, Alice.",
+                Role = Role.Assistant,
+                GenerationId = "g2",
+                RunId = runId,
+            },
+        };
+        await store.AppendMessagesAsync(
+            threadId,
+            MessagePersistenceConverter.ToPersistedMessages(priorMessages, threadId, runId));
+        await store.SaveMetadataAsync(
+            threadId,
+            new ThreadMetadata
+            {
+                ThreadId = threadId,
+                LatestRunId = runId,
+                LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            });
+
+        var agent = new TestMultiTurnAgent(threadId, store: store);
+        using var cts = new CancellationTokenSource();
+
+        // Act: start the loop exactly as the pool does — RunAsync, NOT an explicit RecoverAsync.
+        _ = agent.RunAsync(cts.Token);
+
+        // Recovery runs at loop startup; poll the working history until it rehydrates (or time out).
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        while (agent.SnapshotHistoryForTest().Count < priorMessages.Count && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(20);
+        }
+
+        // Assert: the prior conversation is back in the loop's history, so the next turn resends
+        // it to the LLM.
+        var history = agent.SnapshotHistoryForTest();
+        history.OfType<TextMessage>().Select(m => m.Text)
+            .Should()
+            .Contain("My name is Alice.")
+            .And.Contain("Nice to meet you, Alice.");
+
+        await cts.CancelAsync();
         await agent.DisposeAsync();
     }
 

--- a/tests/LmMultiTurn.Tests/MultiTurnAgentBaseTests.cs
+++ b/tests/LmMultiTurn.Tests/MultiTurnAgentBaseTests.cs
@@ -718,6 +718,122 @@ public class MultiTurnAgentBaseTests
         await agent.DisposeAsync();
     }
 
+    [Fact]
+    public async Task RecoverAsync_TransientLoadFailure_DoesNotPoisonRecovery_AndRetrySucceeds()
+    {
+        // Regression: _historyRecovered must NOT be set when LoadMessagesAsync/LoadMetadataAsync
+        // throws (transient store/IO failure). If the flag were set up front, the failed
+        // RecoverAsync would permanently block both RunAsync's startup recovery and any later
+        // explicit RecoverAsync, leaving the agent stuck with empty history even after the store
+        // recovers. Here the store throws on the FIRST LoadMessagesAsync call then succeeds; the
+        // first RecoverAsync must throw without marking recovered, and a SECOND RecoverAsync must
+        // restore history.
+        var inner = new InMemoryConversationStore();
+        var threadId = "test-thread-transient-recovery";
+        const string runId = "prior-run";
+
+        var priorMessages = new List<IMessage>
+        {
+            new TextMessage { Text = "My name is Bob.", Role = Role.User, GenerationId = "g1", RunId = runId },
+            new TextMessage
+            {
+                Text = "Hello, Bob.",
+                Role = Role.Assistant,
+                GenerationId = "g2",
+                RunId = runId,
+            },
+        };
+        await inner.AppendMessagesAsync(
+            threadId,
+            MessagePersistenceConverter.ToPersistedMessages(priorMessages, threadId, runId));
+        await inner.SaveMetadataAsync(
+            threadId,
+            new ThreadMetadata
+            {
+                ThreadId = threadId,
+                LatestRunId = runId,
+                LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            });
+
+        var store = new FlakyLoadMessagesStore(inner, failuresBeforeSuccess: 1);
+        var agent = new TestMultiTurnAgent(threadId, store: store);
+
+        // Act 1: first RecoverAsync hits the transient failure and throws.
+        var firstRecover = async () => await agent.RecoverAsync();
+        await firstRecover.Should().ThrowAsync<IOException>();
+
+        // The flag must NOT be stuck — history is still empty and a retry is allowed.
+        agent.SnapshotHistoryForTest().Should().BeEmpty(
+            "a failed recovery must not leave partially-restored history");
+
+        // Act 2: a later RunAsync (as the agent pool does — no explicit RecoverAsync) must still
+        // perform startup recovery, because the failed attempt must not have set _historyRecovered.
+        // The store now succeeds on its second LoadMessagesAsync call.
+        using var cts = new CancellationTokenSource();
+        _ = agent.RunAsync(cts.Token);
+
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        while (agent.SnapshotHistoryForTest().Count < priorMessages.Count && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(20);
+        }
+
+        // Assert: the transient failure did not poison recovery — RunAsync rehydrated the history.
+        agent.SnapshotHistoryForTest().OfType<TextMessage>().Select(m => m.Text)
+            .Should()
+            .Contain("My name is Bob.")
+            .And.Contain("Hello, Bob.");
+
+        await cts.CancelAsync();
+        await agent.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Decorator store that throws on the first N <see cref="LoadMessagesAsync"/> calls (modeling a
+    /// transient store/IO failure) then delegates to the inner store. Used to prove that a failed
+    /// recovery does not permanently poison <c>_historyRecovered</c>.
+    /// </summary>
+    private sealed class FlakyLoadMessagesStore : IConversationStore
+    {
+        private readonly IConversationStore _inner;
+        private int _remainingFailures;
+
+        public FlakyLoadMessagesStore(IConversationStore inner, int failuresBeforeSuccess)
+        {
+            _inner = inner;
+            _remainingFailures = failuresBeforeSuccess;
+        }
+
+        public Task<IReadOnlyList<PersistedMessage>> LoadMessagesAsync(string threadId, CancellationToken ct = default)
+        {
+            if (_remainingFailures > 0)
+            {
+                _remainingFailures--;
+                throw new IOException("Transient store failure (simulated).");
+            }
+
+            return _inner.LoadMessagesAsync(threadId, ct);
+        }
+
+        public Task AppendMessagesAsync(string threadId, IReadOnlyList<PersistedMessage> messages, CancellationToken ct = default)
+            => _inner.AppendMessagesAsync(threadId, messages, ct);
+
+        public Task ReplaceMessageAsync(string threadId, PersistedMessage replacement, CancellationToken ct = default)
+            => _inner.ReplaceMessageAsync(threadId, replacement, ct);
+
+        public Task SaveMetadataAsync(string threadId, ThreadMetadata metadata, CancellationToken ct = default)
+            => _inner.SaveMetadataAsync(threadId, metadata, ct);
+
+        public Task<ThreadMetadata?> LoadMetadataAsync(string threadId, CancellationToken ct = default)
+            => _inner.LoadMetadataAsync(threadId, ct);
+
+        public Task DeleteThreadAsync(string threadId, CancellationToken ct = default)
+            => _inner.DeleteThreadAsync(threadId, ct);
+
+        public Task<IReadOnlyList<ThreadMetadata>> ListThreadsAsync(int limit = 50, int offset = 0, CancellationToken ct = default)
+            => _inner.ListThreadsAsync(limit, offset, ct);
+    }
+
     #endregion
 
     #region Metadata Preservation Tests

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
@@ -1,3 +1,7 @@
+using System.Net;
+using System.Text;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Services.Auth;
 using LmStreaming.Sample.Services.Discovery;
@@ -271,6 +275,103 @@ public class ContextDiscoveryControllerTests
         var result = await controller.NotifyAsync(body, CancellationToken.None);
 
         result.Should().BeOfType<OkResult>();
+    }
+
+    [Fact]
+    public async Task NotifyAsync_SubAgentDiscovery_RegistersEachConversationsOwnAgentFactory()
+    {
+        // Provider-bleed regression: a sub-agent discovered while TWO conversations are live on the
+        // shared session is loaded once, but each conversation must receive a template wired to ITS
+        // OWN AgentFactory — not the first conversation's. Otherwise conversation B's discovered
+        // sub-agent would spawn using conversation A's provider.
+        var hostPath = Path.Combine(Path.GetTempPath(), "wi-bleed-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(hostPath, ".claude", "agents"));
+        await File.WriteAllTextAsync(
+            Path.Combine(hostPath, ".claude", "agents", "echo.md"),
+            "---\nname: echo\ndescription: Echoes a marker.\n---\nYou are the echo sub-agent.");
+
+        try
+        {
+            const string gatewaySessionId = "sess-bleed";
+
+            HttpResponseMessage Respond(HttpRequestMessage req)
+            {
+                if (req.Method == HttpMethod.Post
+                    && req.RequestUri!.AbsolutePath.Contains("/sandboxes", StringComparison.Ordinal))
+                {
+                    var containerPath = System.Text.Json.JsonSerializer.Serialize(hostPath);
+                    var json =
+                        "{\"session_id\":\"" + gatewaySessionId + "\",\"volumes\":{\"workspace\":{\"container_path\":"
+                        + containerPath + ",\"read_only\":false}}}";
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(json, Encoding.UTF8, "application/json"),
+                    };
+                }
+
+                // Health probe (and anything else) → healthy.
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+
+            var gateway = new SandboxGatewayLifetime(
+                new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl, AutoSpawn = false },
+                NullLogger<SandboxGatewayLifetime>.Instance,
+                new HttpClient(new StubHandler(Respond)));
+
+            await using var registry = new SandboxSessionRegistry(
+                gateway,
+                new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl, AutoSpawn = false },
+                NullLogger<SandboxSessionRegistry>.Instance,
+                new HttpClient(new StubHandler(Respond)),
+                new AuthOptions(),
+                new AuthSharedSecret(new AuthOptions()));
+
+            // Create the shared session so the webhook can resolve it by id.
+            var session = await registry.GetOrCreateSessionAsync("default");
+            session.SessionId.Should().Be(gatewaySessionId);
+
+            var agentA = new Mock<IStreamingAgent>().Object;
+            var agentB = new Mock<IStreamingAgent>().Object;
+            var emptySeed = new Dictionary<string, SubAgentTemplate>();
+            var bindingA = registry.GetOrAddSubAgentBinding(gatewaySessionId, "conv-A", emptySeed, () => agentA);
+            var bindingB = registry.GetOrAddSubAgentBinding(gatewaySessionId, "conv-B", emptySeed, () => agentB);
+
+            var loader = new WorkspaceSubAgentLoader(registry, NullLogger<WorkspaceSubAgentLoader>.Instance);
+            var controller = CreateController(authorizationHeader: Secret, registry: registry, loader: loader);
+
+            var result = await controller.NotifyAsync(
+                new ContextDiscoveryPayload
+                {
+                    SessionId = gatewaySessionId,
+                    Kind = "subagent",
+                    Name = "echo",
+                    Path = ".claude/agents/echo.md",
+                },
+                CancellationToken.None);
+
+            result.Should().BeOfType<OkResult>();
+
+            bindingA.Source.Templates.Should().ContainKey("echo");
+            bindingB.Source.Templates.Should().ContainKey("echo");
+            bindingA.Source.Templates["echo"].AgentFactory().Should().BeSameAs(agentA);
+            bindingB.Source.Templates["echo"].AgentFactory().Should().BeSameAs(
+                agentB,
+                "conversation B's discovered sub-agent must spawn with B's provider, not the first conversation's");
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(hostPath))
+                {
+                    Directory.Delete(hostPath, recursive: true);
+                }
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
+        }
     }
 
     private sealed class StubHandler : HttpMessageHandler

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistrySubAgentIsolationTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistrySubAgentIsolationTests.cs
@@ -1,0 +1,186 @@
+using System.Net;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Auth;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// Regression coverage for the cross-conversation sub-agent bleed: two chat conversations share
+/// ONE sandbox session (v1 always uses the <c>"default"</c> workspace), but a sub-agent discovered
+/// or registered while conversation A is live must NOT leak into a NEW conversation B that starts
+/// later. The Agent tool's <c>subagent_type</c> catalog (the text a model literally sees — what the
+/// <c>tools_echo</c> probe echoes) is rendered from each conversation's
+/// <see cref="MutableSubAgentTemplateSource"/>, so isolation has to hold at the source level.
+/// </summary>
+public class SandboxSessionRegistrySubAgentIsolationTests
+{
+    private const string SessionId = "session-shared";
+    private const string GatewayBaseUrl = "http://localhost:3000";
+
+    private static readonly Func<IStreamingAgent> AgentFactory = () => new Mock<IStreamingAgent>().Object;
+
+    /// <summary>
+    /// Conversation A registers (as the context-discovery webhook would) a discovered sub-agent into
+    /// the shared session. A later conversation B — created against the same session but seeded only
+    /// with the static built-ins — must not see A's discovered sub-agent in its Agent-tool catalog.
+    /// </summary>
+    [Fact]
+    public async Task NewConversation_DoesNotInheritEarlierConversationsDiscoveredSubAgent()
+    {
+        await using var registry = CreateRegistry();
+
+        var staticSeed = new Dictionary<string, SubAgentTemplate>
+        {
+            ["researcher"] = Template("Researcher", "Researches topics."),
+        };
+
+        // Conversation A boots first and wires the static built-ins for the shared session.
+        var bindingA = registry.GetOrAddSubAgentBinding(SessionId, "conversation-A", staticSeed, AgentFactory);
+
+        // While A is live the gateway discovers a workspace sub-agent; the webhook registers it into
+        // A's catalog (this is ContextDiscoveryController.TryActivateSubAgentAsync's TryRegister step).
+        registry.TryGetSubAgentBinding(SessionId, "conversation-A", out var aForWebhook).Should().BeTrue();
+        aForWebhook!.Source.TryRegister(
+            "alpha_discovered",
+            Template("AlphaDiscovered", "Discovered by conversation A.")).Should().BeTrue();
+
+        bindingA.Source.Templates.Keys.Should().Contain("alpha_discovered");
+
+        // A brand-new conversation B starts on the SAME session, seeded only with the static built-ins.
+        var bindingB = registry.GetOrAddSubAgentBinding(SessionId, "conversation-B", staticSeed, AgentFactory);
+
+        // B's catalog source must carry the statics but NOT A's discovered sub-agent.
+        bindingB.Source.Templates.Keys.Should().Contain("researcher");
+        bindingB.Source.Templates.Keys.Should().NotContain(
+            "alpha_discovered",
+            "a new conversation must not inherit sub-agents discovered/registered by a different conversation");
+
+        // Probe what B's LLM would actually see: the Agent tool description (the catalog the
+        // tools_echo probe surfaces) must not mention A's discovered sub-agent.
+        var agentDescriptionForB = RenderAgentToolDescription(bindingB.Source);
+        agentDescriptionForB.Should().Contain("researcher");
+        agentDescriptionForB.Should().NotContain(
+            "alpha_discovered",
+            "conversation B's Agent tool catalog (what its model sees) must be isolated from A's discoveries");
+    }
+
+    /// <summary>
+    /// Mid-session activation must still reach conversations that are ALREADY live: a discovery that
+    /// arrives while conversation A is active lands in A's catalog. (Isolation is for conversations
+    /// that start LATER, not a blanket suppression of webhook activation.)
+    /// </summary>
+    [Fact]
+    public async Task DiscoveredSubAgent_StillReachesTheLiveConversationThatTriggeredIt()
+    {
+        await using var registry = CreateRegistry();
+
+        var staticSeed = new Dictionary<string, SubAgentTemplate>
+        {
+            ["researcher"] = Template("Researcher", "Researches topics."),
+        };
+
+        var bindingA = registry.GetOrAddSubAgentBinding(SessionId, "conversation-A", staticSeed, AgentFactory);
+
+        registry.TryGetSubAgentBinding(SessionId, "conversation-A", out var aForWebhook).Should().BeTrue();
+        aForWebhook!.Source.TryRegister(
+            "alpha_discovered",
+            Template("AlphaDiscovered", "Discovered by conversation A.")).Should().BeTrue();
+
+        bindingA.Source.Templates.Keys.Should().Contain("alpha_discovered");
+    }
+
+    /// <summary>
+    /// A conversation's per-conversation sub-agent binding must be released when its thread is torn
+    /// down (the pool raises ThreadRemoved → UnregisterThreadFromAllSessions). Per-conversation
+    /// bindings are created on every new chat, so without cleanup they accumulate unbounded for the
+    /// process lifetime.
+    /// </summary>
+    [Fact]
+    public async Task UnregisterThread_ReleasesThatConversationsSubAgentBinding()
+    {
+        await using var registry = CreateRegistry();
+
+        var staticSeed = new Dictionary<string, SubAgentTemplate>
+        {
+            ["researcher"] = Template("Researcher", "Researches topics."),
+        };
+
+        _ = registry.GetOrAddSubAgentBinding(SessionId, "conversation-A", staticSeed, AgentFactory);
+        registry.TryGetSubAgentBinding(SessionId, "conversation-A", out _).Should().BeTrue();
+
+        registry.UnregisterThreadFromAllSessions("conversation-A");
+
+        registry.TryGetSubAgentBinding(SessionId, "conversation-A", out var binding)
+            .Should().BeFalse("a torn-down conversation's binding must be freed, not retained for the process lifetime");
+        binding.Should().BeNull();
+        registry.GetSubAgentBindingsForSession(SessionId).Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Renders the Agent tool's description exactly as the parent LLM would receive it, so the
+    /// assertion probes the real catalog text (the same string the <c>tools_echo</c> mock-LLM
+    /// primitive echoes), not just the backing dictionary.
+    /// </summary>
+    private static string RenderAgentToolDescription(MutableSubAgentTemplateSource source)
+    {
+        var parentMock = new Mock<IMultiTurnAgent>();
+        parentMock
+            .Setup(p => p.SendAsync(
+                It.IsAny<List<IMessage>>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SendReceipt("receipt", null, DateTimeOffset.UtcNow));
+
+        var manager = new SubAgentManager(
+            parentAgent: parentMock.Object,
+            parentContracts: [],
+            parentHandlers: new Dictionary<string, ToolHandler>(),
+            options: new SubAgentOptions { Templates = source.Templates, MaxConcurrentSubAgents = 5 },
+            source: source);
+
+        var provider = new SubAgentToolProvider(manager, source);
+        var agent = provider.GetFunctions().First(f => f.Contract.Name == "Agent");
+        return agent.Contract.Description ?? string.Empty;
+    }
+
+    private static SubAgentTemplate Template(string name, string description) =>
+        new()
+        {
+            Name = name,
+            Description = description,
+            SystemPrompt = $"You are {name}.",
+            AgentFactory = AgentFactory,
+        };
+
+    private static SandboxSessionRegistry CreateRegistry()
+    {
+        static HttpResponseMessage Unused(HttpRequestMessage _) => new(HttpStatusCode.OK);
+
+        var gateway = new SandboxGatewayLifetime(
+            new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl },
+            NullLogger<SandboxGatewayLifetime>.Instance,
+            new HttpClient(new StubHandler(Unused)));
+
+        return new SandboxSessionRegistry(
+            gateway,
+            new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl },
+            NullLogger<SandboxSessionRegistry>.Instance,
+            new HttpClient(new StubHandler(Unused)),
+            new AuthOptions(),
+            new AuthSharedSecret(new AuthOptions()));
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(respond(request));
+        }
+    }
+}

--- a/tests/LmTestUtils.Tests/InstructionChainParserTests.cs
+++ b/tests/LmTestUtils.Tests/InstructionChainParserTests.cs
@@ -246,6 +246,31 @@ public class InstructionChainParserTests
     }
 
     [Fact]
+    public void ExtractInstructionChain_WithToolsEcho_ShouldParseAsExplicitText()
+    {
+        // tools_echo surfaces tool names AND descriptions (unlike tools_list which is names only),
+        // so a probe can inspect content embedded in a tool's description — e.g. the sub-agent
+        // catalog baked into the "Agent" tool description.
+        var content = """
+            <|instruction_start|>
+            {"instruction_chain": [
+                {"id_message": "Echo tools", "messages":[{"tools_echo":{}}]}
+            ]}
+            <|instruction_end|>
+            """;
+
+        var result = _parser.ExtractInstructionChain(content);
+
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Equal("Echo tools", result[0].IdMessage);
+        Assert.Single(result[0].Messages);
+        Assert.Equal("__TOOLS_ECHO__", result[0].Messages[0].ExplicitText);
+        Assert.Null(result[0].Messages[0].TextLength);
+        Assert.Null(result[0].Messages[0].ToolCalls);
+    }
+
+    [Fact]
     public void ExtractInstructionChain_WithMixedDynamicAndStaticMessages_ShouldParseAll()
     {
         // Arrange


### PR DESCRIPTION
Three independent fixes, cherry-picked clean onto `main` (kept off the shared `feat/deferred-sandbox-auth` branch).

## 1. fix(multiturn): recover persisted history on agent (re)create
`MultiTurnAgentBase.RunAsync` now rehydrates conversation history from the store at loop startup. The agent pool creates a loop and starts it via `RunAsync` but never called `RecoverAsync`, so after an app restart (or a mode/provider switch, which rebuilds the agent) the loop began with empty history and the LLM lost all prior context even though every message was still persisted. Idempotent via a `_historyRecovered` guard. Regression test included.

## 2. feat(copilot): resolve token from the macOS keychain
`CliCredentialCopilotTokenProvider` now reads the Copilot CLI's token from the macOS login keychain (service `copilot-cli`), since the CLI stores its token there (not a file) on macOS. Without it the Copilot-API models (sonnet/haiku/gpt-5.5) were unavailable to a keychain-authenticated user. macOS-gated; validated against the GitHub-token regex so a foreign keychain entry can't poison resolution.

## 3. feat(sample): isolate per-conversation sandbox context + tools_echo probe
A new chat in Workspace Agent mode inherited sub-agents discovered by OTHER conversations, because every conversation shared one sandbox session's sub-agent catalog.
- `SandboxSessionRegistry`: key sub-agent bindings by `(sessionId, conversationId)`; each conversation gets its own catalog source seeded only with the static built-ins. Release a conversation's binding on thread teardown so bindings don't accumulate unbounded.
- `ContextDiscoveryController`: fan a discovered sub-agent out to every live conversation, rebinding each registered template to that conversation's own `AgentFactory` (no cross-conversation provider bleed).
- Adds the `tools_echo` InstructionChain probe (echoes tool names **and** descriptions, surfacing the Agent tool's sub-agent catalog that `tools_list` can't see).

Regression tests cover isolation, binding cleanup, and per-conversation factory.

## Notes
- The chore commit from the original branch (`.gitignore` / `.mcp.json` trim) was intentionally dropped — local config, not a code fix, and it conflicted with main.
- `tools_echo` overlaps somewhat with the `tool_schema` directive added by #85; kept both (different shapes). Worth consolidating later if desired.

## Validation
- `LmTestUtils.Tests`: 84 passed
- `LmStreaming.Sample.Tests`: 194 passed
- `LmMultiTurn.Tests` history-recovery regression: passed

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>