### PR TITLE
fix(responses+copilot): retry transient 502s on streaming Responses + WebSocket connect (#114)

### DIFF
--- a/src/GithubCopilotProvider/AchieveAi.LmDotnetTools.GithubCopilotProvider.csproj
+++ b/src/GithubCopilotProvider/AchieveAi.LmDotnetTools.GithubCopilotProvider.csproj
@@ -8,6 +8,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.5" />
     <PackageReference Include="System.Net.Http.Json" Version="9.0.5" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="AchieveAi.LmDotnetTools.GithubCopilotProvider.Tests" />
+  </ItemGroup>
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/GithubCopilotProvider/Agents/CopilotResponsesAgentFactory.cs
+++ b/src/GithubCopilotProvider/Agents/CopilotResponsesAgentFactory.cs
@@ -66,16 +66,20 @@ public static class CopilotResponsesAgentFactory
         return new OpenAiResponsesAgent(name, client, logger);
     }
 
-    private static IOpenAiResponsesClient CreateSseClient(
+    // internal (not private) so a test can drive the REAL SSE construction path through an injected
+    // transport handler and prove that retryOptions + logger are forwarded into the client. The
+    // public Create overload never supplies innerHandler (production uses the default transport).
+    internal static IOpenAiResponsesClient CreateSseClient(
         string host,
         ICopilotTokenProvider tokenProvider,
         CopilotSessionContext context,
         CopilotOptions options,
         ILogger? logger,
-        RetryOptions? retryOptions
+        RetryOptions? retryOptions,
+        HttpMessageHandler? innerHandler = null
     )
     {
-        var httpClient = CopilotHttpClientFactory.Create(host, tokenProvider, context, options);
+        var httpClient = CopilotHttpClientFactory.Create(host, tokenProvider, context, options, innerHandler: innerHandler);
         // Forward the factory's logger (an ILogger<OpenAiResponsesAgent> IS an ILogger) so the SSE
         // pre-stream retries are visible, and the shared retry configuration.
         return new OpenAiResponsesClient(

--- a/src/GithubCopilotProvider/Agents/CopilotResponsesAgentFactory.cs
+++ b/src/GithubCopilotProvider/Agents/CopilotResponsesAgentFactory.cs
@@ -1,4 +1,5 @@
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
+using AchieveAi.LmDotnetTools.LmCore.Http;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
 using Microsoft.Extensions.Logging;
 
@@ -30,13 +31,18 @@ public static class CopilotResponsesAgentFactory
     /// <param name="session">Optional shared tracking ids; a new context is created when omitted.</param>
     /// <param name="options">Optional Copilot header options.</param>
     /// <param name="logger">Optional logger.</param>
+    /// <param name="retryOptions">
+    ///     Optional transient-fault retry configuration; applied to BOTH transports (SSE pre-stream
+    ///     retry and WebSocket connect-retry). Defaults to <see cref="RetryOptions.Default"/>.
+    /// </param>
     public static OpenAiResponsesAgent Create(
         string name,
         ICopilotTokenProvider tokenProvider,
         CopilotResponsesTransport transport = CopilotResponsesTransport.WebSocket,
         CopilotSessionContext? session = null,
         CopilotOptions? options = null,
-        ILogger<OpenAiResponsesAgent>? logger = null
+        ILogger<OpenAiResponsesAgent>? logger = null,
+        RetryOptions? retryOptions = null
     )
     {
         ArgumentNullException.ThrowIfNull(name);
@@ -54,8 +60,8 @@ public static class CopilotResponsesAgentFactory
 
         var client =
             transport == CopilotResponsesTransport.Sse
-                ? CreateSseClient(host, tokenProvider, context, copilotOptions)
-                : CreateWebSocketClient(host, tokenProvider, context, copilotOptions, logger);
+                ? CreateSseClient(host, tokenProvider, context, copilotOptions, logger, retryOptions)
+                : CreateWebSocketClient(host, tokenProvider, context, copilotOptions, logger, retryOptions);
 
         return new OpenAiResponsesAgent(name, client, logger);
     }
@@ -64,11 +70,21 @@ public static class CopilotResponsesAgentFactory
         string host,
         ICopilotTokenProvider tokenProvider,
         CopilotSessionContext context,
-        CopilotOptions options
+        CopilotOptions options,
+        ILogger? logger,
+        RetryOptions? retryOptions
     )
     {
         var httpClient = CopilotHttpClientFactory.Create(host, tokenProvider, context, options);
-        return new OpenAiResponsesClient(httpClient, disposeClient: true, logger: null, responsesPath: ResponsesPath);
+        // Forward the factory's logger (an ILogger<OpenAiResponsesAgent> IS an ILogger) so the SSE
+        // pre-stream retries are visible, and the shared retry configuration.
+        return new OpenAiResponsesClient(
+            httpClient,
+            disposeClient: true,
+            logger: logger,
+            responsesPath: ResponsesPath,
+            retryOptions: retryOptions
+        );
     }
 
     private static IOpenAiResponsesClient CreateWebSocketClient(
@@ -76,11 +92,19 @@ public static class CopilotResponsesAgentFactory
         ICopilotTokenProvider tokenProvider,
         CopilotSessionContext context,
         CopilotOptions options,
-        ILogger? logger
+        ILogger? logger,
+        RetryOptions? retryOptions
     )
     {
         var wsEndpoint = new Uri($"{ToWebSocketScheme(host)}{ResponsesPath}");
-        return new CopilotResponsesWebSocketClient(wsEndpoint, tokenProvider, context, options, logger);
+        return new CopilotResponsesWebSocketClient(
+            wsEndpoint,
+            tokenProvider,
+            context,
+            options,
+            logger,
+            retryOptions: retryOptions
+        );
     }
 
     private static string ToWebSocketScheme(string host)

--- a/src/GithubCopilotProvider/Agents/CopilotResponsesWebSocketClient.cs
+++ b/src/GithubCopilotProvider/Agents/CopilotResponsesWebSocketClient.cs
@@ -238,13 +238,15 @@ public sealed class CopilotResponsesWebSocketClient : IOpenAiResponsesClient, IA
 
         return wsEx.InnerException switch
         {
-            // TryAgain (WSATRY_AGAIN) is the non-authoritative "DNS hiccup, retry" case. HostNotFound
-            // (WSAHOST_NOT_FOUND) is an authoritative "no such host" name-resolution failure and is NOT
-            // retried — see the doc comment above.
+            // Transient transport-layer failures. TryAgain (WSATRY_AGAIN) is the non-authoritative
+            // "DNS hiccup, retry" case; HostUnreachable/NetworkUnreachable are transient routing
+            // failures. HostNotFound (WSAHOST_NOT_FOUND, authoritative "no such host") is NOT here —
+            // it is a permanent name-resolution failure (see the doc comment above).
             SocketException socketEx => socketEx.SocketErrorCode
                 is SocketError.ConnectionRefused
                     or SocketError.TimedOut
                     or SocketError.HostUnreachable
+                    or SocketError.NetworkUnreachable
                     or SocketError.TryAgain,
             HttpRequestException { StatusCode: { } status } => HttpRetryHelper.IsRetryableStatusCode(status),
             _ => false,

--- a/src/GithubCopilotProvider/Agents/CopilotResponsesWebSocketClient.cs
+++ b/src/GithubCopilotProvider/Agents/CopilotResponsesWebSocketClient.cs
@@ -162,6 +162,16 @@ public sealed class CopilotResponsesWebSocketClient : IOpenAiResponsesClient, IA
             return _socket;
         }
 
+        // A previously-stored socket that is no longer connected (e.g. after a faulted/truncated turn)
+        // must be disposed before we replace it, otherwise its underlying connection leaks until
+        // finalization. Null it out first so a failed reconnect never leaves a half-open socket stored.
+        if (_socket is not null)
+        {
+            var stale = _socket;
+            _socket = null;
+            await DisposeSocketSafelyAsync(stale).ConfigureAwait(false);
+        }
+
         // Pre-turn connect-retry: this runs ONLY before the first response.create frame is sent, so a
         // retry is safe (idempotent). Each attempt refreshes the token + headers (fresh x-interaction-id)
         // and creates a NEW socket; a failed socket is disposed locally and _socket is assigned ONLY
@@ -228,12 +238,14 @@ public sealed class CopilotResponsesWebSocketClient : IOpenAiResponsesClient, IA
 
         return wsEx.InnerException switch
         {
+            // TryAgain (WSATRY_AGAIN) is the non-authoritative "DNS hiccup, retry" case. HostNotFound
+            // (WSAHOST_NOT_FOUND) is an authoritative "no such host" name-resolution failure and is NOT
+            // retried — see the doc comment above.
             SocketException socketEx => socketEx.SocketErrorCode
                 is SocketError.ConnectionRefused
                     or SocketError.TimedOut
                     or SocketError.HostUnreachable
-                    or SocketError.TryAgain
-                    or SocketError.HostNotFound,
+                    or SocketError.TryAgain,
             HttpRequestException { StatusCode: { } status } => HttpRetryHelper.IsRetryableStatusCode(status),
             _ => false,
         };

--- a/src/GithubCopilotProvider/Agents/CopilotResponsesWebSocketClient.cs
+++ b/src/GithubCopilotProvider/Agents/CopilotResponsesWebSocketClient.cs
@@ -1,8 +1,10 @@
+using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
+using AchieveAi.LmDotnetTools.LmCore.Http;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
 using Microsoft.Extensions.Logging;
@@ -36,6 +38,7 @@ public sealed class CopilotResponsesWebSocketClient : IOpenAiResponsesClient, IA
     private readonly CopilotOptions _options;
     private readonly Func<ICopilotResponsesSocket> _socketFactory;
     private readonly ILogger _logger;
+    private readonly RetryOptions _retryOptions;
     private readonly SemaphoreSlim _turnGate = new(1, 1);
 
     private ICopilotResponsesSocket? _socket;
@@ -53,13 +56,18 @@ public sealed class CopilotResponsesWebSocketClient : IOpenAiResponsesClient, IA
     /// <param name="socketFactory">
     ///     Optional socket factory (override in tests). Defaults to a real <see cref="ClientWebSocket"/>.
     /// </param>
+    /// <param name="retryOptions">
+    ///     Optional connect-retry configuration (bounds the pre-turn connect-retry loop). Defaults to
+    ///     <see cref="RetryOptions.Default"/>.
+    /// </param>
     public CopilotResponsesWebSocketClient(
         Uri endpoint,
         ICopilotTokenProvider tokenProvider,
         CopilotSessionContext session,
         CopilotOptions? options = null,
         ILogger? logger = null,
-        Func<ICopilotResponsesSocket>? socketFactory = null
+        Func<ICopilotResponsesSocket>? socketFactory = null,
+        RetryOptions? retryOptions = null
     )
     {
         _endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
@@ -68,6 +76,7 @@ public sealed class CopilotResponsesWebSocketClient : IOpenAiResponsesClient, IA
         _options = options ?? new CopilotOptions();
         _logger = logger ?? NullLogger.Instance;
         _socketFactory = socketFactory ?? (() => new ClientWebSocketResponsesSocket());
+        _retryOptions = retryOptions ?? RetryOptions.Default;
     }
 
     /// <inheritdoc />
@@ -107,12 +116,15 @@ public sealed class CopilotResponsesWebSocketClient : IOpenAiResponsesClient, IA
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var text = await socket.ReceiveTextAsync(cancellationToken).ConfigureAwait(false);
-                if (text is null)
-                {
-                    // Socket closed mid-turn.
-                    yield break;
-                }
+                // A null is a genuine peer Close frame. Reaching here means the socket closed BEFORE a
+                // terminal response.completed/response.failed event, i.e. the turn was truncated. Surface
+                // it as an error instead of silently ending the stream as though the turn had completed
+                // (which would also wrongly leave _previousResponseId chained to a partial turn).
+                var text =
+                    await socket.ReceiveTextAsync(cancellationToken).ConfigureAwait(false)
+                    ?? throw new IOException(
+                        "WebSocket closed before turn completion (no response.completed/response.failed received)."
+                    );
 
                 if (string.IsNullOrWhiteSpace(text))
                 {
@@ -150,21 +162,93 @@ public sealed class CopilotResponsesWebSocketClient : IOpenAiResponsesClient, IA
             return _socket;
         }
 
-        var token = await _tokenProvider.GetTokenAsync(cancellationToken).ConfigureAwait(false);
+        // Pre-turn connect-retry: this runs ONLY before the first response.create frame is sent, so a
+        // retry is safe (idempotent). Each attempt refreshes the token + headers (fresh x-interaction-id)
+        // and creates a NEW socket; a failed socket is disposed locally and _socket is assigned ONLY
+        // after a successful connect, so a half-open socket is never observed by a turn.
+        var attempt = 0;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
 
-        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            var token = await _tokenProvider.GetTokenAsync(cancellationToken).ConfigureAwait(false);
+            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Authorization"] = $"Bearer {token}",
+            };
+            foreach (var header in CopilotRequestHeaders.Build(_options, _session, Guid.NewGuid().ToString()))
+            {
+                headers[header.Key] = header.Value;
+            }
+
+            var socket = _socketFactory();
+            try
+            {
+                await socket.ConnectAsync(_endpoint, headers, cancellationToken).ConfigureAwait(false);
+                _socket = socket;
+                return socket;
+            }
+            catch (Exception ex) when (attempt < _retryOptions.MaxRetries && IsRetryableConnect(ex))
+            {
+                attempt++;
+                var delay = _retryOptions.CalculateDelay(attempt);
+                _logger.LogWarning(
+                    "WebSocket connect failed (attempt {Attempt}/{MaxRetries}), retrying in {Delay}ms: {Error}",
+                    attempt,
+                    _retryOptions.MaxRetries + 1,
+                    delay.TotalMilliseconds,
+                    ex.Message
+                );
+
+                await DisposeSocketSafelyAsync(socket).ConfigureAwait(false);
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Non-retryable, retries exhausted, or cancelled: dispose the failed socket and surface.
+                await DisposeSocketSafelyAsync(socket).ConfigureAwait(false);
+                throw;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Classifies a connect/upgrade failure as transient (retryable). Retries when a
+    ///     <see cref="WebSocketException"/> wraps a transient <see cref="SocketException"/>
+    ///     (connection refused / timed out / host unreachable / DNS hiccup) or an inner
+    ///     <see cref="HttpRequestException"/> whose status is a retryable 5xx/429. Auth/permanent
+    ///     failures (401/403/400/404, DNS name-resolution failure) are NOT retried.
+    /// </summary>
+    private static bool IsRetryableConnect(Exception exception)
+    {
+        if (exception is not WebSocketException wsEx)
         {
-            ["Authorization"] = $"Bearer {token}",
-        };
-        foreach (var header in CopilotRequestHeaders.Build(_options, _session, Guid.NewGuid().ToString()))
-        {
-            headers[header.Key] = header.Value;
+            return false;
         }
 
-        var socket = _socketFactory();
-        await socket.ConnectAsync(_endpoint, headers, cancellationToken).ConfigureAwait(false);
-        _socket = socket;
-        return socket;
+        return wsEx.InnerException switch
+        {
+            SocketException socketEx => socketEx.SocketErrorCode
+                is SocketError.ConnectionRefused
+                    or SocketError.TimedOut
+                    or SocketError.HostUnreachable
+                    or SocketError.TryAgain
+                    or SocketError.HostNotFound,
+            HttpRequestException { StatusCode: { } status } => HttpRetryHelper.IsRetryableStatusCode(status),
+            _ => false,
+        };
+    }
+
+    private static async Task DisposeSocketSafelyAsync(ICopilotResponsesSocket socket)
+    {
+        try
+        {
+            await socket.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is WebSocketException or OperationCanceledException)
+        {
+            // Best-effort cleanup of a failed socket — never mask the original connect failure.
+        }
     }
 
     private static string? TryGetResponseId(JsonElement response)
@@ -245,8 +329,10 @@ public interface ICopilotResponsesSocket : IAsyncDisposable
     Task SendTextAsync(string text, CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Receives the next complete text message (reassembling fragments). Returns null when the
-    ///     peer closes the connection.
+    ///     Receives the next complete text message (reassembling fragments). Returns null ONLY on a
+    ///     graceful peer Close frame; an abnormal/abrupt close surfaces as a thrown
+    ///     <see cref="WebSocketException"/> rather than null, so the caller can distinguish a clean
+    ///     close from a fault.
     /// </summary>
     Task<string?> ReceiveTextAsync(CancellationToken cancellationToken);
 }
@@ -292,15 +378,10 @@ public sealed class ClientWebSocketResponsesSocket : ICopilotResponsesSocket
 
         while (true)
         {
-            WebSocketReceiveResult result;
-            try
-            {
-                result = await _socket.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
-            }
-            catch (WebSocketException)
-            {
-                return null;
-            }
+            // A WebSocketException (abnormal/abrupt close, protocol error) is a FAULT, not a graceful
+            // close — let it propagate so the caller can surface it instead of silently truncating the
+            // turn. A null is reserved for a genuine peer Close frame below.
+            var result = await _socket.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
 
             if (result.MessageType == WebSocketMessageType.Close)
             {

--- a/src/LmCore/Http/HttpRetryHelper.cs
+++ b/src/LmCore/Http/HttpRetryHelper.cs
@@ -134,30 +134,34 @@ public static class HttpRetryHelper
                     continue;
                 }
 
-                // Not retryable or max retries exceeded, throw
+                // Not retryable or max retries exceeded. Capture the diagnostics BEFORE disposing, read
+                // the body in a try, dispose the failed response in the finally (so the connection is
+                // not leaked — the success path at :116 keeps the response alive for the caller, and the
+                // retryable branch at :132 already disposes), then throw with the captured values.
+                var statusCode = response.StatusCode;
+                var reasonPhrase = response.ReasonPhrase;
+                string responseBody;
                 try
                 {
-                    if (!response.IsSuccessStatusCode)
-                    {
-                        // Try to read the response body for better error information
-                        var responseBody = await response.Content.ReadAsStringAsync();
-                        var errorMessage =
-                            $"HTTP request failed with status {response.StatusCode} ({response.ReasonPhrase})";
-                        if (!string.IsNullOrWhiteSpace(responseBody))
-                        {
-                            errorMessage += $". Response body: {responseBody}";
-                        }
-
-                        throw new HttpRequestException(errorMessage, null, response.StatusCode);
-                    }
+                    responseBody = await response.Content.ReadAsStringAsync();
                 }
                 catch (Exception ex) when (ex is not HttpRequestException)
                 {
-                    // If reading response body fails, fall back to standard behavior
-                    _ = response.EnsureSuccessStatusCode();
+                    // If reading the body fails, fall back to status-only diagnostics.
+                    responseBody = string.Empty;
+                }
+                finally
+                {
+                    response.Dispose();
                 }
 
-                return default!; // This line should never be reached
+                var errorMessage = $"HTTP request failed with status {statusCode} ({reasonPhrase})";
+                if (!string.IsNullOrWhiteSpace(responseBody))
+                {
+                    errorMessage += $". Response body: {responseBody}";
+                }
+
+                throw new HttpRequestException(errorMessage, null, statusCode);
             }
             catch (HttpRequestException ex) when (attempt < options.MaxRetries && IsRetryableError(ex))
             {

--- a/src/LmCore/Http/HttpRetryHelper.cs
+++ b/src/LmCore/Http/HttpRetryHelper.cs
@@ -145,11 +145,13 @@ public static class HttpRetryHelper
                 {
                     responseBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
                 }
-                catch (Exception ex) when (ex is not HttpRequestException and not OperationCanceledException)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
-                    // If reading the body fails, fall back to status-only diagnostics. Deliberate
-                    // cancellation is NOT swallowed here — it must surface as cancellation, not as a
-                    // synthesized HttpRequestException transport failure.
+                    // A failed body read is diagnostic-only: fall back to status-only diagnostics and throw
+                    // with the ALREADY-CAPTURED original status below. This deliberately also swallows an
+                    // HttpRequestException raised by the body read itself — otherwise it would escape to the
+                    // outer retry catch and could retry a non-retryable status (or mask the real status).
+                    // Deliberate cancellation is NOT swallowed — it must surface as cancellation.
                     responseBody = string.Empty;
                 }
                 finally

--- a/src/LmCore/Http/HttpRetryHelper.cs
+++ b/src/LmCore/Http/HttpRetryHelper.cs
@@ -143,11 +143,13 @@ public static class HttpRetryHelper
                 string responseBody;
                 try
                 {
-                    responseBody = await response.Content.ReadAsStringAsync();
+                    responseBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
                 }
-                catch (Exception ex) when (ex is not HttpRequestException)
+                catch (Exception ex) when (ex is not HttpRequestException and not OperationCanceledException)
                 {
-                    // If reading the body fails, fall back to status-only diagnostics.
+                    // If reading the body fails, fall back to status-only diagnostics. Deliberate
+                    // cancellation is NOT swallowed here — it must surface as cancellation, not as a
+                    // synthesized HttpRequestException transport failure.
                     responseBody = string.Empty;
                 }
                 finally

--- a/src/LmTestUtils/Http/TrackingHttpResponseMessage.cs
+++ b/src/LmTestUtils/Http/TrackingHttpResponseMessage.cs
@@ -1,0 +1,46 @@
+using System.Net;
+
+namespace AchieveAi.LmDotnetTools.LmTestUtils.Http;
+
+/// <summary>
+///     An <see cref="HttpResponseMessage"/> that records whether it has been disposed, so tests can
+///     assert response/connection lifetime (e.g. that a failed or fully-consumed response is disposed
+///     and not leaked). Shared across provider test projects to avoid duplicate definitions.
+/// </summary>
+public sealed class TrackingHttpResponseMessage : HttpResponseMessage
+{
+    private int _disposeCount;
+
+    public TrackingHttpResponseMessage(HttpStatusCode statusCode)
+        : base(statusCode) { }
+
+    /// <summary>True once <see cref="Dispose(bool)"/> has run at least once.</summary>
+    public bool Disposed => Volatile.Read(ref _disposeCount) > 0;
+
+    /// <summary>Optional tracked body stream (success/streaming responses) so its disposal can be asserted too.</summary>
+    public TrackingStream? BodyStream { get; init; }
+
+    protected override void Dispose(bool disposing)
+    {
+        _ = Interlocked.Increment(ref _disposeCount);
+        base.Dispose(disposing);
+    }
+}
+
+/// <summary>A <see cref="MemoryStream"/> that records whether it has been disposed.</summary>
+public sealed class TrackingStream : MemoryStream
+{
+    private int _disposeCount;
+
+    public TrackingStream(byte[] buffer)
+        : base(buffer) { }
+
+    /// <summary>True once <see cref="Dispose(bool)"/> has run at least once.</summary>
+    public bool Disposed => Volatile.Read(ref _disposeCount) > 0;
+
+    protected override void Dispose(bool disposing)
+    {
+        _ = Interlocked.Increment(ref _disposeCount);
+        base.Dispose(disposing);
+    }
+}

--- a/src/LmTestUtils/Logging/ListLogger.cs
+++ b/src/LmTestUtils/Logging/ListLogger.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Logging;
+
+namespace AchieveAi.LmDotnetTools.LmTestUtils.Logging;
+
+/// <summary>
+///     Minimal in-memory <see cref="ILogger"/> that captures emitted entries (level + formatted
+///     message) so tests can assert on what was logged (e.g. that a retry warning was emitted).
+///     Shared across provider test projects to avoid duplicate definitions.
+/// </summary>
+public sealed class ListLogger : ILogger
+{
+    public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter
+    ) => Entries.Add((logLevel, formatter(state, exception)));
+}

--- a/src/LmTestUtils/TestMode/OpenAiResponsesTestSseMessageHandler.cs
+++ b/src/LmTestUtils/TestMode/OpenAiResponsesTestSseMessageHandler.cs
@@ -26,6 +26,7 @@ public sealed class OpenAiResponsesTestSseMessageHandler : HttpMessageHandler
 
     private readonly IInstructionChainParser _chainParser;
     private readonly ILogger<OpenAiResponsesTestSseMessageHandler> _logger;
+    private int _sendCount;
 
     public OpenAiResponsesTestSseMessageHandler()
         : this(NullLogger<OpenAiResponsesTestSseMessageHandler>.Instance) { }
@@ -43,6 +44,16 @@ public sealed class OpenAiResponsesTestSseMessageHandler : HttpMessageHandler
 
     public int ChunkDelayMs { get; set; } = DefaultChunkDelayMs;
 
+    /// <summary>
+    ///     Number of leading matching <c>/responses</c> POSTs to fail with <see cref="FailStatusCode"/>
+    ///     before serving the SSE stream. Lets a client's pre-stream retry be exercised. Instance-scoped
+    ///     (no cross-test leak); default 0 — no injected failures.
+    /// </summary>
+    public int FailFirstCount { get; set; }
+
+    /// <summary>Status returned for the injected failures (default 502 Bad Gateway).</summary>
+    public HttpStatusCode FailStatusCode { get; set; } = HttpStatusCode.BadGateway;
+
     /// <inheritdoc />
     protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
@@ -57,6 +68,16 @@ public sealed class OpenAiResponsesTestSseMessageHandler : HttpMessageHandler
         if (!request.RequestUri.AbsolutePath.EndsWith("/responses", StringComparison.OrdinalIgnoreCase))
         {
             return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+
+        // Optional transient-fault injection: fail the first N matching POSTs so a client's pre-stream
+        // retry can be exercised. Counted per instance (default 0 => never fires, no cross-test leak).
+        if (Interlocked.Increment(ref _sendCount) <= FailFirstCount)
+        {
+            return new HttpResponseMessage(FailStatusCode)
+            {
+                Content = new StringContent($"Injected failure {(int)FailStatusCode}"),
+            };
         }
 
         var body =

--- a/src/OpenAiResponsesProvider/Agents/OpenAiResponsesClient.cs
+++ b/src/OpenAiResponsesProvider/Agents/OpenAiResponsesClient.cs
@@ -94,9 +94,12 @@ public sealed class OpenAiResponsesClient : IOpenAiResponsesClient
         // the processor must NOT call EnsureSuccessStatusCode — it hands back the still-open response
         // and its stream so enumeration happens OUTSIDE the retry scope.
         var setup = await HttpRetryHelper.ExecuteHttpWithRetryAsync(
-            () =>
+            async () =>
             {
-                var httpRequest = new HttpRequestMessage(HttpMethod.Post, _responsesPath)
+                // `using` so the per-attempt request + JsonContent are disposed once the response
+                // headers are read; with ResponseHeadersRead the response stream is owned by the
+                // returned HttpResponseMessage, so disposing the request here does not affect it.
+                using var httpRequest = new HttpRequestMessage(HttpMethod.Post, _responsesPath)
                 {
                     Content = JsonContent.Create(streamingRequest, options: s_serializerOptions),
                 };
@@ -109,12 +112,24 @@ public sealed class OpenAiResponsesClient : IOpenAiResponsesClient
                     streamingRequest.Input.Count
                 );
 
-                return _http.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                return await _http
+                    .SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                    .ConfigureAwait(false);
             },
             async response =>
             {
-                var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-                return (Response: response, Stream: stream);
+                // If acquiring the stream fails/cancels, the tuple is never returned and the iterator's
+                // finally never runs — dispose the response here so the connection is not pinned.
+                try
+                {
+                    var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                    return (Response: response, Stream: stream);
+                }
+                catch
+                {
+                    response.Dispose();
+                    throw;
+                }
             },
             _logger,
             _retryOptions,

--- a/src/OpenAiResponsesProvider/Agents/OpenAiResponsesClient.cs
+++ b/src/OpenAiResponsesProvider/Agents/OpenAiResponsesClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Http;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -32,19 +33,22 @@ public sealed class OpenAiResponsesClient : IOpenAiResponsesClient
     private readonly HttpClient _http;
     private readonly bool _disposeClient;
     private readonly string _responsesPath;
-    private readonly ILogger<OpenAiResponsesClient> _logger;
+    private readonly ILogger _logger;
+    private readonly RetryOptions _retryOptions;
 
     public OpenAiResponsesClient(
         HttpClient httpClient,
         bool disposeClient = false,
-        ILogger<OpenAiResponsesClient>? logger = null,
-        string? responsesPath = null
+        ILogger? logger = null,
+        string? responsesPath = null,
+        RetryOptions? retryOptions = null
     )
     {
         _http = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _disposeClient = disposeClient;
         _responsesPath = string.IsNullOrWhiteSpace(responsesPath) ? DefaultResponsesPath : responsesPath!;
-        _logger = logger ?? NullLogger<OpenAiResponsesClient>.Instance;
+        _logger = logger ?? NullLogger.Instance;
+        _retryOptions = retryOptions ?? RetryOptions.Default;
     }
 
     /// <summary>
@@ -55,8 +59,9 @@ public sealed class OpenAiResponsesClient : IOpenAiResponsesClient
     public static OpenAiResponsesClient Create(
         Uri baseAddress,
         string? apiKey = null,
-        ILogger<OpenAiResponsesClient>? logger = null,
-        string? responsesPath = null
+        ILogger? logger = null,
+        string? responsesPath = null,
+        RetryOptions? retryOptions = null
     )
     {
         ArgumentNullException.ThrowIfNull(baseAddress);
@@ -66,7 +71,7 @@ public sealed class OpenAiResponsesClient : IOpenAiResponsesClient
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
         }
 
-        return new OpenAiResponsesClient(client, disposeClient: true, logger, responsesPath);
+        return new OpenAiResponsesClient(client, disposeClient: true, logger, responsesPath, retryOptions);
     }
 
     /// <inheritdoc />
@@ -82,57 +87,51 @@ public sealed class OpenAiResponsesClient : IOpenAiResponsesClient
         // diagnostic close to the call site.
         var streamingRequest = request.Stream is true ? request : request with { Stream = true };
 
-        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, _responsesPath)
-        {
-            Content = JsonContent.Create(streamingRequest, options: s_serializerOptions),
-        };
-        httpRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+        // Send (and pre-stream retry transient 502/5xx/429 + connection faults) via the shared
+        // HttpRetryHelper. The HttpRequestMessage + JsonContent are rebuilt fresh on every attempt
+        // because a single request message cannot be re-sent (and a fresh attempt also re-stamps the
+        // Copilot auth token + x-interaction-id). The helper performs the status check internally, so
+        // the processor must NOT call EnsureSuccessStatusCode — it hands back the still-open response
+        // and its stream so enumeration happens OUTSIDE the retry scope.
+        var setup = await HttpRetryHelper.ExecuteHttpWithRetryAsync(
+            () =>
+            {
+                var httpRequest = new HttpRequestMessage(HttpMethod.Post, _responsesPath)
+                {
+                    Content = JsonContent.Create(streamingRequest, options: s_serializerOptions),
+                };
+                httpRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
 
-        _logger.LogDebug(
-            "POST {Path} model={Model} inputItemCount={InputCount} stream=true",
-            _responsesPath,
-            streamingRequest.Model,
-            streamingRequest.Input.Count
-        );
+                _logger.LogDebug(
+                    "POST {Path} model={Model} inputItemCount={InputCount} stream=true",
+                    _responsesPath,
+                    streamingRequest.Model,
+                    streamingRequest.Input.Count
+                );
 
-        using var response = await _http.SendAsync(
-            httpRequest,
-            HttpCompletionOption.ResponseHeadersRead,
+                return _http.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+            },
+            async response =>
+            {
+                var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                return (Response: response, Stream: stream);
+            },
+            _logger,
+            _retryOptions,
             cancellationToken
         ).ConfigureAwait(false);
 
-        if (!response.IsSuccessStatusCode)
+        try
         {
-            string errorBody;
-            try
+            await foreach (var ev in ReadSseAsync(setup.Stream, cancellationToken).ConfigureAwait(false))
             {
-                errorBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                yield return ev;
             }
-            catch (Exception readEx) when (readEx is not OperationCanceledException)
-            {
-                errorBody = "<unable to read response body>";
-            }
-
-            _logger.LogError(
-                "OpenAI Responses API error: {StatusCode} {ReasonPhrase} Body={ErrorBody}",
-                (int)response.StatusCode,
-                response.ReasonPhrase,
-                errorBody
-            );
-
-            throw new HttpRequestException(
-                $"OpenAI Responses API returned {(int)response.StatusCode} {response.ReasonPhrase}: {errorBody}",
-                inner: null,
-                response.StatusCode
-            );
         }
-
-        await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        await foreach (var ev in ReadSseAsync(responseStream, cancellationToken).ConfigureAwait(false))
+        finally
         {
-            yield return ev;
+            setup.Stream.Dispose();
+            setup.Response.Dispose();
         }
     }
 

