### PR TITLE
fix: message-identity (pillbox grouping) + incremental render on conversation switch + Anthropic empty-id result guard

### DIFF
--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/api/wsClient.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/api/wsClient.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeKeys } from '@/api/wsClient';
+
+// BLOCKER 3: tool-call wire JSON uses snake_case identity fields (e.g. `generation_id`). The merge
+// key reads camelCase `generationId`, so without a snake_case alias these messages fall back to
+// 'default' and fail to group with their camelCase siblings. normalizeKeys must alias the snake_case
+// identity fields → camelCase at the deserialize boundary so all downstream consumers see one shape.
+describe('normalizeKeys snake_case identity aliasing (BLOCKER 3)', () => {
+  it('aliases snake_case generation_id -> generationId', () => {
+    const out = normalizeKeys({
+      $type: 'tool_call',
+      generation_id: 'gen-1',
+      run_id: 'run-1',
+      parent_run_id: 'parent-1',
+      message_order_idx: 2,
+      tool_call_id: 'call_1',
+    }) as Record<string, unknown>;
+
+    expect(out.generationId).toBe('gen-1');
+    expect(out.runId).toBe('run-1');
+    expect(out.parentRunId).toBe('parent-1');
+    expect(out.messageOrderIdx).toBe(2);
+    // tool_call_id is already consumed directly by the merge key; keep it intact.
+    expect(out.tool_call_id).toBe('call_1');
+  });
+
+  it('still aliases PascalCase keys and does not clobber existing camelCase', () => {
+    const out = normalizeKeys({
+      GenerationId: 'gen-pascal',
+      generation_id: 'gen-snake',
+    }) as Record<string, unknown>;
+
+    // An explicit camelCase wins; aliases are write-once and must not overwrite it.
+    expect(out.generationId).toBe('gen-pascal');
+  });
+
+  it('recurses into nested objects and arrays', () => {
+    const out = normalizeKeys({
+      tool_calls: [{ generation_id: 'g', tool_call_id: 'c' }],
+    }) as { tool_calls: Array<Record<string, unknown>> };
+
+    expect(out.tool_calls[0].generationId).toBe('g');
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChat.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChat.test.ts
@@ -14,6 +14,14 @@ vi.mock('@/api/wsClient', () => ({
   closeWebSocketConnection: wsMocks.closeWebSocketConnection,
 }));
 
+const conversationsMocks = vi.hoisted(() => ({
+  loadConversationMessages: vi.fn(),
+}));
+
+vi.mock('@/api/conversationsApi', () => ({
+  loadConversationMessages: conversationsMocks.loadConversationMessages,
+}));
+
 describe('isTestInstruction', () => {
   it('should return true for messages with both start and end markers', () => {
     const text = '<|instruction_start|>{"instruction_chain": []}<|instruction_end|>';
@@ -200,5 +208,116 @@ describe('useChat deferred-auth prompts', () => {
 
     chat.dismissAuthRequest('github');
     expect(chat.pendingAuthRequests.value).toHaveLength(0);
+  });
+});
+
+describe('useChat rehydration merge-key (BUG A)', () => {
+  beforeEach(() => {
+    wsMocks.createWebSocketConnection.mockReset();
+    wsMocks.sendWebSocketMessage.mockReset();
+    wsMocks.closeWebSocketConnection.mockReset();
+    conversationsMocks.loadConversationMessages.mockReset();
+
+    wsMocks.createWebSocketConnection.mockImplementation(async (options: any) => ({
+      socket: { readyState: WebSocket.OPEN },
+      connectionId: `ws-${Date.now()}`,
+      threadId: options.threadId,
+      isConnected: true,
+    }));
+  });
+
+  it('merges a streaming Text update into a rehydrated message instead of duplicating it', async () => {
+    conversationsMocks.loadConversationMessages.mockResolvedValue([
+      {
+        id: 'persisted-1',
+        threadId: 'thread-x',
+        runId: 'run-1',
+        generationId: 'gen-1',
+        messageOrderIdx: 0,
+        timestamp: 1000,
+        messageType: 'text',
+        role: 'assistant',
+        messageJson: JSON.stringify({
+          $type: MessageType.Text,
+          role: 'assistant',
+          text: 'partial',
+        }),
+      },
+    ]);
+
+    const chat = useChat({ getModeId: () => 'default' });
+
+    await chat.loadMessagesFromBackend('thread-x');
+
+    // Rehydrated message should render exactly one assistant text bubble.
+    const afterLoad = chat.displayItems.value.filter(
+      (i) => i.type === 'assistant-message'
+    );
+    expect(afterLoad).toHaveLength(1);
+
+    await chat.sendMessage('continue');
+    const options = wsMocks.createWebSocketConnection.mock.calls[0]?.[0];
+    expect(options).toBeDefined();
+
+    // Finalizing Text message shares the SAME run/generation/messageOrderIdx as the rehydrated one.
+    options.onMessage({
+      $type: MessageType.Text,
+      role: 'assistant',
+      text: 'partial and more',
+      runId: 'run-1',
+      generationId: 'gen-1',
+      messageOrderIdx: 0,
+      threadId: 'thread-x',
+    });
+
+    const bubbles = chat.displayItems.value.filter(
+      (i) => i.type === 'assistant-message'
+    );
+    expect(bubbles).toHaveLength(1);
+    expect(
+      (bubbles[0] as { content?: { text?: string } }).content?.text
+    ).toBe('partial and more');
+  });
+});
+
+describe('useChat socket reuse honors thread (BUG B)', () => {
+  beforeEach(() => {
+    wsMocks.createWebSocketConnection.mockReset();
+    wsMocks.sendWebSocketMessage.mockReset();
+    wsMocks.closeWebSocketConnection.mockReset();
+
+    wsMocks.createWebSocketConnection.mockImplementation(async (options: any) => ({
+      socket: { readyState: WebSocket.OPEN },
+      connectionId: `ws-${options.threadId}`,
+      threadId: options.threadId,
+      isConnected: true,
+    }));
+  });
+
+  it('does not reuse a socket bound to a different thread', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+
+    await chat.sendMessage('to thread A');
+    expect(wsMocks.createWebSocketConnection).toHaveBeenCalledTimes(1);
+    const threadAConnection = await wsMocks.createWebSocketConnection.mock.results[0]?.value;
+    expect(threadAConnection.threadId).toBeDefined();
+
+    // Switch to a different thread (conversation switch).
+    chat.setThreadId('thread-B');
+
+    await chat.sendMessage('to thread B');
+
+    // The stale thread-A socket must NOT be reused for the thread-B send: a fresh
+    // connection bound to thread-B must be created instead.
+    expect(wsMocks.createWebSocketConnection).toHaveBeenCalledTimes(2);
+    const threadBOptions = wsMocks.createWebSocketConnection.mock.calls[1]?.[0];
+    expect(threadBOptions.threadId).toBe('thread-B');
+
+    // The stale connection should have been closed, not messaged.
+    expect(wsMocks.closeWebSocketConnection).toHaveBeenCalledWith(threadAConnection);
+    expect(wsMocks.sendWebSocketMessage).not.toHaveBeenCalledWith(
+      threadAConnection,
+      'to thread B'
+    );
   });
 });

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChat.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChat.test.ts
@@ -329,3 +329,40 @@ describe('useChat socket reuse honors thread (BUG B)', () => {
     );
   });
 });
+
+describe('useChat concurrent tool-call grouping', () => {
+  beforeEach(() => {
+    wsMocks.createWebSocketConnection.mockReset();
+    wsMocks.sendWebSocketMessage.mockReset();
+    wsMocks.closeWebSocketConnection.mockReset();
+
+    wsMocks.createWebSocketConnection.mockImplementation(async (options: any) => ({
+      socket: { readyState: 1 },
+      connectionId: `ws-${Date.now()}`,
+      threadId: options.threadId,
+      isConnected: true,
+    }));
+  });
+
+  // GPT-5.5 (OpenAI Responses) emits several finalized tool_call messages in one turn that share
+  // runId/generationId/messageOrderIdx and differ only by tool_call_id. They must render as
+  // distinct pills inside ONE pillbox — not collapse into a single pill via a colliding merge key.
+  it('renders concurrent tool calls in one turn as distinct pills under one pillbox', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    await chat.sendMessage('do three calculations');
+    const options = wsMocks.createWebSocketConnection.mock.calls[0]?.[0];
+    expect(options).toBeDefined();
+
+    const base = { role: 'assistant', runId: 'run-1', generationId: 'gen-1', messageOrderIdx: 0 };
+    options.onMessage({ ...base, $type: MessageType.ToolCall, tool_call_id: 'call_1', function_name: 'calculate', function_args: '{"a":12,"b":30}' });
+    options.onMessage({ ...base, $type: MessageType.ToolCall, tool_call_id: 'call_2', function_name: 'calculate', function_args: '{"a":100,"b":45}' });
+    options.onMessage({ ...base, $type: MessageType.ToolCall, tool_call_id: 'call_3', function_name: 'calculate', function_args: '{"a":6,"b":7}' });
+
+    const pills = chat.displayItems.value.filter((i) => i.type === 'pill');
+    expect(pills, 'concurrent calls stay in ONE pillbox').toHaveLength(1);
+    expect(
+      (pills[0] as { items: unknown[] }).items,
+      'each concurrent tool call is its own pill, not collapsed'
+    ).toHaveLength(3);
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChat.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChat.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDisplayText, isTestInstruction, useChat } from '@/composables/useChat';
 import { MessageType } from '@/types';
 
@@ -282,6 +282,10 @@ describe('useChat rehydration merge-key (BUG A)', () => {
 
 describe('useChat socket reuse honors thread (BUG B)', () => {
   beforeEach(() => {
+    // happy-dom does not define a WebSocket global; the production reuse guard and the mock
+    // socket both read WebSocket.OPEN, so stub the readyState constants for this block.
+    vi.stubGlobal('WebSocket', { CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3 });
+
     wsMocks.createWebSocketConnection.mockReset();
     wsMocks.sendWebSocketMessage.mockReset();
     wsMocks.closeWebSocketConnection.mockReset();
@@ -292,6 +296,10 @@ describe('useChat socket reuse honors thread (BUG B)', () => {
       threadId: options.threadId,
       isConnected: true,
     }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('does not reuse a socket bound to a different thread', async () => {

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChat.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChat.test.ts
@@ -280,6 +280,71 @@ describe('useChat rehydration merge-key (BUG A)', () => {
   });
 });
 
+describe('useChat rehydration duplicate merge-key (BLOCKER 1)', () => {
+  beforeEach(() => {
+    wsMocks.createWebSocketConnection.mockReset();
+    wsMocks.sendWebSocketMessage.mockReset();
+    wsMocks.closeWebSocketConnection.mockReset();
+    conversationsMocks.loadConversationMessages.mockReset();
+
+    wsMocks.createWebSocketConnection.mockImplementation(async (options: any) => ({
+      socket: { readyState: WebSocket.OPEN },
+      connectionId: `ws-${Date.now()}`,
+      threadId: options.threadId,
+      isConnected: true,
+    }));
+  });
+
+  // Stream persistence can hold several records that collapse to the SAME logical merge key
+  // (e.g. an intermediate TextUpdate-derived record and the finalizing Text, same
+  // run/generation/messageOrderIdx). The old loader pushed EVERY record into messageOrder, so the
+  // shared key accumulated multiple entries while messageIndex overwrote — the same final message
+  // then rendered/sorted multiple times. The loader must append to messageOrder only on first
+  // insert and merge/overwrite the existing entry afterwards.
+  it('appends one messageOrder entry when two persisted records share a merge key', async () => {
+    conversationsMocks.loadConversationMessages.mockResolvedValue([
+      {
+        id: 'persisted-1',
+        threadId: 'thread-x',
+        runId: 'run-1',
+        generationId: 'gen-1',
+        messageOrderIdx: 0,
+        timestamp: 1000,
+        messageType: 'text',
+        role: 'assistant',
+        messageJson: JSON.stringify({
+          $type: MessageType.Text,
+          role: 'assistant',
+          text: 'partial',
+        }),
+      },
+      {
+        id: 'persisted-2',
+        threadId: 'thread-x',
+        runId: 'run-1',
+        generationId: 'gen-1',
+        messageOrderIdx: 0,
+        timestamp: 1001,
+        messageType: 'text',
+        role: 'assistant',
+        messageJson: JSON.stringify({
+          $type: MessageType.Text,
+          role: 'assistant',
+          text: 'partial and final',
+        }),
+      },
+    ]);
+
+    const chat = useChat({ getModeId: () => 'default' });
+    await chat.loadMessagesFromBackend('thread-x');
+
+    // Both records collapse to ONE merge key → exactly one rendered bubble, holding the last value.
+    const bubbles = chat.displayItems.value.filter((i) => i.type === 'assistant-message');
+    expect(bubbles).toHaveLength(1);
+    expect((bubbles[0] as { content?: { text?: string } }).content?.text).toBe('partial and final');
+  });
+});
+
 describe('useChat socket reuse honors thread (BUG B)', () => {
   beforeEach(() => {
     // happy-dom does not define a WebSocket global; the production reuse guard and the mock
@@ -364,5 +429,35 @@ describe('useChat concurrent tool-call grouping', () => {
       (pills[0] as { items: unknown[] }).items,
       'each concurrent tool call is its own pill, not collapsed'
     ).toHaveLength(3);
+  });
+
+  // TEST 4: the aggregate single-call ToolsCallMessage branch of getMergeKey. Some providers finalize
+  // each concurrent call as its own MessageType.ToolsCall (one tool_call) sharing
+  // run/generation/messageOrderIdx and differing only by tool_calls[0].tool_call_id. These must NOT
+  // collide on the messageOrderIdx-only key — each must render as a distinct pill.
+  it('renders single-call ToolsCallMessages with distinct tool_call_id as distinct pills', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    await chat.sendMessage('do two calculations');
+    const options = wsMocks.createWebSocketConnection.mock.calls[0]?.[0];
+    expect(options).toBeDefined();
+
+    const base = { role: 'assistant', runId: 'run-1', generationId: 'gen-1', messageOrderIdx: 0 };
+    options.onMessage({
+      ...base,
+      $type: MessageType.ToolsCall,
+      tool_calls: [{ tool_call_id: 'call_1', function_name: 'calculate', function_args: '{"a":1}' }],
+    });
+    options.onMessage({
+      ...base,
+      $type: MessageType.ToolsCall,
+      tool_calls: [{ tool_call_id: 'call_2', function_name: 'calculate', function_args: '{"a":2}' }],
+    });
+
+    const pills = chat.displayItems.value.filter((i) => i.type === 'pill');
+    expect(pills, 'aggregate single-call messages stay in ONE pillbox').toHaveLength(1);
+    expect(
+      (pills[0] as { items: unknown[] }).items,
+      'two single-call ToolsCallMessages with distinct ids must not collide'
+    ).toHaveLength(2);
   });
 });

--- a/samples/LmStreaming.Sample/ClientApp/src/api/wsClient.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/api/wsClient.ts
@@ -50,13 +50,30 @@ export interface WebSocketConnection {
 }
 
 /**
+ * Identity fields that arrive in snake_case on some wire shapes (tool-call JSON) but are read in
+ * camelCase by the client merge key (`kind-runId-generationId-messageOrderIdx`). Without a
+ * snake_case → camelCase alias these messages fall back to 'default' and fail to group with their
+ * camelCase siblings. (tool_call_id is consumed directly in snake_case by getMergeKey, so it does
+ * not need aliasing here.)
+ */
+const SNAKE_CASE_IDENTITY_ALIASES: Readonly<Record<string, string>> = {
+  generation_id: 'generationId',
+  run_id: 'runId',
+  parent_run_id: 'parentRunId',
+  message_order_idx: 'messageOrderIdx',
+};
+
+/**
  * Server emits PascalCase JSON (System.Text.Json default policy) but TS Message types
  * are camelCase. Normalize at the deserialize boundary so downstream handlers don't
  * need per-field dual-casing reads. Recurses into nested objects/arrays. Preserves the
- * original PascalCase keys alongside the camelCase aliases (write-once, never overwrite)
- * so any handler that already reads PascalCase still works during migration.
+ * original keys alongside the camelCase aliases (write-once, never overwrite) so any handler
+ * that already reads the original casing still works during migration. Handles both PascalCase
+ * (leading-uppercase) and a known set of snake_case identity fields.
+ *
+ * Exported for unit testing of the aliasing contract.
  */
-function normalizeKeys(value: unknown): unknown {
+export function normalizeKeys(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(normalizeKeys);
   }
@@ -78,6 +95,11 @@ function normalizeKeys(value: unknown): unknown {
           out[camel] = normalized;
         }
       }
+    }
+    // Add camelCase alias for known snake_case identity fields (write-once).
+    const snakeAlias = SNAKE_CASE_IDENTITY_ALIASES[k];
+    if (snakeAlias && !(snakeAlias in out)) {
+      out[snakeAlias] = normalized;
     }
   }
   return out;

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -1080,8 +1080,16 @@ export function useChat(options: UseChatOptions = {}) {
           isStreaming: false,
         };
 
+        // Stream persistence can hold several records that collapse to one logical merge key
+        // (e.g. an intermediate update record beside the finalizing message, same
+        // run/generation/messageOrderIdx). Append to messageOrder only on FIRST insert; otherwise
+        // overwrite the existing messageIndex entry in place so the final record wins WITHOUT
+        // accumulating a duplicate key that would render/sort the same message multiple times.
+        const isFirstInsert = !messageIndex.value.has(mergeKey);
         messageIndex.value.set(mergeKey, chatMessage);
-        messageOrder.value.push(mergeKey);
+        if (isFirstInsert) {
+          messageOrder.value.push(mergeKey);
+        }
       } catch (e) {
         log.warn('Failed to parse persisted message', { messageId: pm.id, error: e });
       }

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -97,17 +97,21 @@ function getMergeKey(msg: Message): string {
   const messageOrderIdx = msg.messageOrderIdx ?? 0;
   const mergeKind = getMergeKind(msg);
   
-  // For tool call updates, include toolCallIdx
-  if (isToolCallUpdateMessage(msg) || isToolsCallUpdateMessage(msg)) {
-    if (isToolCallUpdateMessage(msg)) {
-      // Individual tool call - use tool_call_id as unique identifier
-      return `${mergeKind}-${runId}-${generationId}-${messageOrderIdx}-${msg.tool_call_id || 'tc'}`;
-    } else {
-      // ToolsCallUpdate - use messageOrderIdx only (tools are accumulated in array)
-      return `${mergeKind}-${runId}-${generationId}-${messageOrderIdx}`;
-    }
+  // Individual tool calls — streaming OR finalized — are keyed by tool_call_id. Several concurrent
+  // tool calls in one turn share runId/generationId/messageOrderIdx and differ only by tool_call_id
+  // (e.g. GPT-5.5 via the OpenAI Responses API); without it they collapse into a single pill.
+  if (isToolCallUpdateMessage(msg) || isToolCallMessage(msg)) {
+    return `${mergeKind}-${runId}-${generationId}-${messageOrderIdx}-${msg.tool_call_id || 'tc'}`;
   }
-  
+
+  // A finalized single-call ToolsCallMessage is the same case wrapped in the aggregate type —
+  // disambiguate by its tool_call_id too. Multi-call aggregates already carry every call in one
+  // message (rendered as N pills), so they key on messageOrderIdx only.
+  if (isToolsCallMessage(msg) && msg.tool_calls?.length === 1 && msg.tool_calls[0]?.tool_call_id) {
+    return `${mergeKind}-${runId}-${generationId}-${messageOrderIdx}-${msg.tool_calls[0].tool_call_id}`;
+  }
+
+  // ToolsCallUpdate accumulates tools into one array → key on messageOrderIdx only.
   return `${mergeKind}-${runId}-${generationId}-${messageOrderIdx}`;
 }
 

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -854,13 +854,21 @@ export function useChat(options: UseChatOptions = {}) {
   ): Promise<void> {
     const effectiveThreadId = getOrCreateThreadId();
     
-    // Check if we have an open connection
-    if (wsConnection && wsConnection.isConnected && wsConnection.socket.readyState === WebSocket.OPEN) {
-      log.info('Reusing existing WebSocket connection', { 
+    // Check if we have an open connection that belongs to the current thread.
+    // A socket bound to a previously-viewed conversation must not be reused for a
+    // different thread (e.g. after switching conversations); close it and fall
+    // through to create a fresh connection with the current callbacks instead.
+    if (
+      wsConnection &&
+      wsConnection.isConnected &&
+      wsConnection.socket.readyState === WebSocket.OPEN &&
+      wsConnection.threadId === threadId.value
+    ) {
+      log.info('Reusing existing WebSocket connection', {
         connectionId: wsConnection.connectionId,
-        threadId: wsConnection.threadId 
+        threadId: wsConnection.threadId
       });
-      
+
       // Send message on existing connection
       const { sendWebSocketMessage } = await import('@/api/wsClient');
       sendWebSocketMessage(wsConnection, text);
@@ -1042,9 +1050,21 @@ export function useChat(options: UseChatOptions = {}) {
           }
         }
 
+        // Ensure the parsed message carries the persisted identity fields so the
+        // merge key matches what live streaming computes for the same logical message.
+        parsedMessage.runId = parsedMessage.runId ?? pm.runId;
+        parsedMessage.parentRunId = parsedMessage.parentRunId ?? pm.parentRunId ?? undefined;
+        parsedMessage.generationId = parsedMessage.generationId ?? pm.generationId ?? undefined;
+        parsedMessage.messageOrderIdx = parsedMessage.messageOrderIdx ?? pm.messageOrderIdx ?? undefined;
+
+        // Index rehydrated messages by the same merge key used by live streaming
+        // (kind-runId-generationId-messageOrderIdx) so a subsequent streaming update
+        // sharing that identity merges in place instead of creating a duplicate bubble.
+        const mergeKey = getMergeKey(parsedMessage);
+
         // Create chat message
         const chatMessage: InternalChatMessage = {
-          id: pm.id,
+          id: mergeKey,
           role,
           status: 'completed',
           content: parsedMessage,
@@ -1056,8 +1076,8 @@ export function useChat(options: UseChatOptions = {}) {
           isStreaming: false,
         };
 
-        messageIndex.value.set(pm.id, chatMessage);
-        messageOrder.value.push(pm.id);
+        messageIndex.value.set(mergeKey, chatMessage);
+        messageOrder.value.push(mergeKey);
       } catch (e) {
         log.warn('Failed to parse persisted message', { messageId: pm.id, error: e });
       }

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -710,37 +710,10 @@ try
                         ? allBuiltInTools
                         : ModeToolFilter.FilterBuiltInTools(allBuiltInTools, mode.EnabledTools);
 
-                    // Surface model reasoning. Anthropic-format providers (incl. the Copilot-backed
-                    // sonnet/haiku — the Copilot proxy accepts the thinking parameter, verified by
-                    // CopilotAnthropicLiveTests.Thinking_param_is_accepted_by_copilot_backend) get
-                    // extended thinking; the OpenAI Responses providers (gpt-5.5/gpt-5.5-mini) get a
-                    // reasoning summary. Without this, Copilot-backed models returned no thinking blocks.
-                    var extraProperties = ImmutableDictionary<string, object?>.Empty;
-                    if (
-                        string.Equals(normalizedProviderId, "anthropic", StringComparison.Ordinal)
-                        || string.Equals(normalizedProviderId, "test-anthropic", StringComparison.Ordinal)
-                        || string.Equals(normalizedProviderId, "sonnet", StringComparison.Ordinal)
-                        || string.Equals(normalizedProviderId, "haiku", StringComparison.Ordinal)
-                    )
-                    {
-                        var budgetTokens = int.TryParse(
-                            Environment.GetEnvironmentVariable("ANTHROPIC_THINKING_BUDGET"),
-                            out var parsed
-                        )
-                            ? parsed
-                            : 2048;
-                        extraProperties = extraProperties.Add("Thinking", new AnthropicThinking(budgetTokens));
-                    }
-                    else if (
-                        string.Equals(normalizedProviderId, "gpt-5.5", StringComparison.Ordinal)
-                        || string.Equals(normalizedProviderId, "gpt-5.5-mini", StringComparison.Ordinal)
-                    )
-                    {
-                        extraProperties = extraProperties.Add(
-                            "Reasoning",
-                            new ResponseReasoningOptions { Summary = "auto" }
-                        );
-                    }
+                    // Surface model reasoning (provider→Thinking/Reasoning mapping). Extracted to a
+                    // testable helper so the per-provider wiring is regression-guarded; see
+                    // ProgramReasoningExtraPropertiesTests.
+                    var extraProperties = BuildReasoningExtraProperties(normalizedProviderId);
 
                     // Sub-agent orchestration options. Only the middleware providers reach this
                     // path — the CLI providers (codex/claude/copilot and their *-mock variants)
@@ -1056,6 +1029,44 @@ finally
 
 public partial class Program
 {
+    /// <summary>
+    ///     Maps a normalized provider id to the reasoning/thinking request options that surface a
+    ///     model's reasoning. Anthropic-format providers (incl. the Copilot-backed sonnet/haiku — the
+    ///     Copilot proxy accepts the thinking parameter, verified by
+    ///     CopilotAnthropicLiveTests.Thinking_param_is_accepted_by_copilot_backend) get an extended-
+    ///     thinking budget; the OpenAI Responses providers (gpt-5.5/gpt-5.5-mini) get a reasoning-
+    ///     summary request (CopilotResponsesLiveTests confirms gpt-5.5 returns reasoning). Other
+    ///     providers get none. Without this wiring, Copilot-backed models return no thinking blocks.
+    /// </summary>
+    internal static ImmutableDictionary<string, object?> BuildReasoningExtraProperties(string normalizedProviderId)
+    {
+        var extraProperties = ImmutableDictionary<string, object?>.Empty;
+        if (
+            string.Equals(normalizedProviderId, "anthropic", StringComparison.Ordinal)
+            || string.Equals(normalizedProviderId, "test-anthropic", StringComparison.Ordinal)
+            || string.Equals(normalizedProviderId, "sonnet", StringComparison.Ordinal)
+            || string.Equals(normalizedProviderId, "haiku", StringComparison.Ordinal)
+        )
+        {
+            var budgetTokens = int.TryParse(
+                Environment.GetEnvironmentVariable("ANTHROPIC_THINKING_BUDGET"),
+                out var parsed
+            )
+                ? parsed
+                : 2048;
+            extraProperties = extraProperties.Add("Thinking", new AnthropicThinking(budgetTokens));
+        }
+        else if (
+            string.Equals(normalizedProviderId, "gpt-5.5", StringComparison.Ordinal)
+            || string.Equals(normalizedProviderId, "gpt-5.5-mini", StringComparison.Ordinal)
+        )
+        {
+            extraProperties = extraProperties.Add("Reasoning", new ResponseReasoningOptions { Summary = "auto" });
+        }
+
+        return extraProperties;
+    }
+
     /// <summary>
     ///     Creates a test-mode agent using an <see cref="ITestAgentBuilder"/>-supplied handler.
     /// </summary>

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -9,6 +9,7 @@ using AchieveAi.LmDotnetTools.GithubCopilotProvider.Agents;
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
 using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
 using AchieveAi.LmDotnetTools.CodexSdkProvider.Configuration;
 using AchieveAi.LmDotnetTools.CodexSdkProvider.Models;
 using AchieveAi.LmDotnetTools.CopilotSdkProvider.Configuration;
@@ -709,11 +710,17 @@ try
                         ? allBuiltInTools
                         : ModeToolFilter.FilterBuiltInTools(allBuiltInTools, mode.EnabledTools);
 
-                    // Enable extended thinking for Anthropic-compatible providers
+                    // Surface model reasoning. Anthropic-format providers (incl. the Copilot-backed
+                    // sonnet/haiku — the Copilot proxy accepts the thinking parameter, verified by
+                    // CopilotAnthropicLiveTests.Thinking_param_is_accepted_by_copilot_backend) get
+                    // extended thinking; the OpenAI Responses providers (gpt-5.5/gpt-5.5-mini) get a
+                    // reasoning summary. Without this, Copilot-backed models returned no thinking blocks.
                     var extraProperties = ImmutableDictionary<string, object?>.Empty;
                     if (
                         string.Equals(normalizedProviderId, "anthropic", StringComparison.Ordinal)
                         || string.Equals(normalizedProviderId, "test-anthropic", StringComparison.Ordinal)
+                        || string.Equals(normalizedProviderId, "sonnet", StringComparison.Ordinal)
+                        || string.Equals(normalizedProviderId, "haiku", StringComparison.Ordinal)
                     )
                     {
                         var budgetTokens = int.TryParse(
@@ -723,6 +730,16 @@ try
                             ? parsed
                             : 2048;
                         extraProperties = extraProperties.Add("Thinking", new AnthropicThinking(budgetTokens));
+                    }
+                    else if (
+                        string.Equals(normalizedProviderId, "gpt-5.5", StringComparison.Ordinal)
+                        || string.Equals(normalizedProviderId, "gpt-5.5-mini", StringComparison.Ordinal)
+                    )
+                    {
+                        extraProperties = extraProperties.Add(
+                            "Reasoning",
+                            new ResponseReasoningOptions { Summary = "auto" }
+                        );
                     }
 
                     // Sub-agent orchestration options. Only the middleware providers reach this

--- a/src/AnthropicProvider/Models/AnthropicRequest.cs
+++ b/src/AnthropicProvider/Models/AnthropicRequest.cs
@@ -752,6 +752,29 @@ public record AnthropicRequest
                 content.RemoveAt(i + 1);
             }
         }
+
+        // Any thinking block still lacking a signature after merging cannot be replayed: Anthropic
+        // (and compatible backends like Kimi, which emit thinking text but no signature) reject a
+        // signatureless thinking block in multi-turn history with 400 "invalid_request_error".
+        // Demote those to plain text so the reasoning context is kept without breaking the request;
+        // drop empty ones outright.
+        for (var i = content.Count - 1; i >= 0; i--)
+        {
+            var block = content[i];
+            if (block.Type != "thinking" || !string.IsNullOrEmpty(block.ThinkingSignature))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(block.Thinking))
+            {
+                content[i] = new AnthropicContent { Type = "text", Text = block.Thinking };
+            }
+            else
+            {
+                content.RemoveAt(i);
+            }
+        }
     }
 
     private static string GetJsonType(JsonSchemaObject schemaObject)

--- a/src/AnthropicProvider/Models/AnthropicRequest.cs
+++ b/src/AnthropicProvider/Models/AnthropicRequest.cs
@@ -443,17 +443,25 @@ public record AnthropicRequest
         }
         else if (message is ToolCallResultMessage singularToolResultMsg)
         {
-            var toolResultBlocks = ToAnthropicToolResultContentBlocks(
-                singularToolResultMsg.ContentBlocks, singularToolResultMsg.IsError);
-            anthropicMessage.Content.Add(
-                new AnthropicContent
-                {
-                    Type = "tool_result",
-                    ToolUseId = singularToolResultMsg.ToolCallId,
-                    Content = toolResultBlocks != null ? null : singularToolResultMsg.Result,
-                    ToolResultContentBlocks = toolResultBlocks,
-                }
-            );
+            // Drop the orphan result of a dropped empty-id server_tool_use. When an
+            // Anthropic-compatible provider (e.g. Kimi) omits the server_tool_use id, the empty-id
+            // call is dropped above; its matching empty-id server-tool result must be dropped too,
+            // otherwise it survives as a tool_result with a blank tool_use_id and replay fails with
+            // "tool_call_id is not found".
+            if (!IsEmptyIdServerToolCall(singularToolResultMsg.ExecutionTarget, singularToolResultMsg.ToolCallId))
+            {
+                var toolResultBlocks = ToAnthropicToolResultContentBlocks(
+                    singularToolResultMsg.ContentBlocks, singularToolResultMsg.IsError);
+                anthropicMessage.Content.Add(
+                    new AnthropicContent
+                    {
+                        Type = "tool_result",
+                        ToolUseId = singularToolResultMsg.ToolCallId,
+                        Content = toolResultBlocks != null ? null : singularToolResultMsg.Result,
+                        ToolResultContentBlocks = toolResultBlocks,
+                    }
+                );
+            }
         }
         else if (message is ToolsCallMessage toolsCallMsg && toolsCallMsg.ToolCalls?.Any() == true)
         {

--- a/src/LmCore/Core/GenerateReplyOptions.cs
+++ b/src/LmCore/Core/GenerateReplyOptions.cs
@@ -75,6 +75,16 @@ public record GenerateReplyOptions
     public string? RunId { get; init; }
 
     /// <summary>
+    ///     Generation ID for the current run. Identifies a single agent generation within a run
+    ///     and is the value advertised by the run assignment. Every message emitted while
+    ///     processing this run must carry this GenerationId so consumers can merge messages by
+    ///     (kind, runId, generationId, messageOrderIdx), regardless of the opaque ids a provider
+    ///     may stamp on individual messages.
+    /// </summary>
+    [JsonIgnore]
+    public string? GenerationId { get; init; }
+
+    /// <summary>
     ///     Parent Run ID for branching/time travel (creates git-like lineage).
     /// </summary>
     [JsonIgnore]
@@ -147,6 +157,10 @@ public record GenerateReplyOptions
             BuiltInTools = other.BuiltInTools ?? BuiltInTools,
             ToolChoice = other.ToolChoice ?? ToolChoice,
             ContainerId = other.ContainerId ?? ContainerId,
+            RunId = other.RunId ?? RunId,
+            ParentRunId = other.ParentRunId ?? ParentRunId,
+            ThreadId = other.ThreadId ?? ThreadId,
+            GenerationId = other.GenerationId ?? GenerationId,
             PromptCaching = other.PromptCaching != PromptCachingMode.Off ? other.PromptCaching : PromptCaching,
             RequestResponseDumpFileName = other.RequestResponseDumpFileName ?? RequestResponseDumpFileName,
             ExtraProperties = mergedExtraProps,

--- a/src/LmCore/Messages/MessageExtensions.cs
+++ b/src/LmCore/Messages/MessageExtensions.cs
@@ -214,11 +214,26 @@ public static class MessageExtensions
     }
 
     /// <summary>
-    ///     Updates the message with run, parent run, and thread IDs from the options.
+    ///     Updates the message with run, parent run, and thread IDs from the options, and — when
+    ///     the run advertises a <see cref="GenerateReplyOptions.GenerationId" /> — overrides the
+    ///     message's GenerationId with the run's.
     /// </summary>
+    /// <remarks>
+    ///     BUG H1 seam. Providers stamp their own GenerationId on each message; reasoning providers
+    ///     (e.g. GPT-5.5 via Copilot/OpenAI) stamp a distinct OPAQUE encrypted response/reasoning
+    ///     token per message, so the values fan out across many ids that the run never advertised.
+    ///     The client merges messages by (kind, runId, generationId, messageOrderIdx); a mismatched
+    ///     generationId silently drops tool calls and results. This is the single provider-agnostic
+    ///     seam every provider already calls to apply run identity, so the run's GenerationId is
+    ///     overridden here — every provider (including Anthropic) benefits with no provider edits.
+    ///     When the run supplies no GenerationId the provider's value is preserved (no behavior
+    ///     change for non-run callers).
+    /// </remarks>
     public static IMessage WithIds(this IMessage message, GenerateReplyOptions? options)
     {
-        return options == null ? message : message.WithIds(options.RunId, options.ParentRunId, options.ThreadId);
+        return options == null
+            ? message
+            : message.WithIds(options.RunId, options.ParentRunId, options.ThreadId, options.GenerationId);
     }
 
     /// <summary>
@@ -226,20 +241,102 @@ public static class MessageExtensions
     /// </summary>
     public static IMessage WithIds(this IMessage message, string? runId, string? parentRunId, string? threadId)
     {
+        return message.WithIds(runId, parentRunId, threadId, generationId: null);
+    }
+
+    /// <summary>
+    ///     Updates the message with run, parent run, and thread IDs, optionally overriding the
+    ///     message's GenerationId with the run's <paramref name="generationId" /> when it is
+    ///     non-empty. See the <see cref="WithIds(IMessage, GenerateReplyOptions?)" /> remarks for
+    ///     why the run's GenerationId must win over the provider's per-message id (BUG H1).
+    /// </summary>
+    public static IMessage WithIds(
+        this IMessage message,
+        string? runId,
+        string? parentRunId,
+        string? threadId,
+        string? generationId
+    )
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        // Preserve the provider's GenerationId unless the run advertises one to stamp.
+        var genId = string.IsNullOrEmpty(generationId) ? message.GenerationId : generationId;
+
         return message switch
         {
-            TextMessage m => m with { RunId = runId, ParentRunId = parentRunId, ThreadId = threadId },
-            TextUpdateMessage m => m with { RunId = runId, ParentRunId = parentRunId, ThreadId = threadId },
-            TextWithCitationsMessage m => m with { RunId = runId, ParentRunId = parentRunId, ThreadId = threadId },
-            ToolCallMessage m => m with { RunId = runId, ParentRunId = parentRunId, ThreadId = threadId },
-            ToolCallUpdateMessage m => m with { RunId = runId, ParentRunId = parentRunId, ThreadId = threadId },
-            ToolCallResultMessage m => m with { RunId = runId, ParentRunId = parentRunId, ThreadId = threadId },
-            ToolsCallMessage m => m with { RunId = runId, ParentRunId = parentRunId, ThreadId = threadId },
-            ToolsCallUpdateMessage m => m with { RunId = runId, ParentRunId = parentRunId, ThreadId = threadId },
-            ToolsCallResultMessage m => m with { RunId = runId, ThreadId = threadId },
-            ReasoningMessage m => m with { RunId = runId, ParentRunId = parentRunId, ThreadId = threadId },
-            ReasoningUpdateMessage m => m with { RunId = runId, ParentRunId = parentRunId, ThreadId = threadId },
-            UsageMessage m => m with { RunId = runId, ThreadId = threadId },
+            TextMessage m => m with
+            {
+                RunId = runId,
+                ParentRunId = parentRunId,
+                ThreadId = threadId,
+                GenerationId = genId,
+            },
+            TextUpdateMessage m => m with
+            {
+                RunId = runId,
+                ParentRunId = parentRunId,
+                ThreadId = threadId,
+                GenerationId = genId,
+            },
+            TextWithCitationsMessage m => m with
+            {
+                RunId = runId,
+                ParentRunId = parentRunId,
+                ThreadId = threadId,
+                GenerationId = genId,
+            },
+            ToolCallMessage m => m with
+            {
+                RunId = runId,
+                ParentRunId = parentRunId,
+                ThreadId = threadId,
+                GenerationId = genId,
+            },
+            ToolCallUpdateMessage m => m with
+            {
+                RunId = runId,
+                ParentRunId = parentRunId,
+                ThreadId = threadId,
+                GenerationId = genId,
+            },
+            ToolCallResultMessage m => m with
+            {
+                RunId = runId,
+                ParentRunId = parentRunId,
+                ThreadId = threadId,
+                GenerationId = genId,
+            },
+            ToolsCallMessage m => m with
+            {
+                RunId = runId,
+                ParentRunId = parentRunId,
+                ThreadId = threadId,
+                GenerationId = genId,
+            },
+            ToolsCallUpdateMessage m => m with
+            {
+                RunId = runId,
+                ParentRunId = parentRunId,
+                ThreadId = threadId,
+                GenerationId = genId,
+            },
+            ToolsCallResultMessage m => m with { RunId = runId, ThreadId = threadId, GenerationId = genId },
+            ReasoningMessage m => m with
+            {
+                RunId = runId,
+                ParentRunId = parentRunId,
+                ThreadId = threadId,
+                GenerationId = genId,
+            },
+            ReasoningUpdateMessage m => m with
+            {
+                RunId = runId,
+                ParentRunId = parentRunId,
+                ThreadId = threadId,
+                GenerationId = genId,
+            },
+            UsageMessage m => m with { RunId = runId, ThreadId = threadId, GenerationId = genId },
             _ => message,
         };
     }

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -509,6 +509,17 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
     {
         var result = await ExecuteToolCallAsync(toolCall, ct);
 
+        // Stamp ordering onto the result so the client merge/order logic (keyed partly on
+        // messageOrderIdx) does not drop it (BUG H3b). The loop publishes tool results out-of-band,
+        // bypassing the MessageTransformation middleware that stamps ordering on streamed messages,
+        // so without this the result reaches subscribers with MessageOrderIdx == null. The result
+        // immediately follows its tool call, so it takes the call's index + 1 (a different message
+        // kind than the call, so no merge-key collision with the next call at the same index).
+        if (result.MessageOrderIdx == null && toolCall.MessageOrderIdx is { } callOrderIdx)
+        {
+            result = result with { MessageOrderIdx = callOrderIdx + 1 };
+        }
+
         if (result.IsDeferred)
         {
             // Register the deferred entry BEFORE making the placeholder visible to history

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -384,11 +384,16 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         int turnNumber,
         CancellationToken ct)
     {
-        // Use defaultOptions as template, override run-specific fields
+        // Use defaultOptions as template, override run-specific fields.
+        // GenerationId carries the run's generation so providers stamp it (via WithIds) onto every
+        // emitted message, overriding any opaque per-message id a provider would otherwise set
+        // (BUG H1). This is the value run_assignment advertises, keeping the client merge key
+        // kind-runId-generationId-messageOrderIdx consistent across the whole run.
         var options = DefaultOptions with
         {
             RunId = runId,
             ThreadId = ThreadId,
+            GenerationId = generationId,
         };
 
         // Build messages list with system prompt prepended (if configured)

--- a/src/LmTestUtils/TestMode/OpenAiResponsesEventStreamWriter.cs
+++ b/src/LmTestUtils/TestMode/OpenAiResponsesEventStreamWriter.cs
@@ -85,7 +85,7 @@ public static class OpenAiResponsesEventStreamWriter
         if (plan.ReasoningLength is int reasoningLength && reasoningLength > 0)
         {
             var reasoningText = string.Join(' ', GenerateLoremWords(reasoningLength));
-            AppendReasoningOutput(events, ref seq, outputIndex, reasoningText);
+            AppendReasoningOutput(events, ref seq, outputIndex, reasoningText, effectiveChunkSize);
             outputIndex++;
         }
 
@@ -138,15 +138,20 @@ public static class OpenAiResponsesEventStreamWriter
         List<ResponseEvent> events,
         ref int seq,
         int outputIndex,
-        string reasoningText
+        string reasoningText,
+        int wordsPerChunk
     )
     {
         var itemId = $"rs_{Guid.NewGuid():N}";
+        // Faithful to real reasoning-capable models: the reasoning item opens (and closes) with an
+        // EMPTY summary array; the human-readable summary streams via reasoning_summary_text.delta
+        // events and is finalized by reasoning_summary_text.done. Emitting the text inside the
+        // item's summary (the old shape) would not exercise the provider's streaming parser.
         var itemJson = new JsonObject
         {
             ["id"] = itemId,
             ["type"] = "reasoning",
-            ["summary"] = new JsonArray(new JsonObject { ["type"] = "summary_text", ["text"] = reasoningText }),
+            ["summary"] = new JsonArray(),
         };
 
         events.Add(
@@ -156,6 +161,33 @@ public static class OpenAiResponsesEventStreamWriter
                 SequenceNumber = seq++,
                 OutputIndex = outputIndex,
                 Item = ToJsonElement(itemJson),
+            }
+        );
+
+        foreach (var chunk in ChunkWords(reasoningText, wordsPerChunk))
+        {
+            events.Add(
+                new ResponseReasoningSummaryTextDeltaEvent
+                {
+                    Type = ResponseEventTypes.ReasoningSummaryTextDelta,
+                    SequenceNumber = seq++,
+                    ItemId = itemId,
+                    OutputIndex = outputIndex,
+                    SummaryIndex = 0,
+                    Delta = chunk,
+                }
+            );
+        }
+
+        events.Add(
+            new ResponseReasoningSummaryTextDoneEvent
+            {
+                Type = ResponseEventTypes.ReasoningSummaryTextDone,
+                SequenceNumber = seq++,
+                ItemId = itemId,
+                OutputIndex = outputIndex,
+                SummaryIndex = 0,
+                Text = reasoningText,
             }
         );
 

--- a/src/OpenAiResponsesProvider/Agents/MessageMapper.cs
+++ b/src/OpenAiResponsesProvider/Agents/MessageMapper.cs
@@ -29,6 +29,19 @@ internal static class MessageMapper
             MapMessage(message, instructionsBuilder, inputItems);
         }
 
+        // Reasoning-capable models only return reasoning summaries when asked. Mirror the Anthropic
+        // "Thinking" convention: a ResponseReasoningOptions placed in ExtraProperties["Reasoning"]
+        // (e.g. { Summary = "auto" }) is mapped onto the request so thinking blocks come back.
+        ResponseReasoningOptions? reasoning = null;
+        if (
+            options?.ExtraProperties != null
+            && options.ExtraProperties.TryGetValue("Reasoning", out var reasoningObj)
+            && reasoningObj is ResponseReasoningOptions reasoningValue
+        )
+        {
+            reasoning = reasoningValue;
+        }
+
         IReadOnlyList<ResponseToolSpec>? tools = null;
         if (options?.Functions is { Length: > 0 } functions)
         {
@@ -55,6 +68,7 @@ internal static class MessageMapper
             MaxOutputTokens = options?.MaxToken,
             Tools = tools,
             ToolChoice = options?.ToolChoice is null ? null : JsonValue.Create(options.ToolChoice),
+            Reasoning = reasoning,
         };
     }
 

--- a/src/OpenAiResponsesProvider/Agents/OpenAiResponsesAgent.cs
+++ b/src/OpenAiResponsesProvider/Agents/OpenAiResponsesAgent.cs
@@ -58,7 +58,9 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
         var stream = await GenerateReplyStreamingAsync(messages, options, cancellationToken).ConfigureAwait(false);
 
         var aggregateText = new StringBuilder();
-        var generationId = Guid.NewGuid().ToString("N");
+        var generationId = string.IsNullOrEmpty(options?.GenerationId)
+            ? Guid.NewGuid().ToString("N")
+            : options.GenerationId;
         var resultMessages = new List<IMessage>();
 
         await foreach (var update in stream.ConfigureAwait(false))
@@ -121,16 +123,23 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
         );
 
         var eventStream = _client.StreamResponseAsync(request, cancellationToken);
-        return Task.FromResult(EventStreamToMessages(eventStream, Name, cancellationToken));
+        return Task.FromResult(EventStreamToMessages(eventStream, Name, options?.GenerationId, cancellationToken));
     }
 
     private static async IAsyncEnumerable<IMessage> EventStreamToMessages(
         IAsyncEnumerable<ResponseEvent> events,
         string fromAgent,
+        string? runGenerationId,
         [EnumeratorCancellation] CancellationToken cancellationToken
     )
     {
-        var generationId = Guid.NewGuid().ToString("N");
+        // Prefer the run's GenerationId so every message emitted in a run shares one id — the client
+        // merge key is kind-runId-generationId-messageOrderIdx, and the provider's opaque per-response
+        // id never matches the run, which breaks tool-call grouping (the pillbox bug). Fall back to a
+        // synthetic id only when the run advertises none.
+        var generationId = string.IsNullOrEmpty(runGenerationId)
+            ? Guid.NewGuid().ToString("N")
+            : runGenerationId;
         var pendingFunctionCalls = new Dictionary<string, PendingFunctionCall>(StringComparer.Ordinal);
         var textBuffers = new Dictionary<int, StringBuilder>();
         // Tool calls already surfaced, keyed by call_id, so the delta-correlated path and the
@@ -144,7 +153,12 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
             switch (ev)
             {
                 case ResponseLifecycleEvent lifecycle when lifecycle.Type == ResponseEventTypes.ResponseCreated:
-                    if (TryReadString(lifecycle.Response, "id", out var responseId))
+                    // Only adopt the provider's opaque response id when the run advertised no
+                    // GenerationId; otherwise the run's id must win so messages stay groupable.
+                    if (
+                        string.IsNullOrEmpty(runGenerationId)
+                        && TryReadString(lifecycle.Response, "id", out var responseId)
+                    )
                     {
                         generationId = responseId;
                     }

--- a/src/OpenAiResponsesProvider/Agents/OpenAiResponsesAgent.cs
+++ b/src/OpenAiResponsesProvider/Agents/OpenAiResponsesAgent.cs
@@ -207,10 +207,13 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
                 case ResponseReasoningSummaryTextDeltaEvent reasoningDelta:
                     // Reasoning summary streams as its own event channel (the reasoning output_item's
                     // summary array stays empty until done) — surface each delta as a reasoning update.
+                    // These are provider SUMMARIES, not full chain-of-thought: emit them as
+                    // ReasoningVisibility.Summary so an Anthropic-format replay serializes them as text
+                    // (AnthropicRequest's Summary branch) instead of an unsigned thinking block (400).
                     yield return new ReasoningUpdateMessage
                     {
                         Reasoning = reasoningDelta.Delta,
-                        Visibility = ReasoningVisibility.Plain,
+                        Visibility = ReasoningVisibility.Summary,
                         Role = Role.Assistant,
                         FromAgent = fromAgent,
                         GenerationId = generationId,
@@ -223,7 +226,7 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
                     yield return new ReasoningMessage
                     {
                         Reasoning = reasoningDone.Text,
-                        Visibility = ReasoningVisibility.Plain,
+                        Visibility = ReasoningVisibility.Summary,
                         Role = Role.Assistant,
                         FromAgent = fromAgent,
                         GenerationId = generationId,
@@ -415,6 +418,10 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
             if (builder.Length > 0)
             {
                 reasoning = builder.ToString();
+                // The summary array carries the provider's human-readable SUMMARY, not full
+                // chain-of-thought — mark it Summary so it never replays as an unsigned Anthropic
+                // thinking block (the encrypted_content path below stays Encrypted).
+                visibility = ReasoningVisibility.Summary;
                 return true;
             }
         }

--- a/src/OpenAiResponsesProvider/Agents/OpenAiResponsesAgent.cs
+++ b/src/OpenAiResponsesProvider/Agents/OpenAiResponsesAgent.cs
@@ -204,6 +204,34 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
 
                     break;
 
+                case ResponseReasoningSummaryTextDeltaEvent reasoningDelta:
+                    // Reasoning summary streams as its own event channel (the reasoning output_item's
+                    // summary array stays empty until done) — surface each delta as a reasoning update.
+                    yield return new ReasoningUpdateMessage
+                    {
+                        Reasoning = reasoningDelta.Delta,
+                        Visibility = ReasoningVisibility.Plain,
+                        Role = Role.Assistant,
+                        FromAgent = fromAgent,
+                        GenerationId = generationId,
+                        MessageOrderIdx = reasoningDelta.OutputIndex,
+                    };
+
+                    break;
+
+                case ResponseReasoningSummaryTextDoneEvent reasoningDone:
+                    yield return new ReasoningMessage
+                    {
+                        Reasoning = reasoningDone.Text,
+                        Visibility = ReasoningVisibility.Plain,
+                        Role = Role.Assistant,
+                        FromAgent = fromAgent,
+                        GenerationId = generationId,
+                        MessageOrderIdx = reasoningDone.OutputIndex,
+                    };
+
+                    break;
+
                 case ResponseOutputTextDeltaEvent deltaEvent:
                     if (!textBuffers.TryGetValue(deltaEvent.OutputIndex, out var textBuf))
                     {

--- a/src/OpenAiResponsesProvider/Models/ResponseEvent.cs
+++ b/src/OpenAiResponsesProvider/Models/ResponseEvent.cs
@@ -146,3 +146,42 @@ public sealed record ResponseFunctionCallArgumentsDoneEvent : ResponseEvent
     [JsonPropertyName("arguments")]
     public string Arguments { get; init; } = string.Empty;
 }
+
+/// <summary>
+///     <c>response.reasoning_summary_text.delta</c>: incremental token of a reasoning summary.
+///     Reasoning-capable models stream their human-readable summary through these events; the
+///     reasoning output_item's <c>summary</c> array is empty until the stream completes.
+/// </summary>
+public sealed record ResponseReasoningSummaryTextDeltaEvent : ResponseEvent
+{
+    [JsonPropertyName("item_id")]
+    public string ItemId { get; init; } = string.Empty;
+
+    [JsonPropertyName("output_index")]
+    public int OutputIndex { get; init; }
+
+    [JsonPropertyName("summary_index")]
+    public int SummaryIndex { get; init; }
+
+    [JsonPropertyName("delta")]
+    public string Delta { get; init; } = string.Empty;
+}
+
+/// <summary>
+///     <c>response.reasoning_summary_text.done</c>: terminal frame for a reasoning summary part —
+///     carries the full concatenated summary <c>text</c>.
+/// </summary>
+public sealed record ResponseReasoningSummaryTextDoneEvent : ResponseEvent
+{
+    [JsonPropertyName("item_id")]
+    public string ItemId { get; init; } = string.Empty;
+
+    [JsonPropertyName("output_index")]
+    public int OutputIndex { get; init; }
+
+    [JsonPropertyName("summary_index")]
+    public int SummaryIndex { get; init; }
+
+    [JsonPropertyName("text")]
+    public string Text { get; init; } = string.Empty;
+}

--- a/src/OpenAiResponsesProvider/Models/ResponseEventParser.cs
+++ b/src/OpenAiResponsesProvider/Models/ResponseEventParser.cs
@@ -114,6 +114,28 @@ public static class ResponseEventParser
                     Arguments = obj["arguments"]?.GetValue<string>() ?? string.Empty,
                 },
 
+            ResponseEventTypes.ReasoningSummaryTextDelta =>
+                new ResponseReasoningSummaryTextDeltaEvent
+                {
+                    Type = type,
+                    SequenceNumber = seq,
+                    ItemId = obj["item_id"]?.GetValue<string>() ?? string.Empty,
+                    OutputIndex = obj["output_index"]?.GetValue<int>() ?? 0,
+                    SummaryIndex = obj["summary_index"]?.GetValue<int>() ?? 0,
+                    Delta = obj["delta"]?.GetValue<string>() ?? string.Empty,
+                },
+
+            ResponseEventTypes.ReasoningSummaryTextDone =>
+                new ResponseReasoningSummaryTextDoneEvent
+                {
+                    Type = type,
+                    SequenceNumber = seq,
+                    ItemId = obj["item_id"]?.GetValue<string>() ?? string.Empty,
+                    OutputIndex = obj["output_index"]?.GetValue<int>() ?? 0,
+                    SummaryIndex = obj["summary_index"]?.GetValue<int>() ?? 0,
+                    Text = obj["text"]?.GetValue<string>() ?? string.Empty,
+                },
+
             _ => new GenericResponseEvent
             {
                 Type = type,
@@ -174,6 +196,18 @@ public static class ResponseEventParser
                 obj["item_id"] = fcdone.ItemId;
                 obj["output_index"] = fcdone.OutputIndex;
                 obj["arguments"] = fcdone.Arguments;
+                break;
+            case ResponseReasoningSummaryTextDeltaEvent rsd:
+                obj["item_id"] = rsd.ItemId;
+                obj["output_index"] = rsd.OutputIndex;
+                obj["summary_index"] = rsd.SummaryIndex;
+                obj["delta"] = rsd.Delta;
+                break;
+            case ResponseReasoningSummaryTextDoneEvent rsdone:
+                obj["item_id"] = rsdone.ItemId;
+                obj["output_index"] = rsdone.OutputIndex;
+                obj["summary_index"] = rsdone.SummaryIndex;
+                obj["text"] = rsdone.Text;
                 break;
             case GenericResponseEvent generic when generic.ExtraProperties is { } extras:
                 foreach (var kvp in extras)

--- a/src/OpenAiResponsesProvider/Models/ResponseEventTypes.cs
+++ b/src/OpenAiResponsesProvider/Models/ResponseEventTypes.cs
@@ -24,6 +24,13 @@ public static class ResponseEventTypes
     public const string FunctionCallArgumentsDelta = "response.function_call_arguments.delta";
     public const string FunctionCallArgumentsDone = "response.function_call_arguments.done";
 
+    // Reasoning-summary streaming. Reasoning-capable models (e.g. GPT-5.5) deliver their
+    // human-readable reasoning summary via these dedicated events — NOT inside the reasoning
+    // output_item's "summary" array, which is empty while streaming. Without handling these,
+    // requested reasoning summaries are silently dropped (no thinking blocks).
+    public const string ReasoningSummaryTextDelta = "response.reasoning_summary_text.delta";
+    public const string ReasoningSummaryTextDone = "response.reasoning_summary_text.done";
+
     /// <summary>
     ///     Client→server frame requesting a response generation. Currently the only
     ///     client-originated frame the mock host accepts.

--- a/tests/AnthropicProvider.Tests/Models/ServerToolRequestTests.cs
+++ b/tests/AnthropicProvider.Tests/Models/ServerToolRequestTests.cs
@@ -245,6 +245,80 @@ public class ServerToolRequestTests
     }
 
     [Fact]
+    public void FromMessages_WithEmptyIdServerToolResult_DropsItFromRequest()
+    {
+        // Regression (Kimi 400 "tool_call_id  is not found"): the empty-id server_tool_use that an
+        // Anthropic-compatible provider omits the id for is dropped on replay. Its matching
+        // server-tool RESULT lands in history as a singular ToolCallResultMessage with the same
+        // empty id. Without a guard it survives as an orphan tool_result whose tool_use_id is blank,
+        // which is rejected on replay just like the orphan call. The empty-id result must be dropped
+        // while the valid call+result survive.
+        var messages = new IMessage[]
+        {
+            new TextMessage { Role = Role.User, Text = "Search the web." },
+            // The finalized call with a real (synthetic) id.
+            new ToolCallMessage
+            {
+                ToolCallId = "srvtoolu_synth_1_abc",
+                FunctionName = "web_search",
+                FunctionArgs = """{"query":"news"}""",
+                ExecutionTarget = ExecutionTarget.ProviderServer,
+                Role = Role.Assistant,
+            },
+            // Empty-id orphan result (the matching result for the dropped empty-id preview call).
+            new ToolCallResultMessage
+            {
+                ToolCallId = "",
+                ToolName = "web_search",
+                Result = "[]",
+                ExecutionTarget = ExecutionTarget.ProviderServer,
+                Role = Role.Assistant,
+            },
+            // The finalized result with the real id.
+            new ToolCallResultMessage
+            {
+                ToolCallId = "srvtoolu_synth_1_abc",
+                ToolName = "web_search",
+                Result = "[]",
+                ExecutionTarget = ExecutionTarget.ProviderServer,
+                Role = Role.Assistant,
+            },
+            new TextMessage { Role = Role.User, Text = "Thanks." },
+        };
+
+        var options = new GenerateReplyOptions
+        {
+            ModelId = "claude-sonnet-4-20250514",
+            BuiltInTools = [new AnthropicWebSearchTool()],
+        };
+
+        var request = AnthropicRequest.FromMessages(messages, options);
+        var json = JsonSerializer.Serialize(request, _jsonOptions);
+        var doc = JsonDocument.Parse(json);
+
+        var toolResultIds = new List<string?>();
+        foreach (var msg in doc.RootElement.GetProperty("messages").EnumerateArray())
+        {
+            if (!msg.TryGetProperty("content", out var content) || content.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            foreach (var block in content.EnumerateArray())
+            {
+                if (block.TryGetProperty("type", out var t) && t.GetString() == "tool_result")
+                {
+                    toolResultIds.Add(block.TryGetProperty("tool_use_id", out var id) ? id.GetString() : null);
+                }
+            }
+        }
+
+        // Exactly the finalized result survives — no empty/blank tool_use_id ever reaches the wire.
+        Assert.Equal(new[] { "srvtoolu_synth_1_abc" }, toolResultIds);
+        Assert.DoesNotContain(toolResultIds, string.IsNullOrWhiteSpace);
+    }
+
+    [Fact]
     public void FromMessages_FullKimiLikeFlow_ProducesCorrectMergedWireJson()
     {
         // Full IMessage sequence: User text, Assistant text + ToolCallMessage (server),

--- a/tests/AnthropicProvider.Tests/Models/ThinkingReplayTests.cs
+++ b/tests/AnthropicProvider.Tests/Models/ThinkingReplayTests.cs
@@ -1,0 +1,110 @@
+using System.Collections.Immutable;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+
+namespace AchieveAi.LmDotnetTools.AnthropicProvider.Tests.Models;
+
+/// <summary>
+///     Replaying thinking blocks in multi-turn history. Real Anthropic emits thinking with an
+///     encrypted <c>signature</c>; Anthropic-compatible backends (notably Kimi) emit thinking TEXT
+///     but NO signature. A <c>thinking</c> content block without a signature is rejected on replay
+///     with <c>400 invalid_request_error</c>. Such reasoning must be demoted to a <c>text</c> block
+///     (content preserved) rather than sent as an unsigned thinking block.
+/// </summary>
+public class ThinkingReplayTests
+{
+    private static readonly JsonSerializerOptions _jsonOptions =
+        AnthropicJsonSerializerOptionsFactory.CreateUniversal();
+
+    private static GenerateReplyOptions ThinkingOptions() =>
+        new()
+        {
+            ModelId = "kimi-for-coding",
+            ExtraProperties = ImmutableDictionary.Create<string, object?>().Add("Thinking", new AnthropicThinking(2048)),
+        };
+
+    /// <summary>Every <c>thinking</c> block in the rebuilt request must carry a non-empty signature.</summary>
+    private static void AssertNoUnsignedThinkingBlocks(JsonDocument doc)
+    {
+        foreach (var msg in doc.RootElement.GetProperty("messages").EnumerateArray())
+        {
+            if (!msg.TryGetProperty("content", out var content) || content.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            foreach (var block in content.EnumerateArray())
+            {
+                if (!block.TryGetProperty("type", out var t) || t.GetString() != "thinking")
+                {
+                    continue;
+                }
+
+                var hasSignature =
+                    block.TryGetProperty("signature", out var sig) && !string.IsNullOrEmpty(sig.GetString());
+                Assert.True(
+                    hasSignature,
+                    "an unsigned thinking block was sent on replay; Anthropic/Kimi reject thinking-in-history without a signature"
+                );
+            }
+        }
+    }
+
+    [Fact]
+    public void FromMessages_PlainReasoningWithoutSignature_IsNotSentAsUnsignedThinkingBlock()
+    {
+        var messages = new IMessage[]
+        {
+            new TextMessage { Role = Role.User, Text = "What is 2+2?" },
+            // Kimi-style: thinking captured as plain reasoning with NO following encrypted signature.
+            new ReasoningMessage
+            {
+                Role = Role.Assistant,
+                Reasoning = "Let me add 2 and 2.",
+                Visibility = ReasoningVisibility.Plain,
+            },
+            new TextMessage { Role = Role.Assistant, Text = "4" },
+            new TextMessage { Role = Role.User, Text = "And 3+3?" },
+        };
+
+        var request = AnthropicRequest.FromMessages(messages, ThinkingOptions());
+        var json = JsonSerializer.Serialize(request, _jsonOptions);
+        using var doc = JsonDocument.Parse(json);
+
+        AssertNoUnsignedThinkingBlocks(doc);
+        // The reasoning content is preserved (demoted to text), not dropped.
+        Assert.Contains("Let me add 2 and 2.", json);
+    }
+
+    [Fact]
+    public void FromMessages_SignedThinkingBlock_IsPreserved()
+    {
+        // A plain thinking block immediately followed by its encrypted signature must still merge
+        // into one signed thinking block (the real-Anthropic happy path must keep working).
+        var messages = new IMessage[]
+        {
+            new TextMessage { Role = Role.User, Text = "What is 2+2?" },
+            new ReasoningMessage
+            {
+                Role = Role.Assistant,
+                Reasoning = "Let me add 2 and 2.",
+                Visibility = ReasoningVisibility.Plain,
+            },
+            new ReasoningMessage
+            {
+                Role = Role.Assistant,
+                Reasoning = "sig-abc123",
+                Visibility = ReasoningVisibility.Encrypted,
+            },
+            new TextMessage { Role = Role.Assistant, Text = "4" },
+            new TextMessage { Role = Role.User, Text = "And 3+3?" },
+        };
+
+        var request = AnthropicRequest.FromMessages(messages, ThinkingOptions());
+        var json = JsonSerializer.Serialize(request, _jsonOptions);
+        using var doc = JsonDocument.Parse(json);
+
+        AssertNoUnsignedThinkingBlocks(doc);
+        Assert.Contains("sig-abc123", json);
+        Assert.Contains("Let me add 2 and 2.", json);
+    }
+}

--- a/tests/AnthropicProvider.Tests/Models/ThinkingWithToolCallSerializationTests.cs
+++ b/tests/AnthropicProvider.Tests/Models/ThinkingWithToolCallSerializationTests.cs
@@ -222,8 +222,10 @@ public class ThinkingWithToolCallSerializationTests
     }
 
     /// <summary>
-    ///     Tests that two consecutive Plain reasoning messages produce two separate thinking
-    ///     blocks and are NOT incorrectly merged (merge requires text+signature pair).
+    ///     Two consecutive Plain reasoning messages with no signature stay SEPARATE (the merge
+    ///     requires a text+signature pair, which isn't present here). Because neither acquires a
+    ///     signature, both are demoted to <c>text</c> blocks — an unsigned <c>thinking</c> block is
+    ///     rejected on replay (e.g. Kimi: <c>400 invalid_request_error</c>), so it must never be sent.
     /// </summary>
     [Fact]
     public void FromMessages_DoesNotMerge_WhenBothThinkingBlocksHaveText()
@@ -252,19 +254,21 @@ public class ThinkingWithToolCallSerializationTests
         var assistantMsg = request.Messages[1];
         Assert.Equal("assistant", assistantMsg.Role);
 
-        // Should have 3 content blocks: two separate thinking blocks + text
+        // Three content blocks: the two unsigned reasoning blocks stay SEPARATE (not merged) but
+        // are demoted to text (no signature → not a valid thinking block on replay), then the answer.
         Assert.Equal(3, assistantMsg.Content.Count);
 
-        Assert.Equal("thinking", assistantMsg.Content[0].Type);
-        Assert.Equal("First thought", assistantMsg.Content[0].Thinking);
-        Assert.Null(assistantMsg.Content[0].ThinkingSignature);
+        Assert.Equal("text", assistantMsg.Content[0].Type);
+        Assert.Equal("First thought", assistantMsg.Content[0].Text);
 
-        Assert.Equal("thinking", assistantMsg.Content[1].Type);
-        Assert.Equal("Second thought", assistantMsg.Content[1].Thinking);
-        Assert.Null(assistantMsg.Content[1].ThinkingSignature);
+        Assert.Equal("text", assistantMsg.Content[1].Type);
+        Assert.Equal("Second thought", assistantMsg.Content[1].Text);
 
         Assert.Equal("text", assistantMsg.Content[2].Type);
         Assert.Equal("Answer.", assistantMsg.Content[2].Text);
+
+        // Crucially: no unsigned thinking block survives (that's what the backend rejects).
+        Assert.DoesNotContain(assistantMsg.Content, c => c.Type == "thinking" && string.IsNullOrEmpty(c.ThinkingSignature));
     }
 
     /// <summary>

--- a/tests/CopilotLive.Tests/CopilotAnthropicLiveTests.cs
+++ b/tests/CopilotLive.Tests/CopilotAnthropicLiveTests.cs
@@ -147,6 +147,54 @@ public sealed class CopilotAnthropicLiveTests
         exception!.Message.Should().MatchRegex("(?i)web search.*not supported|not supported.*web search|unsupported");
     }
 
+    /// <summary>
+    ///     Canary: does the GitHub Copilot proxy ACCEPT the Anthropic extended-thinking parameter?
+    ///     Copilot rejects some Anthropic features (see the web_search canary), so before enabling
+    ///     extended thinking for the Copilot-backed sonnet/haiku providers in LmStreaming.Sample we
+    ///     must confirm the backend honors it rather than 400-ing every request. This test sends a
+    ///     normal turn WITH a <c>Thinking</c> budget and asserts the request succeeds and returns
+    ///     assistant text. If Copilot ever starts REJECTING thinking, this test fails — the signal to
+    ///     gate thinking off for sonnet/haiku (the same way web_search is gated off).
+    /// </summary>
+    [SkippableFact]
+    public async Task Thinking_param_is_accepted_by_copilot_backend()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+        var cancellationToken = cts.Token;
+
+        var model = await _fixture.ResolveAnthropicModelAsync(cancellationToken);
+        _output.WriteLine($"Anthropic model: {model}");
+
+        var agent = CopilotAnthropicAgentFactory.Create(
+            "copilot-anthropic-thinking",
+            _fixture.TokenProvider,
+            _fixture.Session,
+            _fixture.Options
+        );
+
+        // Extended thinking requires temperature == 1 and max_tokens > thinking budget.
+        var reply = await agent.GenerateReplyAsync(
+            [new TextMessage { Role = Role.User, Text = "Think step by step, then answer: what is 17 * 23?" }],
+            new GenerateReplyOptions
+            {
+                ModelId = model,
+                MaxToken = 4096,
+                Temperature = 1,
+                ExtraProperties = System.Collections.Immutable.ImmutableDictionary<string, object?>.Empty.Add(
+                    "Thinking",
+                    new AnthropicThinking(1024)
+                ),
+            },
+            cancellationToken
+        );
+
+        var text = ExtractText(reply);
+        var thinking = reply.OfType<TextMessage>().Any(m => m.IsThinking);
+        _output.WriteLine($"Accepted. thinkingPresent={thinking} reply={text}");
+        text.Should().NotBeNullOrWhiteSpace("Copilot should accept the Anthropic thinking parameter and still answer");
+    }
+
     private static string ExtractText(IEnumerable<IMessage> messages)
     {
         var builder = new StringBuilder();

--- a/tests/CopilotLive.Tests/CopilotResponsesLiveTests.cs
+++ b/tests/CopilotLive.Tests/CopilotResponsesLiveTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Agents;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
 using FluentAssertions;
 using Xunit.Abstractions;
 
@@ -120,6 +121,71 @@ public sealed class CopilotResponsesLiveTests
         var text = ExtractText(reply);
         _output.WriteLine($"Reply: {text}");
         text.Should().NotBeNullOrWhiteSpace();
+    }
+
+    /// <summary>
+    ///     Canary: does the Copilot Responses backend RETURN reasoning summaries when asked? Requests
+    ///     reasoning via <c>ExtraProperties["Reasoning"]</c> and checks for reasoning frames. If this
+    ///     passes, the GPT-5.5 thinking pill works end-to-end (request → backend → parser → UI). If it
+    ///     fails with zero reasoning, the Copilot proxy strips reasoning summaries server-side (not
+    ///     fixable client-side) — the signal to document it rather than chase the parser.
+    /// </summary>
+    [SkippableFact]
+    public async Task Reasoning_summary_is_returned_by_copilot_responses_backend()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+        var cancellationToken = cts.Token;
+
+        // Reasoning summaries only come from a reasoning-capable model; pin gpt-5.5 (the fixture's
+        // default resolves to a nano model that does not reason).
+        const string model = "gpt-5.5";
+        _output.WriteLine($"OpenAI model: {model}");
+
+        using var agent = CopilotResponsesAgentFactory.Create(
+            "copilot-responses-reasoning",
+            _fixture.TokenProvider,
+            CopilotResponsesTransport.Sse,
+            _fixture.Session,
+            _fixture.Options
+        );
+
+        var stream = await agent.GenerateReplyStreamingAsync(
+            [new TextMessage { Role = Role.User, Text = "Think step by step, then answer: what is 17 * 23?" }],
+            new GenerateReplyOptions
+            {
+                ModelId = model,
+                MaxToken = 2048,
+                ExtraProperties = System.Collections.Immutable.ImmutableDictionary<string, object?>.Empty.Add(
+                    "Reasoning",
+                    new ResponseReasoningOptions { Summary = "auto" }
+                ),
+            },
+            cancellationToken
+        );
+
+        var reasoningUpdates = 0;
+        var finalReasoning = 0;
+        var reasoningText = new StringBuilder();
+        await foreach (var message in stream.WithCancellation(cancellationToken))
+        {
+            if (message is ReasoningUpdateMessage ru)
+            {
+                reasoningUpdates++;
+                _ = reasoningText.Append(ru.Reasoning);
+            }
+            else if (message is ReasoningMessage)
+            {
+                finalReasoning++;
+            }
+        }
+
+        _output.WriteLine(
+            $"reasoningUpdates={reasoningUpdates} finalReasoning={finalReasoning} reasoning=\"{reasoningText}\""
+        );
+        (reasoningUpdates + finalReasoning)
+            .Should()
+            .BeGreaterThan(0, "Copilot Responses should return a reasoning summary when reasoning is requested");
     }
 
     private static string ExtractText(IEnumerable<IMessage> messages)

--- a/tests/LmCore.Tests/Core/GenerateReplyOptionsMergeIdentityTests.cs
+++ b/tests/LmCore.Tests/Core/GenerateReplyOptionsMergeIdentityTests.cs
@@ -1,0 +1,80 @@
+using AchieveAi.LmDotnetTools.LmCore.Core;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.Core;
+
+/// <summary>
+///     The run-identity fields (<see cref="GenerateReplyOptions.RunId"/>,
+///     <see cref="GenerateReplyOptions.ParentRunId"/>, <see cref="GenerateReplyOptions.ThreadId"/>,
+///     <see cref="GenerateReplyOptions.GenerationId"/>) are now part of the Merge contract — the
+///     other's value overrides when set, otherwise the original is preserved. These ids drive the
+///     client merge key, so a regression here silently breaks message grouping.
+/// </summary>
+public class GenerateReplyOptionsMergeIdentityTests
+{
+    [Fact]
+    public void Merge_OverridesIdentityFields_WhenOtherSetsThem()
+    {
+        var original = new GenerateReplyOptions
+        {
+            RunId = "run-original",
+            ParentRunId = "parent-original",
+            ThreadId = "thread-original",
+            GenerationId = "gen-original",
+        };
+        var other = new GenerateReplyOptions
+        {
+            RunId = "run-new",
+            ParentRunId = "parent-new",
+            ThreadId = "thread-new",
+            GenerationId = "gen-new",
+        };
+
+        var merged = original.Merge(other);
+
+        Assert.Equal("run-new", merged.RunId);
+        Assert.Equal("parent-new", merged.ParentRunId);
+        Assert.Equal("thread-new", merged.ThreadId);
+        Assert.Equal("gen-new", merged.GenerationId);
+    }
+
+    [Fact]
+    public void Merge_PreservesIdentityFields_WhenOtherLeavesThemNull()
+    {
+        var original = new GenerateReplyOptions
+        {
+            RunId = "run-original",
+            ParentRunId = "parent-original",
+            ThreadId = "thread-original",
+            GenerationId = "gen-original",
+        };
+        // other carries no identity fields (all null) — original must survive the merge.
+        var other = new GenerateReplyOptions { ModelId = "some-model" };
+
+        var merged = original.Merge(other);
+
+        Assert.Equal("run-original", merged.RunId);
+        Assert.Equal("parent-original", merged.ParentRunId);
+        Assert.Equal("thread-original", merged.ThreadId);
+        Assert.Equal("gen-original", merged.GenerationId);
+    }
+
+    [Fact]
+    public void Merge_AppliesIdentityFields_WhenOriginalHadNone()
+    {
+        var original = new GenerateReplyOptions { ModelId = "some-model" };
+        var other = new GenerateReplyOptions
+        {
+            RunId = "run-new",
+            ParentRunId = "parent-new",
+            ThreadId = "thread-new",
+            GenerationId = "gen-new",
+        };
+
+        var merged = original.Merge(other);
+
+        Assert.Equal("run-new", merged.RunId);
+        Assert.Equal("parent-new", merged.ParentRunId);
+        Assert.Equal("thread-new", merged.ThreadId);
+        Assert.Equal("gen-new", merged.GenerationId);
+    }
+}

--- a/tests/LmCore.Tests/Messages/MessageExtensionsWithIdsTests.cs
+++ b/tests/LmCore.Tests/Messages/MessageExtensionsWithIdsTests.cs
@@ -1,9 +1,85 @@
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Models;
 
 namespace AchieveAi.LmDotnetTools.LmCore.Tests.Messages;
 
 public class MessageExtensionsWithIdsTests
 {
+    // The run's GenerationId must be stamped across EVERY WithIds arm — especially the
+    // update/result/usage arms (TextUpdateMessage, ToolCallUpdateMessage, ToolsCallUpdateMessage,
+    // ToolCallResultMessage, ToolsCallResultMessage, ReasoningUpdateMessage, UsageMessage). A
+    // future arm that forgets GenerationId silently breaks client merge-key grouping, so cover
+    // every variant here parameterized rather than sampling a few.
+    public static TheoryData<string, IMessage> MessageVariants()
+    {
+        const string opaque = "provider-opaque-id";
+        return new TheoryData<string, IMessage>
+        {
+            { nameof(TextMessage), new TextMessage { Text = "t", Role = Role.Assistant, GenerationId = opaque } },
+            { nameof(TextUpdateMessage), new TextUpdateMessage { Text = "t", Role = Role.Assistant, GenerationId = opaque } },
+            {
+                nameof(TextWithCitationsMessage),
+                new TextWithCitationsMessage { Text = "t", Role = Role.Assistant, GenerationId = opaque }
+            },
+            {
+                nameof(ToolCallMessage),
+                new ToolCallMessage { ToolCallId = "c1", FunctionName = "f", FunctionArgs = "{}", Role = Role.Assistant, GenerationId = opaque }
+            },
+            {
+                nameof(ToolCallUpdateMessage),
+                new ToolCallUpdateMessage { ToolCallId = "c1", FunctionName = "f", FunctionArgs = "{}", Role = Role.Assistant, IsUpdate = true, GenerationId = opaque }
+            },
+            {
+                nameof(ToolCallResultMessage),
+                new ToolCallResultMessage { ToolCallId = "c1", ToolName = "f", Result = "{}", Role = Role.User, GenerationId = opaque }
+            },
+            {
+                nameof(ToolsCallMessage),
+                new ToolsCallMessage { Role = Role.Assistant, GenerationId = opaque }
+            },
+            {
+                nameof(ToolsCallUpdateMessage),
+                new ToolsCallUpdateMessage { Role = Role.Assistant, GenerationId = opaque }
+            },
+            {
+                nameof(ToolsCallResultMessage),
+                new ToolsCallResultMessage { Role = Role.User, ToolCallResults = [new ToolCallResult("c1", "{}")], GenerationId = opaque }
+            },
+            {
+                nameof(ReasoningMessage),
+                new ReasoningMessage { Reasoning = "r", Role = Role.Assistant, GenerationId = opaque }
+            },
+            {
+                nameof(ReasoningUpdateMessage),
+                new ReasoningUpdateMessage { Reasoning = "r", Role = Role.Assistant, GenerationId = opaque }
+            },
+            {
+                nameof(UsageMessage),
+                new UsageMessage { Usage = new Usage { PromptTokens = 1, CompletionTokens = 1, TotalTokens = 2 }, Role = Role.Assistant, GenerationId = opaque }
+            },
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(MessageVariants))]
+    public void WithIds_StampsRunGenerationId_AcrossAllArms(string variantName, IMessage message)
+    {
+        const string runGenerationId = "0123456789abcdef0123456789abcdef";
+        const string runId = "run-1";
+        var options = new GenerateReplyOptions { RunId = runId, GenerationId = runGenerationId };
+
+        var updated = message.WithIds(options);
+
+        Assert.Equal(runGenerationId, updated.GenerationId);
+        Assert.Equal(runId, updated.RunId);
+        // The arm preserved its concrete type (no fall-through to the default '_ => message' case)
+        // — a missing switch arm would return the original instance unchanged.
+        Assert.True(
+            message.GetType() == updated.GetType(),
+            $"{variantName} must be handled by a dedicated WithIds arm preserving its type"
+        );
+    }
+
     // BUG H1: every message emitted within a run must carry the run's GenerationId (the value
     // advertised by run_assignment), NOT the opaque per-message response/reasoning id a provider
     // stamps. WithIds(options) is the provider-agnostic seam every provider already calls to apply

--- a/tests/LmCore.Tests/Messages/MessageExtensionsWithIdsTests.cs
+++ b/tests/LmCore.Tests/Messages/MessageExtensionsWithIdsTests.cs
@@ -1,7 +1,81 @@
+using AchieveAi.LmDotnetTools.LmCore.Core;
+
 namespace AchieveAi.LmDotnetTools.LmCore.Tests.Messages;
 
 public class MessageExtensionsWithIdsTests
 {
+    // BUG H1: every message emitted within a run must carry the run's GenerationId (the value
+    // advertised by run_assignment), NOT the opaque per-message response/reasoning id a provider
+    // stamps. WithIds(options) is the provider-agnostic seam every provider already calls to apply
+    // run identity, so it must also override GenerationId from options.GenerationId. Tested with
+    // real (non-mock) message objects.
+    [Fact]
+    public void WithIds_StampsRunGenerationId_OverridingProviderGenerationId()
+    {
+        const string runId = "fedcba9876543210fedcba9876543210";
+        const string runGenerationId = "0123456789abcdef0123456789abcdef";
+        var options = new GenerateReplyOptions { RunId = runId, GenerationId = runGenerationId };
+
+        // Provider stamped distinct opaque ids on each message (encrypted response/reasoning tokens).
+        var toolCall = new ToolCallMessage
+        {
+            ToolCallId = "call-1",
+            FunctionName = "get_weather",
+            FunctionArgs = "{}",
+            Role = Role.Assistant,
+            GenerationId = "resp_opaque_AAAA",
+        };
+        var toolCallResult = new ToolCallResultMessage
+        {
+            ToolCallId = "call-1",
+            ToolName = "get_weather",
+            Result = "{}",
+            Role = Role.User,
+            GenerationId = "resp_opaque_BBBB",
+        };
+        var text = new TextMessage
+        {
+            Text = "hi",
+            Role = Role.Assistant,
+            GenerationId = "resp_opaque_CCCC",
+        };
+
+        var updatedToolCall = Assert.IsType<ToolCallMessage>(toolCall.WithIds(options));
+        var updatedToolCallResult = Assert.IsType<ToolCallResultMessage>(toolCallResult.WithIds(options));
+        var updatedText = Assert.IsType<TextMessage>(text.WithIds(options));
+
+        // The run's GenerationId overrides every provider opaque id.
+        Assert.Equal(runGenerationId, updatedToolCall.GenerationId);
+        Assert.Equal(runGenerationId, updatedToolCallResult.GenerationId);
+        Assert.Equal(runGenerationId, updatedText.GenerationId);
+
+        // RunId still applied as before.
+        Assert.Equal(runId, updatedToolCall.RunId);
+        Assert.Equal(runId, updatedToolCallResult.RunId);
+        Assert.Equal(runId, updatedText.RunId);
+    }
+
+    // When the run advertises no GenerationId, the provider's GenerationId is preserved (no-op),
+    // so non-run callers and providers that don't thread a run generation are unaffected.
+    [Fact]
+    public void WithIds_PreservesProviderGenerationId_WhenOptionsHaveNone()
+    {
+        var options = new GenerateReplyOptions { RunId = "run-1" };
+        var toolCall = new ToolCallMessage
+        {
+            ToolCallId = "call-1",
+            FunctionName = "f",
+            FunctionArgs = "{}",
+            Role = Role.Assistant,
+            GenerationId = "provider-gen",
+        };
+
+        var updated = Assert.IsType<ToolCallMessage>(toolCall.WithIds(options));
+
+        Assert.Equal("provider-gen", updated.GenerationId);
+        Assert.Equal("run-1", updated.RunId);
+    }
+
     [Fact]
     public void WithIds_AppliesIds_ToUnifiedToolMessages()
     {

--- a/tests/LmMultiTurn.Tests/MultiTurnAgentLoopTests.cs
+++ b/tests/LmMultiTurn.Tests/MultiTurnAgentLoopTests.cs
@@ -182,6 +182,86 @@ public class MultiTurnAgentLoopTests
         await cts.CancelAsync();
     }
 
+    // BUG H3b: tool_call_result messages must carry a non-null MessageOrderIdx consistent with
+    // their ordering, so the client merge/order logic (keyed partly on messageOrderIdx) does not
+    // drop them. The loop publishes locally-executed tool results out-of-band (not through the
+    // MessageTransformation middleware that stamps ordering), so without an explicit stamp they
+    // reach subscribers with MessageOrderIdx == null.
+    [Fact]
+    public async Task ExecuteRunAsync_LocalToolResult_CarriesMessageOrderIdx()
+    {
+        // Arrange
+        // GenerationId present so the pipeline assigns ordering, as it does for a real run.
+        var toolCallMessage = new ToolCallMessage
+        {
+            FunctionName = "get_weather",
+            FunctionArgs = "{\"location\": \"Seattle\"}",
+            ToolCallId = "call_123",
+            Role = Role.Assistant,
+            GenerationId = "gen1",
+        };
+        var finalMessage = new TextMessage { Text = "Done!", Role = Role.Assistant, GenerationId = "gen1" };
+
+        var callCount = 0;
+        _mockAgent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>((_, _, _) =>
+            {
+                callCount++;
+                return Task.FromResult(
+                    callCount == 1
+                        ? ToAsyncEnumerable([toolCallMessage])
+                        : ToAsyncEnumerable([finalMessage]));
+            });
+
+        var registry = new FunctionRegistry();
+        var weatherContract = new FunctionContract
+        {
+            Name = "get_weather",
+            Description = "Get weather for a location",
+            Parameters =
+            [
+                new FunctionParameterContract
+                {
+                    Name = "location",
+                    Description = "The location to get weather for",
+                    ParameterType = new JsonSchemaObject { Type = JsonSchemaTypeHelper.ToType("string") },
+                    IsRequired = true,
+                },
+            ],
+        };
+        registry.AddFunction(weatherContract, (_, _, _) =>
+            Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText("{\"temperature\": \"72F\"}")));
+
+        await using var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            registry,
+            "test-thread",
+            logger: _loggerMock.Object);
+
+        using var cts = new CancellationTokenSource();
+        var runTask = loop.RunAsync(cts.Token);
+
+        var userInput = new UserInput(
+            [new TextMessage { Text = "What's the weather in Seattle?", Role = Role.User }]);
+
+        var messages = new List<IMessage>();
+        await foreach (var msg in loop.ExecuteRunAsync(userInput, cts.Token))
+        {
+            messages.Add(msg);
+        }
+
+        // Assert — the published tool result carries a non-null MessageOrderIdx.
+        var results = messages.OfType<ToolCallResultMessage>().ToList();
+        results.Should().NotBeEmpty();
+        results.Should().OnlyContain(r => r.MessageOrderIdx != null);
+
+        await cts.CancelAsync();
+    }
+
     [Fact]
     public async Task ExecuteRunAsync_WithProviderServerToolCall_DoesNotExecuteLocalToolHandler()
     {

--- a/tests/LmStreaming.Sample.Tests/ProgramReasoningExtraPropertiesTests.cs
+++ b/tests/LmStreaming.Sample.Tests/ProgramReasoningExtraPropertiesTests.cs
@@ -1,0 +1,64 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using AchieveAi.LmDotnetTools.AnthropicProvider.Models;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+
+namespace LmStreaming.Sample.Tests;
+
+/// <summary>
+///     Regression coverage for the provider → reasoning/thinking extra-properties wiring in Program.
+///     This is what makes thinking blocks appear for Copilot-backed models: the Anthropic-format
+///     providers (incl. sonnet/haiku via Copilot) must get a "Thinking" budget, and the OpenAI
+///     Responses providers (gpt-5.5/gpt-5.5-mini) must get a "Reasoning" summary request. Without
+///     this test, deleting either provider-id branch would silently turn thinking back off.
+/// </summary>
+public sealed class ProgramReasoningExtraPropertiesTests
+{
+    private static ImmutableDictionary<string, object?> Build(string normalizedProviderId)
+    {
+        var programType = typeof(LmStreaming.Sample.Controllers.DiagnosticsController)
+            .Assembly.GetType("Program");
+        programType.Should().NotBeNull();
+        var method = programType!.GetMethod(
+            "BuildReasoningExtraProperties",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        method.Should().NotBeNull("Program must expose the provider→reasoning extra-properties helper");
+        return (ImmutableDictionary<string, object?>)method!.Invoke(null, [normalizedProviderId])!;
+    }
+
+    [Theory]
+    [InlineData("anthropic")]
+    [InlineData("test-anthropic")]
+    [InlineData("sonnet")]
+    [InlineData("haiku")]
+    public void Anthropic_format_providers_get_thinking_budget(string providerId)
+    {
+        var props = Build(providerId);
+
+        props.Should().ContainKey("Thinking");
+        props["Thinking"].Should().BeOfType<AnthropicThinking>();
+    }
+
+    [Theory]
+    [InlineData("gpt-5.5")]
+    [InlineData("gpt-5.5-mini")]
+    public void OpenAi_responses_providers_get_reasoning_summary(string providerId)
+    {
+        var props = Build(providerId);
+
+        props.Should().ContainKey("Reasoning");
+        props["Reasoning"].Should().BeOfType<ResponseReasoningOptions>().Which.Summary.Should().Be("auto");
+    }
+
+    [Theory]
+    [InlineData("openai")]
+    [InlineData("codex")]
+    [InlineData("test")]
+    public void Other_providers_get_no_reasoning_extra_properties(string providerId)
+    {
+        var props = Build(providerId);
+
+        props.Should().BeEmpty();
+    }
+}

--- a/tests/OpenAiResponsesProvider.Tests/MessageMapperReasoningTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/MessageMapperReasoningTests.cs
@@ -1,0 +1,46 @@
+using System.Collections.Immutable;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Tests;
+
+/// <summary>
+///     Reasoning request plumbing. Reasoning-capable models (e.g. GPT-5.5 via Copilot) only return
+///     reasoning summaries when the request asks for them. The request never set
+///     <see cref="ResponseCreateRequest.Reasoning"/>, so no thinking blocks ever came back. Mirroring
+///     the Anthropic "Thinking" convention, a <see cref="ResponseReasoningOptions"/> placed in
+///     <see cref="GenerateReplyOptions.ExtraProperties"/> under key "Reasoning" must map onto the request.
+/// </summary>
+public sealed class MessageMapperReasoningTests
+{
+    private static readonly IMessage[] s_userTurn = [new TextMessage { Role = Role.User, Text = "hi" }];
+
+    [Fact]
+    public void Reasoning_option_from_extra_properties_maps_onto_request()
+    {
+        var options = new GenerateReplyOptions
+        {
+            ExtraProperties = ImmutableDictionary<string, object?>.Empty.Add(
+                "Reasoning",
+                new ResponseReasoningOptions { Effort = "high", Summary = "auto" }
+            ),
+        };
+
+        var request = MessageMapper.BuildRequest(s_userTurn, options);
+
+        request.Reasoning.Should().NotBeNull();
+        request.Reasoning!.Effort.Should().Be("high");
+        request.Reasoning.Summary.Should().Be("auto");
+    }
+
+    [Fact]
+    public void No_reasoning_option_leaves_request_reasoning_null()
+    {
+        var request = MessageMapper.BuildRequest(s_userTurn, options: null);
+
+        request.Reasoning.Should().BeNull();
+    }
+}

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentGenerationIdTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentGenerationIdTests.cs
@@ -1,0 +1,123 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Tests;
+
+/// <summary>
+///     BUG H1 (Responses path). GPT-5.5 (Copilot) routes through the Responses provider, which stamped
+///     the opaque provider response id (e.g. <c>resp_…</c>) as the message GenerationId instead of the
+///     run's GenerationId. The client merges messages by (kind, runId, generationId, messageOrderIdx);
+///     an opaque per-response id that never matches the run breaks tool-call grouping (the "pillbox"
+///     bug). Every message emitted while processing a run must carry the run's GenerationId from
+///     <see cref="GenerateReplyOptions.GenerationId"/>. The <c>WithIds</c> fix does not cover this path
+///     because the Responses agent constructs messages itself and never calls <c>WithIds</c>.
+/// </summary>
+public sealed class OpenAiResponsesAgentGenerationIdTests
+{
+    private sealed class ScriptedClient(IReadOnlyList<ResponseEvent> events) : IOpenAiResponsesClient
+    {
+        public async IAsyncEnumerable<ResponseEvent> StreamResponseAsync(
+            ResponseCreateRequest request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            foreach (var ev in events)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return ev;
+                await Task.Yield();
+            }
+        }
+
+        public void Dispose() { }
+    }
+
+    private static JsonElement El(string json) => JsonSerializer.Deserialize<JsonElement>(json);
+
+    private static ResponseEvent[] FunctionCallStreamWithResponseId(string opaqueResponseId) =>
+        [
+            new ResponseLifecycleEvent
+            {
+                Type = ResponseEventTypes.ResponseCreated,
+                Response = El($"{{\"id\":\"{opaqueResponseId}\"}}"),
+            },
+            new ResponseOutputItemEvent
+            {
+                Type = ResponseEventTypes.OutputItemAdded,
+                OutputIndex = 0,
+                Item = El("{\"type\":\"function_call\",\"id\":\"item-1\",\"call_id\":\"call_1\",\"name\":\"add\"}"),
+            },
+            new ResponseFunctionCallArgumentsDoneEvent
+            {
+                Type = ResponseEventTypes.FunctionCallArgumentsDone,
+                ItemId = "item-1",
+                Arguments = "{\"a\":1}",
+            },
+            new ResponseOutputItemEvent
+            {
+                Type = ResponseEventTypes.OutputItemDone,
+                OutputIndex = 0,
+                Item = El(
+                    "{\"type\":\"function_call\",\"id\":\"item-1\",\"call_id\":\"call_1\",\"name\":\"add\",\"arguments\":\"{\\\"a\\\":1}\"}"
+                ),
+            },
+            new ResponseLifecycleEvent
+            {
+                Type = ResponseEventTypes.ResponseCompleted,
+                Response = El($"{{\"id\":\"{opaqueResponseId}\"}}"),
+            },
+        ];
+
+    [Fact]
+    public async Task Emitted_tool_call_carries_run_generation_id_not_opaque_response_id()
+    {
+        const string runGenerationId = "run-gen-ABC";
+        const string opaqueResponseId = "resp_OPAQUE_xyz";
+
+        using var agent = new OpenAiResponsesAgent("test", new ScriptedClient(FunctionCallStreamWithResponseId(opaqueResponseId)));
+        var stream = await agent.GenerateReplyStreamingAsync(
+            [new TextMessage { Role = Role.User, Text = "go" }],
+            new GenerateReplyOptions { GenerationId = runGenerationId }
+        );
+
+        var messages = new List<IMessage>();
+        await foreach (var message in stream)
+        {
+            messages.Add(message);
+        }
+
+        var toolCalls = messages.OfType<ToolsCallMessage>().ToList();
+        toolCalls.Should().NotBeEmpty("the scripted stream emits a function call");
+        toolCalls
+            .Should()
+            .OnlyContain(
+                tc => tc.GenerationId == runGenerationId,
+                "Responses-path tool calls must carry the run's GenerationId, not the opaque provider response id"
+            );
+    }
+
+    [Fact]
+    public async Task Falls_back_to_synthetic_generation_id_when_options_have_none()
+    {
+        // When the run advertises no GenerationId, the provider's own id remains (no behavior change).
+        using var agent = new OpenAiResponsesAgent("test", new ScriptedClient(FunctionCallStreamWithResponseId("resp_X")));
+        var stream = await agent.GenerateReplyStreamingAsync([new TextMessage { Role = Role.User, Text = "go" }]);
+
+        var toolCalls = new List<ToolsCallMessage>();
+        await foreach (var message in stream)
+        {
+            if (message is ToolsCallMessage tc)
+            {
+                toolCalls.Add(tc);
+            }
+        }
+
+        toolCalls.Should().NotBeEmpty();
+        toolCalls.Should().OnlyContain(tc => !string.IsNullOrEmpty(tc.GenerationId));
+    }
+}

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentTests.cs
@@ -106,15 +106,19 @@ public sealed class OpenAiResponsesAgentTests
 
         var reasoning = collected.OfType<ReasoningMessage>().Single();
         reasoning.Role.Should().Be(Role.Assistant);
-        reasoning.Visibility.Should().Be(ReasoningVisibility.Plain);
+        // The reasoning here comes from the provider's reasoning_summary_text stream — a SUMMARY,
+        // not full chain-of-thought — so it must carry Summary visibility (otherwise an Anthropic
+        // replay serializes it as an unsigned thinking block and is rejected with 400).
+        reasoning.Visibility.Should().Be(ReasoningVisibility.Summary);
         reasoning.Reasoning.Should().NotBeNullOrWhiteSpace();
         reasoning.MessageOrderIdx.Should().Be(0);
 
         // Whole-flow coverage: the summary streamed as reasoning_summary_text.delta events (surfaced
         // as ReasoningUpdateMessage) through the mock SSE handler before the terminal reasoning
-        // message; the deltas must concatenate to the final reasoning text.
+        // message; the deltas must concatenate to the final reasoning text and share its visibility.
         var reasoningUpdates = collected.OfType<ReasoningUpdateMessage>().ToList();
         reasoningUpdates.Should().NotBeEmpty("the reasoning summary must stream incrementally through the SSE pipe");
+        reasoningUpdates.Should().OnlyContain(u => u.Visibility == ReasoningVisibility.Summary);
         string.Concat(reasoningUpdates.Select(u => u.Reasoning)).Should().Be(reasoning.Reasoning);
 
         var finalText = collected.OfType<TextMessage>().Single();

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentTests.cs
@@ -110,6 +110,13 @@ public sealed class OpenAiResponsesAgentTests
         reasoning.Reasoning.Should().NotBeNullOrWhiteSpace();
         reasoning.MessageOrderIdx.Should().Be(0);
 
+        // Whole-flow coverage: the summary streamed as reasoning_summary_text.delta events (surfaced
+        // as ReasoningUpdateMessage) through the mock SSE handler before the terminal reasoning
+        // message; the deltas must concatenate to the final reasoning text.
+        var reasoningUpdates = collected.OfType<ReasoningUpdateMessage>().ToList();
+        reasoningUpdates.Should().NotBeEmpty("the reasoning summary must stream incrementally through the SSE pipe");
+        string.Concat(reasoningUpdates.Select(u => u.Reasoning)).Should().Be(reasoning.Reasoning);
+
         var finalText = collected.OfType<TextMessage>().Single();
         finalText.Text.Should().Be("final answer");
         finalText.MessageOrderIdx.Should().Be(1);

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesEventStreamWriterTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesEventStreamWriterTests.cs
@@ -73,18 +73,23 @@ public sealed class OpenAiResponsesEventStreamWriterTests
         itemEvents.Should().HaveCount(2);
         itemEvents[0].OutputIndex.Should().Be(0);
         itemEvents[0].Item.GetProperty("type").GetString().Should().Be("reasoning");
-        itemEvents[0]
-            .Item.GetProperty("summary")
-            .EnumerateArray()
-            .Should()
-            .ContainSingle()
-            .Which.GetProperty("text")
-            .GetString()
-            .Should()
-            .NotBeNullOrWhiteSpace();
+        // Faithful to real providers: the reasoning item opens with an EMPTY summary array — the
+        // human-readable text arrives via response.reasoning_summary_text.delta/.done events, not
+        // the item's summary. (This is the grammar the provider parser must handle.)
+        itemEvents[0].Item.GetProperty("summary").EnumerateArray().Should().BeEmpty();
 
         itemEvents[1].OutputIndex.Should().Be(1);
         itemEvents[1].Item.GetProperty("type").GetString().Should().Be("message");
+
+        // The summary streams as delta events whose concatenation equals the terminal done text.
+        events.OfType<ResponseReasoningSummaryTextDeltaEvent>().Should().NotBeEmpty();
+        var summaryDone = events.OfType<ResponseReasoningSummaryTextDoneEvent>().Should().ContainSingle().Subject;
+        summaryDone.Text.Should().NotBeNullOrWhiteSpace();
+        summaryDone.OutputIndex.Should().Be(0);
+        string
+            .Concat(events.OfType<ResponseReasoningSummaryTextDeltaEvent>().Select(e => e.Delta))
+            .Should()
+            .Be(summaryDone.Text);
     }
 
     [Fact]

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesReasoningSummaryTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesReasoningSummaryTests.cs
@@ -94,11 +94,61 @@ public sealed class OpenAiResponsesReasoningSummaryTests
         }
 
         // Streaming deltas surface as reasoning updates...
-        messages.OfType<ReasoningUpdateMessage>().Should().NotBeEmpty("reasoning summary deltas must stream as updates");
+        var updates = messages.OfType<ReasoningUpdateMessage>().ToList();
+        updates.Should().NotBeEmpty("reasoning summary deltas must stream as updates");
         // ...and the completed summary as a final reasoning message carrying the full text.
         var finalReasoning = messages.OfType<ReasoningMessage>().ToList();
         finalReasoning.Should().ContainSingle("the summary stream completes with one reasoning message");
         finalReasoning[0].Reasoning.Should().Be("Let me think.");
         finalReasoning[0].GenerationId.Should().Be("run-1");
+
+        // These are provider SUMMARIES, not full chain-of-thought. Persisting them as Plain makes an
+        // Anthropic-format replay serialize them as UNSIGNED thinking blocks (rejected with 400). They
+        // must carry ReasoningVisibility.Summary so AnthropicRequest emits them as text instead.
+        updates.Should().OnlyContain(
+            u => u.Visibility == ReasoningVisibility.Summary,
+            "reasoning summary deltas are provider summaries, not unsigned thinking"
+        );
+        finalReasoning[0].Visibility.Should().Be(ReasoningVisibility.Summary);
+    }
+
+    // The reasoning output_item's summary[].text array is the same provider-summary content as the
+    // streaming summary events; TryExtractReasoning must classify it as Summary (encrypted_content
+    // stays Encrypted) so it never replays as an unsigned Anthropic thinking block.
+    [Fact]
+    public async Task Agent_emits_summary_visibility_from_reasoning_item_summary_array()
+    {
+        var reasoningItem = System.Text.Json.JsonDocument.Parse(
+            "{\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"step one\"}]}"
+        ).RootElement;
+
+        ResponseEvent[] events =
+        [
+            new ResponseLifecycleEvent { Type = ResponseEventTypes.ResponseCreated },
+            new ResponseOutputItemEvent
+            {
+                Type = ResponseEventTypes.OutputItemDone,
+                OutputIndex = 0,
+                Item = reasoningItem,
+            },
+            new ResponseLifecycleEvent { Type = ResponseEventTypes.ResponseCompleted },
+        ];
+
+        using var agent = new OpenAiResponsesAgent("test", new ScriptedClient(events));
+        var stream = await agent.GenerateReplyStreamingAsync(
+            [new TextMessage { Role = Role.User, Text = "go" }],
+            new GenerateReplyOptions { GenerationId = "run-1" }
+        );
+
+        var messages = new List<IMessage>();
+        await foreach (var message in stream)
+        {
+            messages.Add(message);
+        }
+
+        var reasoning = messages.OfType<ReasoningMessage>().ToList();
+        reasoning.Should().ContainSingle();
+        reasoning[0].Reasoning.Should().Be("step one");
+        reasoning[0].Visibility.Should().Be(ReasoningVisibility.Summary);
     }
 }

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesReasoningSummaryTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesReasoningSummaryTests.cs
@@ -1,0 +1,104 @@
+using System.Runtime.CompilerServices;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Tests;
+
+/// <summary>
+///     Reasoning-summary streaming. The OpenAI Responses API delivers a reasoning-capable model's
+///     human-readable summary via <c>response.reasoning_summary_text.delta</c>/<c>.done</c> events
+///     (NOT inside the reasoning output_item's <c>summary</c> array, which stays empty while
+///     streaming). The parser previously decoded these to <see cref="GenericResponseEvent"/> and the
+///     agent dropped them, so requested reasoning summaries never surfaced as thinking blocks.
+/// </summary>
+public sealed class OpenAiResponsesReasoningSummaryTests
+{
+    private sealed class ScriptedClient(IReadOnlyList<ResponseEvent> events) : IOpenAiResponsesClient
+    {
+        public async IAsyncEnumerable<ResponseEvent> StreamResponseAsync(
+            ResponseCreateRequest request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            foreach (var ev in events)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return ev;
+                await Task.Yield();
+            }
+        }
+
+        public void Dispose() { }
+    }
+
+    [Fact]
+    public void Parser_decodes_reasoning_summary_text_delta_and_done()
+    {
+        var delta = ResponseEventParser.Parse(
+            "{\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_1\",\"output_index\":0,\"summary_index\":0,\"delta\":\"Let me \"}"
+        );
+        var done = ResponseEventParser.Parse(
+            "{\"type\":\"response.reasoning_summary_text.done\",\"item_id\":\"rs_1\",\"output_index\":0,\"summary_index\":0,\"text\":\"Let me think.\"}"
+        );
+
+        delta.Should().BeOfType<ResponseReasoningSummaryTextDeltaEvent>().Which.Delta.Should().Be("Let me ");
+        done.Should().BeOfType<ResponseReasoningSummaryTextDoneEvent>().Which.Text.Should().Be("Let me think.");
+    }
+
+    [Fact]
+    public async Task Agent_emits_reasoning_from_summary_stream()
+    {
+        ResponseEvent[] events =
+        [
+            new ResponseLifecycleEvent { Type = ResponseEventTypes.ResponseCreated },
+            new ResponseReasoningSummaryTextDeltaEvent
+            {
+                Type = ResponseEventTypes.ReasoningSummaryTextDelta,
+                ItemId = "rs_1",
+                OutputIndex = 0,
+                SummaryIndex = 0,
+                Delta = "Let me ",
+            },
+            new ResponseReasoningSummaryTextDeltaEvent
+            {
+                Type = ResponseEventTypes.ReasoningSummaryTextDelta,
+                ItemId = "rs_1",
+                OutputIndex = 0,
+                SummaryIndex = 0,
+                Delta = "think.",
+            },
+            new ResponseReasoningSummaryTextDoneEvent
+            {
+                Type = ResponseEventTypes.ReasoningSummaryTextDone,
+                ItemId = "rs_1",
+                OutputIndex = 0,
+                SummaryIndex = 0,
+                Text = "Let me think.",
+            },
+            new ResponseLifecycleEvent { Type = ResponseEventTypes.ResponseCompleted },
+        ];
+
+        using var agent = new OpenAiResponsesAgent("test", new ScriptedClient(events));
+        var stream = await agent.GenerateReplyStreamingAsync(
+            [new TextMessage { Role = Role.User, Text = "go" }],
+            new GenerateReplyOptions { GenerationId = "run-1" }
+        );
+
+        var messages = new List<IMessage>();
+        await foreach (var message in stream)
+        {
+            messages.Add(message);
+        }
+
+        // Streaming deltas surface as reasoning updates...
+        messages.OfType<ReasoningUpdateMessage>().Should().NotBeEmpty("reasoning summary deltas must stream as updates");
+        // ...and the completed summary as a final reasoning message carrying the full text.
+        var finalReasoning = messages.OfType<ReasoningMessage>().ToList();
+        finalReasoning.Should().ContainSingle("the summary stream completes with one reasoning message");
+        finalReasoning[0].Reasoning.Should().Be("Let me think.");
+        finalReasoning[0].GenerationId.Should().Be("run-1");
+    }
+}


### PR DESCRIPTION
Closes #104.

Fixes a cluster of message-identity defects in the streaming pipeline plus two related frontend state bugs. All changes are TDD (failing test first, then minimal fix). Branches were developed in parallel by file-disjoint area and merged.

## Bugs & fixes

### Backend — message identity
- **H1 — tool-call `GenerationId` mis-stamped.** The run mints a `generationId` but never threads it into `GenerateReplyOptions`, so providers stamp their own per-message id (for GPT-5.5/Copilot, an opaque encrypted response token). The client merge key `kind-runId-generationId-messageOrderIdx` then can't group tool-call pills to their run → tools render in the wrong pillbox.
  - Add `GenerateReplyOptions.GenerationId`; `MessageExtensions.WithIds(options)` now stamps the run's `GenerationId` onto every message arm (overriding the provider's, preserving the provider value when the run advertises none). This is the single seam every provider already calls to apply run identity, so it is provider-agnostic — Anthropic benefits too with no provider edits. `MultiTurnAgentLoop` threads the run's generation into options.
- **H3b — local tool-result `MessageOrderIdx` was `null`.** Locally-executed tool results are published out-of-band, bypassing the ordering middleware. Stamp `MessageOrderIdx = callOrderIdx + 1` in `MultiTurnAgentLoop`.
- **H3a — `toolCallIdx` always `0`:** investigated and intentionally **not** changed — proven (via a test against the real reconstruction pipeline) to be a downstream symptom of H1's `generationId` fragmentation, already resolved by H1.

### Frontend — `useChat` (incremental render after switching conversations)
- **Rehydration merge-key mismatch.** `loadMessagesFromBackend` indexed rehydrated messages by `pm.id` while live streaming indexes by `getMergeKey(...)`; a later streaming update couldn't merge and duplicated. Now rehydrate by `getMergeKey(parsedMessage)` (restores the documented contract).
- **Cross-thread socket reuse.** The reuse path reused a socket bound to a different conversation's thread. Now the reuse guard requires `wsConnection.threadId === threadId.value`; otherwise it closes and recreates with the current callbacks.

### Anthropic — replay 400
- Guard the **singular `ToolCallResultMessage`** branch in `AnthropicRequest` with the existing `IsEmptyIdServerToolCall` check so an orphaned empty-id server-tool `tool_result` is dropped on request rebuild (the aggregate path was already guarded).

## Tests (TDD, red→green verified)
- `tests/LmCore.Tests/Messages/MessageExtensionsWithIdsTests.cs` — run `GenerationId` overrides the provider's opaque id; preserved when the run advertises none.
- `tests/LmMultiTurn.Tests/MultiTurnAgentLoopTests.cs` — local tool result carries `MessageOrderIdx`.
- `tests/AnthropicProvider.Tests/Models/ServerToolRequestTests.cs` — empty-id server-tool result dropped.
- `ClientApp/.../useChat.test.ts` — rehydrated message merges a later streaming update in place (no duplicate); a socket bound to a different thread is not reused. (Each verified to fail against the pre-fix code.)

## Verification
- `dotnet build LmDotnetTools.sln`: clean, 0 warnings / 0 errors.
- Changed projects (isolated): LmCore 746, LmMultiTurn 276, OpenAIProvider 89, AnthropicProvider 169, LmStreaming.Sample 279 — all green. Frontend: 237/237.
- Pre-existing/unrelated and **not** caused by this PR: `McpIntegrationTests` ×4 (hardcoded `McpSampleServer.exe`, can't run on macOS); `LmMultiTurn` ×2 only under full-parallel `dotnet test` load (passes 276/276 in isolation).

## Notes / follow-ups (out of scope here)
- The two frontend fixes restore the documented merge-key contract and are correct, but reproducing the *exact* on-screen symptom would benefit from a `Browser.E2E.Tests` switch-away-and-back scenario (proposed follow-up).
- Unrelated to code: a live `GITHUB_COPILOT_TOKEN` in `samples/LmStreaming.Sample/.env` should be rotated; the GitHub-auth Prod→Dev workaround is a config/symptom fix (missing prod `ClientId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
