### PR TITLE
fix: collect cached/reasoning token counts from OpenAI usage

### DIFF
--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ChatLayout.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ChatLayout.test.ts
@@ -106,6 +106,7 @@ vi.mock('@/composables/useChat', async () => {
       usage: ref(null),
       cumulativeUsage: ref({
         promptTokens: 0,
+        uncachedInputTokens: 0,
         completionTokens: 0,
         totalTokens: 0,
         cachedTokens: 0,

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChatUsage.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChatUsage.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useChat } from '@/composables/useChat';
+import { MessageType } from '@/types';
+
+// Mock the transport + history APIs so useChat can open a (fake) connection and we can hand it
+// usage messages directly via the captured onMessage callback.
+const wsMocks = vi.hoisted(() => ({
+  createWebSocketConnection: vi.fn(),
+  sendWebSocketMessage: vi.fn(),
+  closeWebSocketConnection: vi.fn(),
+}));
+
+vi.mock('@/api/wsClient', () => ({
+  createWebSocketConnection: wsMocks.createWebSocketConnection,
+  sendWebSocketMessage: wsMocks.sendWebSocketMessage,
+  closeWebSocketConnection: wsMocks.closeWebSocketConnection,
+}));
+
+const convMocks = vi.hoisted(() => ({
+  loadConversationMessages: vi.fn(),
+}));
+
+vi.mock('@/api/conversationsApi', () => ({
+  loadConversationMessages: convMocks.loadConversationMessages,
+}));
+
+function usageMessage(promptTokens: number, completionTokens: number, cachedTokens: number) {
+  return {
+    $type: MessageType.Usage,
+    role: 'assistant',
+    runId: 'run-1',
+    generationId: 'gen-1',
+    usage: {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: promptTokens + completionTokens,
+      // OpenAI-family shape: cached_tokens is a SUBSET of prompt_tokens.
+      input_tokens_details: { cached_tokens: cachedTokens },
+    },
+  };
+}
+
+describe('useChat — cumulative usage cached/uncached accounting', () => {
+  let captured: any[];
+
+  beforeEach(() => {
+    captured = [];
+    wsMocks.createWebSocketConnection.mockReset();
+    wsMocks.sendWebSocketMessage.mockReset();
+    wsMocks.closeWebSocketConnection.mockReset();
+    convMocks.loadConversationMessages.mockReset();
+
+    wsMocks.createWebSocketConnection.mockImplementation(async (options: any) => {
+      captured.push(options);
+      return {
+        socket: { readyState: WebSocket.OPEN },
+        connectionId: `ws-${captured.length}`,
+        threadId: options.threadId,
+        isConnected: true,
+      };
+    });
+    convMocks.loadConversationMessages.mockResolvedValue([]);
+  });
+
+  it('reports In as uncached input (prompt - cached), disjoint from Cached, summing to Total', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    chat.setThreadId('thread-1');
+    await chat.sendMessage('hi');
+
+    // A real gpt-5.5 turn: 13696 of 14986 prompt tokens were served from cache.
+    captured[0].onMessage(usageMessage(14986, 121, 13696));
+
+    const u = chat.cumulativeUsage.value;
+    expect(u.promptTokens).toBe(14986); // total input, backend-consistent
+    expect(u.cachedTokens).toBe(13696);
+    expect(u.uncachedInputTokens).toBe(1290); // 14986 - 13696 — the value shown as "In"
+    expect(u.completionTokens).toBe(121);
+    expect(u.totalTokens).toBe(15107);
+    // In + Cached + Out must reconcile to Total (no double counting).
+    expect(u.uncachedInputTokens + u.cachedTokens + u.completionTokens).toBe(u.totalTokens);
+  });
+
+  it('accumulates uncached input across multiple turns', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    chat.setThreadId('thread-1');
+    await chat.sendMessage('hi');
+
+    captured[0].onMessage(usageMessage(14986, 121, 13696)); // uncached 1290
+    captured[0].onMessage(usageMessage(20000, 200, 18000)); // uncached 2000
+
+    const u = chat.cumulativeUsage.value;
+    expect(u.uncachedInputTokens).toBe(3290);
+    expect(u.cachedTokens).toBe(31696);
+    expect(u.promptTokens).toBe(34986);
+  });
+
+  it('falls back to prompt when cached exceeds prompt (additive-cache providers) — never negative', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    chat.setThreadId('thread-1');
+    await chat.sendMessage('hi');
+
+    // Anthropic-style: input_tokens (200) excludes the cache read (13000), which is additive.
+    captured[0].onMessage(usageMessage(200, 50, 13000));
+
+    const u = chat.cumulativeUsage.value;
+    expect(u.uncachedInputTokens).toBe(200); // not -12800
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
@@ -458,7 +458,7 @@ onBeforeUnmount(() => {
 
         <div v-if="cumulativeUsage.totalTokens > 0" class="usage-banner">
           Total: {{ cumulativeUsage.totalTokens }} |
-          In: {{ cumulativeUsage.promptTokens }} |
+          In: {{ cumulativeUsage.uncachedInputTokens }} |
           Out: {{ cumulativeUsage.completionTokens }}
           <template v-if="cumulativeUsage.cachedTokens > 0">
             | Cached: {{ cumulativeUsage.cachedTokens }}

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ChatView.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ChatView.vue
@@ -36,7 +36,7 @@ function handleCancel() {
 
     <div v-if="cumulativeUsage.totalTokens > 0" class="usage-banner">
       Total: {{ cumulativeUsage.totalTokens }} |
-      In: {{ cumulativeUsage.promptTokens }} |
+      In: {{ cumulativeUsage.uncachedInputTokens }} |
       Out: {{ cumulativeUsage.completionTokens }}
       <template v-if="cumulativeUsage.cachedTokens > 0">
         | Cached: {{ cumulativeUsage.cachedTokens }}

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -171,6 +171,9 @@ export function useChat(options: UseChatOptions = {}) {
   const usage = ref<UsageMessage | null>(null);
   const cumulativeUsage = ref({
     promptTokens: 0,
+    // Fresh (uncached) input tokens — promptTokens minus the cached read. For the OpenAI family
+    // cachedTokens is a SUBSET of promptTokens, so In/Cached/Out are disjoint and sum to Total.
+    uncachedInputTokens: 0,
     completionTokens: 0,
     totalTokens: 0,
     cachedTokens: 0,
@@ -558,8 +561,14 @@ export function useChat(options: UseChatOptions = {}) {
       const totalTokens = u.total_tokens ?? (promptTokens + completionTokens);
       const cachedTokens = u.input_tokens_details?.cached_tokens ?? u.cacheReadTokens ?? 0;
       const cacheCreationTokens = u.cache_creation_input_tokens ?? u.cacheCreationTokens ?? 0;
+      // Fresh input for this turn = prompt minus the cached read. cachedTokens is a SUBSET of
+      // promptTokens for the OpenAI family; if it ever exceeds it (e.g. providers that report cache
+      // reads additively) fall back to the prompt so this never goes negative. Accumulate per-turn so
+      // In + Cached + Out == Total holds across the whole conversation.
+      const uncachedInputTokens = cachedTokens <= promptTokens ? promptTokens - cachedTokens : promptTokens;
       cumulativeUsage.value = {
         promptTokens: cumulativeUsage.value.promptTokens + promptTokens,
+        uncachedInputTokens: cumulativeUsage.value.uncachedInputTokens + uncachedInputTokens,
         completionTokens: cumulativeUsage.value.completionTokens + completionTokens,
         totalTokens: cumulativeUsage.value.totalTokens + totalTokens,
         cachedTokens: cumulativeUsage.value.cachedTokens + cachedTokens,
@@ -1112,7 +1121,7 @@ export function useChat(options: UseChatOptions = {}) {
     messageIndex.value.clear();
     messageOrder.value = [];
     usage.value = null;
-    cumulativeUsage.value = { promptTokens: 0, completionTokens: 0, totalTokens: 0, cachedTokens: 0, cacheCreationTokens: 0 };
+    cumulativeUsage.value = { promptTokens: 0, uncachedInputTokens: 0, completionTokens: 0, totalTokens: 0, cachedTokens: 0, cacheCreationTokens: 0 };
     error.value = null;
     threadId.value = null;
     currentRunId.value = null;

--- a/samples/LmStreaming.Sample/WebSocket/ChatWebSocketManager.cs
+++ b/samples/LmStreaming.Sample/WebSocket/ChatWebSocketManager.cs
@@ -224,10 +224,19 @@ public sealed class ChatWebSocketManager
                 {
                     var u = usageMsg.Usage;
                     var cacheCreation = u.GetExtraProperty<int>("cache_creation_input_tokens");
+                    // cached_tokens is a SUBSET of PromptTokens for the OpenAI family (Responses + chat
+                    // completions), so uncached = prompt - cached. Anthropic instead reports cache reads
+                    // SEPARATELY from input_tokens, so when the cache read exceeds the reported prompt we
+                    // fall back to PromptTokens (the additive case) and never go negative. The proper
+                    // cross-provider normalization of Usage is tracked as a follow-up.
+                    var uncachedInput = u.TotalCachedTokens <= u.PromptTokens
+                        ? u.PromptTokens - u.TotalCachedTokens
+                        : u.PromptTokens;
                     _logger.LogInformation(
-                        "Cache: read={CacheRead}, created={CacheCreation}, uncached_input={Input}, output={Output}, total={Total}",
+                        "Cache: read={CacheRead}, created={CacheCreation}, uncached_input={Uncached}, prompt={Prompt}, output={Output}, total={Total}",
                         u.TotalCachedTokens,
                         cacheCreation,
+                        uncachedInput,
                         u.PromptTokens,
                         u.CompletionTokens,
                         u.TotalTokens);

--- a/src/LmCore/Models/Usage.cs
+++ b/src/LmCore/Models/Usage.cs
@@ -44,6 +44,21 @@ public record Usage
     public ImmutableDictionary<string, object?> ExtraProperties { get; init; } =
         ImmutableDictionary<string, object?>.Empty;
 
+    /// <summary>
+    ///     Returns a copy with the nested cached/reasoning detail objects populated from raw counts.
+    ///     A non-positive count leaves the corresponding detail untouched. Centralizes the
+    ///     provider → core token-detail mapping so every provider surfaces details the same way.
+    /// </summary>
+    public Usage WithTokenDetails(int cachedTokens, int reasoningTokens)
+    {
+        return this with
+        {
+            InputTokenDetails = cachedTokens > 0 ? new InputTokenDetails { CachedTokens = cachedTokens } : InputTokenDetails,
+            OutputTokenDetails =
+                reasoningTokens > 0 ? new OutputTokenDetails { ReasoningTokens = reasoningTokens } : OutputTokenDetails,
+        };
+    }
+
     public Usage SetExtraProperty<T>(string key, T value)
     {
         var rv = this;

--- a/src/LmTestUtils/TestMode/OpenAiResponsesEventStreamWriter.cs
+++ b/src/LmTestUtils/TestMode/OpenAiResponsesEventStreamWriter.cs
@@ -126,7 +126,14 @@ public static class OpenAiResponsesEventStreamWriter
                     effectiveResponseId,
                     effectiveModel,
                     status: "completed",
-                    usage: new UsageSnapshot(InputTokens: 100, OutputTokens: 50)
+                    // Faithful to the real Responses API: surface prompt-cache hits and reasoning spend
+                    // via the nested *_tokens_details objects so the provider's usage parser is exercised.
+                    usage: new UsageSnapshot(
+                        InputTokens: 100,
+                        OutputTokens: 50,
+                        CachedTokens: plan.CacheReadInputTokens,
+                        ReasoningTokens: plan.ReasoningLength ?? 0
+                    )
                 ),
             }
         );
@@ -409,12 +416,24 @@ public static class OpenAiResponsesEventStreamWriter
 
         if (usage is { } u)
         {
-            node["usage"] = new JsonObject
+            var usageNode = new JsonObject
             {
                 ["input_tokens"] = u.InputTokens,
                 ["output_tokens"] = u.OutputTokens,
                 ["total_tokens"] = u.InputTokens + u.OutputTokens,
             };
+
+            if (u.CachedTokens > 0)
+            {
+                usageNode["input_tokens_details"] = new JsonObject { ["cached_tokens"] = u.CachedTokens };
+            }
+
+            if (u.ReasoningTokens > 0)
+            {
+                usageNode["output_tokens_details"] = new JsonObject { ["reasoning_tokens"] = u.ReasoningTokens };
+            }
+
+            node["usage"] = usageNode;
         }
 
         return ToJsonElement(node);
@@ -458,5 +477,10 @@ public static class OpenAiResponsesEventStreamWriter
         }
     }
 
-    private readonly record struct UsageSnapshot(int InputTokens, int OutputTokens);
+    private readonly record struct UsageSnapshot(
+        int InputTokens,
+        int OutputTokens,
+        int CachedTokens = 0,
+        int ReasoningTokens = 0
+    );
 }

--- a/src/OpenAIProvider/Agents/OpenAgent.cs
+++ b/src/OpenAIProvider/Agents/OpenAgent.cs
@@ -135,6 +135,8 @@ public class OpenClientAgent : IStreamingAgent, IDisposable
                 PromptTokens = response.Usage?.PromptTokens ?? 0,
                 CompletionTokens = response.Usage?.CompletionTokens ?? 0,
                 TotalCost = totalCost,
+                CachedTokens = response.Usage?.TotalCachedTokens ?? 0,
+                ReasoningTokens = response.Usage?.TotalReasoningTokens ?? 0,
             };
 
             var openMessage = new OpenMessage
@@ -307,6 +309,8 @@ public class OpenClientAgent : IStreamingAgent, IDisposable
                                 item.Usage.ExtraProperties?.TryGetValue("estimated_cost", out var cost) == true
                                     ? cost as double?
                                     : null,
+                            CachedTokens = item.Usage.TotalCachedTokens,
+                            ReasoningTokens = item.Usage.TotalReasoningTokens,
                         }
                         : null,
             };

--- a/src/OpenAIProvider/Models/OpenAIProviderUsage.cs
+++ b/src/OpenAIProvider/Models/OpenAIProviderUsage.cs
@@ -91,17 +91,7 @@ public record OpenAIProviderUsage
 
         // Convert nested token details using the unified accessors so every shape (Responses-API
         // nesting, Chat Completions nesting, and OpenRouter direct fields) maps to core consistently.
-        if (TotalCachedTokens > 0)
-        {
-            usage = usage with { InputTokenDetails = new InputTokenDetails { CachedTokens = TotalCachedTokens } };
-        }
-
-        if (TotalReasoningTokens > 0)
-        {
-            usage = usage with { OutputTokenDetails = new OutputTokenDetails { ReasoningTokens = TotalReasoningTokens } };
-        }
-
-        return usage;
+        return usage.WithTokenDetails(TotalCachedTokens, TotalReasoningTokens);
     }
 
     /// <summary>

--- a/src/OpenAIProvider/Models/OpenAIProviderUsage.cs
+++ b/src/OpenAIProvider/Models/OpenAIProviderUsage.cs
@@ -26,7 +26,7 @@ public record OpenAIProviderUsage
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public double? TotalCost { get; init; }
 
-    // OpenAI-style nested token details
+    // OpenAI Responses-style nested token details (input_tokens_details / output_tokens_details)
     [JsonPropertyName("input_tokens_details")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public OpenAIInputTokenDetails? InputTokenDetails { get; init; }
@@ -34,6 +34,17 @@ public record OpenAIProviderUsage
     [JsonPropertyName("output_tokens_details")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public OpenAIOutputTokenDetails? OutputTokenDetails { get; init; }
+
+    // OpenAI Chat Completions-style nested token details. The /v1/chat/completions endpoint reports
+    // cache/reasoning under prompt_tokens_details / completion_tokens_details (different names than
+    // the Responses API above); without these the cached/reasoning counts are silently dropped.
+    [JsonPropertyName("prompt_tokens_details")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public OpenAIInputTokenDetails? PromptTokenDetails { get; init; }
+
+    [JsonPropertyName("completion_tokens_details")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public OpenAIOutputTokenDetails? CompletionTokenDetails { get; init; }
 
     // OpenRouter-style direct fields (for compatibility)
     [JsonPropertyName("reasoning_tokens")]
@@ -50,19 +61,19 @@ public record OpenAIProviderUsage
     // Unified access properties with precedence logic
     [JsonIgnore]
     public int TotalReasoningTokens =>
-        // OpenRouter direct field takes precedence
+        // OpenRouter direct field takes precedence, then the Responses-API nested shape, then the
+        // Chat Completions nested shape.
         ReasoningTokens != 0
             ? ReasoningTokens
-            // Fallback to OpenAI nested structure
-            : OutputTokenDetails?.ReasoningTokens ?? 0;
+            : OutputTokenDetails?.ReasoningTokens ?? CompletionTokenDetails?.ReasoningTokens ?? 0;
 
     [JsonIgnore]
     public int TotalCachedTokens =>
-        // OpenRouter direct field takes precedence
+        // OpenRouter direct field takes precedence, then the Responses-API nested shape, then the
+        // Chat Completions nested shape.
         CachedTokens != 0
             ? CachedTokens
-            // Fallback to OpenAI nested structure
-            : InputTokenDetails?.CachedTokens ?? 0;
+            : InputTokenDetails?.CachedTokens ?? PromptTokenDetails?.CachedTokens ?? 0;
 
     /// <summary>
     ///     Convert to core Usage model
@@ -78,21 +89,16 @@ public record OpenAIProviderUsage
             ExtraProperties = ExtraProperties.ToImmutableDictionary(kvp => kvp.Key, kvp => (object?)kvp.Value),
         };
 
-        // Convert nested token details if present
-        if (InputTokenDetails != null)
+        // Convert nested token details using the unified accessors so every shape (Responses-API
+        // nesting, Chat Completions nesting, and OpenRouter direct fields) maps to core consistently.
+        if (TotalCachedTokens > 0)
         {
-            usage = usage with
-            {
-                InputTokenDetails = new InputTokenDetails { CachedTokens = InputTokenDetails.CachedTokens },
-            };
+            usage = usage with { InputTokenDetails = new InputTokenDetails { CachedTokens = TotalCachedTokens } };
         }
 
-        if (OutputTokenDetails != null)
+        if (TotalReasoningTokens > 0)
         {
-            usage = usage with
-            {
-                OutputTokenDetails = new OutputTokenDetails { ReasoningTokens = OutputTokenDetails.ReasoningTokens },
-            };
+            usage = usage with { OutputTokenDetails = new OutputTokenDetails { ReasoningTokens = TotalReasoningTokens } };
         }
 
         return usage;

--- a/src/OpenAIProvider/Models/OpenMessage.cs
+++ b/src/OpenAIProvider/Models/OpenMessage.cs
@@ -78,11 +78,7 @@ public record OpenMessage
             PromptTokens = usage.PromptTokens,
             CompletionTokens = usage.CompletionTokens,
             TotalTokens = usage.PromptTokens + usage.CompletionTokens,
-            InputTokenDetails =
-                usage.CachedTokens > 0 ? new InputTokenDetails { CachedTokens = usage.CachedTokens } : null,
-            OutputTokenDetails =
-                usage.ReasoningTokens > 0 ? new OutputTokenDetails { ReasoningTokens = usage.ReasoningTokens } : null,
-        };
+        }.WithTokenDetails(usage.CachedTokens, usage.ReasoningTokens);
     }
 
     public IEnumerable<IMessage> ToStreamingMessage()

--- a/src/OpenAIProvider/Models/OpenMessage.cs
+++ b/src/OpenAIProvider/Models/OpenMessage.cs
@@ -58,12 +58,7 @@ public record OpenMessage
             messages.Add(
                 new UsageMessage
                 {
-                    Usage = new Usage
-                    {
-                        PromptTokens = Usage.PromptTokens,
-                        CompletionTokens = Usage.CompletionTokens,
-                        TotalTokens = Usage.PromptTokens + Usage.CompletionTokens,
-                    },
+                    Usage = BuildCoreUsage(Usage),
                     Role = Role.Assistant,
                     FromAgent = ChatMessage.Name,
                     GenerationId = CompletionId,
@@ -72,6 +67,22 @@ public record OpenMessage
         }
 
         return messages;
+    }
+
+    // Carries cached/reasoning detail counts onto the core Usage so prompt-cache and reasoning
+    // telemetry survive the provider→core boundary (nested *_tokens_details on OpenAI/OpenRouter).
+    private static Usage BuildCoreUsage(OpenUsage usage)
+    {
+        return new Usage
+        {
+            PromptTokens = usage.PromptTokens,
+            CompletionTokens = usage.CompletionTokens,
+            TotalTokens = usage.PromptTokens + usage.CompletionTokens,
+            InputTokenDetails =
+                usage.CachedTokens > 0 ? new InputTokenDetails { CachedTokens = usage.CachedTokens } : null,
+            OutputTokenDetails =
+                usage.ReasoningTokens > 0 ? new OutputTokenDetails { ReasoningTokens = usage.ReasoningTokens } : null,
+        };
     }
 
     public IEnumerable<IMessage> ToStreamingMessage()
@@ -127,12 +138,7 @@ public record OpenMessage
             messages.Add(
                 new UsageMessage
                 {
-                    Usage = new Usage
-                    {
-                        PromptTokens = Usage.PromptTokens,
-                        CompletionTokens = Usage.CompletionTokens,
-                        TotalTokens = Usage.PromptTokens + Usage.CompletionTokens,
-                    },
+                    Usage = BuildCoreUsage(Usage),
                     Role = Role.Assistant,
                     FromAgent = ChatMessage.Name,
                     GenerationId = CompletionId,
@@ -156,6 +162,12 @@ public record OpenUsage
 
     public bool IsCached { get; init; }
 
+    /// <summary>Cached (prompt-cache hit) input tokens — a subset of <see cref="PromptTokens"/>.</summary>
+    public int CachedTokens { get; init; }
+
+    /// <summary>Reasoning tokens — a subset of <see cref="CompletionTokens"/>.</summary>
+    public int ReasoningTokens { get; init; }
+
     public static OpenUsage operator +(OpenUsage a, OpenUsage b)
     {
         ArgumentNullException.ThrowIfNull(a);
@@ -168,6 +180,8 @@ public record OpenUsage
             PromptTokens = a.PromptTokens + b.PromptTokens,
             TotalCost = a.TotalCost + b.TotalCost,
             IsCached = a.IsCached,
+            CachedTokens = a.CachedTokens + b.CachedTokens,
+            ReasoningTokens = a.ReasoningTokens + b.ReasoningTokens,
         };
     }
 }

--- a/src/OpenAiResponsesProvider/Agents/OpenAiResponsesAgent.cs
+++ b/src/OpenAiResponsesProvider/Agents/OpenAiResponsesAgent.cs
@@ -483,13 +483,32 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
                 ? totEl.GetInt32()
                 : inputTokens + outputTokens;
 
+        // The Responses API reports prompt-cache hits and reasoning spend in NESTED detail objects.
+        // Surface them so consumers see real cache/reasoning counts (otherwise every cache hit reads 0).
+        var cachedTokens = TryReadNestedInt(usageEl, "input_tokens_details", "cached_tokens");
+        var reasoningTokens = TryReadNestedInt(usageEl, "output_tokens_details", "reasoning_tokens");
+
         usage = new Usage
         {
             PromptTokens = inputTokens,
             CompletionTokens = outputTokens,
             TotalTokens = totalTokens,
+            InputTokenDetails = cachedTokens > 0 ? new InputTokenDetails { CachedTokens = cachedTokens } : null,
+            OutputTokenDetails = reasoningTokens > 0
+                ? new OutputTokenDetails { ReasoningTokens = reasoningTokens }
+                : null,
         };
         return true;
+    }
+
+    private static int TryReadNestedInt(JsonElement parent, string objectProperty, string numberProperty)
+    {
+        return parent.TryGetProperty(objectProperty, out var nestedEl)
+            && nestedEl.ValueKind == JsonValueKind.Object
+            && nestedEl.TryGetProperty(numberProperty, out var valueEl)
+            && valueEl.ValueKind == JsonValueKind.Number
+            ? valueEl.GetInt32()
+            : 0;
     }
 
     private sealed record PendingFunctionCall(

--- a/src/OpenAiResponsesProvider/Agents/OpenAiResponsesAgent.cs
+++ b/src/OpenAiResponsesProvider/Agents/OpenAiResponsesAgent.cs
@@ -493,21 +493,20 @@ public sealed class OpenAiResponsesAgent : IStreamingAgent, IDisposable
             PromptTokens = inputTokens,
             CompletionTokens = outputTokens,
             TotalTokens = totalTokens,
-            InputTokenDetails = cachedTokens > 0 ? new InputTokenDetails { CachedTokens = cachedTokens } : null,
-            OutputTokenDetails = reasoningTokens > 0
-                ? new OutputTokenDetails { ReasoningTokens = reasoningTokens }
-                : null,
-        };
+        }.WithTokenDetails(cachedTokens, reasoningTokens);
         return true;
     }
 
     private static int TryReadNestedInt(JsonElement parent, string objectProperty, string numberProperty)
     {
+        // Non-throwing: optional usage telemetry must never abort an otherwise valid stream just
+        // because a count is encoded in a way GetInt32() would reject (out-of-range / non-int number).
         return parent.TryGetProperty(objectProperty, out var nestedEl)
             && nestedEl.ValueKind == JsonValueKind.Object
             && nestedEl.TryGetProperty(numberProperty, out var valueEl)
             && valueEl.ValueKind == JsonValueKind.Number
-            ? valueEl.GetInt32()
+            && valueEl.TryGetInt32(out var value)
+            ? value
             : 0;
     }
 

--- a/tests/OpenAIProvider.Tests/Agents/ChatCompletionsCacheTokenUsageTests.cs
+++ b/tests/OpenAIProvider.Tests/Agents/ChatCompletionsCacheTokenUsageTests.cs
@@ -59,4 +59,39 @@ public sealed class ChatCompletionsCacheTokenUsageTests
         Assert.Equal(13696, usage.TotalCachedTokens);
         Assert.Equal(64, usage.TotalReasoningTokens);
     }
+
+    // Streamed chat-completions chunks. The usage is co-located on the final (stop) chunk because the
+    // streaming reader expects each chunk to carry a choice/delta. Mirrors the nested detail shape.
+    private static readonly string[] StreamingChunks =
+    [
+        """{"id":"chatcmpl-stream","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}""",
+        """{"id":"chatcmpl-stream","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":14986,"completion_tokens":121,"total_tokens":15107,"prompt_tokens_details":{"cached_tokens":13696},"completion_tokens_details":{"reasoning_tokens":64}}}""",
+        "[DONE]",
+    ];
+
+    [Fact]
+    public async Task Streaming_UsageMessage_preserves_cached_and_reasoning_tokens_from_chat_completions()
+    {
+        using var httpClient = new HttpClient(FakeHttpMessageHandler.CreateSimpleSseStreamHandler(StreamingChunks));
+        var client = new OpenClient(httpClient, BaseUrl);
+        var agent = new OpenClientAgent("TestAgent", client);
+
+        var stream = await agent.GenerateReplyStreamingAsync(
+            [new TextMessage { Role = Role.User, Text = "hi" }],
+            new GenerateReplyOptions { ModelId = "gpt-4o" }
+        );
+
+        UsageMessage? usageMessage = null;
+        await foreach (var m in stream)
+        {
+            if (m is UsageMessage u)
+            {
+                usageMessage = u;
+            }
+        }
+
+        Assert.NotNull(usageMessage);
+        Assert.Equal(13696, usageMessage!.Usage.TotalCachedTokens);
+        Assert.Equal(64, usageMessage.Usage.TotalReasoningTokens);
+    }
 }