--- a/src/OpenAiResponsesProvider/Agents/OpenAiResponsesClient.cs
+++ b/src/OpenAiResponsesProvider/Agents/OpenAiResponsesClient.cs
@@ -164,7 +164,10 @@ public sealed class OpenAiResponsesClient : IOpenAiResponsesClient
         using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, 1024, leaveOpen: true);
         var dataBuffer = new StringBuilder();
 
-        while (!reader.EndOfStream)
+        // Fully async/cancellation-driven: do NOT gate on StreamReader.EndOfStream, which performs a
+        // synchronous read to detect EOF and can block on an idle-but-open SSE stream. ReadLineAsync
+        // returns null at EOF, which terminates the loop.
+        while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/tests/AnthropicProvider.Tests/Agents/AnthropicClientHttpTests.cs
+++ b/tests/AnthropicProvider.Tests/Agents/AnthropicClientHttpTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using AchieveAi.LmDotnetTools.LmCore.Http;
 using AchieveAi.LmDotnetTools.LmCore.Performance;
 using AchieveAi.LmDotnetTools.LmTestUtils.Logging;
 using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
@@ -217,6 +218,58 @@ public class AnthropicClientHttpTests : LoggingTestBase
         var metrics = _performanceTracker.GetProviderStatistics("Anthropic");
         Assert.NotNull(metrics);
         Assert.Equal(1, metrics.TotalRequests);
