### PR TITLE
fix: Workspace Agent loop + web_search replay 400 (server-tool id & missing date)

### DIFF
--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -337,6 +337,14 @@ try
             {
                 var threadId = context.ThreadId;
                 var mode = context.Mode;
+                // Anchor the model to the real current date. Injected once at the single mode entry
+                // point so every derived system prompt (workspace suffix, medical context, etc.)
+                // carries it. Without it, models fall back to a training-era date, distrust
+                // correctly-dated web_search results as "future"/unreliable, and loop.
+                mode = mode with
+                {
+                    SystemPrompt = SystemPromptAugmenter.PrependCurrentDate(mode.SystemPrompt, DateTimeOffset.UtcNow),
+                };
                 var providerId = context.ProviderId;
                 var requestResponseDumpFileName = context.DumpFile;
                 var workspaceId = context.WorkspaceId;

--- a/samples/LmStreaming.Sample/Services/SystemPromptAugmenter.cs
+++ b/samples/LmStreaming.Sample/Services/SystemPromptAugmenter.cs
@@ -1,0 +1,21 @@
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+/// Augments a chat mode's system prompt with runtime context the model would otherwise lack.
+/// </summary>
+public static class SystemPromptAugmenter
+{
+    /// <summary>
+    /// Prepends the current UTC date so the model is anchored to "today". Without it, a model can
+    /// fall back to a training-era date, treat correctly-dated tool results (e.g. web_search hits
+    /// dated in the future relative to its training) as unreliable, and loop re-searching and
+    /// re-verifying instead of answering. Mirrors what production agent harnesses inject.
+    /// </summary>
+    /// <param name="systemPrompt">The mode's existing system prompt (may be null/empty).</param>
+    /// <param name="now">The current instant; the UTC calendar date is used.</param>
+    public static string PrependCurrentDate(string? systemPrompt, DateTimeOffset now)
+    {
+        var dateLine = $"The current date is {now.UtcDateTime:yyyy-MM-dd} (UTC).";
+        return string.IsNullOrEmpty(systemPrompt) ? dateLine : $"{dateLine}\n\n{systemPrompt}";
+    }
+}

--- a/src/AnthropicProvider/Models/AnthropicRequest.cs
+++ b/src/AnthropicProvider/Models/AnthropicRequest.cs
@@ -404,33 +404,42 @@ public record AnthropicRequest
         }
         else if (message is ToolCallMessage singularToolCallMsg)
         {
-            var contentType = singularToolCallMsg.ExecutionTarget == ExecutionTarget.ProviderServer
-                ? "server_tool_use"
-                : "tool_use";
-            anthropicMessage.Content.Add(
-                new AnthropicContent
-                {
-                    Type = contentType,
-                    Id = singularToolCallMsg.ToolCallId,
-                    Name = singularToolCallMsg.FunctionName,
-                    Input = SafeDeserializeArgs(singularToolCallMsg.FunctionArgs),
-                }
-            );
+            // Drop empty-id server_tool_use blocks. Anthropic-compatible providers that omit the
+            // id (e.g. Kimi) can leave a duplicate, empty-id streaming preview in persisted history
+            // beside the finalized call; replaying it fails with "tool_call_id is not found".
+            if (!IsEmptyIdServerToolCall(singularToolCallMsg.ExecutionTarget, singularToolCallMsg.ToolCallId))
+            {
+                var contentType = singularToolCallMsg.ExecutionTarget == ExecutionTarget.ProviderServer
+                    ? "server_tool_use"
+                    : "tool_use";
+                anthropicMessage.Content.Add(
+                    new AnthropicContent
+                    {
+                        Type = contentType,
+                        Id = singularToolCallMsg.ToolCallId,
+                        Name = singularToolCallMsg.FunctionName,
+                        Input = SafeDeserializeArgs(singularToolCallMsg.FunctionArgs),
+                    }
+                );
+            }
         }
         else if (message is ToolCallUpdateMessage toolCallUpdateMsg
             && toolCallUpdateMsg.ExecutionTarget == ExecutionTarget.ProviderServer)
         {
             // ToolCallUpdateMessage is the streaming equivalent of ToolCallMessage for server tools.
             // When it appears in history (without the joiner middleware), serialize it as server_tool_use.
-            anthropicMessage.Content.Add(
-                new AnthropicContent
-                {
-                    Type = "server_tool_use",
-                    Id = toolCallUpdateMsg.ToolCallId,
-                    Name = toolCallUpdateMsg.FunctionName,
-                    Input = SafeDeserializeArgs(toolCallUpdateMsg.FunctionArgs),
-                }
-            );
+            if (!IsEmptyIdServerToolCall(toolCallUpdateMsg.ExecutionTarget, toolCallUpdateMsg.ToolCallId))
+            {
+                anthropicMessage.Content.Add(
+                    new AnthropicContent
+                    {
+                        Type = "server_tool_use",
+                        Id = toolCallUpdateMsg.ToolCallId,
+                        Name = toolCallUpdateMsg.FunctionName,
+                        Input = SafeDeserializeArgs(toolCallUpdateMsg.FunctionArgs),
+                    }
+                );
+            }
         }
         else if (message is ToolCallResultMessage singularToolResultMsg)
         {
@@ -451,6 +460,11 @@ public record AnthropicRequest
             // Handle tool calls in assistant messages
             foreach (var toolCall in toolsCallMsg.ToolCalls)
             {
+                if (IsEmptyIdServerToolCall(toolCall.ExecutionTarget, toolCall.ToolCallId))
+                {
+                    continue;
+                }
+
                 var contentType = toolCall.ExecutionTarget == ExecutionTarget.ProviderServer ? "server_tool_use" : "tool_use";
                 anthropicMessage.Content.Add(
                     new AnthropicContent
@@ -506,6 +520,11 @@ public record AnthropicRequest
                 )
             )
             {
+                if (IsEmptyIdServerToolCall(toolCall.ExecutionTarget, toolCall.ToolCallId))
+                {
+                    continue;
+                }
+
                 var toolResultBlocks = ToAnthropicToolResultContentBlocks(
                     toolResult.ContentBlocks, toolResult.IsError);
                 yield return (
@@ -527,6 +546,16 @@ public record AnthropicRequest
             }
         }
     }