--- a/tests/OpenAIProvider.Tests/Agents/ChatCompletionsCacheTokenUsageTests.cs
+++ b/tests/OpenAIProvider.Tests/Agents/ChatCompletionsCacheTokenUsageTests.cs
@@ -1,0 +1,62 @@
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmTestUtils;
+using AchieveAi.LmDotnetTools.OpenAIProvider.Agents;
+
+namespace AchieveAi.LmDotnetTools.OpenAIProvider.Tests.Agents;
+
+/// <summary>
+/// Regression: OpenAI Chat Completions reports prompt-cache hits and reasoning spend in the
+/// <c>prompt_tokens_details.cached_tokens</c> / <c>completion_tokens_details.reasoning_tokens</c>
+/// nested objects (distinct from the Responses API's <c>input_tokens_details</c> naming). The
+/// emitted <see cref="UsageMessage"/> must carry those through to <c>TotalCachedTokens</c> /
+/// <c>TotalReasoningTokens</c>; otherwise every chat-completions cache hit is reported as zero.
+/// Drives the real <see cref="OpenClientAgent"/> against a canned chat-completion response.
+/// </summary>
+public sealed class ChatCompletionsCacheTokenUsageTests
+{
+    private const string BaseUrl = "http://test-mode/v1";
+
+    // A non-streaming Chat Completions body whose usage carries the chat-completions-style nested
+    // detail objects (13696 of 14986 prompt tokens cached; 64 reasoning tokens).
+    private const string ResponseJson = """
+        {
+          "id": "chatcmpl-cache-test",
+          "object": "chat.completion",
+          "created": 0,
+          "model": "gpt-4o",
+          "choices": [
+            { "index": 0, "message": { "role": "assistant", "content": "hi" }, "finish_reason": "stop" }
+          ],
+          "usage": {
+            "prompt_tokens": 14986,
+            "completion_tokens": 121,
+            "total_tokens": 15107,
+            "prompt_tokens_details": { "cached_tokens": 13696 },
+            "completion_tokens_details": { "reasoning_tokens": 64 }
+          }
+        }
+        """;
+
+    [Fact]
+    public async Task UsageMessage_preserves_cached_and_reasoning_tokens_from_chat_completions()
+    {
+        using var httpClient = new HttpClient(FakeHttpMessageHandler.CreateSimpleJsonHandler(ResponseJson));
+        var client = new OpenClient(httpClient, BaseUrl);
+        var agent = new OpenClientAgent("TestAgent", client);
+
+        var response = await agent.GenerateReplyAsync(
+            [new TextMessage { Role = Role.User, Text = "hi" }],
+            new GenerateReplyOptions { ModelId = "gpt-4o" }
+        );
+
+        var usageMessage = Assert.Single(response.OfType<UsageMessage>());
+        var usage = usageMessage.Usage;
+        Assert.Equal(14986, usage.PromptTokens);
+        Assert.Equal(121, usage.CompletionTokens);
+        // Chat Completions reported 13696 cached tokens (prompt_tokens_details.cached_tokens)
+        // and 64 reasoning tokens (completion_tokens_details.reasoning_tokens).
+        Assert.Equal(13696, usage.TotalCachedTokens);
+        Assert.Equal(64, usage.TotalReasoningTokens);
+    }
+}