+        Assert.Equal(1, metrics.SuccessfulRequests);
+    }
+
+    /// <summary>
+    ///     Verify-only (#114): the Copilot-Anthropic path already retries a transient pre-stream 502 via
+    ///     <see cref="AnthropicClient"/> streaming. Confirms a 502-then-200 sequence streams successfully
+    ///     using <see cref="RetryOptions.FastForTests"/> (no separate fix needed for that transport).
+    /// </summary>
+    [Fact]
+    public async Task StreamingChatCompletionsAsync_RetriesTransient502_ShouldSucceed()
+    {
+        // Arrange
+        var httpClient = TestModeHttpClientFactory.CreateAnthropicTestClient(
+            LoggerFactory,
+            statusSequence: [HttpStatusCode.BadGateway, HttpStatusCode.OK],
+            chunkDelayMs: 0
+        );
+        var client = new AnthropicClient(
+            httpClient,
+            performanceTracker: _performanceTracker,
+            logger: _anthropicClientLogger,
+            retryOptions: RetryOptions.FastForTests
+        );
+
+        var request = new AnthropicRequest
+        {
+            Model = "claude-3-sonnet-20240229",
+            MaxTokens = 1000,
+            Stream = true,
+            Messages =
+            [
+                new AnthropicMessage
+                {
+                    Role = "user",
+                    Content = [new AnthropicContent { Type = "text", Text = "Hello" }],
+                },
+            ],
+        };
+
+        // Act
+        var responseStream = await client.StreamingChatCompletionsAsync(request);
+        var events = new List<AnthropicStreamEvent>();
+        await foreach (var streamEvent in responseStream)
+        {
+            events.Add(streamEvent);
+        }
+
+        // Assert — the 502 was retried and the stream completed.
+        Assert.NotEmpty(events);
+
+        var metrics = _performanceTracker.GetProviderStatistics("Anthropic");
+        Assert.NotNull(metrics);
         Assert.Equal(1, metrics.SuccessfulRequests);
     }
 

--- a/tests/GithubCopilotProvider.Tests/Agents/CopilotResponsesSseRetryTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Agents/CopilotResponsesSseRetryTests.cs
@@ -15,9 +15,9 @@ namespace AchieveAi.LmDotnetTools.GithubCopilotProvider.Tests.Agents;
 ///     <see cref="CopilotResponsesAgentFactory"/>) must retry a transient pre-stream 502 and surface
 ///     the retry through the forwarded logger. Built the way <c>CreateSseClient</c> builds it — a
 ///     <see cref="CopilotHttpClientFactory"/> client (so the Copilot auth/header handler is in the
