### PR TITLE
fix: load workspace CLAUDE.md/AGENTS.md in Workspace Agent mode

### DIFF
--- a/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
@@ -97,6 +97,15 @@ public sealed class ContextDiscoveryController(
             payloads.Add(payload);
         }
 
+        // Dispatch the batch concurrently. Sub-agent activations are independent (first-wins
+        // registration into a ConcurrentDictionary) and run in parallel. Context-file injections
+        // must preserve their delivery order — the injected user-turn messages should reach the
+        // model in a deterministic sequence (e.g. a nested CLAUDE.md after the root one), and the
+        // agent input channel gives no ordering guarantee across concurrent writers — so they run
+        // as one ordered chain. Both groups are awaited together.
+        var pending = new List<Task>(payloads.Count);
+        var contextFiles = new List<ContextDiscoveryPayload>();
+
         foreach (var payload in payloads)
         {
             logger.LogInformation(
@@ -111,20 +120,45 @@ public sealed class ContextDiscoveryController(
             // Record the arrival for the diagnostics endpoint BEFORE the kind-specific handling
             // (which is best-effort and may no-op). This is what lets an operator confirm webhooks
             // are reaching the app at all — the count staying at zero is the signature of an
-            // unreachable callback host OR a rejected (401) delivery.
+            // unreachable callback host OR a rejected (401) delivery. RecordReceived is a fast,
+            // thread-safe, order-independent counter update.
             diagnostics.RecordReceived(payload.SessionId, payload.Kind, payload.Path ?? payload.Name);
 
             if (string.Equals(payload.Kind, ContextDiscoveryKinds.SubAgent, StringComparison.Ordinal))
             {
-                await TryActivateSubAgentAsync(payload, cancellationToken).ConfigureAwait(false);
+                pending.Add(TryActivateSubAgentAsync(payload, cancellationToken));
             }
             else if (string.Equals(payload.Kind, ContextDiscoveryKinds.ContextFile, StringComparison.Ordinal))
             {
-                await contextInjector.InjectAsync(payload, cancellationToken).ConfigureAwait(false);
+                contextFiles.Add(payload);
             }
         }
 
+        if (contextFiles.Count > 0)
+        {
+            pending.Add(InjectContextFilesInOrderAsync(contextFiles, cancellationToken));
+        }
+
+        await Task.WhenAll(pending).ConfigureAwait(false);
+
         return Ok();
+    }
+
+    /// <summary>
+    /// Injects the batch's context files into the conversation in delivery order. Kept sequential
+    /// on purpose: the injected user-turn messages must reach the model in a deterministic sequence
+    /// (e.g. a nested CLAUDE.md after the root one), and concurrent writes to the agent input
+    /// channel carry no ordering guarantee. Each injection is a fast non-blocking enqueue, so the
+    /// chain adds no meaningful latency.
+    /// </summary>
+    private async Task InjectContextFilesInOrderAsync(
+        IReadOnlyList<ContextDiscoveryPayload> contextFiles,
+        CancellationToken cancellationToken)
+    {
+        foreach (var payload in contextFiles)
+        {
+            await contextInjector.InjectAsync(payload, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     /// <summary>

--- a/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
@@ -43,13 +43,15 @@ public sealed class ContextDiscoveryController(
     ILogger<ContextDiscoveryController> logger) : ControllerBase
 {
     /// <summary>
-    /// Gateway callback for one discovered context item. Returns 200 on success (including
-    /// best-effort no-ops), 401 if the shared secret doesn't match, 400 if the payload is
-    /// malformed.
+    /// Gateway callback for a batch of discovered context items. The gateway batches every newly
+    /// discovered item for a session into one POST — a <see cref="ContextDiscoveryEnvelope"/>
+    /// carrying the session id plus a <c>discoveries</c> array. Returns 200 on success (including
+    /// best-effort no-ops), 401 if the shared secret doesn't match, 400 if the envelope is null or
+    /// any item is malformed for its kind.
     /// </summary>
     [HttpPost("context_discovery")]
     public async Task<IActionResult> NotifyAsync(
-        [FromBody] ContextDiscoveryPayload? body,
+        [FromBody] ContextDiscoveryEnvelope? body,
         CancellationToken cancellationToken)
     {
         if (!sharedSecret.Matches(Request.Headers.Authorization.ToString()))
@@ -59,33 +61,67 @@ public sealed class ContextDiscoveryController(
             return Unauthorized();
         }
 
-        if (body is null || !IsValid(body))
+        if (body is null)
         {
             logger.LogWarning("Rejected context-discovery webhook with malformed payload.");
             return BadRequest();
         }
 
-        logger.LogInformation(
-            "ContextDiscovery: kind={Kind} name={Name} path={Path} description={Description} session={SessionId} truncated={Truncated}",
-            body.Kind,
-            body.Name,
-            body.Path,
-            body.Description,
-            body.SessionId,
-            body.Truncated);
-
-        // Record the arrival for the diagnostics endpoint BEFORE the kind-specific handling (which is
-        // best-effort and may no-op). This is what lets an operator confirm webhooks are reaching the
-        // app at all — the count staying at zero is the signature of an unreachable callback host.
-        diagnostics.RecordReceived(body.SessionId, body.Kind, body.Path ?? body.Name);
-
-        if (string.Equals(body.Kind, ContextDiscoveryKinds.SubAgent, StringComparison.Ordinal))
+        // Project each batched item onto the per-item carrier the downstream handlers consume,
+        // stamping the envelope-level session id onto each. Validate the WHOLE batch up front so a
+        // malformed item is rejected at the boundary rather than partially applied.
+        var items = body.Discoveries ?? [];
+        var payloads = new List<ContextDiscoveryPayload>(items.Count);
+        foreach (var item in items)
         {
-            await TryActivateSubAgentAsync(body, cancellationToken).ConfigureAwait(false);
+            var payload = new ContextDiscoveryPayload
+            {
+                SessionId = body.SessionId,
+                Kind = item.Kind,
+                Name = item.Name,
+                Description = item.Description,
+                Path = item.Path,
+                Content = item.Content,
+                Truncated = item.Truncated,
+            };
+
+            if (!IsValid(payload))
+            {
+                logger.LogWarning(
+                    "Rejected context-discovery webhook with malformed item (kind={Kind}, path={Path}).",
+                    item.Kind,
+                    item.Path);
+                return BadRequest();
+            }
+
+            payloads.Add(payload);
         }
-        else if (string.Equals(body.Kind, ContextDiscoveryKinds.ContextFile, StringComparison.Ordinal))
+
+        foreach (var payload in payloads)
         {
-            await contextInjector.InjectAsync(body, cancellationToken).ConfigureAwait(false);
+            logger.LogInformation(
+                "ContextDiscovery: kind={Kind} name={Name} path={Path} description={Description} session={SessionId} truncated={Truncated}",
+                payload.Kind,
+                payload.Name,
+                payload.Path,
+                payload.Description,
+                payload.SessionId,
+                payload.Truncated);
+
+            // Record the arrival for the diagnostics endpoint BEFORE the kind-specific handling
+            // (which is best-effort and may no-op). This is what lets an operator confirm webhooks
+            // are reaching the app at all — the count staying at zero is the signature of an
+            // unreachable callback host OR a rejected (401) delivery.
+            diagnostics.RecordReceived(payload.SessionId, payload.Kind, payload.Path ?? payload.Name);
+
+            if (string.Equals(payload.Kind, ContextDiscoveryKinds.SubAgent, StringComparison.Ordinal))
+            {
+                await TryActivateSubAgentAsync(payload, cancellationToken).ConfigureAwait(false);
+            }
+            else if (string.Equals(payload.Kind, ContextDiscoveryKinds.ContextFile, StringComparison.Ordinal))
+            {
+                await contextInjector.InjectAsync(payload, cancellationToken).ConfigureAwait(false);
+            }
         }
 
         return Ok();
@@ -262,10 +298,63 @@ internal readonly record struct SubAgentSessionRegistryItem(string Kind, string 
 }
 
 /// <summary>
-/// Gateway → app payload for a single discovered context item. Field names are the gateway's
-/// wire contract (snake_case), pinned via <see cref="JsonPropertyNameAttribute"/> so they bind
-/// regardless of the app's JSON naming defaults. Unknown fields are tolerated by System.Text.Json
-/// by default so the gateway can add new fields without breaking older app builds.
+/// Gateway → app batch payload for a <c>context_discovery</c> webhook delivery. The gateway
+/// batches every newly-discovered item for a session into ONE POST: a top-level envelope carrying
+/// the session id plus a <c>discoveries</c> array of per-kind items (see SandboxedOstoolsMcpServer
+/// <c>Docs/context-discovery.md</c> §Webhook payload). Field names are the gateway's wire contract
+/// (snake_case), pinned via <see cref="JsonPropertyNameAttribute"/>. Unknown fields (e.g.
+/// <c>event</c>, <c>app_id</c>) are tolerated by System.Text.Json so the gateway can evolve its
+/// envelope without breaking older app builds.
+/// </summary>
+public sealed record ContextDiscoveryEnvelope
+{
+    [JsonPropertyName("event")]
+    public string? Event { get; init; }
+
+    [JsonPropertyName("session_id")]
+    public string? SessionId { get; init; }
+
+    [JsonPropertyName("app_id")]
+    public string? AppId { get; init; }
+
+    [JsonPropertyName("discoveries")]
+    public List<ContextDiscoveryItem>? Discoveries { get; init; }
+}
+
+/// <summary>
+/// One discovered item inside a <see cref="ContextDiscoveryEnvelope"/>, discriminated by
+/// <see cref="Kind"/>. Only the fields the app acts on are bound here; the gateway's richer
+/// per-kind fields (<c>frontmatter</c>/<c>prompt</c>/<c>directory</c>/<c>plugin</c>/…) are
+/// tolerated and ignored.
+/// </summary>
+public sealed record ContextDiscoveryItem
+{
+    [JsonPropertyName("kind")]
+    public string? Kind { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("path")]
+    public string? Path { get; init; }
+
+    /// <summary>Body of a discovered context file (CLAUDE.md / AGENTS.md). Present for
+    /// <c>kind == "context_file"</c> items; other kinds resolve their content elsewhere.</summary>
+    [JsonPropertyName("content")]
+    public string? Content { get; init; }
+
+    [JsonPropertyName("truncated")]
+    public bool? Truncated { get; init; }
+}
+
+/// <summary>
+/// Per-item carrier passed to the kind-specific handlers (<see cref="ContextDiscoveryInjector"/>,
+/// sub-agent activation) after the controller flattens a <see cref="ContextDiscoveryEnvelope"/> and
+/// stamps the envelope's session id onto each item. Retains <see cref="JsonPropertyNameAttribute"/>
+/// bindings so it still deserializes the historical single-item shape in unit tests.
 /// </summary>
 public sealed record ContextDiscoveryPayload
 {

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -1662,12 +1662,15 @@ public partial class Program
             }
             catch (Exception ex)
             {
+                // A thrown read (timeout / transport) means the gateway is unreachable, not that the
+                // file is merely absent (a missing file returns null, handled below). Abandon the whole
+                // seed instead of spending another bounded wait on the next candidate.
                 logger.LogWarning(
                     ex,
-                    "Failed to read workspace root context file {Path} for session {SessionId}; skipping seed.",
+                    "Failed to read workspace root context file {Path} for session {SessionId}; gateway unreachable, skipping root context seed.",
                     path,
                     sandboxSession.SessionId);
-                continue;
+                return string.Empty;
             }
 
             if (string.IsNullOrWhiteSpace(content))

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -1616,12 +1616,16 @@ public partial class Program
     }
 
     /// <summary>
-    /// Asks the gateway for every <c>context_file</c> the workspace contains, host-reads each
-    /// one (via the same containment guard the sub-agent loader uses), and concatenates the
-    /// formatted blocks. Returns an empty string when discovery hasn't surfaced any context
-    /// files yet, the session has no host path, the gateway call fails, or every file fails
-    /// the containment / read step. All failures are logged and swallowed — context-file
-    /// seeding is a best-effort enrichment, never a precondition for the chat session.
+    /// Seeds the workspace's root instruction file (AGENTS.md, else CLAUDE.md) into the system
+    /// prompt at agent build, so the model has the workspace's high-priority instructions on turn 1
+    /// WITHOUT having to read any file. The content is fetched THROUGH the gateway's MCP <c>Read</c>
+    /// tool (<see cref="SandboxSessionRegistry.ReadWorkspaceFileAsync"/>): the local-host backend
+    /// cannot read the container's <c>/workspace</c> filesystem, and this path is race-free (it does
+    /// not depend on the async discovery webhook, which fires after the system prompt is built).
+    /// AGENTS.md takes precedence over CLAUDE.md — the first file that exists is injected and the
+    /// search stops. Returns an empty string when neither exists, the session has no host path, or
+    /// the read fails; every failure is logged and swallowed — seeding is a best-effort enrichment,
+    /// never a precondition for the chat session.
     /// </summary>
     private static string TryBuildRootContextSuffix(
         SandboxSessionRegistry sandboxRegistry,
@@ -1636,72 +1640,62 @@ public partial class Program
             return string.Empty;
         }
 
-        IReadOnlyList<SandboxSessionRegistry.DiscoveredItem> items;
-        try
+        // The workspace mount root inside the sandbox (e.g. "/workspace"). Root instruction files
+        // sit directly under it; AGENTS.md wins over CLAUDE.md when both are present.
+        var baseDir = sandboxSession.HostPath.TrimEnd('/', '\\');
+        string[] candidates = ["AGENTS.md", "CLAUDE.md"];
+
+        foreach (var name in candidates)
         {
-            // Bound this sync-over-async gateway GET so a slow/unresponsive gateway can't park a
-            // thread-pool thread for the HttpClient default (100s) on every agent creation.
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            items = sandboxRegistry
-                .ListDiscoveredAsync(sandboxSession.SessionId, cts.Token)
-                .GetAwaiter()
-                .GetResult();
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(
-                ex,
-                "Failed to list discovered context files for session {SessionId}; skipping root context seed.",
-                sandboxSession.SessionId);
-            return string.Empty;
-        }
+            var path = $"{baseDir}/{name}";
 
-        var basePath = WorkspaceSubAgentLoader.NormalizeBasePath(sandboxSession.HostPath);
-        var blocks = new List<string>();
-
-        foreach (var item in items)
-        {
-            if (!string.Equals(item.Kind, ContextFileKind, StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            if (!WorkspaceSubAgentLoader.TryResolveContainedPath(basePath, item.Path, out var fullPath))
-            {
-                logger.LogWarning(
-                    "Skipping discovered context file {Path} for session {SessionId}: outside workspace.",
-                    item.Path,
-                    sandboxSession.SessionId);
-                continue;
-            }
-
-            string content;
+            string? content;
             try
             {
-                content = File.ReadAllText(fullPath);
+                // Bound this sync-over-async gateway read so a slow/unresponsive gateway can't park a
+                // thread-pool thread for the HttpClient default (100s) on every agent creation.
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                content = sandboxRegistry
+                    .ReadWorkspaceFileAsync(sandboxSession.SessionId, path, cts.Token)
+                    .GetAwaiter()
+                    .GetResult();
             }
             catch (Exception ex)
             {
                 logger.LogWarning(
                     ex,
-                    "Skipping discovered context file {Path} for session {SessionId}: read failed.",
-                    item.Path,
+                    "Failed to read workspace root context file {Path} for session {SessionId}; skipping seed.",
+                    path,
                     sandboxSession.SessionId);
                 continue;
             }
 
-            var block = formatter.BuildSystemPromptBlock(item.Path, content, truncated: false);
-            if (!string.IsNullOrEmpty(block))
+            if (string.IsNullOrWhiteSpace(content))
             {
-                blocks.Add(block);
-                // Mark each seeded file as seen so a same-file delivery on the webhook side
-                // (the gateway re-emits the same path right after session creation) is dropped
-                // by the injector — otherwise the model would see the file twice on turn 1.
-                _ = sandboxRegistry.TryMarkDiscoverySeen(sandboxSession.SessionId, ContextFileKind, item.Path);
+                continue;
             }
+
+            var block = formatter.BuildSystemPromptBlock(path, content, truncated: false);
+            if (string.IsNullOrEmpty(block))
+            {
+                continue;
+            }
+
+            // Mark the seeded file as seen so a same-file delivery on the webhook side (the gateway
+            // re-emits the root path right after session creation) is dropped by the injector —
+            // otherwise the model would see the file twice on turn 1.
+            _ = sandboxRegistry.TryMarkDiscoverySeen(sandboxSession.SessionId, ContextFileKind, path);
+
+            logger.LogInformation(
+                "Seeded workspace root context file {Path} ({Length} chars) into the system prompt for session {SessionId}.",
+                path,
+                content.Length,
+                sandboxSession.SessionId);
+
+            return "\n\n" + block;
         }
 
-        return blocks.Count == 0 ? string.Empty : "\n\n" + string.Join("\n\n", blocks);
+        return string.Empty;
     }
 
     private static int ResolveCodexMcpPort()

--- a/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using LmStreaming.Sample.Services.Auth;
@@ -63,7 +64,7 @@ public sealed record WorkspaceRef(
 /// call can retry.
 /// </para>
 /// </remarks>
-public sealed class SandboxSessionRegistry : IAsyncDisposable
+public sealed partial class SandboxSessionRegistry : IAsyncDisposable
 {
     /// <summary>
     /// Logical id of the default workspace, which maps to the configured
@@ -667,10 +668,14 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
 
     /// <summary>
     /// Strips the <c>Read</c> tool's <c>cat -n</c> line-number prefixes (<c>"   123\t"</c>) so the
-    /// recovered text is the raw file content, suitable for injecting into the system prompt.
+    /// recovered text is the raw file content, suitable for injecting into the system prompt. The
+    /// matcher is source-generated (compiled once at build) rather than constructed per call.
     /// </summary>
     private static string StripReadLineNumbers(string text) =>
-        System.Text.RegularExpressions.Regex.Replace(text, "(?m)^ *\\d+\\t", string.Empty);
+        ReadLineNumberPrefixRegex().Replace(text, string.Empty);
+
+    [GeneratedRegex(@"^ *\d+\t", RegexOptions.Multiline | RegexOptions.CultureInvariant)]
+    private static partial Regex ReadLineNumberPrefixRegex();
 
     /// <summary>
     /// Returns the <see cref="SubAgentSessionBinding"/> for the

--- a/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/SandboxSessionRegistry.cs
@@ -592,6 +592,87 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
     }
 
     /// <summary>
+    /// Reads the text content of a file inside the session's sandbox through the gateway's MCP
+    /// <c>Read</c> tool (<c>POST {gateway}/mcp</c>, <c>tools/call</c>, scoped by the
+    /// <c>X-Session-ID</c> header). This is the ONLY way the (local-host) backend can obtain a
+    /// workspace file's content in the Docker topology — it cannot read the container's
+    /// <c>/workspace</c> filesystem directly, and the discovery query API is metadata-only.
+    /// </summary>
+    /// <param name="sessionId">Gateway session id whose sandbox the file lives in.</param>
+    /// <param name="absolutePath">Absolute path INSIDE the sandbox (e.g. <c>/workspace/CLAUDE.md</c>).</param>
+    /// <param name="ct">Cancellation token observed by the HTTP call.</param>
+    /// <returns>
+    /// The file's text with the <c>Read</c> tool's <c>cat -n</c> line-number prefixes stripped, or
+    /// <c>null</c> when the file is missing, the tool reports an error, or the call fails. Best-effort
+    /// by contract: callers treat <c>null</c> as "no content" and degrade.
+    /// </returns>
+    public async Task<string?> ReadWorkspaceFileAsync(string sessionId, string absolutePath, CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(absolutePath);
+
+        // JSON-RPC field names are the MCP wire contract (jsonrpc/method/params/name/arguments/
+        // file_path) — serialize them verbatim rather than through the snake_case JsonOptions.
+        var body = JsonSerializer.Serialize(new
+        {
+            jsonrpc = "2.0",
+            id = 1,
+            method = "tools/call",
+            @params = new { name = "Read", arguments = new { file_path = absolutePath } },
+        });
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{_gateway.GatewayBaseUrl}/mcp")
+        {
+            Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+        };
+        request.Headers.TryAddWithoutValidation("X-Session-ID", sessionId);
+
+        using var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            // Best-effort: a non-2xx transport result is "no content", never a thrown error — the
+            // caller (boot-time system-prompt seed) degrades to no workspace instructions.
+            return null;
+        }
+
+        McpReadResponse? payload;
+        try
+        {
+            payload = await response
+                .Content.ReadFromJsonAsync<McpReadResponse>(JsonOptions, ct)
+                .ConfigureAwait(false);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        // JSON-RPC error (e.g. evicted session) OR a tool-level error (isError, e.g. missing file)
+        // both mean "no usable content".
+        if (payload?.Error is not null || payload?.Result is null || payload.Result.IsError == true)
+        {
+            return null;
+        }
+
+        var text = payload.Result.Content?
+            .FirstOrDefault(c => string.Equals(c.Type, "text", StringComparison.Ordinal))?.Text;
+        if (string.IsNullOrEmpty(text))
+        {
+            return null;
+        }
+
+        return StripReadLineNumbers(text);
+    }
+
+    /// <summary>
+    /// Strips the <c>Read</c> tool's <c>cat -n</c> line-number prefixes (<c>"   123\t"</c>) so the
+    /// recovered text is the raw file content, suitable for injecting into the system prompt.
+    /// </summary>
+    private static string StripReadLineNumbers(string text) =>
+        System.Text.RegularExpressions.Regex.Replace(text, "(?m)^ *\\d+\\t", string.Empty);
+
+    /// <summary>
     /// Returns the <see cref="SubAgentSessionBinding"/> for the
     /// (<paramref name="sessionId"/>, <paramref name="conversationId"/>) pair, creating one on
     /// first access — seeded with <paramref name="seed"/> and remembering
@@ -1056,12 +1137,16 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
         [property: JsonPropertyName("webhook")] DiscoveryWebhookDto Webhook
     );
 
-    /// <summary>Webhook descriptor inside the outbound <c>discovery</c> block. <c>auth</c>
-    /// matches the value the gateway later presents in the <c>Authorization</c> header on its
-    /// callbacks — same convention as the auth-provider <c>gateway_auth</c> field.</summary>
+    /// <summary>Webhook descriptor inside the outbound <c>discovery</c> block. The gateway reads
+    /// the secret from <c>auth_header</c> (its <c>WebhookConfig</c> field) and sends it back
+    /// <em>verbatim</em> as the <c>Authorization</c> header on every context-discovery callback —
+    /// which is what <see cref="LmStreaming.Sample.Controllers.ContextDiscoveryController"/> then
+    /// validates. The field name MUST be <c>auth_header</c>: under the legacy name <c>auth</c> the
+    /// gateway parses it as absent and sends no <c>Authorization</c> header, so every callback is
+    /// rejected 401 and no context file is ever delivered.</summary>
     internal sealed record DiscoveryWebhookDto(
         [property: JsonPropertyName("url")] string Url,
-        [property: JsonPropertyName("auth")] string Auth
+        [property: JsonPropertyName("auth_header")] string Auth
     );
 
     /// <summary>One item the gateway has discovered for the workspace (a sub-agent file,
@@ -1076,6 +1161,30 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
 
     private sealed record DiscoveredItemsResponse(
         [property: JsonPropertyName("items")] IReadOnlyList<DiscoveredItem> Items
+    );
+
+    // --- Gateway MCP /mcp JSON-RPC contract (for ReadWorkspaceFileAsync) ---
+    // Explicit names: the gateway emits camelCase `isError` (MCP convention), which the snake_case
+    // JsonOptions would otherwise look for as `is_error`.
+
+    private sealed record McpReadResponse(
+        [property: JsonPropertyName("result")] McpReadResult? Result,
+        [property: JsonPropertyName("error")] McpRpcError? Error
+    );
+
+    private sealed record McpReadResult(
+        [property: JsonPropertyName("content")] IReadOnlyList<McpContentItem>? Content,
+        [property: JsonPropertyName("isError")] bool? IsError
+    );
+
+    private sealed record McpContentItem(
+        [property: JsonPropertyName("type")] string? Type,
+        [property: JsonPropertyName("text")] string? Text
+    );
+
+    private sealed record McpRpcError(
+        [property: JsonPropertyName("code")] int Code,
+        [property: JsonPropertyName("message")] string? Message
     );
 
     private sealed record AppRef([property: JsonPropertyName("id")] string Id);

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
@@ -93,11 +93,17 @@ public class ContextDiscoveryControllerTests
             new AuthSharedSecret(new AuthOptions()));
     }
 
+    // The gateway delivers a BATCHED `context_discovery` envelope (a `discoveries` array with the
+    // session id at the envelope level). These helpers wrap a single item in that envelope so each
+    // test reads as "one discovered item for a session".
+    private static ContextDiscoveryEnvelope Envelope(string? sessionId, params ContextDiscoveryItem[] items)
+        => new() { SessionId = sessionId, Discoveries = [.. items] };
+
     [Fact]
     public async Task NotifyAsync_NoAuthorizationHeader_ReturnsUnauthorized()
     {
         var controller = CreateController(authorizationHeader: null);
-        var body = new ContextDiscoveryPayload { Kind = "subagent", Name = "echo" };
+        var body = Envelope(null, new ContextDiscoveryItem { Kind = "subagent", Name = "echo" });
 
         var result = await controller.NotifyAsync(body, CancellationToken.None);
 
@@ -108,7 +114,7 @@ public class ContextDiscoveryControllerTests
     public async Task NotifyAsync_WrongSecret_ReturnsUnauthorized()
     {
         var controller = CreateController(authorizationHeader: "wrong-secret");
-        var body = new ContextDiscoveryPayload { Kind = "subagent", Name = "echo" };
+        var body = Envelope(null, new ContextDiscoveryItem { Kind = "subagent", Name = "echo" });
 
         var result = await controller.NotifyAsync(body, CancellationToken.None);
 
@@ -129,7 +135,7 @@ public class ContextDiscoveryControllerTests
     public async Task NotifyAsync_CorrectSecret_MissingKind_ReturnsBadRequest()
     {
         var controller = CreateController(authorizationHeader: Secret);
-        var body = new ContextDiscoveryPayload { Name = "echo" };
+        var body = Envelope(null, new ContextDiscoveryItem { Name = "echo" });
 
         var result = await controller.NotifyAsync(body, CancellationToken.None);
 
@@ -142,7 +148,7 @@ public class ContextDiscoveryControllerTests
         // Sub-agent activations are keyed by name (the value the model picks via the Agent tool's
         // subagent_type enum). Without it we can't register or look up the template, so reject.
         var controller = CreateController(authorizationHeader: Secret);
-        var body = new ContextDiscoveryPayload { Kind = "subagent" };
+        var body = Envelope(null, new ContextDiscoveryItem { Kind = "subagent" });
 
         var result = await controller.NotifyAsync(body, CancellationToken.None);
 
@@ -155,7 +161,7 @@ public class ContextDiscoveryControllerTests
         // context_file deliveries are keyed by path (the dedup key + the pill label) — a missing
         // path can't be deduped against retries and can't be displayed to the user.
         var controller = CreateController(authorizationHeader: Secret);
-        var body = new ContextDiscoveryPayload { Kind = "context_file", Content = "body" };
+        var body = Envelope(null, new ContextDiscoveryItem { Kind = "context_file", Content = "body" });
 
         var result = await controller.NotifyAsync(body, CancellationToken.None);
 
@@ -168,7 +174,7 @@ public class ContextDiscoveryControllerTests
         // Null content means the gateway has nothing for the model to read; the injector would
         // drop it anyway, but rejecting at the boundary keeps the contract crisp.
         var controller = CreateController(authorizationHeader: Secret);
-        var body = new ContextDiscoveryPayload { Kind = "context_file", Path = "CLAUDE.md" };
+        var body = Envelope(null, new ContextDiscoveryItem { Kind = "context_file", Path = "CLAUDE.md" });
 
         var result = await controller.NotifyAsync(body, CancellationToken.None);
 
@@ -182,13 +188,12 @@ public class ContextDiscoveryControllerTests
         // empty file. The injector treats it as a drop downstream so nothing reaches the model,
         // but the contract at the boundary is "non-null is acceptable".
         var controller = CreateController(authorizationHeader: Secret);
-        var body = new ContextDiscoveryPayload
+        var body = Envelope("session-x", new ContextDiscoveryItem
         {
-            SessionId = "session-x",
             Kind = "context_file",
             Path = "CLAUDE.md",
             Content = string.Empty,
-        };
+        });
 
         var result = await controller.NotifyAsync(body, CancellationToken.None);
 
@@ -204,13 +209,12 @@ public class ContextDiscoveryControllerTests
         var registry = CreateEmptyRegistry();
         var controller = CreateController(authorizationHeader: Secret, registry: registry);
 
-        var body = new ContextDiscoveryPayload
+        var body = Envelope("session-dispatch", new ContextDiscoveryItem
         {
-            SessionId = "session-dispatch",
             Kind = "context_file",
             Path = "CLAUDE.md",
             Content = "body",
-        };
+        });
 
         var result = await controller.NotifyAsync(body, CancellationToken.None);
 
@@ -228,13 +232,12 @@ public class ContextDiscoveryControllerTests
         var controller = CreateController(authorizationHeader: Secret, diagnostics: diagnostics);
 
         var result = await controller.NotifyAsync(
-            new ContextDiscoveryPayload
+            Envelope("session-diag", new ContextDiscoveryItem
             {
-                SessionId = "session-diag",
                 Kind = "context_file",
                 Path = "CLAUDE.md",
                 Content = "body",
-            },
+            }),
             CancellationToken.None);
 
         result.Should().BeOfType<OkResult>();
@@ -253,13 +256,12 @@ public class ContextDiscoveryControllerTests
         var controller = CreateController(authorizationHeader: "wrong-secret", diagnostics: diagnostics);
 
         _ = await controller.NotifyAsync(
-            new ContextDiscoveryPayload
+            Envelope("session-diag", new ContextDiscoveryItem
             {
-                SessionId = "session-diag",
                 Kind = "context_file",
                 Path = "CLAUDE.md",
                 Content = "body",
-            },
+            }),
             CancellationToken.None);
 
         diagnostics.Snapshot().Should().BeEmpty();
@@ -269,13 +271,13 @@ public class ContextDiscoveryControllerTests
     public async Task NotifyAsync_CorrectSecret_WellFormedPayload_ReturnsOk()
     {
         var controller = CreateController(authorizationHeader: Secret);
-        var body = new ContextDiscoveryPayload
+        var body = Envelope(null, new ContextDiscoveryItem
         {
             Kind = "subagent",
             Name = "echo",
             Description = "Echoes a marker.",
             Path = ".claude/agents/echo.md",
-        };
+        });
 
         var result = await controller.NotifyAsync(body, CancellationToken.None);
 
@@ -289,12 +291,12 @@ public class ContextDiscoveryControllerTests
         // must NOT try to resolve a session for them. Verifies that path stays a no-op even when
         // session_id is absent from the payload.
         var controller = CreateController(authorizationHeader: Secret);
-        var body = new ContextDiscoveryPayload
+        var body = Envelope(null, new ContextDiscoveryItem
         {
             Kind = "skill",
             Name = "review-skill",
             Path = ".claude/skills/review.md",
-        };
+        });
 
         var result = await controller.NotifyAsync(body, CancellationToken.None);
 
@@ -312,13 +314,12 @@ public class ContextDiscoveryControllerTests
             authorizationHeader: Secret,
             registry: registry);
 
-        var body = new ContextDiscoveryPayload
+        var body = Envelope("session-not-in-registry", new ContextDiscoveryItem
         {
-            SessionId = "session-not-in-registry",
             Kind = "subagent",
             Name = "ghost",
             Path = ".claude/agents/ghost.md",
-        };
+        });
 
         var result = await controller.NotifyAsync(body, CancellationToken.None);
 
