### PR TITLE
Harden LmStreaming: multi-turn replay/identity, gateway + sandbox resilience, empty web_search loop

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,6 +37,11 @@
     <!-- IDE0330: Prefer readonly span (uses .NET 9 Lock type, incompatible with .NET 8) -->
     <!-- Enforce zero-warning builds repo-wide. Local opt-out via -p:TreatWarningsAsErrors=false. -->
     <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == ''">true</TreatWarningsAsErrors>
+    <!-- NuGet audit advisories must NOT fail the build: NU1902 (moderate) currently fires for the
+         transitive Scriban 7.2.0 dependency (GHSA-6q7j-xr26-3h2c, GHSA-q6rr-fm2g-g5x8), which has no
+         patched release we can move to. Keep the advisory VISIBLE as a warning (not NoWarn-hidden) so
+         it resurfaces when a fix ships, but don't break CI on an advisory we can't yet remediate. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1902</WarningsNotAsErrors>
     <!-- Common Tags -->
     <PackageTags>dotnet;ai;llm;language-model;achieve-ai</PackageTags>
   </PropertyGroup>

--- a/samples/LmStreaming.Sample/CLAUDE.md
+++ b/samples/LmStreaming.Sample/CLAUDE.md
@@ -76,21 +76,28 @@ assume it uniquely identifies one logical message:
    **concatenate** onto the earlier turn's growing string; `finalize()` only runs per-run, never
    per-turn).
 