-///     chain) wrapping an SSE handler that fails once before streaming. The public factory has no
-///     transport seam, so the SSE construction path is exercised directly here; a smoke test confirms
-///     the public <see cref="CopilotResponsesAgentFactory.Create"/> accepts the retry seam.
+///     chain) wrapping an SSE handler that fails once before streaming. The real internal
+///     <c>CreateSseClient</c> construction path is exercised directly through an injected transport
+///     handler to prove it forwards both <c>retryOptions</c> and <c>logger</c> into the client.
 /// </summary>
 public sealed class CopilotResponsesSseRetryTests
 {
@@ -95,15 +95,71 @@ public sealed class CopilotResponsesSseRetryTests
     }
 
     [Fact]
-    public void Factory_create_accepts_retry_options_for_sse_transport()
+    public async Task CreateSseClient_forwards_retry_options_and_logger()
     {
-        using var agent = CopilotResponsesAgentFactory.Create(
-            "copilot-sse",
+        var sse = new OpenAiResponsesTestSseMessageHandler
+        {
+            ChunkDelayMs = 0,
+            FailFirstCount = 1,
+            FailStatusCode = HttpStatusCode.BadGateway,
+        };
+        var logger = new ListLogger();
+
+        // Drive the REAL CreateSseClient construction path (not a hand-rolled replica) through an injected
+        // transport handler, so a regression that stopped forwarding retryOptions/logger would fail here.
+        using var client = CopilotResponsesAgentFactory.CreateSseClient(
+            "https://copilot.test",
             new StubTokenProvider(),
-            CopilotResponsesTransport.Sse,
-            retryOptions: RetryOptions.FastForTests
+            new CopilotSessionContext("m", "s"),
+            new CopilotOptions(),
+            logger,
+            RetryOptions.FastForTests,
+            innerHandler: sse
         );
 
-        agent.Should().NotBeNull();
+        var events = new List<ResponseEvent>();
+        await foreach (var ev in client.StreamResponseAsync(Request()))
+        {
+            events.Add(ev);
+        }
+
+        events.Should().NotBeEmpty();
+        events[^1].Type.Should().Be(ResponseEventTypes.ResponseCompleted);
+        logger
+            .Entries.Should()
+            .Contain(e => e.Level == LogLevel.Warning, "the forwarded logger must observe the retry warning");
+    }
+
+    [Fact]
+    public async Task CreateSseClient_forwarded_retry_options_disable_retry_when_max_retries_zero()
+    {
+        var sse = new OpenAiResponsesTestSseMessageHandler
+        {
+            ChunkDelayMs = 0,
+            FailFirstCount = 1,
+            FailStatusCode = HttpStatusCode.BadGateway,
+        };
+
+        // MaxRetries=0: the single 502 must surface immediately. If CreateSseClient dropped the forwarded
+        // retryOptions and fell back to RetryOptions.Default, the 502 would be retried and SUCCEED — so this
+        // pins the retryOptions wiring (not just that *some* retry happens).
+        var noRetry = RetryOptions.FastForTests with { MaxRetries = 0 };
+        using var client = CopilotResponsesAgentFactory.CreateSseClient(
+            "https://copilot.test",
+            new StubTokenProvider(),
+            new CopilotSessionContext("m", "s"),
+            new CopilotOptions(),
+            logger: null,
+            retryOptions: noRetry,
+            innerHandler: sse
+        );
+
+        var act = async () =>
+        {
+            await foreach (var _ in client.StreamResponseAsync(Request())) { }
+        };
+
+        var ex = (await act.Should().ThrowAsync<HttpRequestException>()).Which;
+        ex.StatusCode.Should().Be(HttpStatusCode.BadGateway);
     }
 }

--- a/tests/GithubCopilotProvider.Tests/Agents/CopilotResponsesSseRetryTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Agents/CopilotResponsesSseRetryTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Agents;
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
 using AchieveAi.LmDotnetTools.LmCore.Http;
+using AchieveAi.LmDotnetTools.LmTestUtils.Logging;
 using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
@@ -24,24 +25,6 @@ public sealed class CopilotResponsesSseRetryTests
     private sealed class StubTokenProvider : ICopilotTokenProvider
     {
         public Task<string> GetTokenAsync(CancellationToken cancellationToken = default) => Task.FromResult("gho_test");
-    }
-
-    private sealed class ListLogger : ILogger
-    {
-        public List<(LogLevel Level, string Message)> Entries { get; } = [];
-
-        public IDisposable? BeginScope<TState>(TState state)
-            where TState : notnull => null;
-
-        public bool IsEnabled(LogLevel logLevel) => true;
-
-        public void Log<TState>(
-            LogLevel logLevel,
-            EventId eventId,
-            TState state,
-            Exception? exception,
-            Func<TState, Exception?, string> formatter
-        ) => Entries.Add((logLevel, formatter(state, exception)));
     }
 
     private static ResponseCreateRequest Request() =>

--- a/tests/GithubCopilotProvider.Tests/Agents/CopilotResponsesSseRetryTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Agents/CopilotResponsesSseRetryTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Agents;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
+using AchieveAi.LmDotnetTools.LmCore.Http;
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+
+namespace AchieveAi.LmDotnetTools.GithubCopilotProvider.Tests.Agents;
+
+/// <summary>
+///     The Copilot SSE transport (the construction path of
+///     <see cref="CopilotResponsesAgentFactory"/>) must retry a transient pre-stream 502 and surface
+///     the retry through the forwarded logger. Built the way <c>CreateSseClient</c> builds it — a
+///     <see cref="CopilotHttpClientFactory"/> client (so the Copilot auth/header handler is in the
+///     chain) wrapping an SSE handler that fails once before streaming. The public factory has no
+///     transport seam, so the SSE construction path is exercised directly here; a smoke test confirms
+///     the public <see cref="CopilotResponsesAgentFactory.Create"/> accepts the retry seam.
+/// </summary>
+public sealed class CopilotResponsesSseRetryTests
+{
+    private sealed class StubTokenProvider : ICopilotTokenProvider
+    {
+        public Task<string> GetTokenAsync(CancellationToken cancellationToken = default) => Task.FromResult("gho_test");
+    }
+
+    private sealed class ListLogger : ILogger
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter
+        ) => Entries.Add((logLevel, formatter(state, exception)));
+    }
+
+    private static ResponseCreateRequest Request() =>
+        new()
+        {
+            Model = "gpt-5.5",
+            Input = [new ResponseInputItem { Role = "user", Content = [new ResponseInputContent { Text = "hi" }] }],
+        };
+
+    [Fact]
+    public async Task Copilot_sse_path_retries_502_and_logs_through_forwarded_logger()
+    {
+        var sse = new OpenAiResponsesTestSseMessageHandler
+        {
+            ChunkDelayMs = 0,
+            FailFirstCount = 1,
+            FailStatusCode = HttpStatusCode.BadGateway,
+        };
+
+        // CopilotHttpClientFactory puts the auth + Copilot headers handler in front of the SSE handler,
+        // exactly as the SSE transport is wired by the factory.
+        var httpClient = CopilotHttpClientFactory.Create(
+            "https://copilot.test",
+            new StubTokenProvider(),
+            new CopilotSessionContext("m", "s"),
+            new CopilotOptions(),
+            innerHandler: sse
+        );
+
+        var logger = new ListLogger();
+        using var client = new OpenAiResponsesClient(
+            httpClient,
+            disposeClient: true,
+            logger: logger,
+            responsesPath: "/responses",
+            retryOptions: RetryOptions.FastForTests
+        );
+
+        var events = new List<ResponseEvent>();
+        await foreach (var ev in client.StreamResponseAsync(Request()))
+        {
+            events.Add(ev);
+        }
+
+        // The 502 was retried and the SSE stream was read end-to-end.
+        events.Should().NotBeEmpty();
+        events[^1].Type.Should().Be(ResponseEventTypes.ResponseCompleted);
+
+        // The forwarded logger captured the retry warning (it only fires on a retry).
+        logger.Entries.Should().Contain(e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public void Factory_create_accepts_retry_options_for_sse_transport()
+    {
+        using var agent = CopilotResponsesAgentFactory.Create(
+            "copilot-sse",
+            new StubTokenProvider(),
+            CopilotResponsesTransport.Sse,
+            retryOptions: RetryOptions.FastForTests
+        );
+
+        agent.Should().NotBeNull();
+    }
+}

--- a/tests/GithubCopilotProvider.Tests/Agents/CopilotResponsesWebSocketClientRetryTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Agents/CopilotResponsesWebSocketClientRetryTests.cs
@@ -223,6 +223,32 @@ public sealed class CopilotResponsesWebSocketClientRetryTests
     }
 
     [Fact]
