### PR TITLE
Bug fixes

### DIFF
--- a/samples/LmStreaming.Sample/CLAUDE.md
+++ b/samples/LmStreaming.Sample/CLAUDE.md
@@ -106,3 +106,35 @@ thinking/text distinctly. Regression coverage:
   (`useChat`/`displayItems`). Unit/single-turn green ≠ correct; the bug is emergent across turns.
 - "Consistent across the whole run" is a **two-field** claim: pinning `generationId` silently
   requires `messageOrderIdx` to be run-unique. State and test both halves.
+
+## Streaming resume (why a switched-away tool run's count "freezes" / pills duplicate)
+Switching to another conversation mid-run and coming back used to leave the in-flight run's
+**tool-call pills duplicated and never settling** ("tool count stuck") — text resumed fine, tools did
+not. Root cause is a **merge-key divergence on the resume path** (key =
+`kind-runId-generationId-messageOrderIdx-toolCallId`):
+- On the wire, **finalized `tool_call` / `tool_call_result` messages arrive WITHOUT a `runId`** (verified
+  across `recordings/*.ws.jsonl`: `tool_call` carried one in **0 of 267**). `text_update` *does* carry it —
+  exactly why text-resume worked and tool-resume didn't. Only `run_assignment` reliably carries the id.
+- `getMergeKey` (`useChat.ts`) keys a runId-less message to `'default'`.
+- `loadMessagesFromBackend` rehydrates the **persisted** copy of the same message stamped with the run's
+  **real** id (`pm.runId`). So on switch-back the REST-rehydrated tool call (real runId) and the
+  WS-replayed tool call (runId-less → `'default'`) get **different keys → never merge → duplicate pill**.
+- A full page **reload "fixes" it** because it loads completed history via REST only and never takes the
+  WS resume path. Useful localizer: *reload-works + switch-breaks ⇒ bug is in live resume, not the backend.*
+
+**Fix:** in `useChat.handleMessage`, stamp the active run id onto runId-less live content **before** the
+merge key is computed: `if (!msg.runId && currentRunId.value) msg = { ...msg, runId: currentRunId.value }`.
+`currentRunId` is set from `run_assignment`, which the backend replay buffer (`MultiTurnAgentBase`) delivers
+first on resume, so the live key now matches the rehydrated one. Guarded on `!msg.runId` so providers that
+already send a runId are untouched.
+
+**Rules when touching streaming resume / merge keys (these bit us):**
+- Test **every message kind** that flows the path — `text`, `reasoning`, `tool_call`, `tool_call_result` —
+  not just text. The first resume fix shipped **11 green tests that only fed `textUpdate`/`TextMessage`**, so
+  the tool path stayed broken behind a fully-green suite. *A passing suite that never exercises the failing
+  modality is false confidence.*
+- Verify wire assumptions against **recorded traffic** (`recordings/*.ws.jsonl`), not the agent code:
+  `AnthropicAgent` calls `WithIds`, yet finalized `tool_call` still reaches the client runId-less.
+- Reproduce the user's exact **modality + scale** (1 tool vs 10–15 tools; tool vs text are different paths).
+- Coverage: `ClientApp/src/__tests__/composables/useChatResume.test.ts` (1-tool and 12-tool switch-back,
+  RED-without-fix / GREEN-with) and `LmMultiTurn.Tests/MultiTurnAgentReplayTests` (replay carries tool messages).

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChatResume.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChatResume.test.ts
@@ -117,4 +117,67 @@ describe('useChat — resume in-flight stream after switch/refresh', () => {
     // No active run ⇒ no reconnect.
     expect(wsMocks.createWebSocketConnection).toHaveBeenCalledTimes(1);
   });
+
+  it('does not query run-state or reconnect when already streaming the same thread', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    chat.setThreadId('thread-1');
+
+    await chat.sendMessage('hi');
+    expect(wsMocks.createWebSocketConnection).toHaveBeenCalledTimes(1);
+
+    // Already connected to thread-1 — resume must be a no-op.
+    await chat.resumeStreamIfActive('thread-1');
+    expect(convMocks.getRunState).not.toHaveBeenCalled();
+    expect(wsMocks.createWebSocketConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not resume under the SSE transport', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    chat.setThreadId('thread-1');
+    chat.setTransport('sse');
+
+    await chat.resumeStreamIfActive('thread-1');
+
+    expect(convMocks.getRunState).not.toHaveBeenCalled();
+    expect(wsMocks.createWebSocketConnection).not.toHaveBeenCalled();
+  });
+
+  it('resets isLoading when the resume connection fails to open', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    chat.setThreadId('thread-1');
+    convMocks.getRunState.mockResolvedValue({
+      threadId: 'thread-1',
+      isInProgress: true,
+      currentRunId: 'run-1',
+    });
+    wsMocks.createWebSocketConnection.mockRejectedValueOnce(new Error('ws open failed'));
+
+    await chat.resumeStreamIfActive('thread-1');
+
+    // A failed resume must not leave the UI stuck "streaming" forever.
+    expect(chat.isLoading.value).toBe(false);
+  });
+
+  it('aborts resume if the active thread changed during the run-state check', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    chat.setThreadId('thread-A');
+
+    // Hold getRunState open so we can simulate a conversation switch mid-await.
+    let resolveRunState!: (v: unknown) => void;
+    convMocks.getRunState.mockImplementation(
+      () => new Promise((resolve) => { resolveRunState = resolve; })
+    );
+
+    const pending = chat.resumeStreamIfActive('thread-A');
+    // Wait until the run-state request is actually in flight (after the dynamic import), then
+    // simulate the user switching to a different conversation before it resolves.
+    await vi.waitFor(() => expect(convMocks.getRunState).toHaveBeenCalledTimes(1));
+    chat.setThreadId('thread-B');
+    resolveRunState({ threadId: 'thread-A', isInProgress: true, currentRunId: 'run-1' });
+    await pending;
+
+    // The stream for thread-A must NOT be bound to the now-current thread-B state.
+    expect(wsMocks.createWebSocketConnection).not.toHaveBeenCalled();
+    expect(chat.isLoading.value).toBe(false);
+  });
 });

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChatResume.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChatResume.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useChat } from '@/composables/useChat';
+
+// Resume bug: an ongoing (streaming) conversation stops streaming if you switch to another
+// conversation and come back, or refresh. Switching tears down the WebSocket and returning only
+// reloads persisted REST history (everything marked completed) — it never re-subscribes to the
+// still-running backend run. These tests pin the fix: on return, when the backend reports an
+// in-flight run, the client re-opens the WebSocket (subscribe-only) and resumes the live stream.
+
+const wsMocks = vi.hoisted(() => ({
+  createWebSocketConnection: vi.fn(),
+  sendWebSocketMessage: vi.fn(),
+  closeWebSocketConnection: vi.fn(),
+}));
+
+vi.mock('@/api/wsClient', () => ({
+  createWebSocketConnection: wsMocks.createWebSocketConnection,
+  sendWebSocketMessage: wsMocks.sendWebSocketMessage,
+  closeWebSocketConnection: wsMocks.closeWebSocketConnection,
+}));
+
+const convMocks = vi.hoisted(() => ({
+  loadConversationMessages: vi.fn(),
+  getRunState: vi.fn(),
+}));
+
+vi.mock('@/api/conversationsApi', () => ({
+  loadConversationMessages: convMocks.loadConversationMessages,
+  getRunState: convMocks.getRunState,
+}));
+
+function textUpdate(text: string) {
+  return {
+    $type: 'text_update',
+    text,
+    role: 'assistant',
+    runId: 'run-1',
+    generationId: 'gen-1',
+    messageOrderIdx: 0,
+  };
+}
+
+describe('useChat — resume in-flight stream after switch/refresh', () => {
+  let captured: any[];
+
+  beforeEach(() => {
+    captured = [];
+    wsMocks.createWebSocketConnection.mockReset();
+    wsMocks.sendWebSocketMessage.mockReset();
+    wsMocks.closeWebSocketConnection.mockReset();
+    convMocks.loadConversationMessages.mockReset();
+    convMocks.getRunState.mockReset();
+
+    wsMocks.createWebSocketConnection.mockImplementation(async (options: any) => {
+      captured.push(options);
+      return {
+        socket: { readyState: WebSocket.OPEN },
+        connectionId: `ws-${captured.length}`,
+        threadId: options.threadId,
+        isConnected: true,
+      };
+    });
+    convMocks.loadConversationMessages.mockResolvedValue([]);
+  });
+
+  it('reconnects (subscribe-only) and resumes when the conversation has an in-flight run', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    chat.setThreadId('thread-1');
+
+    // Start a streaming run on the first connection and stream a partial delta.
+    await chat.sendMessage('hi');
+    expect(wsMocks.createWebSocketConnection).toHaveBeenCalledTimes(1);
+    captured[0].onMessage(textUpdate('Hel'));
+
+    // Switch away (disconnect), then switch back: load history (empty) + attempt resume.
+    await chat.disconnectWebSocket();
+    await chat.loadMessagesFromBackend('thread-1');
+
+    convMocks.getRunState.mockResolvedValue({
+      threadId: 'thread-1',
+      isInProgress: true,
+      currentRunId: 'run-1',
+    });
+    await chat.resumeStreamIfActive('thread-1');
+
+    // A second connection is opened to RESUME, and it is subscribe-only (no new chat message sent).
+    expect(convMocks.getRunState).toHaveBeenCalledWith('thread-1');
+    expect(wsMocks.createWebSocketConnection).toHaveBeenCalledTimes(2);
+    expect(wsMocks.sendWebSocketMessage).toHaveBeenCalledTimes(1); // only the original send
+
+    // Backend replays the in-flight run on the resumed connection, then completes.
+    captured[1].onMessage(textUpdate('Hel'));
+    captured[1].onMessage(textUpdate('lo'));
+    captured[1].onDone();
+
+    expect(chat.isLoading.value).toBe(false);
+    const bubbles = chat.displayItems.value.filter((i) => i.type === 'assistant-message');
+    expect((bubbles[0] as { content?: { text?: string } }).content?.text).toBe('Hello');
+  });
+
+  it('does NOT reconnect when no run is in progress', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    chat.setThreadId('thread-1');
+
+    await chat.sendMessage('hi');
+    captured[0].onMessage(textUpdate('done'));
+    await chat.disconnectWebSocket();
+    await chat.loadMessagesFromBackend('thread-1');
+
+    convMocks.getRunState.mockResolvedValue({
+      threadId: 'thread-1',
+      isInProgress: false,
+      currentRunId: null,
+    });
+    await chat.resumeStreamIfActive('thread-1');
+
+    // No active run ⇒ no reconnect.
+    expect(wsMocks.createWebSocketConnection).toHaveBeenCalledTimes(1);
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChatResume.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChatResume.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useChat } from '@/composables/useChat';
+import { MessageType } from '@/types';
 
 // Resume bug: an ongoing (streaming) conversation stops streaming if you switch to another
 // conversation and come back, or refresh. Switching tears down the WebSocket and returning only
@@ -179,5 +180,243 @@ describe('useChat — resume in-flight stream after switch/refresh', () => {
     // The stream for thread-A must NOT be bound to the now-current thread-B state.
     expect(wsMocks.createWebSocketConnection).not.toHaveBeenCalled();
     expect(chat.isLoading.value).toBe(false);
+  });
+});
+
+// A tool call that is still RUNNING (issued, result not yet produced) when the user switches away
+// and comes back. The persisted REST history loaded on return carries the UNRESOLVED tool call; the
+// resumed WebSocket then replays the run including the tool call AND its result. The resolved pill
+// must show (the result must land in the toolResults map) AND there must be exactly one pill for the
+// call (the REST-rehydrated tool call and the WS-replayed tool call must merge, not duplicate).
+describe('useChat — resume resolves an in-flight tool call after switch-back', () => {
+  let captured: any[];
+
+  beforeEach(() => {
+    captured = [];
+    wsMocks.createWebSocketConnection.mockReset();
+    wsMocks.sendWebSocketMessage.mockReset();
+    wsMocks.closeWebSocketConnection.mockReset();
+    convMocks.loadConversationMessages.mockReset();
+    convMocks.getRunState.mockReset();
+
+    wsMocks.createWebSocketConnection.mockImplementation(async (options: any) => {
+      captured.push(options);
+      return {
+        socket: { readyState: WebSocket.OPEN },
+        connectionId: `ws-${captured.length}`,
+        threadId: options.threadId,
+        isConnected: true,
+      };
+    });
+    convMocks.loadConversationMessages.mockResolvedValue([]);
+  });
+
+  // The real wire: ONLY run_assignment carries the runId; tool_call / text / tool_call_result are
+  // streamed WITHOUT a runId field (verified against recorded WS traffic). The persisted record,
+  // however, stores the producing run on its top-level `runId` column, so on switch-back the loader
+  // stamps the rehydrated message with the real run GUID — diverging from the live (runId-less) copy.
+  const ID = { runId: '39018c20a1b540a2b51627f3835e75b9', generationId: 'gen-1' };
+
+  // Live wire shape — NO runId (matches recorded WS frames).
+  function toolCall() {
+    return {
+      $type: MessageType.ToolCall,
+      role: 'assistant',
+      tool_call_id: 'call_1',
+      function_name: 'Read',
+      function_args: '{"path":"x"}',
+      generationId: ID.generationId,
+      messageOrderIdx: 1,
+    };
+  }
+
+  function toolResult() {
+    return {
+      $type: MessageType.ToolCallResult,
+      role: 'tool',
+      tool_call_id: 'call_1',
+      result: 'file contents here',
+      generationId: ID.generationId,
+      messageOrderIdx: 2,
+    };
+  }
+
+  function runAssignment() {
+    return {
+      $type: MessageType.RunAssignment,
+      Assignment: { runId: ID.runId, generationId: ID.generationId, inputIds: [] },
+    };
+  }
+
+  function runCompleted() {
+    return {
+      $type: MessageType.RunCompleted,
+      completedRunId: ID.runId,
+      hasPendingMessages: false,
+    };
+  }
+
+  // PersistedMessage rows the loader rehydrates on switch-back: the user turn + the UNRESOLVED
+  // tool call (its result was not yet persisted when the user switched away).
+  function persistedHistory() {
+    return [
+      {
+        id: 'p-user',
+        threadId: 'thread-1',
+        runId: ID.runId,
+        generationId: ID.generationId,
+        messageOrderIdx: 0,
+        timestamp: 1000,
+        messageType: 'text',
+        role: 'user',
+        messageJson: JSON.stringify({ $type: MessageType.Text, role: 'user', text: 'read a file' }),
+      },
+      {
+        id: 'p-call_1',
+        threadId: 'thread-1',
+        runId: ID.runId,
+        generationId: ID.generationId,
+        messageOrderIdx: 1,
+        timestamp: 1001,
+        messageType: 'tool_call',
+        role: 'assistant',
+        messageJson: JSON.stringify(toolCall()),
+      },
+    ];
+  }
+
+  function call1Pills(chat: ReturnType<typeof useChat>) {
+    return chat.displayItems.value
+      .filter((i) => i.type === 'pill')
+      .flatMap((i) => (i as { items: Array<{ tool_calls?: Array<{ tool_call_id?: string }> }> }).items)
+      .filter((m) => m.tool_calls?.some((tc) => tc.tool_call_id === 'call_1'));
+  }
+
+  it('resolves the tool pill and keeps it single after a switch-away/back resume', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    chat.setThreadId('thread-1');
+
+    // 1) Start the run on connection 1; the tool call is issued but NOT yet resolved.
+    await chat.sendMessage('read a file');
+    expect(wsMocks.createWebSocketConnection).toHaveBeenCalledTimes(1);
+    captured[0].onMessage(runAssignment());
+    captured[0].onMessage(toolCall());
+    expect(chat.getResultForToolCall('call_1')).toBeNull();
+
+    // 2) Switch away: tear down the socket.
+    await chat.disconnectWebSocket();
+
+    // 3) Switch back: load persisted history (result NOT yet persisted → tool call unresolved).
+    convMocks.loadConversationMessages.mockResolvedValue(persistedHistory());
+    await chat.loadMessagesFromBackend('thread-1');
+    expect(chat.getResultForToolCall('call_1'), 'rehydrated history has no result yet').toBeNull();
+    expect(call1Pills(chat), 'exactly one pill after rehydrate').toHaveLength(1);
+
+    // 4) Resume: backend reports the run is still in flight.
+    convMocks.getRunState.mockResolvedValue({
+      threadId: 'thread-1',
+      isInProgress: true,
+      currentRunId: ID.runId,
+    });
+    await chat.resumeStreamIfActive('thread-1');
+    expect(wsMocks.createWebSocketConnection).toHaveBeenCalledTimes(2);
+
+    // 5) The resumed connection replays the run: assignment, the tool call, THEN its result, done.
+    captured[1].onMessage(runAssignment());
+    captured[1].onMessage(toolCall());
+    captured[1].onMessage(toolResult());
+    captured[1].onMessage(runCompleted());
+    captured[1].onDone();
+
+    // The pill must resolve (result in the toolResults map) and there must be exactly ONE pill.
+    expect(chat.getResultForToolCall('call_1'), 'tool result must resolve the pill after resume').not.toBeNull();
+    expect(call1Pills(chat), 'the replayed tool call must merge with the rehydrated one, not duplicate').toHaveLength(1);
+  });
+
+  // User-reported repro: a turn with MANY tool calls (10-15), streamed while the user switches away
+  // mid-run and comes back. The concurrent tool calls in one turn share runId/generationId/
+  // messageOrderIdx and differ only by tool_call_id (the real Anthropic shape). Each must resolve and
+  // render as exactly ONE pill after resume — without the runId stamp every one of them duplicates
+  // (rehydrated real-runId key vs replayed 'default' key), so the user sees a doubled, never-settling
+  // tool count.
+  it('resolves all 12 tool pills and keeps each single after a many-tool switch-back', async () => {
+    const N = 12;
+    const ids = Array.from({ length: N }, (_, i) => `call_${i + 1}`);
+    const ORDER = 1; // concurrent tools in one turn share messageOrderIdx, differ by tool_call_id
+
+    const liveToolCall = (id: string) => ({
+      $type: MessageType.ToolCall,
+      role: 'assistant',
+      tool_call_id: id,
+      function_name: 'Read',
+      function_args: '{"path":"x"}',
+      generationId: ID.generationId,
+      messageOrderIdx: ORDER,
+    });
+    const liveResult = (id: string) => ({
+      $type: MessageType.ToolCallResult,
+      role: 'tool',
+      tool_call_id: id,
+      result: `result ${id}`,
+      generationId: ID.generationId,
+      messageOrderIdx: 2,
+    });
+    const persisted = ids.map((id, i) => ({
+      id: `p-${id}`,
+      threadId: 'thread-1',
+      runId: ID.runId,
+      generationId: ID.generationId,
+      messageOrderIdx: ORDER,
+      timestamp: 1001 + i,
+      messageType: 'tool_call',
+      role: 'assistant',
+      messageJson: JSON.stringify(liveToolCall(id)),
+    }));
+
+    const pillsFor = (chat: ReturnType<typeof useChat>, id: string) =>
+      chat.displayItems.value
+        .filter((i) => i.type === 'pill')
+        .flatMap((i) => (i as { items: Array<{ tool_calls?: Array<{ tool_call_id?: string }> }> }).items)
+        .filter((m) => m.tool_calls?.some((tc) => tc.tool_call_id === id));
+
+    const chat = useChat({ getModeId: () => 'default' });
+    chat.setThreadId('thread-1');
+
+    // 1) Run starts; 12 tool calls issued, none resolved yet (user switches away mid-stream).
+    await chat.sendMessage('use many tools');
+    captured[0].onMessage(runAssignment());
+    ids.forEach((id) => captured[0].onMessage(liveToolCall(id)));
+
+    // 2) Switch away.
+    await chat.disconnectWebSocket();
+
+    // 3) Switch back: history has 12 UNRESOLVED tool calls (results not yet persisted).
+    convMocks.loadConversationMessages.mockResolvedValue(persisted);
+    await chat.loadMessagesFromBackend('thread-1');
+    ids.forEach((id) =>
+      expect(pillsFor(chat, id), `one pill for ${id} after rehydrate`).toHaveLength(1),
+    );
+
+    // 4) Resume the in-flight run.
+    convMocks.getRunState.mockResolvedValue({
+      threadId: 'thread-1',
+      isInProgress: true,
+      currentRunId: ID.runId,
+    });
+    await chat.resumeStreamIfActive('thread-1');
+    expect(wsMocks.createWebSocketConnection).toHaveBeenCalledTimes(2);
+
+    // 5) Replay: assignment, the 12 tool calls, then their 12 results, completed.
+    captured[1].onMessage(runAssignment());
+    ids.forEach((id) => captured[1].onMessage(liveToolCall(id)));
+    ids.forEach((id) => captured[1].onMessage(liveResult(id)));
+    captured[1].onMessage(runCompleted());
+    captured[1].onDone();
+
+    // Every tool resolves, and each renders as exactly ONE pill (no duplicate from the resume).
+    for (const id of ids) {
+      expect(chat.getResultForToolCall(id), `${id} must resolve after resume`).not.toBeNull();
+      expect(pillsFor(chat, id), `exactly one pill for ${id} (no resume duplicate)`).toHaveLength(1);
+    }
   });
 });

