### PR TITLE
Sub-agents inherit the parent's model instead of a stale provider default

### DIFF
--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -117,7 +117,10 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                 parentHandlers: handlers,
                 options: subAgentOptions,
                 source: source,
-                logger: logger);
+                logger: logger,
+                // Sub-agents whose template/override sets no model inherit the parent's model, so a
+                // built-in template doesn't fall back to the provider's stale hardcoded default.
+                parentModelId: DefaultOptions.ModelId);
 
             var toolProvider = new SubAgentToolProvider(
                 _subAgentManager,

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -19,6 +19,7 @@ namespace AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 public sealed class SubAgentManager : IAsyncDisposable
 {
     private readonly IMultiTurnAgent _parentAgent;
+    private readonly string? _parentModelId;
     private readonly IReadOnlyList<FunctionContract> _parentContracts;
     private readonly IDictionary<string, ToolHandler> _parentHandlers;
     private readonly SubAgentOptions _options;
@@ -35,7 +36,8 @@ public sealed class SubAgentManager : IAsyncDisposable
         IDictionary<string, ToolHandler> parentHandlers,
         SubAgentOptions options,
         MutableSubAgentTemplateSource source,
-        ILogger? logger = null)
+        ILogger? logger = null,
+        string? parentModelId = null)
     {
         ArgumentNullException.ThrowIfNull(parentAgent);
         ArgumentNullException.ThrowIfNull(parentContracts);
@@ -49,6 +51,9 @@ public sealed class SubAgentManager : IAsyncDisposable
         _options = options;
         _source = source;
         _logger = logger ?? NullLogger.Instance;
+        // The parent's model, inherited by sub-agents whose template/override sets none (see
+        // ResolveSubAgentOptions). Null when the parent has no model (e.g. CLI-backed parents).
+        _parentModelId = parentModelId;
         _concurrencyGate = new SemaphoreSlim(
             options.MaxConcurrentSubAgents,
             options.MaxConcurrentSubAgents);
@@ -448,10 +453,8 @@ public sealed class SubAgentManager : IAsyncDisposable
     {
         var providerAgent = template.AgentFactory();
 
-        // Apply the per-spawn model override (if any) on top of the template defaults.
-        var defaultOptions = string.IsNullOrWhiteSpace(modelOverride)
-            ? template.DefaultOptions
-            : (template.DefaultOptions ?? new GenerateReplyOptions()) with { ModelId = modelOverride };
+        // Resolve the sub-agent's options with model inheritance (override > template > parent).
+        var defaultOptions = ResolveSubAgentOptions(template.DefaultOptions, modelOverride, _parentModelId);
 
         // Determine conversation store
         var storeFactory =
@@ -488,6 +491,34 @@ public sealed class SubAgentManager : IAsyncDisposable
             maxTurnsPerRun: template.MaxTurnsPerRun,
             store: store,
             logger: _logger is NullLogger ? null : new SubAgentLoopLoggerAdapter(_logger));
+    }
+
+    /// <summary>
+    /// Resolves the sub-agent's <see cref="GenerateReplyOptions"/> with model inheritance: an explicit
+    /// per-spawn <paramref name="modelOverride"/> wins, else the template's own
+    /// <see cref="GenerateReplyOptions.ModelId"/>, else the PARENT agent's model
+    /// (<paramref name="parentModelId"/>). The parent fallback stops a template that sets no model
+    /// (e.g. the built-in sub-agents) from letting the provider agent use its hardcoded default model,
+    /// which often isn't valid on the parent's backend (observed: a sub-agent sending
+    /// <c>claude-3-sonnet-20240229</c> to a backend that only serves the parent's model → HTTP 400
+    /// <c>model_not_supported</c>). Any other template option fields are preserved. Returns null only
+    /// when no model is available anywhere AND the template carried no options, so the previous
+    /// "inherit the provider's own defaults" behavior is unchanged when there is genuinely nothing to set.
+    /// </summary>
+    internal static GenerateReplyOptions? ResolveSubAgentOptions(
+        GenerateReplyOptions? templateDefaults,
+        string? modelOverride,
+        string? parentModelId)
+    {
+        var model = !string.IsNullOrWhiteSpace(modelOverride)
+            ? modelOverride
+            : !string.IsNullOrWhiteSpace(templateDefaults?.ModelId)
+                ? templateDefaults!.ModelId
+                : parentModelId;
+
+        return string.IsNullOrWhiteSpace(model)
+            ? templateDefaults
+            : (templateDefaults ?? new GenerateReplyOptions()) with { ModelId = model };
     }
 
     /// <summary>

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -510,10 +510,11 @@ public sealed class SubAgentManager : IAsyncDisposable
         string? modelOverride,
         string? parentModelId)
     {
+        var templateModel = templateDefaults?.ModelId;
         var model = !string.IsNullOrWhiteSpace(modelOverride)
             ? modelOverride
-            : !string.IsNullOrWhiteSpace(templateDefaults?.ModelId)
-                ? templateDefaults!.ModelId
+            : !string.IsNullOrWhiteSpace(templateModel)
+                ? templateModel
                 : parentModelId;
 
         return string.IsNullOrWhiteSpace(model)

--- a/tests/LmMultiTurn.Tests/SubAgentModelResolutionTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentModelResolutionTests.cs
@@ -1,0 +1,93 @@
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using FluentAssertions;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+/// <summary>
+/// Pins the sub-agent model-inheritance contract (<see cref="SubAgentManager.ResolveSubAgentOptions"/>):
+/// a spawned sub-agent must inherit the PARENT's model when neither a per-spawn override nor the
+/// template specifies one. Without this, a template carrying no model (e.g. the built-in sub-agents)
+/// lets the provider agent fall back to its hardcoded default model — observed in production as a
+/// sub-agent sending <c>claude-3-sonnet-20240229</c> to a backend that only serves the parent's
+/// model, yielding HTTP 400 <c>model_not_supported</c>.
+/// </summary>
+public class SubAgentModelResolutionTests
+{
+    [Fact]
+    public void Override_WinsOverTemplateAndParent()
+    {
+        var result = SubAgentManager.ResolveSubAgentOptions(
+            templateDefaults: new GenerateReplyOptions { ModelId = "template-model" },
+            modelOverride: "override-model",
+            parentModelId: "parent-model");
+
+        result!.ModelId.Should().Be("override-model");
+    }
+
+    [Fact]
+    public void TemplateModel_UsedWhenNoOverride_ParentIgnored()
+    {
+        var result = SubAgentManager.ResolveSubAgentOptions(
+            templateDefaults: new GenerateReplyOptions { ModelId = "template-model" },
+            modelOverride: null,
+            parentModelId: "parent-model");
+
+        result!.ModelId.Should().Be("template-model");
+    }
+
+    [Fact]
+    public void ParentModel_InheritedWhenNeitherOverrideNorTemplateModel()
+    {
+        // The fix: a built-in template (no DefaultOptions at all) inherits the parent's model
+        // instead of letting the provider agent use its stale hardcoded default.
+        var result = SubAgentManager.ResolveSubAgentOptions(
+            templateDefaults: null,
+            modelOverride: null,
+            parentModelId: "parent-model");
+
+        result.Should().NotBeNull();
+        result!.ModelId.Should().Be("parent-model");
+    }
+
+    [Fact]
+    public void ParentModel_InheritedWhenTemplateHasOptionsButBlankModel()
+    {
+        // ModelId defaults to "" on GenerateReplyOptions — that must count as "no model".
+        var result = SubAgentManager.ResolveSubAgentOptions(
+            templateDefaults: new GenerateReplyOptions { Temperature = 0.5f },
+            modelOverride: null,
+            parentModelId: "parent-model");
+
+        result!.ModelId.Should().Be("parent-model");
+        result.Temperature.Should().Be(0.5f, "applying the parent model must preserve other template options");
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenNoModelAnywhere_AndNoTemplateOptions()
+    {
+        // Nothing to set and no template options → keep the previous "inherit provider defaults"
+        // behavior (null options), rather than fabricating an empty options object.
+        var result = SubAgentManager.ResolveSubAgentOptions(
+            templateDefaults: null,
+            modelOverride: null,
+            parentModelId: null);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void KeepsTemplateOptions_WhenNoModelAnywhere_ButTemplateHasOtherFields()
+    {
+        var templateDefaults = new GenerateReplyOptions { Temperature = 0.2f };
+
+        var result = SubAgentManager.ResolveSubAgentOptions(
+            templateDefaults: templateDefaults,
+            modelOverride: null,
+            parentModelId: null);
+
+        result.Should().BeSameAs(templateDefaults);
+        result!.ModelId.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
A spawned sub-agent whose template/override sets no model now inherits the **parent's** model,
instead of falling back to the provider agent's hardcoded default. This fixes built-in (and
marketplace) sub-agent delegation failing with HTTP 400 `model_not_supported` on backends that
only serve the parent's model family.

## Root cause
`SubAgentManager.CreateSubAgent` used `override ?? template.DefaultOptions`. With both absent
(the built-in `general-purpose` / `researcher` templates), the sub-agent got `null` options and
the provider used its default-model constant (`claude-3-sonnet-20240229`) — rejected by the
parent's backend. Observed live: parent on `claude-sonnet-4.5` works; spawned sub-agents on
`claude-3-sonnet-20240229` 400.

## Change
- `SubAgentManager.ResolveSubAgentOptions(templateDefaults, modelOverride, parentModelId)` —
  model inheritance: **override > template model > parent model**, preserving other option fields.
- `MultiTurnAgentLoop` passes its `DefaultOptions.ModelId` into `SubAgentManager` as the parent model.
- No public interface change (new ctor arg is a trailing optional).

## Validation
`SubAgentModelResolutionTests` pins the resolution table; full **LmMultiTurn suite green (275 tests)**.

## Related Issues
- Fixes #99
- Surfaced while validating #98 (marketplace sub-agents); independent fix in the core
  `LmMultiTurn` spawn path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)