+    public async Task Connect_dns_host_not_found_is_not_retried()
+    {
+        var created = new List<FakeSocket>();
+        // WSAHOST_NOT_FOUND — an authoritative DNS "no such host" name-resolution failure (permanent),
+        // distinct from the transient WSATRY_AGAIN. It must NOT consume the retry budget.
+        var dnsFailure = new WebSocketException(
+            WebSocketError.Faulted,
+            new SocketException((int)SocketError.HostNotFound)
+        );
+        await using var client = NewClient(() =>
+        {
+            var socket = new FakeSocket { ConnectError = dnsFailure };
+            created.Add(socket);
+            return socket;
+        });
+
+        var act = async () => await CollectAsync(client.StreamResponseAsync(Request()));
+
+        await act.Should().ThrowAsync<WebSocketException>();
+
+        created.Should().ContainSingle("a DNS name-resolution failure (HostNotFound) is permanent and not retried");
+        created[0].Disposed.Should().BeTrue();
+        created[0].Sent.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task Cancel_during_connect_throws_and_disposes_socket()
     {
         using var cts = new CancellationTokenSource();
@@ -329,6 +355,9 @@ public sealed class CopilotResponsesWebSocketClientRetryTests
         _ = await CollectAsync(client.StreamResponseAsync(Request()));
 
         created.Should().HaveCount(2);
+        created[0]
+            .Disposed.Should()
+            .BeTrue("the stale, disconnected socket from the truncated turn must be disposed on reconnect, not leaked");
         var secondFrame = JsonDocument.Parse(created[1].Sent.Single()).RootElement;
         secondFrame.TryGetProperty("previous_response_id", out _).Should().BeFalse();
     }

--- a/tests/GithubCopilotProvider.Tests/Agents/CopilotResponsesWebSocketClientRetryTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Agents/CopilotResponsesWebSocketClientRetryTests.cs
@@ -105,6 +105,10 @@ public sealed class CopilotResponsesWebSocketClientRetryTests
     private static WebSocketException RetryableConnect() =>
         new(WebSocketError.Faulted, new SocketException((int)SocketError.ConnectionRefused));
 
+    /// <summary>A 502 returned during the WebSocket upgrade — the core gateway case from #114.</summary>
+    private static WebSocketException BadGatewayUpgrade() =>
+        new("upgrade rejected", new HttpRequestException("Bad Gateway", null, HttpStatusCode.BadGateway));
+
     private static IEnumerable<string> ScriptedTurn(int turnIndex)
     {
         var id = "resp-" + turnIndex;
@@ -196,6 +200,58 @@ public sealed class CopilotResponsesWebSocketClientRetryTests
         created.Should().HaveCount(RetryOptions.FastForTests.MaxRetries + 1);
         created.Should().OnlyContain(s => s.Disposed);
         created.Should().OnlyContain(s => s.Sent.Count == 0);
+    }
+
+    [Fact]
+    public async Task Connect_retries_after_transient_bad_gateway_upgrade()
+    {
+        var created = new List<FakeSocket>();
+        var turn = 0;
+        await using var client = NewClient(() =>
+        {
+            var socket = new FakeSocket();
+            if (created.Count == 0)
+            {
+                socket.ConnectError = BadGatewayUpgrade(); // 502 during upgrade -> retryable
+            }
+            else
+            {
+                var index = turn++;
+                socket.Respond = _ => ScriptedTurn(index);
+            }
+
+            created.Add(socket);
+            return socket;
+        });
+
+        var events = await CollectAsync(client.StreamResponseAsync(Request()));
+
+        events.Select(e => e.Type).Should().Contain(ResponseEventTypes.ResponseCompleted);
+        created.Should().HaveCount(2);
+        created[0].Should().NotBeSameAs(created[1]);
+        created[0].Disposed.Should().BeTrue("the failed-upgrade socket must be disposed");
+        created[0].Sent.Should().BeEmpty("response.create must not be sent before a successful connect");
+        created[1].Sent.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Connect_persistent_bad_gateway_upgrade_throws_after_bounded_attempts()
+    {
+        var created = new List<FakeSocket>();
+        await using var client = NewClient(() =>
+        {
+            var socket = new FakeSocket { ConnectError = BadGatewayUpgrade() };
+            created.Add(socket);
+            return socket;
+        });
+
+        var act = async () => await CollectAsync(client.StreamResponseAsync(Request()));
+
+        await act.Should().ThrowAsync<WebSocketException>();
+
+        created.Should().HaveCount(RetryOptions.FastForTests.MaxRetries + 1);
+        created.Should().OnlyContain(s => s.Disposed);
+        created.Should().OnlyContain(s => s.Sent.Count == 0, "no response.create is sent before a successful connect");
     }
 
     [Fact]

--- a/tests/GithubCopilotProvider.Tests/Agents/CopilotResponsesWebSocketClientRetryTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Agents/CopilotResponsesWebSocketClientRetryTests.cs
@@ -142,8 +142,25 @@ public sealed class CopilotResponsesWebSocketClientRetryTests
             Input = [new ResponseInputItem { Role = "user", Content = [new ResponseInputContent { Text = "hi" }] }],
         };
 
-    [Fact]
-    public async Task Connect_retries_with_fresh_socket_after_transient_failure()
+    /// <summary>Transient connect/upgrade failures that must be retried (socket refused, 502 upgrade).</summary>
+    public enum TransientConnectError
+    {
+        SocketConnectionRefused,
+        BadGatewayUpgrade,
+    }
+
+    private static WebSocketException MakeConnectError(TransientConnectError kind) =>
+        kind switch
+        {
+            TransientConnectError.SocketConnectionRefused => RetryableConnect(),
+            TransientConnectError.BadGatewayUpgrade => BadGatewayUpgrade(),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+    [Theory]
+    [InlineData(TransientConnectError.SocketConnectionRefused)]
+    [InlineData(TransientConnectError.BadGatewayUpgrade)]
+    public async Task Connect_retries_transient_failure_with_fresh_socket(TransientConnectError kind)
     {
         var created = new List<FakeSocket>();
         var turn = 0;
@@ -152,7 +169,7 @@ public sealed class CopilotResponsesWebSocketClientRetryTests
             var socket = new FakeSocket();
             if (created.Count == 0)
             {
-                socket.ConnectError = RetryableConnect();
+                socket.ConnectError = MakeConnectError(kind);
             }
             else
             {
@@ -182,65 +199,15 @@ public sealed class CopilotResponsesWebSocketClientRetryTests
         created[1].Sent.Should().ContainSingle("response.create is sent once, on the connected socket");
     }
 
-    [Fact]
-    public async Task Connect_persistent_failure_throws_after_bounded_attempts_without_sending()
+    [Theory]
+    [InlineData(TransientConnectError.SocketConnectionRefused)]
+    [InlineData(TransientConnectError.BadGatewayUpgrade)]
+    public async Task Connect_persistent_failure_throws_after_bounded_attempts(TransientConnectError kind)
     {
         var created = new List<FakeSocket>();
         await using var client = NewClient(() =>
         {
-            var socket = new FakeSocket { ConnectError = RetryableConnect() };
-            created.Add(socket);
-            return socket;
-        });
-
-        var act = async () => await CollectAsync(client.StreamResponseAsync(Request()));
-
-        await act.Should().ThrowAsync<WebSocketException>();
-
-        created.Should().HaveCount(RetryOptions.FastForTests.MaxRetries + 1);
-        created.Should().OnlyContain(s => s.Disposed);
-        created.Should().OnlyContain(s => s.Sent.Count == 0);
-    }
-
-    [Fact]
-    public async Task Connect_retries_after_transient_bad_gateway_upgrade()
-    {
-        var created = new List<FakeSocket>();
-        var turn = 0;
-        await using var client = NewClient(() =>
-        {
-            var socket = new FakeSocket();
-            if (created.Count == 0)
-            {
-                socket.ConnectError = BadGatewayUpgrade(); // 502 during upgrade -> retryable
-            }
-            else
-            {
-                var index = turn++;
-                socket.Respond = _ => ScriptedTurn(index);
-            }
-
-            created.Add(socket);
-            return socket;
-        });
-
-        var events = await CollectAsync(client.StreamResponseAsync(Request()));
-
-        events.Select(e => e.Type).Should().Contain(ResponseEventTypes.ResponseCompleted);
-        created.Should().HaveCount(2);
-        created[0].Should().NotBeSameAs(created[1]);
-        created[0].Disposed.Should().BeTrue("the failed-upgrade socket must be disposed");
-        created[0].Sent.Should().BeEmpty("response.create must not be sent before a successful connect");
-        created[1].Sent.Should().ContainSingle();
-    }
-
-    [Fact]
-    public async Task Connect_persistent_bad_gateway_upgrade_throws_after_bounded_attempts()
-    {
-        var created = new List<FakeSocket>();
-        await using var client = NewClient(() =>
-        {
-            var socket = new FakeSocket { ConnectError = BadGatewayUpgrade() };
+            var socket = new FakeSocket { ConnectError = MakeConnectError(kind) };
             created.Add(socket);
             return socket;
         });

--- a/tests/GithubCopilotProvider.Tests/Agents/CopilotResponsesWebSocketClientRetryTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Agents/CopilotResponsesWebSocketClientRetryTests.cs
@@ -1,0 +1,346 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Agents;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
+using AchieveAi.LmDotnetTools.LmCore.Http;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.GithubCopilotProvider.Tests.Agents;
+
+/// <summary>
+///     Connect-retry + close/fault behaviour for <see cref="CopilotResponsesWebSocketClient"/>:
+///     transient connect failures are retried with a FRESH socket per attempt (bounded by
+///     <see cref="RetryOptions"/>); non-retryable failures and cancellation surface immediately; a
+///     mid-turn peer close before the terminal lifecycle event is reported as an error; and a
+///     truncated turn never advances the <c>previous_response_id</c> chain.
+/// </summary>
+public sealed class CopilotResponsesWebSocketClientRetryTests
+{
+    private sealed class StubTokenProvider : ICopilotTokenProvider
+    {
+        public Task<string> GetTokenAsync(CancellationToken cancellationToken = default) => Task.FromResult("gho_test");
+    }
+
+    /// <summary>Configurable in-memory socket: scriptable connect failure, frames, receive fault, disposal.</summary>
+    private sealed class FakeSocket : ICopilotResponsesSocket
+    {
+        private readonly Queue<string> _incoming = new();
+
+        /// <summary>Exception thrown from <see cref="ConnectAsync"/> (after <see cref="OnConnect"/>).</summary>
+        public Exception? ConnectError { get; set; }
+
+        /// <summary>Callback run inside <see cref="ConnectAsync"/> (e.g. to cancel a token).</summary>
+        public Action? OnConnect { get; set; }
+
+        /// <summary>Frames to enqueue in response to a sent <c>response.create</c>.</summary>
+        public Func<string, IEnumerable<string>>? Respond { get; set; }
+
+        /// <summary>Exception thrown by <see cref="ReceiveTextAsync"/> once the queue drains.</summary>
+        public Exception? ReceiveError { get; set; }
+
+        public List<string> Sent { get; } = [];
+        public List<IReadOnlyDictionary<string, string>> Connects { get; } = [];
+        public bool IsConnected { get; private set; }
+        public int DisposeCount { get; private set; }
+        public bool Disposed => DisposeCount > 0;
+
+        public Task ConnectAsync(Uri endpoint, IReadOnlyDictionary<string, string> headers, CancellationToken ct)
+        {
+            Connects.Add(headers);
+            OnConnect?.Invoke();
+
+            // ConnectError models an upgrade/transport failure; a cancelled token models a cancelled connect.
+            if (ConnectError is not null)
+            {
+                throw ConnectError;
+            }
+
+            ct.ThrowIfCancellationRequested();
+            IsConnected = true;
+            return Task.CompletedTask;
+        }
+
+        public Task SendTextAsync(string text, CancellationToken ct)
+        {
+            Sent.Add(text);
+            if (Respond is not null)
+            {
+                foreach (var frame in Respond(text))
+                {
+                    _incoming.Enqueue(frame);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> ReceiveTextAsync(CancellationToken ct)
+        {
+            if (_incoming.Count > 0)
+            {
+                return Task.FromResult<string?>(_incoming.Dequeue());
+            }
+
+            if (ReceiveError is not null)
+            {
+                throw ReceiveError;
+            }
+
+            // Drained with no terminal event => peer closed mid-turn.
+            IsConnected = false;
+            return Task.FromResult<string?>(null);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            IsConnected = false;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static WebSocketException RetryableConnect() =>
+        new(WebSocketError.Faulted, new SocketException((int)SocketError.ConnectionRefused));
+
+    private static IEnumerable<string> ScriptedTurn(int turnIndex)
+    {
+        var id = "resp-" + turnIndex;
+        yield return "{\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"" + id + "\"}}";
+        yield return "{\"type\":\"response.output_text.delta\",\"sequence_number\":1,\"item_id\":\"i\",\"output_index\":0,\"content_index\":0,\"delta\":\"hi\"}";
+        yield return "{\"type\":\"response.completed\",\"sequence_number\":2,\"response\":{\"id\":\"" + id + "\"}}";
+    }
+
+    private static IEnumerable<string> TruncatedTurn()
+    {
+        yield return "{\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp-trunc\"}}";
+        yield return "{\"type\":\"response.output_text.delta\",\"sequence_number\":1,\"item_id\":\"i\",\"output_index\":0,\"content_index\":0,\"delta\":\"hi\"}";
+        // No response.completed — the socket then returns null (peer close).
+    }
+
+    private static CopilotResponsesWebSocketClient NewClient(Func<ICopilotResponsesSocket> factory) =>
+        new(
+            new Uri("wss://host/responses"),
+            new StubTokenProvider(),
+            new CopilotSessionContext("m", "s"),
+            options: null,
+            logger: null,
+            socketFactory: factory,
+            retryOptions: RetryOptions.FastForTests
+        );
+
+    private static ResponseCreateRequest Request() =>
+        new()
+        {
+            Model = "gpt-5.5",
+            Input = [new ResponseInputItem { Role = "user", Content = [new ResponseInputContent { Text = "hi" }] }],
+        };
+
+    [Fact]
+    public async Task Connect_retries_with_fresh_socket_after_transient_failure()
+    {
+        var created = new List<FakeSocket>();
+        var turn = 0;
+        await using var client = NewClient(() =>
+        {
+            var socket = new FakeSocket();
+            if (created.Count == 0)
+            {
+                socket.ConnectError = RetryableConnect();
+            }
+            else
+            {
+                var index = turn++;
+                socket.Respond = _ => ScriptedTurn(index);
+            }
+
+            created.Add(socket);
+            return socket;
+        });
+
+        var events = await CollectAsync(client.StreamResponseAsync(Request()));
+
+        events
+            .Select(e => e.Type)
+            .Should()
+            .ContainInOrder(
+                ResponseEventTypes.ResponseCreated,
+                ResponseEventTypes.OutputTextDelta,
+                ResponseEventTypes.ResponseCompleted
+            );
+
+        created.Should().HaveCount(2);
+        created[0].Should().NotBeSameAs(created[1]); // a FRESH socket per attempt
+        created[0].Disposed.Should().BeTrue("the failed socket must be disposed");
+        created[0].Sent.Should().BeEmpty("response.create must not be sent on a socket that never connected");
+        created[1].Sent.Should().ContainSingle("response.create is sent once, on the connected socket");
+    }
+
+    [Fact]
+    public async Task Connect_persistent_failure_throws_after_bounded_attempts_without_sending()
+    {
+        var created = new List<FakeSocket>();
+        await using var client = NewClient(() =>
+        {
+            var socket = new FakeSocket { ConnectError = RetryableConnect() };
+            created.Add(socket);
+            return socket;
+        });
+
+        var act = async () => await CollectAsync(client.StreamResponseAsync(Request()));
+
+        await act.Should().ThrowAsync<WebSocketException>();
+
+        created.Should().HaveCount(RetryOptions.FastForTests.MaxRetries + 1);
+        created.Should().OnlyContain(s => s.Disposed);
+        created.Should().OnlyContain(s => s.Sent.Count == 0);
+    }
+
+    [Fact]
+    public async Task Connect_non_retryable_failure_throws_immediately()
+    {
+        var created = new List<FakeSocket>();
+        var nonRetryable = new WebSocketException(
+            "upgrade rejected",
+            new HttpRequestException("Unauthorized", null, HttpStatusCode.Unauthorized)
+        );
+        await using var client = NewClient(() =>
+        {
+            var socket = new FakeSocket { ConnectError = nonRetryable };
+            created.Add(socket);
+            return socket;
+        });
+
+        var act = async () => await CollectAsync(client.StreamResponseAsync(Request()));
+
+        await act.Should().ThrowAsync<WebSocketException>();
+
+        created.Should().ContainSingle("a non-retryable connect failure is not retried");
+        created[0].Disposed.Should().BeTrue();
+        created[0].Sent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Cancel_during_connect_throws_and_disposes_socket()
+    {
+        using var cts = new CancellationTokenSource();
+        var created = new List<FakeSocket>();
+        await using var client = NewClient(() =>
+        {
+            var socket = new FakeSocket { OnConnect = cts.Cancel };
+            created.Add(socket);
+            return socket;
+        });
+
+        var act = async () => await CollectAsync(client.StreamResponseAsync(Request(), cts.Token));
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        created.Should().ContainSingle();
+        created[0].Disposed.Should().BeTrue();
+        created[0].Sent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Cancel_during_backoff_throws_and_stops()
+    {
+        using var cts = new CancellationTokenSource();
+        var created = new List<FakeSocket>();
+        await using var client = NewClient(() =>
+        {
+            // First attempt fails retryably AND cancels the token, so the backoff delay is cancelled.
+            var socket = new FakeSocket { ConnectError = RetryableConnect() };
+            if (created.Count == 0)
+            {
+                socket.OnConnect = cts.Cancel;
+            }
+
+            created.Add(socket);
+            return socket;
+        });
+
+        var act = async () => await CollectAsync(client.StreamResponseAsync(Request(), cts.Token));
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        created.Should().ContainSingle("the retry never creates a second socket after cancellation");
+        created[0].Disposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Mid_turn_close_before_completion_throws()
+    {
+        var fake = new FakeSocket { Respond = _ => TruncatedTurn() };
+        await using var client = NewClient(() => fake);
+
+        var act = async () => await CollectAsync(client.StreamResponseAsync(Request()));
+
+        var ex = (await act.Should().ThrowAsync<IOException>()).Which;
+        ex.Message.Should().Contain("closed before", "the truncated turn must surface as a clear error");
+    }
+
+    [Fact]
+    public async Task Receive_websocket_exception_propagates_with_detail()
+    {
+        const string detail = "boom-1011";
+        var fake = new FakeSocket
+        {
+            Respond = _ => TruncatedTurn(),
+            ReceiveError = new WebSocketException(WebSocketError.ConnectionClosedPrematurely, detail),
+        };
+        await using var client = NewClient(() => fake);
+
+        var act = async () => await CollectAsync(client.StreamResponseAsync(Request()));
+
+        var ex = (await act.Should().ThrowAsync<WebSocketException>()).Which;
+        ex.Message.Should().Contain(detail);
+    }
+
+    [Fact]
+    public async Task Truncated_turn_does_not_advance_previous_response_id()
+    {
+        var created = new List<FakeSocket>();
+        var turn = 0;
+        await using var client = NewClient(() =>
+        {
+            FakeSocket socket;
+            if (created.Count == 0)
+            {
+                socket = new FakeSocket { Respond = _ => TruncatedTurn() };
+            }
+            else
+            {
+                var index = turn++;
+                socket = new FakeSocket { Respond = _ => ScriptedTurn(index) };
+            }
+
+            created.Add(socket);
+            return socket;
+        });
+
+        // First turn truncates -> throws and must NOT advance _previousResponseId.
+        var act = async () => await CollectAsync(client.StreamResponseAsync(Request()));
+        await act.Should().ThrowAsync<IOException>();
+
+        // Second turn reconnects (peer closed the first socket) and completes; its frame must carry
+        // no previous_response_id because the truncated turn never reached response.completed.
+        _ = await CollectAsync(client.StreamResponseAsync(Request()));
+
+        created.Should().HaveCount(2);
+        var secondFrame = JsonDocument.Parse(created[1].Sent.Single()).RootElement;
+        secondFrame.TryGetProperty("previous_response_id", out _).Should().BeFalse();
+    }
+
+    private static async Task<List<ResponseEvent>> CollectAsync(IAsyncEnumerable<ResponseEvent> stream)
+    {
+        var list = new List<ResponseEvent>();
+        await foreach (var ev in stream)
+        {
+            list.Add(ev);
+        }
+
+        return list;
+    }
+}

--- a/tests/LmCore.Tests/Http/HttpRetryHelperDisposalTests.cs
+++ b/tests/LmCore.Tests/Http/HttpRetryHelperDisposalTests.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using AchieveAi.LmDotnetTools.LmCore.Http;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.Http;
+
+/// <summary>
+///     Pins the lifetime contract of <see cref="HttpRetryHelper"/>'s HTTP retry overload: the
+///     FINAL failed response (non-retryable status, or after retries are exhausted) must be disposed
+///     before the helper throws, so the connection is not leaked. The success path is unaffected
+///     (the caller owns and disposes the returned response).
+/// </summary>
+public sealed class HttpRetryHelperDisposalTests
+{
+    [Fact]
+    public async Task ExecuteHttpWithRetryAsync_non_retryable_disposes_final_failed_response()
+    {
+        var responses = new List<TrackingHttpResponseMessage>();
+
+        var act = async () =>
+            await HttpRetryHelper.ExecuteHttpWithRetryAsync(
+                () => NewResponse(responses, HttpStatusCode.BadRequest),
+                resp => Task.FromResult(resp),
+                NullLogger.Instance,
+                RetryOptions.FastForTests
+            );
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+
+        // 400 is non-retryable: exactly one response, and it must be disposed before the throw.
+        responses.Should().ContainSingle();
+        responses[0].Disposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteHttpWithRetryAsync_exhausted_retries_disposes_every_failed_response()
+    {
+        var responses = new List<TrackingHttpResponseMessage>();
+
+        var act = async () =>
+            await HttpRetryHelper.ExecuteHttpWithRetryAsync(
+                () => NewResponse(responses, HttpStatusCode.InternalServerError),
+                resp => Task.FromResult(resp),
+                NullLogger.Instance,
+                RetryOptions.FastForTests
+            );
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+
+        // Initial attempt + MaxRetries; the intermediate retryable responses AND the final one disposed.
+        responses.Should().HaveCount(RetryOptions.FastForTests.MaxRetries + 1);
+        responses.Should().OnlyContain(r => r.Disposed);
+    }
+
+    private static Task<HttpResponseMessage> NewResponse(
+        List<TrackingHttpResponseMessage> sink,
+        HttpStatusCode status
+    )
+    {
+        var response = new TrackingHttpResponseMessage(status) { Content = new StringContent($"error {(int)status}") };
+        sink.Add(response);
+        return Task.FromResult<HttpResponseMessage>(response);
+    }
+}
+
+/// <summary>An <see cref="HttpResponseMessage"/> that records whether it has been disposed.</summary>
+internal sealed class TrackingHttpResponseMessage : HttpResponseMessage
+{
+    public TrackingHttpResponseMessage(HttpStatusCode statusCode)
+        : base(statusCode) { }
+
+    private int _disposeCount;
+
+    public bool Disposed => Volatile.Read(ref _disposeCount) > 0;
+
+    protected override void Dispose(bool disposing)
+    {
+        _ = Interlocked.Increment(ref _disposeCount);
+        base.Dispose(disposing);
+    }
+}

--- a/tests/LmCore.Tests/Http/HttpRetryHelperDisposalTests.cs
+++ b/tests/LmCore.Tests/Http/HttpRetryHelperDisposalTests.cs
@@ -82,6 +82,39 @@ public sealed class HttpRetryHelperDisposalTests
         responses[0].Disposed.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task ExecuteHttpWithRetryAsync_body_read_failure_keeps_status_and_does_not_retry()
+    {
+        var responses = new List<TrackingHttpResponseMessage>();
+        var attempts = 0;
+
+        var act = async () =>
+            await HttpRetryHelper.ExecuteHttpWithRetryAsync(
+                () =>
+                {
+                    attempts++;
+                    var resp = new TrackingHttpResponseMessage(HttpStatusCode.BadRequest)
+                    {
+                        // The body read fails with an exception whose message LOOKS retryable.
+                        Content = new ThrowOnReadContent(new HttpRequestException("502 Bad Gateway")),
+                    };
+                    responses.Add(resp);
+                    return Task.FromResult<HttpResponseMessage>(resp);
+                },
+                resp => Task.FromResult(resp),
+                NullLogger.Instance,
+                RetryOptions.FastForTests
+            );
+
+        var ex = (await act.Should().ThrowAsync<HttpRequestException>()).Which;
+
+        // The ORIGINAL 400 status is preserved, and a non-retryable status is NOT retried just because the
+        // body read threw a retryable-looking exception (it must not escape to the outer retry catch).
+        ex.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        attempts.Should().Be(1);
+        responses.Should().ContainSingle().Which.Disposed.Should().BeTrue();
+    }
+
     private static Task<HttpResponseMessage> NewResponse(
         List<TrackingHttpResponseMessage> sink,
         HttpStatusCode status
@@ -97,6 +130,22 @@ public sealed class HttpRetryHelperDisposalTests
     {
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
             throw new OperationCanceledException();
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+    }
+
+    /// <summary>Content that throws a supplied exception when its body is read.</summary>
+    private sealed class ThrowOnReadContent : HttpContent
+    {
+        private readonly Exception _exception;
+
+        public ThrowOnReadContent(Exception exception) => _exception = exception;
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) => throw _exception;
 
         protected override bool TryComputeLength(out long length)
         {

--- a/tests/LmCore.Tests/Http/HttpRetryHelperDisposalTests.cs
+++ b/tests/LmCore.Tests/Http/HttpRetryHelperDisposalTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using AchieveAi.LmDotnetTools.LmCore.Http;
+using AchieveAi.LmDotnetTools.LmTestUtils.Http;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -53,6 +54,34 @@ public sealed class HttpRetryHelperDisposalTests
         responses.Should().OnlyContain(r => r.Disposed);
     }
 
+    [Fact]
+    public async Task ExecuteHttpWithRetryAsync_cancellation_reading_error_body_surfaces_as_cancellation()
+    {
+        var responses = new List<TrackingHttpResponseMessage>();
+
+        var act = async () =>
+            await HttpRetryHelper.ExecuteHttpWithRetryAsync(
+                () =>
+                {
+                    var resp = new TrackingHttpResponseMessage(HttpStatusCode.BadRequest)
+                    {
+                        Content = new CancelOnReadContent(),
+                    };
+                    responses.Add(resp);
+                    return Task.FromResult<HttpResponseMessage>(resp);
+                },
+                resp => Task.FromResult(resp),
+                NullLogger.Instance,
+                RetryOptions.FastForTests
+            );
+
+        // A cancellation raised while reading the final error body must surface AS cancellation, not be
+        // repackaged into an HttpRequestException — and the response is still disposed.
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        responses.Should().ContainSingle();
+        responses[0].Disposed.Should().BeTrue();
+    }
+
     private static Task<HttpResponseMessage> NewResponse(
         List<TrackingHttpResponseMessage> sink,
         HttpStatusCode status
@@ -62,21 +91,17 @@ public sealed class HttpRetryHelperDisposalTests
         sink.Add(response);
         return Task.FromResult<HttpResponseMessage>(response);
     }
-}
 
-/// <summary>An <see cref="HttpResponseMessage"/> that records whether it has been disposed.</summary>
-internal sealed class TrackingHttpResponseMessage : HttpResponseMessage
-{
-    public TrackingHttpResponseMessage(HttpStatusCode statusCode)
-        : base(statusCode) { }
-
-    private int _disposeCount;
-
-    public bool Disposed => Volatile.Read(ref _disposeCount) > 0;
-
-    protected override void Dispose(bool disposing)
+    /// <summary>Content that throws <see cref="OperationCanceledException"/> when its body is read.</summary>
+    private sealed class CancelOnReadContent : HttpContent
     {
-        _ = Interlocked.Increment(ref _disposeCount);
-        base.Dispose(disposing);
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            throw new OperationCanceledException();
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
     }
 }

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesClientRetryTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesClientRetryTests.cs
@@ -63,6 +63,9 @@ public sealed class OpenAiResponsesClientRetryTests
 
         // Initial attempt + MaxRetries retries.
         handler.SendCount.Should().Be(RetryOptions.FastForTests.MaxRetries + 1);
+
+        // Every failed response — including the final one — is disposed (no leaked connection).
+        handler.Responses.Should().OnlyContain(r => r.Disposed);
     }
 
     [Fact]
@@ -79,6 +82,9 @@ public sealed class OpenAiResponsesClientRetryTests
 
         // No retry on a non-retryable status: exactly one POST.
         handler.SendCount.Should().Be(1);
+
+        // The final failed response is disposed (no leaked connection).
+        handler.Responses.Should().ContainSingle().Which.Disposed.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesClientRetryTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesClientRetryTests.cs
@@ -154,6 +154,24 @@ public sealed class OpenAiResponsesClientRetryTests
     }
 
     [Fact]
+    public async Task ReadSseAsync_cancels_promptly_on_idle_open_stream()
+    {
+        using var stream = new NeverEndingStream();
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+
+        var act = async () =>
+        {
+            await foreach (var _ in OpenAiResponsesClient.ReadSseAsync(stream, cts.Token)) { }
+        };
+
+        // The async/cancellation-driven loop surfaces cancellation promptly on an idle-but-open stream.
+        // The old `while (!reader.EndOfStream)` would instead perform a SYNCHRONOUS read to probe EOF —
+        // which this stream forbids (throws) and would block — so this fails under the old implementation.
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
     public async Task StreamResponseAsync_emits_retry_warning_through_supplied_logger()
     {
         var logger = new ListLogger();
@@ -225,5 +243,40 @@ public sealed class OpenAiResponsesClientRetryTests
             length = 0;
             return false;
         }
+    }
+
+    /// <summary>
+    ///     An open stream that never yields data or EOF until cancelled (an idle-but-open SSE stream).
+    ///     The synchronous <see cref="Read(byte[], int, int)"/> throws so a synchronous EOF probe (the
+    ///     old <c>StreamReader.EndOfStream</c> code path) is caught immediately rather than blocking.
+    /// </summary>
+    private sealed class NeverEndingStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+            return 0; // unreachable — the await above only completes by throwing on cancellation
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException("synchronous Read must not be used on a live SSE stream");
+
+        public override void Flush() { }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 }

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesClientRetryTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesClientRetryTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using AchieveAi.LmDotnetTools.LmCore.Http;
 using AchieveAi.LmDotnetTools.LmTestUtils.Http;
+using AchieveAi.LmDotnetTools.LmTestUtils.Logging;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
 using FluentAssertions;

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesClientRetryTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesClientRetryTests.cs
@@ -1,0 +1,173 @@
+using System.Net;
+using AchieveAi.LmDotnetTools.LmCore.Http;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+
+namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Tests;
+
+/// <summary>
+///     Pre-stream retry coverage for <see cref="OpenAiResponsesClient.StreamResponseAsync"/>. A
+///     transient 502 (and other 5xx/429) must be retried by reusing <see cref="HttpRetryHelper"/>,
+///     building a FRESH <see cref="HttpRequestMessage"/> per attempt, and the SSE stream must still be
+///     enumerated end-to-end. Persistent / non-retryable failures surface unchanged, cancellation is
+///     honoured, and the response + stream are always disposed.
+/// </summary>
+public sealed class OpenAiResponsesClientRetryTests
+{
+    private const string ResponsesPath = "/v1/responses";
+
+    [Fact]
+    public async Task StreamResponseAsync_retries_once_after_502_then_yields_full_sequence()
+    {
+        var handler = new RecordingResponsesSseHandler(Sse(), failFirst: 1, failStatus: HttpStatusCode.BadGateway);
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("http://mock.local/") };
+        using var client = new OpenAiResponsesClient(http, retryOptions: RetryOptions.FastForTests);
+
+        var events = await CollectAsync(client.StreamResponseAsync(Request()));
+
+        events
+            .Select(e => e.Type)
+            .Should()
+            .ContainInOrder(
+                ResponseEventTypes.ResponseCreated,
+                ResponseEventTypes.OutputTextDelta,
+                ResponseEventTypes.ResponseCompleted
+            );
+
+        // Exactly one retry: the 502 attempt + the successful SSE attempt.
+        handler.SendCount.Should().Be(2);
+        handler.Requests.Should().HaveCount(2);
+
+        // Each attempt is a DISTINCT, freshly-built request (a single HttpRequestMessage cannot be re-sent).
+        ReferenceEquals(handler.Requests[0], handler.Requests[1]).Should().BeFalse();
+
+        // Both attempts carried a readable JSON body and the SSE Accept header.
+        handler.Bodies.Should().HaveCount(2);
+        handler.Bodies.Should().OnlyContain(b => b.Contains("\"model\"", StringComparison.Ordinal));
+        handler.AcceptHeaders.Should().OnlyContain(a => a.Contains("text/event-stream", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task StreamResponseAsync_persistent_502_throws_BadGateway_after_max_retries()
+    {
+        var handler = new RecordingResponsesSseHandler(Sse(), failFirst: 99, failStatus: HttpStatusCode.BadGateway);
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("http://mock.local/") };
+        using var client = new OpenAiResponsesClient(http, retryOptions: RetryOptions.FastForTests);
+
+        var act = async () => await CollectAsync(client.StreamResponseAsync(Request()));
+
+        var ex = (await act.Should().ThrowAsync<HttpRequestException>()).Which;
+        ex.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+
+        // Initial attempt + MaxRetries retries.
+        handler.SendCount.Should().Be(RetryOptions.FastForTests.MaxRetries + 1);
+    }
+
+    [Fact]
+    public async Task StreamResponseAsync_non_retryable_400_throws_immediately()
+    {
+        var handler = new RecordingResponsesSseHandler(Sse(), failFirst: 1, failStatus: HttpStatusCode.BadRequest);
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("http://mock.local/") };
+        using var client = new OpenAiResponsesClient(http, retryOptions: RetryOptions.FastForTests);
+
+        var act = async () => await CollectAsync(client.StreamResponseAsync(Request()));
+
+        var ex = (await act.Should().ThrowAsync<HttpRequestException>()).Which;
+        ex.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        // No retry on a non-retryable status: exactly one POST.
+        handler.SendCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task StreamResponseAsync_consumer_break_disposes_response_and_stream()
+    {
+        var handler = new RecordingResponsesSseHandler(Sse(), failFirst: 0);
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("http://mock.local/") };
+        using var client = new OpenAiResponsesClient(http, retryOptions: RetryOptions.FastForTests);
+
+        // Break after the first event so the iterator's finally must dispose the in-flight stream + response.
+        await foreach (var _ in client.StreamResponseAsync(Request()))
+        {
+            break;
+        }
+
+        handler.SendCount.Should().Be(1);
+        var response = handler.Responses.Should().ContainSingle().Subject;
+        response.Disposed.Should().BeTrue("the iterator must dispose the HttpResponseMessage when the consumer stops early");
+        response.BodyStream.Should().NotBeNull();
+        response.BodyStream!.Disposed.Should().BeTrue("the iterator must dispose the SSE stream when the consumer stops early");
+    }
+
+    [Fact]
+    public async Task StreamResponseAsync_cancel_during_backoff_throws_and_stops()
+    {
+        using var cts = new CancellationTokenSource();
+        var handler = new RecordingResponsesSseHandler(Sse(), failFirst: 99, failStatus: HttpStatusCode.BadGateway)
+        {
+            // Cancel as soon as the first (failing) attempt is observed, so the backoff delay is cancelled.
+            OnSend = n =>
+            {
+                if (n == 1)
+                {
+                    cts.Cancel();
+                }
+            },
+        };
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("http://mock.local/") };
+        using var client = new OpenAiResponsesClient(http, retryOptions: RetryOptions.FastForTests);
+
+        var act = async () => await CollectAsync(client.StreamResponseAsync(Request(), cts.Token));
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        // The retry never fires a second POST after cancellation.
+        handler.SendCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task StreamResponseAsync_emits_retry_warning_through_supplied_logger()
+    {
+        var logger = new ListLogger();
+        var handler = new RecordingResponsesSseHandler(Sse(), failFirst: 1, failStatus: HttpStatusCode.BadGateway);
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("http://mock.local/") };
+
+        // Built the way the Copilot SSE factory builds it: a non-null logger + a custom responses path.
+        using var client = new OpenAiResponsesClient(
+            http,
+            disposeClient: false,
+            logger: logger,
+            responsesPath: ResponsesPath,
+            retryOptions: RetryOptions.FastForTests
+        );
+
+        _ = await CollectAsync(client.StreamResponseAsync(Request()));
+
+        logger.Entries.Should().Contain(e => e.Level == LogLevel.Warning);
+    }
+
+    private static ResponseCreateRequest Request() =>
+        new()
+        {
+            Model = "gpt-5.5",
+            Input = [new ResponseInputItem { Role = "user", Content = [new ResponseInputContent { Text = "hi" }] }],
+        };
+
+    private static string Sse() =>
+        "data: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_1\"}}\n\n"
+        + "data: {\"type\":\"response.output_text.delta\",\"sequence_number\":1,\"item_id\":\"i\",\"output_index\":0,\"content_index\":0,\"delta\":\"hello\"}\n\n"
+        + "data: {\"type\":\"response.completed\",\"sequence_number\":2,\"response\":{\"id\":\"resp_1\"}}\n\n";
+
+    private static async Task<List<ResponseEvent>> CollectAsync(IAsyncEnumerable<ResponseEvent> stream)
+    {
+        var list = new List<ResponseEvent>();
+        await foreach (var ev in stream)
+        {
+            list.Add(ev);
+        }
+
+        return list;
+    }
+}

--- a/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesClientRetryTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/OpenAiResponsesClientRetryTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using AchieveAi.LmDotnetTools.LmCore.Http;
+using AchieveAi.LmDotnetTools.LmTestUtils.Http;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
 using FluentAssertions;
@@ -108,6 +109,24 @@ public sealed class OpenAiResponsesClientRetryTests
     }
 
     [Fact]
+    public async Task StreamResponseAsync_disposes_response_when_stream_acquisition_fails()
+    {
+        var handler = new StreamAcquisitionFailureHandler();
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("http://mock.local/") };
+        using var client = new OpenAiResponsesClient(http, retryOptions: RetryOptions.FastForTests);
+
+        // A 200 whose body stream cannot be opened: the (Response, Stream) tuple is never produced, so the
+        // iterator's finally never runs — responseProcessor must dispose the response before rethrowing.
+        var act = async () => await CollectAsync(client.StreamResponseAsync(Request()));
+
+        await act.Should().ThrowAsync<IOException>();
+        handler.Response.Should().NotBeNull();
+        handler
+            .Response!.Disposed.Should()
+            .BeTrue("the successful response must be disposed when its stream cannot be acquired");
+    }
+
+    [Fact]
     public async Task StreamResponseAsync_cancel_during_backoff_throws_and_stops()
     {
         using var cts = new CancellationTokenSource();
@@ -175,5 +194,35 @@ public sealed class OpenAiResponsesClientRetryTests
         }
 
         return list;
+    }
+
+    /// <summary>Returns a single 200 whose body stream cannot be opened (models a post-headers fault).</summary>
+    private sealed class StreamAcquisitionFailureHandler : HttpMessageHandler
+    {
+        public TrackingHttpResponseMessage? Response { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            Response = new TrackingHttpResponseMessage(HttpStatusCode.OK) { Content = new ThrowOnReadStreamContent() };
+            return Task.FromResult<HttpResponseMessage>(Response);
+        }
+    }
+
+    /// <summary>Content whose read stream cannot be acquired — <see cref="HttpContent.ReadAsStreamAsync()"/> throws.</summary>
+    private sealed class ThrowOnReadStreamContent : HttpContent
+    {
+        protected override Task<Stream> CreateContentReadStreamAsync() => throw new IOException("stream boom");
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            throw new IOException("stream boom");
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
     }
 }

--- a/tests/OpenAiResponsesProvider.Tests/RetryTestInfra.cs
+++ b/tests/OpenAiResponsesProvider.Tests/RetryTestInfra.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using AchieveAi.LmDotnetTools.LmTestUtils.Http;
 using Microsoft.Extensions.Logging;
 
 namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Tests;
@@ -84,43 +85,6 @@ internal sealed class RecordingResponsesSseHandler : HttpMessageHandler
 
         Responses.Add(response);
         return response;
-    }
-}
-
-/// <summary>An <see cref="HttpResponseMessage"/> that records whether it has been disposed.</summary>
-internal sealed class TrackingHttpResponseMessage : HttpResponseMessage
-{
-    public TrackingHttpResponseMessage(HttpStatusCode statusCode)
-        : base(statusCode) { }
-
-    private int _disposeCount;
-
-    public bool Disposed => Volatile.Read(ref _disposeCount) > 0;
-
-    /// <summary>The tracked SSE body stream (success responses only).</summary>
-    public TrackingStream? BodyStream { get; init; }
-
-    protected override void Dispose(bool disposing)
-    {
-        _ = Interlocked.Increment(ref _disposeCount);
-        base.Dispose(disposing);
-    }
-}
-
-/// <summary>A <see cref="MemoryStream"/> that records whether it has been disposed.</summary>
-internal sealed class TrackingStream : MemoryStream
-{
-    public TrackingStream(byte[] buffer)
-        : base(buffer) { }
-
-    private int _disposeCount;
-
-    public bool Disposed => Volatile.Read(ref _disposeCount) > 0;
-
-    protected override void Dispose(bool disposing)
-    {
-        _ = Interlocked.Increment(ref _disposeCount);
-        base.Dispose(disposing);
     }
 }
 

--- a/tests/OpenAiResponsesProvider.Tests/RetryTestInfra.cs
+++ b/tests/OpenAiResponsesProvider.Tests/RetryTestInfra.cs
@@ -1,0 +1,147 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Tests;
+
+/// <summary>
+///     Test-local transport that records every <see cref="HttpRequestMessage"/> the client sends
+///     (count, request instance, cloned body string, Accept header), optionally fails the first
+///     <see cref="FailFirst"/> attempts with <see cref="FailStatus"/>, then serves a fixed Responses
+///     SSE stream. Responses and their body streams are tracked so disposal can be asserted.
+/// </summary>
+internal sealed class RecordingResponsesSseHandler : HttpMessageHandler
+{
+    private readonly string _sse;
+    private int _count;
+
+    public RecordingResponsesSseHandler(
+        string sse,
+        int failFirst = 0,
+        HttpStatusCode failStatus = HttpStatusCode.BadGateway
+    )
+    {
+        _sse = sse ?? throw new ArgumentNullException(nameof(sse));
+        FailFirst = failFirst;
+        FailStatus = failStatus;
+    }
+
+    /// <summary>Number of leading attempts to fail before serving the SSE stream.</summary>
+    public int FailFirst { get; }
+
+    /// <summary>Status returned for the failing attempts.</summary>
+    public HttpStatusCode FailStatus { get; }
+
+    /// <summary>Total number of <see cref="SendAsync"/> invocations observed.</summary>
+    public int SendCount => Volatile.Read(ref _count);
+
+    /// <summary>The request instance captured for each attempt (used to assert per-attempt freshness).</summary>
+    public List<HttpRequestMessage> Requests { get; } = [];
+
+    /// <summary>The cloned request body string captured for each attempt.</summary>
+    public List<string> Bodies { get; } = [];
+
+    /// <summary>The Accept header captured for each attempt.</summary>
+    public List<string> AcceptHeaders { get; } = [];
+
+    /// <summary>The (tracking) responses returned for each attempt.</summary>
+    public List<TrackingHttpResponseMessage> Responses { get; } = [];
+
+    /// <summary>Optional callback invoked with the 1-based attempt number before the response is built.</summary>
+    public Action<int>? OnSend { get; set; }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken
+    )
+    {
+        var n = Interlocked.Increment(ref _count);
+
+        Requests.Add(request);
+        var body = request.Content is null ? string.Empty : await request.Content.ReadAsStringAsync(CancellationToken.None);
+        Bodies.Add(body);
+        AcceptHeaders.Add(request.Headers.Accept.ToString());
+
+        OnSend?.Invoke(n);
+
+        TrackingHttpResponseMessage response;
+        if (n <= FailFirst)
+        {
+            response = new TrackingHttpResponseMessage(FailStatus)
+            {
+                Content = new StringContent($"error {(int)FailStatus}"),
+            };
+        }
+        else
+        {
+            var stream = new TrackingStream(Encoding.UTF8.GetBytes(_sse));
+            response = new TrackingHttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(stream),
+                BodyStream = stream,
+            };
+        }
+
+        Responses.Add(response);
+        return response;
+    }
+}
+
+/// <summary>An <see cref="HttpResponseMessage"/> that records whether it has been disposed.</summary>
+internal sealed class TrackingHttpResponseMessage : HttpResponseMessage
+{
+    public TrackingHttpResponseMessage(HttpStatusCode statusCode)
+        : base(statusCode) { }
+
+    private int _disposeCount;
+
+    public bool Disposed => Volatile.Read(ref _disposeCount) > 0;
+
+    /// <summary>The tracked SSE body stream (success responses only).</summary>
+    public TrackingStream? BodyStream { get; init; }
+
+    protected override void Dispose(bool disposing)
+    {
+        _ = Interlocked.Increment(ref _disposeCount);
+        base.Dispose(disposing);
+    }
+}
+
+/// <summary>A <see cref="MemoryStream"/> that records whether it has been disposed.</summary>
+internal sealed class TrackingStream : MemoryStream
+{
+    public TrackingStream(byte[] buffer)
+        : base(buffer) { }
+
+    private int _disposeCount;
+
+    public bool Disposed => Volatile.Read(ref _disposeCount) > 0;
+
+    protected override void Dispose(bool disposing)
+    {
+        _ = Interlocked.Increment(ref _disposeCount);
+        base.Dispose(disposing);
+    }
+}
+
+/// <summary>Minimal in-memory <see cref="ILogger"/> that captures emitted entries for assertions.</summary>
+internal sealed class ListLogger : ILogger
+{
+    public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter
+    )
+    {
+        Entries.Add((logLevel, formatter(state, exception)));
+    }
+}

