### PR TITLE
fix(sandbox): recreate gateway session on 404 so marketplace tools persist

### DIFF
--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -383,7 +383,11 @@ try
                         workspace?.DirectoryRelPath,
                         workspace?.Marketplaces);
 
-                    sandboxSession = sandboxRegistry.GetOrCreateSessionAsync(workspaceRef).GetAwaiter().GetResult();
+                    // Use the liveness-checked variant: the gateway evicts idle sessions on its own
+                    // schedule, and reusing a cached-but-evicted handle silently strips the session's
+                    // marketplace-provided tools (e.g. sandbox-Skill). This recreates the session on a
+                    // gateway 404 so the agent always gets the full tool set without a process restart.
+                    sandboxSession = sandboxRegistry.GetOrCreateLiveSessionAsync(workspaceRef).GetAwaiter().GetResult();
                     var wsSuffix =
                         "\n\nYour workspace directory is: "
                         + sandboxSession.HostPath

--- a/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
@@ -69,6 +70,12 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
     /// <see cref="SandboxGatewayOptions.Workspace"/>. Also the seeded id used by the workspace store.
     /// </summary>
     public const string DefaultWorkspaceId = "default";
+
+    /// <summary>
+    /// Upper bound on the gateway session-liveness probe so a wedged gateway degrades to "assume
+    /// alive" quickly rather than blocking the turn for the full shared-client timeout.
+    /// </summary>
+    private static readonly TimeSpan SessionLivenessProbeTimeout = TimeSpan.FromSeconds(5);
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -227,6 +234,129 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
             );
             throw;
         }