@@ -388,13 +389,12 @@ public class ContextDiscoveryControllerTests
             var controller = CreateController(authorizationHeader: Secret, registry: registry, loader: loader);
 
             var result = await controller.NotifyAsync(
-                new ContextDiscoveryPayload
+                Envelope(gatewaySessionId, new ContextDiscoveryItem
                 {
-                    SessionId = gatewaySessionId,
                     Kind = "subagent",
                     Name = "echo",
                     Path = ".claude/agents/echo.md",
-                },
+                }),
                 CancellationToken.None);
 
             result.Should().BeOfType<OkResult>();

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryEndToEndTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryEndToEndTests.cs
@@ -85,6 +85,52 @@ public sealed class ContextDiscoveryEndToEndTests
     }
 
     [Fact]
+    public async Task MixedBatch_InjectsContextFilesInOrder_AlongsideSubAgent()
+    {
+        // The batch partitions by kind: the sub-agent dispatches in parallel (a no-op here — the
+        // harness has no gateway session/binding for it, so it logs-and-skips), while the two
+        // context files still inject into the live thread in delivery order.
+        using var harness = new Harness();
+        var agent = harness.RegisterLiveThread(SessionId, ThreadId);
+
+        var controller = harness.CreateController(authorizationHeader: Secret);
+        var payload = new ContextDiscoveryEnvelope
+        {
+            SessionId = SessionId,
+            Discoveries =
+            [
+                new ContextDiscoveryItem { Kind = "subagent", Name = "reviewer", Path = ".claude/agents/reviewer.md" },
+                new ContextDiscoveryItem { Kind = "context_file", Path = "AGENTS.md", Content = "ROOT_MARKER" },
+                new ContextDiscoveryItem { Kind = "context_file", Path = "sub/CLAUDE.md", Content = "NESTED_MARKER" },
+            ],
+        };
+
+        var result = await controller.NotifyAsync(payload, CancellationToken.None);
+
+        result.Should().BeOfType<OkResult>();
+        agent.SentMessages.Should().SatisfyRespectively(
+            first => first.Should().BeOfType<TextMessage>().Which.Text.Should().Contain("ROOT_MARKER"),
+            second => second.Should().BeOfType<TextMessage>().Which.Text.Should().Contain("NESTED_MARKER"));
+    }
+
+    [Fact]
+    public async Task EmptyBatch_ReturnsOkWithoutInjecting()
+    {
+        // An authenticated envelope with no discoveries is a valid no-op: Task.WhenAll over an empty
+        // set completes immediately, the controller returns 200, and nothing is injected.
+        using var harness = new Harness();
+        var agent = harness.RegisterLiveThread(SessionId, ThreadId);
+
+        var controller = harness.CreateController(authorizationHeader: Secret);
+        var result = await controller.NotifyAsync(
+            new ContextDiscoveryEnvelope { SessionId = SessionId, Discoveries = [] },
+            CancellationToken.None);
+
+        result.Should().BeOfType<OkResult>();
+        agent.SentMessages.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ContextFileWebhook_WrongSecret_DoesNotReachAgent()
     {
         // The auth gate is part of the chain: a bad secret must 401 and never inject.

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryEndToEndTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryEndToEndTests.cs
@@ -57,6 +57,34 @@ public sealed class ContextDiscoveryEndToEndTests
     }
 
     [Fact]
+    public async Task BatchedContextFiles_AreInjectedInDeliveryOrder()
+    {
+        // The controller dispatches the batch with Task.WhenAll but keeps context-file injection
+        // in an ordered chain, so a multi-file batch reaches the model in delivery order (root
+        // before nested) rather than the non-deterministic order of concurrent channel writes.
+        using var harness = new Harness();
+        var agent = harness.RegisterLiveThread(SessionId, ThreadId);
+
+        var controller = harness.CreateController(authorizationHeader: Secret);
+        var payload = new ContextDiscoveryEnvelope
+        {
+            SessionId = SessionId,
+            Discoveries =
+            [
+                new ContextDiscoveryItem { Kind = "context_file", Path = "AGENTS.md", Content = "ROOT_MARKER" },
+                new ContextDiscoveryItem { Kind = "context_file", Path = "sub/CLAUDE.md", Content = "NESTED_MARKER" },
+            ],
+        };
+
+        var result = await controller.NotifyAsync(payload, CancellationToken.None);
+
+        result.Should().BeOfType<OkResult>();
+        agent.SentMessages.Should().SatisfyRespectively(
+            first => first.Should().BeOfType<TextMessage>().Which.Text.Should().Contain("ROOT_MARKER"),
+            second => second.Should().BeOfType<TextMessage>().Which.Text.Should().Contain("NESTED_MARKER"));
+    }
+
+    [Fact]
     public async Task ContextFileWebhook_WrongSecret_DoesNotReachAgent()
     {
         // The auth gate is part of the chain: a bad secret must 401 and never inject.

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryEndToEndTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryEndToEndTests.cs
@@ -30,12 +30,18 @@ public sealed class ContextDiscoveryEndToEndTests
         var agent = harness.RegisterLiveThread(SessionId, ThreadId);
 
         var controller = harness.CreateController(authorizationHeader: Secret);
-        var payload = new ContextDiscoveryPayload
+        var payload = new ContextDiscoveryEnvelope
         {
             SessionId = SessionId,
-            Kind = "context_file",
-            Path = "CLAUDE.md",
-            Content = "# Project rules\nAlways be concise.",
+            Discoveries =
+            [
+                new ContextDiscoveryItem
+                {
+                    Kind = "context_file",
+                    Path = "CLAUDE.md",
+                    Content = "# Project rules\nAlways be concise.",
+                },
+            ],
         };
 
         var result = await controller.NotifyAsync(payload, CancellationToken.None);
@@ -59,12 +65,18 @@ public sealed class ContextDiscoveryEndToEndTests
 
         var controller = harness.CreateController(authorizationHeader: "not-the-secret");
         var result = await controller.NotifyAsync(
-            new ContextDiscoveryPayload
+            new ContextDiscoveryEnvelope
             {
                 SessionId = SessionId,
-                Kind = "context_file",
-                Path = "CLAUDE.md",
-                Content = "secret-gated",
+                Discoveries =
+                [
+                    new ContextDiscoveryItem
+                    {
+                        Kind = "context_file",
+                        Path = "CLAUDE.md",
+                        Content = "secret-gated",
+                    },
+                ],
             },
             CancellationToken.None);
 
@@ -73,33 +85,38 @@ public sealed class ContextDiscoveryEndToEndTests
     }
 
     [Fact]
-    public void GatewayPayload_SnakeCaseJson_BindsToContextDiscoveryPayload()
+    public void GatewayPayload_SnakeCaseBatchedEnvelope_BindsToContextDiscoveryEnvelope()
     {
-        // The gateway's wire contract is snake_case. The [JsonPropertyName] bindings on the DTO are
-        // what make a real POST body map correctly; this pins them deterministically (the over-HTTP
-        // test exercises the same path through the live ASP.NET pipeline).
+        // The gateway's wire contract is a snake_case BATCHED envelope: a top-level `session_id`
+        // plus a `discoveries` array (with `event`/`app_id` the app ignores). The [JsonPropertyName]
+        // bindings are what make a real POST body map correctly; this pins them deterministically
+        // (the over-HTTP test exercises the same path through the live ASP.NET pipeline).
         const string json = """
             {
+              "event": "context_discovery",
               "session_id": "sess-1",
-              "kind": "context_file",
-              "name": "CLAUDE.md",
-              "description": "root context",
-              "path": "CLAUDE.md",
-              "content": "hello world",
-              "truncated": true
+              "app_id": "lmstreaming",
+              "discoveries": [
+                {
+                  "kind": "context_file",
+                  "path": "CLAUDE.md",
+                  "content": "hello world",
+                  "truncated": true
+                }
+              ]
             }
             """;
 
-        var payload = JsonSerializer.Deserialize<ContextDiscoveryPayload>(json);
+        var envelope = JsonSerializer.Deserialize<ContextDiscoveryEnvelope>(json);
 
-        payload.Should().NotBeNull();
-        payload!.SessionId.Should().Be("sess-1");
-        payload.Kind.Should().Be("context_file");
-        payload.Name.Should().Be("CLAUDE.md");
-        payload.Description.Should().Be("root context");
-        payload.Path.Should().Be("CLAUDE.md");
-        payload.Content.Should().Be("hello world");
-        payload.Truncated.Should().BeTrue();
+        envelope.Should().NotBeNull();
+        envelope!.SessionId.Should().Be("sess-1");
+        envelope.Discoveries.Should().ContainSingle();
+        var item = envelope.Discoveries![0];
+        item.Kind.Should().Be("context_file");
+        item.Path.Should().Be("CLAUDE.md");
+        item.Content.Should().Be("hello world");
+        item.Truncated.Should().BeTrue();
     }
 
     private sealed class Harness : IDisposable

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryWebhookHttpTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryWebhookHttpTests.cs
@@ -29,17 +29,23 @@ public sealed class ContextDiscoveryWebhookHttpTests
     private const string ThreadId = "thread-http";
 
     [Fact]
-    public async Task PostContextFileWebhook_WithValidSecret_BindsJsonAndReachesAgent()
+    public async Task PostBatchedContextFileWebhook_BindsAndReachesAgent()
     {
+        // The REAL gateway wire contract (SandboxedOstoolsMcpServer
+        // Docs/context-discovery.md §Webhook payload) is a BATCHED envelope with a
+        // `discoveries` array — NOT a single flat item. This drives that exact shape end to
+        // end and asserts the context_file reaches the live agent, plus that the diagnostics
+        // endpoint reports the arrival over HTTP.
         await using var app = await TestApp.BuildAsync();
 
         const string json = """
             {
+              "event": "context_discovery",
               "session_id": "sess-http",
-              "kind": "context_file",
-              "path": "CLAUDE.md",
-              "content": "# Project rules\nBe terse.",
-              "truncated": false
+              "app_id": "lmstreaming",
+              "discoveries": [
+                { "kind": "context_file", "path": "CLAUDE.md", "content": "# Project rules\nBe terse.", "truncated": false }
+              ]
             }
             """;
         using var request = new HttpRequestMessage(HttpMethod.Post, "/api/discovery/context_discovery")
@@ -52,14 +58,12 @@ public sealed class ContextDiscoveryWebhookHttpTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        // snake_case body bound correctly AND the injection reached the live agent.
         var message = app.Agent.SentMessages.Should().ContainSingle().Which
             .Should().BeOfType<TextMessage>().Subject;
         message.Role.Should().Be(Role.User);
         message.Text.Should().Contain("<context-discovery path=\"CLAUDE.md\">");
         message.Text.Should().Contain("Be terse.");
 
-        // And the diagnostics endpoint now reports the arrival over HTTP.
         var diagJson = await app.Client.GetStringAsync("/api/diagnostics/context-discovery");
         using var doc = JsonDocument.Parse(diagJson);
         var root = doc.RootElement;
@@ -76,10 +80,12 @@ public sealed class ContextDiscoveryWebhookHttpTests
     {
         await using var app = await TestApp.BuildAsync();
 
+        // Batched envelope (the real contract) with a wrong secret → auth gate rejects it before
+        // the body is even processed, so nothing is injected.
         using var request = new HttpRequestMessage(HttpMethod.Post, "/api/discovery/context_discovery")
         {
             Content = new StringContent(
-                /*lang=json,strict*/ "{\"session_id\":\"sess-http\",\"kind\":\"context_file\",\"path\":\"CLAUDE.md\",\"content\":\"x\"}",
+                /*lang=json,strict*/ "{\"event\":\"context_discovery\",\"session_id\":\"sess-http\",\"discoveries\":[{\"kind\":\"context_file\",\"path\":\"CLAUDE.md\",\"content\":\"x\"}]}",
                 Encoding.UTF8,
                 "application/json"),
         };

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryDiscoveryWebhookContractTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryDiscoveryWebhookContractTests.cs
@@ -1,0 +1,122 @@
+using System.Net;
+using System.Text;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Auth;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// Pins the OUTBOUND half of the context-discovery contract: the per-session secret the backend
+/// hands the gateway in the sandbox-create request must ride under the JSON field the gateway
+/// actually reads — <c>discovery.webhook.auth_header</c> — and be sent verbatim. The gateway
+/// (SandboxedOstoolsMcpServer <c>WebhookConfig</c>) deserializes <c>auth_header</c> with
+/// <c>#[serde(default)]</c>; if the backend sends the wrong field name the gateway parses
+/// <c>None</c>, sends its callbacks with NO <c>Authorization</c> header, and every context-discovery
+/// webhook is rejected 401 — the exact failure that stopped CLAUDE.md/AGENTS.md from loading.
+/// </summary>
+public sealed class SandboxSessionRegistryDiscoveryWebhookContractTests
+{
+    private const string GatewayBaseUrl = "http://localhost:3000";
+    private const string DefaultLeaf = "default-leaf";
+
+    [Fact]
+    public async Task CreateSession_SendsDiscoveryWebhookSecret_UnderAuthHeaderField_NotAuth()
+    {
+        const string secret = "gw-shared-secret-2f9c";
+        using var baseDir = new TempWorkspaceBase();
+        string? capturedBody = null;
+
+        HttpResponseMessage Respond(HttpRequestMessage req)
+        {
+            if (req.Method == HttpMethod.Post
+                && req.RequestUri!.AbsolutePath.EndsWith("/api/v1/sandboxes", StringComparison.Ordinal))
+            {
+                capturedBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        "{\"session_id\":\"sess-contract\",\"volumes\":{\"workspace\":{\"container_path\":\"/workspace\",\"read_only\":false}}}",
+                        Encoding.UTF8,
+                        "application/json"),
+                };
+            }
+
+            // Health probe (and anything else) → healthy.
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+
+        var options = new SandboxGatewayOptions
+        {
+            BaseUrl = GatewayBaseUrl,
+            WorkspaceBasePath = baseDir.Path,
+            Workspace = DefaultLeaf,
+        };
+        var authOptions = new AuthOptions
+        {
+            Webhook = new WebhookOptions
+            {
+                PublicBaseUrl = "http://127.0.0.1:5000",
+                GatewaySharedSecret = secret,
+            },
+        };
+
+        var gateway = new SandboxGatewayLifetime(
+            options,
+            NullLogger<SandboxGatewayLifetime>.Instance,
+            new HttpClient(new StubHandler(Respond)));
+
+        await using var registry = new SandboxSessionRegistry(
+            gateway,
+            options,
+            NullLogger<SandboxSessionRegistry>.Instance,
+            new HttpClient(new StubHandler(Respond)),
+            authOptions,
+            new AuthSharedSecret(authOptions));
+
+        _ = await registry.GetOrCreateSessionAsync(new WorkspaceRef("ws-1", "projA"));
+
+        capturedBody.Should().NotBeNull("the registry must POST a create request to the gateway");
+        using var doc = JsonDocument.Parse(capturedBody!);
+        var webhook = doc.RootElement.GetProperty("discovery").GetProperty("webhook");
+
+        webhook.GetProperty("url").GetString()
+            .Should().EndWith("/api/discovery/context_discovery");
+        webhook.GetProperty("auth_header").GetString()
+            .Should().Be(secret, "the gateway reads the secret from `auth_header` and sends it verbatim as Authorization");
+        webhook.TryGetProperty("auth", out _)
+            .Should().BeFalse("the legacy `auth` field name is ignored by the gateway → it would send no Authorization header → 401");
+    }
+
+    private sealed class TempWorkspaceBase : IDisposable
+    {
+        public string Path { get; } =
+            System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ws-contract-" + Guid.NewGuid().ToString("N"));
+
+        public TempWorkspaceBase() => Directory.CreateDirectory(Path);
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(Path))
+                {
+                    Directory.Delete(Path, recursive: true);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup; a leaked temp dir must not fail the test.
+            }
+        }
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(respond(request));
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryReadWorkspaceFileTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryReadWorkspaceFileTests.cs
@@ -1,0 +1,127 @@
+using System.Net;
+using System.Text;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Auth;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// Pins the gateway-read seam used to inject workspace context files (CLAUDE.md / AGENTS.md) into
+/// the system prompt at boot. The backend cannot read the container's <c>/workspace</c> filesystem,
+/// so it fetches content through the gateway's MCP <c>Read</c> tool (<c>POST {gateway}/mcp</c>,
+/// <c>tools/call</c>, scoped by the <c>X-Session-ID</c> header). These tests pin the request shape,
+/// the <c>cat -n</c> line-number stripping, and the best-effort null contract on errors.
+/// </summary>
+public sealed class SandboxSessionRegistryReadWorkspaceFileTests
+{
+    private const string GatewayBaseUrl = "http://localhost:3000";
+
+    [Fact]
+    public async Task ReadWorkspaceFile_CallsGatewayMcpRead_AndStripsLineNumbers()
+    {
+        HttpRequestMessage? captured = null;
+        string? capturedBody = null;
+
+        HttpResponseMessage Respond(HttpRequestMessage req)
+        {
+            captured = req;
+            capturedBody = req.Content?.ReadAsStringAsync().GetAwaiter().GetResult();
+            // Mock the gateway's MCP Read result — content is cat -n line-number prefixed.
+            const string mcp = """
+                {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"     1\t# Hello\n     2\tWorld\n     3\t"}],"isError":false}}
+                """;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(mcp, Encoding.UTF8, "application/json"),
+            };
+        }
+
+        await using var registry = CreateRegistry(Respond);
+
+        var content = await registry.ReadWorkspaceFileAsync("sess-1", "/workspace/CLAUDE.md");
+
+        // Line-number prefixes stripped; the empty trailing numbered line becomes a blank line.
+        content.Should().Be("# Hello\nWorld\n");
+
+        // Request shape: POST {gateway}/mcp with the session header and a tools/call Read body.
+        captured.Should().NotBeNull();
+        captured!.Method.Should().Be(HttpMethod.Post);
+        captured.RequestUri!.AbsoluteUri.Should().Be($"{GatewayBaseUrl}/mcp");
+        captured.Headers.GetValues("X-Session-ID").Should().ContainSingle().Which.Should().Be("sess-1");
+
+        capturedBody.Should().NotBeNull();
+        using var doc = JsonDocument.Parse(capturedBody!);
+        var root = doc.RootElement;
+        root.GetProperty("method").GetString().Should().Be("tools/call");
+        var p = root.GetProperty("params");
+        p.GetProperty("name").GetString().Should().Be("Read");
+        p.GetProperty("arguments").GetProperty("file_path").GetString().Should().Be("/workspace/CLAUDE.md");
+    }
+
+    [Fact]
+    public async Task ReadWorkspaceFile_ToolReportsIsError_ReturnsNull()
+    {
+        // A missing file surfaces as an MCP result with isError=true (not a transport failure).
+        static HttpResponseMessage Respond(HttpRequestMessage _) => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"File not found"}],"isError":true}}""",
+                Encoding.UTF8,
+                "application/json"),
+        };
+
+        await using var registry = CreateRegistry(Respond);
+
+        var content = await registry.ReadWorkspaceFileAsync("sess-1", "/workspace/missing.md");
+
+        content.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ReadWorkspaceFile_JsonRpcError_ReturnsNull()
+    {
+        // The gateway returns a JSON-RPC error (e.g. evicted session) — best-effort null, never throw.
+        static HttpResponseMessage Respond(HttpRequestMessage _) => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"Session not found"}}""",
+                Encoding.UTF8,
+                "application/json"),
+        };
+
+        await using var registry = CreateRegistry(Respond);
+
+        var content = await registry.ReadWorkspaceFileAsync("sess-gone", "/workspace/CLAUDE.md");
+
+        content.Should().BeNull();
+    }
+
+    private static SandboxSessionRegistry CreateRegistry(Func<HttpRequestMessage, HttpResponseMessage> respond)
+    {
+        static HttpResponseMessage Healthy(HttpRequestMessage _) => new(HttpStatusCode.OK);
+
+        var options = new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl };
+        var gateway = new SandboxGatewayLifetime(
+            options,
+            NullLogger<SandboxGatewayLifetime>.Instance,
+            new HttpClient(new StubHandler(Healthy)));
+
+        return new SandboxSessionRegistry(
+            gateway,
+            options,
+            NullLogger<SandboxSessionRegistry>.Instance,
+            new HttpClient(new StubHandler(respond)),
+            new AuthOptions(),
+            new AuthSharedSecret(new AuthOptions()));
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(respond(request));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Workspace Agent conversations never loaded the workspace-root `CLAUDE.md` / `AGENTS.md`. This fixes two independent defects so that (a) context files discovered mid-session are injected into the conversation and (b) the workspace-root file's **content is present in the system prompt at conversation start** — without the model having to read the file.