--- a/tests/OpenAiResponsesProvider.Tests/RetryTestInfra.cs
+++ b/tests/OpenAiResponsesProvider.Tests/RetryTestInfra.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Text;
 using AchieveAi.LmDotnetTools.LmTestUtils.Http;
-using Microsoft.Extensions.Logging;
 
 namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Tests;
 
@@ -85,27 +84,5 @@ internal sealed class RecordingResponsesSseHandler : HttpMessageHandler
 
         Responses.Add(response);
         return response;
-    }
-}
-
-/// <summary>Minimal in-memory <see cref="ILogger"/> that captures emitted entries for assertions.</summary>
-internal sealed class ListLogger : ILogger
-{
-    public List<(LogLevel Level, string Message)> Entries { get; } = [];
-
-    public IDisposable? BeginScope<TState>(TState state)
-        where TState : notnull => null;
-
-    public bool IsEnabled(LogLevel logLevel) => true;
-
-    public void Log<TState>(
-        LogLevel logLevel,
-        EventId eventId,
-        TState state,
-        Exception? exception,
-        Func<TState, Exception?, string> formatter
-    )
-    {
-        Entries.Add((logLevel, formatter(state, exception)));
     }
 }


### PR DESCRIPTION
## Summary

Transient **502 Bad Gateway** responses from the GitHub Copilot proxy were killing an agent turn instead of being retried, and the Copilot **WebSocket** transport silently truncated a mid-turn drop as if the turn had completed. This adds **pre-stream retry** to the streaming Responses client (covering both the Copilot SSE path and the direct OpenAI Responses provider, reusing the existing retry framework), gives the WebSocket transport its own **connect-retry**, and surfaces a mid-turn drop as a real error. Also fixes a latent response-disposal leak in `HttpRetryHelper`.

