### PR TITLE
Workspace Agent: expose marketplace sub-agents in the Agent tool (incl. test providers)

### DIFF
--- a/samples/LmStreaming.Sample/LmStreaming.Sample.csproj
+++ b/samples/LmStreaming.Sample/LmStreaming.Sample.csproj
@@ -11,6 +11,9 @@
     <InternalsVisibleTo Include="LmStreaming.Sample.E2E.Tests" />
     <!-- Expose internal sub-agent merge helper + loader internals to the unit test project. -->
     <InternalsVisibleTo Include="LmStreaming.Sample.Tests" />
+    <!-- Expose the marketplace sub-agent mapping (MarketplaceSubAgentLoader.MapCatalog) to the
+         browser E2E project so it can prove a catalog-derived agent is spawnable through the UI. -->
+    <InternalsVisibleTo Include="LmStreaming.Sample.Browser.E2E.Tests" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.84.1" />

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -1464,21 +1464,39 @@ public partial class Program
         IWorkspaceStore workspaceStore,
         Microsoft.Extensions.Logging.ILogger logger)
     {
-        var discovered = await workspaceLoader
-            .LoadAsync(sandboxSession, providerAgentFactory)
+        // Workspace file-discovery and the marketplace catalog are independent gateway round-trips.
+        // Fetch them concurrently so the (sync-over-async) blocking window is one round-trip, not two.
+        // Both loaders are best-effort (log + return empty on failure), so neither task faults; the
+        // dictionary is mutated only AFTER both complete, so the in-order merge stays single-threaded.
+        var discoveredTask = workspaceLoader.LoadAsync(sandboxSession, providerAgentFactory);
+        var marketplaceTask = LoadMarketplaceSubAgentsAsync(
+            marketplaceLoader, workspaceStore, sandboxSession.WorkspaceId, providerAgentFactory, logger);
+
+        await Task.WhenAll(discoveredTask, marketplaceTask).ConfigureAwait(false);
+
+        // Merge in precedence order: built-in (already present) > workspace file > marketplace.
+        WorkspaceSubAgentLoader.MergeBuiltInWins(templates, discoveredTask.Result, logger);
+        MarketplaceSubAgentLoader.MergeFillGaps(templates, marketplaceTask.Result, logger);
+    }
+
+    /// <summary>
+    /// Resolves the workspace's enabled marketplaces and loads their catalog agents as one awaitable,
+    /// so it can run concurrently with workspace file-discovery in
+    /// <see cref="EnrichWithWorkspaceCatalogAsync"/>. Best-effort throughout.
+    /// </summary>
+    private static async Task<IReadOnlyDictionary<string, SubAgentTemplate>> LoadMarketplaceSubAgentsAsync(
+        MarketplaceSubAgentLoader marketplaceLoader,
+        IWorkspaceStore workspaceStore,
+        string workspaceId,
+        Func<IStreamingAgent> providerAgentFactory,
+        Microsoft.Extensions.Logging.ILogger logger)
+    {
+        var marketplaces = await ResolveWorkspaceMarketplacesAsync(workspaceStore, workspaceId, logger)
             .ConfigureAwait(false);
 
-        WorkspaceSubAgentLoader.MergeBuiltInWins(templates, discovered, logger);
-
-        var marketplaces = await ResolveWorkspaceMarketplacesAsync(
-                workspaceStore, sandboxSession.WorkspaceId, logger)
-            .ConfigureAwait(false);
-
-        var fromMarketplace = await marketplaceLoader
+        return await marketplaceLoader
             .LoadAsync(marketplaces, providerAgentFactory)
             .ConfigureAwait(false);
-
-        MarketplaceSubAgentLoader.MergeFillGaps(templates, fromMarketplace, logger);
     }
 
     /// <summary>

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -229,6 +229,11 @@ try
     // them into SubAgentTemplate so they show up as spawnable types in the Agent tool catalog.
     _ = builder.Services.AddSingleton<WorkspaceSubAgentLoader>();
 
+    // Marketplace sub-agent bridge. Maps the agents the UI's marketplace browser lists (the
+    // gateway's read-only catalog) into spawnable templates, filling any gap left by workspace
+    // file-discovery so a browsable marketplace agent is also a usable Agent tool subagent_type.
+    _ = builder.Services.AddSingleton<MarketplaceSubAgentLoader>();
+
     // Sandbox context-file (CLAUDE.md / AGENTS.md) injection. The formatter owns the
     // <context-discovery> wrapper tag shared by the boot-time system prompt and the mid-session
     // user-turn injection; the injector wires gateway webhook deliveries into every live agent
@@ -678,9 +683,13 @@ try
 
                     // Sub-agent orchestration options. Only the middleware providers reach this
                     // path — the CLI providers (codex/claude/copilot and their *-mock variants)
-                    // returned earlier and have no sub-agent hook, so they are out of scope. Test
-                    // modes go through the ITestAgentBuilder DI seam (scripted templates for E2E);
-                    // the real providers get the production template catalog. In both cases the
+                    // returned earlier and have no sub-agent hook, so they are out of scope. Mock
+                    // providers (test/test-anthropic) go through the ITestAgentBuilder DI seam for
+                    // their base catalog (scripted templates for E2E); real providers start from the
+                    // shared built-ins. BOTH then get the same workspace + marketplace enrichment when
+                    // a sandbox session is active, so the Agent tool advertises an identical catalog
+                    // regardless of provider — and the mock-only instruction-chain tool_schema probe
+                    // can validate the workspace-discovered/marketplace sub-agents. In all cases the
                     // template AgentFactory reuses agentFactory(normalizedProviderId) so each spawn
                     // builds a FRESH provider agent on the same backend as the parent.
                     var isTestMode =
@@ -690,18 +699,20 @@ try
                     // seam exposed by the pool's agent factory contract, and this runs on the
                     // pool-creation path (no ASP.NET SynchronizationContext) so a .Result here
                     // cannot deadlock. The blocking call is HTTP only when a sandbox session is
-                    // active; otherwise BuildProductionSubAgentOptionsAsync returns synchronously.
+                    // active; otherwise it completes synchronously.
                     Func<IStreamingAgent> subAgentFactory = () => agentFactory(normalizedProviderId);