--- a/samples/LmStreaming.Sample/ClientApp/src/api/conversationsApi.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/api/conversationsApi.ts
@@ -45,6 +45,29 @@ export async function loadConversationMessages(
 }
 
 /**
+ * In-memory run state for a conversation. `isInProgress` is true while a run is still streaming
+ * on the backend (the pooled agent keeps running after the client disconnects), which lets a
+ * client returning to the conversation decide whether to re-open the WebSocket and resume.
+ */
+export interface ConversationRunState {
+  threadId: string;
+  isInProgress: boolean;
+  currentRunId?: string | null;
+}
+
+/**
+ * Fetches whether a conversation currently has an in-flight run, so a client returning to it
+ * (switch-back or refresh) can resume the live stream instead of showing a frozen partial.
+ */
+export async function getRunState(threadId: string): Promise<ConversationRunState> {
+  const response = await fetch(`/api/conversations/${encodeURIComponent(threadId)}/run-state`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch run state: ${response.statusText}`);
+  }
+  return response.json();
+}
+
+/**
  * Updates conversation metadata (title, preview).
  */
 export async function updateConversationMetadata(

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
@@ -83,6 +83,7 @@ const {
   disconnectWebSocket,
   setThreadId,
   loadMessagesFromBackend,
+  resumeStreamIfActive,
   getResultForToolCall,
 } = useChat({
   getModeId: () => currentModeId.value,
@@ -213,6 +214,10 @@ async function handleSelectConversation(threadId: string): Promise<void> {
   // Load existing messages
   try {
     await loadMessagesFromBackend(threadId);
+    // If a run is still streaming on the backend (the pooled agent keeps running after we
+    // disconnected on switch/refresh), re-open the WebSocket to resume the live stream instead
+    // of leaving the partial frozen.
+    await resumeStreamIfActive(threadId);
   } catch (e) {
     console.error('Failed to load messages:', e);
   }

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ConversationSidebar.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ConversationSidebar.vue
@@ -83,6 +83,8 @@ function handleDelete(event: Event, threadId: string): void {
           v-for="conv in conversations"
           :key="conv.threadId"
           :class="['conversation-item', { active: conv.threadId === currentThreadId }]"
+          data-testid="conversation-item"
+          :data-thread-id="conv.threadId"
           @click="emit('selectConversation', conv.threadId)"
         >
           <div class="conversation-content">

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -871,30 +871,7 @@ export function useChat(options: UseChatOptions = {}) {
     pendingMessages.value.push(userMessage);
     log.debug('Added message to pending queue', { tempId, text: displayText.substring(0, 50) });
 
-    const callbacks = {
-      onMessage: handleMessage,
-      onDone: () => {
-        log.info('Stream completed', { transport: transport.value });
-        
-        // Mark all streaming messages as completed
-        for (const message of messageIndex.value.values()) {
-          if (message.isStreaming) {
-            message.isStreaming = false;
-            if (message.status === 'active') {
-              message.status = 'completed';
-            }
-          }
-        }
-        
-        finalize();
-        isLoading.value = false;
-      },
-      onError: (err: string) => {
-        log.error('Stream error', { error: err, transport: transport.value });
-        error.value = err;
-        isLoading.value = false;
-      },
-    };
+    const callbacks = buildStreamCallbacks();
 
     try {
       if (transport.value === 'websocket') {
@@ -913,6 +890,97 @@ export function useChat(options: UseChatOptions = {}) {
   }
   
   /**
+   * Build the stream callbacks (message handler + completion/error handling) shared by the
+   * send path and the resume path. Extracted so `resumeStreamIfActive` can re-attach the exact
+   * same rendering pipeline to a reconnected, subscribe-only socket.
+   */
+  function buildStreamCallbacks(): {
+    onMessage: (msg: Message) => void;
+    onDone: () => void;
+    onError: (err: string) => void;
+  } {
+    return {
+      onMessage: handleMessage,
+      onDone: () => {
+        log.info('Stream completed', { transport: transport.value });
+
+        // Mark all streaming messages as completed
+        for (const message of messageIndex.value.values()) {
+          if (message.isStreaming) {
+            message.isStreaming = false;
+            if (message.status === 'active') {
+              message.status = 'completed';
+            }
+          }
+        }
+
+        finalize();
+        isLoading.value = false;
+      },
+      onError: (err: string) => {
+        log.error('Stream error', { error: err, transport: transport.value });
+        error.value = err;
+        isLoading.value = false;
+      },
+    };
+  }
+
+  /**
+   * Open (or replace) the persistent WebSocket for a thread and wire the stream callbacks.
+   * Does NOT send anything — callers send afterwards (new message) or leave it subscribe-only
+   * (resume). Shared by `sendMessageViaWebSocket` and `resumeStreamIfActive`.
+   */
+  async function openStreamConnection(
+    effectiveThreadId: string,
+    callbacks: { onMessage: (msg: Message) => void; onDone: () => void; onError: (err: string) => void }
+  ): Promise<void> {
+    const currentModeId = getModeId?.();
+    const currentProviderId = getProviderId?.() ?? null;
+    const currentWorkspaceId = getWorkspaceId?.() ?? null;
+    log.info('Creating new WebSocket connection', {
+      threadId: effectiveThreadId,
+      modeId: currentModeId,
+      providerId: currentProviderId,
+      workspaceId: currentWorkspaceId,
+      recordEnabled,
+    });
+
+    // Close old connection if exists
+    if (wsConnection) {
+      const { closeWebSocketConnection } = await import('@/api/wsClient');
+      closeWebSocketConnection(wsConnection);
+      wsConnection = null;
+    }
+
+    const { createWebSocketConnection } = await import('@/api/wsClient');
+
+    wsConnection = await createWebSocketConnection({
+      threadId: effectiveThreadId,
+      modeId: currentModeId,
+      providerId: currentProviderId,
+      workspaceId: currentWorkspaceId,
+      record: recordEnabled,
+      ...callbacks,
+      onAuthEvent: handleAuthEvent,
+      onDone: () => {
+        log.debug('WebSocket stream done signal received');
+        callbacks.onDone();
+        // Keep connection open for next message (don't close)
+      },
+      onError: async (error) => {
+        log.error('WebSocket error', { error });
+        callbacks.onError(error);
+        // Close and cleanup on error
+        if (wsConnection) {
+          const { closeWebSocketConnection } = await import('@/api/wsClient');
+          closeWebSocketConnection(wsConnection);
+          wsConnection = null;
+        }
+      },
+    });
+  }
+
+  /**
    * Send message via WebSocket (persistent or new connection)
    */
   async function sendMessageViaWebSocket(
@@ -920,7 +988,7 @@ export function useChat(options: UseChatOptions = {}) {
     callbacks: { onMessage: (msg: Message) => void; onDone: () => void; onError: (err: string) => void }
   ): Promise<void> {
     const effectiveThreadId = getOrCreateThreadId();
-    
+
     // Check if we have an open connection that belongs to the current thread.
     // A socket bound to a previously-viewed conversation must not be reused for a
     // different thread (e.g. after switching conversations); close it and fall
@@ -940,55 +1008,61 @@ export function useChat(options: UseChatOptions = {}) {
       const { sendWebSocketMessage } = await import('@/api/wsClient');
       sendWebSocketMessage(wsConnection, text);
     } else {
-      const currentModeId = getModeId?.();
-      const currentProviderId = getProviderId?.() ?? null;
-      const currentWorkspaceId = getWorkspaceId?.() ?? null;
-      log.info('Creating new WebSocket connection', {
-        threadId: effectiveThreadId,
-        modeId: currentModeId,
-        providerId: currentProviderId,
-        workspaceId: currentWorkspaceId,
-        recordEnabled,
-      });
+      await openStreamConnection(effectiveThreadId, callbacks);
 
-      // Close old connection if exists
-      if (wsConnection) {
-        const { closeWebSocketConnection } = await import('@/api/wsClient');
-        closeWebSocketConnection(wsConnection);
-        wsConnection = null;
-      }
-
-      // Create new persistent connection
-      const { createWebSocketConnection, sendWebSocketMessage } = await import('@/api/wsClient');
-
-      wsConnection = await createWebSocketConnection({
-        threadId: effectiveThreadId,
-        modeId: currentModeId,
-        providerId: currentProviderId,
-        workspaceId: currentWorkspaceId,
-        record: recordEnabled,
-        ...callbacks,
-        onAuthEvent: handleAuthEvent,
-        onDone: () => {
-          log.debug('WebSocket stream done signal received');
-          callbacks.onDone();
-          // Keep connection open for next message (don't close)
-        },
-        onError: async (error) => {
-          log.error('WebSocket error', { error });
-          callbacks.onError(error);
-          // Close and cleanup on error
-          if (wsConnection) {
-            const { closeWebSocketConnection } = await import('@/api/wsClient');
-            closeWebSocketConnection(wsConnection);
-            wsConnection = null;
-          }
-        },
-      });
-      
       // Send message on new connection
-      sendWebSocketMessage(wsConnection, text);
+      const { sendWebSocketMessage } = await import('@/api/wsClient');
+      sendWebSocketMessage(wsConnection!, text);
     }
+  }
+
+  /**
+   * Resume an in-flight stream after returning to a conversation (switch-back or refresh).
+   *
+   * The backend run keeps running after the client disconnects (the agent is pooled), so when a
+   * conversation still has an in-flight run we re-open the WebSocket in subscribe-only mode (no
+   * send). The backend replays the in-flight run's already-emitted messages and then continues
+   * delivering live deltas, which merge with the persisted history just loaded (the merge key
+   * kind-runId-generationId-messageOrderIdx dedups replay vs history). Without this, returning to
+   * a streaming conversation showed the partial frozen at the last persisted point.
+   */
+  async function resumeStreamIfActive(existingThreadId: string): Promise<void> {
+    // Only the WebSocket transport maintains a resumable live backend run.
+    if (transport.value !== 'websocket') return;
+
+    // Already streaming this thread on an open socket — nothing to resume.
+    if (
+      wsConnection &&
+      wsConnection.isConnected &&
+      wsConnection.socket.readyState === WebSocket.OPEN &&
+      wsConnection.threadId === existingThreadId
+    ) {
+      return;
+    }
+
+    let runState;
+    try {
+      const { getRunState } = await import('@/api/conversationsApi');
+      runState = await getRunState(existingThreadId);
+    } catch (err) {
+      log.warn('Failed to query run state for resume', { threadId: existingThreadId, error: err });
+      return;
+    }
+
+    if (!runState?.isInProgress) {
+      log.debug('No in-flight run to resume', { threadId: existingThreadId });
+      return;
+    }
+
+    log.info('Resuming in-flight stream', {
+      threadId: existingThreadId,
+      runId: runState.currentRunId,
+    });
+
+    // Reflect the live run in the UI (spinner / stop button) while the replayed + live deltas arrive.
+    isLoading.value = true;
+    await openStreamConnection(existingThreadId, buildStreamCallbacks());
+    // No send: this is a subscribe-only resume.
   }
 
   /**
@@ -1220,6 +1294,7 @@ export function useChat(options: UseChatOptions = {}) {
     getResultForToolCall,
     setThreadId,
     loadMessagesFromBackend,
+    resumeStreamIfActive,
   };
 }
 

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -772,6 +772,19 @@ export function useChat(options: UseChatOptions = {}) {
       return;
     }
 
+    // Stamp the active run's id onto live content that arrives without one. On the wire only
+    // run_assignment carries a runId; text/reasoning/tool-call messages are streamed runId-less, so
+    // getMergeKey would key them to 'default'. The PERSISTED copy of the same message, however, is
+    // rehydrated with the producing run's id (loadMessagesFromBackend stamps pm.runId), keying it to
+    // the real run id. After a switch-away/back resume those two keys diverged ('default' vs the run
+    // id), so the replayed message failed to merge with its rehydrated twin and rendered a duplicate,
+    // never-resolving pill (the frozen-tool-pill bug). currentRunId is set by the run_assignment that
+    // opens (and, on resume, replays first for) every run, so this aligns the live key with the
+    // rehydrated one. No run id yet (e.g. no run_assignment) ⇒ unchanged 'default' fallback.
+    if (!msg.runId && currentRunId.value) {
+      msg = { ...msg, runId: currentRunId.value };
+    }
+
     // Advance the content turn epoch in arrival order (BUG #8 + text interleaving) so multi-turn
     // thinking/text does not collapse onto the first block; non-content kinds just record the turn
     // boundary. The SAME sequence scopes both the merger accumulator (so deltas don't concatenate

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -1049,6 +1049,17 @@ export function useChat(options: UseChatOptions = {}) {
       return;
     }
 
+    // The active conversation may have changed while getRunState was in flight (rapid switching).
+    // Binding this thread's stream to whatever conversation is now current would contaminate it,
+    // so abort if we've moved on.
+    if (threadId.value !== existingThreadId) {
+      log.debug('Thread changed during resume check; aborting', {
+        requested: existingThreadId,
+        current: threadId.value,
+      });
+      return;
+    }
+
     if (!runState?.isInProgress) {
       log.debug('No in-flight run to resume', { threadId: existingThreadId });
       return;
@@ -1061,8 +1072,14 @@ export function useChat(options: UseChatOptions = {}) {
 
     // Reflect the live run in the UI (spinner / stop button) while the replayed + live deltas arrive.
     isLoading.value = true;
-    await openStreamConnection(existingThreadId, buildStreamCallbacks());
-    // No send: this is a subscribe-only resume.
+    try {
+      // No send: this is a subscribe-only resume.
+      await openStreamConnection(existingThreadId, buildStreamCallbacks());
+    } catch (err) {
+      // A failure opening the resume socket must not leave the UI stuck "streaming" forever.
+      isLoading.value = false;
+      log.error('Failed to open resume connection', { threadId: existingThreadId, error: err });
+    }
   }
 
   /**

--- a/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
@@ -39,6 +39,7 @@ public sealed class ContextDiscoveryController(
     SandboxSessionRegistry sessionRegistry,
     WorkspaceSubAgentLoader subAgentLoader,
     ContextDiscoveryInjector contextInjector,
+    ContextDiscoveryDiagnostics diagnostics,
     ILogger<ContextDiscoveryController> logger) : ControllerBase
 {
     /// <summary>
@@ -72,6 +73,11 @@ public sealed class ContextDiscoveryController(
             body.Description,
             body.SessionId,
             body.Truncated);
+
+        // Record the arrival for the diagnostics endpoint BEFORE the kind-specific handling (which is
+        // best-effort and may no-op). This is what lets an operator confirm webhooks are reaching the
+        // app at all — the count staying at zero is the signature of an unreachable callback host.
+        diagnostics.RecordReceived(body.SessionId, body.Kind, body.Path ?? body.Name);
 
         if (string.Equals(body.Kind, ContextDiscoveryKinds.SubAgent, StringComparison.Ordinal))
         {

--- a/samples/LmStreaming.Sample/Controllers/ContextDiscoveryDiagnosticsController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ContextDiscoveryDiagnosticsController.cs
@@ -1,0 +1,66 @@
+using LmStreaming.Sample.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LmStreaming.Sample.Controllers;
+
+/// <summary>
+/// Read-only diagnostics for the context-discovery (CLAUDE.md / AGENTS.md) feature. Answers
+/// "is discovery actually happening?" without booting a real sandbox: it reports where the gateway
+/// was told to deliver discoveries (so an operator can recognise an unreachable/loopback callback
+/// host), whether discovery is even enabled, and the per-session count + timestamp of webhooks the
+/// app has actually received. A live session whose received count stays at zero is the signature of
+/// the gateway failing to reach the callback host — not an app-side bug.
+/// </summary>
+[ApiController]
+[Route("api/diagnostics")]
+public sealed class ContextDiscoveryDiagnosticsController(
+    SandboxSessionRegistry registry,
+    ContextDiscoveryDiagnostics diagnostics) : ControllerBase
+{
+    [HttpGet("context-discovery")]
+    public IActionResult Get()
+    {
+        var received = diagnostics.Snapshot();
+
+        // Union of live sessions and sessions that have received a discovery (the latter may have
+        // since been torn down but their counts are still worth reporting). Ordered for stable output.
+        var sessionIds = new SortedSet<string>(StringComparer.Ordinal);
+        sessionIds.UnionWith(registry.GetActiveSessionIds());
+        sessionIds.UnionWith(received.Keys);
+
+        var sessions = sessionIds
+            .Select(id =>
+            {
+                _ = received.TryGetValue(id, out var r);
+                return new ContextDiscoverySessionInfo(
+                    SessionId: id,
+                    Active: registry.TryGetSessionById(id, out _),
+                    ReceivedCount: r?.Count ?? 0,
+                    LastReceivedAt: r?.LastReceivedAt,
+                    LastKind: r?.LastKind,
+                    LastPath: r?.LastPath);
+            })
+            .ToList();
+
+        return Ok(new ContextDiscoveryDiagnosticsResponse(
+            DiscoveryEnabled: registry.DiscoveryEnabled,
+            WebhookUrl: registry.DiscoveryWebhookUrl,
+            Sessions: sessions));
+    }
+}
+
+/// <summary>Top-level response for <c>GET /api/diagnostics/context-discovery</c>.</summary>
+public sealed record ContextDiscoveryDiagnosticsResponse(
+    bool DiscoveryEnabled,
+    string WebhookUrl,
+    IReadOnlyList<ContextDiscoverySessionInfo> Sessions);
+
+/// <summary>Per-session discovery state. <see cref="ReceivedCount"/> is 0 (with null timestamps)
+/// for a live session that has not yet received any discovery webhook.</summary>
+public sealed record ContextDiscoverySessionInfo(
+    string SessionId,
+    bool Active,
+    long ReceivedCount,
+    DateTimeOffset? LastReceivedAt,
+    string? LastKind,
+    string? LastPath);

--- a/samples/LmStreaming.Sample/Controllers/ConversationsController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ConversationsController.cs
@@ -89,6 +89,25 @@ public class ConversationsController(
         return Ok(normalized);
     }
 
+    /// <summary>
+    /// Reports whether a conversation currently has an in-flight run. A client returning to a
+    /// conversation (switch-back or refresh) calls this after loading persisted history; when
+    /// <see cref="ConversationRunState.IsInProgress"/> is true it re-opens the WebSocket to resume
+    /// the live stream (the pooled agent keeps running after the client disconnects). The signal is
+    /// in-memory run state, not persisted metadata, so it reflects the actual live run.
+    /// </summary>
+    [HttpGet("{threadId}/run-state")]
+    public IActionResult GetRunState(string threadId)
+    {
+        var runState = agentPool.GetRunStateInfo(threadId);
+        return Ok(new ConversationRunState
+        {
+            ThreadId = threadId,
+            IsInProgress = runState.IsInProgress,
+            CurrentRunId = runState.CurrentRunId,
+        });
+    }
+
     [HttpPut("{threadId}/metadata")]
     public async Task<IActionResult> UpdateMetadata(
         string threadId,

--- a/samples/LmStreaming.Sample/Models/ConversationDtos.cs
+++ b/samples/LmStreaming.Sample/Models/ConversationDtos.cs
@@ -26,6 +26,19 @@ public record ConversationSummary
 }
 
 /// <summary>
+/// In-memory run state for a conversation. Lets a reconnecting client decide whether to resume
+/// the live stream: after switching conversations or refreshing, the backend run keeps running
+/// (the agent is pooled), so a client returning to a conversation with <see cref="IsInProgress"/>
+/// re-opens the WebSocket to resume the in-flight stream instead of showing a frozen partial.
+/// </summary>
+public record ConversationRunState
+{
+    public required string ThreadId { get; init; }
+    public required bool IsInProgress { get; init; }
+    public string? CurrentRunId { get; init; }
+}
+
+/// <summary>
 /// DTO for updating conversation metadata (title, preview).
 /// </summary>
 public record ConversationMetadataUpdate

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -242,6 +242,10 @@ try
     // thread bound to the same sandbox session.
     _ = builder.Services.AddSingleton<ContextDiscoveryFormatter>();
     _ = builder.Services.AddSingleton<ContextDiscoveryInjector>();
+    // Tracks received discovery webhooks per session for GET /api/diagnostics/context-discovery,
+    // so an operator can confirm discoveries are actually arriving (vs. silently lost to an
+    // unreachable callback host).
+    _ = builder.Services.AddSingleton<ContextDiscoveryDiagnostics>();
 
     // Codex MCP server: registered unconditionally but started lazily, so non-codex boots
     // don't pay the startup cost and so the codex provider stays selectable from the

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -797,6 +797,10 @@ try
                             PromptCaching = PromptCachingMode.Auto,
                             ExtraProperties = extraProperties,
                         },
+                        // LmStreaming.Sample allows longer agentic runs than the library's 50-turn
+                        // default: workspace/tool-heavy conversations routinely need more turns before
+                        // the run hits its cap.
+                        maxTurnsPerRun: 150,
                         store: conversationStore,
                         logger: loggerFactory.CreateLogger<MultiTurnAgentLoop>(),
                         subAgentOptions: subAgentOptions,
@@ -1798,7 +1802,9 @@ public partial class Program
         // "the agent completes with no assistant content rendered" (issue #29).
         var claudeOptions = new ClaudeAgentSdkOptions
         {
-            MaxTurnsPerRun = 50,
+            // Match the generic MultiTurnAgentLoop cap above so the Claude SDK provider path allows
+            // the same longer agentic runs in this sample.
+            MaxTurnsPerRun = 150,
             AllowedTools = allowedTools,
             BaseUrl = string.IsNullOrWhiteSpace(mockBaseUrlOverride) ? null : mockBaseUrlOverride,
             AuthToken = string.IsNullOrWhiteSpace(mockAuthTokenOverride) ? null : mockAuthTokenOverride,

--- a/samples/LmStreaming.Sample/Services/BuiltInSubAgentTemplates.cs
+++ b/samples/LmStreaming.Sample/Services/BuiltInSubAgentTemplates.cs
@@ -15,9 +15,14 @@ internal static class BuiltInSubAgentTemplates
 {
     /// <summary>
     /// Default concurrent sub-agent cap applied wherever these templates are wrapped in a
-    /// <see cref="SubAgentOptions"/>.
+    /// <see cref="SubAgentOptions"/>. Bounds how many sub-agents the <c>Agent</c> tool can run in
+    /// parallel before an additional spawn waits (up to 5s) for a slot — each concurrent sub-agent
+    /// is a live provider/LLM call, so this is also the concurrent-request fan-out per conversation.
+    /// Scaled to the host like the workflow engine: <c>min(16, cores - 2)</c>, floored at 1 so a
+    /// low-core/CI host can never produce an invalid <c>SemaphoreSlim(0)</c>. On a 16-core box = 14.
     /// </summary>
-    internal const int DefaultMaxConcurrentSubAgents = 5;
+    internal static readonly int DefaultMaxConcurrentSubAgents =
+        Math.Max(1, Math.Min(16, Environment.ProcessorCount - 2));
 
     /// <summary>
     /// Builds a fresh dictionary of the built-in templates. Each template reuses

--- a/samples/LmStreaming.Sample/Services/ContextDiscoveryDiagnostics.cs
+++ b/samples/LmStreaming.Sample/Services/ContextDiscoveryDiagnostics.cs
@@ -1,0 +1,63 @@
+using System.Collections.Concurrent;
+
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+/// In-memory, process-lifetime tracker of context-discovery webhooks the app has actually received,
+/// keyed by sandbox session. Surfaced by <c>GET /api/diagnostics/context-discovery</c> so an
+/// operator can answer "is discovery happening?" at a glance: a session whose
+/// <see cref="SessionReceived.Count"/> stays at zero while threads are live is the signature of the
+/// gateway failing to reach the callback host (the loopback trap), not an app-side bug.
+/// </summary>
+/// <remarks>
+/// Registered as a singleton. Only the count/last-arrival metadata is retained — never the file
+/// body and never the gateway shared secret — so this is safe to expose over the diagnostics
+/// endpoint.
+/// </remarks>
+public sealed class ContextDiscoveryDiagnostics
+{
+    private readonly ConcurrentDictionary<string, SessionReceived> _received =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Records one authenticated, well-formed discovery webhook for <paramref name="sessionId"/>.
+    /// No-op when the session id is blank (the arrival can't be attributed to a session). Thread
+    /// safe: concurrent gateway callbacks for the same session fold into a monotonic count.
+    /// </summary>
+    public void RecordReceived(string? sessionId, string? kind, string? path)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        _ = _received.AddOrUpdate(
+            sessionId,
+            _ => new SessionReceived(1, now, kind, path),
+            (_, existing) => existing with
+            {
+                Count = existing.Count + 1,
+                LastReceivedAt = now,
+                LastKind = kind,
+                LastPath = path,
+            });
+    }
+
+    /// <summary>
+    /// Point-in-time copy of every session's received-discovery state. The returned dictionary is a
+    /// snapshot — safe to iterate without holding any lock.
+    /// </summary>
+    public IReadOnlyDictionary<string, SessionReceived> Snapshot() =>
+        new Dictionary<string, SessionReceived>(_received, StringComparer.Ordinal);
+}
+
+/// <summary>
+/// Per-session tally of received context-discovery webhooks. <see cref="LastKind"/> /
+/// <see cref="LastPath"/> describe the most recent arrival only.
+/// </summary>
+public sealed record SessionReceived(
+    long Count,
+    DateTimeOffset LastReceivedAt,
+    string? LastKind,
+    string? LastPath);

--- a/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
@@ -812,6 +812,34 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
         return set.TryAdd($"{kind}\0{path}", 0);
     }
 
+    /// <summary>
+    /// The exact URL the gateway is told to deliver context-discovery webhooks to (the auth-callback
+    /// base plus the discovery route). Surfaced by the diagnostics endpoint so an operator can spot
+    /// an unreachable/loopback callback host — the silent-failure mode where discoveries are fired
+    /// by the gateway but never arrive at the app.
+    /// </summary>
+    public string DiscoveryWebhookUrl =>
+        $"{_authOptions.Webhook.CallbackBaseUrl}/api/discovery/context_discovery";
+
+    /// <summary>
+    /// True when a callback base URL is configured. The default (a loopback host) is non-empty, so
+    /// this is normally true; it only reports false if an operator explicitly blanks the webhook
+    /// PublicBaseUrl. The more actionable "why is nothing arriving?" signal is the host visible in
+    /// <see cref="DiscoveryWebhookUrl"/> — a loopback callback the gateway (in a container) often
+    /// cannot reach.
+    /// </summary>
+    public bool DiscoveryEnabled => !string.IsNullOrWhiteSpace(_authOptions.Webhook.CallbackBaseUrl);
+
+    /// <summary>
+    /// Snapshot of the ids of every gateway session currently known to the registry. Used by the
+    /// diagnostics endpoint to pair live sessions against their received-discovery counts.
+    /// </summary>
+    public IReadOnlyCollection<string> GetActiveSessionIds()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return [.. _sessionsById.Keys];
+    }
+
     private const int ErrorBodyMaxLength = 500;
 
     /// <summary>
@@ -992,10 +1020,17 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
     /// </summary>
     private DiscoveryDto BuildDiscovery()
     {
-        var baseUrl = _authOptions.Webhook.CallbackBaseUrl;
+        var url = DiscoveryWebhookUrl;
+        // Registration breadcrumb: logs WHERE the gateway will deliver discoveries so an operator
+        // can correlate it against the diagnostics endpoint's received counts. NEVER logs the auth
+        // value (the gateway↔webhook shared secret) — only the URL and the enabled flag.
+        _logger.LogInformation(
+            "ContextDiscovery: gateway will deliver discoveries to {WebhookUrl} (enabled={Enabled}).",
+            url,
+            DiscoveryEnabled);
         return new DiscoveryDto(
             new DiscoveryWebhookDto(
-                Url: $"{baseUrl}/api/discovery/context_discovery",
+                Url: url,
                 Auth: _sharedSecret.Value
             )
         );

--- a/src/LmMultiTurn/MultiTurnAgentBase.cs
+++ b/src/LmMultiTurn/MultiTurnAgentBase.cs
@@ -40,7 +40,13 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     private readonly List<IMessage> _replayBuffer = [];
     private bool _replayRunActive;
     private bool _replayBufferTruncated;
-    private const int MaxReplayBufferSize = 10_000;
+    private long _replayBufferBytes;
+    // Replay is bounded by BOTH a message count and an estimated byte budget: a long tool/reasoning
+    // turn can stay under the count cap while still retaining large per-message payloads (text, tool
+    // args/results), and multiple live conversations multiply that. Whichever cap trips first stops
+    // buffering — the run keeps streaming live; only a mid-run reconnect's replay is truncated.
+    private readonly int _maxReplayBufferSize;
+    private readonly long _maxReplayBufferBytes;
 
     // State
     private string? _currentRunId;
@@ -164,6 +170,8 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     /// <param name="outputChannelCapacity">Capacity per subscriber output channel (default: 1000)</param>
     /// <param name="store">Optional persistence store for conversation state</param>
     /// <param name="logger">Optional logger</param>
+    /// <param name="maxReplayBufferSize">Max messages buffered for mid-run reconnect replay (default: 10,000).</param>
+    /// <param name="maxReplayBufferBytes">Max estimated bytes buffered for mid-run reconnect replay (default: 8 MiB).</param>
     protected MultiTurnAgentBase(
         string threadId,
         string? systemPrompt = null,
@@ -172,7 +180,9 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
         int inputChannelCapacity = 100,
         int outputChannelCapacity = 1000,
         IConversationStore? store = null,
-        ILogger? logger = null)
+        ILogger? logger = null,
+        int maxReplayBufferSize = 10_000,
+        long maxReplayBufferBytes = 8L * 1024 * 1024)
     {
         ArgumentNullException.ThrowIfNull(threadId);
 
@@ -181,6 +191,8 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
         MaxTurnsPerRun = maxTurnsPerRun;
         _inputChannelCapacity = inputChannelCapacity;
         _outputChannelCapacity = outputChannelCapacity;
+        _maxReplayBufferSize = maxReplayBufferSize;
+        _maxReplayBufferBytes = maxReplayBufferBytes;
         DefaultOptions = defaultOptions ?? new GenerateReplyOptions();
         Store = store;
         Logger = logger ?? NullLogger.Instance;
@@ -858,8 +870,9 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     /// </summary>
     /// <param name="message">The message to publish</param>
     /// <param name="ct">Cancellation token</param>
-    protected async ValueTask PublishToAllAsync(IMessage message, CancellationToken ct)
+    protected ValueTask PublishToAllAsync(IMessage message, CancellationToken ct)
     {
+        _ = ct;
         List<KeyValuePair<string, Channel<IMessage>>> targets;
         lock (_replayLock)
         {
@@ -872,22 +885,27 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
             if (message is RunAssignmentMessage)
             {
                 _replayBuffer.Clear();
+                _replayBufferBytes = 0;
                 _replayRunActive = true;
                 _replayBufferTruncated = false;
             }
 
             if (_replayRunActive)
             {
-                if (_replayBuffer.Count < MaxReplayBufferSize)
+                if (_replayBuffer.Count < _maxReplayBufferSize && _replayBufferBytes < _maxReplayBufferBytes)
                 {
                     _replayBuffer.Add(message);
+                    _replayBufferBytes += EstimateMessageBytes(message);
                 }
                 else if (!_replayBufferTruncated)
                 {
                     _replayBufferTruncated = true;
                     Logger.LogWarning(
-                        "In-flight replay buffer hit the {Cap}-message cap; a client reconnecting mid-run may miss the earliest deltas of this run (persisted history still covers its completed messages).",
-                        MaxReplayBufferSize);
+                        "In-flight replay buffer hit its cap ({CountCap} messages / {ByteCap} bytes); a client "
+                            + "reconnecting mid-run may miss the earliest deltas of this run (persisted history "
+                            + "still covers its completed messages).",
+                        _maxReplayBufferSize,
+                        _maxReplayBufferBytes);
                 }
             }
 
@@ -897,46 +915,82 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
                 // Free the buffered run now that it can no longer be replayed (replay is gated on
                 // _replayRunActive). A subscriber joining after completion uses persisted history.
                 _replayBuffer.Clear();
+                _replayBufferBytes = 0;
             }
 
             targets = [.. _outputSubscribers];
         }
 
-        if (targets.Count == 0)
+        foreach (var (subscriberId, channel) in targets)
+        {
+            PublishToSubscriber(subscriberId, channel, message);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Delivers <paramref name="message"/> to one subscriber WITHOUT ever blocking the publisher.
+    /// A bounded per-subscriber channel means a slow/stalled consumer (classically a reconnecting
+    /// client still draining the in-flight run's replay buffer) can fill its channel; awaiting the
+    /// write there would put that consumer on the live run's hot path and let it backpressure the
+    /// active run and every other subscriber. So we write non-blocking and, when
+    /// the channel is full, DROP the subscriber: remove it from the fan-out and complete its channel
+    /// so its <see cref="SubscribeAsync"/> enumerator ends. The client can reconnect; resume replays
+    /// the in-flight run from the buffer. A reconnecting replay consumer can therefore never block
+    /// <see cref="PublishToAllAsync"/>.
+    /// </summary>
+    private void PublishToSubscriber(string subscriberId, Channel<IMessage> channel, IMessage message)
+    {
+        // Fast path: succeeds whenever the subscriber is keeping up (the overwhelming common case).
+        if (channel.Writer.TryWrite(message))
         {
             return;
         }
 
-        var tasks = new List<Task>(targets.Count);
-        foreach (var (subscriberId, channel) in targets)
+        if (_outputSubscribers.TryRemove(subscriberId, out var removed))
         {
-            tasks.Add(PublishToSubscriberAsync(subscriberId, channel, message, ct));
+            _ = removed.Writer.TryComplete();
+            Logger.LogWarning(
+                "Dropping slow subscriber {SubscriberId}: output channel full at capacity {Capacity}; "
+                    + "the live run is not blocked and the client can reconnect to resume.",
+                subscriberId,
+                _outputChannelCapacity);
         }
-
-        await Task.WhenAll(tasks);
     }
 
-    private async Task PublishToSubscriberAsync(
-        string subscriberId,
-        Channel<IMessage> channel,
-        IMessage message,
-        CancellationToken ct)
+    /// <summary>
+    /// Cheap estimate of the heap a buffered message retains, used only to bound total replay memory
+    /// against <c>_maxReplayBufferBytes</c>. Dominated by text-ish payloads (≈2 bytes/char); other
+    /// shapes fall back to a small base overhead. Intentionally approximate — it caps memory, it is
+    /// not exact accounting, and runs under the replay lock so it must stay allocation-free and O(1)
+    /// per message (tool-call args are summed, which is bounded by the call count).
+    /// </summary>
+    private static long EstimateMessageBytes(IMessage message)
     {
-        try
+        const long baseOverhead = 128;
+        switch (message)
         {
-            await channel.Writer.WriteAsync(message, ct);
-        }
-        catch (ChannelClosedException)
-        {
-            Logger.LogDebug("Channel for subscriber {SubscriberId} is closed", subscriberId);
-        }
-        catch (OperationCanceledException)
-        {
-            // Ignore cancellation
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex, "Error publishing to subscriber {SubscriberId}", subscriberId);
+            case TextUpdateMessage t:
+                return baseOverhead + (t.Text?.Length ?? 0) * 2L;
+            case TextMessage t:
+                return baseOverhead + (t.Text?.Length ?? 0) * 2L;
+            case ToolsCallMessage tc:
+                {
+                    var bytes = baseOverhead;
+                    if (tc.ToolCalls is { } calls)
+                    {
+                        foreach (var call in calls)
+                        {
+                            bytes += ((call.FunctionName?.Length ?? 0) + (call.FunctionArgs?.Length ?? 0)) * 2L;
+                        }
+                    }
+
+                    return bytes;
+                }
+
+            default:
+                return baseOverhead;
         }
     }
 

--- a/src/LmMultiTurn/MultiTurnAgentBase.cs
+++ b/src/LmMultiTurn/MultiTurnAgentBase.cs
@@ -26,6 +26,21 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     private readonly object _channelLock = new();
     private readonly ConcurrentDictionary<string, Channel<IMessage>> _outputSubscribers = new();
 
+    // Replay buffer for the in-flight run. A client that reconnects mid-run (after switching
+    // conversations or refreshing the page) re-subscribes via SubscribeAsync; without replay it
+    // would only see messages published AFTER re-subscribing, so the visible stream froze. We
+    // buffer the current run's published messages (from its RunAssignmentMessage until its
+    // RunCompletedMessage) and replay them to a joining subscriber. `_replayLock` guards
+    // register-subscriber + buffer-snapshot (SubscribeAsync) atomically against the buffer-append +
+    // subscriber-snapshot (PublishToAllAsync), so a message published concurrently with a subscribe
+    // reaches that subscriber EXACTLY once (replay XOR live). Publishes are serialized by the run
+    // loop, so the only race is Subscribe vs a single in-flight publish.
+    private readonly object _replayLock = new();
+    private readonly List<IMessage> _replayBuffer = [];
+    private bool _replayRunActive;
+    private bool _replayBufferTruncated;
+    private const int MaxReplayBufferSize = 10_000;
+
     // State
     private string? _currentRunId;
     private string? _latestRunId;
@@ -793,11 +808,33 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
             SingleWriter = false,
         });
 
-        _outputSubscribers[subscriberId] = channel;
-        Logger.LogDebug("Subscriber {SubscriberId} connected", subscriberId);
+        // Atomically register this subscriber AND snapshot the in-flight run's buffered messages,
+        // so a message published concurrently is delivered EITHER via this replay snapshot OR via
+        // the live channel below — never both, never neither. See `_replayLock` remarks.
+        IReadOnlyList<IMessage> replay;
+        lock (_replayLock)
+        {
+            _outputSubscribers[subscriberId] = channel;
+            replay = _replayRunActive && _replayBuffer.Count > 0
+                ? [.. _replayBuffer]
+                : [];
+        }
+
+        Logger.LogDebug(
+            "Subscriber {SubscriberId} connected (replaying {ReplayCount} in-flight message(s))",
+            subscriberId,
+            replay.Count);
 
         try
         {
+            // Replay the in-flight run's already-published messages first (so a reconnecting client
+            // resumes from the start of the live run), then stream subsequent live messages.
+            foreach (var buffered in replay)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return buffered;
+            }
+
             await foreach (var message in channel.Reader.ReadAllAsync(ct))
             {
                 yield return message;
@@ -822,9 +859,52 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     /// <param name="ct">Cancellation token</param>
     protected async ValueTask PublishToAllAsync(IMessage message, CancellationToken ct)
     {
-        var tasks = new List<Task>();
+        List<KeyValuePair<string, Channel<IMessage>>> targets;
+        lock (_replayLock)
+        {
+            // Maintain the in-flight run's replay buffer. RunAssignmentMessage opens a fresh run;
+            // RunCompletedMessage closes it (after which a joining subscriber must NOT replay it —
+            // the client already has completed messages via persisted REST history, so replaying
+            // would duplicate). Snapshotting subscribers under the SAME lock SubscribeAsync uses to
+            // register + snapshot the buffer guarantees this message reaches each subscriber exactly
+            // once (replay XOR live).
+            if (message is RunAssignmentMessage)
+            {
+                _replayBuffer.Clear();
+                _replayRunActive = true;
+                _replayBufferTruncated = false;
+            }
 
-        foreach (var (subscriberId, channel) in _outputSubscribers)
+            if (_replayRunActive)
+            {
+                if (_replayBuffer.Count < MaxReplayBufferSize)
+                {
+                    _replayBuffer.Add(message);
+                }
+                else if (!_replayBufferTruncated)
+                {
+                    _replayBufferTruncated = true;
+                    Logger.LogWarning(
+                        "In-flight replay buffer hit the {Cap}-message cap; a client reconnecting mid-run may miss the earliest deltas of this run (persisted history still covers its completed messages).",
+                        MaxReplayBufferSize);
+                }
+            }
+
+            if (message is RunCompletedMessage)
+            {
+                _replayRunActive = false;
+            }
+
+            targets = [.. _outputSubscribers];
+        }
+
+        if (targets.Count == 0)
+        {
+            return;
+        }
+
+        var tasks = new List<Task>(targets.Count);
+        foreach (var (subscriberId, channel) in targets)
         {
             tasks.Add(PublishToSubscriberAsync(subscriberId, channel, message, ct));
         }

--- a/src/LmMultiTurn/MultiTurnAgentBase.cs
+++ b/src/LmMultiTurn/MultiTurnAgentBase.cs
@@ -33,8 +33,9 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     // RunCompletedMessage) and replay them to a joining subscriber. `_replayLock` guards
     // register-subscriber + buffer-snapshot (SubscribeAsync) atomically against the buffer-append +
     // subscriber-snapshot (PublishToAllAsync), so a message published concurrently with a subscribe
-    // reaches that subscriber EXACTLY once (replay XOR live). Publishes are serialized by the run
-    // loop, so the only race is Subscribe vs a single in-flight publish.
+    // reaches that subscriber EXACTLY once (replay XOR live) — this holds even if publishes overlap
+    // (e.g. parallel tool-call results). Relative ordering of concurrently-published messages is not
+    // guaranteed (the channel writes happen outside the lock), exactly as before this change.
     private readonly object _replayLock = new();
     private readonly List<IMessage> _replayBuffer = [];
     private bool _replayRunActive;
@@ -893,6 +894,9 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
             if (message is RunCompletedMessage)
             {
                 _replayRunActive = false;
+                // Free the buffered run now that it can no longer be replayed (replay is gated on
+                // _replayRunActive). A subscriber joining after completion uses persisted history.
+                _replayBuffer.Clear();
             }
 
             targets = [.. _outputSubscribers];

--- a/src/LmMultiTurn/MultiTurnAgentBase.cs
+++ b/src/LmMultiTurn/MultiTurnAgentBase.cs
@@ -972,9 +972,9 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
         switch (message)
         {
             case TextUpdateMessage t:
-                return baseOverhead + (t.Text?.Length ?? 0) * 2L;
+                return baseOverhead + ((t.Text?.Length ?? 0) * 2L);
             case TextMessage t:
-                return baseOverhead + (t.Text?.Length ?? 0) * 2L;
+                return baseOverhead + ((t.Text?.Length ?? 0) * 2L);
             case ToolsCallMessage tc:
                 {
                     var bytes = baseOverhead;

--- a/src/OpenAiResponsesProvider/Agents/OpenAiResponsesAgent.cs
+++ b/src/OpenAiResponsesProvider/Agents/OpenAiResponsesAgent.cs
@@ -97,7 +97,7 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
                     Role = Role.Assistant,
                     FromAgent = Name,
                     GenerationId = generationId,
-                }
+                }.WithIds(options)
             );
         }
 
@@ -123,7 +123,26 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
         );
 
         var eventStream = _client.StreamResponseAsync(request, cancellationToken);
-        return Task.FromResult(EventStreamToMessages(eventStream, Name, options?.GenerationId, cancellationToken));
+        var mapped = EventStreamToMessages(eventStream, Name, options?.GenerationId, cancellationToken);
+        // The agent constructs messages itself, so (unlike OpenAgent/AnthropicAgent) it must stamp the
+        // run's RunId/ParentRunId/ThreadId explicitly — otherwise every emitted message carries a null
+        // RunId and the client merge key (kind, runId, generationId, messageOrderIdx) loses a segment.
+        // WithIds preserves the GenerationId already set above (BUG H1), only overriding it when the run
+        // advertises one — which equals the id the messages already carry.
+        return Task.FromResult(StampRunIds(mapped, options, cancellationToken));
+    }
+
+    private static async IAsyncEnumerable<IMessage> StampRunIds(
+        IAsyncEnumerable<IMessage> source,
+        GenerateReplyOptions? options,
+        [EnumeratorCancellation] CancellationToken cancellationToken
+    )
+    {
+        await foreach (var message in source.ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return message.WithIds(options);
+        }
     }
 
     private static async IAsyncEnumerable<IMessage> EventStreamToMessages(

--- a/tests/LmMultiTurn.Tests/MultiTurnAgentReplayTests.cs
+++ b/tests/LmMultiTurn.Tests/MultiTurnAgentReplayTests.cs
@@ -89,4 +89,120 @@ public sealed class MultiTurnAgentReplayTests
         (await first).Should().BeTrue();
         e.Current.Should().BeOfType<TextUpdateMessage>().Which.Text.Should().Be("new");
     }
+
+    [Fact]
+    public async Task Live_and_reconnecting_subscribers_both_receive_every_message_once()
+    {
+        await using var agent = new ReplayTestAgent("thread-1");
+        const string runId = "run-1";
+        const string genId = "gen-1";
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        // Subscriber A is live from before the run starts. The first MoveNextAsync registers it
+        // synchronously (the lock/register runs before the first await), so publishes below reach it.
+        await using var a = agent.SubscribeAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+        var aFirst = a.MoveNextAsync();
+
+        await agent.PublishForTest(Assignment("thread-1", runId, genId));
+        await agent.PublishForTest(TextDelta(runId, genId, "Hel"));
+
+        (await aFirst).Should().BeTrue();
+        a.Current.Should().BeOfType<RunAssignmentMessage>();
+        (await a.MoveNextAsync()).Should().BeTrue();
+        a.Current.Should().BeOfType<TextUpdateMessage>().Which.Text.Should().Be("Hel");
+
+        // Subscriber B reconnects mid-run and REPLAYS what A already saw live.
+        await using var b = agent.SubscribeAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+        (await b.MoveNextAsync()).Should().BeTrue();
+        b.Current.Should().BeOfType<RunAssignmentMessage>();
+        (await b.MoveNextAsync()).Should().BeTrue();
+        b.Current.Should().BeOfType<TextUpdateMessage>().Which.Text.Should().Be("Hel");
+
+        // A subsequent live message reaches BOTH exactly once.
+        await agent.PublishForTest(TextDelta(runId, genId, "lo"));
+        (await a.MoveNextAsync()).Should().BeTrue();
+        a.Current.Should().BeOfType<TextUpdateMessage>().Which.Text.Should().Be("lo");
+        (await b.MoveNextAsync()).Should().BeTrue();
+        b.Current.Should().BeOfType<TextUpdateMessage>().Which.Text.Should().Be("lo");
+    }
+
+    [Fact]
+    public async Task Concurrent_subscribe_during_active_publishing_delivers_each_message_exactly_once()
+    {
+        // Exercises the real race the `_replayLock` guards: a subscriber registering WHILE a
+        // publisher is actively publishing. With a single serial publisher the messages are totally
+        // ordered, so the subscriber must observe a contiguous, gap-free, duplicate-free run made of
+        // a replay prefix + a live suffix.
+        await using var agent = new ReplayTestAgent("thread-1");
+        const string runId = "run-1";
+        const string genId = "gen-1";
+        const int total = 500;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        await agent.PublishForTest(Assignment("thread-1", runId, genId));
+
+        var publisher = Task.Run(async () =>
+        {
+            for (var i = 0; i < total; i++)
+            {
+                await agent.PublishForTest(TextDelta(runId, genId, i.ToString()));
+            }
+
+            await agent.PublishForTest(new RunCompletedMessage { CompletedRunId = runId, ThreadId = "thread-1" });
+        }, cts.Token);
+
+        var received = new List<int>();
+        await foreach (var m in agent.SubscribeAsync(cts.Token))
+        {
+            if (m is TextUpdateMessage t && int.TryParse(t.Text, out var n))
+            {
+                received.Add(n);
+            }
+
+            if (m is RunCompletedMessage)
+            {
+                break;
+            }
+        }
+
+        await publisher;
+
+        received.Should().OnlyHaveUniqueItems("no message may be delivered twice (replay XOR live)");
+        received.Should().BeInAscendingOrder("a single serial publisher produces a total order");
+        received.Should().Contain(total - 1, "the subscriber must receive through the end of the run");
+    }
+
+    [Fact]
+    public async Task Replay_buffer_is_capped_so_a_huge_run_does_not_grow_unbounded()
+    {
+        await using var agent = new ReplayTestAgent("thread-1");
+        const string runId = "run-1";
+        const string genId = "gen-1";
+        const int cap = 10_000; // mirrors MultiTurnAgentBase.MaxReplayBufferSize
+
+        // Assignment fills slot #1; the next `cap` deltas overflow by one, which must be dropped.
+        await agent.PublishForTest(Assignment("thread-1", runId, genId));
+        for (var i = 0; i < cap; i++)
+        {
+            await agent.PublishForTest(TextDelta(runId, genId, i.ToString()));
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        await using var e = agent.SubscribeAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+
+        // Drain exactly `cap` replayed messages — the buffer must hold no more than this.
+        for (var i = 0; i < cap; i++)
+        {
+            (await e.MoveNextAsync()).Should().BeTrue();
+        }
+
+        // Prove the buffer held EXACTLY `cap` (not cap+1): the next message must be a sentinel
+        // published live AFTER subscribing, not the overflowed delta that was dropped.
+        await agent.PublishForTest(TextDelta(runId, genId, "SENTINEL"));
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should()
+            .BeOfType<TextUpdateMessage>()
+            .Which.Text.Should()
+            .Be("SENTINEL", "the in-flight replay buffer is bounded at the cap, so the overflow delta was dropped");
+    }
 }

--- a/tests/LmMultiTurn.Tests/MultiTurnAgentReplayTests.cs
+++ b/tests/LmMultiTurn.Tests/MultiTurnAgentReplayTests.cs
@@ -1,0 +1,92 @@
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using FluentAssertions;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+/// <summary>
+/// Streaming resume: a client that reconnects mid-run (after switching conversations or
+/// refreshing) must be able to resume the in-flight stream. The backend run keeps running after
+/// the client disconnects (pooled agent), but <see cref="MultiTurnAgentBase.SubscribeAsync"/>
+/// historically created a fresh subscriber with NO replay — so a reconnecting client received
+/// only messages published after it re-subscribed and the visible stream "froze". These tests
+/// pin the replay contract: a subscriber joining mid-run gets the in-flight run's already-published
+/// messages first, then live ones; a subscriber joining after completion gets no replay.
+/// </summary>
+public sealed class MultiTurnAgentReplayTests
+{
+    private sealed class ReplayTestAgent(string threadId) : MultiTurnAgentBase(threadId, systemPrompt: null, store: null, logger: null)
+    {
+        // The loop is driven manually in these tests via PublishForTest; never started.
+        protected override Task RunLoopAsync(CancellationToken ct) => Task.CompletedTask;
+
+        public ValueTask PublishForTest(IMessage message) => PublishToAllAsync(message, CancellationToken.None);
+    }
+
+    private static RunAssignmentMessage Assignment(string threadId, string runId, string genId) =>
+        new() { Assignment = new RunAssignment(runId, genId), ThreadId = threadId };
+
+    private static TextUpdateMessage TextDelta(string runId, string genId, string text) =>
+        new() { Text = text, Role = Role.Assistant, RunId = runId, GenerationId = genId, MessageOrderIdx = 0 };
+
+    [Fact]
+    public async Task Subscriber_joining_mid_run_replays_buffered_messages_then_streams_live()
+    {
+        await using var agent = new ReplayTestAgent("thread-1");
+        const string runId = "run-1";
+        const string genId = "gen-1";
+
+        // The run is already in flight and has published several messages BEFORE the client
+        // (re)connects — exactly the switch-away/refresh window.
+        await agent.PublishForTest(Assignment("thread-1", runId, genId));
+        await agent.PublishForTest(TextDelta(runId, genId, "Hel"));
+        await agent.PublishForTest(TextDelta(runId, genId, "lo"));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await using var e = agent.SubscribeAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+
+        // The reconnecting subscriber must REPLAY the in-flight run's already-published messages.
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<RunAssignmentMessage>();
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<TextUpdateMessage>().Which.Text.Should().Be("Hel");
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<TextUpdateMessage>().Which.Text.Should().Be("lo");
+
+        // Now the run continues live — the same subscriber must keep receiving.
+        await agent.PublishForTest(TextDelta(runId, genId, "!"));
+        await agent.PublishForTest(new RunCompletedMessage { CompletedRunId = runId, ThreadId = "thread-1" });
+
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<TextUpdateMessage>().Which.Text.Should().Be("!");
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<RunCompletedMessage>();
+    }
+
+    [Fact]
+    public async Task Subscriber_joining_after_run_completed_does_not_replay_the_finished_run()
+    {
+        await using var agent = new ReplayTestAgent("thread-1");
+        const string runId = "run-1";
+        const string genId = "gen-1";
+
+        await agent.PublishForTest(Assignment("thread-1", runId, genId));
+        await agent.PublishForTest(TextDelta(runId, genId, "Hello"));
+        await agent.PublishForTest(new RunCompletedMessage { CompletedRunId = runId, ThreadId = "thread-1" });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await using var e = agent.SubscribeAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+
+        // No active run ⇒ the first read must NOT synchronously yield the finished run's messages
+        // (the client already has those via persisted REST history; replaying them would duplicate).
+        var first = e.MoveNextAsync();
+        first.IsCompleted.Should().BeFalse("a subscriber joining after completion must not replay the finished run");
+
+        // It only receives genuinely new live messages.
+        await agent.PublishForTest(TextDelta("run-2", "gen-2", "new"));
+        (await first).Should().BeTrue();
+        e.Current.Should().BeOfType<TextUpdateMessage>().Which.Text.Should().Be("new");
+    }
+}

--- a/tests/LmMultiTurn.Tests/MultiTurnAgentReplayTests.cs
+++ b/tests/LmMultiTurn.Tests/MultiTurnAgentReplayTests.cs
@@ -31,6 +31,29 @@ public sealed class MultiTurnAgentReplayTests
     private static TextUpdateMessage TextDelta(string runId, string genId, string text) =>
         new() { Text = text, Role = Role.Assistant, RunId = runId, GenerationId = genId, MessageOrderIdx = 0 };
 
+    private static ToolCallMessage ToolCall(string runId, string genId, string toolCallId, int orderIdx) =>
+        new()
+        {
+            Role = Role.Assistant,
+            RunId = runId,
+            GenerationId = genId,
+            MessageOrderIdx = orderIdx,
+            ToolCallId = toolCallId,
+            FunctionName = "get_weather",
+            FunctionArgs = "{\"location\":\"Seattle\"}",
+        };
+
+    private static ToolCallResultMessage ToolResult(string runId, string genId, string toolCallId, int orderIdx) =>
+        new()
+        {
+            Role = Role.Tool,
+            RunId = runId,
+            GenerationId = genId,
+            MessageOrderIdx = orderIdx,
+            ToolCallId = toolCallId,
+            Result = "{\"location\":\"Seattle\",\"temperature\":72}",
+        };
+
     [Fact]
     public async Task Subscriber_joining_mid_run_replays_buffered_messages_then_streams_live()
     {
@@ -61,6 +84,45 @@ public sealed class MultiTurnAgentReplayTests
 
         (await e.MoveNextAsync()).Should().BeTrue();
         e.Current.Should().BeOfType<TextUpdateMessage>().Which.Text.Should().Be("!");
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<RunCompletedMessage>();
+    }
+
+    [Fact]
+    public async Task Subscriber_joining_mid_run_replays_tool_call_and_result()
+    {
+        // The frozen-tool-pill resume bug needs the replay to carry BOTH the tool call AND its
+        // result: a client that switches away mid-tool-call and returns rebuilds the unresolved
+        // pill from REST history, then resolves it ONLY if the resumed stream replays the tool
+        // call and its result. This pins that the in-flight replay includes tool messages, not
+        // just text — the contract the client switch-back/resume render path depends on.
+        await using var agent = new ReplayTestAgent("thread-1");
+        const string runId = "run-1";
+        const string genId = "gen-1";
+        const string toolCallId = "call_1";
+
+        // The run issued a tool call and produced its result BEFORE the client (re)connects.
+        await agent.PublishForTest(Assignment("thread-1", runId, genId));
+        await agent.PublishForTest(ToolCall(runId, genId, toolCallId, orderIdx: 1));
+        await agent.PublishForTest(ToolResult(runId, genId, toolCallId, orderIdx: 2));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await using var e = agent.SubscribeAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+
+        // The reconnecting subscriber must replay the run assignment, the tool call, and its result.
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<RunAssignmentMessage>();
+
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<ToolCallMessage>()
+            .Which.ToolCallId.Should().Be(toolCallId);
+
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<ToolCallResultMessage>()
+            .Which.ToolCallId.Should().Be(toolCallId);
+
+        // The run then completes live and the same subscriber receives it.
+        await agent.PublishForTest(new RunCompletedMessage { CompletedRunId = runId, ThreadId = "thread-1" });
         (await e.MoveNextAsync()).Should().BeTrue();
         e.Current.Should().BeOfType<RunCompletedMessage>();
     }

--- a/tests/LmMultiTurn.Tests/MultiTurnAgentReplayTests.cs
+++ b/tests/LmMultiTurn.Tests/MultiTurnAgentReplayTests.cs
@@ -17,8 +17,24 @@ namespace LmMultiTurn.Tests;
 /// </summary>
 public sealed class MultiTurnAgentReplayTests
 {
-    private sealed class ReplayTestAgent(string threadId) : MultiTurnAgentBase(threadId, systemPrompt: null, store: null, logger: null)
+    private sealed class ReplayTestAgent : MultiTurnAgentBase
     {
+        public ReplayTestAgent(
+            string threadId,
+            int outputChannelCapacity = 1000,
+            int maxReplayBufferSize = 10_000,
+            long maxReplayBufferBytes = 8L * 1024 * 1024)
+            : base(
+                threadId,
+                systemPrompt: null,
+                store: null,
+                logger: null,
+                outputChannelCapacity: outputChannelCapacity,
+                maxReplayBufferSize: maxReplayBufferSize,
+                maxReplayBufferBytes: maxReplayBufferBytes)
+        {
+        }
+
         // The loop is driven manually in these tests via PublishForTest; never started.
         protected override Task RunLoopAsync(CancellationToken ct) => Task.CompletedTask;
 
@@ -266,5 +282,94 @@ public sealed class MultiTurnAgentReplayTests
             .BeOfType<TextUpdateMessage>()
             .Which.Text.Should()
             .Be("SENTINEL", "the in-flight replay buffer is bounded at the cap, so the overflow delta was dropped");
+    }
+
+    [Fact]
+    public async Task A_stalled_subscriber_neither_blocks_the_publisher_nor_starves_other_subscribers()
+    {
+        // Regression for the publisher hot-path BLOCKER: a slow/stalled subscriber whose bounded
+        // output channel fills must NOT backpressure the live run (or other subscribers). Before the
+        // fix, the publisher awaited each subscriber's WriteAsync via Task.WhenAll, so one full channel
+        // hung PublishToAllAsync indefinitely; now a full subscriber is dropped instead.
+        await using var agent = new ReplayTestAgent("thread-1", outputChannelCapacity: 4);
+        const string runId = "run-1";
+        const string genId = "gen-1";
+        const int burst = 50; // >> the slow subscriber's capacity, so its channel overflows
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        // Fast subscriber B and slow subscriber A are both registered before the run starts.
+        var bEnum = agent.SubscribeAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+        var bFirst = bEnum.MoveNextAsync();
+        var aEnum = agent.SubscribeAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+        var aFirst = aEnum.MoveNextAsync(); // A consumes only the assignment below, then never drains.
+
+        await agent.PublishForTest(Assignment("thread-1", runId, genId));
+        (await aFirst).Should().BeTrue("A receives the assignment, then stops draining (its channel fills)");
+        (await bFirst).Should().BeTrue();
+        bEnum.Current.Should().BeOfType<RunAssignmentMessage>();
+
+        // Publish a burst far exceeding A's capacity, draining B one message per publish so B never
+        // backs up. Each publish must return PROMPTLY: before the fix, the (capacity+1)th write to the
+        // stalled A would await forever inside Task.WhenAll, so the per-publish timeout would fire.
+        for (var i = 0; i < burst; i++)
+        {
+            await agent.PublishForTest(TextDelta(runId, genId, i.ToString()))
+                .AsTask()
+                .WaitAsync(TimeSpan.FromSeconds(3), cts.Token);
+
+            (await bEnum.MoveNextAsync()).Should().BeTrue("the fast subscriber keeps receiving while A is stalled");
+            bEnum.Current.Should().BeOfType<TextUpdateMessage>().Which.Text.Should().Be(i.ToString());
+        }
+
+        await agent.PublishForTest(new RunCompletedMessage { CompletedRunId = runId, ThreadId = "thread-1" })
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(3), cts.Token);
+
+        // B (which kept pace) received every delta in order plus RunCompleted, even though A stalled
+        // on the same publisher and was dropped.
+        (await bEnum.MoveNextAsync()).Should().BeTrue();
+        bEnum.Current.Should().BeOfType<RunCompletedMessage>();
+
+        await aEnum.DisposeAsync();
+        await bEnum.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Replay_buffer_is_capped_by_estimated_bytes_not_just_count()
+    {
+        // Generous count cap, tiny byte budget: prove the BYTE cap stops buffering before the count
+        // cap would. EstimateMessageBytes ≈ 128 + text.Length*2, so a 200-char delta ≈ 528 bytes:
+        // assignment (≈128) + two deltas (≈528 each = 1184) crosses the 1000-byte budget, so only the
+        // assignment + first two deltas are retained; the third and all later deltas are dropped.
+        await using var agent = new ReplayTestAgent(
+            "thread-1",
+            maxReplayBufferSize: 1_000_000,
+            maxReplayBufferBytes: 1_000);
+        const string runId = "run-1";
+        const string genId = "gen-1";
+        var big = new string('x', 200);
+
+        await agent.PublishForTest(Assignment("thread-1", runId, genId));
+        for (var i = 0; i < 20; i++)
+        {
+            await agent.PublishForTest(TextDelta(runId, genId, big));
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await using var e = agent.SubscribeAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+
+        // Exactly three messages were buffered before the byte budget tripped.
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<RunAssignmentMessage>();
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<TextUpdateMessage>();
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<TextUpdateMessage>();
+
+        // Prove the buffer held EXACTLY those three: the next message must be a sentinel published live
+        // AFTER subscribing, not the byte-capped (dropped) third delta.
+        await agent.PublishForTest(TextDelta(runId, genId, "SENTINEL"));
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<TextUpdateMessage>().Which.Text.Should().Be("SENTINEL");
     }
 }

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs
@@ -37,6 +37,12 @@ public static class UiHelpers
         return page.GetByRole(AriaRole.Button, new PageGetByRoleOptions { Name = "+ New Chat" });
     }
 
+    /// <summary>All conversation list items in the sidebar (one per started conversation).</summary>
+    public static ILocator ConversationItems(this IPage page)
+    {
+        return page.GetByTestId("conversation-item");
+    }
+
     /// <summary>Error banner — rendered only when an error is present.</summary>
     public static ILocator ErrorBanner(this IPage page)
     {

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/StreamingResumeToolPillsTests.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/StreamingResumeToolPillsTests.cs
@@ -1,0 +1,229 @@
+using System.Text.RegularExpressions;
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using FluentAssertions;
+using LmStreaming.Sample.Browser.E2E.Tests.Infrastructure;
+
+namespace LmStreaming.Sample.Browser.E2E.Tests.Scenarios;
+
+/// <summary>
+/// Browser-level regression for the streaming-resume "stuck / duplicated tool pills" bug
+/// (user repro: a provider that makes MANY tool calls, switch away mid-stream, switch back →
+/// the tool-call pills duplicate and the tool count never settles; a full page reload "fixes" it).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Root cause (client live-resume render path, WebSocket transport only): on the wire, finalized
+/// <c>tool_call</c> / <c>tool_call_update</c> messages from the real Anthropic provider arrive WITHOUT
+/// a <c>runId</c> (verified across recorded traffic — <c>tool_call</c> carried one in 0 of 267 frames),
+/// so <c>getMergeKey</c> keys them to <c>'default'</c>. The PERSISTED copy of the same message is
+/// rehydrated by <c>loadMessagesFromBackend</c> (REST) stamped with the run's REAL id. After a
+/// switch-away/back, <c>resumeStreamIfActive</c> re-opens the WebSocket and replays the in-flight run;
+/// the runId-less replayed tool calls (key <c>'default'</c>) fail to merge with their rehydrated twins
+/// (key = real runId) and render as duplicate, never-resolving pills. The fix
+/// (<c>useChat.handleMessage</c>) stamps the active run id — learned from the <c>run_assignment</c>
+/// frame, which the replay buffer delivers first — onto runId-less live content so the keys align.
+/// </para>
+/// <para>
+/// This drives the REAL chat client over its default <b>WebSocket</b> transport (so the WS-only resume
+/// path is exercised), against the InstructionChain scripted provider which emits 12 sequential tool
+/// calls (each with a result) and then a long final text turn that keeps the backend run in-flight
+/// while we switch conversations. The pooled agent keeps running after the socket is torn down, so
+/// switching back re-subscribes and replays the in-flight run — the exact condition that triggered the
+/// bug.
+/// </para>
+/// <para>
+/// IMPORTANT — reproducing the real wire shape: the scripted test providers (unlike real Anthropic)
+/// stamp a <c>runId</c> on every tool-call frame, so on their own they cannot reproduce the
+/// runId-divergence the fix addresses. This test therefore strips <c>runId</c> from the server→client
+/// tool-call frames (via Playwright WebSocket routing) so the browser sees exactly the documented
+/// real-provider wire (runId-less tool calls, runId-bearing <c>run_assignment</c>). With this, the
+/// fix is necessary and sufficient: GREEN (fix present) settles to 12 pills; RED (fix reverted) shows
+/// the duplicated/never-settling count.
+/// </para>
+/// </remarks>
+[Collection(PlaywrightCollection.Name)]
+public sealed class StreamingResumeToolPillsTests
+{
+    /// <summary>Number of tool calls the scripted run emits before its final text turn (user repro: 10-15).</summary>
+    private const int ToolCallCount = 12;
+
+    private readonly PlaywrightFixture _fixture;
+
+    public StreamingResumeToolPillsTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Theory]
+    [InlineData("test-anthropic")]
+    [InlineData("test")]
+    public async Task Many_tool_calls_resolve_after_switch_away_and_back(string providerMode)
+    {
+        // A single role (the default-mode parent agent) serves every turn: twelve tool-call turns,
+        // each executed by a real local tool (calculate) so the multi-turn loop produces a result and
+        // advances, followed by a deliberately long final text turn. The scripted SSE handler streams
+        // in small delayed chunks, so a multi-thousand-word tail keeps the backend run in-flight for
+        // several seconds — the window during which we switch away and back.
+        var role = ScriptedSseResponder
+            .New()
+            .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"));
+
+        for (var i = 0; i < ToolCallCount; i++)
+        {
+            var n = i;
+            role = role.Turn(t => t.ToolCall("calculate", new { a = n, operation = "add", b = 1 }));
+        }
+
+        var responder = role
+            .Turn(t => t.TextLen(6_000))
+            .Build();
+
+        await using var session = await _fixture.OpenAsync(providerMode, responder.HandlerFor(providerMode));
+        var page = session.Page;
+
+        // Reproduce the real-provider wire: strip runId from server→client tool-call frames (the
+        // scripted providers stamp it; real Anthropic does not). run_assignment keeps its runId so the
+        // client still learns the active run id (which the fix stamps onto the runId-less tool calls).
+        await page.RouteWebSocketAsync(
+            url => url.Contains("/ws?", StringComparison.Ordinal),
+            ws =>
+            {
+                var server = ws.ConnectToServer();
+                // server → client: strip runId from tool-call frames (text); pass binary through.
+                server.OnMessage(frame =>
+                {
+                    if (frame.Text is { } serverText)
+                    {
+                        ws.Send(StripToolCallRunId(serverText));
+                    }
+                    else
+                    {
+                        ws.Send(frame.Binary ?? []);
+                    }
+                });
+                // client → server: pass through unchanged.
+                ws.OnMessage(frame =>
+                {
+                    if (frame.Text is { } clientText)
+                    {
+                        server.Send(clientText);
+                    }
+                    else
+                    {
+                        server.Send(frame.Binary ?? []);
+                    }
+                });
+            });
+
+        // RouteWebSocketAsync only intercepts WebSockets created on a document loaded AFTER it is
+        // registered (it installs a page-init wrapper around WebSocket). OpenAsync already navigated,
+        // so reload now to activate the interception before the SPA opens its socket on first send.
+        await page.ReloadAsync();
+        await page.Textarea().WaitForAsync();
+
+        // Open a fresh conversation so it registers a current thread id — without this the first
+        // message streams on a thread that is never added to the sidebar (nothing to switch back to).
+        // Mirrors how the real app and the other scenarios open a conversation.
+        await page.NewChatButton().ClickAsync();
+
+        // 1) Start the streaming run in conversation A.
+        await page.SendMessageAsync("run twelve calculations, then write a long summary");
+        await page.WaitForStreamActiveAsync();
+
+        // 2) Wait until all 12 tool-call pills have streamed live. The run is now on its final, long
+        //    text turn — still in-flight. Live streaming renders exactly one pill per call (the bug
+        //    only manifests on the resume path), so the count is exactly 12 here.
+        await page.ToolCallPills().WaitForCountAtLeastAsync(ToolCallCount, timeoutMs: 30_000);
+        (await page.ToolCallPills().CountAsync())
+            .Should()
+            .Be(ToolCallCount, "live streaming renders exactly one pill per tool call (no duplication before any switch)");
+
+        // Conversation A is added to the sidebar on its first send.
+        await page.ConversationItems().WaitForCountAtLeastAsync(1);
+        var threadIdA = await page.ConversationItems().First.GetAttributeAsync("data-thread-id");
+        threadIdA.Should().NotBeNullOrEmpty();
+
+        // 3) Switch AWAY to a brand-new chat. This tears down conversation A's WebSocket; its backend
+        //    run keeps streaming the long final turn (the pooled agent is not bound to the socket).
+        await page.NewChatButton().ClickAsync();
+        await Assertions.Expect(page.ToolCallPills()).ToHaveCountAsync(0);
+
+        // 4) Switch BACK to conversation A (the only started conversation in the sidebar). This loads
+        //    persisted history (rehydrated tool calls carry the run's REAL id) and, because the run is
+        //    still in-flight, re-opens the WebSocket to RESUME — replaying the runId-less tool calls.
+        await page.ConversationItems().First.ClickAsync();
+
+        // 5) PROOF the WebSocket resume path is actually exercised: the pooled backend run is still
+        //    in-flight at switch-back, so resumeStreamIfActive (which only proceeds on the WebSocket
+        //    transport) re-subscribes and replays. If the run had already finished there would be
+        //    nothing to resume — making a vacuous pass impossible.
+        var runStateJson = await GetRunStateAsync(page, threadIdA!);
+        runStateJson
+            .Should()
+            .Contain("\"isInProgress\":true", "the pooled run must still be live at switch-back so the WebSocket resume path fires");
+
+        // 6) The stream only goes idle if the RESUMED WebSocket delivered RunCompleted. Without an
+        //    active resume the spinner stays stuck and this times out.
+        await page.WaitForStreamIdleAsync(timeoutMs: 60_000);
+
+        // The final summary text only arrives over the live resume (it was not yet persisted when we
+        // switched away), so its presence confirms the resumed stream actually delivered new content.
+        (await page.AssistantText().CountAsync())
+            .Should()
+            .BeGreaterThanOrEqualTo(1, "the resumed live stream delivered the final summary text after the replayed tool calls");
+
+        // 7) THE ASSERTION: each tool call renders as exactly ONE pill after the resume. Without the
+        //    runId-stamp fix, the WS-replayed (runId-less → 'default') tool calls fail to merge with
+        //    the REST-rehydrated (real-runId) copies, so every pill duplicates and the tool count
+        //    never settles (24, not 12) — the user-reported symptom.
+        (await page.ToolCallPills().CountAsync())
+            .Should()
+            .Be(
+                ToolCallCount,
+                "the resumed run must MERGE replayed tool calls with rehydrated history, not duplicate them — "
+                    + "a count above 12 is the stuck/duplicated-pill bug");
+
+        responder.RemainingTurns["parent"]
+            .Should()
+            .Be(0, "the full scripted plan ran to completion server-side regardless of the client switch");
+
+        await session.SaveSuccessScreenshotAsync(
+            $"StreamingResume.Many_tool_calls_resolve_after_switch_away_and_back_{providerMode}");
+    }
+
+    /// <summary>
+    /// Removes the <c>runId</c> property from tool-call WS frames (finalized, update, or result) to
+    /// mirror the real Anthropic wire, where those messages arrive runId-less. Lifecycle frames
+    /// (notably <c>run_assignment</c>, which carries the id the fix relies on), text, and reasoning are
+    /// left untouched. <c>runId</c> is never the first property and <c>parentRunId</c> is not matched.
+    /// </summary>
+    private static string StripToolCallRunId(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text ?? string.Empty;
+        }
+
+        var isToolFrame =
+            text.Contains("\"$type\":\"tool_call\"", StringComparison.Ordinal)
+            || text.Contains("\"$type\":\"tool_call_update\"", StringComparison.Ordinal)
+            || text.Contains("\"$type\":\"tool_call_result\"", StringComparison.Ordinal)
+            || text.Contains("\"$type\":\"tools_call\"", StringComparison.Ordinal)
+            || text.Contains("\"$type\":\"tools_call_update\"", StringComparison.Ordinal);
+
+        return isToolFrame
+            ? Regex.Replace(text, ",\"[Rr]unId\":\"[^\"]*\"", string.Empty)
+            : text;
+    }
+
+    /// <summary>
+    /// Reads the backend in-memory run-state for a thread via the same REST endpoint the client's
+    /// resume path uses, so the test can assert the run was genuinely in-flight at switch-back.
+    /// </summary>
+    private static Task<string> GetRunStateAsync(IPage page, string threadId)
+    {
+        return page.EvaluateAsync<string>(
+            "async (tid) => { const r = await fetch(`${location.origin}/api/conversations/${encodeURIComponent(tid)}/run-state`, { headers: { 'Accept': 'application/json' } }); return await r.text(); }",
+            threadId);
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
@@ -24,7 +24,8 @@ public class ContextDiscoveryControllerTests
         string? authorizationHeader,
         SandboxSessionRegistry? registry = null,
         WorkspaceSubAgentLoader? loader = null,
-        ContextDiscoveryInjector? injector = null)
+        ContextDiscoveryInjector? injector = null,
+        ContextDiscoveryDiagnostics? diagnostics = null)
     {
         var sharedSecret = new AuthSharedSecret(new AuthOptions
         {
@@ -34,12 +35,14 @@ public class ContextDiscoveryControllerTests
         registry ??= CreateEmptyRegistry();
         loader ??= new WorkspaceSubAgentLoader(registry, NullLogger<WorkspaceSubAgentLoader>.Instance);
         injector ??= CreateNoopInjector(registry);
+        diagnostics ??= new ContextDiscoveryDiagnostics();
 
         var controller = new ContextDiscoveryController(
             sharedSecret,
             registry,
             loader,
             injector,
+            diagnostics,
             NullLogger<ContextDiscoveryController>.Instance);
 
         var httpContext = new DefaultHttpContext();
@@ -215,6 +218,51 @@ public class ContextDiscoveryControllerTests
         registry
             .TryMarkDiscoverySeen("session-dispatch", "context_file", "CLAUDE.md")
             .Should().BeFalse("the injector should have already marked this entry as seen during dispatch");
+    }
+
+    [Fact]
+    public async Task NotifyAsync_CorrectSecret_ContextFile_RecordsArrivalInDiagnostics()
+    {
+        // The diagnostics endpoint reads these counts to prove webhooks are actually arriving.
+        var diagnostics = new ContextDiscoveryDiagnostics();
+        var controller = CreateController(authorizationHeader: Secret, diagnostics: diagnostics);
+
+        var result = await controller.NotifyAsync(
+            new ContextDiscoveryPayload
+            {
+                SessionId = "session-diag",
+                Kind = "context_file",
+                Path = "CLAUDE.md",
+                Content = "body",
+            },
+            CancellationToken.None);
+
+        result.Should().BeOfType<OkResult>();
+        var snapshot = diagnostics.Snapshot();
+        snapshot.Should().ContainKey("session-diag");
+        snapshot["session-diag"].Count.Should().Be(1);
+        snapshot["session-diag"].LastPath.Should().Be("CLAUDE.md");
+    }
+
+    [Fact]
+    public async Task NotifyAsync_Unauthorized_DoesNotRecordArrival()
+    {
+        // An unauthenticated call must never be counted — otherwise the diagnostic would mask a
+        // gateway that can't authenticate as if discoveries were flowing.
+        var diagnostics = new ContextDiscoveryDiagnostics();
+        var controller = CreateController(authorizationHeader: "wrong-secret", diagnostics: diagnostics);
+
+        _ = await controller.NotifyAsync(
+            new ContextDiscoveryPayload
+            {
+                SessionId = "session-diag",
+                Kind = "context_file",
+                Path = "CLAUDE.md",
+                Content = "body",
+            },
+            CancellationToken.None);
+
+        diagnostics.Snapshot().Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryDiagnosticsControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryDiagnosticsControllerTests.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Auth;
+
+namespace LmStreaming.Sample.Tests.Controllers;
+
+/// <summary>
+/// Tests for <c>GET /api/diagnostics/context-discovery</c>: it must surface the discovery webhook
+/// URL + enabled flag (so an operator can spot a loopback/unreachable callback host) and the
+/// per-session received counts the app has actually recorded.
+/// </summary>
+public sealed class ContextDiscoveryDiagnosticsControllerTests
+{
+    [Fact]
+    public async Task Get_ReportsEnabledAndWebhookUrl_WithNoSessions()
+    {
+        await using var registry = CreateRegistry(publicBaseUrl: "http://gateway.test:5000");
+        var controller = new ContextDiscoveryDiagnosticsController(registry, new ContextDiscoveryDiagnostics());
+
+        var response = GetResponse(controller);
+
+        response.DiscoveryEnabled.Should().BeTrue();
+        response.WebhookUrl.Should().Be("http://gateway.test:5000/api/discovery/context_discovery");
+        response.Sessions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Get_LoopbackCallbackHost_IsVisibleInWebhookUrl()
+    {
+        // The whole point of the endpoint: the default callback base is a loopback host the gateway
+        // (in a container) often can't reach. Surfacing it lets an operator diagnose the silent
+        // failure at a glance.
+        await using var registry = CreateRegistry(publicBaseUrl: null); // default 127.0.0.1:5000
+        var controller = new ContextDiscoveryDiagnosticsController(registry, new ContextDiscoveryDiagnostics());
+
+        GetResponse(controller).WebhookUrl.Should().Be("http://127.0.0.1:5000/api/discovery/context_discovery");
+    }
+
+    [Fact]
+    public async Task Get_ReportsDisabled_WhenCallbackBaseBlank()
+    {
+        await using var registry = CreateRegistry(publicBaseUrl: string.Empty);
+        var controller = new ContextDiscoveryDiagnosticsController(registry, new ContextDiscoveryDiagnostics());
+
+        GetResponse(controller).DiscoveryEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Get_ReportsReceivedCountsPerSession()
+    {
+        await using var registry = CreateRegistry();
+        var diagnostics = new ContextDiscoveryDiagnostics();
+        diagnostics.RecordReceived("sess-a", "context_file", "CLAUDE.md");
+        diagnostics.RecordReceived("sess-a", "context_file", "AGENTS.md");
+        diagnostics.RecordReceived("sess-b", "subagent", "echo");
+        var controller = new ContextDiscoveryDiagnosticsController(registry, diagnostics);
+
+        var response = GetResponse(controller);
+
+        response.Sessions.Should().HaveCount(2);
+        var a = response.Sessions.Single(s => s.SessionId == "sess-a");
+        a.ReceivedCount.Should().Be(2);
+        a.LastPath.Should().Be("AGENTS.md");
+        a.LastReceivedAt.Should().NotBeNull();
+        a.Active.Should().BeFalse("the session was never created on the registry — only discoveries arrived");
+
+        response.Sessions.Single(s => s.SessionId == "sess-b").ReceivedCount.Should().Be(1);
+    }
+
+    private static ContextDiscoveryDiagnosticsResponse GetResponse(ContextDiscoveryDiagnosticsController controller)
+    {
+        var result = controller.Get();
+        return result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<ContextDiscoveryDiagnosticsResponse>().Subject;
+    }
+
+    private static SandboxSessionRegistry CreateRegistry(string? publicBaseUrl = null)
+    {
+        static HttpResponseMessage Unused(HttpRequestMessage _) => new(HttpStatusCode.OK);
+
+        var authOptions = new AuthOptions();
+        if (publicBaseUrl is not null)
+        {
+            authOptions.Webhook.PublicBaseUrl = publicBaseUrl;
+        }
+
+        var gateway = new SandboxGatewayLifetime(
+            new SandboxGatewayOptions { BaseUrl = "http://localhost:3000" },
+            NullLogger<SandboxGatewayLifetime>.Instance,
+            new HttpClient(new StubHandler(Unused)));
+
+        return new SandboxSessionRegistry(
+            gateway,
+            new SandboxGatewayOptions { BaseUrl = "http://localhost:3000" },
+            NullLogger<SandboxSessionRegistry>.Instance,
+            new HttpClient(new StubHandler(Unused)),
+            authOptions,
+            new AuthSharedSecret(authOptions));
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(respond(request));
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryEndToEndTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryEndToEndTests.cs
@@ -1,0 +1,203 @@
+using System.Collections.Concurrent;
+using System.Net;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Auth;
+using LmStreaming.Sample.Services.Discovery;
+using LmStreaming.Sample.Tests.TestDoubles;
+using Microsoft.AspNetCore.Http;
+
+namespace LmStreaming.Sample.Tests.Controllers;
+
+/// <summary>
+/// End-to-end (in-process) proof that a context_file discovery actually reaches a live agent:
+/// drives the REAL <see cref="ContextDiscoveryController"/> → <see cref="ContextDiscoveryInjector"/>
+/// → real <see cref="SandboxSessionRegistry"/> + <see cref="MultiTurnAgentPool"/> chain and asserts
+/// the pooled agent received the formatted <c>&lt;context-discovery&gt;</c> message. The existing
+/// suites split this — controller tests prove dispatch (dedup side effect), injector tests prove the
+/// message shape — but nothing ran the whole chain together. If discovery is broken, this goes RED.
+/// </summary>
+public sealed class ContextDiscoveryEndToEndTests
+{
+    private const string Secret = "e2e-shared-secret-9f3a";
+    private const string SessionId = "sess-e2e";
+    private const string ThreadId = "thread-e2e";
+    private const string GatewayBaseUrl = "http://localhost:3000";
+
+    [Fact]
+    public async Task ContextFileWebhook_FlowsThroughControllerAndInjector_ReachesLiveAgent()
+    {
+        using var harness = new Harness();
+        var agent = harness.RegisterLiveThread(SessionId, ThreadId);
+
+        var controller = harness.CreateController(authorizationHeader: Secret);
+        var payload = new ContextDiscoveryPayload
+        {
+            SessionId = SessionId,
+            Kind = "context_file",
+            Path = "CLAUDE.md",
+            Content = "# Project rules\nAlways be concise.",
+        };
+
+        var result = await controller.NotifyAsync(payload, CancellationToken.None);
+
+        result.Should().BeOfType<OkResult>();
+        var message = agent.SentMessages.Should().ContainSingle().Which
+            .Should().BeOfType<TextMessage>().Subject;
+        message.Role.Should().Be(Role.User);
+        message.Text.Should().Contain("<context-discovery path=\"CLAUDE.md\">");
+        message.Text.Should().Contain("Always be concise.");
+        message.Metadata.Should().NotBeNull();
+        message.Metadata!.Should().ContainKey(ContextDiscoveryInjector.MetadataKey);
+    }
+
+    [Fact]
+    public async Task ContextFileWebhook_WrongSecret_DoesNotReachAgent()
+    {
+        // The auth gate is part of the chain: a bad secret must 401 and never inject.
+        using var harness = new Harness();
+        var agent = harness.RegisterLiveThread(SessionId, ThreadId);
+
+        var controller = harness.CreateController(authorizationHeader: "not-the-secret");
+        var result = await controller.NotifyAsync(
+            new ContextDiscoveryPayload
+            {
+                SessionId = SessionId,
+                Kind = "context_file",
+                Path = "CLAUDE.md",
+                Content = "secret-gated",
+            },
+            CancellationToken.None);
+
+        result.Should().BeOfType<UnauthorizedResult>();
+        agent.SentMessages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GatewayPayload_SnakeCaseJson_BindsToContextDiscoveryPayload()
+    {
+        // The gateway's wire contract is snake_case. The [JsonPropertyName] bindings on the DTO are
+        // what make a real POST body map correctly; this pins them deterministically (the over-HTTP
+        // test exercises the same path through the live ASP.NET pipeline).
+        const string json = """
+            {
+              "session_id": "sess-1",
+              "kind": "context_file",
+              "name": "CLAUDE.md",
+              "description": "root context",
+              "path": "CLAUDE.md",
+              "content": "hello world",
+              "truncated": true
+            }
+            """;
+
+        var payload = JsonSerializer.Deserialize<ContextDiscoveryPayload>(json);
+
+        payload.Should().NotBeNull();
+        payload!.SessionId.Should().Be("sess-1");
+        payload.Kind.Should().Be("context_file");
+        payload.Name.Should().Be("CLAUDE.md");
+        payload.Description.Should().Be("root context");
+        payload.Path.Should().Be("CLAUDE.md");
+        payload.Content.Should().Be("hello world");
+        payload.Truncated.Should().BeTrue();
+    }
+
+    private sealed class Harness : IDisposable
+    {
+        private readonly ConcurrentDictionary<string, RecordingMultiTurnAgent> _agents = new();
+
+        public Harness()
+        {
+            Registry = CreateRegistry();
+            Pool = new MultiTurnAgentPool(
+                (threadId, _, _) =>
+                {
+                    var agent = _agents.GetOrAdd(threadId, id => new RecordingMultiTurnAgent(id));
+                    return new MultiTurnAgentPool.AgentCreationResult(agent);
+                },
+                NullLogger<MultiTurnAgentPool>.Instance);
+            Pool.ThreadRemoved += threadId => Registry.UnregisterThreadFromAllSessions(threadId);
+
+            Injector = new ContextDiscoveryInjector(
+                Registry,
+                Pool,
+                new ContextDiscoveryFormatter(),
+                NullLogger<ContextDiscoveryInjector>.Instance);
+            Loader = new WorkspaceSubAgentLoader(Registry, NullLogger<WorkspaceSubAgentLoader>.Instance);
+            SharedSecret = new AuthSharedSecret(new AuthOptions
+            {
+                Webhook = new WebhookOptions { GatewaySharedSecret = Secret },
+            });
+            Diagnostics = new ContextDiscoveryDiagnostics();
+        }
+
+        public SandboxSessionRegistry Registry { get; }
+        public MultiTurnAgentPool Pool { get; }
+        public ContextDiscoveryInjector Injector { get; }
+        public WorkspaceSubAgentLoader Loader { get; }
+        public AuthSharedSecret SharedSecret { get; }
+        public ContextDiscoveryDiagnostics Diagnostics { get; }
+
+        public RecordingMultiTurnAgent RegisterLiveThread(string sessionId, string threadId)
+        {
+            var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+            _ = Pool.GetOrCreateAgent(threadId, mode);
+            Registry.RegisterThread(sessionId, threadId);
+            return _agents[threadId];
+        }
+
+        public ContextDiscoveryController CreateController(string? authorizationHeader)
+        {
+            var controller = new ContextDiscoveryController(
+                SharedSecret,
+                Registry,
+                Loader,
+                Injector,
+                Diagnostics,
+                NullLogger<ContextDiscoveryController>.Instance);
+
+            var httpContext = new DefaultHttpContext();
+            if (authorizationHeader is not null)
+            {
+                httpContext.Request.Headers.Authorization = authorizationHeader;
+            }
+
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+            return controller;
+        }
+
+        public void Dispose()
+        {
+            Pool.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            Registry.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+
+        private static SandboxSessionRegistry CreateRegistry()
+        {
+            static HttpResponseMessage Unused(HttpRequestMessage _) => new(HttpStatusCode.OK);
+
+            var gateway = new SandboxGatewayLifetime(
+                new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl },
+                NullLogger<SandboxGatewayLifetime>.Instance,
+                new HttpClient(new StubHandler(Unused)));
+
+            return new SandboxSessionRegistry(
+                gateway,
+                new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl },
+                NullLogger<SandboxSessionRegistry>.Instance,
+                new HttpClient(new StubHandler(Unused)),
+                new AuthOptions(),
+                new AuthSharedSecret(new AuthOptions()));
+        }
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(respond(request));
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryWebhookHttpTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryWebhookHttpTests.cs
@@ -1,0 +1,197 @@
+using System.Net;
+using System.Text;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Auth;
+using LmStreaming.Sample.Services.Discovery;
+using LmStreaming.Sample.Tests.TestDoubles;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace LmStreaming.Sample.Tests.Controllers;
+
+/// <summary>
+/// Over-HTTP proof of the context-discovery webhook: drives a real <c>POST</c> through the live
+/// ASP.NET pipeline (routing, snake_case <c>[FromBody]</c> binding, the <c>Authorization</c> header,
+/// and the real <see cref="ContextDiscoveryController"/> + discovery services) into a pre-seeded
+/// session/thread, and asserts the pooled agent received the formatted message. Uses an in-process
+/// <see cref="TestServer"/> hosting the app's real controllers (loaded as an application part) rather
+/// than booting all of <c>Program</c> — Program's startup does blocking I/O (MCP client creation,
+/// sandbox/session spawn) that would make the test flaky in CI, while adding nothing to the webhook
+/// path under test.
+/// </summary>
+public sealed class ContextDiscoveryWebhookHttpTests
+{
+    private const string Secret = "http-shared-secret-7c2b";
+    private const string SessionId = "sess-http";
+    private const string ThreadId = "thread-http";
+
+    [Fact]
+    public async Task PostContextFileWebhook_WithValidSecret_BindsJsonAndReachesAgent()
+    {
+        await using var app = await TestApp.BuildAsync();
+
+        const string json = """
+            {
+              "session_id": "sess-http",
+              "kind": "context_file",
+              "path": "CLAUDE.md",
+              "content": "# Project rules\nBe terse.",
+              "truncated": false
+            }
+            """;
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/discovery/context_discovery")
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+        request.Headers.TryAddWithoutValidation("Authorization", Secret);
+
+        var response = await app.Client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // snake_case body bound correctly AND the injection reached the live agent.
+        var message = app.Agent.SentMessages.Should().ContainSingle().Which
+            .Should().BeOfType<TextMessage>().Subject;
+        message.Role.Should().Be(Role.User);
+        message.Text.Should().Contain("<context-discovery path=\"CLAUDE.md\">");
+        message.Text.Should().Contain("Be terse.");
+
+        // And the diagnostics endpoint now reports the arrival over HTTP.
+        var diagJson = await app.Client.GetStringAsync("/api/diagnostics/context-discovery");
+        using var doc = JsonDocument.Parse(diagJson);
+        var root = doc.RootElement;
+        root.GetProperty("discoveryEnabled").GetBoolean().Should().BeTrue();
+        root.GetProperty("webhookUrl").GetString().Should().EndWith("/api/discovery/context_discovery");
+        var session = root.GetProperty("sessions").EnumerateArray()
+            .Should().ContainSingle(s => s.GetProperty("sessionId").GetString() == SessionId).Subject;
+        session.GetProperty("receivedCount").GetInt64().Should().Be(1);
+        session.GetProperty("lastPath").GetString().Should().Be("CLAUDE.md");
+    }
+
+    [Fact]
+    public async Task PostContextFileWebhook_WithWrongSecret_Returns401_AndDoesNotInject()
+    {
+        await using var app = await TestApp.BuildAsync();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/discovery/context_discovery")
+        {
+            Content = new StringContent(
+                /*lang=json,strict*/ "{\"session_id\":\"sess-http\",\"kind\":\"context_file\",\"path\":\"CLAUDE.md\",\"content\":\"x\"}",
+                Encoding.UTF8,
+                "application/json"),
+        };
+        request.Headers.TryAddWithoutValidation("Authorization", "wrong-secret");
+
+        var response = await app.Client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        app.Agent.SentMessages.Should().BeEmpty();
+    }
+
+    private sealed class TestApp : IAsyncDisposable
+    {
+        private readonly IHost _host;
+
+        private TestApp(IHost host, HttpClient client, RecordingMultiTurnAgent agent)
+        {
+            _host = host;
+            Client = client;
+            Agent = agent;
+        }
+
+        public HttpClient Client { get; }
+        public RecordingMultiTurnAgent Agent { get; }
+
+        public static async Task<TestApp> BuildAsync()
+        {
+            var registry = CreateRegistry();
+
+            RecordingMultiTurnAgent? created = null;
+            var pool = new MultiTurnAgentPool(
+                (threadId, _, _) =>
+                {
+                    created = new RecordingMultiTurnAgent(threadId);
+                    return new MultiTurnAgentPool.AgentCreationResult(created);
+                },
+                NullLogger<MultiTurnAgentPool>.Instance);
+            pool.ThreadRemoved += threadId => registry.UnregisterThreadFromAllSessions(threadId);
+
+            // Seed a live thread so the injection has somewhere to land — mirrors Program.cs:774.
+            var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+            _ = pool.GetOrCreateAgent(ThreadId, mode);
+            registry.RegisterThread(SessionId, ThreadId);
+            var agent = created ?? throw new InvalidOperationException("recording agent was not created");
+
+            var sharedSecret = new AuthSharedSecret(new AuthOptions
+            {
+                Webhook = new WebhookOptions { GatewaySharedSecret = Secret },
+            });
+
+            var host = await new HostBuilder()
+                .ConfigureWebHost(webBuilder =>
+                {
+                    webBuilder.UseTestServer();
+                    webBuilder.ConfigureServices(services =>
+                    {
+                        services.AddControllers()
+                            .AddApplicationPart(typeof(ContextDiscoveryController).Assembly);
+
+                        services.AddSingleton(registry);
+                        services.AddSingleton(pool);
+                        services.AddSingleton(sharedSecret);
+                        services.AddSingleton<ContextDiscoveryFormatter>();
+                        services.AddSingleton<ContextDiscoveryInjector>();
+                        services.AddSingleton<ContextDiscoveryDiagnostics>();
+                        services.AddSingleton<WorkspaceSubAgentLoader>();
+                    });
+                    webBuilder.Configure(appBuilder =>
+                    {
+                        appBuilder.UseRouting();
+                        appBuilder.UseEndpoints(endpoints => endpoints.MapControllers());
+                    });
+                })
+                .StartAsync();
+
+            return new TestApp(host, host.GetTestClient(), agent);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Client.Dispose();
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        private static SandboxSessionRegistry CreateRegistry()
+        {
+            static HttpResponseMessage Unused(HttpRequestMessage _) => new(HttpStatusCode.OK);
+
+            var authOptions = new AuthOptions();
+            var gateway = new SandboxGatewayLifetime(
+                new SandboxGatewayOptions { BaseUrl = "http://localhost:3000" },
+                NullLogger<SandboxGatewayLifetime>.Instance,
+                new HttpClient(new StubHandler(Unused)));
+
+            return new SandboxSessionRegistry(
+                gateway,
+                new SandboxGatewayOptions { BaseUrl = "http://localhost:3000" },
+                NullLogger<SandboxSessionRegistry>.Instance,
+                new HttpClient(new StubHandler(Unused)),
+                authOptions,
+                new AuthSharedSecret(authOptions));
+        }
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(respond(request));
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerWorkspaceTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerWorkspaceTests.cs
@@ -46,7 +46,7 @@ public class ConversationsControllerWorkspaceTests
     {
         var result = await controller.List(ct: CancellationToken.None);
         var ok = Assert.IsType<OkObjectResult>(result);
-        return [.. Assert.IsAssignableFrom<IEnumerable<ConversationSummary>>(ok.Value!)];
+        return [.. Assert.IsAssignableFrom<IEnumerable<ConversationSummary>>(ok.Value)];
     }
 
     private static ThreadMetadata ThreadWithProperties(string threadId, ImmutableDictionary<string, object> properties) =>

--- a/tests/LmStreaming.Sample.Tests/LmStreaming.Sample.Tests.csproj
+++ b/tests/LmStreaming.Sample.Tests/LmStreaming.Sample.Tests.csproj
@@ -21,6 +21,9 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="7.1.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <!-- In-process TestServer for the over-HTTP context-discovery webhook test (exercises the real
+         ASP.NET routing, snake_case [FromBody] binding, and Authorization header handling). -->
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\samples\LmStreaming.Sample\LmStreaming.Sample.csproj" />

--- a/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryDiagnosticsTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryDiagnosticsTests.cs
@@ -1,0 +1,76 @@
+using LmStreaming.Sample.Services;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// Pins the in-memory arrival tracker behind <c>GET /api/diagnostics/context-discovery</c>: it
+/// records each authenticated context-discovery webhook the app receives, keyed by session, so an
+/// operator can see whether anything is actually arriving (and when). The silent-failure mode this
+/// guards against is the gateway never reaching the loopback callback host — in which case the
+/// count stays at zero for every session.
+/// </summary>
+public sealed class ContextDiscoveryDiagnosticsTests
+{
+    [Fact]
+    public void RecordReceived_FirstArrival_SetsCountTimestampAndPath()
+    {
+        var diagnostics = new ContextDiscoveryDiagnostics();
+        var before = DateTimeOffset.UtcNow;
+
+        diagnostics.RecordReceived("sess-1", "context_file", "CLAUDE.md");
+
+        var after = DateTimeOffset.UtcNow;
+        var snapshot = diagnostics.Snapshot();
+        snapshot.Should().ContainKey("sess-1");
+        var state = snapshot["sess-1"];
+        state.Count.Should().Be(1);
+        state.LastKind.Should().Be("context_file");
+        state.LastPath.Should().Be("CLAUDE.md");
+        state.LastReceivedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+    }
+
+    [Fact]
+    public void RecordReceived_MultipleSameSession_IncrementsAndKeepsLatest()
+    {
+        var diagnostics = new ContextDiscoveryDiagnostics();
+
+        diagnostics.RecordReceived("sess-1", "context_file", "CLAUDE.md");
+        diagnostics.RecordReceived("sess-1", "context_file", "AGENTS.md");
+
+        var state = diagnostics.Snapshot()["sess-1"];
+        state.Count.Should().Be(2);
+        state.LastPath.Should().Be("AGENTS.md", "the latest arrival's path is surfaced");
+    }
+
+    [Fact]
+    public void RecordReceived_DifferentSessions_TrackedIndependently()
+    {
+        var diagnostics = new ContextDiscoveryDiagnostics();
+
+        diagnostics.RecordReceived("sess-1", "context_file", "CLAUDE.md");
+        diagnostics.RecordReceived("sess-2", "subagent", "echo");
+        diagnostics.RecordReceived("sess-2", "context_file", "AGENTS.md");
+
+        var snapshot = diagnostics.Snapshot();
+        snapshot["sess-1"].Count.Should().Be(1);
+        snapshot["sess-2"].Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void RecordReceived_BlankSessionId_Ignored()
+    {
+        var diagnostics = new ContextDiscoveryDiagnostics();
+
+        diagnostics.RecordReceived("", "context_file", "CLAUDE.md");
+        diagnostics.RecordReceived("   ", "context_file", "CLAUDE.md");
+        diagnostics.RecordReceived(null, "context_file", "CLAUDE.md");
+
+        diagnostics.Snapshot().Should().BeEmpty("a discovery with no session id can't be attributed");
+    }
+
+    [Fact]
+    public void Snapshot_OnFreshInstance_IsEmpty()
+    {
+        new ContextDiscoveryDiagnostics().Snapshot().Should().BeEmpty();
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Net;
 using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Services.Auth;
+using LmStreaming.Sample.Tests.TestDoubles;
 
 namespace LmStreaming.Sample.Tests.Services;
 
@@ -287,90 +288,6 @@ public class ContextDiscoveryInjectorTests
                 new HttpClient(new StubHandler(Unused)),
                 new AuthOptions(),
                 new AuthSharedSecret(new AuthOptions()));
-        }
-    }
-
-    private sealed class RecordingMultiTurnAgent : IMultiTurnAgent
-    {
-        private readonly List<IMessage> _sent = [];
-        private readonly Lock _lock = new();
-
-        public RecordingMultiTurnAgent(string threadId)
-        {
-            ThreadId = threadId;
-        }
-
-        public string ThreadId { get; }
-
-        public string? CurrentRunId { get; set; }
-
-        public bool IsRunning { get; set; } = true;
-
-        public bool ThrowOnSend { get; set; }
-
-        public IReadOnlyList<IMessage> SentMessages
-        {
-            get
-            {
-                lock (_lock)
-                {
-                    return [.. _sent];
-                }
-            }
-        }
-
-        public ValueTask<SendReceipt> SendAsync(
-            List<IMessage> messages,
-            string? inputId = null,
-            string? parentRunId = null,
-            CancellationToken ct = default)
-        {
-            if (ThrowOnSend)
-            {
-                throw new InvalidOperationException("send failed");
-            }
-
-            lock (_lock)
-            {
-                _sent.AddRange(messages);
-            }
-
-            var receiptId = inputId ?? Guid.NewGuid().ToString("N");
-            return ValueTask.FromResult(new SendReceipt(receiptId, inputId, DateTimeOffset.UtcNow));
-        }
-
-#pragma warning disable CS1998, IDE0391
-        public async IAsyncEnumerable<IMessage> ExecuteRunAsync(
-            UserInput userInput,
-            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
-        {
-            _ = userInput;
-            _ = ct;
-            yield break;
-        }
-
-        public async IAsyncEnumerable<IMessage> SubscribeAsync(
-            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
-        {
-            _ = ct;
-            yield break;
-        }
-#pragma warning restore CS1998, IDE0391
-
-        public Task RunAsync(CancellationToken ct = default)
-        {
-            return Task.Delay(Timeout.InfiniteTimeSpan, ct);
-        }
-
-        public Task StopAsync(TimeSpan? timeout = null)
-        {
-            _ = timeout;
-            return Task.CompletedTask;
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            return ValueTask.CompletedTask;
         }
     }
 

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryDiscoveryDiagnosticsTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryDiscoveryDiagnosticsTests.cs
@@ -1,0 +1,76 @@
+using System.Net;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Auth;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// Pins the read-only members the context-discovery diagnostics endpoint reads off the registry:
+/// <see cref="SandboxSessionRegistry.DiscoveryWebhookUrl"/> (so an operator can see — and recognise
+/// a loopback/unreachable — callback host), <see cref="SandboxSessionRegistry.DiscoveryEnabled"/>
+/// (false when no callback base is configured), and
+/// <see cref="SandboxSessionRegistry.GetActiveSessionIds"/>.
+/// </summary>
+public sealed class SandboxSessionRegistryDiscoveryDiagnosticsTests
+{
+    [Fact]
+    public async Task DiscoveryWebhookUrl_AppendsRouteToCallbackBase_AndEnabledIsTrue()
+    {
+        await using var registry = CreateRegistry(publicBaseUrl: "http://example.test:5000/");
+
+        // Trailing slash is normalised away by CallbackBaseUrl, so the route concatenation is clean.
+        registry.DiscoveryWebhookUrl.Should().Be("http://example.test:5000/api/discovery/context_discovery");
+        registry.DiscoveryEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DiscoveryEnabled_IsFalse_WhenCallbackBaseIsBlank()
+    {
+        await using var registry = CreateRegistry(publicBaseUrl: string.Empty);
+
+        registry.DiscoveryEnabled.Should().BeFalse("no callback base means the gateway has nowhere to deliver discoveries");
+        registry.DiscoveryWebhookUrl.Should().Be("/api/discovery/context_discovery");
+    }
+
+    [Fact]
+    public async Task GetActiveSessionIds_IsEmpty_BeforeAnySessionCreated()
+    {
+        await using var registry = CreateRegistry();
+
+        registry.GetActiveSessionIds().Should().BeEmpty();
+    }
+
+    private static SandboxSessionRegistry CreateRegistry(string? publicBaseUrl = null)
+    {
+        static HttpResponseMessage Unused(HttpRequestMessage _) => new(HttpStatusCode.OK);
+
+        var authOptions = new AuthOptions();
+        if (publicBaseUrl is not null)
+        {
+            authOptions.Webhook.PublicBaseUrl = publicBaseUrl;
+        }
+
+        var gateway = new SandboxGatewayLifetime(
+            new SandboxGatewayOptions { BaseUrl = "http://localhost:3000" },
+            NullLogger<SandboxGatewayLifetime>.Instance,
+            new HttpClient(new StubHandler(Unused)));
+
+        return new SandboxSessionRegistry(
+            gateway,
+            new SandboxGatewayOptions { BaseUrl = "http://localhost:3000" },
+            NullLogger<SandboxSessionRegistry>.Instance,
+            new HttpClient(new StubHandler(Unused)),
+            authOptions,
+            new AuthSharedSecret(authOptions));
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(respond(request));
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/TestDoubles/RecordingMultiTurnAgent.cs
+++ b/tests/LmStreaming.Sample.Tests/TestDoubles/RecordingMultiTurnAgent.cs
@@ -1,0 +1,93 @@
+using System.Runtime.CompilerServices;
+
+namespace LmStreaming.Sample.Tests.TestDoubles;
+
+/// <summary>
+/// An <see cref="IMultiTurnAgent"/> test double that records every message passed to
+/// <see cref="SendAsync"/>, so tests can assert exactly what the context-discovery injector (and
+/// the chain above it) enqueued onto the thread. <see cref="ThrowOnSend"/> simulates a thread
+/// whose send fails, to exercise per-thread error isolation.
+/// </summary>
+internal sealed class RecordingMultiTurnAgent : IMultiTurnAgent
+{
+    private readonly List<IMessage> _sent = [];
+    private readonly Lock _lock = new();
+
+    public RecordingMultiTurnAgent(string threadId)
+    {
+        ThreadId = threadId;
+    }
+
+    public string ThreadId { get; }
+
+    public string? CurrentRunId { get; set; }
+
+    public bool IsRunning { get; set; } = true;
+
+    public bool ThrowOnSend { get; set; }
+
+    public IReadOnlyList<IMessage> SentMessages
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return [.. _sent];
+            }
+        }
+    }
+
+    public ValueTask<SendReceipt> SendAsync(
+        List<IMessage> messages,
+        string? inputId = null,
+        string? parentRunId = null,
+        CancellationToken ct = default)
+    {
+        if (ThrowOnSend)
+        {
+            throw new InvalidOperationException("send failed");
+        }
+
+        lock (_lock)
+        {
+            _sent.AddRange(messages);
+        }
+
+        var receiptId = inputId ?? Guid.NewGuid().ToString("N");
+        return ValueTask.FromResult(new SendReceipt(receiptId, inputId, DateTimeOffset.UtcNow));
+    }
+
+#pragma warning disable CS1998, IDE0391
+    public async IAsyncEnumerable<IMessage> ExecuteRunAsync(
+        UserInput userInput,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        _ = userInput;
+        _ = ct;
+        yield break;
+    }
+
+    public async IAsyncEnumerable<IMessage> SubscribeAsync(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        _ = ct;
+        yield break;
+    }
+#pragma warning restore CS1998, IDE0391
+
+    public Task RunAsync(CancellationToken ct = default)
+    {
+        return Task.Delay(Timeout.InfiniteTimeSpan, ct);
+    }
+
+    public Task StopAsync(TimeSpan? timeout = null)
+    {
+        _ = timeout;
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/LmTestUtils.Tests/TestMode/EchoDirectivesEndToEndTests.cs
+++ b/tests/LmTestUtils.Tests/TestMode/EchoDirectivesEndToEndTests.cs
@@ -86,7 +86,7 @@ public class EchoDirectivesEndToEndTests
             .GetString();
 
         Assert.NotNull(content);
-        return content!;
+        return content;
     }
 
     [Fact]
@@ -171,7 +171,7 @@ public class EchoDirectivesEndToEndTests
         Assert.True(contentArray.GetArrayLength() > 0);
         var text = contentArray[0].GetProperty("text").GetString();
         Assert.NotNull(text);
-        return text!;
+        return text;
     }
 
     [Fact]

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentRunIdTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentRunIdTests.cs
@@ -90,6 +90,48 @@ public sealed class OpenAiResponsesAgentRunIdTests
             },
         ];
 
+    /// <summary>A function call surfaced ONLY via the terminal output_item.done fallback (no
+    /// function_call_arguments.done) — the path used by backends that rotate the per-event item_id.</summary>
+    private static ResponseEvent[] ToolCallViaOutputItemDoneOnly() =>
+        [
+            new ResponseLifecycleEvent
+            {
+                Type = ResponseEventTypes.ResponseCreated,
+                Response = El("{\"id\":\"resp_OPAQUE\"}"),
+            },
+            new ResponseOutputItemEvent
+            {
+                Type = ResponseEventTypes.OutputItemAdded,
+                OutputIndex = 0,
+                Item = El("{\"type\":\"function_call\",\"id\":\"item-1\",\"call_id\":\"call_1\",\"name\":\"add\"}"),
+            },
+            new ResponseOutputItemEvent
+            {
+                Type = ResponseEventTypes.OutputItemDone,
+                OutputIndex = 0,
+                Item = El(
+                    "{\"type\":\"function_call\",\"id\":\"item-1\",\"call_id\":\"call_1\",\"name\":\"add\",\"arguments\":\"{\\\"a\\\":1}\"}"
+                ),
+            },
+        ];
+
+    /// <summary>A reasoning part surfaced via the output_item.done "reasoning" branch (summary array),
+    /// a distinct code path from the reasoning_summary_text delta/done events.</summary>
+    private static ResponseEvent[] ReasoningViaOutputItemDone() =>
+        [
+            new ResponseLifecycleEvent
+            {
+                Type = ResponseEventTypes.ResponseCreated,
+                Response = El("{\"id\":\"resp_OPAQUE\"}"),
+            },
+            new ResponseOutputItemEvent
+            {
+                Type = ResponseEventTypes.OutputItemDone,
+                OutputIndex = 0,
+                Item = El("{\"type\":\"reasoning\",\"summary\":[{\"text\":\"deep thought\"}]}"),
+            },
+        ];
+
     [Fact]
     public async Task Every_emitted_message_carries_the_runs_run_id()
     {
@@ -124,6 +166,80 @@ public sealed class OpenAiResponsesAgentRunIdTests
                 "every Responses-path message emitted during a run must carry the run's RunId "
                     + "(parity with OpenAgent/AnthropicAgent .WithIds(options))"
             );
+        messages
+            .Should()
+            .OnlyContain(m => m.ThreadId == threadId, "WithIds stamps ThreadId on every emitted type");
+        messages
+            .Where(m => m is not UsageMessage)
+            .Should()
+            .OnlyContain(
+                m => m.ParentRunId == parentRunId,
+                "WithIds stamps ParentRunId on every emitted type except UsageMessage (which carries none)"
+            );
+    }
+
+    [Fact]
+    public async Task Tool_call_via_output_item_done_fallback_carries_run_ids()
+    {
+        const string runId = "run-123";
+        const string parentRunId = "parent-456";
+        const string threadId = "thread-789";
+        const string runGenerationId = "run-gen-ABC";
+
+        using var agent = new OpenAiResponsesAgent("test", new ScriptedClient(ToolCallViaOutputItemDoneOnly()));
+        var stream = await agent.GenerateReplyStreamingAsync(
+            [new TextMessage { Role = Role.User, Text = "go" }],
+            new GenerateReplyOptions
+            {
+                RunId = runId,
+                ParentRunId = parentRunId,
+                ThreadId = threadId,
+                GenerationId = runGenerationId,
+            }
+        );
+
+        var messages = new List<IMessage>();
+        await foreach (var message in stream)
+        {
+            messages.Add(message);
+        }
+
+        var toolCall = messages.OfType<ToolsCallMessage>().Single();
+        toolCall.RunId.Should().Be(runId);
+        toolCall.ParentRunId.Should().Be(parentRunId);
+        toolCall.ThreadId.Should().Be(threadId);
+    }
+
+    [Fact]
+    public async Task Reasoning_via_output_item_done_carries_run_ids()
+    {
+        const string runId = "run-123";
+        const string parentRunId = "parent-456";
+        const string threadId = "thread-789";
+        const string runGenerationId = "run-gen-ABC";
+
+        using var agent = new OpenAiResponsesAgent("test", new ScriptedClient(ReasoningViaOutputItemDone()));
+        var stream = await agent.GenerateReplyStreamingAsync(
+            [new TextMessage { Role = Role.User, Text = "go" }],
+            new GenerateReplyOptions
+            {
+                RunId = runId,
+                ParentRunId = parentRunId,
+                ThreadId = threadId,
+                GenerationId = runGenerationId,
+            }
+        );
+
+        var messages = new List<IMessage>();
+        await foreach (var message in stream)
+        {
+            messages.Add(message);
+        }
+
+        var reasoning = messages.OfType<ReasoningMessage>().Single();
+        reasoning.RunId.Should().Be(runId);
+        reasoning.ParentRunId.Should().Be(parentRunId);
+        reasoning.ThreadId.Should().Be(threadId);
     }
 
     [Fact]

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentRunIdTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentRunIdTests.cs
@@ -132,6 +132,25 @@ public sealed class OpenAiResponsesAgentRunIdTests
             },
         ];
 
+    /// <summary>Text deltas with NO finalizing output_text.done — a truncated/aborted stream. The
+    /// non-streaming <c>GenerateReplyAsync</c> then synthesizes a leftover <c>TextMessage</c> at its
+    /// OWN fix site (distinct from the streaming <c>StampRunIds</c> wrapper), which must still stamp
+    /// the run ids.</summary>
+    private static ResponseEvent[] TextDeltasOnlyStream() =>
+        [
+            new ResponseLifecycleEvent
+            {
+                Type = ResponseEventTypes.ResponseCreated,
+                Response = El("{\"id\":\"resp_OPAQUE\"}"),
+            },
+            new ResponseOutputTextDeltaEvent
+            {
+                Type = ResponseEventTypes.OutputTextDelta,
+                OutputIndex = 0,
+                Delta = "Hello",
+            },
+        ];
+
     [Fact]
     public async Task Every_emitted_message_carries_the_runs_run_id()
     {
@@ -176,6 +195,14 @@ public sealed class OpenAiResponsesAgentRunIdTests
                 m => m.ParentRunId == parentRunId,
                 "WithIds stamps ParentRunId on every emitted type except UsageMessage (which carries none)"
             );
+
+        // BUG H1: the run's GenerationId must be preserved on the finalized tool call (folded in from
+        // a former near-duplicate test, asserted against the same MixedStream run).
+        messages
+            .OfType<ToolsCallMessage>()
+            .Single()
+            .GenerationId.Should()
+            .Be(runGenerationId, "the BUG H1 GenerationId behavior must be preserved");
     }
 
     [Fact]
@@ -243,36 +270,32 @@ public sealed class OpenAiResponsesAgentRunIdTests
     }
 
     [Fact]
-    public async Task Tool_call_carries_full_run_thread_and_parent_ids()
+    public async Task GenerateReplyAsync_leftover_text_carries_run_ids()
     {
+        // The non-streaming path has its OWN fix site: when the stream emits text deltas but no
+        // finalizing output_text.done (truncated/aborted), GenerateReplyAsync synthesizes the leftover
+        // TextMessage itself and stamps it directly with .WithIds(options) — separate from the
+        // streaming StampRunIds wrapper the other tests exercise. This pins that path against the
+        // null-RunId identity bug it is most prone to.
         const string runId = "run-123";
         const string parentRunId = "parent-456";
         const string threadId = "thread-789";
-        const string runGenerationId = "run-gen-ABC";
 
-        using var agent = new OpenAiResponsesAgent("test", new ScriptedClient(MixedStream()));
-        var stream = await agent.GenerateReplyStreamingAsync(
+        using var agent = new OpenAiResponsesAgent("test", new ScriptedClient(TextDeltasOnlyStream()));
+        var result = await agent.GenerateReplyAsync(
             [new TextMessage { Role = Role.User, Text = "go" }],
             new GenerateReplyOptions
             {
                 RunId = runId,
                 ParentRunId = parentRunId,
                 ThreadId = threadId,
-                GenerationId = runGenerationId,
             }
         );
 
-        var messages = new List<IMessage>();
-        await foreach (var message in stream)
-        {
-            messages.Add(message);
-        }
-
-        var toolCall = messages.OfType<ToolsCallMessage>().Single();
-        toolCall.RunId.Should().Be(runId);
-        toolCall.ParentRunId.Should().Be(parentRunId);
-        toolCall.ThreadId.Should().Be(threadId);
-        toolCall.GenerationId.Should().Be(runGenerationId, "the BUG H1 GenerationId behavior must be preserved");
+        var text = result.OfType<TextMessage>().Single();
+        text.RunId.Should().Be(runId);
+        text.ParentRunId.Should().Be(parentRunId);
+        text.ThreadId.Should().Be(threadId);
     }
 
     [Fact]

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentRunIdTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesAgentRunIdTests.cs
@@ -1,0 +1,179 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Tests;
+
+/// <summary>
+///     runId==null leak. GPT-5.5 (Copilot) routes through the Responses provider, which constructs
+///     messages itself and never calls <c>WithIds(options)</c> — so unlike <c>OpenAgent</c> and
+///     <c>AnthropicAgent</c>, it stamped only the GenerationId and left <c>RunId</c>/<c>ParentRunId</c>/
+///     <c>ThreadId</c> null on every emitted message. The client merge key is
+///     (kind, runId, generationId, messageOrderIdx); a uniformly-empty runId segment is a latent
+///     identity bug masked only by per-turn generationId uniqueness. Every message emitted while
+///     processing a run must carry the run's ids from <see cref="GenerateReplyOptions"/>.
+/// </summary>
+public sealed class OpenAiResponsesAgentRunIdTests
+{
+    private sealed class ScriptedClient(IReadOnlyList<ResponseEvent> events) : IOpenAiResponsesClient
+    {
+        public async IAsyncEnumerable<ResponseEvent> StreamResponseAsync(
+            ResponseCreateRequest request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            foreach (var ev in events)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return ev;
+                await Task.Yield();
+            }
+        }
+
+        public void Dispose() { }
+    }
+
+    private static JsonElement El(string json) => JsonSerializer.Deserialize<JsonElement>(json);
+
+    /// <summary>A single response that exercises reasoning, text, a function call, and usage.</summary>
+    private static ResponseEvent[] MixedStream() =>
+        [
+            new ResponseLifecycleEvent
+            {
+                Type = ResponseEventTypes.ResponseCreated,
+                Response = El("{\"id\":\"resp_OPAQUE\"}"),
+            },
+            new ResponseReasoningSummaryTextDeltaEvent
+            {
+                Type = ResponseEventTypes.ReasoningSummaryTextDelta,
+                OutputIndex = 0,
+                Delta = "think",
+            },
+            new ResponseReasoningSummaryTextDoneEvent
+            {
+                Type = ResponseEventTypes.ReasoningSummaryTextDone,
+                OutputIndex = 0,
+                Text = "think done",
+            },
+            new ResponseOutputTextDeltaEvent
+            {
+                Type = ResponseEventTypes.OutputTextDelta,
+                OutputIndex = 1,
+                Delta = "Hello",
+            },
+            new ResponseOutputTextDoneEvent
+            {
+                Type = ResponseEventTypes.OutputTextDone,
+                OutputIndex = 1,
+                Text = "Hello",
+            },
+            new ResponseOutputItemEvent
+            {
+                Type = ResponseEventTypes.OutputItemAdded,
+                OutputIndex = 2,
+                Item = El("{\"type\":\"function_call\",\"id\":\"item-1\",\"call_id\":\"call_1\",\"name\":\"add\"}"),
+            },
+            new ResponseFunctionCallArgumentsDoneEvent
+            {
+                Type = ResponseEventTypes.FunctionCallArgumentsDone,
+                ItemId = "item-1",
+                Arguments = "{\"a\":1}",
+            },
+            new ResponseLifecycleEvent
+            {
+                Type = ResponseEventTypes.ResponseCompleted,
+                Response = El("{\"id\":\"resp_OPAQUE\",\"usage\":{\"input_tokens\":1,\"output_tokens\":2,\"total_tokens\":3}}"),
+            },
+        ];
+
+    [Fact]
+    public async Task Every_emitted_message_carries_the_runs_run_id()
+    {
+        const string runId = "run-123";
+        const string parentRunId = "parent-456";
+        const string threadId = "thread-789";
+        const string runGenerationId = "run-gen-ABC";
+
+        using var agent = new OpenAiResponsesAgent("test", new ScriptedClient(MixedStream()));
+        var stream = await agent.GenerateReplyStreamingAsync(
+            [new TextMessage { Role = Role.User, Text = "go" }],
+            new GenerateReplyOptions
+            {
+                RunId = runId,
+                ParentRunId = parentRunId,
+                ThreadId = threadId,
+                GenerationId = runGenerationId,
+            }
+        );
+
+        var messages = new List<IMessage>();
+        await foreach (var message in stream)
+        {
+            messages.Add(message);
+        }
+
+        messages.Should().NotBeEmpty("the scripted stream emits reasoning, text, a tool call, and usage");
+        messages
+            .Should()
+            .OnlyContain(
+                m => m.RunId == runId,
+                "every Responses-path message emitted during a run must carry the run's RunId "
+                    + "(parity with OpenAgent/AnthropicAgent .WithIds(options))"
+            );
+    }
+
+    [Fact]
+    public async Task Tool_call_carries_full_run_thread_and_parent_ids()
+    {
+        const string runId = "run-123";
+        const string parentRunId = "parent-456";
+        const string threadId = "thread-789";
+        const string runGenerationId = "run-gen-ABC";
+
+        using var agent = new OpenAiResponsesAgent("test", new ScriptedClient(MixedStream()));
+        var stream = await agent.GenerateReplyStreamingAsync(
+            [new TextMessage { Role = Role.User, Text = "go" }],
+            new GenerateReplyOptions
+            {
+                RunId = runId,
+                ParentRunId = parentRunId,
+                ThreadId = threadId,
+                GenerationId = runGenerationId,
+            }
+        );
+
+        var messages = new List<IMessage>();
+        await foreach (var message in stream)
+        {
+            messages.Add(message);
+        }
+
+        var toolCall = messages.OfType<ToolsCallMessage>().Single();
+        toolCall.RunId.Should().Be(runId);
+        toolCall.ParentRunId.Should().Be(parentRunId);
+        toolCall.ThreadId.Should().Be(threadId);
+        toolCall.GenerationId.Should().Be(runGenerationId, "the BUG H1 GenerationId behavior must be preserved");
+    }
+
+    [Fact]
+    public async Task Run_id_stays_null_when_options_advertise_none()
+    {
+        // No regression for the no-run case: when the caller supplies no RunId, messages keep a null
+        // RunId (which the serializer omits) rather than inventing one.
+        using var agent = new OpenAiResponsesAgent("test", new ScriptedClient(MixedStream()));
+        var stream = await agent.GenerateReplyStreamingAsync([new TextMessage { Role = Role.User, Text = "go" }]);
+
+        var messages = new List<IMessage>();
+        await foreach (var message in stream)
+        {
+            messages.Add(message);
+        }
+
+        messages.Should().NotBeEmpty();
+        messages.Should().OnlyContain(m => m.RunId == null);
+    }
+}


### PR DESCRIPTION
## Summary
Generic bug fixes bundled into one PR.

### 1. OpenAI Responses provider drops run identity (`runId == null`)
`OpenAiResponsesAgent` (gpt-5.5 / gpt-5.5-mini via Copilot) constructed its own `IMessage`s and never called `.WithIds(options)`, so every emitted message carried a null `RunId` / `ParentRunId` / `ThreadId` — ~23% of LmStreaming.Sample outbound logs showed `runId: null`. Now stamps the run ids on every emitted message, matching `OpenAgent` / `AnthropicAgent`. `GenerationId` / BUG-H1 behavior unchanged (the stamp is idempotent).

### 2. Streaming stops when switching conversations or refreshing
Switching conversations or refreshing tore down the WebSocket and, on return, only reloaded persisted REST history (everything marked completed) — the client never re-subscribed to the still-running backend run (the pooled agent keeps running after the client disconnects), and `SubscribeAsync` had no replay, so the visible stream froze. Fix:
- **Backend:** `MultiTurnAgentBase` keeps a bounded per-run replay buffer; `SubscribeAsync` atomically registers the subscriber and replays the in-flight run's already-published messages, then streams live ones (each message delivered exactly once — replay XOR live). New `GET /api/conversations/{threadId}/run-state` exposes the in-memory active-run signal.
- **Client:** `useChat.resumeStreamIfActive(threadId)` re-opens the WebSocket subscribe-only (no send) when the backend reports an in-flight run; `ChatLayout` calls it after loading history on switch / initial-load / refresh.

## Changes
- `OpenAiResponsesAgent`: `StampRunIds` wrapper applying `.WithIds(options)` to every emitted message.
- `MultiTurnAgentBase`: per-run replay buffer + atomic register/replay in `SubscribeAsync` (lock-guarded, no await under lock); buffer freed on run completion.
- `ConversationsController` + `ConversationDtos`: `GET {threadId}/run-state`.
- Client: `useChat.resumeStreamIfActive` + `conversationsApi.getRunState`; `ChatLayout` wiring; `buildStreamCallbacks`/`openStreamConnection` refactor (no behavior change to send).

## Testing
- OpenAiResponsesProvider.Tests **67/67** · LmMultiTurn.Tests **282/282** · client vitest **258/258** · vue-tsc clean.
- New coverage: `OpenAiResponsesAgentRunIdTests`; `MultiTurnAgentReplayTests` (replay contract, concurrent-subscribe exactly-once, multi-subscriber, buffer cap); `useChatResume.test.ts` (reconnect-and-resume, no-reconnect-when-idle, SSE skip, failed-open `isLoading` reset, stale-thread abort).
- Both fixes independently reviewed in fresh context; review findings addressed.

## Related Issues
Fixes #110