Fixes #114

## Changes

- **`OpenAiResponsesClient.StreamResponseAsync`** — wraps the **initial POST + status check only** in `HttpRetryHelper.ExecuteHttpWithRetryAsync` (reusing `RetryOptions`, which already classifies 502/5xx/429 as retryable). The request is rebuilt **fresh inside the retry lambda** (a sent `HttpRequestMessage` can't be re-sent — and this refreshes the bearer token + `x-interaction-id` per attempt); the `(Response, Stream)` tuple is enumerated **outside** the retry scope in a `try/finally` that disposes both, so early cancel / consumer break / parser failure never pins the connection. Single public ctor: logger → non-generic `ILogger?`, appended `RetryOptions?`.
- **`CopilotResponsesAgentFactory`** — `Create` accepts an optional `RetryOptions`, forwarded to **both** transports; the SSE path now forwards a real logger (was `logger: null`, so retries were invisible).
- **`CopilotResponsesWebSocketClient`** — a bounded **connect-retry** loop (fresh socket + token + headers per attempt; failed sockets disposed; `_socket` assigned only on success; retry **only before** `response.create`). A mid-turn peer close before a terminal event now **throws** ("closed before turn completion") instead of `yield break`; `ReceiveTextAsync` lets a `WebSocketException` propagate (with detail) and reserves `null` for a genuine peer close; `_previousResponseId` advances only on `response.completed`.
- **`HttpRetryHelper`** — the final non-retryable / max-retries branch now **disposes the failed `HttpResponseMessage`** (capture status/body → dispose in `finally` → throw), fixing a leak that affected every caller.

## Key Decisions

1. **In-client retry, not handler-level.** Retrying inside `OpenAiResponsesClient` fixes the Copilot SSE path *and* the direct OpenAI Responses provider in one place; a handler-level retry would have missed both the direct path and the (non-`HttpClient`) WebSocket transport.
2. **Pre-stream only.** Only faults before the first SSE byte / before `response.create` are retried; a mid-stream drop surfaces as an error. True mid-stream resume (buffering + `previous_response_id` replay) is intentionally **out of scope** (follow-up).
3. **Reuse the existing retry framework** with its default `RetryOptions` (3 attempts, exponential backoff), consistent with `AnthropicClient`/`OpenClient`. The Copilot-Anthropic path already retried — covered here only by a verify-only regression test.
4. **Source-compatible API change (not binary).** A single public constructor (no overload ambiguity); the logger parameter type change + appended `RetryOptions` recompile cleanly for in-tree callers — flagged explicitly rather than claimed as binary-compatible.
5. **DNS `HostNotFound` is not retried** — an authoritative name-resolution failure is permanent; the transient DNS case stays covered by `TryAgain`.

## Testing

- `dotnet build LmDotnetTools.sln` — **0 errors, 6 warnings** (all pre-existing `NU1902`; zero new).
- `dotnet test` (touched projects, all green): `OpenAiResponsesProvider.Tests` **76**, `GithubCopilotProvider.Tests` **30**, `LmCore.Tests` **765**, `AnthropicProvider.Tests` **175**.
- New coverage: 502-once-then-SSE retry (distinct fresh request per attempt, `Accept: text/event-stream`), persistent-502 → `BadGateway` after `MaxRetries+1` with the final response disposed, non-retryable 400 → immediate single POST, early-cancel/consumer-break disposes response + stream, cancel-during-backoff, SSE logger propagation; WS connect-retry (fresh socket per attempt), persistent/non-retryable connect, `HostNotFound` not retried, cancel during connect & backoff, mid-turn close → error, `WebSocketException` propagation, stale-socket disposal on reconnect, `previous_response_id` not advanced after a truncated turn; `HttpRetryHelper` final-failed-response disposal; Copilot-Anthropic pre-stream 502 (verify-only).

## Out of scope (follow-ups)

Mid-stream SSE resume; `Idempotency-Key` for `/responses`; backoff jitter / `Retry-After`; a UI "retrying…" indicator.