## Changes

- **Context-discovery webhook contract** (`SandboxSessionRegistry`, `ContextDiscoveryController`): send the per-session secret under `auth_header` (the gateway's field name — previously `auth`, which made the gateway omit the `Authorization` header and 401 every callback), and parse the gateway's **batched** `{ event, session_id, discoveries:[...] }` envelope (previously a single flat item), injecting each `context_file`. Fixes mid-session discovery.
- **System-prompt seed at startup** (`SandboxSessionRegistry.ReadWorkspaceFileAsync`, `Program.cs`): the local-host backend cannot read the container's `/workspace` filesystem, so the boot seeder now fetches the root `AGENTS.md` (preferred) or `CLAUDE.md` through the gateway's MCP `Read` tool (`POST /mcp`) and injects the content into the system prompt — race-free, independent of the asynchronous discovery webhook.
- Migrated the existing context-discovery tests to the batched / `auth_header` contract; added `SandboxSessionRegistryReadWorkspaceFileTests` and `SandboxSessionRegistryDiscoveryWebhookContractTests`.

## Testing

- `dotnet test tests/LmStreaming.Sample.Tests` — **329/329 green** (the project that contains every changed file). The full-solution suite was not run.
- Verified live against the running app + sandbox gateway: diagnostics `receivedCount` 0→40 with **zero 401s** (mid-session delivery now works), and `system_prompt_echo` on a fresh Reviews + Test(Anthropic) + Workspace Agent conversation shows the full `CLAUDE.md` body in the system prompt (`Seeded workspace root context file /workspace/CLAUDE.md Length=4925`).

## Notes

- The seeded content reuses the existing `<context-discovery path="…">` wrapper (the formatter is shared between boot-time and mid-session injection); switching to a `<workspace-instructions source="…">` tag is a trivial follow-up if preferred.
- Root-only at boot; nested `CLAUDE.md` (by cwd) still loads mid-session via the now-working webhook.

## Related Issues

Fixes #122