-In a multi-turn run this identity is **NOT unique by default**: `generationId` is **run-scoped**
-(constant across all turns — `MultiTurnAgentLoop` threads one id to every turn, `WithIds` stamps it;
-see #105/H1), while `messageOrderIdx` **resets every turn** (`MessageTransformationMiddleware` makes
-a fresh `OrderingState` per streaming invocation). So turn N and turn N+1 collide. **Tool calls
-survive** because their key also carries `tool_call_id`; **reasoning and text have no per-instance id
-and collapse** — this is the only reason they regress while tool calls don't.
+**Server-side root fix (shipped):** `MultiTurnAgentLoop.ExecuteRunTurnsAsync` now mints a **per-turn
+(per-generation) `generationId`** — turn 1 reuses the run's id (so `run_assignment`'s advertised id
+matches the first turn and single-turn runs are unchanged), turns 2+ get a fresh `Guid`. Each turn's
+messages still share one id (so a turn's `tool_call` + `tool_call_result` group together — the
+#105/H1 requirement) while turns stay distinct, so `(generationId, messageOrderIdx)` no longer
+collides across turns. Pillbox grouping is arrival-order based on the client (not `generationId`), so
+this doesn't change grouping; `run_assignment.generationId` / `run_completed.generationId` are not
+load-bearing on the client (only logged / used to stamp error messages). Coverage:
+`LmMultiTurn.Tests` → `ExecuteRunAsync_MultiTurn_AssignsDistinctGenerationIdPerTurn`. Backstory: prior
+to this, `generationId` was **run-scoped** (constant across all turns — #105/H1 over-corrected from
+per-message to per-run), while `messageOrderIdx` **resets every turn**, so turn N and N+1 collided;
+tool calls survived (key carries `tool_call_id`), reasoning/text collapsed.
 
-Client defense (current fix): a per-message **content turn epoch** in `useChat` (bumps when
-text/reasoning resumes after an intervening tool call), threaded into BOTH consumers — the merge key
-(`…-t{seq}`) and the merger accumulator key (`genId::t{seq}`). Regression coverage:
-`ClientApp/src/__tests__/composables/useChat.test.ts` (multi-turn reasoning + text interleaving) and
-`useMessageMerger.test.ts` (per-turn `turnSeq` separation). The durable root fix is server-side and
-deferred: prefer a **per-turn (per-generation) `generationId`** over run-scoped, or make
-`messageOrderIdx` monotonic across the run (riskier — two stamping paths: the middleware + the
-loop's H3b out-of-band tool-result stamping).
+**Client defense (kept — defense-in-depth + backward compat):** a per-message **content turn epoch**
+in `useChat` (bumps when text/reasoning resumes after an intervening tool call), threaded into BOTH
+consumers — the merge key (`…-t{seq}`) and the merger accumulator key (`genId::t{seq}`). Do **not**
+remove it: conversations **already persisted** before the server fix still carry the run-scoped
+collision on disk, so the rehydration path relies on the epoch to render reloaded multi-turn
+thinking/text distinctly. Regression coverage:
+`ClientApp/src/__tests__/composables/useChat.test.ts` (multi-turn reasoning, text interleaving,
+**merge-key invariant guard**, **rehydration multi-turn identity**) and `useMessageMerger.test.ts`
+(per-turn `turnSeq` separation).
 
 **Rules when touching message identity (these caused the regression once already):**
 - Changing the scope of an identity field (e.g. `generationId`) requires auditing **every** consumer

--- a/samples/LmStreaming.Sample/CLAUDE.md
+++ b/samples/LmStreaming.Sample/CLAUDE.md
@@ -66,3 +66,36 @@ Regression coverage (all CI-runnable): `LmCore.Tests/Middleware/MessageTransform
 `OpenAiResponsesProvider.Tests/OpenAiResponsesAgentTests` (drives the real mock OpenAI `/responses`
 SSE stream through the pipeline). Add new duplicate-render checks at these levels first; a browser
 scenario in `Browser.E2E.Tests` is the optional top-of-pyramid.
+
+## Message identity across turns (why multi-turn thinking/text "collapses to the top")
+The merge key `kind-runId-generationId-messageOrderIdx` has **TWO** client consumers, and BOTH
+assume it uniquely identifies one logical message:
+1. `useChat.getMergeKey` — the display/dedup key (collision ⇒ later turns overwrite the first block,
+   pinned to first-insert position = the top).
+2. `useMessageMerger` — the streaming accumulator key (collision ⇒ a later turn's `*_update` deltas
+   **concatenate** onto the earlier turn's growing string; `finalize()` only runs per-run, never
+   per-turn).
+
+In a multi-turn run this identity is **NOT unique by default**: `generationId` is **run-scoped**
+(constant across all turns — `MultiTurnAgentLoop` threads one id to every turn, `WithIds` stamps it;
+see #105/H1), while `messageOrderIdx` **resets every turn** (`MessageTransformationMiddleware` makes
+a fresh `OrderingState` per streaming invocation). So turn N and turn N+1 collide. **Tool calls
+survive** because their key also carries `tool_call_id`; **reasoning and text have no per-instance id
+and collapse** — this is the only reason they regress while tool calls don't.
+
+Client defense (current fix): a per-message **content turn epoch** in `useChat` (bumps when
+text/reasoning resumes after an intervening tool call), threaded into BOTH consumers — the merge key
+(`…-t{seq}`) and the merger accumulator key (`genId::t{seq}`). Regression coverage:
+`ClientApp/src/__tests__/composables/useChat.test.ts` (multi-turn reasoning + text interleaving) and
+`useMessageMerger.test.ts` (per-turn `turnSeq` separation). The durable root fix is server-side and
+deferred: prefer a **per-turn (per-generation) `generationId`** over run-scoped, or make
+`messageOrderIdx` monotonic across the run (riskier — two stamping paths: the middleware + the
+loop's H3b out-of-band tool-result stamping).
+
+**Rules when touching message identity (these caused the regression once already):**
+- Changing the scope of an identity field (e.g. `generationId`) requires auditing **every** consumer
+  — there are two here, not one.
+- Any fix that changes message identity MUST ship a **multi-turn (2+ turns) end-to-end client** test
+  (`useChat`/`displayItems`). Unit/single-turn green ≠ correct; the bug is emergent across turns.
+- "Consistent across the whole run" is a **two-field** claim: pinning `generationId` silently
+  requires `messageOrderIdx` to be run-unique. State and test both halves.

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChat.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChat.test.ts
@@ -395,6 +395,99 @@ describe('useChat socket reuse honors thread (BUG B)', () => {
   });
 });
 
+describe('useChat multi-turn reasoning (BUG #8 thinking collapse)', () => {
+  beforeEach(() => {
+    wsMocks.createWebSocketConnection.mockReset();
+    wsMocks.sendWebSocketMessage.mockReset();
+    wsMocks.closeWebSocketConnection.mockReset();
+
+    wsMocks.createWebSocketConnection.mockImplementation(async (options: any) => ({
+      socket: { readyState: 1 },
+      connectionId: `ws-${Date.now()}`,
+      threadId: options.threadId,
+      isConnected: true,
+    }));
+  });
+
+  // Proven from recording thread-1782467009826-a6pnxeu (GPT-5.5/Copilot, 24 turns): every turn's
+  // finalized reasoning shares the RUN's generationId (#105/H1 stamps the run generationId on every
+  // message) and the per-turn messageOrderIdx counter resets each turn, so turn N and turn N+1
+  // reasoning collide on (generationId, messageOrderIdx). Tool calls avoid this because their merge
+  // key already carries tool_call_id; reasoning had no per-instance discriminator, so later turns'
+  // thinking collapsed onto the first ~2 blocks. Each turn's reasoning must render as its own block.
+  function reasoningTextsIn(items: ReturnType<typeof useChat>['displayItems']['value']): string[] {
+    return items
+      .filter((i) => i.type === 'pill')
+      .flatMap((i) => (i as { items: Array<{ $type?: string; reasoning?: string }> }).items)
+      .filter((m) => m.$type === MessageType.Reasoning)
+      .map((m) => m.reasoning ?? '');
+  }
+
+  it('renders each turn reasoning as a distinct block when generationId+messageOrderIdx collide across turns', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    await chat.sendMessage('do a multi-step task');
+    const options = wsMocks.createWebSocketConnection.mock.calls[0]?.[0];
+    expect(options).toBeDefined();
+
+    // runId omitted (null on the wire → 'default'); generationId is the run's, constant across turns.
+    const base = { role: 'assistant', generationId: 'gen-run-1', threadId: 'thread-1' };
+
+    // Turn 1: reasoning (moi 1) then a tool call (moi 3).
+    options.onMessage({ ...base, $type: MessageType.Reasoning, reasoning: 'Turn 1: read the file', visibility: 1, messageOrderIdx: 1 });
+    options.onMessage({ ...base, $type: MessageType.ToolCall, tool_call_id: 'call_1', function_name: 'Read', function_args: '{}', messageOrderIdx: 3 });
+
+    // Turn 2: reasoning REUSES generationId + messageOrderIdx=1 (the collision) with new content.
+    options.onMessage({ ...base, $type: MessageType.Reasoning, reasoning: 'Turn 2: edit the file', visibility: 1, messageOrderIdx: 1 });
+    options.onMessage({ ...base, $type: MessageType.ToolCall, tool_call_id: 'call_2', function_name: 'Edit', function_args: '{}', messageOrderIdx: 3 });
+
+    // Turn 3: same collision again.
+    options.onMessage({ ...base, $type: MessageType.Reasoning, reasoning: 'Turn 3: run the tests', visibility: 1, messageOrderIdx: 1 });
+    options.onMessage({ ...base, $type: MessageType.ToolCall, tool_call_id: 'call_3', function_name: 'Bash', function_args: '{}', messageOrderIdx: 3 });
+
+    const texts = reasoningTextsIn(chat.displayItems.value);
+    expect(texts, 'every turn reasoning must survive, not collapse onto the first').toEqual([
+      'Turn 1: read the file',
+      'Turn 2: edit the file',
+      'Turn 3: run the tests',
+    ]);
+  });
+
+  it('does not fragment a single turn streaming reasoning: updates then finalize stay one block', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    await chat.sendMessage('stream then finalize');
+    const options = wsMocks.createWebSocketConnection.mock.calls[0]?.[0];
+    expect(options).toBeDefined();
+
+    const base = { role: 'assistant', generationId: 'gen-run-1', threadId: 'thread-1', messageOrderIdx: 0 };
+    // Streamed reasoning deltas then the finalizing reasoning, all same generationId+messageOrderIdx
+    // (the within-turn merge case). The turn epoch must NOT advance between them.
+    options.onMessage({ ...base, $type: MessageType.ReasoningUpdate, reasoning: 'Think', visibility: 1, chunkIdx: 0 });
+    options.onMessage({ ...base, $type: MessageType.ReasoningUpdate, reasoning: 'ing...', visibility: 1, chunkIdx: 1 });
+    options.onMessage({ ...base, $type: MessageType.Reasoning, reasoning: 'Thinking...', visibility: 1 });
+
+    const texts = reasoningTextsIn(chat.displayItems.value);
+    expect(texts, 'streamed + finalized reasoning of one turn render as a single block').toEqual(['Thinking...']);
+  });
+
+  it('keeps two reasoning blocks within ONE turn (distinct messageOrderIdx) and does not bump turn epoch mid-turn', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    await chat.sendMessage('multi-part thinking');
+    const options = wsMocks.createWebSocketConnection.mock.calls[0]?.[0];
+    expect(options).toBeDefined();
+
+    const base = { role: 'assistant', generationId: 'gen-run-1', threadId: 'thread-1' };
+    // One turn, two distinct reasoning parts (moi 1 and 2), then a tool call.
+    options.onMessage({ ...base, $type: MessageType.Reasoning, reasoning: 'Part A', visibility: 1, messageOrderIdx: 1 });
+    options.onMessage({ ...base, $type: MessageType.Reasoning, reasoning: 'Part B', visibility: 1, messageOrderIdx: 2 });
+    options.onMessage({ ...base, $type: MessageType.ToolCall, tool_call_id: 'call_1', function_name: 'Read', function_args: '{}', messageOrderIdx: 3 });
+    // Next turn reuses moi 1 with new content.
+    options.onMessage({ ...base, $type: MessageType.Reasoning, reasoning: 'Part C', visibility: 1, messageOrderIdx: 1 });
+
+    const texts = reasoningTextsIn(chat.displayItems.value);
+    expect(texts).toEqual(['Part A', 'Part B', 'Part C']);
+  });
+});
+
 describe('useChat concurrent tool-call grouping', () => {
   beforeEach(() => {
     wsMocks.createWebSocketConnection.mockReset();

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChat.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChat.test.ts
@@ -280,6 +280,85 @@ describe('useChat rehydration merge-key (BUG A)', () => {
   });
 });
 
+describe('useChat rehydration multi-turn identity (reload keeps turns distinct)', () => {
+  beforeEach(() => {
+    wsMocks.createWebSocketConnection.mockReset();
+    wsMocks.sendWebSocketMessage.mockReset();
+    wsMocks.closeWebSocketConnection.mockReset();
+    conversationsMocks.loadConversationMessages.mockReset();
+
+    wsMocks.createWebSocketConnection.mockImplementation(async (options: any) => ({
+      socket: { readyState: 1 },
+      connectionId: `ws-${Date.now()}`,
+      threadId: options.threadId,
+      isConnected: true,
+    }));
+  });
+
+  // Helper: build a PersistedMessage row carrying the wire identity fields the loader reads.
+  function persisted(
+    id: string,
+    timestamp: number,
+    message: Record<string, unknown>,
+    identity: { runId: string; generationId: string; messageOrderIdx: number }
+  ) {
+    return {
+      id,
+      threadId: 'thread-x',
+      runId: identity.runId,
+      generationId: identity.generationId,
+      messageOrderIdx: identity.messageOrderIdx,
+      timestamp,
+      messageType: String(message.$type),
+      role: String(message.role),
+      messageJson: JSON.stringify(message),
+    };
+  }
+
+  // The live-stream path is covered by the multi-turn reasoning/text describes above; this is the
+  // REHYDRATION counterpart (the open PR-review item). loadMessagesFromBackend replays the same
+  // content turn epoch in persisted order, so reloading an OLD conversation — whose persisted records
+  // share the run's generationId with messageOrderIdx reset each turn (the #105/H1 shape on disk) —
+  // must still render each turn's reasoning/text as a distinct, correctly-ordered block, exactly like
+  // live streaming. Without the epoch replay, reloaded multi-turn thinking/text would collapse onto
+  // the first block after a conversation switch.
+  it('renders distinct per-turn reasoning and text when reloading a colliding-identity history', async () => {
+    const id = { runId: 'run-1', generationId: 'gen-run-1', messageOrderIdx: 0 };
+    conversationsMocks.loadConversationMessages.mockResolvedValue([
+      // Turn 1: reasoning(moi1) + text(moi2) + tool call(moi3)
+      persisted('p1', 1000, { $type: MessageType.Reasoning, role: 'assistant', reasoning: 'R1', visibility: 1 }, { ...id, messageOrderIdx: 1 }),
+      persisted('p2', 1001, { $type: MessageType.Text, role: 'assistant', text: 'A1' }, { ...id, messageOrderIdx: 2 }),
+      persisted('p3', 1002, { $type: MessageType.ToolCall, role: 'assistant', tool_call_id: 'call_1', function_name: 'Read', function_args: '{}' }, { ...id, messageOrderIdx: 3 }),
+      // Turn 2: identity RESETS (same generationId, moi back to 1/2/3) — the on-disk collision.
+      persisted('p4', 1003, { $type: MessageType.Reasoning, role: 'assistant', reasoning: 'R2', visibility: 1 }, { ...id, messageOrderIdx: 1 }),
+      persisted('p5', 1004, { $type: MessageType.Text, role: 'assistant', text: 'A2' }, { ...id, messageOrderIdx: 2 }),
+      persisted('p6', 1005, { $type: MessageType.ToolCall, role: 'assistant', tool_call_id: 'call_2', function_name: 'Edit', function_args: '{}' }, { ...id, messageOrderIdx: 3 }),
+    ]);
+
+    const chat = useChat({ getModeId: () => 'default' });
+    await chat.loadMessagesFromBackend('thread-x');
+
+    const items = chat.displayItems.value;
+    const reasonings = items
+      .filter((i) => i.type === 'pill')
+      .flatMap((i) => (i as { items: Array<{ $type?: string; reasoning?: string }> }).items)
+      .filter((m) => m.$type === MessageType.Reasoning)
+      .map((m) => m.reasoning ?? '');
+    const texts = items
+      .filter((i) => i.type === 'assistant-message')
+      .map((i) => (i as { content: { text?: string } }).content.text ?? '');
+    const toolIds = items
+      .filter((i) => i.type === 'pill')
+      .flatMap((i) => (i as { items: Array<{ tool_calls?: Array<{ tool_call_id?: string }> }> }).items)
+      .map((m) => m.tool_calls?.[0]?.tool_call_id)
+      .filter((id): id is string => typeof id === 'string');
+
+    expect(reasonings, 'reloaded reasoning must stay distinct per turn').toEqual(['R1', 'R2']);
+    expect(texts, 'reloaded text must stay distinct per turn').toEqual(['A1', 'A2']);
+    expect(toolIds, 'reloaded tool calls must stay distinct').toEqual(['call_1', 'call_2']);
+  });
+});
+
 describe('useChat rehydration duplicate merge-key (BLOCKER 1)', () => {
   beforeEach(() => {
     wsMocks.createWebSocketConnection.mockReset();
@@ -562,6 +641,72 @@ describe('useChat multi-turn text interleaving (BUG: text between tool calls col
       .filter((i) => i.type === 'assistant-message')
       .map((i) => (i as { content: { text?: string } }).content.text);
     expect(texts).toEqual(['First answer.', 'Second answer.']);
+  });
+});
+
+describe('useChat merge-key invariant guard (distinct logical messages never collapse)', () => {
+  beforeEach(() => {
+    wsMocks.createWebSocketConnection.mockReset();
+    wsMocks.sendWebSocketMessage.mockReset();
+    wsMocks.closeWebSocketConnection.mockReset();
+
+    wsMocks.createWebSocketConnection.mockImplementation(async (options: any) => ({
+      socket: { readyState: 1 },
+      connectionId: `ws-${Date.now()}`,
+      threadId: options.threadId,
+      isConnected: true,
+    }));
+  });
+
+  // Executable form of the documented invariant (CLAUDE.md "Message identity across turns",
+  // post-mortem prevention #3): two logically distinct messages must NEVER collapse onto one rendered
+  // block. This guard drives the worst case the wire can present — every turn reusing ONE
+  // generationId with messageOrderIdx reset each turn (the #105/H1 run-scoped collision) — across a
+  // mixed reasoning + text + tool-call sequence over 3 turns, and asserts that all 9 logical messages
+  // survive as their own distinct, correctly-ordered blocks. The backend now mints a per-turn
+  // generationId (its own regression test lives in LmMultiTurn.Tests), so this guards the CLIENT
+  // defense layer by simulating the collision directly: if the client turn epoch ever regresses, the
+  // collapsed turns make these arrays short/duplicated and this fails.
+  function reasoningTextsIn(items: ReturnType<typeof useChat>['displayItems']['value']): string[] {
+    return items
+      .filter((i) => i.type === 'pill')
+      .flatMap((i) => (i as { items: Array<{ $type?: string; reasoning?: string }> }).items)
+      .filter((m) => m.$type === MessageType.Reasoning)
+      .map((m) => m.reasoning ?? '');
+  }
+  function toolCallIdsIn(items: ReturnType<typeof useChat>['displayItems']['value']): (string | undefined)[] {
+    return items
+      .filter((i) => i.type === 'pill')
+      .flatMap((i) => (i as { items: Array<{ tool_calls?: Array<{ tool_call_id?: string }> }> }).items)
+      .map((m) => m.tool_calls?.[0]?.tool_call_id)
+      .filter((id): id is string => typeof id === 'string');
+  }
+  function assistantTextsIn(items: ReturnType<typeof useChat>['displayItems']['value']): string[] {
+    return items
+      .filter((i) => i.type === 'assistant-message')
+      .map((i) => (i as { content: { text?: string } }).content.text ?? '');
+  }
+
+  it('preserves all 9 mixed messages across 3 turns under a fully colliding (generationId, messageOrderIdx) stream', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    await chat.sendMessage('mixed multi-turn task');
+    const options = wsMocks.createWebSocketConnection.mock.calls[0]?.[0];
+    expect(options).toBeDefined();
+
+    // Every message of every turn shares ONE generationId; messageOrderIdx resets each turn
+    // (reasoning=1, text=2, tool call=3). Without a per-turn discriminator turn N and N+1 collide.
+    const base = { role: 'assistant', generationId: 'gen-run-1', threadId: 'thread-1' };
+    for (const turn of [1, 2, 3]) {
+      options.onMessage({ ...base, $type: MessageType.Reasoning, reasoning: `R${turn}`, visibility: 1, messageOrderIdx: 1 });
+      options.onMessage({ ...base, $type: MessageType.Text, text: `A${turn}`, messageOrderIdx: 2 });
+      options.onMessage({ ...base, $type: MessageType.ToolCall, tool_call_id: `call_${turn}`, function_name: 'Do', function_args: '{}', messageOrderIdx: 3 });
+    }
+
+    const items = chat.displayItems.value;
+    // All three of each kind survive in chronological order — none collapsed onto turn 1's block.
+    expect(reasoningTextsIn(items), 'each turn reasoning is its own block').toEqual(['R1', 'R2', 'R3']);
+    expect(assistantTextsIn(items), 'each turn text is its own bubble').toEqual(['A1', 'A2', 'A3']);
+    expect(toolCallIdsIn(items), 'each turn tool call is its own pill').toEqual(['call_1', 'call_2', 'call_3']);
   });
 });
 

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChat.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChat.test.ts
@@ -488,6 +488,83 @@ describe('useChat multi-turn reasoning (BUG #8 thinking collapse)', () => {
   });
 });
 
+describe('useChat multi-turn text interleaving (BUG: text between tool calls collapses to top)', () => {
+  beforeEach(() => {
+    wsMocks.createWebSocketConnection.mockReset();
+    wsMocks.sendWebSocketMessage.mockReset();
+    wsMocks.closeWebSocketConnection.mockReset();
+
+    wsMocks.createWebSocketConnection.mockImplementation(async (options: any) => ({
+      socket: { readyState: 1 },
+      connectionId: `ws-${Date.now()}`,
+      threadId: options.threadId,
+      isConnected: true,
+    }));
+  });
+
+  // Project displayItems to a compact shape: assistant text bubbles and tool-call pills in order.
+  function layout(items: ReturnType<typeof useChat>['displayItems']['value']): string[] {
+    return items
+      .filter((i) => i.type === 'assistant-message' || i.type === 'pill')
+      .map((i) =>
+        i.type === 'assistant-message'
+          ? `text:${(i as { content: { text?: string } }).content.text}`
+          : `pill:${(i as { items: Array<{ tool_calls?: Array<{ tool_call_id?: string }> }> }).items
+              .map((m) => m.tool_calls?.[0]?.tool_call_id)
+              .join(',')}`
+      );
+  }
+
+  // The backend narrates with text BETWEEN tool calls across turns; every turn shares the run's
+  // generationId (#105/H1) and resets messageOrderIdx, so turn N and turn N+1 text collide on the
+  // client merge key AND the merger accumulator. Before the fix the text collapsed into a single
+  // block pinned to the top (first-insert position) instead of interleaving with the tool pills.
+  it('interleaves streamed text with the tool calls of each turn instead of collapsing at the top', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    await chat.sendMessage('multi-step with narration');
+    const options = wsMocks.createWebSocketConnection.mock.calls[0]?.[0];
+    expect(options).toBeDefined();
+
+    const base = { role: 'assistant', generationId: 'gen-run-1', threadId: 'thread-1' };
+
+    // Turn 1: streamed narration (moi 0) then a tool call (moi 1).
+    options.onMessage({ ...base, $type: MessageType.TextUpdate, text: 'Let me ', messageOrderIdx: 0, chunkIdx: 0 });
+    options.onMessage({ ...base, $type: MessageType.TextUpdate, text: 'read the file.', messageOrderIdx: 0, chunkIdx: 1 });
+    options.onMessage({ ...base, $type: MessageType.Text, text: 'Let me read the file.', messageOrderIdx: 0 });
+    options.onMessage({ ...base, $type: MessageType.ToolCall, tool_call_id: 'call_1', function_name: 'Read', function_args: '{}', messageOrderIdx: 1 });
+
+    // Turn 2: narration reuses moi 0 (reset) with NEW content, then another tool call.
+    options.onMessage({ ...base, $type: MessageType.TextUpdate, text: 'Now I will ', messageOrderIdx: 0, chunkIdx: 0 });
+    options.onMessage({ ...base, $type: MessageType.TextUpdate, text: 'edit it.', messageOrderIdx: 0, chunkIdx: 1 });
+    options.onMessage({ ...base, $type: MessageType.Text, text: 'Now I will edit it.', messageOrderIdx: 0 });
+    options.onMessage({ ...base, $type: MessageType.ToolCall, tool_call_id: 'call_2', function_name: 'Edit', function_args: '{}', messageOrderIdx: 1 });
+
+    expect(layout(chat.displayItems.value)).toEqual([
+      'text:Let me read the file.',
+      'pill:call_1',
+      'text:Now I will edit it.',
+      'pill:call_2',
+    ]);
+  });
+
+  it('keeps finalized (non-streamed) text distinct per turn when generationId+messageOrderIdx collide', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    await chat.sendMessage('finalized text per turn');
+    const options = wsMocks.createWebSocketConnection.mock.calls[0]?.[0];
+    expect(options).toBeDefined();
+
+    const base = { role: 'assistant', generationId: 'gen-run-1', threadId: 'thread-1' };
+    options.onMessage({ ...base, $type: MessageType.Text, text: 'First answer.', messageOrderIdx: 0 });
+    options.onMessage({ ...base, $type: MessageType.ToolCall, tool_call_id: 'call_1', function_name: 'Read', function_args: '{}', messageOrderIdx: 1 });
+    options.onMessage({ ...base, $type: MessageType.Text, text: 'Second answer.', messageOrderIdx: 0 });
+
+    const texts = chat.displayItems.value
+      .filter((i) => i.type === 'assistant-message')
+      .map((i) => (i as { content: { text?: string } }).content.text);
+    expect(texts).toEqual(['First answer.', 'Second answer.']);
+  });
+});
+
 describe('useChat concurrent tool-call grouping', () => {
   beforeEach(() => {
     wsMocks.createWebSocketConnection.mockReset();

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useMessageMerger.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useMessageMerger.test.ts
@@ -88,6 +88,51 @@ describe('useMessageMerger', () => {
       expect(result2.text).toBe('Second gen');
       expect(result2.generationId).toBe('gen-2');
     });
+
+    // BUG: across the turns of ONE run the backend reuses a single run-scoped generationId
+    // (#105/H1). Keying the accumulator by generationId alone made turn N+1's text deltas
+    // concatenate onto turn N's, so the UI showed one giant text block instead of one per turn.
+    // The caller (useChat) now passes a per-turn sequence; same genId + different turnSeq must NOT
+    // share an accumulator, while same genId + same turnSeq still accumulates within the turn.
+    it('does not concatenate text across turns that share a generationId but differ in turnSeq', () => {
+      const mk = (text: string, chunkIdx: number): TextUpdateMessage => ({
+        $type: MessageType.TextUpdate,
+        text,
+        isUpdate: true,
+        role: 'assistant',
+        generationId: 'run-gen',
+        messageOrderIdx: 0,
+        chunkIdx,
+      });
+
+      // Turn 1 (seq 1): two deltas accumulate within the turn.
+      merger.processUpdate(mk('Let me ', 0), 1);
+      const t1 = merger.processUpdate(mk('read the file.', 1), 1) as TextMessage;
+      expect(t1.text).toBe('Let me read the file.');
+      expect(t1.generationId).toBe('run-gen');
+
+      // Turn 2 (seq 2): SAME generationId, new turn — must start fresh, not append to turn 1.
+      const t2 = merger.processUpdate(mk('Now I will edit it.', 0), 2) as TextMessage;
+      expect(t2.text, 'turn 2 text must not carry turn 1 content').toBe('Now I will edit it.');
+      expect(t2.generationId).toBe('run-gen');
+    });
+
+    it('does not concatenate reasoning across turns that share a generationId but differ in turnSeq', () => {
+      const mk = (reasoning: string): ReasoningUpdateMessage => ({
+        $type: MessageType.ReasoningUpdate,
+        reasoning,
+        isUpdate: true,
+        visibility: 'Plain',
+        role: 'assistant',
+        generationId: 'run-gen',
+        messageOrderIdx: 0,
+      });
+
+      const r1 = merger.processUpdate(mk('Thinking about turn one.'), 1) as ReasoningMessage;
+      expect(r1.reasoning).toBe('Thinking about turn one.');
+      const r2 = merger.processUpdate(mk('Thinking about turn two.'), 2) as ReasoningMessage;
+      expect(r2.reasoning, 'turn 2 reasoning must not carry turn 1 content').toBe('Thinking about turn two.');
+    });
   });
 
   describe('processUpdate - reasoning updates', () => {

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -111,14 +111,15 @@ function getMergeKey(msg: Message, turnSeq = 0): string {
     return `${mergeKind}-${runId}-${generationId}-${messageOrderIdx}-${msg.tool_calls[0].tool_call_id}`;
   }
 
-  // Reasoning and text have no per-instance id (unlike tool_call_id). The backend reuses
-  // (generationId, messageOrderIdx) for them across the turns of ONE run — #105/H1 stamps the run's
-  // generationId onto every message, and the per-turn messageOrderIdx counter restarts each turn —
-  // so turn N and turn N+1 content collide: later turns' thinking/text collapse onto the first
-  // block (text between tool calls ends up pinned to the top instead of interleaving). Fold in a
-  // caller-supplied turn epoch (contentTurnEpoch in useChat, bumped when content resumes after
-  // intervening non-content) to keep each turn a distinct block. Mirrors the tool_call_id
-  // disambiguation above.
+  // Reasoning and text have no per-instance id (unlike tool_call_id). The server now mints a
+  // per-turn generationId (MultiTurnAgentLoop.ExecuteRunTurnsAsync), so live streams keep turns
+  // distinct on their own. But conversations PERSISTED before that fix still carry the old
+  // run-scoped shape on disk — one generationId across every turn with messageOrderIdx reset each
+  // turn — so turn N and N+1 content would collide on reload (later turns' thinking/text collapsing
+  // onto the first block, text between tool calls pinned to the top instead of interleaving). Fold
+  // in a caller-supplied turn epoch (contentTurnEpoch in useChat, bumped when content resumes after
+  // intervening non-content) so each turn stays a distinct block regardless. Defense-in-depth that
+  // also covers that on-disk legacy data. Mirrors the tool_call_id disambiguation above.
   if (
     isReasoningMessage(msg) || isReasoningUpdateMessage(msg) ||
     isTextMessage(msg) || isTextUpdateMessage(msg)
@@ -179,10 +180,11 @@ export function useChat(options: UseChatOptions = {}) {
   const threadId = ref<string | null>(null);
   const currentRunId = ref<string | null>(null);
 
-  // Content turn epoch (BUG #8 + text interleaving). The backend reuses (generationId,
-  // messageOrderIdx) for reasoning AND text across the turns of one run, so without a per-turn
-  // discriminator later turns' thinking/text collapse onto the first block (e.g. text between tool
-  // calls gets pinned to the top instead of interleaving). These are plain closure vars (no
+  // Content turn epoch (BUG #8 + text interleaving). The server now mints a per-turn generationId so
+  // live streams are unambiguous, but this stays as defense-in-depth AND to render conversations
+  // PERSISTED before that fix — whose reasoning/text reuse one run-scoped generationId with
+  // messageOrderIdx reset each turn — without later turns collapsing onto the first block (e.g. text
+  // between tool calls pinned to the top instead of interleaving). These are plain closure vars (no
   // reactivity needed) tracking arrival order: bump the epoch whenever content (text/reasoning)
   // resumes after intervening non-content (a tool call), then fold it into the content merge key via
   // getMergeKey AND the merger accumulator key via processUpdate. Reset on conversation clear/load.

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -91,7 +91,7 @@ export interface UseChatOptions {
 /**
  * Generate merge key for message updates
  */
-function getMergeKey(msg: Message, reasoningTurnSeq = 0): string {
+function getMergeKey(msg: Message, turnSeq = 0): string {
   const runId = msg.runId || 'default';
   const generationId = msg.generationId || 'default';
   const messageOrderIdx = msg.messageOrderIdx ?? 0;
@@ -111,15 +111,19 @@ function getMergeKey(msg: Message, reasoningTurnSeq = 0): string {
     return `${mergeKind}-${runId}-${generationId}-${messageOrderIdx}-${msg.tool_calls[0].tool_call_id}`;
   }
 
-  // Reasoning has no per-instance id (unlike tool_call_id). The backend reuses
-  // (generationId, messageOrderIdx) for reasoning across the turns of ONE run — #105/H1 stamps the
-  // run's generationId onto every message, and the per-turn messageOrderIdx counter restarts each
-  // turn — so turn N and turn N+1 thinking collide and later turns collapse onto the first block.
-  // Fold in a caller-supplied turn epoch (reasoningTurnEpoch in useChat, bumped when reasoning
-  // resumes after intervening non-reasoning content) to keep each turn a distinct block. Mirrors the
-  // tool_call_id disambiguation above.
-  if (isReasoningMessage(msg) || isReasoningUpdateMessage(msg)) {
-    return `${mergeKind}-${runId}-${generationId}-${messageOrderIdx}-t${reasoningTurnSeq}`;
+  // Reasoning and text have no per-instance id (unlike tool_call_id). The backend reuses
+  // (generationId, messageOrderIdx) for them across the turns of ONE run — #105/H1 stamps the run's
+  // generationId onto every message, and the per-turn messageOrderIdx counter restarts each turn —
+  // so turn N and turn N+1 content collide: later turns' thinking/text collapse onto the first
+  // block (text between tool calls ends up pinned to the top instead of interleaving). Fold in a
+  // caller-supplied turn epoch (contentTurnEpoch in useChat, bumped when content resumes after
+  // intervening non-content) to keep each turn a distinct block. Mirrors the tool_call_id
+  // disambiguation above.
+  if (
+    isReasoningMessage(msg) || isReasoningUpdateMessage(msg) ||
+    isTextMessage(msg) || isTextUpdateMessage(msg)
+  ) {
+    return `${mergeKind}-${runId}-${generationId}-${messageOrderIdx}-t${turnSeq}`;
   }
 
   // ToolsCallUpdate accumulates tools into one array → key on messageOrderIdx only.
@@ -175,35 +179,44 @@ export function useChat(options: UseChatOptions = {}) {
   const threadId = ref<string | null>(null);
   const currentRunId = ref<string | null>(null);
 
-  // Reasoning turn epoch (BUG #8). The backend reuses (generationId, messageOrderIdx) for reasoning
-  // across the turns of one run, so without a per-turn discriminator later turns' thinking blocks
-  // collapse onto the first. These are plain closure vars (no reactivity needed) tracking arrival
-  // order: bump the epoch whenever reasoning resumes after intervening non-reasoning content, then
-  // fold it into the reasoning merge key via getMergeKey. Reset on conversation clear/load.
-  let reasoningTurnEpoch = 0;
-  let sawContentSinceReasoning = true; // seed true so the very first reasoning opens epoch 1
+  // Content turn epoch (BUG #8 + text interleaving). The backend reuses (generationId,
+  // messageOrderIdx) for reasoning AND text across the turns of one run, so without a per-turn
+  // discriminator later turns' thinking/text collapse onto the first block (e.g. text between tool
+  // calls gets pinned to the top instead of interleaving). These are plain closure vars (no
+  // reactivity needed) tracking arrival order: bump the epoch whenever content (text/reasoning)
+  // resumes after intervening non-content (a tool call), then fold it into the content merge key via
+  // getMergeKey AND the merger accumulator key via processUpdate. Reset on conversation clear/load.
+  let contentTurnEpoch = 0;
+  let sawNonContentSinceContent = true; // seed true so the very first content opens epoch 1
 
-  /**
-   * Advance and return the reasoning turn epoch for a message in arrival order. Consecutive
-   * reasoning messages (a turn's thinking parts + their finalization) share one epoch; any
-   * intervening non-reasoning content (tool call, text, user message) marks the next reasoning as a
-   * new turn. Non-reasoning messages only record that boundary.
-   */
-  function reasoningEpochFor(msg: Message): number {
-    if (isReasoningMessage(msg) || isReasoningUpdateMessage(msg)) {
-      if (sawContentSinceReasoning) {
-        reasoningTurnEpoch++;
-        sawContentSinceReasoning = false;
-      }
-      return reasoningTurnEpoch;
-    }
-    sawContentSinceReasoning = true;
-    return reasoningTurnEpoch;
+  function isContentMessage(msg: Message): boolean {
+    return (
+      isReasoningMessage(msg) || isReasoningUpdateMessage(msg) ||
+      isTextMessage(msg) || isTextUpdateMessage(msg)
+    );
   }
 
-  function resetReasoningEpoch(): void {
-    reasoningTurnEpoch = 0;
-    sawContentSinceReasoning = true;
+  /**
+   * Advance and return the content turn epoch for a message in arrival order. Consecutive content
+   * messages of one turn (its thinking + text parts and their finalizations) share one epoch; any
+   * intervening non-content (a tool call) marks the next content message as a new turn. Non-content
+   * messages only record that boundary.
+   */
+  function contentTurnSeqFor(msg: Message): number {
+    if (isContentMessage(msg)) {
+      if (sawNonContentSinceContent) {
+        contentTurnEpoch++;
+        sawNonContentSinceContent = false;
+      }
+      return contentTurnEpoch;
+    }
+    sawNonContentSinceContent = true;
+    return contentTurnEpoch;
+  }
+
+  function resetContentTurnEpoch(): void {
+    contentTurnEpoch = 0;
+    sawNonContentSinceContent = true;
   }
 
   // Tool results map: tool_call_id -> ToolCallResultMessage
@@ -757,12 +770,15 @@ export function useChat(options: UseChatOptions = {}) {
       return;
     }
 
+    // Advance the content turn epoch in arrival order (BUG #8 + text interleaving) so multi-turn
+    // thinking/text does not collapse onto the first block; non-content kinds just record the turn
+    // boundary. The SAME sequence scopes both the merger accumulator (so deltas don't concatenate
+    // across turns) and the display merge key (so each turn is a distinct, correctly-ordered block).
+    const turnSeq = contentTurnSeqFor(msg);
+
     // Process through merger (handles both updates and complete messages)
-    const mergedMessage = isUpdate ? processUpdate(msg) : msg;
-    // Advance the reasoning turn epoch in arrival order (BUG #8) so multi-turn thinking does not
-    // collapse onto the first block; non-reasoning kinds just record the turn boundary.
-    const reasoningSeq = reasoningEpochFor(msg);
-    const mergeKey = getMergeKey(msg, reasoningSeq);
+    const mergedMessage = isUpdate ? processUpdate(msg, turnSeq) : msg;
+    const mergeKey = getMergeKey(msg, turnSeq);
 
     // Find or create message in index
     let chatMessage = messageIndex.value.get(mergeKey);
@@ -995,7 +1011,7 @@ export function useChat(options: UseChatOptions = {}) {
     threadId.value = null;
     currentRunId.value = null;
     toolResults.value.clear();
-    resetReasoningEpoch();
+    resetContentTurnEpoch();
     reset();
 
     // Close WebSocket connection
@@ -1063,7 +1079,7 @@ export function useChat(options: UseChatOptions = {}) {
     messageIndex.value.clear();
     messageOrder.value = [];
     toolResults.value.clear();
-    resetReasoningEpoch();
+    resetContentTurnEpoch();
     reset();
 
     // Set the thread ID
@@ -1111,10 +1127,10 @@ export function useChat(options: UseChatOptions = {}) {
         // Index rehydrated messages by the same merge key used by live streaming
         // (kind-runId-generationId-messageOrderIdx) so a subsequent streaming update
         // sharing that identity merges in place instead of creating a duplicate bubble. Replay the
-        // reasoning turn epoch (BUG #8) in persisted order so reloaded multi-turn thinking renders
-        // as distinct blocks too, matching what live streaming computes.
-        const reasoningSeq = reasoningEpochFor(parsedMessage);
-        const mergeKey = getMergeKey(parsedMessage, reasoningSeq);
+        // content turn epoch (BUG #8 + text interleaving) in persisted order so reloaded multi-turn
+        // thinking/text renders as distinct, correctly-ordered blocks too, matching live streaming.
+        const turnSeq = contentTurnSeqFor(parsedMessage);
+        const mergeKey = getMergeKey(parsedMessage, turnSeq);
 
         // Create chat message
         const chatMessage: InternalChatMessage = {

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -91,12 +91,12 @@ export interface UseChatOptions {
 /**
  * Generate merge key for message updates
  */
-function getMergeKey(msg: Message): string {
+function getMergeKey(msg: Message, reasoningTurnSeq = 0): string {
   const runId = msg.runId || 'default';
   const generationId = msg.generationId || 'default';
   const messageOrderIdx = msg.messageOrderIdx ?? 0;
   const mergeKind = getMergeKind(msg);
-  
+
   // Individual tool calls — streaming OR finalized — are keyed by tool_call_id. Several concurrent
   // tool calls in one turn share runId/generationId/messageOrderIdx and differ only by tool_call_id
   // (e.g. GPT-5.5 via the OpenAI Responses API); without it they collapse into a single pill.
@@ -109,6 +109,17 @@ function getMergeKey(msg: Message): string {
   // message (rendered as N pills), so they key on messageOrderIdx only.
   if (isToolsCallMessage(msg) && msg.tool_calls?.length === 1 && msg.tool_calls[0]?.tool_call_id) {
     return `${mergeKind}-${runId}-${generationId}-${messageOrderIdx}-${msg.tool_calls[0].tool_call_id}`;
+  }
+
+  // Reasoning has no per-instance id (unlike tool_call_id). The backend reuses
+  // (generationId, messageOrderIdx) for reasoning across the turns of ONE run — #105/H1 stamps the
+  // run's generationId onto every message, and the per-turn messageOrderIdx counter restarts each
+  // turn — so turn N and turn N+1 thinking collide and later turns collapse onto the first block.
+  // Fold in a caller-supplied turn epoch (reasoningTurnEpoch in useChat, bumped when reasoning
+  // resumes after intervening non-reasoning content) to keep each turn a distinct block. Mirrors the
+  // tool_call_id disambiguation above.
+  if (isReasoningMessage(msg) || isReasoningUpdateMessage(msg)) {
+    return `${mergeKind}-${runId}-${generationId}-${messageOrderIdx}-t${reasoningTurnSeq}`;
   }
 
   // ToolsCallUpdate accumulates tools into one array → key on messageOrderIdx only.
@@ -163,6 +174,37 @@ export function useChat(options: UseChatOptions = {}) {
   const transport = ref<TransportType>(initialTransport);
   const threadId = ref<string | null>(null);
   const currentRunId = ref<string | null>(null);
+
+  // Reasoning turn epoch (BUG #8). The backend reuses (generationId, messageOrderIdx) for reasoning
+  // across the turns of one run, so without a per-turn discriminator later turns' thinking blocks
+  // collapse onto the first. These are plain closure vars (no reactivity needed) tracking arrival
+  // order: bump the epoch whenever reasoning resumes after intervening non-reasoning content, then
+  // fold it into the reasoning merge key via getMergeKey. Reset on conversation clear/load.
+  let reasoningTurnEpoch = 0;
+  let sawContentSinceReasoning = true; // seed true so the very first reasoning opens epoch 1
+
+  /**
+   * Advance and return the reasoning turn epoch for a message in arrival order. Consecutive
+   * reasoning messages (a turn's thinking parts + their finalization) share one epoch; any
+   * intervening non-reasoning content (tool call, text, user message) marks the next reasoning as a
+   * new turn. Non-reasoning messages only record that boundary.
+   */
+  function reasoningEpochFor(msg: Message): number {
+    if (isReasoningMessage(msg) || isReasoningUpdateMessage(msg)) {
+      if (sawContentSinceReasoning) {
+        reasoningTurnEpoch++;
+        sawContentSinceReasoning = false;
+      }
+      return reasoningTurnEpoch;
+    }
+    sawContentSinceReasoning = true;
+    return reasoningTurnEpoch;
+  }
+
+  function resetReasoningEpoch(): void {
+    reasoningTurnEpoch = 0;
+    sawContentSinceReasoning = true;
+  }
 
   // Tool results map: tool_call_id -> ToolCallResultMessage
   const toolResults = ref<Map<string, ToolCallResultMessage>>(new Map());
@@ -717,7 +759,10 @@ export function useChat(options: UseChatOptions = {}) {
 
     // Process through merger (handles both updates and complete messages)
     const mergedMessage = isUpdate ? processUpdate(msg) : msg;
-    const mergeKey = getMergeKey(msg);
+    // Advance the reasoning turn epoch in arrival order (BUG #8) so multi-turn thinking does not
+    // collapse onto the first block; non-reasoning kinds just record the turn boundary.
+    const reasoningSeq = reasoningEpochFor(msg);
+    const mergeKey = getMergeKey(msg, reasoningSeq);
 
     // Find or create message in index
     let chatMessage = messageIndex.value.get(mergeKey);
@@ -950,6 +995,7 @@ export function useChat(options: UseChatOptions = {}) {
     threadId.value = null;
     currentRunId.value = null;
     toolResults.value.clear();
+    resetReasoningEpoch();
     reset();
 
     // Close WebSocket connection
@@ -1017,6 +1063,7 @@ export function useChat(options: UseChatOptions = {}) {
     messageIndex.value.clear();
     messageOrder.value = [];
     toolResults.value.clear();
+    resetReasoningEpoch();
     reset();
 
     // Set the thread ID
@@ -1063,8 +1110,11 @@ export function useChat(options: UseChatOptions = {}) {
 
         // Index rehydrated messages by the same merge key used by live streaming
         // (kind-runId-generationId-messageOrderIdx) so a subsequent streaming update
-        // sharing that identity merges in place instead of creating a duplicate bubble.
-        const mergeKey = getMergeKey(parsedMessage);
+        // sharing that identity merges in place instead of creating a duplicate bubble. Replay the
+        // reasoning turn epoch (BUG #8) in persisted order so reloaded multi-turn thinking renders
+        // as distinct blocks too, matching what live streaming computes.
+        const reasoningSeq = reasoningEpochFor(parsedMessage);
+        const mergeKey = getMergeKey(parsedMessage, reasoningSeq);
 
         // Create chat message
         const chatMessage: InternalChatMessage = {

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useMessageMerger.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useMessageMerger.ts
@@ -57,23 +57,29 @@ export function useMessageMerger() {
    * For update messages, returns the accumulated state.
    * For non-update messages, returns them directly.
    */
-  function processUpdate(message: Message): Message {
+  function processUpdate(message: Message, turnSeq = 0): Message {
     const genId = message.generationId || 'default';
+    // Accumulators are scoped per logical TURN, not just per generationId. A multi-turn run reuses
+    // one run-scoped generationId (#105/H1) with messageOrderIdx reset each turn, so keying by
+    // generationId alone made a later turn's text/reasoning deltas concatenate onto an earlier
+    // turn's (one giant block instead of one per turn). The caller (useChat) supplies a per-turn
+    // sequence so each turn accumulates independently.
+    const accKey = `${genId}::t${turnSeq}`;
 
     if (isTextUpdateMessage(message)) {
-      return processTextUpdate(genId, message);
+      return processTextUpdate(accKey, message);
     }
 
     if (isToolsCallUpdateMessage(message)) {
-      return processToolsCallUpdate(genId, message);
+      return processToolsCallUpdate(accKey, message);
     }
 
     if (isToolCallUpdateMessage(message)) {
-      return processToolCallUpdate(genId, message);
+      return processToolCallUpdate(accKey, message);
     }
 
     if (isReasoningUpdateMessage(message)) {
-      return processReasoningUpdate(genId, message);
+      return processReasoningUpdate(accKey, message);
     }
 
     // Tool call messages and tool call result messages pass through directly
@@ -89,8 +95,8 @@ export function useMessageMerger() {
   /**
    * Process a TextUpdateMessage and return accumulated TextMessage
    */
-  function processTextUpdate(genId: string, update: TextUpdateMessage): TextMessage {
-    let acc = accumulators.value.get(genId);
+  function processTextUpdate(accKey: string, update: TextUpdateMessage): TextMessage {
+    let acc = accumulators.value.get(accKey);
 
     if (!acc || acc.type !== 'text') {
       acc = {
@@ -100,7 +106,7 @@ export function useMessageMerger() {
         isThinking: update.isThinking,
         role: update.role,
       };
-      accumulators.value.set(genId, acc);
+      accumulators.value.set(accKey, acc);
     }
 
     // Concatenate text updates: each update is a delta chunk that should be appended
@@ -126,10 +132,10 @@ export function useMessageMerger() {
    * Process a ToolsCallUpdateMessage and return accumulated ToolsCallMessage
    */
   function processToolsCallUpdate(
-    genId: string,
+    accKey: string,
     update: ToolsCallUpdateMessage
   ): ToolsCallMessage {
-    let acc = accumulators.value.get(genId);
+    let acc = accumulators.value.get(accKey);
 
     if (!acc || acc.type !== 'tools_call') {
       acc = {
@@ -139,7 +145,7 @@ export function useMessageMerger() {
         toolCalls: [],
         currentToolCall: {},
       };
-      accumulators.value.set(genId, acc);
+      accumulators.value.set(accKey, acc);
     }
 
     // Process each tool call update (matching ToolsCallMessageBuilder logic)
@@ -200,11 +206,11 @@ export function useMessageMerger() {
    * Process a ToolCallUpdateMessage (individual tool call streaming) and return accumulated ToolCallMessage
    */
   function processToolCallUpdate(
-    genId: string,
+    accKey: string,
     update: ToolCallUpdateMessage
   ): ToolCallMessage {
     // Use tool_call_id as key to support multiple concurrent tool calls
-    const toolCallKey = `${genId}-${update.tool_call_id || 'tc'}`;
+    const toolCallKey = `${accKey}-${update.tool_call_id || 'tc'}`;
     let acc = accumulators.value.get(toolCallKey);
 
     if (!acc || acc.type !== 'tool_call') {
@@ -248,10 +254,10 @@ export function useMessageMerger() {
    * Process a ReasoningUpdateMessage and return accumulated ReasoningMessage
    */
   function processReasoningUpdate(
-    genId: string,
+    accKey: string,
     update: ReasoningUpdateMessage
   ): ReasoningMessage {
-    let acc = accumulators.value.get(genId);
+    let acc = accumulators.value.get(accKey);
 
     if (!acc || acc.type !== 'reasoning') {
       acc = {
@@ -261,7 +267,7 @@ export function useMessageMerger() {
         role: update.role,
         visibility: normalizeReasoningVisibility(update.visibility) ?? 'Plain',
       };
-      accumulators.value.set(genId, acc);
+      accumulators.value.set(accKey, acc);
     }
 
     // Accumulate reasoning text
@@ -282,11 +288,18 @@ export function useMessageMerger() {
   }
 
   /**
-   * Finalize and clear accumulator for a generation
+   * Finalize and clear accumulators for a generation. Accumulators are keyed per turn
+   * (`${genId}::t${turnSeq}` plus a `-${toolCallId}` suffix for individual tool calls), so clear
+   * every turn-scoped entry belonging to this generation, not just an exact key match.
    */
   function finalize(generationId?: string): void {
     const genId = generationId || 'default';
-    accumulators.value.delete(genId);
+    const prefix = `${genId}::`;
+    for (const key of [...accumulators.value.keys()]) {
+      if (key === genId || key.startsWith(prefix)) {
+        accumulators.value.delete(key);
+      }
+    }
   }
 
   /**

--- a/samples/LmStreaming.Sample/Controllers/ConversationsController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ConversationsController.cs
@@ -6,6 +6,7 @@ using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
 using LmStreaming.Sample.Agents;
 using LmStreaming.Sample.Models;
 using LmStreaming.Sample.Persistence;
+using LmStreaming.Sample.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LmStreaming.Sample.Controllers;
@@ -166,7 +167,38 @@ public class ConversationsController(
                 });
         }
 
-        _ = await agentPool.RecreateAgentWithModeAsync(threadId, mode);
+        // Switching into a sandbox-backed mode (e.g. Workspace Agent) eagerly creates the sandbox
+        // session. A gateway rejection or an unreachable gateway must answer a clean 503 — not crash
+        // the request with an unhandled 500 (which, in Development, also leaks a stack-trace page).
+        try
+        {
+            _ = await agentPool.RecreateAgentWithModeAsync(threadId, mode);
+        }
+        catch (SandboxSessionUnavailableException ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Mode switch to {ModeId} for thread {ThreadId} failed: sandbox unavailable (gateway status {StatusCode})",
+                request.ModeId,
+                threadId,
+                ex.StatusCode);
+            return StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                new { error = "sandbox_unavailable", code = "sandbox_unavailable", detail = ex.Message, threadId });
+        }
+        catch (ProviderUnavailableException ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Mode switch to {ModeId} for thread {ThreadId} failed: provider {ProviderId} unavailable",
+                request.ModeId,
+                threadId,
+                ex.ProviderId);
+            return StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                new { error = "provider_unavailable", code = "provider_unavailable", providerId = ex.ProviderId, detail = ex.Message, threadId });
+        }
+
         return Ok(new { modeId = mode.Id, modeName = mode.Name });
     }
 

--- a/samples/LmStreaming.Sample/Models/ChatMode.cs
+++ b/samples/LmStreaming.Sample/Models/ChatMode.cs
@@ -26,9 +26,18 @@ public record ChatMode
     public required string SystemPrompt { get; init; }
 
     /// <summary>
-    /// List of enabled tool names. If null, all tools are enabled.
+    /// List of enabled (function/MCP) tool names. If null, all tools are enabled.
     /// </summary>
     public IReadOnlyList<string>? EnabledTools { get; init; }
+
+    /// <summary>
+    /// List of enabled server-side built-in tool names (e.g. <c>web_search</c>). Kept separate from
+    /// <see cref="EnabledTools"/> so a mode can curate its function tools elsewhere (e.g. Workspace
+    /// Agent sets <c>EnabledTools = []</c> and resolves function tools via the sandbox MCP gateway)
+    /// while still declaring which server-side built-ins it wants. When null, built-in selection
+    /// falls back to <see cref="EnabledTools"/> for backward compatibility.
+    /// </summary>
+    public IReadOnlyList<string>? EnabledBuiltInTools { get; init; }
 
     /// <summary>
     /// Whether this mode is system-defined (read-only) or user-created.

--- a/samples/LmStreaming.Sample/Persistence/FileChatModeStore.cs
+++ b/samples/LmStreaming.Sample/Persistence/FileChatModeStore.cs
@@ -185,6 +185,7 @@ public sealed class FileChatModeStore : IChatModeStore
                 Description = sourceMode.Description,
                 SystemPrompt = sourceMode.SystemPrompt,
                 EnabledTools = sourceMode.EnabledTools,
+                EnabledBuiltInTools = sourceMode.EnabledBuiltInTools,
                 IsSystemDefined = false,
                 CreatedAt = now,
                 UpdatedAt = now,

--- a/samples/LmStreaming.Sample/Persistence/SystemChatModes.cs
+++ b/samples/LmStreaming.Sample/Persistence/SystemChatModes.cs
@@ -75,6 +75,7 @@ public static class SystemChatModes
             Description = m.Description,
             SystemPrompt = Require(m.SystemPrompt, "systemPrompt"),
             EnabledTools = m.EnabledTools,
+            EnabledBuiltInTools = m.EnabledBuiltInTools,
             IsSystemDefined = true,
             CreatedAt = now,
             UpdatedAt = now,
@@ -167,5 +168,7 @@ public static class SystemChatModes
         public string? SystemPrompt { get; init; }
 
         public List<string>? EnabledTools { get; init; }
+
+        public List<string>? EnabledBuiltInTools { get; init; }
     }
 }

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -663,7 +663,10 @@ try
                         loggerFactory,
                         // Expose sandbox tools under their natural names (bash, edit, …) rather than
                         // sandbox-bash; the gateway is the sole MCP server here, so no collisions.
-                        omitServerPrefix: true
+                        omitServerPrefix: true,
+                        // Collapse the "container has no sandbox user" Docker-exec failure class into a
+                        // single actionable message so the model stops retrying it (see SandboxToolHealth).
+                        handlerDecorator: SandboxToolHealth.Wrap
                     );
                     if (sandboxClients.Count > 0)
                     {
@@ -698,17 +701,17 @@ try
                 {
                     var modelId = GetModelIdForProvider(normalizedProviderId);
 
-                    // Filter built-in (server-side) tools based on mode's enabled tools.
-                    // Workspace Agent mode curates its FUNCTION tools via the sandbox MCP gateway and
-                    // so sets enabledTools: [] — but that empty allow-list would also strip server-side
-                    // built-ins like Anthropic web_search. A workspace agent benefits from web search,
-                    // so keep the built-ins unfiltered in workspace mode (this only affects the
-                    // Anthropic-format providers, since GetBuiltInToolsForProvider returns null for the
-                    // rest). Other modes still gate built-ins through their enabledTools list.
+                    // Built-in (server-side) tools are selected by the MODE — never injected per
+                    // provider or via a per-mode override. A mode declares its server-side built-ins in
+                    // EnabledBuiltInTools (e.g. Workspace Agent => ["web_search"], decoupled from its
+                    // empty function-tool allow-list); when that is null we fall back to EnabledTools for
+                    // backward compat (e.g. Research Assistant lists web_search there). A mode that
+                    // enables nothing gets no built-ins. This keeps tool availability mode-driven and
+                    // leaves each provider's core behavior unchanged — we never add a tool the active
+                    // mode didn't ask for.
                     var allBuiltInTools = GetBuiltInToolsForProvider(normalizedProviderId);
-                    var filteredBuiltInTools = isWorkspaceMode
-                        ? allBuiltInTools
-                        : ModeToolFilter.FilterBuiltInTools(allBuiltInTools, mode.EnabledTools);
+                    var modeBuiltInAllowList = mode.EnabledBuiltInTools ?? mode.EnabledTools;
+                    var filteredBuiltInTools = ModeToolFilter.FilterBuiltInTools(allBuiltInTools, modeBuiltInAllowList);
 
                     // Surface model reasoning (provider→Thinking/Reasoning mapping). Extracted to a
                     // testable helper so the per-provider wiring is regression-guarded; see
@@ -2032,7 +2035,8 @@ public partial class Program
         string endpoint,
         IReadOnlyDictionary<string, string> headers,
         ILoggerFactory loggerFactory,
-        bool omitServerPrefix = false
+        bool omitServerPrefix = false,
+        Func<ToolHandler, ToolHandler>? handlerDecorator = null
     )
     {
         var createdClients = new List<McpClient>();
@@ -2054,10 +2058,35 @@ public partial class Program
             createdClients.Add(client);
 
             var mcpClients = new Dictionary<string, McpClient> { [name] = client };
-            _ = registry
-                .AddMcpClientsAsync(mcpClients, name, omitServerPrefix: omitServerPrefix)
-                .GetAwaiter()
-                .GetResult();
+            if (handlerDecorator is null)
+            {
+                _ = registry
+                    .AddMcpClientsAsync(mcpClients, name, omitServerPrefix: omitServerPrefix)
+                    .GetAwaiter()
+                    .GetResult();
+            }
+            else
+            {
+                // Register the MCP tools into a scratch registry first so each tool handler can be
+                // wrapped (e.g. the sandbox container-health guard) before it reaches the agent. The
+                // wrapped tools are then exposed on the target registry as explicit functions; the
+                // scratch registry has no other provider for `name`, so there is nothing to conflict
+                // with. The McpClient stays owned by the caller (returned for disposal), so the
+                // wrapped handlers keep working.
+                var scratch = new FunctionRegistry();
+                _ = scratch
+                    .AddMcpClientsAsync(mcpClients, name, omitServerPrefix: omitServerPrefix)
+                    .GetAwaiter()
+                    .GetResult();
+                var (contracts, handlers) = scratch.Build();
+                foreach (var contract in contracts)
+                {
+                    if (handlers.TryGetValue(contract.Name, out var handler))
+                    {
+                        _ = registry.AddFunction(contract, handlerDecorator(handler), name);
+                    }
+                }
+            }
 
             logger.LogInformation("Connected to MCP server '{Name}' at {Endpoint}", name, endpoint);
         }

--- a/samples/LmStreaming.Sample/Prompts.yaml
+++ b/samples/LmStreaming.Sample/Prompts.yaml
@@ -75,4 +75,9 @@ chatModes:
       current directory or environment. Work step-by-step: explore the workspace before
       editing, always read before editing, verify the result, and summarize what you
       changed when done.
+    # Function tools are curated via the sandbox MCP gateway (so enabledTools is empty), but the
+    # workspace agent still benefits from server-side web search. Declared here (NOT in enabledTools)
+    # so built-in selection stays decoupled from the function-tool allow-list.
     enabledTools: []
+    enabledBuiltInTools:
+      - web_search

--- a/samples/LmStreaming.Sample/Services/SandboxGatewayOptions.cs
+++ b/samples/LmStreaming.Sample/Services/SandboxGatewayOptions.cs
@@ -12,9 +12,12 @@ public sealed class SandboxGatewayOptions
     public const string SectionName = "SandboxGateway";
 
     /// <summary>
-    /// Base URL of the gateway the app connects to.
+    /// Base URL of the gateway the app connects to. Uses the IPv4 loopback literal (not
+    /// <c>localhost</c>) on purpose: the gateway binds <c>BIND_ADDRESS=127.0.0.1</c> (IPv4 only),
+    /// while <c>localhost</c> resolves to <c>::1</c> first on Windows — the IPv6 connect then
+    /// black-holes and burns the full HttpClient timeout before falling back to IPv4.
     /// </summary>
-    public string BaseUrl { get; set; } = "http://localhost:3000";
+    public string BaseUrl { get; set; } = "http://127.0.0.1:3000";
 
     /// <summary>
     /// Workspace path relative to <see cref="WorkspaceBasePath"/>, mounted as the sandbox

--- a/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
@@ -370,8 +370,17 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
         var workspaceId = workspaceRef.Id;
 
         // Surface the clear, actionable gateway error here (not at app startup) — this is the
-        // first point at which Workspace Agent mode actually requires a healthy gateway.
-        await _gateway.EnsureReadyAsync(ct).ConfigureAwait(false);
+        // first point at which Workspace Agent mode actually requires a healthy gateway. Wrap the
+        // gateway-unreachable failure as SandboxSessionUnavailableException so the WebSocket layer
+        // surfaces a clean client error instead of crashing the connection with an unhandled 500.
+        try
+        {
+            await _gateway.EnsureReadyAsync(ct).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException ex) when (ex is not SandboxSessionUnavailableException)
+        {
+            throw new SandboxSessionUnavailableException(workspaceId, statusCode: null, ex.Message, ex);
+        }
 
         var (_, workspaceLeaf, workspaceFullPath) = _options.ResolveWorkspace(workspaceRef.DirectoryRelPath);
         var workspaceRelPath = workspaceLeaf ?? string.Empty;
@@ -429,9 +438,35 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
             );
         }
 
-        using var response = await _httpClient
-            .PostAsJsonAsync(requestUri, request, JsonOptions, ct)
-            .ConfigureAwait(false);
+        HttpResponseMessage response;
+        try
+        {
+            response = await _httpClient
+                .PostAsJsonAsync(requestUri, request, JsonOptions, ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException && !ct.IsCancellationRequested)
+        {
+            // The gateway became unreachable mid-request (down / restarting / connection refused).
+            // Surface it as the same clean, handled "sandbox unavailable" signal the WebSocket and
+            // mode-switch layers already catch — not a raw HttpRequestException that crashes the
+            // request with an unhandled 500.
+            _logger.LogWarning(
+                ex,
+                "Sandbox create could not reach the gateway at {GatewayBaseUrl} for workspace {WorkspaceId}",
+                _gateway.GatewayBaseUrl,
+                workspaceId
+            );
+            throw new SandboxSessionUnavailableException(
+                workspaceId,
+                statusCode: null,
+                $"Could not reach the sandbox gateway at {_gateway.GatewayBaseUrl} to create a session "
+                    + $"for workspace '{workspaceId}'.",
+                ex
+            );
+        }
+
+        using var responseScope = response;
 
         if (!response.IsSuccessStatusCode)
         {
@@ -442,7 +477,9 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
                 (int)response.StatusCode,
                 body
             );
-            throw new InvalidOperationException(
+            throw new SandboxSessionUnavailableException(
+                workspaceId,
+                (int)response.StatusCode,
                 $"Sandbox gateway returned {(int)response.StatusCode} creating a session for "
                     + $"workspace '{workspaceId}': {body}"
             );

--- a/samples/LmStreaming.Sample/Services/SandboxSessionUnavailableException.cs
+++ b/samples/LmStreaming.Sample/Services/SandboxSessionUnavailableException.cs
@@ -1,0 +1,32 @@
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+/// Thrown when a Workspace Agent sandbox session cannot be created — either the gateway returned a
+/// non-success status (e.g. a rejected network policy) or it could not be reached / started. Derives
+/// from <see cref="InvalidOperationException"/> so existing callers that catch the broader type keep
+/// working, while the WebSocket layer can catch this specific type to surface a clean, structured
+/// client error (the <c>error-banner</c>) instead of crashing the connection with an unhandled 500.
+/// </summary>
+public sealed class SandboxSessionUnavailableException : InvalidOperationException
+{
+    public SandboxSessionUnavailableException(
+        string workspaceId,
+        int? statusCode,
+        string message,
+        Exception? inner = null
+    )
+        : base(message, inner)
+    {
+        WorkspaceId = workspaceId;
+        StatusCode = statusCode;
+    }
+
+    /// <summary>The workspace whose sandbox session could not be created.</summary>
+    public string WorkspaceId { get; }
+
+    /// <summary>
+    /// The gateway HTTP status when the failure was a non-success response; <c>null</c> when the
+    /// gateway was unreachable or could not be started.
+    /// </summary>
+    public int? StatusCode { get; }
+}

--- a/samples/LmStreaming.Sample/Services/SandboxToolHealth.cs
+++ b/samples/LmStreaming.Sample/Services/SandboxToolHealth.cs
@@ -1,0 +1,99 @@
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+/// Classifies a sandbox MCP tool result as a "container unhealthy" infrastructure failure and
+/// rewrites it into a single, actionable message.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When the sandbox gateway runs on a Docker backend whose container has no <c>sandbox</c> user in
+/// <c>/etc/passwd</c>, the gateway's <c>docker exec -u sandbox …</c> fails for EVERY tool call with a
+/// Docker exec 400 — surfaced through the shared MCP middleware as
+/// <c>"Error executing MCP tool &lt;name&gt;: … no matching entries in passwd file"</c> (or
+/// <c>"Timed out waiting for 'sandbox' user in container …"</c>). This is an environment/container
+/// defect (owned by the gateway image, e.g. <c>SandboxedOstoolsMcpServer</c>), NOT something a retry
+/// can fix.
+/// </para>
+/// <para>
+/// Left untouched, the model treats each failure as a transient tool error and retries the same call
+/// hundreds of times, ballooning the conversation and burning tokens. <see cref="Wrap"/> intercepts
+/// the sandbox tool handlers (sample-local, only the middleware-provider path where the app executes
+/// the tool) and collapses this error class into one clear message that tells the model to stop and
+/// the user how to recover. It does not — and cannot — fix the root cause; that belongs in the gateway
+/// image / its container entrypoint (provision the <c>sandbox</c> user) or by running the gateway on
+/// the local (non-Docker) backend.
+/// </para>
+/// </remarks>
+internal static class SandboxToolHealth
+{
+    /// <summary>Error code stamped on the rewritten tool result (lets providers flag it as an error).</summary>
+    internal const string UnhealthyErrorCode = "sandbox_container_unhealthy";
+
+    /// <summary>
+    /// Single, actionable message substituted for the raw gateway exec error. Phrased to (a) stop the
+    /// model retrying and (b) tell the user exactly how to recover.
+    /// </summary>
+    internal const string UnhealthyMessage =
+        "The sandbox workspace is unavailable: the gateway's container is unhealthy — its 'sandbox' "
+        + "user account is missing (the container's /etc/passwd has no 'sandbox' entry), so no file or "
+        + "shell tools can run. This is an infrastructure failure that retrying will NOT fix. Stop "
+        + "calling sandbox tools and tell the user to restart the sandbox gateway/container (or run it "
+        + "on the local backend) to recover.";
+
+    /// <summary>
+    /// Signatures the gateway emits when the container lacks the <c>sandbox</c> user. Matched
+    /// case-insensitively against the tool result text. Kept narrow so only this specific
+    /// container-provisioning failure is rewritten — ordinary tool errors pass through untouched.
+    /// </summary>
+    private static readonly string[] UnhealthySignatures =
+    [
+        "no matching entries in passwd file",
+        "waiting for 'sandbox' user",
+        "unable to find user sandbox",
+    ];
+
+    /// <summary>
+    /// True when <paramref name="toolResultText"/> carries one of the known
+    /// "container has no sandbox user" gateway signatures.
+    /// </summary>
+    internal static bool IsContainerUnhealthy(string? toolResultText)
+    {
+        if (string.IsNullOrEmpty(toolResultText))
+        {
+            return false;
+        }
+
+        foreach (var signature in UnhealthySignatures)
+        {
+            if (toolResultText.Contains(signature, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Decorates a sandbox tool handler so that a result matching the "container unhealthy" signature
+    /// is replaced with the single actionable <see cref="UnhealthyMessage"/> (flagged as an error).
+    /// Healthy results — and deferrals — pass through unchanged.
+    /// </summary>
+    internal static ToolHandler Wrap(ToolHandler inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+
+        return async (argsJson, context, cancellationToken) =>
+        {
+            var result = await inner(argsJson, context, cancellationToken).ConfigureAwait(false);
+
+            return result is ToolHandlerResult.Resolved resolved
+                && IsContainerUnhealthy(resolved.Payload.Text)
+                ? ToolHandlerResult.FromError(UnhealthyMessage, UnhealthyErrorCode)
+                : result;
+        };
+    }
+}

--- a/samples/LmStreaming.Sample/WebSocket/ChatWebSocketManager.cs
+++ b/samples/LmStreaming.Sample/WebSocket/ChatWebSocketManager.cs
@@ -131,6 +131,21 @@ public sealed class ChatWebSocketManager
                 await SendProviderUnavailableErrorAsync(connection, ex, recordWriter, cancellationToken);
                 return;
             }
+            catch (SandboxSessionUnavailableException ex)
+            {
+                // Workspace Agent mode creates the sandbox session during agent setup; a gateway
+                // rejection (e.g. an invalid network policy) or an unreachable gateway must surface
+                // as a structured client error, not crash the connection with an unhandled 500.
+                _logger.LogWarning(
+                    ex,
+                    "Sandbox unavailable for thread {ThreadId} (workspace {WorkspaceId}, gateway status {StatusCode})",
+                    threadId,
+                    workspaceId,
+                    ex.StatusCode);
+
+                await SendSandboxUnavailableErrorAsync(connection, ex, recordWriter, cancellationToken);
+                return;
+            }
 
             // Create linked cancellation for connection lifetime
             using var connectionCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -379,6 +394,45 @@ public sealed class ChatWebSocketManager
         await connection.TryCloseAsync(
             WebSocketCloseStatus.NormalClosure,
             "Provider unavailable",
+            CancellationToken.None);
+    }
+
+    private async Task SendSandboxUnavailableErrorAsync(
+        RegisteredWebSocketConnection connection,
+        SandboxSessionUnavailableException ex,
+        StreamWriter? recordWriter,
+        CancellationToken ct)
+    {
+        var summary = ex.StatusCode is { } status
+            ? $"Workspace Agent is unavailable: the sandbox gateway rejected the session (HTTP {status})."
+            : "Workspace Agent is unavailable: the sandbox gateway could not be reached.";
+
+        var payload = new Dictionary<string, object?>
+        {
+            ["$type"] = "error",
+            ["code"] = "sandbox_unavailable",
+            ["statusCode"] = ex.StatusCode,
+            // Keep the gateway's own message in the client error — this is a developer sample and the
+            // detail (e.g. which network-policy rule was rejected) is exactly what's needed to act.
+            ["message"] = $"{summary} {ex.Message}",
+        };
+        var json = JsonSerializer.Serialize(payload, _jsonOptions);
+
+        if (!await connection.TrySendTextAsync(json, ct))
+        {
+            return;
+        }
+
+        if (recordWriter != null)
+        {
+            await recordWriter.WriteLineAsync(json);
+            await recordWriter.FlushAsync();
+        }
+
+        // Close through the wrapper so the single-write-path contract holds (closing is outbound).
+        await connection.TryCloseAsync(
+            WebSocketCloseStatus.NormalClosure,
+            "Sandbox unavailable",
             CancellationToken.None);
     }
 }

--- a/samples/LmStreaming.Sample/appsettings.Development.json
+++ b/samples/LmStreaming.Sample/appsettings.Development.json
@@ -15,7 +15,7 @@
     "ExamType": "NeetPG"
   },
   "SandboxGateway": {
-    "BaseUrl": "http://localhost:3000",
+    "BaseUrl": "http://127.0.0.1:3000",
     "Workspace": "demo",
     "WorkspaceBasePath": "B:\\sandbox-workspaces",
     "_WorkspacePath_comment": "Optional: set to ANY absolute folder to use it as the sandbox workspace (auto-created if missing). When non-empty it overrides WorkspaceBasePath+Workspace. Only applied when the app SPAWNS the gateway (stop any gateway already on :3000 first). Example: B:\\\\sources\\\\my-repo",

--- a/samples/LmStreaming.Sample/appsettings.json
+++ b/samples/LmStreaming.Sample/appsettings.json
@@ -34,7 +34,7 @@
     ]
   },
   "SandboxGateway": {
-    "BaseUrl": "http://localhost:3000",
+    "BaseUrl": "http://127.0.0.1:3000",
     "AutoSpawn": true
   },
   "Auth": {

--- a/src/AnthropicProvider/Models/AnthropicRequest.cs
+++ b/src/AnthropicProvider/Models/AnthropicRequest.cs
@@ -719,9 +719,46 @@ public record AnthropicRequest
         foreach (var msg in merged)
         {
             MergeAdjacentThinkingBlocks(msg.Content);
+            OrderAssistantToolUseLast(msg);
         }
 
         return merged;
+    }
+
+    /// <summary>
+    /// Anthropic requires tool_use blocks to be the trailing content of an assistant turn: any
+    /// text/thinking block appearing AFTER a tool_use makes the API reject the whole turn with
+    /// "tool_use ids were found without tool_result blocks immediately after". History reconstruction
+    /// can interleave demoted-thinking / trailing text after the tool calls (the streaming + merge
+    /// order is not the wire order Anthropic mandates), so stably reorder each assistant turn that has
+    /// tool calls into thinking → text → tool_use.
+    /// </summary>
+    private static void OrderAssistantToolUseLast(AnthropicMessage message)
+    {
+        if (message.Role != "assistant")
+        {
+            return;
+        }
+
+        var content = message.Content;
+        if (!content.Any(b => b.Type is "tool_use" or "server_tool_use"))
+        {
+            return;
+        }
+
+        static int Rank(AnthropicContent block) => block.Type switch
+        {
+            "thinking" => 0,
+            "tool_use" or "server_tool_use" => 2,
+            _ => 1,
+        };
+
+        // OrderBy performs a stable sort, so the relative order within each group is preserved — in
+        // particular the tool_use blocks keep their order, which Anthropic pairs to tool_result blocks
+        // by id (not position) in the next message.
+        var ordered = content.OrderBy(Rank).ToList();
+        content.Clear();
+        content.AddRange(ordered);
     }
 
     /// <summary>
@@ -753,20 +790,31 @@ public record AnthropicRequest
             }
         }
 
-        // Any thinking block still lacking a signature after merging cannot be replayed: Anthropic
-        // (and compatible backends like Kimi, which emit thinking text but no signature) reject a
-        // signatureless thinking block in multi-turn history with 400 "invalid_request_error".
-        // Demote those to plain text so the reasoning context is kept without breaking the request;
-        // drop empty ones outright.
+        // A valid thinking block needs BOTH thinking text and a signature. Any block that isn't a
+        // complete pair after merging cannot be replayed — Anthropic (and compatible backends like
+        // Kimi) reject it in multi-turn history with 400 "invalid_request_error" /
+        // "thinking.thinking: Field required". Normalise the leftovers:
+        //   - text but no signature  → demote to plain text (keeps the reasoning context).
+        //   - no text (signature-only orphan, or fully empty) → drop. This happens when the
+        //     text/signature halves get separated (e.g. a tool_use block lands between them, so the
+        //     adjacent-merge above can't combine them), leaving a stranded signature with no thinking
+        //     text — an empty `thinking` field the backend requires to be present and non-empty.
         for (var i = content.Count - 1; i >= 0; i--)
         {
             var block = content[i];
-            if (block.Type != "thinking" || !string.IsNullOrEmpty(block.ThinkingSignature))
+            if (block.Type != "thinking")
             {
                 continue;
             }
 
-            if (!string.IsNullOrEmpty(block.Thinking))
+            var hasText = !string.IsNullOrEmpty(block.Thinking);
+            var hasSignature = !string.IsNullOrEmpty(block.ThinkingSignature);
+            if (hasText && hasSignature)
+            {
+                continue; // complete, valid thinking block — keep as-is
+            }
+
+            if (hasText)
             {
                 content[i] = new AnthropicContent { Type = "text", Text = block.Thinking };
             }

--- a/src/LmCore/Middleware/MessageUpdateJoinerMiddleware.cs
+++ b/src/LmCore/Middleware/MessageUpdateJoinerMiddleware.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Utils;
@@ -82,6 +83,12 @@ public class MessageUpdateJoinerMiddleware : IStreamingMiddleware
         // Track the number of completed tool calls for ToolCallIdx assignment
         var completedToolCallCount = 0;
 
+        // Ids of query-less server (provider-executed) tool calls — e.g. a web_search the model
+        // emitted with empty {} input — that the joiner skipped building. Their now-orphaned empty
+        // results (which arrive as standalone messages) are dropped too, so neither half is persisted
+        // or replayed (the "empty web_search loop").
+        var skippedServerToolCallIds = new HashSet<string>(StringComparer.Ordinal);
+
         // Use the usage accumulator to track usage data
         var usageAccumulator = new UsageAccumulator();
 
@@ -144,10 +151,13 @@ public class MessageUpdateJoinerMiddleware : IStreamingMiddleware
                     }
 
                     // Complete the previous builder before processing the new message
-                    var builtMessage = activeBuilder.Build();
+                    var builtMessage = BuildJoinedOrSkip(activeBuilder, skippedServerToolCallIds, logger);
                     activeBuilder = null;
                     activeBuilderType = null;
-                    yield return builtMessage;
+                    if (builtMessage != null)
+                    {
+                        yield return builtMessage;
+                    }
                 }
             }
 
@@ -167,10 +177,13 @@ public class MessageUpdateJoinerMiddleware : IStreamingMiddleware
                 {
                     // Complete the previous tool call before starting the new one
                     completedToolCallCount++;
-                    var builtMessage = activeBuilder.Build();
+                    var builtMessage = BuildJoinedOrSkip(activeBuilder, skippedServerToolCallIds, logger);
                     activeBuilder = null;
                     activeBuilderType = null;
-                    yield return builtMessage;
+                    if (builtMessage != null)
+                    {
+                        yield return builtMessage;
+                    }
                 }
             }
 
@@ -198,6 +211,17 @@ public class MessageUpdateJoinerMiddleware : IStreamingMiddleware
 
             if (!isBeingAccumulated)
             {
+                // Drop the empty server-tool RESULT whose query-less call the joiner just skipped.
+                // Without its matching call it is an orphan tool_result the provider rejects on replay,
+                // and keeping it would defeat the point of not recording the empty search at all.
+                if (processedMessage is ToolCallResultMessage serverResult
+                    && serverResult.ExecutionTarget == ExecutionTarget.ProviderServer
+                    && !string.IsNullOrEmpty(serverResult.ToolCallId)
+                    && skippedServerToolCallIds.Contains(serverResult.ToolCallId))
+                {
+                    continue;
+                }
+
                 yield return processedMessage;
             }
         }
@@ -205,7 +229,11 @@ public class MessageUpdateJoinerMiddleware : IStreamingMiddleware
         // Process final built message at the end of the stream
         if (activeBuilder != null)
         {
-            yield return activeBuilder.Build();
+            var builtMessage = BuildJoinedOrSkip(activeBuilder, skippedServerToolCallIds, logger);
+            if (builtMessage != null)
+            {
+                yield return builtMessage;
+            }
         }
 
         // Emit accumulated usage message at the end if we have one
@@ -249,6 +277,78 @@ public class MessageUpdateJoinerMiddleware : IStreamingMiddleware
         return message is ReasoningUpdateMessage reasoningUpdate
             ? ProcessReasoningUpdate(reasoningUpdate, ref activeBuilder, ref activeBuilderType)
             : message;
+    }
+
+    /// <summary>
+    ///     Builds the active builder's message, but returns <c>null</c> (skipping it) when the result
+    ///     is a query-less server (provider-executed) tool call — e.g. a web_search the model emitted
+    ///     with empty <c>{}</c> input. The provider answers such a call with empty results, and
+    ///     recording/replaying the degenerate call teaches the model to repeat it every turn until
+    ///     "Max turns reached" (the "empty web_search loop"). Not creating the message keeps the empty
+    ///     search out of joined history (and therefore out of the next request) entirely. The skipped
+    ///     call id is recorded so its orphaned empty result can be dropped too. Real, query-bearing
+    ///     searches build normally.
+    /// </summary>
+    private static IMessage? BuildJoinedOrSkip(
+        IMessageBuilder builder,
+        HashSet<string> skippedServerToolCallIds,
+        ILogger logger
+    )
+    {
+        var built = builder.Build();
+        if (built is ToolCallMessage toolCall && IsQuerylessServerToolCall(toolCall))
+        {
+            if (!string.IsNullOrEmpty(toolCall.ToolCallId))
+            {
+                _ = skippedServerToolCallIds.Add(toolCall.ToolCallId);
+            }
+
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug(
+                    "Joiner skipped query-less server tool call {FunctionName} (id {ToolCallId}); not creating a history message for an empty server-tool call",
+                    toolCall.FunctionName,
+                    toolCall.ToolCallId
+                );
+            }
+
+            return null;
+        }
+
+        return built;
+    }
+
+    /// <summary>
+    ///     True for a provider-executed (server-side) tool call whose arguments are empty — null,
+    ///     blank, or an empty object (<c>{}</c>). Mirrors the request-side guard
+    ///     (<c>AnthropicRequest.IsQuerylessServerToolUse</c>) but at the joiner, so the empty call is
+    ///     never recorded in the first place. Conservative: any arguments object with at least one
+    ///     property (a real query) is left intact, and unparseable arguments are kept rather than risk
+    ///     dropping signal.
+    /// </summary>
+    private static bool IsQuerylessServerToolCall(ToolCallMessage toolCall)
+    {
+        if (toolCall.ExecutionTarget != ExecutionTarget.ProviderServer)
+        {
+            return false;
+        }
+
+        var args = toolCall.FunctionArgs;
+        if (string.IsNullOrWhiteSpace(args))
+        {
+            return true;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(args);
+            return doc.RootElement.ValueKind == JsonValueKind.Object
+                && !doc.RootElement.EnumerateObject().MoveNext();
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 
     private static IMessage ProcessToolCallUpdate(

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -342,26 +342,44 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
             }
 
             turnCount++;
-            Logger.LogDebug("Executing turn {Turn} of run {RunId}", turnCount, runId);
 
-            var hasToolCalls = await ExecuteTurnAsync(runId, generationId, turnCount, ct);
+            // Per-turn generationId. The client merge key is kind-runId-generationId-messageOrderIdx
+            // and messageOrderIdx RESETS every turn (a fresh OrderingState per streaming invocation),
+            // so a single run-scoped generationId makes turn N and turn N+1 collide — later turns'
+            // reasoning/text (which carry no per-instance id, unlike tool calls' tool_call_id)
+            // collapse onto the first block. Give each turn its own generationId so turns stay
+            // distinct, while every message WITHIN a turn still shares one id (the #105/H1
+            // requirement that a turn's tool_call + tool_call_result group together). Turn 1 reuses
+            // the run's generationId so run_assignment's advertised id matches the first turn and
+            // single-turn runs are unchanged; turns 2+ get a fresh id. Pillbox grouping is
+            // arrival-order based on the client (not generationId), so this never changes grouping.
+            var turnGenerationId = turnCount == 1 ? generationId : Guid.NewGuid().ToString("N");
+
+            Logger.LogDebug(
+                "Executing turn {Turn} of run {RunId} (generation {GenerationId})",
+                turnCount,
+                runId,
+                turnGenerationId);
+
+            var hasToolCalls = await ExecuteTurnAsync(runId, turnGenerationId, turnCount, ct);
 
             // If any tool call from this generation deferred and is still unresolved, end
             // the run cleanly. Resolution of the last deferred entry will auto-trigger a
-            // new run via the resume sentinel.
-            if (HasUnresolvedDeferralsForGeneration(generationId))
+            // new run via the resume sentinel. Keyed on the per-turn generationId — the turn's
+            // tool calls are tagged with it, so this stays internally consistent.
+            if (HasUnresolvedDeferralsForGeneration(turnGenerationId))
             {
                 lock (_resumeLock)
                 {
                     _lastDeferringRunId = runId;
-                    _lastDeferringGenerationId = generationId;
+                    _lastDeferringGenerationId = turnGenerationId;
                     _resumeScheduled = false;
                 }
 
                 Logger.LogInformation(
                     "Run {RunId} pausing on {Count} deferred tool call(s); awaiting external resolution",
                     runId,
-                    _deferred.Values.Count(d => d.GenerationId == generationId));
+                    _deferred.Values.Count(d => d.GenerationId == turnGenerationId));
                 break;
             }
 

--- a/tests/AnthropicProvider.Tests/Models/ThinkingWithToolCallSerializationTests.cs
+++ b/tests/AnthropicProvider.Tests/Models/ThinkingWithToolCallSerializationTests.cs
@@ -319,4 +319,130 @@ public class ThinkingWithToolCallSerializationTests
         Assert.DoesNotContain("\"thinking\":", sigOnlyJson);
         Assert.Contains("\"signature\":\"sig-blob\"", sigOnlyJson);
     }
+
+    /// <summary>
+    ///     Regression: a signature-only ("Encrypted") reasoning block with NO adjacent thinking-text
+    ///     block to merge with must be DROPPED — never emitted as a <c>thinking</c> block with an empty
+    ///     <c>thinking</c> field. This happens whenever the thinking-text and signature halves get
+    ///     separated (e.g. a tool_use block lands between them, so the adjacent-merge can't combine
+    ///     them), or when only the signature survived in history. Anthropic/Copilot reject the stranded
+    ///     block with <c>400 "messages.N.content.M.thinking.thinking: Field required"</c>. The previous
+    ///     cleanup only demoted/dropped <em>signatureless</em> blocks, leaving this orphan stranded.
+    /// </summary>
+    [Fact]
+    public void FromMessages_DropsOrphanedSignatureOnlyThinkingBlock()
+    {
+        var messages = new IMessage[]
+        {
+            new TextMessage { Role = Role.User, Text = "Hi" },
+            // Signature-only reasoning, immediately followed by a non-thinking block: nothing to merge with.
+            new ReasoningMessage
+            {
+                Reasoning = "sig-encrypted-blob",
+                Visibility = ReasoningVisibility.Encrypted,
+                Role = Role.Assistant,
+            },
+            new TextMessage { Role = Role.Assistant, Text = "Answer." },
+        };
+
+        var request = AnthropicRequest.FromMessages(messages);
+
+        // No thinking block with an empty 'thinking' field may survive — that's exactly what the
+        // backend rejects with "thinking.thinking: Field required".
+        var allContent = request.Messages.SelectMany(m => m.Content).ToList();
+        Assert.DoesNotContain(allContent, c => c.Type == "thinking" && string.IsNullOrEmpty(c.Thinking));
+    }
+
+    /// <summary>
+    ///     Regression mirroring the real Workspace-Agent failure: an assistant turn whose thinking
+    ///     text and signature get split by tool_use blocks. The plain-text half is demoted to text and
+    ///     the signature-only half must be dropped, so no empty <c>thinking</c> block reaches the wire.
+    /// </summary>
+    [Fact]
+    public void FromMessages_ThinkingSplitByToolUse_DropsEmptyThinkingBlock()
+    {
+        var toolCall = new ToolCall
+        {
+            FunctionName = "Skill",
+            FunctionArgs = "{}",
+            ToolCallId = "toolu_skill_1",
+            ToolCallIdx = 0,
+        };
+        var aggregate = new ToolsCallAggregateMessage(
+            new ToolsCallMessage { ToolCalls = [toolCall], GenerationId = "gen1" },
+            new ToolsCallResultMessage
+            {
+                ToolCallResults = [new ToolCallResult("toolu_skill_1", "ok")],
+                GenerationId = "gen1",
+            },
+            "assistant"
+        );
+
+        var messages = new IMessage[]
+        {
+            new TextMessage { Role = Role.User, Text = "Set up the repos." },
+            new TextMessage { Role = Role.Assistant, Text = "I'll help with that." },
+            aggregate, // tool_use lands between the assistant text and the trailing signature block
+            new ReasoningMessage
+            {
+                Reasoning = "sig-encrypted-blob",
+                Visibility = ReasoningVisibility.Encrypted,
+                Role = Role.Assistant,
+            },
+            new TextMessage { Role = Role.Assistant, Text = "Done." },
+        };
+
+        var request = AnthropicRequest.FromMessages(messages);
+
+        var allContent = request.Messages.SelectMany(m => m.Content).ToList();
+        Assert.DoesNotContain(allContent, c => c.Type == "thinking" && string.IsNullOrEmpty(c.Thinking));
+    }
+
+    /// <summary>
+    ///     Regression: an assistant turn whose history interleaves text/thinking AFTER its tool_use
+    ///     blocks must be reordered so the tool_use blocks are LAST. Anthropic rejects a turn with a
+    ///     text block after a tool_use with 400 "tool_use ids were found without tool_result blocks
+    ///     immediately after" — even when the matching tool_result blocks ARE present in the next
+    ///     message. Streaming/merge order can place demoted-thinking or trailing text after the calls.
+    /// </summary>
+    [Fact]
+    public void FromMessages_OrdersToolUseLast_WhenTextFollowsToolUseInSameTurn()
+    {
+        // CompositeMessage flattens these into ONE assistant message: text, tool_use, text.
+        var composite = new CompositeMessage
+        {
+            Messages =
+            [
+                new TextMessage { Role = Role.Assistant, Text = "The user wants to set up two repos." },
+                new ToolCallMessage
+                {
+                    FunctionName = "Skill",
+                    FunctionArgs = "{}",
+                    ToolCallId = "toolu_skill_1",
+                    ToolCallIdx = 0,
+                },
+                new TextMessage { Role = Role.Assistant, Text = "I'll help you set up those repos." },
+            ],
+            Role = Role.Assistant,
+            GenerationId = "gen1",
+        };
+
+        var messages = new IMessage[]
+        {
+            new TextMessage { Role = Role.User, Text = "Set up the repos." },
+            composite,
+        };
+
+        var request = AnthropicRequest.FromMessages(messages);
+
+        var assistant = request.Messages.First(m =>
+            m.Role == "assistant" && m.Content.Any(c => c.Type is "tool_use" or "server_tool_use"));
+
+        // No text/thinking block may appear after any tool_use block (Anthropic requires tool_use last).
+        var firstToolIdx = assistant.Content.FindIndex(c => c.Type is "tool_use" or "server_tool_use");
+        var lastNonToolIdx = assistant.Content.FindLastIndex(c => c.Type is not ("tool_use" or "server_tool_use"));
+        Assert.True(
+            firstToolIdx > lastNonToolIdx,
+            $"tool_use must come after all text/thinking blocks; got: [{string.Join(", ", assistant.Content.Select(c => c.Type))}]");
+    }
 }

--- a/tests/LmCore.Tests/Middleware/MessageUpdateJoinerMiddlewareTests.cs
+++ b/tests/LmCore.Tests/Middleware/MessageUpdateJoinerMiddlewareTests.cs
@@ -428,7 +428,128 @@ public class MessageUpdateJoinerMiddlewareTests
         Assert.Contains(textMessages, t => ((ICanGetText)t).GetText() == "gen2 complete");
     }
 
+    [Fact]
+    public async Task InvokeStreamingAsync_SkipsEmptyServerToolCall_AndItsEmptyResult()
+    {
+        // The "empty web_search loop": a provider/model emits a web_search server_tool_use with empty
+        // {} input. The Anthropic parser streams it as ToolCallUpdateMessage(s) for the joiner to build
+        // into a single ToolCallMessage (see AnthropicStreamParser.FinalizeServerToolUseBlock). The
+        // joiner must NOT create that message for an empty server-tool call, and must drop its orphaned
+        // empty result — so neither half is persisted or replayed.
+        var stream = new List<IMessage>
+        {
+            // content_block_start: server_tool_use web_search, no input yet.
+            new ToolCallUpdateMessage
+            {
+                ToolCallId = "srvtoolu_1",
+                Index = 0,
+                FunctionName = "web_search",
+                FunctionArgs = null,
+                ExecutionTarget = ExecutionTarget.ProviderServer,
+                Role = Role.Assistant,
+            },
+            // content_block_stop: finalized with empty {} input.
+            new ToolCallUpdateMessage
+            {
+                ToolCallId = "srvtoolu_1",
+                Index = 0,
+                FunctionName = "web_search",
+                FunctionArgs = "{}",
+                ExecutionTarget = ExecutionTarget.ProviderServer,
+                Role = Role.Assistant,
+            },
+            // The empty server-tool result paired with the (skipped) call.
+            new ToolCallResultMessage
+            {
+                ToolCallId = "srvtoolu_1",
+                ToolName = "web_search",
+                Result = "[]",
+                ExecutionTarget = ExecutionTarget.ProviderServer,
+                Role = Role.Assistant,
+            },
+            // The model's actual answer.
+            new TextMessage { Text = "Here is the answer.", Role = Role.Assistant, GenerationId = "g1" },
+        };
+
+        var results = await RunThroughJoinerAsync(stream);
+
+        Assert.DoesNotContain(results, m => m is ToolCallMessage);
+        Assert.DoesNotContain(results, m => m is ToolCallResultMessage);
+        Assert.Contains(results, m => m is TextMessage t && t.Text == "Here is the answer.");
+    }
+
+    [Fact]
+    public async Task InvokeStreamingAsync_KeepsRealQueryBearingServerToolCall_AndResult()
+    {
+        // A genuine, query-bearing web_search must build normally — call and result both survive.
+        var stream = new List<IMessage>
+        {
+            new ToolCallUpdateMessage
+            {
+                ToolCallId = "srvtoolu_2",
+                Index = 0,
+                FunctionName = "web_search",
+                FunctionArgs = null,
+                ExecutionTarget = ExecutionTarget.ProviderServer,
+                Role = Role.Assistant,
+            },
+            new ToolCallUpdateMessage
+            {
+                ToolCallId = "srvtoolu_2",
+                Index = 0,
+                FunctionName = "web_search",
+                FunctionArgs = """{"query":"latest news"}""",
+                ExecutionTarget = ExecutionTarget.ProviderServer,
+                Role = Role.Assistant,
+            },
+            new ToolCallResultMessage
+            {
+                ToolCallId = "srvtoolu_2",
+                ToolName = "web_search",
+                Result = """[{"type":"web_search_result","url":"https://example.com","title":"News"}]""",
+                ExecutionTarget = ExecutionTarget.ProviderServer,
+                Role = Role.Assistant,
+            },
+            new TextMessage { Text = "Based on the search...", Role = Role.Assistant, GenerationId = "g2" },
+        };
+
+        var results = await RunThroughJoinerAsync(stream);
+
+        var call = Assert.Single(results.OfType<ToolCallMessage>());
+        Assert.Equal("web_search", call.FunctionName);
+        Assert.Equal("srvtoolu_2", call.ToolCallId);
+        _ = Assert.Single(results.OfType<ToolCallResultMessage>());
+        Assert.Contains(results, m => m is TextMessage t && t.Text == "Based on the search...");
+    }
+
     #region Helper Methods
+
+    // Run a scripted provider stream through the joiner middleware and collect the joined output.
+    private static async Task<List<IMessage>> RunThroughJoinerAsync(IEnumerable<IMessage> stream)
+    {
+        var middleware = new MessageUpdateJoinerMiddleware();
+        var mockStreamingAgent = new Mock<IStreamingAgent>();
+        _ = mockStreamingAgent
+            .Setup(a =>
+                a.GenerateReplyStreamingAsync(
+                    It.IsAny<IEnumerable<IMessage>>(),
+                    It.IsAny<GenerateReplyOptions>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(stream.ToAsyncEnumerable());
+
+        var context = new MiddlewareContext([], new GenerateReplyOptions());
+        var resultStream = await middleware.InvokeStreamingAsync(context, mockStreamingAgent.Object, CancellationToken.None);
+
+        var results = new List<IMessage>();
+        await foreach (var message in resultStream)
+        {
+            results.Add(message);
+        }
+
+        return results;
+    }
 
     // Helper method to split string on spaces while including spaces in the parts
     private static List<string> SplitStringPreservingSpaces(string input)

--- a/tests/LmMultiTurn.Tests/MultiTurnAgentLoopTests.cs
+++ b/tests/LmMultiTurn.Tests/MultiTurnAgentLoopTests.cs
@@ -262,6 +262,92 @@ public class MultiTurnAgentLoopTests
         await cts.CancelAsync();
     }
 
+    // Multi-turn message identity: each agentic TURN within a run must advertise a DISTINCT
+    // generationId via options.GenerationId. The client merge key is
+    // kind-runId-generationId-messageOrderIdx and messageOrderIdx resets every turn (a fresh
+    // OrderingState per streaming invocation), so a run-scoped generationId makes turn N and turn N+1
+    // collide — later turns' reasoning/text collapse onto the first block (#105/H1 over-corrected
+    // from per-message to per-run; per-turn is the correct middle). A per-turn generationId stays
+    // consistent WITHIN a turn (so a turn's tool_call + tool_call_result still share an id — the
+    // #105 grouping requirement) while keeping turns distinct.
+    [Fact]
+    public async Task ExecuteRunAsync_MultiTurn_AssignsDistinctGenerationIdPerTurn()
+    {
+        // Arrange: turn 1 emits a tool call (forces a 2nd turn); turn 2 emits final text.
+        var toolCallMessage = new ToolCallMessage
+        {
+            FunctionName = "get_weather",
+            FunctionArgs = "{\"location\": \"Seattle\"}",
+            ToolCallId = "call_123",
+            Role = Role.Assistant,
+        };
+        var finalMessage = new TextMessage { Text = "Done!", Role = Role.Assistant };
+
+        var capturedGenerationIds = new List<string?>();
+        var callCount = 0;
+        _mockAgent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>((_, options, _) =>
+            {
+                capturedGenerationIds.Add(options.GenerationId);
+                callCount++;
+                return Task.FromResult(
+                    callCount == 1
+                        ? ToAsyncEnumerable([toolCallMessage])
+                        : ToAsyncEnumerable([finalMessage]));
+            });
+
+        var registry = new FunctionRegistry();
+        var weatherContract = new FunctionContract
+        {
+            Name = "get_weather",
+            Description = "Get weather for a location",
+            Parameters =
+            [
+                new FunctionParameterContract
+                {
+                    Name = "location",
+                    Description = "The location to get weather for",
+                    ParameterType = new JsonSchemaObject { Type = JsonSchemaTypeHelper.ToType("string") },
+                    IsRequired = true,
+                },
+            ],
+        };
+        registry.AddFunction(weatherContract, (_, _, _) =>
+            Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText("{\"temperature\": \"72F\"}")));
+
+        await using var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            registry,
+            "test-thread",
+            logger: _loggerMock.Object);
+
+        using var cts = new CancellationTokenSource();
+        var runTask = loop.RunAsync(cts.Token);
+
+        var userInput = new UserInput(
+            [new TextMessage { Text = "What's the weather in Seattle?", Role = Role.User }]);
+
+        var messages = new List<IMessage>();
+        await foreach (var msg in loop.ExecuteRunAsync(userInput, cts.Token))
+        {
+            messages.Add(msg);
+        }
+
+        // Assert — two turns ran, each advertised a non-empty generationId, and they DIFFER.
+        capturedGenerationIds.Should().HaveCount(2, "the tool call should force a second turn");
+        capturedGenerationIds.Should().OnlyContain(g => !string.IsNullOrEmpty(g),
+            "every turn must advertise a run generationId so WithIds can stamp it onto messages");
+        capturedGenerationIds[0].Should().NotBe(capturedGenerationIds[1],
+            "each agentic turn must advertise a DISTINCT generationId so the client merge key "
+            + "(kind-runId-generationId-messageOrderIdx) stays unique across turns when messageOrderIdx resets");
+
+        await cts.CancelAsync();
+    }
+
     [Fact]
     public async Task ExecuteRunAsync_WithProviderServerToolCall_DoesNotExecuteLocalToolHandler()
     {

--- a/tests/LmStreaming.Sample.Tests/ModeToolFilterTests.cs
+++ b/tests/LmStreaming.Sample.Tests/ModeToolFilterTests.cs
@@ -1,0 +1,87 @@
+using AchieveAi.LmDotnetTools.AnthropicProvider.Models;
+using LmStreaming.Sample.Persistence;
+using LmStreaming.Sample.Services;
+
+namespace LmStreaming.Sample.Tests;
+
+/// <summary>
+///     Regression coverage for mode-driven selection of server-side built-in tools (e.g. Anthropic
+///     <c>web_search</c>). Built-ins must follow the active mode's <c>enabledTools</c> exactly like
+///     function tools — we never inject a built-in the mode didn't ask for. This guards the removal of
+///     the old <c>isWorkspaceMode ? allBuiltInTools : Filter(...)</c> override in <c>Program.cs</c>,
+///     which force-kept <c>web_search</c> even when a mode (Workspace Agent) declared
+///     <c>enabledTools: []</c> — surfacing as a <c>web_search</c> tool prepended ahead of every real
+///     tool in the request.
+/// </summary>
+public sealed class ModeToolFilterTests
+{
+    private static List<object> WebSearchBuiltIns() => [new AnthropicWebSearchTool()];
+
+    [Fact]
+    public void NullEnabledTools_keeps_all_builtins()
+    {
+        // null == "all tools enabled" (system/default modes).
+        var result = ModeToolFilter.FilterBuiltInTools(WebSearchBuiltIns(), enabledTools: null);
+
+        result.Should().NotBeNull();
+        result!.OfType<AnthropicWebSearchTool>().Should().ContainSingle();
+    }
+
+    [Fact]
+    public void EmptyEnabledTools_drops_all_builtins()
+    {
+        // The Workspace-Agent case: enabledTools: [] means "no tools beyond what the mode curates
+        // (via the sandbox MCP gateway)". It MUST also yield no server-side built-ins — this is the
+        // exact behavior the removed override used to violate (it prepended web_search regardless).
+        var result = ModeToolFilter.FilterBuiltInTools(WebSearchBuiltIns(), enabledTools: []);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void EnabledTools_containing_web_search_keeps_it()
+    {
+        var result = ModeToolFilter.FilterBuiltInTools(WebSearchBuiltIns(), enabledTools: ["web_search"]);
+
+        result.Should().NotBeNull();
+        result!.OfType<AnthropicWebSearchTool>().Should().ContainSingle();
+    }
+
+    [Fact]
+    public void EnabledTools_without_web_search_drops_it()
+    {
+        // A mode that enables other tools but not web_search (e.g. Math Helper -> ["calculate"]).
+        var result = ModeToolFilter.FilterBuiltInTools(WebSearchBuiltIns(), enabledTools: ["calculate"]);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void NoProviderBuiltins_stays_null()
+    {
+        // Providers with no server-side built-ins (GetBuiltInToolsForProvider returns null) never get
+        // any, regardless of the mode.
+        ModeToolFilter.FilterBuiltInTools(null, enabledTools: null).Should().BeNull();
+        ModeToolFilter.FilterBuiltInTools(null, enabledTools: ["web_search"]).Should().BeNull();
+    }
+
+    [Fact]
+    public void WorkspaceAgentMode_declares_web_search_via_dedicated_field_not_enabledTools()
+    {
+        var workspace = SystemChatModes.GetById(SystemChatModes.WorkspaceAgentModeId);
+
+        workspace.Should().NotBeNull();
+        // Function tools are curated via the sandbox MCP gateway, so the function allow-list is empty...
+        workspace!.EnabledTools.Should().BeEmpty();
+        // ...but web_search is declared on the dedicated built-in field, decoupled from enabledTools.
+        workspace.EnabledBuiltInTools.Should().Contain("web_search");
+
+        // Resolution mirrors Program.cs: EnabledBuiltInTools governs (falling back to EnabledTools only
+        // when null). So web_search survives even though enabledTools is empty.
+        var allowList = workspace.EnabledBuiltInTools ?? workspace.EnabledTools;
+        var result = ModeToolFilter.FilterBuiltInTools(WebSearchBuiltIns(), allowList);
+
+        result.Should().NotBeNull();
+        result!.OfType<AnthropicWebSearchTool>().Should().ContainSingle();
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/ModeToolFilterTests.cs
+++ b/tests/LmStreaming.Sample.Tests/ModeToolFilterTests.cs
@@ -1,5 +1,4 @@
 using AchieveAi.LmDotnetTools.AnthropicProvider.Models;
-using LmStreaming.Sample.Persistence;
 using LmStreaming.Sample.Services;
 
 namespace LmStreaming.Sample.Tests;

--- a/tests/LmStreaming.Sample.Tests/SandboxToolHealthTests.cs
+++ b/tests/LmStreaming.Sample.Tests/SandboxToolHealthTests.cs
@@ -1,0 +1,90 @@
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using LmStreaming.Sample.Services;
+
+namespace LmStreaming.Sample.Tests;
+
+/// <summary>
+///     Regression coverage for the sandbox "container unhealthy" guard. When the adopted/Docker-backed
+///     sandbox gateway runs tools in a container whose <c>/etc/passwd</c> has no <c>sandbox</c> user,
+///     EVERY tool call (Glob/Bash/…) comes back as a Docker exec 400 ("no matching entries in passwd
+///     file" / "Timed out waiting for 'sandbox' user"). Left untouched, the model retries the same
+///     infrastructure failure 500+ times. The guard converts that error class into ONE actionable
+///     message so the model stops and tells the user to restart the gateway/container.
+/// </summary>
+public sealed class SandboxToolHealthTests
+{
+    [Theory]
+    [InlineData(
+        "Error executing MCP tool Glob: Request failed (remote): Internal error: Failed to create "
+            + "exec: Docker responded with status code 400: unable to find user sandbox: no matching "
+            + "entries in passwd file")]
+    [InlineData(
+        "Error executing MCP tool Glob: Request failed (remote): Internal error: Timed out waiting "
+            + "for 'sandbox' user in container 72f3f918517825fb7b380d0a7db67aed06635d02")]
+    [InlineData("Internal error: unable to find user sandbox: no matching entries in passwd file")]
+    public void IsContainerUnhealthy_detects_known_gateway_signatures(string toolResult)
+    {
+        SandboxToolHealth.IsContainerUnhealthy(toolResult).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Found 3 files: a.cs, b.cs, c.cs")]
+    [InlineData("Error executing MCP tool Bash: command failed: exit code 1")]
+    public void IsContainerUnhealthy_ignores_normal_results_and_unrelated_errors(string? toolResult)
+    {
+        SandboxToolHealth.IsContainerUnhealthy(toolResult).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Wrap_replaces_unhealthy_result_with_a_single_actionable_error()
+    {
+        ToolHandler inner = (_, _, _) =>
+            Task.FromResult<ToolHandlerResult>(
+                ToolHandlerResult.FromText(
+                    "Error executing MCP tool Glob: Request failed (remote): Internal error: Failed "
+                        + "to create exec: Docker responded with status code 400: unable to find user "
+                        + "sandbox: no matching entries in passwd file"));
+
+        var wrapped = SandboxToolHealth.Wrap(inner);
+        var result = await wrapped("{}", new ToolCallContext(), CancellationToken.None);
+
+        var resolved = result.Should().BeOfType<ToolHandlerResult.Resolved>().Subject;
+        resolved.Payload.IsError.Should().BeTrue();
+        resolved.Payload.ErrorCode.Should().Be(SandboxToolHealth.UnhealthyErrorCode);
+        resolved.Payload.Text.Should().Be(SandboxToolHealth.UnhealthyMessage);
+    }
+
+    [Fact]
+    public void UnhealthyMessage_is_actionable()
+    {
+        // The model must learn NOT to retry, and the user must learn HOW to recover.
+        SandboxToolHealth.UnhealthyMessage.Should().ContainEquivalentOf("restart");
+        SandboxToolHealth.UnhealthyMessage.Should().ContainEquivalentOf("sandbox");
+    }
+
+    [Fact]
+    public async Task Wrap_passes_through_healthy_results_unchanged()
+    {
+        ToolHandler inner = (_, _, _) =>
+            Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText("Found 3 files"));
+
+        var wrapped = SandboxToolHealth.Wrap(inner);
+        var result = await wrapped("{}", new ToolCallContext(), CancellationToken.None);
+
+        result.ResultText.Should().Be("Found 3 files");
+        result.Should().BeOfType<ToolHandlerResult.Resolved>().Which.Payload.IsError.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Wrap_passes_through_deferred_results_unchanged()
+    {
+        ToolHandler inner = (_, _, _) => Task.FromResult<ToolHandlerResult>(new ToolHandlerResult.Deferred());
+
+        var wrapped = SandboxToolHealth.Wrap(inner);
+        var result = await wrapped("{}", new ToolCallContext(), CancellationToken.None);
+
+        result.Should().BeOfType<ToolHandlerResult.Deferred>();
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryRecreateOnGateway404Tests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryRecreateOnGateway404Tests.cs
@@ -203,6 +203,38 @@ public class SandboxSessionRegistryRecreateOnGateway404Tests
         return (registry, calls);
     }
 
+    /// <summary>
+    /// Regression: when the gateway is reachable for the /health adopt probe but then REFUSES the
+    /// create POST (down / restarting — <c>SocketException 10061</c> surfaced as
+    /// <see cref="HttpRequestException"/>), the registry must surface a handled
+    /// <see cref="SandboxSessionUnavailableException"/> so the WebSocket / mode-switch layers answer a
+    /// clean error — not let the raw exception crash the request with an unhandled 500.
+    /// </summary>
+    [Fact]
+    public async Task GetOrCreateSessionAsync_GatewayConnectionRefusedOnCreate_ThrowsSandboxUnavailable()
+    {
+        var options = new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl, Marketplaces = null };
+        // Health probe answers 200 (adopt), but the create POST connection is refused.
+        var gateway = new SandboxGatewayLifetime(
+            options,
+            NullLogger<SandboxGatewayLifetime>.Instance,
+            new HttpClient(new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK))));
+        var auth = new AuthOptions();
+        var registry = new SandboxSessionRegistry(
+            gateway,
+            options,
+            NullLogger<SandboxSessionRegistry>.Instance,
+            new HttpClient(new StubHandler(_ =>
+                throw new HttpRequestException(
+                    "No connection could be made because the target machine actively refused it."))),
+            auth,
+            new AuthSharedSecret(auth));
+
+        var act = async () => await registry.GetOrCreateSessionAsync();
+
+        await act.Should().ThrowAsync<SandboxSessionUnavailableException>();
+    }
+
     // Thread-safe: the concurrency test fires parallel liveness GETs (and a recreate POST) through
     // the stub handler from multiple threads at once.
     private sealed class CallLog


### PR DESCRIPTION
## Summary

Hardens the `LmStreaming.Sample` streaming pipeline against issues found while driving real providers (Kimi-backed Anthropic and Copilot-Claude) through multi-turn, sandboxed Workspace-Agent tasks: multi-turn message-identity collapse, Anthropic/Kimi replay 400s, gateway/sandbox connectivity, and the "empty web_search loop". `web_search` stays enabled in every mode.

## Changes

- **Multi-turn message identity (server-side root fix)** — `MultiTurnAgentLoop` mints a per-turn `generationId` (turn 1 reuses the run's id; turns 2+ get a fresh one) so later turns' thinking/text no longer collide on the merge key and collapse onto the first turn. Client-side per-turn epoch kept as defense-in-depth for already-persisted conversations.
- **Anthropic/Kimi replay correctness** — drop orphaned signature-only thinking blocks, demote signatureless thinking to text, and stably order each assistant turn `thinking → text → tool_use` so `tool_use` is always last (avoids 400 `invalid_request_error`).
- **Gateway + sandbox resilience** — IPv4 gateway resolution (don't let dual-stack mask single-family failures), graceful sandbox-unavailable handling, container-health guard, and recreate-on-404.
- **Mode-driven built-in tools** — server-side built-ins (e.g. `web_search`) follow the mode's declaration, decoupled from the function-tool allow-list.
- **Empty web_search loop** — a provider/model sometimes emits a query-less `web_search` (`server_tool_use` with `{}` input); the server returns empty results and replaying the degenerate call teaches the model to repeat it until "Max turns reached". The message joiner (`MessageUpdateJoinerMiddleware`) now skips building an empty server-tool call and drops its orphaned empty result, so it is never persisted, shown on reload, or replayed. Real, query-bearing searches are unchanged.

## Testing

- `dotnet test` green on the affected suites: `LmCore.Tests` (763, incl. new joiner empty-web_search coverage), `AnthropicProvider.Tests` (174), `LmMultiTurn.Tests` (277), `LmStreaming.Sample.Tests` (306).
- New regression tests: joiner drops an empty server-tool call + its empty result while preserving a real query-bearing search; per-turn generationId; thinking/tool_use replay ordering; sandbox health + gateway-404 recreate.

## Related Issues

Fixes #108
