### PR TITLE
refactor(sandbox): status-only liveness probe + observable probe-failure log

### DIFF
--- a/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
@@ -309,7 +309,9 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
         probeCts.CancelAfter(SessionLivenessProbeTimeout);
         try
         {
-            using var response = await _httpClient.GetAsync(requestUri, probeCts.Token).ConfigureAwait(false);
+            using var response = await _httpClient
+                .GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, probeCts.Token)
+                .ConfigureAwait(false);
             return response.StatusCode != HttpStatusCode.NotFound;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -320,7 +322,7 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
         {
             // Probe timeout or transient error → assume alive so a flaky/slow gateway never churns a
             // healthy session (recreating wouldn't help if the gateway is unreachable anyway).
-            _logger.LogDebug(
+            _logger.LogInformation(
                 ex,
                 "Liveness probe for sandbox session {SessionId} failed or timed out; assuming the session is still alive.",
                 sessionId


### PR DESCRIPTION
Follow-up to #92 addressing the reviewer's two non-blocking inline findings (the PR merged before these landed).

## Changes
- **[MEDIUM, partial]** `IsSessionAliveAsync` only checks the status code, so it now uses `HttpCompletionOption.ResponseHeadersRead` instead of buffering the (404) response body.
- **[LOW]** Probe-failure log raised `Debug` → `Information` so a persistently unreachable gateway (which makes every session "assume alive") is observable at typical production log levels.

## Deferred
The reviewer's freshness-TTL suggestion (skip the probe when a session was verified <30–60s ago) and the 5s→2s timeout tuning are tracked in #93 — they add per-session state and are out of scope for this small follow-up.

## Verification
Build 0 warnings / 0 errors; `SandboxSessionRegistry` tests 38/38 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)