--- a/tests/OpenAIProvider.Tests/Models/OpenAIProviderUsageTests.cs
+++ b/tests/OpenAIProvider.Tests/Models/OpenAIProviderUsageTests.cs
@@ -54,6 +54,39 @@ public class OpenAIProviderUsageTests
     }
 
     [Fact]
+    public void OpenAIProviderUsage_ShouldDeserializeChatCompletionsNestedDetails()
+    {
+        // Arrange - the REAL OpenAI Chat Completions usage shape uses prompt_tokens_details /
+        // completion_tokens_details (the Responses API uses input_tokens_details / output_tokens_details).
+        var chatJson = """
+            {
+                "prompt_tokens": 14986,
+                "completion_tokens": 121,
+                "total_tokens": 15107,
+                "prompt_tokens_details": {
+                    "cached_tokens": 13696
+                },
+                "completion_tokens_details": {
+                    "reasoning_tokens": 64
+                }
+            }
+            """;
+
+        // Act
+        var usage = JsonSerializer.Deserialize<OpenAIProviderUsage>(chatJson, _options);
+
+        // Assert
+        Assert.NotNull(usage);
+        Assert.Equal(13696, usage.TotalCachedTokens);
+        Assert.Equal(64, usage.TotalReasoningTokens);
+
+        // ToCoreUsage must carry the details across the boundary.
+        var core = usage.ToCoreUsage();
+        Assert.Equal(13696, core.TotalCachedTokens);
+        Assert.Equal(64, core.TotalReasoningTokens);
+    }
+
+    [Fact]
     public void OpenAIProviderUsage_ShouldDeserializeOpenRouterResponse()
     {
         // Arrange - OpenRouter API response format with direct fields

--- a/tests/OpenAiResponsesProvider.Tests/CacheTokenUsageRegressionTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/CacheTokenUsageRegressionTests.cs
@@ -1,0 +1,101 @@
+using System.Runtime.CompilerServices;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Tests;
+
+/// <summary>
+/// Regression: the OpenAI Responses API (and the GitHub Copilot proxy of it) reports prompt-cache
+/// hits and reasoning tokens via the NESTED detail objects on the usage block —
+/// <c>input_tokens_details.cached_tokens</c> and <c>output_tokens_details.reasoning_tokens</c>.
+/// <see cref="OpenAiResponsesAgent"/> must surface those on the emitted <see cref="UsageMessage"/>
+/// (the core <see cref="AchieveAi.LmDotnetTools.LmCore.Models.Usage"/> model exposes them as
+/// <c>TotalCachedTokens</c> / <c>TotalReasoningTokens</c>), otherwise every cache hit is silently
+/// reported as zero and cost/cache telemetry is wrong.
+/// </summary>
+public sealed class CacheTokenUsageRegressionTests
+{
+    // Verbatim usage block from a live OpenAI Responses `response.completed` event, captured in
+    // samples/MockProviderHost/fixtures/openai-responses-websocket/sample_ws_stream_001.redacted.json
+    // (13,696 of 14,986 input tokens served from cache — a ~91% hit). reasoning_tokens is bumped to a
+    // non-zero value here so the same test also guards the reasoning-token detail path.
+    private const string CompletedEventJson = """
+        {
+          "type": "response.completed",
+          "response": {
+            "id": "resp_regression",
+            "object": "response",
+            "status": "completed",
+            "usage": {
+              "input_tokens": 14986,
+              "input_tokens_details": { "cached_tokens": 13696 },
+              "output_tokens": 121,
+              "output_tokens_details": { "reasoning_tokens": 64 },
+              "total_tokens": 15107
+            }
+          }
+        }
+        """;
+
+    [Fact]
+    public async Task UsageMessage_preserves_cached_and_reasoning_tokens_from_responses_api()
+    {
+        var completed = ResponseEventParser.Parse(CompletedEventJson);
+        using var agent = new OpenAiResponsesAgent("test-agent", new StubResponsesClient(completed));
+
+        var stream = await agent.GenerateReplyStreamingAsync(
+            [new TextMessage { Role = Role.User, Text = "hi" }]
+        );
+
+        UsageMessage? usage = null;
+        await foreach (var m in stream)
+        {
+            if (m is UsageMessage u)
+            {
+                usage = u;
+            }
+        }
+
+        usage.Should().NotBeNull("the response.completed event carries a usage block");
+
+        // Baseline counts already map correctly today.
+        usage!.Usage.PromptTokens.Should().Be(14986);
+        usage.Usage.CompletionTokens.Should().Be(121);
+        usage.Usage.TotalTokens.Should().Be(15107);
+
+        // The bug: the nested *_tokens_details objects are dropped, so cache/reasoning read 0.
+        usage.Usage.TotalCachedTokens.Should().Be(
+            13696,
+            "the Responses API reported 13696 cached input tokens in input_tokens_details.cached_tokens"
+        );
+        usage.Usage.TotalReasoningTokens.Should().Be(
+            64,
+            "the Responses API reported 64 reasoning tokens in output_tokens_details.reasoning_tokens"
+        );
+    }
+
+    /// <summary>Minimal <see cref="IOpenAiResponsesClient"/> that replays a fixed event sequence.</summary>
+    private sealed class StubResponsesClient : IOpenAiResponsesClient
+    {
+        private readonly ResponseEvent[] _events;
+
+        public StubResponsesClient(params ResponseEvent[] events) => _events = events;
+
+        public async IAsyncEnumerable<ResponseEvent> StreamResponseAsync(
+            ResponseCreateRequest request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            foreach (var ev in _events)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return ev;
+                await Task.Yield();
+            }
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesEventStreamWriterTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesEventStreamWriterTests.cs
@@ -122,6 +122,51 @@ public sealed class OpenAiResponsesEventStreamWriterTests
     }
 
     [Fact]
+    public void Completed_lifecycle_emits_nested_token_details_when_plan_simulates_cache_and_reasoning()
+    {
+        var plan = new InstructionPlan("with-cache", reasoningLength: 8, [InstructionMessage.ForExplicitText("ok")])
+        {
+            CacheReadInputTokens = 13696,
+        };
+
+        var events = OpenAiResponsesEventStreamWriter.Write(plan);
+
+        var usage = events
+            .OfType<ResponseLifecycleEvent>()
+            .Single(e => e.Type == ResponseEventTypes.ResponseCompleted)
+            .Response.GetProperty("usage");
+
+        usage
+            .GetProperty("input_tokens_details")
+            .GetProperty("cached_tokens")
+            .GetInt32()
+            .Should()
+            .Be(13696, "the mock must reproduce the real Responses API's nested cached_tokens shape");
+        usage
+            .GetProperty("output_tokens_details")
+            .GetProperty("reasoning_tokens")
+            .GetInt32()
+            .Should()
+            .Be(8);
+    }
+
+    [Fact]
+    public void Completed_lifecycle_omits_token_details_when_plan_simulates_no_cache_or_reasoning()
+    {
+        var plan = new InstructionPlan("no-cache", null, [InstructionMessage.ForExplicitText("ok")]);
+
+        var events = OpenAiResponsesEventStreamWriter.Write(plan);
+
+        var usage = events
+            .OfType<ResponseLifecycleEvent>()
+            .Single(e => e.Type == ResponseEventTypes.ResponseCompleted)
+            .Response.GetProperty("usage");
+
+        usage.TryGetProperty("input_tokens_details", out _).Should().BeFalse();
+        usage.TryGetProperty("output_tokens_details", out _).Should().BeFalse();
+    }
+
+    [Fact]
     public void Multiple_messages_get_distinct_output_indexes()
     {
         var plan = new InstructionPlan(


### PR DESCRIPTION
## What & Why
Prompt-cache and reasoning token counts were silently dropped for OpenAI usage, so `Usage.TotalCachedTokens` / `TotalReasoningTokens` always read `0` — even on large cache hits (a real captured Responses event showed **13696/14986 input tokens cached, ~91%**, all discarded).

The OpenAI **Responses API** (including GitHub Copilot `gpt-5.5`) and **Chat Completions** report cache/reasoning in *nested* usage detail objects that the providers weren't reading. This is the bug reported for "OpenAI responses APIs (through copilot)" (#115); the chat-completions half of the same family is fixed here too (opted in), with the rest tracked in #116.

## Root Cause
- **Responses:** `OpenAiResponsesAgent.TryExtractUsage` read only `input_tokens` / `output_tokens` / `total_tokens` and ignored `input_tokens_details.cached_tokens` + `output_tokens_details.reasoning_tokens`.
- **Chat Completions:** `OpenAIProviderUsage` only mapped the *Responses-API* detail names (`input_tokens_details`), not the chat-completions names (`prompt_tokens_details` / `completion_tokens_details`), **and** the emit path (`OpenUsage` → `OpenMessage`) rebuilt a bare `Usage` that dropped details regardless.

## Changes
- **`OpenAiResponsesAgent.TryExtractUsage`** — parse the nested `input_tokens_details` / `output_tokens_details` into `Usage.InputTokenDetails` / `OutputTokenDetails`. Covers SSE + WebSocket, direct + Copilot (shared agent).
- **`OpenAIProviderUsage`** — also parse the chat-completions `prompt_tokens_details` / `completion_tokens_details` names; `ToCoreUsage` now maps details via the unified `TotalCachedTokens` / `TotalReasoningTokens` so OpenRouter-direct fields reach core too.
- **`OpenUsage` / `OpenMessage` / `OpenClientAgent`** — carry cached/reasoning onto the emitted `UsageMessage` (non-streaming + streaming).
- **`OpenAiResponsesEventStreamWriter` (mock)** — emit the nested details when a plan simulates cache/reasoning, closing the test-infra gap that hid this.
- **`LmStreaming.Sample` `Cache:` log** — report true uncached input (`prompt - cached` for the OpenAI family; defensive fallback for the Anthropic additive case; clamped ≥ 0).

## Tests (RED→GREEN)
- `OpenAiResponsesProvider.Tests/CacheTokenUsageRegressionTests` — replays the real `13696`-cached `response.completed` event through the agent (failed `found 0` before, passes after).
- `OpenAiResponsesProvider.Tests/OpenAiResponsesEventStreamWriterTests` — mock emits / omits nested details.
- `OpenAIProvider.Tests/Agents/ChatCompletionsCacheTokenUsageTests` — end-to-end through `OpenClientAgent` with a canned chat-completion body.
- `OpenAIProvider.Tests/Models/OpenAIProviderUsageTests` — chat-completions nested-detail parsing + `ToCoreUsage`.

All green: OpenAiResponsesProvider 70 · MockProviderHost 41 · LmTestUtils 91 · OpenAIProvider 91 · LmStreaming.Sample 325 · LmCore (Usage) 16 · GithubCopilotProvider 19. Full solution build: 0 errors.

## Risk
Additive parsing + emit changes; defaults preserve prior behavior when no details are present (existing byte-identity and usage tests unchanged). The sample-log change is diagnostic only.

## Related Issues
Fixes #115
Relates to #116