+    }
+
+    /// <summary>
+    /// Like <see cref="GetOrCreateSessionAsync(string, CancellationToken)"/>, but additionally
+    /// verifies the cached session still exists on the gateway and transparently recreates it when
+    /// it does not. See the <see cref="WorkspaceRef"/> overload for the full rationale.
+    /// </summary>
+    public Task<SandboxSession> GetOrCreateLiveSessionAsync(
+        string workspaceId = DefaultWorkspaceId,
+        CancellationToken ct = default
+    )
+    {
+        return GetOrCreateLiveSessionAsync(new WorkspaceRef(workspaceId), ct);
+    }
+
+    /// <summary>
+    /// Returns a sandbox session for <paramref name="workspaceRef"/> that is guaranteed to still be
+    /// known to the gateway. The in-memory cache (<see cref="GetOrCreateSessionAsync(WorkspaceRef, CancellationToken)"/>)
+    /// is reused as-is while the session is healthy, but the gateway evicts idle sessions on its own
+    /// schedule — after which every call for that id returns <c>404 "Session not found"</c>. Reusing
+    /// the dead handle silently strips the session's marketplace-provided tools (e.g.
+    /// <c>sandbox-Skill</c>). On a definitive 404 this method drops the stale cache entry and
+    /// recreates the session with the same workspace + marketplace selection, so callers always get a
+    /// live session with the full tool set. Non-404 probe failures are treated as "still ours" to
+    /// avoid churning a healthy session when the gateway is briefly unreachable.
+    /// </summary>
+    public async Task<SandboxSession> GetOrCreateLiveSessionAsync(
+        WorkspaceRef workspaceRef,
+        CancellationToken ct = default
+    )
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(workspaceRef);
+
+        var workspaceId = string.IsNullOrWhiteSpace(workspaceRef.Id) ? DefaultWorkspaceId : workspaceRef.Id;
+        var effectiveRef = workspaceRef with { Id = workspaceId };
+
+        var session = await GetOrCreateSessionAsync(effectiveRef, ct).ConfigureAwait(false);
+        if (await IsSessionAliveAsync(session.SessionId, ct).ConfigureAwait(false))
+        {
+            return session;
+        }
+
+        _logger.LogWarning(
+            "Sandbox gateway no longer recognizes session {SessionId} for workspace {WorkspaceId} "
+                + "(likely evicted after idle); recreating it so marketplace tools are restored.",
+            session.SessionId,
+            workspaceId
+        );
+
+        InvalidateSession(workspaceId, session);
+        return await GetOrCreateSessionAsync(effectiveRef, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Probes the gateway for <paramref name="sessionId"/>. Returns <c>false</c> only on a definitive
+    /// <c>404</c> (the gateway has forgotten the session); any other status — success OR a transient
+    /// error — is reported as alive so a flaky gateway never triggers needless recreation.
+    /// </summary>
+    private async Task<bool> IsSessionAliveAsync(string sessionId, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            return false;
+        }
+
+        var requestUri = $"{_gateway.GatewayBaseUrl}/api/v1/sandboxes/{sessionId}";
+
+        // Cap the probe well under the shared client timeout: a wedged (non-404) gateway must not
+        // stall the turn — degrade quickly to "assume alive" instead. The linked token still honours
+        // a genuine caller cancellation.
+        using var probeCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        probeCts.CancelAfter(SessionLivenessProbeTimeout);
+        try
+        {
+            using var response = await _httpClient.GetAsync(requestUri, probeCts.Token).ConfigureAwait(false);
+            return response.StatusCode != HttpStatusCode.NotFound;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw; // genuine caller cancellation — propagate
+        }
+        catch (Exception ex)
+        {
+            // Probe timeout or transient error → assume alive so a flaky/slow gateway never churns a
+            // healthy session (recreating wouldn't help if the gateway is unreachable anyway).
+            _logger.LogDebug(
+                ex,
+                "Liveness probe for sandbox session {SessionId} failed or timed out; assuming the session is still alive.",
+                sessionId
+            );
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Drops a dead session from both caches so the next request recreates it. Removes the
+    /// per-workspace creation entry and the reverse id mapping (the latter only when it still points
+    /// at <paramref name="session"/>, so a concurrent recreation is never clobbered).
+    /// </summary>
+    private void InvalidateSession(string workspaceId, SandboxSession session)
+    {
+        // Remove the cached creation ONLY when it still holds the exact dead session — mirroring
+        // AwaitAndEvictOnFailureAsync's "only evict the entry we own" discipline. A plain key-removal
+        // would clobber a fresh session a concurrent caller may have just installed, orphaning it on
+        // the gateway and causing churn.
+        if (
+            _sessions.TryGetValue(workspaceId, out var lazy)
+            && lazy.IsValueCreated
+            && lazy.Value.IsCompletedSuccessfully
+            && ReferenceEquals(lazy.Value.Result, session)
+        )
+        {
+            _ = ((ICollection<KeyValuePair<string, Lazy<Task<SandboxSession>>>>)_sessions).Remove(
+                new KeyValuePair<string, Lazy<Task<SandboxSession>>>(workspaceId, lazy)
+            );
+        }
+
+        // Reverse map removal is already exact: only drops the entry when it still points at this
+        // dead session, so a concurrent recreation's mapping is never clobbered.
+        _ = ((ICollection<KeyValuePair<string, SandboxSession>>)_sessionsById).Remove(
+            new KeyValuePair<string, SandboxSession>(session.SessionId, session)
+        );
     }
 
     /// <summary>

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryRecreateOnGateway404Tests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryRecreateOnGateway404Tests.cs
@@ -1,0 +1,282 @@
+using System.Net;
+using System.Text;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Auth;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// Regression coverage for the "stale cached session" failure: the registry caches a created
+/// session in-memory per workspace and reuses it without re-validating. When the gateway evicts
+/// that session (e.g. after an idle period) every later gateway call for it returns
+/// <c>404 "Session not found"</c>, and — before this fix — the app kept handing back the dead
+/// handle, so the agent silently lost its marketplace-provided tools (e.g. <c>sandbox-Skill</c>)
+/// until a process restart cleared the cache.
+///
+/// <para>
+/// <see cref="SandboxSessionRegistry.GetOrCreateLiveSessionAsync(WorkspaceRef, CancellationToken)"/>
+/// closes the gap: it probes the gateway for the cached session and, on a definitive 404, evicts
+/// the cache and re-creates the session (re-mounting the workspace's marketplaces).
+/// </para>
+///
+/// <para>
+/// The stub gateway models reality: a freshly-created session is alive until a test explicitly
+/// <see cref="CallLog.Evict"/>s it (simulating the gateway forgetting an idle session).
+/// </para>
+/// </summary>
+public class SandboxSessionRegistryRecreateOnGateway404Tests
+{
+    private const string GatewayBaseUrl = "http://localhost:3000";
+
+    [Fact]
+    public async Task Live_session_check_recreates_session_when_gateway_returns_404()
+    {
+        var (registry, calls) = CreateRegistry();
+
+        var first = await registry.GetOrCreateSessionAsync();
+        first.SessionId.Should().Be("sess-1");
+        calls.PostCount.Should().Be(1);
+
+        calls.Evict("sess-1"); // the gateway forgets the idle session
+
+        var live = await registry.GetOrCreateLiveSessionAsync();
+
+        live.SessionId.Should().Be("sess-2", "the dead session must be replaced, not reused");
+        calls.PostCount.Should().Be(2, "exactly one extra create POST should happen for the recreate");
+        calls.LivenessGets.Should().Contain("sess-1");
+    }
+
+    [Fact]
+    public async Task Live_session_check_reuses_session_when_gateway_still_knows_it()
+    {
+        var (registry, calls) = CreateRegistry();
+
+        var first = await registry.GetOrCreateSessionAsync(); // stays alive — never evicted
+        var live = await registry.GetOrCreateLiveSessionAsync();
+
+        live.SessionId.Should().Be("sess-1");
+        first.SessionId.Should().Be("sess-1");
+        calls.PostCount.Should().Be(1, "a live session must be reused, never recreated");
+        calls.LivenessGets.Should().Contain("sess-1");
+    }
+
+    [Fact]
+    public async Task Live_session_check_does_not_recreate_on_transient_gateway_error()
+    {
+        // A non-404 failure (gateway flapping) must NOT trigger churn — recreating wouldn't help and
+        // would tear down a possibly-healthy session.
+        var (registry, calls) = CreateRegistry(livenessStatusOverride: HttpStatusCode.ServiceUnavailable);
+
+        _ = await registry.GetOrCreateSessionAsync();
+        var live = await registry.GetOrCreateLiveSessionAsync();
+
+        live.SessionId.Should().Be("sess-1", "a 503 is not a definitive 'session gone' signal");
+        calls.PostCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Recreate_preserves_the_workspace_marketplace_selection()
+    {
+        // The headline promise of the fix: when a session is recreated after eviction, the workspace's
+        // marketplaces must be re-sent so its marketplace-provided tools (e.g. sandbox-Skill) come back.
+        var (registry, calls) = CreateRegistry();
+        var workspaceRef = new WorkspaceRef("ws-1", DirectoryRelPath: null, Marketplaces: ["superpowers", "official"]);
+
+        _ = await registry.GetOrCreateSessionAsync(workspaceRef);
+        calls.Evict("sess-1");
+        var live = await registry.GetOrCreateLiveSessionAsync(workspaceRef);
+
+        live.SessionId.Should().Be("sess-2");
+        calls.PostBodies.Should().HaveCount(2);
+        ReadMarketplaces(calls.PostBodies[1]).Should().Equal("superpowers", "official");
+    }
+
+    [Fact]
+    public async Task Recreate_updates_the_reverse_session_id_map()
+    {
+        // The context-discovery webhook resolves sessions via TryGetSessionById; after a recreate it
+        // must point at the live session, not the dead one.
+        var (registry, calls) = CreateRegistry();
+
+        _ = await registry.GetOrCreateSessionAsync();
+        calls.Evict("sess-1");
+        _ = await registry.GetOrCreateLiveSessionAsync();
+
+        registry.TryGetSessionById("sess-2", out var live).Should().BeTrue();
+        live!.SessionId.Should().Be("sess-2");
+        registry.TryGetSessionById("sess-1", out _).Should().BeFalse("the dead session id must be dropped");
+    }
+
+    [Fact]
+    public async Task Concurrent_live_checks_converge_on_a_single_recreated_session()
+    {
+        // Two callers racing the recreate must converge on ONE new session (the cache is not clobbered)
+        // — guards the InvalidateSession "only evict the entry we own" invariant.
+        var (registry, calls) = CreateRegistry();
+
+        _ = await registry.GetOrCreateSessionAsync();
+        calls.Evict("sess-1");
+
+        var results = await Task.WhenAll(
+            registry.GetOrCreateLiveSessionAsync(),
+            registry.GetOrCreateLiveSessionAsync());
+
+        results[0].SessionId.Should().Be(results[1].SessionId, "both callers must converge on the same session");
+        calls.PostCount.Should().Be(2, "the recreate must be single-flighted, not duplicated per caller");
+        registry.TryGetSessionById(results[0].SessionId, out _).Should().BeTrue();
+    }
+
+    private static IReadOnlyList<string> ReadMarketplaces(string body)
+    {
+        using var doc = JsonDocument.Parse(body);
+        return [.. doc.RootElement.GetProperty("marketplaces").EnumerateArray().Select(e => e.GetString()!)];
+    }
+
+    private static (SandboxSessionRegistry Registry, CallLog Calls) CreateRegistry(
+        HttpStatusCode? livenessStatusOverride = null)
+    {
+        var calls = new CallLog();
+
+        var registryHandler = new StubHandler(req =>
+        {
+            var path = req.RequestUri!.AbsolutePath;
+
+            // Create: POST /api/v1/sandboxes — a freshly-created session is alive.
+            if (req.Method == HttpMethod.Post && path.EndsWith("/sandboxes", StringComparison.Ordinal))
+            {
+                var requestBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                var ordinal = calls.RecordPost(requestBody);
+                var sessionId = $"sess-{ordinal}";
+                calls.MarkCreated(sessionId);
+                var responseBody = $$"""
+                    { "session_id": "{{sessionId}}", "container_id": "c-{{ordinal}}",
+                      "volumes": { "workspace": { "container_path": "/workspace", "read_only": false } } }
+                    """;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
+                };
+            }
+
+            // Liveness: GET /api/v1/sandboxes/{id}
+            if (req.Method == HttpMethod.Get && path.Contains("/sandboxes/", StringComparison.Ordinal))
+            {
+                var id = path[(path.LastIndexOf('/') + 1)..];
+                calls.RecordLiveness(id);
+                if (livenessStatusOverride is { } forced)
+                {
+                    return new HttpResponseMessage(forced);
+                }
+
+                return calls.IsAlive(id)
+                    ? new HttpResponseMessage(HttpStatusCode.OK)
+                    : new HttpResponseMessage(HttpStatusCode.NotFound)
+                    {
+                        Content = new StringContent(
+                            $$"""{ "code": 404, "error": "Session not found: {{id}}" }""",
+                            Encoding.UTF8,
+                            "application/json"),
+                    };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+
+        var options = new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl, Marketplaces = null };
+
+        // The gateway lifetime client only serves the /health probe; 200 ⇒ adopt an "existing"
+        // gateway and proceed straight to create/liveness calls on the registry's own client.
+        var gateway = new SandboxGatewayLifetime(
+            options,
+            NullLogger<SandboxGatewayLifetime>.Instance,
+            new HttpClient(new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK))));
+
+        var auth = new AuthOptions();
+        var registry = new SandboxSessionRegistry(
+            gateway,
+            options,
+            NullLogger<SandboxSessionRegistry>.Instance,
+            new HttpClient(registryHandler),
+            auth,
+            new AuthSharedSecret(auth));
+
+        return (registry, calls);
+    }
+
+    // Thread-safe: the concurrency test fires parallel liveness GETs (and a recreate POST) through
+    // the stub handler from multiple threads at once.
+    private sealed class CallLog
+    {
+        private readonly object _gate = new();
+        private readonly List<string> _postBodies = [];
+        private readonly List<string> _livenessGets = [];
+        private readonly HashSet<string> _created = new(StringComparer.Ordinal);
+        private readonly HashSet<string> _evicted = new(StringComparer.Ordinal);
+
+        public int PostCount
+        {
+            get { lock (_gate) { return _postBodies.Count; } }
+        }
+
+        public IReadOnlyList<string> PostBodies
+        {
+            get { lock (_gate) { return [.. _postBodies]; } }
+        }
+
+        public IReadOnlyList<string> LivenessGets
+        {
+            get { lock (_gate) { return [.. _livenessGets]; } }
+        }
+
+        /// <summary>Records a create POST body and returns its 1-based ordinal.</summary>
+        public int RecordPost(string body)
+        {
+            lock (_gate)
+            {
+                _postBodies.Add(body);
+                return _postBodies.Count;
+            }
+        }
+
+        public void RecordLiveness(string sessionId)
+        {
+            lock (_gate)
+            {
+                _livenessGets.Add(sessionId);
+            }
+        }
+
+        public void MarkCreated(string sessionId)
+        {
+            lock (_gate)
+            {
+                _ = _created.Add(sessionId);
+            }
+        }
+
+        /// <summary>Simulates the gateway forgetting an idle session.</summary>
+        public void Evict(string sessionId)
+        {
+            lock (_gate)
+            {
+                _ = _evicted.Add(sessionId);
+            }
+        }
+
+        public bool IsAlive(string sessionId)
+        {
+            lock (_gate)
+            {
+                return _created.Contains(sessionId) && !_evicted.Contains(sessionId);
+            }
+        }
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(respond(request));
+    }
+}


### PR DESCRIPTION
## Problem

The Workspace Agent silently loses its marketplace-provided tools (e.g. `sandbox-Skill`) after the sandbox gateway has been idle for a while. A `tool_schema`/`tools_list` probe shows only the 10 base sandbox tools; `tool_schema{name:"sandbox-Skill"}` returns *"Tool 'sandbox-Skill' not found"*.

## Root cause

`SandboxSessionRegistry` caches sandbox sessions per-workspace in memory (a `Lazy<Task<SandboxSession>>`) and reuses them without re-validating. The gateway evicts idle sessions on its own schedule — after which every call for that id returns `404 "Session not found"`. The app kept handing back the dead handle, so the gateway no longer mounted the workspace's marketplaces and only its always-on base tools remained. The session was only re-created by a full app restart (which clears the cache).

Confirmed via logs + live gateway: the same session that successfully called `sandbox-Skill` in the morning later 404'd (`GET /api/v1/sandboxes/{id}` → 404; `GET /api/v1/sandboxes` → `{"sandboxes": []}`), and a fresh Demo2 session (marketplaces `ClaudePlugins, knowledge-work-plugins, superpowers`) restored `sandbox-Skill`.

## Fix

- **`GetOrCreateLiveSessionAsync`** probes the gateway for the cached session and, on a definitive `404`, evicts the stale cache entry and re-creates the session with the same workspace + marketplace selection. Non-404 / transient probe failures are treated as "still alive" so a flaky gateway never churns a healthy session.
- **`Program.cs`** uses it at workspace-agent session acquisition (before the MCP client connects).
- **`InvalidateSession`** evicts only the exact dead `Lazy` (matching `AwaitAndEvictOnFailureAsync`'s discipline) so a concurrent caller's fresh session is never clobbered / orphaned.
- The liveness probe is capped at 5s (linked CTS) so a hung gateway can't stall a turn for the full client timeout.

## Tests

`SandboxSessionRegistryRecreateOnGateway404Tests` (6): recreate-on-404, reuse-when-alive, no-churn-on-503, **marketplace preservation on recreate**, reverse-map cleanup, concurrent-recreate convergence.

All registry tests (38) and the full `LmStreaming.Sample.Tests` project (261) pass; concurrency test 5/5; sample builds 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)