+
+    /// <summary>
+    ///     A server-side (provider-executed) tool call with no id. These appear when an
+    ///     Anthropic-compatible provider omits the server_tool_use id and a duplicate, empty-id
+    ///     streaming preview lands in persisted history. Replaying a <c>server_tool_use</c> block
+    ///     with an empty id makes the provider reject the request ("tool_call_id is not found"),
+    ///     so such blocks are dropped when rebuilding the request.
+    /// </summary>
+    private static bool IsEmptyIdServerToolCall(ExecutionTarget executionTarget, string? toolCallId) =>
+        executionTarget == ExecutionTarget.ProviderServer && string.IsNullOrWhiteSpace(toolCallId);
 
     /// <summary>
     ///     Combines function contracts and built-in tools into a single list for the API request.

--- a/src/AnthropicProvider/Models/AnthropicStreamParser.cs
+++ b/src/AnthropicProvider/Models/AnthropicStreamParser.cs
@@ -14,6 +14,9 @@ namespace AchieveAi.LmDotnetTools.AnthropicProvider.Models;
 /// </summary>
 public class AnthropicStreamParser
 {
+    /// <summary>Prefix for synthetic server_tool_use ids generated when a provider omits the id.</summary>
+    private const string SyntheticServerToolIdPrefix = "srvtoolu_synth_";
+
     private readonly Dictionary<int, StreamingContentBlock> _contentBlocks = [];
     private readonly JsonSerializerOptions _jsonOptions;
     private readonly ILogger _logger;
@@ -229,8 +232,12 @@ public class AnthropicStreamParser
         // The final ToolCallMessage with accumulated args is emitted at content_block_stop.
         if (blockType == "server_tool_use")
         {
-            // Store tool_use_id for correlating with results (may be empty — synthetic ID generated at stop)
-            _contentBlocks[index].ToolUseId = _contentBlocks[index].Id ?? string.Empty;
+            // Some Anthropic-compatible providers (e.g. Kimi) omit the server_tool_use id.
+            // Synthesize it HERE so the streaming update, the finalized ToolCallMessage, and the
+            // result all carry the SAME non-empty id. Emitting an empty id at this point produces
+            // a duplicate, empty-id tool_call message in history that fails replay with
+            // "tool_call_id is not found".
+            EnsureServerToolUseId(_contentBlocks[index]);
 
             var serverToolUpdate = new ToolCallUpdateMessage
             {
@@ -751,21 +758,9 @@ public class AnthropicStreamParser
     /// </summary>
     private List<IMessage> FinalizeServerToolUseBlock(StreamingContentBlock block)
     {
-        // Generate a synthetic ID if none provided (e.g., Kimi doesn't send id for server_tool_use)
-        if (string.IsNullOrEmpty(block.Id))
-        {
-            block.Id = $"srvtoolu_synth_{block.Index}_{Guid.NewGuid():N}";
-            _logger.LogDebug(
-                "Generated synthetic ID {SyntheticId} for server_tool_use block {Index} (provider did not send id)",
-                block.Id,
-                block.Index
-            );
-        }
-
-        if (string.IsNullOrEmpty(block.ToolUseId))
-        {
-            block.ToolUseId = block.Id;
-        }
+        // Safety net: synthesize the id if it was not already assigned at content_block_start
+        // (e.g., a provider that only reveals the missing id by the time the block stops).
+        EnsureServerToolUseId(block);
 
         // If input_json_delta accumulated a complete object, it overwrites any content_block_start input.
         // Otherwise, block.Input retains whatever was set at content_block_start (or null).
@@ -1016,11 +1011,16 @@ public class AnthropicStreamParser
         // The final ToolCallMessage with accumulated args is emitted at content_block_stop.
         if (contentBlock is AnthropicResponseServerToolUseContent serverToolUseContent)
         {
-            _contentBlocks[index].ToolUseId = serverToolUseContent.Id;
+            _contentBlocks[index].Id = serverToolUseContent.Id;
+            // Synthesize a stable id when the provider omits it (see untyped path above) so the
+            // streaming update, the finalized call, and the result all share one non-empty id.
+            EnsureServerToolUseId(_contentBlocks[index]);
 
             var serverToolUpdate = new ToolCallUpdateMessage
             {
-                ToolCallId = serverToolUseContent.Id,
+                // Id is non-null here: assigned from serverToolUseContent.Id above and guaranteed by
+                // EnsureServerToolUseId, so the null-forgiving operator would be redundant (IDE0370).
+                ToolCallId = _contentBlocks[index].Id,
                 Index = index,
                 FunctionName = serverToolUseContent.Name,
                 // For streaming server_tool_use blocks, do not emit "{}" as a placeholder.
@@ -1467,6 +1467,30 @@ public class AnthropicStreamParser
         public string GetRawJson()
         {
             return _jsonBuffer.ToString();
+        }
+    }
+
+    /// <summary>
+    ///     Ensures a server_tool_use block has a non-empty id, synthesizing a stable one when the
+    ///     provider omits it (e.g. Kimi). Keeps <see cref="StreamingContentBlock.Id"/> and
+    ///     <see cref="StreamingContentBlock.ToolUseId"/> consistent so the streaming update, the
+    ///     finalized ToolCallMessage, and the matching result all carry the same id. Idempotent.
+    /// </summary>
+    private void EnsureServerToolUseId(StreamingContentBlock block)
+    {
+        if (string.IsNullOrEmpty(block.Id))
+        {
+            block.Id = $"{SyntheticServerToolIdPrefix}{block.Index}_{Guid.NewGuid():N}";
+            _logger.LogDebug(
+                "Generated synthetic ID {SyntheticId} for server_tool_use block {Index} (provider did not send id)",
+                block.Id,
+                block.Index
+            );
+        }
+
+        if (string.IsNullOrEmpty(block.ToolUseId))
+        {
+            block.ToolUseId = block.Id;
         }
     }
 

--- a/tests/AnthropicProvider.Tests/Models/ServerToolRequestTests.cs
+++ b/tests/AnthropicProvider.Tests/Models/ServerToolRequestTests.cs
@@ -174,6 +174,77 @@ public class ServerToolRequestTests
     }
 
     [Fact]
+    public void FromMessages_WithEmptyIdServerToolCall_DropsItFromRequest()
+    {
+        // Regression (Kimi 400 "tool_call_id  is not found"): an Anthropic-compatible provider that
+        // omits the server_tool_use id leaves a duplicate, empty-id streaming preview in persisted
+        // history beside the finalized call. Replaying a server_tool_use block with an empty id is
+        // rejected, so the empty-id duplicate must be dropped while the valid call+result survive.
+        var messages = new IMessage[]
+        {
+            new TextMessage { Role = Role.User, Text = "Search the web." },
+            // Empty-id duplicate (the streaming preview that landed in history).
+            new ToolCallMessage
+            {
+                ToolCallId = "",
+                FunctionName = "web_search",
+                FunctionArgs = "",
+                ExecutionTarget = ExecutionTarget.ProviderServer,
+                Role = Role.Assistant,
+            },
+            // The finalized call with a real (synthetic) id.
+            new ToolCallMessage
+            {
+                ToolCallId = "srvtoolu_synth_1_abc",
+                FunctionName = "web_search",
+                FunctionArgs = """{"query":"news"}""",
+                ExecutionTarget = ExecutionTarget.ProviderServer,
+                Role = Role.Assistant,
+            },
+            new ToolCallResultMessage
+            {
+                ToolCallId = "srvtoolu_synth_1_abc",
+                ToolName = "web_search",
+                Result = "[]",
+                ExecutionTarget = ExecutionTarget.ProviderServer,
+                Role = Role.Assistant,
+            },
+            new TextMessage { Role = Role.User, Text = "Thanks." },
+        };
+
+        var options = new GenerateReplyOptions
+        {
+            ModelId = "claude-sonnet-4-20250514",
+            BuiltInTools = [new AnthropicWebSearchTool()],
+        };
+
+        var request = AnthropicRequest.FromMessages(messages, options);
+        var json = JsonSerializer.Serialize(request, _jsonOptions);
+        var doc = JsonDocument.Parse(json);
+
+        var serverToolUseIds = new List<string?>();
+        foreach (var msg in doc.RootElement.GetProperty("messages").EnumerateArray())
+        {
+            if (!msg.TryGetProperty("content", out var content) || content.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            foreach (var block in content.EnumerateArray())
+            {
+                if (block.TryGetProperty("type", out var t) && t.GetString() == "server_tool_use")
+                {
+                    serverToolUseIds.Add(block.TryGetProperty("id", out var id) ? id.GetString() : null);
+                }
+            }
+        }
+
+        // Exactly the finalized call survives — no empty/blank id ever reaches the wire.
+        Assert.Equal(new[] { "srvtoolu_synth_1_abc" }, serverToolUseIds);
+        Assert.DoesNotContain(serverToolUseIds, string.IsNullOrWhiteSpace);
+    }
+
+    [Fact]
     public void FromMessages_FullKimiLikeFlow_ProducesCorrectMergedWireJson()
     {
         // Full IMessage sequence: User text, Assistant text + ToolCallMessage (server),

--- a/tests/AnthropicProvider.Tests/Models/ServerToolStreamParserTests.cs
+++ b/tests/AnthropicProvider.Tests/Models/ServerToolStreamParserTests.cs
@@ -828,7 +828,7 @@ public class ServerToolStreamParserTests
     public void ProcessEvent_ServerToolUse_WithoutId_GeneratesSyntheticId()
     {
         // Regression test: Kimi doesn't send 'id' on server_tool_use blocks.
-        // The parser should handle missing IDs gracefully (empty string in ToolCallMessage).
+        // The parser synthesizes a non-empty id at content_block_start so it can be matched and replayed.
         var parser = new AnthropicStreamParser();
         parser.ProcessEvent("event", BuildMessageStart());
 
@@ -847,11 +847,12 @@ public class ServerToolStreamParserTests
 
         var startMessages = parser.ProcessEvent("event", startData);
 
-        // ToolCallUpdateMessage emitted at content_block_start
+        // ToolCallUpdateMessage emitted at content_block_start with a synthesized, non-empty id
         Assert.Single(startMessages);
         var msg = Assert.IsType<ToolCallUpdateMessage>(startMessages[0]);
         Assert.Equal("web_search", msg.FunctionName);
         Assert.Equal(ExecutionTarget.ProviderServer, msg.ExecutionTarget);
+        Assert.False(string.IsNullOrEmpty(msg.ToolCallId), "synthetic id must be assigned at content_block_start");
         var args = JsonDocument.Parse(msg.FunctionArgs ?? "{}").RootElement;
         Assert.Equal("hello", args.GetProperty("query").GetString());
     }
@@ -859,8 +860,9 @@ public class ServerToolStreamParserTests
     [Fact]
     public void ProcessEvent_ServerToolUse_WithoutId_ResultResolvesSyntheticId()
     {
-        // Regression test: when server_tool_use has no id, tool call and result
-        // should use empty string and still resolve via tool name matching.
+        // Regression (Kimi): when server_tool_use has no id, the parser synthesizes a non-empty id
+        // at content_block_start and the result (even with an empty tool_use_id) resolves to that
+        // SAME id. An empty id on either block makes replay fail with "tool_call_id is not found".
         var parser = new AnthropicStreamParser();
         parser.ProcessEvent("event", BuildMessageStart());
 
@@ -878,8 +880,9 @@ public class ServerToolStreamParserTests
         }));
 
         var toolCall = Assert.IsType<ToolCallUpdateMessage>(Assert.Single(startMessages));
+        Assert.False(string.IsNullOrEmpty(toolCall.ToolCallId), "streaming update id must not be empty");
 
-        // Now send the result with empty tool_use_id — it should resolve to empty as well
+        // Now send the result with empty tool_use_id — it should resolve to the call's synthetic id
         var resultData = JsonSerializer.Serialize(new
         {
             type = "content_block_start",
@@ -895,7 +898,67 @@ public class ServerToolStreamParserTests
 
         Assert.Single(resultMessages);
         var result = Assert.IsType<ToolCallResultMessage>(resultMessages[0]);
-        Assert.Equal("", result.ToolCallId);
+        Assert.False(string.IsNullOrEmpty(result.ToolCallId), "result id must not be empty");
+        Assert.Equal(toolCall.ToolCallId, result.ToolCallId);
+    }
+
+    [Fact]
+    public void ProcessEvent_ServerToolUse_WithoutId_NoMessageHasEmptyToolCallId()
+    {
+        // Regression (Kimi 400 "tool_call_id  is not found"): a server_tool_use stream that omits
+        // the id must never yield ANY message with an empty ToolCallId, and the streaming update,
+        // the finalized call, and the result must all share the same id so replay round-trips.
+        var parser = new AnthropicStreamParser();
+        var all = new List<IMessage>();
+
+        all.AddRange(parser.ProcessEvent("event", BuildMessageStart()));
+
+        // server_tool_use content_block_start WITHOUT an id
+        all.AddRange(parser.ProcessEvent("event", JsonSerializer.Serialize(new
+        {
+            type = "content_block_start",
+            index = 0,
+            content_block = new { type = "server_tool_use", name = "web_search" },
+        })));
+        // input streamed as a delta, then the block stops (finalize)
+        all.AddRange(parser.ProcessEvent("event", JsonSerializer.Serialize(new
+        {
+            type = "content_block_delta",
+            index = 0,
+            delta = new { type = "input_json_delta", partial_json = "{\"query\":\"x\"}" },
+        })));
+        all.AddRange(parser.ProcessEvent("event", JsonSerializer.Serialize(new
+        {
+            type = "content_block_stop",
+            index = 0,
+        })));
+        // web_search_tool_result with an empty tool_use_id (Kimi behavior)
+        all.AddRange(parser.ProcessEvent("event", JsonSerializer.Serialize(new
+        {
+            type = "content_block_start",
+            index = 1,
+            content_block = new
+            {
+                type = "web_search_tool_result",
+                tool_use_id = "",
+                content = new { type = "web_search_result", results = Array.Empty<object>() },
+            },
+        })));
+
+        var serverToolCallIds = all
+            .Where(m => m is ToolCallUpdateMessage u && u.ExecutionTarget == ExecutionTarget.ProviderServer)
+            .Select(m => ((ToolCallUpdateMessage)m).ToolCallId)
+            .Concat(all.OfType<ToolCallMessage>()
+                .Where(m => m.ExecutionTarget == ExecutionTarget.ProviderServer)
+                .Select(m => m.ToolCallId))
+            .Concat(all.OfType<ToolCallResultMessage>()
+                .Where(m => m.ExecutionTarget == ExecutionTarget.ProviderServer)
+                .Select(m => m.ToolCallId))
+            .ToList();
+
+        Assert.NotEmpty(serverToolCallIds);
+        Assert.All(serverToolCallIds, id => Assert.False(string.IsNullOrEmpty(id), "no server tool message may have an empty id"));
+        Assert.Single(serverToolCallIds.Distinct());
     }
 
     /// <summary>

--- a/tests/LmStreaming.Sample.Tests/Services/SystemPromptAugmenterTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SystemPromptAugmenterTests.cs
@@ -1,0 +1,41 @@
+using LmStreaming.Sample.Services;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+public class SystemPromptAugmenterTests
+{
+    [Fact]
+    public void PrependCurrentDate_PrependsUtcDateLine_BeforeExistingPrompt()
+    {
+        var now = new DateTimeOffset(2026, 6, 23, 22, 30, 0, TimeSpan.Zero);
+
+        var result = SystemPromptAugmenter.PrependCurrentDate("You are a helpful assistant.", now);
+
+        result.Should().StartWith("The current date is 2026-06-23 (UTC).");
+        result.Should().EndWith("You are a helpful assistant.");
+        result.Should().Contain("\n\nYou are a helpful assistant.");
+    }
+
+    [Fact]
+    public void PrependCurrentDate_UsesUtcDate_NotLocalOffset()
+    {
+        // 2026-06-23 23:30 at -07:00 is 2026-06-24 06:30 UTC — the date line must be the UTC date.
+        var now = new DateTimeOffset(2026, 6, 23, 23, 30, 0, TimeSpan.FromHours(-7));
+
+        var result = SystemPromptAugmenter.PrependCurrentDate("x", now);
+
+        result.Should().StartWith("The current date is 2026-06-24 (UTC).");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void PrependCurrentDate_ReturnsDateLineOnly_WhenPromptNullOrEmpty(string? prompt)
+    {
+        var now = new DateTimeOffset(2026, 6, 23, 0, 0, 0, TimeSpan.Zero);
+
+        var result = SystemPromptAugmenter.PrependCurrentDate(prompt, now);
+
+        result.Should().Be("The current date is 2026-06-23 (UTC).");
+    }
+}


### PR DESCRIPTION
## Summary
Two related fixes for the Workspace Agent chat path, both diagnosed via `?record=1` recordings + Playwright reproduction and log analysis.

### 1. `web_search` replay fails with `400 "tool_call_id is not found"`
Anthropic-compatible providers (e.g. Kimi) sometimes omit the `server_tool_use` id on `web_search`. The stream parser emitted the streaming preview with an **empty** id and only synthesized one at `content_block_stop`, leaving a duplicate empty-id `tool_call` in history. Replaying it produced `400 invalid_request_error: "tool_call_id  is not found"` (empty id), killing the run.

- **`AnthropicStreamParser`**: synthesize the id at `content_block_start` (typed + untyped paths) via `EnsureServerToolUseId`, so the streaming update, finalized call, and result share one non-empty id.
- **`AnthropicRequest`**: drop empty-id `server_tool_use` blocks when rebuilding the request — heals already-persisted broken histories too.

### 2. Workspace Agent loops on time-sensitive queries ("today's news")
The system prompt contained **no current date**. The model fell back to its training-era date, treated correctly-dated 2026 `web_search` results as "future/unreliable", and looped: re-search -> run `date`/`timedatectl` -> `curl` (egress-denied) -> repeat, with no turn-cap.

- Add **`SystemPromptAugmenter.PrependCurrentDate`** (UTC date line) and apply it once at the single `mode = context.Mode` entry point, so every derived prompt (workspace suffix, medical context) inherits it.

## Root cause evidence
- Recorded pre-fix `system` prompt: zero date references.
- Model's own reasoning pre-fix: *"knowledge cutoff is early 2025... June 2026? suspect."*
- Recorded post-fix request now starts with `The current date is YYYY-MM-DD (UTC).`

## Verification (log-first)
| metric | pre-fix loop | 5 independent post-fix threads |
|---|---|---|
| Bash date-probes (`date`/`timedatectl`) | 8 | **0** (all 5) |
| web_search calls | 10 | 1 each |
| turns terminated | spun to 100 msgs | **yes, all 5** |

## Tests
- `ServerToolStreamParserTests`: no-id streaming flow keeps a consistent non-empty id; no message has an empty id.
- `ServerToolRequestTests`: empty-id server-tool block is dropped on replay; valid call+result survive.
- `SystemPromptAugmenterTests`: date prepend incl. UTC date-rollover.
- AnthropicProvider 168/168, LmStreaming.Sample 279/279 pass.

## Notes / out of scope
- Injected date is **UTC**; for "US news" a US-local date might read more naturally - easy follow-up.
- Separate, intermittent quality issue (not the loop): when Kimi `web_search` returns poor results, the model now cleanly *declines* ("I don't have a web search tool") instead of looping. Distinct from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)