-                    var subAgentOptions = isTestMode
-                        ? sp.GetRequiredService<ITestAgentBuilder>()
-                            .CreateSubAgentOptions(loggerFactory, subAgentFactory)
-                        : BuildProductionSubAgentOptionsAsync(
-                                subAgentFactory,
-                                sandboxSession,
-                                sp.GetRequiredService<WorkspaceSubAgentLoader>(),
-                                loggerFactory.CreateLogger("LmStreaming.Sample.SubAgentCatalog"))
-                            .GetAwaiter()
-                            .GetResult();
+                    var subAgentOptions = BuildSubAgentOptionsAsync(
+                            isTestMode,
+                            sp.GetRequiredService<ITestAgentBuilder>(),
+                            loggerFactory,
+                            subAgentFactory,
+                            sandboxSession,
+                            sp.GetRequiredService<WorkspaceSubAgentLoader>(),
+                            sp.GetRequiredService<MarketplaceSubAgentLoader>(),
+                            sp.GetRequiredService<IWorkspaceStore>(),
+                            loggerFactory.CreateLogger("LmStreaming.Sample.SubAgentCatalog"))
+                        .GetAwaiter()
+                        .GetResult();
 
                     // When a sandbox session is active, share the catalog with the session
                     // registry so the context-discovery webhook can activate newly discovered
@@ -1380,40 +1391,120 @@ public partial class Program
     }
 
     /// <summary>
-    ///     Builds the production sub-agent orchestration options for the real middleware
-    ///     providers (OpenAI / Anthropic / Copilot-backed). Each template reuses the parent's
-    ///     provider via <paramref name="providerAgentFactory"/> — invoked per spawn so every
-    ///     sub-agent gets a FRESH provider agent on the same backend — and carries its own
-    ///     system prompt and turn budget. The CLI providers (codex/claude/copilot) have no
-    ///     sub-agent hook and are out of scope, so this is only called from the middleware path.
+    ///     Builds the sub-agent orchestration options for a chat agent, used by BOTH the real
+    ///     middleware providers (OpenAI / Anthropic / Copilot-backed) AND the mock providers
+    ///     (<c>test</c> / <c>test-anthropic</c>). The base catalog differs by provider kind — mock
+    ///     providers go through the <see cref="ITestAgentBuilder"/> seam (built-ins by default, or
+    ///     scripted templates injected by E2E); real providers start from the shared built-ins — but
+    ///     the workspace enrichment is identical for both, so the <c>Agent</c> tool advertises the
+    ///     same workspace + marketplace catalog regardless of provider. That parity is what lets the
+    ///     instruction-chain <c>tools_echo</c> / <c>tool_schema</c> probe (mock-only) validate the
+    ///     workspace-discovered and marketplace sub-agents. Each template reuses
+    ///     <paramref name="providerAgentFactory"/> — invoked per spawn so every sub-agent gets a
+    ///     FRESH provider agent on the same backend as the parent.
     /// </summary>
-    private static async Task<SubAgentOptions> BuildProductionSubAgentOptionsAsync(
+    private static async Task<SubAgentOptions?> BuildSubAgentOptionsAsync(
+        bool isTestMode,
+        ITestAgentBuilder testAgentBuilder,
+        ILoggerFactory loggerFactory,
         Func<IStreamingAgent> providerAgentFactory,
         SandboxSession? sandboxSession,
         WorkspaceSubAgentLoader workspaceLoader,
+        MarketplaceSubAgentLoader marketplaceLoader,
+        IWorkspaceStore workspaceStore,
         Microsoft.Extensions.Logging.ILogger logger)
     {
-        var templates = BuiltInSubAgentTemplates.Create(providerAgentFactory);
+        // Base catalog: mock providers go through the ITestAgentBuilder seam (built-ins by default,
+        // or scripted templates an E2E test injected); real providers start from the shared built-ins.
+        var baseOptions = isTestMode
+            ? testAgentBuilder.CreateSubAgentOptions(loggerFactory, providerAgentFactory)
+            : new SubAgentOptions
+            {
+                Templates = BuiltInSubAgentTemplates.Create(providerAgentFactory),
+                MaxConcurrentSubAgents = BuiltInSubAgentTemplates.DefaultMaxConcurrentSubAgents,
+            };
 
-        // When a sandbox session is available, merge in any sub-agents the gateway has
-        // discovered in the workspace. Collision policy: BUILT-IN WINS — a discovered template
-        // cannot shadow one of the hardcoded entries above. Failures inside the loader are
-        // already logged and surfaced as an empty dictionary, so this call cannot throw and
-        // never aborts the agent-creation path.
-        if (sandboxSession is not null)
+        // No sandbox session (e.g. a non-workspace chat, or an E2E scenario with no gateway) means
+        // nothing to discover — keep the base catalog exactly as-is so injected E2E templates and the
+        // plain built-in surface are untouched.
+        if (baseOptions is null || sandboxSession is null)
         {
-            var discovered = await workspaceLoader
-                .LoadAsync(sandboxSession, providerAgentFactory)
-                .ConfigureAwait(false);
-
-            WorkspaceSubAgentLoader.MergeBuiltInWins(templates, discovered, logger);
+            return baseOptions;
         }
 
-        return new SubAgentOptions
+        var templates = new Dictionary<string, SubAgentTemplate>(baseOptions.Templates, StringComparer.Ordinal);
+        await EnrichWithWorkspaceCatalogAsync(
+                templates, providerAgentFactory, sandboxSession, workspaceLoader, marketplaceLoader, workspaceStore, logger)
+            .ConfigureAwait(false);
+
+        return baseOptions with { Templates = templates };
+    }
+
+    /// <summary>
+    ///     Layers workspace-discovered and marketplace sub-agents onto a base catalog
+    ///     <paramref name="templates"/> in three tiers of decreasing trust/richness, each only
+    ///     filling keys the prior tier left open:
+    ///     <list type="number">
+    ///       <item>Base catalog (built-ins / scripted) — already present, always wins.</item>
+    ///       <item>Workspace-discovered files — the gateway found a real agent markdown in the
+    ///         workspace; it carries the agent's full instruction body. The base catalog still wins.</item>
+    ///       <item>Marketplace catalog — agents the UI's marketplace browser lists but that were never
+    ///         materialised as workspace files. Best-effort prompt only, so they FILL GAPS left by the
+    ///         tiers above. This is what makes a browsable marketplace agent a spawnable subagent_type.</item>
+    ///     </list>
+    ///     Every loader is best-effort (logs + returns empty on failure), so none of this can throw or
+    ///     abort agent creation.
+    /// </summary>
+    private static async Task EnrichWithWorkspaceCatalogAsync(
+        IDictionary<string, SubAgentTemplate> templates,
+        Func<IStreamingAgent> providerAgentFactory,
+        SandboxSession sandboxSession,
+        WorkspaceSubAgentLoader workspaceLoader,
+        MarketplaceSubAgentLoader marketplaceLoader,
+        IWorkspaceStore workspaceStore,
+        Microsoft.Extensions.Logging.ILogger logger)
+    {
+        var discovered = await workspaceLoader
+            .LoadAsync(sandboxSession, providerAgentFactory)
+            .ConfigureAwait(false);
+
+        WorkspaceSubAgentLoader.MergeBuiltInWins(templates, discovered, logger);
+
+        var marketplaces = await ResolveWorkspaceMarketplacesAsync(
+                workspaceStore, sandboxSession.WorkspaceId, logger)
+            .ConfigureAwait(false);
+
+        var fromMarketplace = await marketplaceLoader
+            .LoadAsync(marketplaces, providerAgentFactory)
+            .ConfigureAwait(false);
+
+        MarketplaceSubAgentLoader.MergeFillGaps(templates, fromMarketplace, logger);
+    }
+
+    /// <summary>
+    /// Resolves the marketplace aliases enabled for <paramref name="workspaceId"/> so the marketplace
+    /// sub-agent bridge only exposes agents from marketplaces this workspace actually enabled. Returns
+    /// null (gateway default set) when the workspace is unknown or enables none, and never throws —
+    /// catalog enrichment is best-effort.
+    /// </summary>
+    private static async Task<IReadOnlyList<string>?> ResolveWorkspaceMarketplacesAsync(
+        IWorkspaceStore workspaceStore,
+        string workspaceId,
+        Microsoft.Extensions.Logging.ILogger logger)
+    {
+        try
         {
-            Templates = templates,
-            MaxConcurrentSubAgents = BuiltInSubAgentTemplates.DefaultMaxConcurrentSubAgents,
-        };
+            var workspace = await workspaceStore.GetAsync(workspaceId).ConfigureAwait(false);
+            return workspace?.Marketplaces is { Count: > 0 } selected ? selected : null;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Failed to resolve marketplaces for workspace {WorkspaceId}; using the gateway default set.",
+                workspaceId);
+            return null;
+        }
     }
 
     /// <summary>

--- a/samples/LmStreaming.Sample/Services/Discovery/MarketplaceSubAgentLoader.cs
+++ b/samples/LmStreaming.Sample/Services/Discovery/MarketplaceSubAgentLoader.cs
@@ -79,6 +79,17 @@ public sealed class MarketplaceSubAgentLoader
                 "Marketplace catalog unavailable; continuing without marketplace sub-agents.");
             return new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal);
         }
+        catch (Exception ex)
+        {
+            // Defensive backstop matching WorkspaceSubAgentLoader: the catalog client should only
+            // surface MarketplaceCatalogUnavailableException, but an unexpected failure (e.g. an
+            // ObjectDisposedException during shutdown, or a non-cancellation HttpRequestException)
+            // must NOT abort agent creation — enrichment is best-effort.
+            _logger.LogWarning(
+                ex,
+                "Unexpected error fetching marketplace catalog; continuing without marketplace sub-agents.");
+            return new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal);
+        }
 
         return MapCatalog(catalog, agentFactory, _logger);
     }

--- a/samples/LmStreaming.Sample/Services/Discovery/MarketplaceSubAgentLoader.cs
+++ b/samples/LmStreaming.Sample/Services/Discovery/MarketplaceSubAgentLoader.cs
@@ -1,0 +1,202 @@
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using LmStreaming.Sample.Models;
+
+namespace LmStreaming.Sample.Services.Discovery;
+
+/// <summary>
+/// Bridges the gateway's marketplace catalog (<c>GET /api/v1/marketplaces/preview</c> — the same
+/// source the UI's marketplace browser shows) into spawnable <see cref="SubAgentTemplate"/>s, so an
+/// agent the user can SEE in the workspace's enabled marketplaces is also a <c>subagent_type</c> the
+/// <c>Agent</c> tool can spawn.
+/// </summary>
+/// <remarks>
+/// <para>
+/// WHY THIS EXISTS: workspace file-discovery (<see cref="WorkspaceSubAgentLoader"/>,
+/// <c>/api/v1/sandboxes/{id}/discovered</c> ⇒ <c>kind == "subagent"</c>) only surfaces agent
+/// markdown files physically present in the workspace host directory. Marketplace plugin agents are
+/// NOT copied into the workspace — selecting a marketplace only enables it server-side on the
+/// gateway — so they never appear in that discovery list and were browsable-but-not-spawnable. This
+/// loader closes that gap by mapping each <see cref="CatalogAgent"/> the UI lists into a template.
+/// </para>
+/// <para>
+/// PRECEDENCE: marketplace templates only ever FILL GAPS. A built-in template and a real
+/// workspace-discovered file (which carries the agent's full markdown body) both win over a catalog
+/// entry of the same key — see <see cref="MergeFillGaps"/>. The catalog preview does not return the
+/// agent's instruction body (it lives in the plugin directory on the gateway side, not under the
+/// workspace host path), so a catalog-derived template carries a best-effort system prompt built
+/// from the agent's name/plugin/description. That is enough to make it selectable and usefully
+/// scoped; a workspace file with the real body always takes priority when one exists.
+/// </para>
+/// <para>
+/// Best-effort by design: a gateway that is offline or returns an error surfaces as an empty
+/// dictionary after logging, exactly like <see cref="WorkspaceSubAgentLoader"/>, so sub-agent
+/// orchestration degrades to the built-in catalog instead of failing agent creation.
+/// </para>
+/// </remarks>
+public sealed class MarketplaceSubAgentLoader
+{
+    private readonly IMarketplaceCatalogClient _catalogClient;
+    private readonly ILogger<MarketplaceSubAgentLoader> _logger;
+
+    public MarketplaceSubAgentLoader(
+        IMarketplaceCatalogClient catalogClient,
+        ILogger<MarketplaceSubAgentLoader> logger)
+    {
+        _catalogClient = catalogClient ?? throw new ArgumentNullException(nameof(catalogClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Fetches the marketplace catalog for <paramref name="marketplaces"/> (the workspace's enabled
+    /// aliases; null/empty lets the gateway apply its default set — matching the UI browser) and maps
+    /// every contributed agent to a template. Returns an empty dictionary when the gateway is
+    /// unavailable or the catalog is empty.
+    /// </summary>
+    /// <param name="marketplaces">Enabled marketplace aliases for this workspace, or null for the gateway default.</param>
+    /// <param name="agentFactory">Provider-agent factory reused by every mapped template.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task<IReadOnlyDictionary<string, SubAgentTemplate>> LoadAsync(
+        IReadOnlyList<string>? marketplaces,
+        Func<IStreamingAgent> agentFactory,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(agentFactory);
+
+        MarketplaceCatalog catalog;
+        try
+        {
+            catalog = await _catalogClient.GetCatalogAsync(marketplaces, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (MarketplaceCatalogUnavailableException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Marketplace catalog unavailable; continuing without marketplace sub-agents.");
+            return new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal);
+        }
+
+        return MapCatalog(catalog, agentFactory, _logger);
+    }
+
+    /// <summary>
+    /// Flattens every plugin agent in <paramref name="catalog"/> into templates keyed by the agent's
+    /// name (the spawnable <c>subagent_type</c>). Marketplaces that failed to load (non-null
+    /// <see cref="CatalogMarketplace.Error"/>) contribute nothing. Agents with a blank name are
+    /// skipped; duplicate names keep the FIRST occurrence so the surface is stable. Internal-static
+    /// so unit tests can pin the mapping without a gateway.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, SubAgentTemplate> MapCatalog(
+        MarketplaceCatalog catalog,
+        Func<IStreamingAgent> agentFactory,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        ArgumentNullException.ThrowIfNull(agentFactory);
+
+        var result = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal);
+
+        foreach (var marketplace in catalog.Marketplaces ?? [])
+        {
+            foreach (var plugin in marketplace.Plugins ?? [])
+            {
+                foreach (var agent in plugin.Agents ?? [])
+                {
+                    if (string.IsNullOrWhiteSpace(agent.Name))
+                    {
+                        continue;
+                    }
+
+                    var key = agent.Name.Trim();
+                    if (!result.TryAdd(key, MapToTemplate(agent, agentFactory)))
+                    {
+                        logger?.LogInformation(
+                            "Marketplace sub-agent {Name} appears in more than one plugin/marketplace; keeping the first occurrence.",
+                            key);
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Maps one <see cref="CatalogAgent"/> to a template. <c>description</c> seeds both
+    /// <see cref="SubAgentTemplate.Description"/> and <see cref="SubAgentTemplate.WhenToUse"/> (the
+    /// catalog has no separate when-to-use field), mirroring
+    /// <see cref="WorkspaceSubAgentLoader.MapToTemplate"/>. The system prompt is best-effort because
+    /// the preview never returns the agent's instruction body.
+    /// </summary>
+    internal static SubAgentTemplate MapToTemplate(
+        CatalogAgent agent,
+        Func<IStreamingAgent> agentFactory)
+    {
+        var name = agent.Name.Trim();
+        var description = string.IsNullOrWhiteSpace(agent.Description) ? null : agent.Description.Trim();
+
+        return new SubAgentTemplate
+        {
+            Name = name,
+            Description = description,
+            WhenToUse = description,
+            SystemPrompt = BuildSystemPrompt(name, agent.Plugin, agent.Marketplace, description),
+            AgentFactory = agentFactory,
+            EnabledTools = null,
+            MaxTurnsPerRun = WorkspaceSubAgentLoader.DefaultMaxTurnsPerRun,
+        };
+    }
+
+    /// <summary>
+    /// Builds the best-effort persona prompt for a catalog-derived agent. The plugin/marketplace
+    /// provenance grounds the agent; the description (when present) is the only behavioural hint the
+    /// preview exposes.
+    /// </summary>
+    private static string BuildSystemPrompt(string name, string? plugin, string? marketplace, string? description)
+    {
+        var origin = !string.IsNullOrWhiteSpace(plugin)
+            ? !string.IsNullOrWhiteSpace(marketplace)
+                ? $" contributed by the {plugin.Trim()} plugin (from the {marketplace.Trim()} marketplace)"
+                : $" contributed by the {plugin.Trim()} plugin"
+            : string.Empty;
+
+        var role = string.IsNullOrWhiteSpace(description)
+            ? string.Empty
+            : $" {description}";
+
+        return $"You are the \"{name}\" sub-agent{origin}.{role} "
+            + "Complete the delegated task end to end using the tools available to you, then return a "
+            + "concise, self-contained final answer — the parent only sees your final message.";
+    }
+
+    /// <summary>
+    /// Adds <paramref name="catalog"/> templates into <paramref name="existing"/> only where the key
+    /// is not already present: built-in templates AND real workspace-discovered files both keep their
+    /// place (they are merged first), so a catalog stub can never shadow a richer template. Collisions
+    /// are logged at Information — they are expected (e.g. a workspace file overriding its marketplace
+    /// origin), not errors.
+    /// </summary>
+    internal static void MergeFillGaps(
+        IDictionary<string, SubAgentTemplate> existing,
+        IReadOnlyDictionary<string, SubAgentTemplate> catalog,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(existing);
+        ArgumentNullException.ThrowIfNull(catalog);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        foreach (var (key, template) in catalog)
+        {
+            if (!existing.TryAdd(key, template))
+            {
+                logger.LogInformation(
+                    "Marketplace sub-agent {Name} is already provided by a built-in or workspace file; keeping the existing template.",
+                    key);
+            }
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/MarketplaceSubAgentTests.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/MarketplaceSubAgentTests.cs
@@ -1,0 +1,118 @@
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using FluentAssertions;
+using LmStreaming.Sample.Browser.E2E.Tests.Infrastructure;
+using LmStreaming.Sample.Models;
+using LmStreaming.Sample.Services.Discovery;
+
+namespace LmStreaming.Sample.Browser.E2E.Tests.Scenarios;
+
+/// <summary>
+/// Regression proof for the "Workspace Agent mode omits marketplace agents" bug: an agent that the
+/// UI's marketplace browser lists (a <see cref="CatalogAgent"/>) must be a spawnable
+/// <c>subagent_type</c> in the <c>Agent</c> tool, end to end through the real Vue renderer.
+/// </summary>
+/// <remarks>
+/// The sub-agent templates here are produced by the SAME production mapping the app uses —
+/// <see cref="MarketplaceSubAgentLoader.MapCatalog"/> over a representative catalog — rather than
+/// hand-built, so this exercises the actual catalog→template bridge. The parent (scripted) emits an
+/// <c>Agent</c> tool call with <c>subagent_type = "orleans-reviewer"</c>, a name that exists ONLY
+/// because the catalog agent was mapped into a spawnable template. The decisive assertion is the
+/// sub-agent's own phrase ("grain reentrancy looks correct") appearing in the expanded Agent pill:
+/// it is absent from the parent script, so it can only have come from the catalog-derived sub-agent
+/// actually running — if the mapping had dropped the agent, the spawn would have failed instead.
+/// </remarks>
+[Collection(PlaywrightCollection.Name)]
+public sealed class MarketplaceSubAgentTests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public MarketplaceSubAgentTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    // A representative marketplace catalog (one marketplace → one plugin → one agent), mirroring the
+    // shape the gateway's /marketplaces/preview returns and the UI browser shows.
+    private static MarketplaceCatalog SampleCatalog() => new(
+        Selected: ["ClaudePlugins"],
+        Marketplaces:
+        [
+            new CatalogMarketplace(
+                Alias: "ClaudePlugins",
+                Error: null,
+                Plugins:
+                [
+                    new CatalogPlugin(
+                        Name: "orleans-dev",
+                        Version: "1.0.2",
+                        Description: "Orleans patterns, best practices, and code review.",
+                        Skills: [],
+                        Agents:
+                        [
+                            new CatalogAgent(
+                                "orleans-reviewer", "Senior Orleans code reviewer", "orleans-dev",
+                                "ClaudePlugins", "/marketplaces/ClaudePlugins/orleans-dev/agents/orleans-reviewer.md"),
+                        ]),
+                ]),
+        ]);
+
+    [Theory]
+    [InlineData("test")]
+    [InlineData("test-anthropic")]
+    public async Task Marketplace_catalog_agent_is_spawnable_via_Agent_tool(string providerMode)
+    {
+        var responder = ScriptedSseResponder
+            .New()
+            // The sub-agent's system prompt is the best-effort persona MapToTemplate builds; it
+            // contains the agent's name, so this predicate dispatches the spawned catalog agent.
+            .ForRole("reviewer", ctx => ctx.SystemPromptContains("orleans-reviewer"))
+            .Turn(t => t.Text("Reviewed: grain reentrancy looks correct."))
+            .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
+            // subagent_type "orleans-reviewer" only resolves because the catalog agent was mapped
+            // into a spawnable template — that is exactly the bug fix under test.
+            .Turn(t => t.ToolCall("Agent", new { subagent_type = "orleans-reviewer", prompt = "Review my grain" }))
+            // Deliberately free of the reviewer's phrase — proof of execution must come from the sub-agent.
+            .Turn(t => t.Text("Parent summary: review delegated."))
+            .Build();
+
+        await using var session = await _fixture.OpenAsync(
+            providerMode,
+            responder.HandlerFor(providerMode),
+            subAgentFactory: (_, providerAgentFactory) => new SubAgentOptions
+            {
+                // Real production mapping: catalog → spawnable templates.
+                Templates = MarketplaceSubAgentLoader.MapCatalog(SampleCatalog(), providerAgentFactory),
+                MaxConcurrentSubAgents = 5,
+            });
+        var page = session.Page;
+
+        await page.SendMessageAsync("ask the orleans reviewer to look at my grain");
+        // The synchronous Agent call blocks until the sub-agent returns, so allow extra time.
+        await page.WaitForStreamIdleAsync(timeoutMs: 30_000);
+
+        // The parent delegated via the Agent tool.
+        await page.ToolCallPills().WaitForCountAtLeastAsync(1, timeoutMs: 20_000);
+        var toolNames = await page.ToolCallPills()
+            .EvaluateAllAsync<string[]>("nodes => nodes.map(n => n.getAttribute('data-tool-name') ?? '')");
+        toolNames.Should().Contain("Agent");
+
+        // Parent's final summary rendered (proves the run completed through turn 2).
+        await page.AssistantText().WaitForCountAtLeastAsync(1);
+        var assistantTexts = await page.AssistantText().AllInnerTextsAsync();
+        string.Join(" ", assistantTexts).Should().Contain("review delegated");
+
+        // Decisive check: expand the Agent pill; the sub-agent's own output is the tool result.
+        // "grain reentrancy looks correct" appears nowhere in the parent script, so its presence
+        // proves the catalog-derived sub-agent actually spawned and ran.
+        await page.ToolCallPills().First.ClickAsync();
+        var pillContent = page.Locator(".tool-call-result");
+        await pillContent.First.WaitForAsync();
+        var expanded = string.Join(" ", await pillContent.AllInnerTextsAsync());
+        expanded.Should().Contain("grain reentrancy looks correct",
+            "the Agent tool result is the marketplace catalog agent's own reply");
+
+        responder.RemainingTurns["parent"].Should().Be(0);
+        await session.SaveSuccessScreenshotAsync($"MarketplaceSubAgent.{providerMode}");
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/MarketplaceCatalogFixture.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/MarketplaceCatalogFixture.cs
@@ -1,0 +1,34 @@
+namespace LmStreaming.Sample.Tests.Services.Discovery;
+
+/// <summary>
+/// Shared builders for <see cref="MarketplaceCatalog"/> test fixtures. Centralises the knowledge of
+/// the positional <c>Catalog*</c> records (reordering a record parameter would otherwise break every
+/// hand-built literal across the marketplace sub-agent tests) and the representative sample catalog.
+/// </summary>
+internal static class MarketplaceCatalogFixture
+{
+    internal static CatalogAgent Agent(
+        string name, string? description = "does things", string plugin = "rev", string marketplace = "official")
+        => new(name, description!, plugin, marketplace, $"agents/{name}.md");
+
+    internal static CatalogPlugin Plugin(string name, params CatalogAgent[] agents)
+        => new(name, "1.0.0", $"{name} plugin", Skills: [], Agents: agents);
+
+    internal static CatalogMarketplace Marketplace(string alias, string? error, params CatalogPlugin[] plugins)
+        => new(alias, error, plugins);
+
+    internal static MarketplaceCatalog Catalog(params CatalogMarketplace[] marketplaces)
+        => new(Selected: [.. marketplaces.Select(m => m.Alias)], Marketplaces: marketplaces);
+
+    /// <summary>
+    /// A representative catalog with two agent-bearing plugins (<c>orleans-reviewer</c>,
+    /// <c>silent-failure-hunter</c>) under one marketplace — enough to prove flatten + visibility.
+    /// </summary>
+    internal static MarketplaceCatalog Sample()
+        => Catalog(
+            Marketplace("ClaudePlugins", error: null,
+                Plugin("orleans-dev",
+                    Agent("orleans-reviewer", "Senior Orleans code reviewer", "orleans-dev", "ClaudePlugins")),
+                Plugin("pr-toolkit",
+                    Agent("silent-failure-hunter", "Finds swallowed errors and silent failures", "pr-toolkit", "ClaudePlugins"))));
+}

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/MarketplaceSubAgentCatalogVisibilityTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/MarketplaceSubAgentCatalogVisibilityTests.cs
@@ -1,0 +1,50 @@
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Discovery;
+using Xunit.Abstractions;
+
+namespace LmStreaming.Sample.Tests.Services.Discovery;
+
+/// <summary>
+/// Validates the user-visible payoff of the marketplace bridge: once a marketplace catalog agent is
+/// mapped into the Agent-tool catalog, it shows up in the <c>Agent</c> tool's DESCRIPTION — the exact
+/// string the instruction-chain <c>tools_echo</c> / <c>tool_schema</c> probe echoes and that a parent
+/// LLM literally reads to choose a <c>subagent_type</c>. This is the "do I now see the other agents?"
+/// check, rendered through the real <see cref="SubAgentToolProvider"/>.
+/// </summary>
+public class MarketplaceSubAgentCatalogVisibilityTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public MarketplaceSubAgentCatalogVisibilityTests(ITestOutputHelper output) => _output = output;
+
+    private static readonly Func<IStreamingAgent> AgentFactory = () => new Mock<IStreamingAgent>().Object;
+
+    [Fact]
+    public void AgentToolDescription_ListsMarketplaceAgents_AlongsideBuiltIns()
+    {
+        // Reproduce exactly what Program.BuildSubAgentOptionsAsync produces after the fix:
+        // built-ins, then marketplace catalog filling the gaps.
+        var templates = BuiltInSubAgentTemplates.Create(AgentFactory);
+        var fromMarketplace = MarketplaceSubAgentLoader.MapCatalog(MarketplaceCatalogFixture.Sample(), AgentFactory);
+        MarketplaceSubAgentLoader.MergeFillGaps(templates, fromMarketplace, NullLogger.Instance);
+
+        var source = new MutableSubAgentTemplateSource(templates);
+        var description = SubAgentToolDescriptionProbe.Render(source);
+
+        // Show the actual catalog text a model would read (the tools_echo / tool_schema output).
+        _output.WriteLine(description);
+
+        // Built-ins are still present...
+        description.Should().Contain("general-purpose");
+        description.Should().Contain("researcher");
+
+        // ...AND the marketplace agents now appear — both in the subagent_type enum ("One of: ...")
+        // and in the per-template catalog with their descriptions.
+        description.Should().Contain("orleans-reviewer");
+        description.Should().Contain("Senior Orleans code reviewer");
+        description.Should().Contain("silent-failure-hunter");
+        description.Should().Contain("Finds swallowed errors and silent failures");
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/MarketplaceSubAgentLoaderTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/MarketplaceSubAgentLoaderTests.cs
@@ -1,0 +1,182 @@
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Discovery;
+using static LmStreaming.Sample.Tests.Services.Discovery.MarketplaceCatalogFixture;
+
+namespace LmStreaming.Sample.Tests.Services.Discovery;
+
+/// <summary>
+/// Pins the marketplace → sub-agent bridge: the agents the UI's marketplace browser lists
+/// (<see cref="MarketplaceCatalog"/>) must become spawnable <see cref="SubAgentTemplate"/>s, while
+/// never shadowing a built-in or a real workspace-discovered file (<see cref="MarketplaceSubAgentLoader.MergeFillGaps"/>).
+/// This is the regression guard for the "Agent tool omits marketplace agents" bug.
+/// </summary>
+public class MarketplaceSubAgentLoaderTests
+{
+    private static readonly Mock<IStreamingAgent> AgentStub = new();
+    private static readonly Func<IStreamingAgent> AgentFactory = () => AgentStub.Object;
+
+    // Catalog builders (Agent/Plugin/Marketplace/Catalog) come from MarketplaceCatalogFixture via the
+    // `using static` above, shared with MarketplaceSubAgentCatalogVisibilityTests.
+
+    [Fact]
+    public void MapToTemplate_MapsCatalogFieldsIntoSpawnableTemplate()
+    {
+        var template = MarketplaceSubAgentLoader.MapToTemplate(
+            Agent("code-reviewer", "Reviews code for bugs", plugin: "pr-toolkit", marketplace: "official"),
+            AgentFactory);
+
+        template.Name.Should().Be("code-reviewer");
+        template.Description.Should().Be("Reviews code for bugs");
+        template.WhenToUse.Should().Be("Reviews code for bugs");
+        template.MaxTurnsPerRun.Should().Be(WorkspaceSubAgentLoader.DefaultMaxTurnsPerRun);
+        template.EnabledTools.Should().BeNull("a catalog agent inherits every parent tool");
+        template.AgentFactory.Should().BeSameAs(AgentFactory);
+
+        // Best-effort persona prompt grounds the agent in its name + provenance + description.
+        template.SystemPrompt.Should().Contain("code-reviewer");
+        template.SystemPrompt.Should().Contain("pr-toolkit");
+        template.SystemPrompt.Should().Contain("official");
+        template.SystemPrompt.Should().Contain("Reviews code for bugs");
+    }
+
+    [Fact]
+    public void MapToTemplate_BlankDescription_LeavesDescriptionNull()
+    {
+        var template = MarketplaceSubAgentLoader.MapToTemplate(Agent("planner", description: "   "), AgentFactory);
+
+        template.Description.Should().BeNull();
+        template.WhenToUse.Should().BeNull();
+        template.SystemPrompt.Should().Contain("planner");
+    }
+
+    [Fact]
+    public void MapCatalog_FlattensAgentsAcrossMarketplacesAndPlugins()
+    {
+        var catalog = Catalog(
+            Marketplace("official", error: null,
+                Plugin("pr-toolkit", Agent("code-reviewer"), Agent("test-analyzer")),
+                Plugin("debugging", Agent("logging-review"))),
+            Marketplace("community", error: null,
+                Plugin("orleans", Agent("orleans-reviewer"))));
+
+        var result = MarketplaceSubAgentLoader.MapCatalog(catalog, AgentFactory);
+
+        result.Keys.Should().BeEquivalentTo(
+            "code-reviewer", "test-analyzer", "logging-review", "orleans-reviewer");
+    }
+
+    [Fact]
+    public void MapCatalog_SkipsAgentsWithBlankName()
+    {
+        var catalog = Catalog(
+            Marketplace("official", error: null,
+                Plugin("p", Agent("good"), Agent("   "), Agent(""))));
+
+        var result = MarketplaceSubAgentLoader.MapCatalog(catalog, AgentFactory);
+
+        result.Keys.Should().BeEquivalentTo("good");
+    }
+
+    [Fact]
+    public void MapCatalog_DuplicateAgentName_KeepsFirstOccurrence()
+    {
+        var catalog = Catalog(
+            Marketplace("official", error: null,
+                Plugin("a", Agent("dup", description: "FIRST")),
+                Plugin("b", Agent("dup", description: "SECOND"))));
+
+        var result = MarketplaceSubAgentLoader.MapCatalog(catalog, AgentFactory);
+
+        result.Should().ContainKey("dup");
+        result["dup"].Description.Should().Be("FIRST");
+    }
+
+    [Fact]
+    public void MapCatalog_MarketplaceThatFailedToLoad_ContributesNothing()
+    {
+        // A marketplace the gateway couldn't read reports an Error and an empty plugin list — it must
+        // not blow up the mapping nor contribute phantom agents.
+        var catalog = Catalog(
+            Marketplace("broken", error: "could not read marketplace.json"),
+            Marketplace("official", error: null, Plugin("p", Agent("ok"))));
+
+        var result = MarketplaceSubAgentLoader.MapCatalog(catalog, AgentFactory);
+
+        result.Keys.Should().BeEquivalentTo("ok");
+    }
+
+    [Fact]
+    public void MergeFillGaps_AddsAgentsForKeysNotAlreadyPresent()
+    {
+        var existing = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal)
+        {
+            ["general-purpose"] = MarketplaceSubAgentLoader.MapToTemplate(Agent("general-purpose"), AgentFactory),
+        };
+        var catalog = MarketplaceSubAgentLoader.MapCatalog(
+            Catalog(Marketplace("official", null, Plugin("p", Agent("code-reviewer")))),
+            AgentFactory);
+
+        MarketplaceSubAgentLoader.MergeFillGaps(existing, catalog, NullLogger.Instance);
+
+        existing.Should().ContainKey("code-reviewer");
+    }
+
+    [Fact]
+    public void MergeFillGaps_DoesNotOverrideExistingTemplate()
+    {
+        // A built-in or a real workspace-discovered file (merged before the catalog) must keep its
+        // place: the richer template wins, the catalog stub is dropped.
+        var kept = new SubAgentTemplate
+        {
+            Name = "code-reviewer",
+            Description = "REAL workspace file",
+            SystemPrompt = "REAL-BODY",
+            AgentFactory = AgentFactory,
+            MaxTurnsPerRun = WorkspaceSubAgentLoader.DefaultMaxTurnsPerRun,
+        };
+        var existing = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal)
+        {
+            ["code-reviewer"] = kept,
+        };
+        var catalog = MarketplaceSubAgentLoader.MapCatalog(
+            Catalog(Marketplace("official", null, Plugin("p", Agent("code-reviewer", description: "catalog stub")))),
+            AgentFactory);
+
+        MarketplaceSubAgentLoader.MergeFillGaps(existing, catalog, NullLogger.Instance);
+
+        existing["code-reviewer"].SystemPrompt.Should().Be("REAL-BODY");
+        existing["code-reviewer"].Description.Should().Be("REAL workspace file");
+    }
+
+    [Fact]
+    public async Task LoadAsync_GatewayUnavailable_ReturnsEmptyWithoutThrowing()
+    {
+        var client = new Mock<IMarketplaceCatalogClient>();
+        client
+            .Setup(c => c.GetCatalogAsync(It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new MarketplaceCatalogUnavailableException("gateway offline"));
+        var loader = new MarketplaceSubAgentLoader(client.Object, NullLogger<MarketplaceSubAgentLoader>.Instance);
+
+        var result = await loader.LoadAsync(marketplaces: null, AgentFactory);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LoadAsync_MapsCatalogReturnedByClient_AndPassesMarketplaceFilter()
+    {
+        var selected = new[] { "official" };
+        var client = new Mock<IMarketplaceCatalogClient>();
+        client
+            .Setup(c => c.GetCatalogAsync(selected, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Catalog(Marketplace("official", null, Plugin("p", Agent("code-reviewer")))));
+        var loader = new MarketplaceSubAgentLoader(client.Object, NullLogger<MarketplaceSubAgentLoader>.Instance);
+
+        var result = await loader.LoadAsync(selected, AgentFactory);
+
+        result.Keys.Should().BeEquivalentTo("code-reviewer");
+        client.Verify(c => c.GetCatalogAsync(selected, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistrySubAgentIsolationTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistrySubAgentIsolationTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
-using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Services.Auth;
@@ -60,7 +59,7 @@ public class SandboxSessionRegistrySubAgentIsolationTests
 
         // Probe what B's LLM would actually see: the Agent tool description (the catalog the
         // tools_echo probe surfaces) must not mention A's discovered sub-agent.
-        var agentDescriptionForB = RenderAgentToolDescription(bindingB.Source);
+        var agentDescriptionForB = SubAgentToolDescriptionProbe.Render(bindingB.Source);
         agentDescriptionForB.Should().Contain("researcher");
         agentDescriptionForB.Should().NotContain(
             "alpha_discovered",
@@ -117,34 +116,6 @@ public class SandboxSessionRegistrySubAgentIsolationTests
             .Should().BeFalse("a torn-down conversation's binding must be freed, not retained for the process lifetime");
         binding.Should().BeNull();
         registry.GetSubAgentBindingsForSession(SessionId).Should().BeEmpty();
-    }
-
-    /// <summary>
-    /// Renders the Agent tool's description exactly as the parent LLM would receive it, so the
-    /// assertion probes the real catalog text (the same string the <c>tools_echo</c> mock-LLM
-    /// primitive echoes), not just the backing dictionary.
-    /// </summary>
-    private static string RenderAgentToolDescription(MutableSubAgentTemplateSource source)
-    {
-        var parentMock = new Mock<IMultiTurnAgent>();
-        parentMock
-            .Setup(p => p.SendAsync(
-                It.IsAny<List<IMessage>>(),
-                It.IsAny<string?>(),
-                It.IsAny<string?>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new SendReceipt("receipt", null, DateTimeOffset.UtcNow));
-
-        var manager = new SubAgentManager(
-            parentAgent: parentMock.Object,
-            parentContracts: [],
-            parentHandlers: new Dictionary<string, ToolHandler>(),
-            options: new SubAgentOptions { Templates = source.Templates, MaxConcurrentSubAgents = 5 },
-            source: source);
-
-        var provider = new SubAgentToolProvider(manager, source);
-        var agent = provider.GetFunctions().First(f => f.Contract.Name == "Agent");
-        return agent.Contract.Description ?? string.Empty;
     }
 
     private static SubAgentTemplate Template(string name, string description) =>

--- a/tests/LmStreaming.Sample.Tests/Services/SubAgentToolDescriptionProbe.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SubAgentToolDescriptionProbe.cs
@@ -1,0 +1,37 @@
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// Renders the <c>Agent</c> tool's description exactly as a parent LLM receives it — the same string
+/// the instruction-chain <c>tools_echo</c> / <c>tool_schema</c> probe echoes. Shared by the sub-agent
+/// catalog tests (isolation + marketplace visibility) so the rendering boilerplate lives in one place;
+/// if the <see cref="SubAgentManager"/>/<see cref="SubAgentToolProvider"/> contract changes, only this
+/// helper updates instead of every test that probes the catalog text.
+/// </summary>
+internal static class SubAgentToolDescriptionProbe
+{
+    internal static string Render(MutableSubAgentTemplateSource source)
+    {
+        var parentMock = new Mock<IMultiTurnAgent>();
+        parentMock
+            .Setup(p => p.SendAsync(
+                It.IsAny<List<IMessage>>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SendReceipt("receipt", null, DateTimeOffset.UtcNow));
+
+        var manager = new SubAgentManager(
+            parentAgent: parentMock.Object,
+            parentContracts: [],
+            parentHandlers: new Dictionary<string, ToolHandler>(),
+            options: new SubAgentOptions { Templates = source.Templates, MaxConcurrentSubAgents = 5 },
+            source: source);
+
+        var provider = new SubAgentToolProvider(manager, source);
+        var agent = provider.GetFunctions().First(f => f.Contract.Name == "Agent");
+        return agent.Contract.Description ?? string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary
In **Workspace Agent** mode the `Agent` tool's `subagent_type` catalog omitted agents the
marketplace browser shows. This bridges the marketplace catalog into the spawnable sub-agent
set and gives the mock (`test` / `test-anthropic`) providers the same catalog as the real ones.

## Root cause
The UI marketplace browser (`/api/v1/marketplaces/preview`) and the Agent tool's spawnable set
(`/api/v1/sandboxes/{id}/discovered`, `kind=="subagent"`) are **disjoint** flows with no app-side
bridge — selecting a marketplace only enables it server-side, it doesn't materialise agent files
into the workspace. The mock-provider path also built the catalog from **built-ins only**.

## Changes
- **`MarketplaceSubAgentLoader`** (new): maps the workspace's enabled-marketplace catalog agents
  into spawnable `SubAgentTemplate`s, best-effort, filling gaps left by built-ins and real
  workspace files. Precedence: **built-in > workspace-discovered file > marketplace catalog**.
- **Unified `Program.BuildSubAgentOptionsAsync`**: both mock and real providers now run the same
  workspace + marketplace enrichment when a sandbox session is active — so the catalog is
  validatable via the instruction-chain `tool_schema` / `tools_echo` probe in test mode.
- Shared test helpers (`SubAgentToolDescriptionProbe`, `MarketplaceCatalogFixture`).

## Validation
- Unit: `MarketplaceSubAgentLoaderTests`, `MarketplaceSubAgentCatalogVisibilityTests` (renders the
  exact `tools_echo` string and asserts marketplace agents appear). **277 sample unit tests pass.**
- E2E: mock-provider Playwright test proving a catalog agent is spawnable through the real UI.
- Live: confirmed in both `test` and `test-anthropic` + Workspace Agent mode — the catalog now
  lists marketplace agents (`code-explorer`, `code-reviewer`, `ado-*`, `plugin-validator`, …)
  alongside the built-ins.

## Related Issues
- Fixes #97
- Builds on #96 (Agent tool on test providers, now merged); follows #76, #77; relates to #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)