### PR TITLE
Harden CopilotAnthropicProxy sample: opus model selection, MCP passthrough, strip unsupported request fields

### DIFF
--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -450,47 +450,61 @@ public static class ProxyModelResolver
     /// <summary>
     ///     Extracts ids for models whose <c>supported_endpoints</c> includes <c>/v1/messages</c> — the only
     ///     ones this Anthropic-Messages-shaped proxy can forward to. Copilot also serves GPT/Gemini models
-    ///     that only support <c>/responses</c> or <c>/chat/completions</c>; those are excluded.
+    ///     that only support <c>/responses</c> or <c>/chat/completions</c>; those are excluded. If no entry
+    ///     in the response carries <c>supported_endpoints</c> metadata at all (an older or alternative
+    ///     Copilot-compatible <c>/models</c> shape), falls back to <see cref="ParseModelIds"/> — id-only,
+    ///     no endpoint filtering — rather than treating every model as unsupported and failing startup.
     /// </summary>
     public static IReadOnlyList<string> ParseMessagesCapableModelIds(string json)
     {
-        var ids = new List<string>();
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
         var list = root.ValueKind == JsonValueKind.Object && root.TryGetProperty("data", out var data) ? data : root;
 
-        if (list.ValueKind == JsonValueKind.Array)
+        if (list.ValueKind != JsonValueKind.Array)
         {
-            foreach (var item in list.EnumerateArray())
+            return [];
+        }
+
+        var items = list.EnumerateArray().ToList();
+        var anyEndpointMetadata = items.Any(item =>
+            item.ValueKind == JsonValueKind.Object && item.TryGetProperty("supported_endpoints", out _)
+        );
+        if (!anyEndpointMetadata)
+        {
+            return ParseModelIds(json);
+        }
+
+        var ids = new List<string>();
+        foreach (var item in items)
+        {
+            if (
+                item.ValueKind != JsonValueKind.Object
+                || !item.TryGetProperty("id", out var idEl)
+                || idEl.ValueKind != JsonValueKind.String
+            )
             {
-                if (
-                    item.ValueKind != JsonValueKind.Object
-                    || !item.TryGetProperty("id", out var idEl)
-                    || idEl.ValueKind != JsonValueKind.String
-                )
-                {
-                    continue;
-                }
+                continue;
+            }
 
-                var id = idEl.GetString();
-                if (string.IsNullOrWhiteSpace(id))
-                {
-                    continue;
-                }
+            var id = idEl.GetString();
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                continue;
+            }
 
-                if (
-                    item.TryGetProperty("supported_endpoints", out var endpoints)
-                    && endpoints.ValueKind == JsonValueKind.Array
-                    && endpoints
-                        .EnumerateArray()
-                        .Any(e =>
-                            e.ValueKind == JsonValueKind.String
-                            && string.Equals(e.GetString(), "/v1/messages", StringComparison.OrdinalIgnoreCase)
-                        )
-                )
-                {
-                    ids.Add(id);
-                }
+            if (
+                item.TryGetProperty("supported_endpoints", out var endpoints)
+                && endpoints.ValueKind == JsonValueKind.Array
+                && endpoints
+                    .EnumerateArray()
+                    .Any(e =>
+                        e.ValueKind == JsonValueKind.String
+                        && string.Equals(e.GetString(), "/v1/messages", StringComparison.OrdinalIgnoreCase)
+                    )
+            )
+            {
+                ids.Add(id);
             }
         }
 
@@ -768,7 +782,15 @@ internal static class ProxyHttp
 
             ctx.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
 
-            await CopyBodyAsync(ctx, upstream, idleTimeout, idleCts, linked, logger);
+            await CopyBodyAsync(
+                ctx,
+                upstream,
+                idleTimeout,
+                idleCts,
+                linked,
+                logger,
+                (c, status, message) => WriteAnthropicErrorAsync(c, status, "api_error", message)
+            );
 
             logger.LogInformation(
                 "{Method} {Path} model {IncomingModel} -> {ResolvedModel} stream={Stream} upstream={Status} {Elapsed}ms",
@@ -783,14 +805,20 @@ internal static class ProxyHttp
         }
     }
 
-    /// <summary>Streams the upstream body to the client with an explicit, incrementally-flushed loop.</summary>
+    /// <summary>
+    ///     Streams the upstream body to the client with an explicit, incrementally-flushed loop.
+    ///     <paramref name="writePreStartError" /> writes a protocol-shaped error envelope (Anthropic-JSON
+    ///     vs. JSON-RPC) if the upstream fails before any bytes reached the client — shared by both the
+    ///     <c>/v1/messages</c> and <c>/mcp</c> paths, which disagree on error shape.
+    /// </summary>
     internal static async Task CopyBodyAsync(
         HttpContext ctx,
         HttpResponseMessage upstream,
         TimeSpan idleTimeout,
         CancellationTokenSource idleCts,
         CancellationTokenSource linked,
-        ILogger logger
+        ILogger logger,
+        Func<HttpContext, int, string, Task> writePreStartError
     )
     {
         var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
@@ -829,10 +857,9 @@ internal static class ProxyHttp
                         logger.LogWarning("Mid-stream upstream failure: {Reason}", ex.Message);
                         if (!ctx.Response.HasStarted)
                         {
-                            await WriteAnthropicErrorAsync(
+                            await writePreStartError(
                                 ctx,
                                 StatusCodes.Status502BadGateway,
-                                "api_error",
                                 "The upstream Copilot stream failed before any data was received."
                             );
                         }
@@ -969,9 +996,11 @@ internal static class ProxyHttp
 /// </summary>
 internal static class ProxyMcp
 {
-    // Everything is forwarded verbatim EXCEPT: Authorization (Copilot auth is attached outbound by
-    // CopilotHeadersHandler instead — the caller's own auth, if any, is never forwarded) and a small
-    // set of hop-by-hop/framing headers that .NET's HttpClient must own (Host, Content-Length,
+    // Everything is forwarded verbatim EXCEPT: Authorization/credential headers (Copilot auth is
+    // attached outbound by CopilotHeadersHandler instead — the caller's own auth, if any, is never
+    // forwarded), the Copilot transport/tracking headers CopilotHeadersHandler owns (it only sets
+    // these when missing, so a caller-supplied value would otherwise silently override them), and a
+    // small set of hop-by-hop/framing headers that .NET's HttpClient must own (Host, Content-Length,
     // Content-Type are handled explicitly, Connection/Transfer-Encoding/etc. are per-hop). Accept-Encoding
     // is also excluded: the shared HttpClient never negotiates compression (SocketsHttpHandler.
     // AutomaticDecompression = None) and CopyResponseHeaders always strips Content-Encoding from the
@@ -979,6 +1008,9 @@ internal static class ProxyMcp
     private static readonly HashSet<string> ExcludedRequestHeaders = new(StringComparer.OrdinalIgnoreCase)
     {
         "Authorization",
+        "x-api-key",
+        "Cookie",
+        "Proxy-Authorization",
         "Host",
         "Content-Length",
         "Content-Type",
@@ -989,6 +1021,15 @@ internal static class ProxyMcp
         "TE",
         "Trailer",
         "Accept-Encoding",
+        "User-Agent",
+        "copilot-integration-id",
+        "editor-version",
+        "x-github-api-version",
+        "x-client-machine-id",
+        "x-client-session-id",
+        "x-interaction-id",
+        "x-interaction-type",
+        "x-initiator",
     };
 
     /// <summary>Forwards GET/POST/DELETE on the MCP endpoint to Copilot and streams the response back.</summary>
@@ -1095,7 +1136,7 @@ internal static class ProxyMcp
 
             ctx.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
 
-            await ProxyHttp.CopyBodyAsync(ctx, upstream, idleTimeout, idleCts, linked, logger);
+            await ProxyHttp.CopyBodyAsync(ctx, upstream, idleTimeout, idleCts, linked, logger, WriteMcpErrorAsync);
 
             logger.LogInformation(
                 "{Method} {Path} mcp-session={SessionId} upstream={Status} {Elapsed}ms",
@@ -1108,7 +1149,11 @@ internal static class ProxyMcp
         }
     }
 
-    /// <summary>Forwards every inbound header verbatim except <see cref="ExcludedRequestHeaders"/> (incl. auth).</summary>
+    /// <summary>
+    ///     Forwards every inbound header verbatim except <see cref="ExcludedRequestHeaders"/> — credentials
+    ///     (<c>Authorization</c>, <c>x-api-key</c>, <c>Cookie</c>, <c>Proxy-Authorization</c>), the Copilot
+    ///     transport/tracking headers <c>CopilotHeadersHandler</c> owns, and hop-by-hop/framing headers.
+    /// </summary>
     private static void ApplyRequestHeaderAllowlist(IHeaderDictionary inbound, HttpRequestMessage upstream)
     {
         foreach (var header in inbound)

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -18,6 +18,8 @@ using Microsoft.Extensions.Primitives;
 // and forwards it to GitHub Copilot. It rewrites ONLY the JSON `model` field to a
 // configured Copilot Claude (Opus) id, attaches Copilot auth/headers via the proven
 // GithubCopilotProvider transport, and streams the SSE response back as raw bytes.
+// It also exposes Copilot's MCP server (Streamable HTTP transport) as a transparent
+// byte-level proxy on /mcp and /mcp/readonly, with Copilot auth attached the same way.
 //
 // Point Claude Code (or any Anthropic-Messages client) at it via ANTHROPIC_BASE_URL.
 // SECURITY: binds to loopback only and attaches the developer's Copilot credentials
@@ -174,6 +176,10 @@ app.MapPost(
     "/v1/messages/count_tokens",
     ctx => ProxyHttp.ForwardAsync(ctx, catalog, config.IdleTimeout, isCountTokens: true)
 );
+
+// GET/POST/DELETE /mcp and /mcp/readonly — transparent MCP (Streamable HTTP) proxy.
+app.MapMethods("/mcp", ["GET", "POST", "DELETE"], ctx => ProxyMcp.ForwardAsync(ctx, config.IdleTimeout));
+app.MapMethods("/mcp/readonly", ["GET", "POST", "DELETE"], ctx => ProxyMcp.ForwardAsync(ctx, config.IdleTimeout));
 
 // Unknown route -> Anthropic-shaped 404.
 app.MapFallback(ctx =>
@@ -773,7 +779,7 @@ internal static class ProxyHttp
     }
 
     /// <summary>Streams the upstream body to the client with an explicit, incrementally-flushed loop.</summary>
-    private static async Task CopyBodyAsync(
+    internal static async Task CopyBodyAsync(
         HttpContext ctx,
         HttpResponseMessage upstream,
         TimeSpan idleTimeout,
@@ -942,6 +948,200 @@ internal static class ProxyHttp
                 last_id = models[^1],
             }
         );
+    }
+}
+
+// =============================================================================
+// MCP (Model Context Protocol) reverse proxy — Streamable HTTP transport
+// =============================================================================
+
+/// <summary>
+///     Transparent reverse proxy for GitHub Copilot's MCP server (Streamable HTTP transport). Forwards
+///     GET/POST/DELETE on <c>/mcp</c> and <c>/mcp/readonly</c> verbatim: no JSON-RPC parsing and no
+///     proxy-side session bookkeeping — the <c>Mcp-Session-Id</c> the upstream server assigns on
+///     <c>initialize</c> is just another response header this proxy copies through, and the caller is
+///     responsible for echoing it back on subsequent requests exactly as it would talk to Copilot
+///     directly.
+/// </summary>
+internal static class ProxyMcp
+{
+    // Everything is forwarded verbatim EXCEPT: Authorization (Copilot auth is attached outbound by
+    // CopilotHeadersHandler instead — the caller's own auth, if any, is never forwarded) and a small
+    // set of hop-by-hop/framing headers that .NET's HttpClient must own (Host, Content-Length,
+    // Content-Type are handled explicitly, Connection/Transfer-Encoding/etc. are per-hop). Accept-Encoding
+    // is also excluded: the shared HttpClient never negotiates compression (SocketsHttpHandler.
+    // AutomaticDecompression = None) and CopyResponseHeaders always strips Content-Encoding from the
+    // response, so forwarding a client's Accept-Encoding would risk an undecodable compressed body.
+    private static readonly HashSet<string> ExcludedRequestHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Authorization",
+        "Host",
+        "Content-Length",
+        "Content-Type",
+        "Transfer-Encoding",
+        "Connection",
+        "Keep-Alive",
+        "Upgrade",
+        "TE",
+        "Trailer",
+        "Accept-Encoding",
+    };
+
+    /// <summary>Forwards GET/POST/DELETE on the MCP endpoint to Copilot and streams the response back.</summary>
+    public static async Task ForwardAsync(HttpContext ctx, TimeSpan idleTimeout)
+    {
+        var services = ctx.RequestServices;
+        var httpClient = services.GetRequiredService<HttpClient>();
+        var logger = services.GetRequiredService<ILoggerFactory>().CreateLogger("CopilotAnthropicProxy");
+        var stopwatch = Stopwatch.StartNew();
+
+        var upstreamPath = ctx.Request.Path.Value + ctx.Request.QueryString.Value;
+        using var upstreamRequest = new HttpRequestMessage(new HttpMethod(ctx.Request.Method), upstreamPath);
+
+        if (string.Equals(ctx.Request.Method, "POST", StringComparison.OrdinalIgnoreCase))
+        {
+            byte[] inboundBody;
+            using (var memory = new MemoryStream())
+            {
+                await ctx.Request.Body.CopyToAsync(memory, ctx.RequestAborted);
+                inboundBody = memory.ToArray();
+            }
+
+            upstreamRequest.Content = new ByteArrayContent(inboundBody);
+            upstreamRequest.Content.Headers.ContentType = MediaTypeHeaderValue.TryParse(
+                ctx.Request.ContentType,
+                out var parsedContentType
+            )
+                ? parsedContentType
+                : new MediaTypeHeaderValue("application/json");
+        }
+
+        ApplyRequestHeaderAllowlist(ctx.Request.Headers, upstreamRequest);
+
+        // Per-request deadlines: link client-abort + a reset-per-read idle timeout, same as /v1/messages.
+        // A standalone GET SSE stream lives as long as the server keeps sending events on it.
+        using var idleCts = new CancellationTokenSource();
+        idleCts.CancelAfter(idleTimeout);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted, idleCts.Token);
+
+        HttpResponseMessage upstream;
+        try
+        {
+            upstream = await httpClient.SendAsync(
+                upstreamRequest,
+                HttpCompletionOption.ResponseHeadersRead,
+                linked.Token
+            );
+        }
+        catch (OperationCanceledException) when (ctx.RequestAborted.IsCancellationRequested)
+        {
+            return; // Client disconnected before we connected; nothing to write.
+        }
+        catch (OperationCanceledException) when (idleCts.IsCancellationRequested)
+        {
+            await WriteMcpErrorAsync(
+                ctx,
+                StatusCodes.Status504GatewayTimeout,
+                "Timed out waiting for the upstream Copilot MCP server to respond."
+            );
+            return;
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Token acquisition failure surfaces from CopilotHeadersHandler before the first byte.
+            logger.LogError("Copilot token acquisition failed: {Reason}", ex.Message);
+            await WriteMcpErrorAsync(
+                ctx,
+                StatusCodes.Status401Unauthorized,
+                "Failed to acquire a GitHub Copilot token. Re-authenticate with the GitHub Copilot CLI or "
+                    + "`gh auth login`, or set GITHUB_COPILOT_TOKEN / GH_TOKEN."
+            );
+            return;
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogError("Upstream MCP connection failed: {Reason}", ex.Message);
+            await WriteMcpErrorAsync(
+                ctx,
+                StatusCodes.Status502BadGateway,
+                "Failed to reach the upstream Copilot MCP server."
+            );
+            return;
+        }
+
+        using (upstream)
+        {
+            // Lock status + headers verbatim (minus hop-by-hop/framing) — this is what carries
+            // Mcp-Session-Id back to the client on the initialize response.
+            ctx.Response.StatusCode = (int)upstream.StatusCode;
+            ProxyHttp.CopyResponseHeaders(upstream, ctx.Response);
+
+            var contentType = upstream.Content.Headers.ContentType;
+            if (contentType is not null)
+            {
+                ctx.Response.ContentType = contentType.ToString();
+            }
+
+            var isSse = string.Equals(contentType?.MediaType, "text/event-stream", StringComparison.OrdinalIgnoreCase);
+            if (isSse)
+            {
+                ctx.Response.Headers["X-Accel-Buffering"] = "no";
+                ctx.Response.Headers.CacheControl = "no-cache";
+            }
+
+            ctx.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
+
+            await ProxyHttp.CopyBodyAsync(ctx, upstream, idleTimeout, idleCts, linked, logger);
+
+            logger.LogInformation(
+                "{Method} {Path} mcp-session={SessionId} upstream={Status} {Elapsed}ms",
+                ctx.Request.Method,
+                ctx.Request.Path,
+                ctx.Request.Headers["Mcp-Session-Id"].FirstOrDefault() ?? "(none)",
+                (int)upstream.StatusCode,
+                stopwatch.ElapsedMilliseconds
+            );
+        }
+    }
+
+    /// <summary>Forwards every inbound header verbatim except <see cref="ExcludedRequestHeaders"/> (incl. auth).</summary>
+    private static void ApplyRequestHeaderAllowlist(IHeaderDictionary inbound, HttpRequestMessage upstream)
+    {
+        foreach (var header in inbound)
+        {
+            if (ExcludedRequestHeaders.Contains(header.Key))
+            {
+                continue;
+            }
+
+            foreach (var value in header.Value)
+            {
+                if (!string.IsNullOrEmpty(value))
+                {
+                    _ = upstream.Headers.TryAddWithoutValidation(header.Key, value);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Writes a JSON-RPC-shaped error for proxy-origin failures (never for upstream responses, which
+    ///     are always passed through verbatim). Per the MCP spec, an error response for input the server
+    ///     could not accept has no <c>id</c>.
+    /// </summary>
+    private static async Task WriteMcpErrorAsync(HttpContext ctx, int status, string message)
+    {
+        if (ctx.Response.HasStarted)
+        {
+            return;
+        }
+
+        ctx.Response.StatusCode = status;
+        ctx.Response.ContentType = "application/json";
+        var payload = JsonSerializer.SerializeToUtf8Bytes(
+            new { jsonrpc = "2.0", error = new { code = -32000, message } }
+        );
+        await ctx.Response.Body.WriteAsync(payload, ctx.RequestAborted);
     }
 }
 

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -179,9 +179,11 @@ app.MapPost(
     ctx => ProxyHttp.ForwardAsync(ctx, catalog, config.IdleTimeout, isCountTokens: true)
 );
 
-// GET/POST/DELETE /mcp and /mcp/readonly — transparent MCP (Streamable HTTP) proxy.
-app.MapMethods("/mcp", ["GET", "POST", "DELETE"], ctx => ProxyMcp.ForwardAsync(ctx, config.IdleTimeout));
-app.MapMethods("/mcp/readonly", ["GET", "POST", "DELETE"], ctx => ProxyMcp.ForwardAsync(ctx, config.IdleTimeout));
+// /mcp and /mcp/readonly — transparent MCP (Streamable HTTP) proxy. Every HTTP method is routed
+// here (not just GET/POST/DELETE) so an unsupported method gets ProxyMcp's own MCP/JSON-RPC-shaped
+// 405, not the shared Anthropic-shaped fallback 404.
+app.Map("/mcp", ctx => ProxyMcp.ForwardAsync(ctx, config.IdleTimeout));
+app.Map("/mcp/readonly", ctx => ProxyMcp.ForwardAsync(ctx, config.IdleTimeout));
 
 // Unknown route -> Anthropic-shaped 404.
 app.MapFallback(ctx =>
@@ -285,7 +287,7 @@ public static class ProxyGuard
             return false;
         }
 
-        return IsAllowedOrigin(origin);
+        return IsAllowedOrigin(origin, port);
     }
 
     /// <summary>Exact loopback Host-header allowlist: bare host or host with the configured port.</summary>
@@ -311,15 +313,20 @@ public static class ProxyGuard
         return false;
     }
 
-    /// <summary>An absent Origin is fine; a present one must resolve to a loopback host.</summary>
-    private static bool IsAllowedOrigin(string? origin)
+    /// <summary>
+    ///     An absent Origin is fine; a present one must be a loopback host on the exact configured port —
+    ///     matching <see cref="IsAllowedHost"/>'s exact-port match, not just any loopback port. Otherwise a
+    ///     page on a different local port (e.g. another dev server, or something malicious) could still
+    ///     satisfy "loopback" and reach this proxy cross-origin.
+    /// </summary>
+    private static bool IsAllowedOrigin(string? origin, int port)
     {
         if (string.IsNullOrEmpty(origin))
         {
             return true;
         }
 
-        if (!Uri.TryCreate(origin, UriKind.Absolute, out var uri))
+        if (!Uri.TryCreate(origin, UriKind.Absolute, out var uri) || uri.Port != port)
         {
             return false;
         }
@@ -1032,9 +1039,21 @@ internal static class ProxyMcp
         "x-initiator",
     };
 
+    private static readonly string[] AllowedMethods = ["GET", "POST", "DELETE"];
+
     /// <summary>Forwards GET/POST/DELETE on the MCP endpoint to Copilot and streams the response back.</summary>
     public static async Task ForwardAsync(HttpContext ctx, TimeSpan idleTimeout)
     {
+        if (!AllowedMethods.Contains(ctx.Request.Method, StringComparer.OrdinalIgnoreCase))
+        {
+            await WriteMcpErrorAsync(
+                ctx,
+                StatusCodes.Status405MethodNotAllowed,
+                $"Unsupported method {ctx.Request.Method}. Use GET, POST, or DELETE."
+            );
+            return;
+        }
+
         var services = ctx.RequestServices;
         var httpClient = services.GetRequiredService<HttpClient>();
         var logger = services.GetRequiredService<ILoggerFactory>().CreateLogger("CopilotAnthropicProxy");

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Primitives;
@@ -44,16 +45,13 @@ builder.WebHost.ConfigureKestrel(options =>
 // Token provider: default to the non-interactive CLI credential provider (re-resolves per
 // request, auto-picks-up re-auth, no permanent cache). Device flow is an explicit opt-in only.
 builder.Services.AddSingleton<ICopilotTokenProvider>(_ =>
-    config.EnableDeviceFlow
-        ? CompositeCopilotTokenProvider.CreateDefault()
-        : new CliCredentialCopilotTokenProvider());
+    config.EnableDeviceFlow ? CompositeCopilotTokenProvider.CreateDefault() : new CliCredentialCopilotTokenProvider()
+);
 
 builder.Services.AddSingleton(new CopilotSessionContext());
-builder.Services.AddSingleton(new CopilotOptions
-{
-    BaseUrl = config.BaseUrl,
-    DefaultInteractionType = "conversation-user",
-});
+builder.Services.AddSingleton(
+    new CopilotOptions { BaseUrl = config.BaseUrl, DefaultInteractionType = "conversation-user" }
+);
 
 // Inner transport handler: a pooled SocketsHttpHandler. AutomaticDecompression is OFF so the proxy
 // relays upstream bytes verbatim (we never re-encode). Tests swap this for a fake handler.
@@ -67,13 +65,16 @@ builder.Services.AddSingleton<HttpMessageHandler>(_ => new SocketsHttpHandler
 // Timeout is INFINITE: HttpClient.Timeout is a total-exchange deadline even with
 // ResponseHeadersRead, so any finite value would silently cap long streams and break the
 // RequestAborted cancellation filter. Per-request deadlines are enforced by a linked CTS instead.
-builder.Services.AddSingleton(sp => CopilotHttpClientFactory.Create(
-    config.BaseUrl,
-    sp.GetRequiredService<ICopilotTokenProvider>(),
-    sp.GetRequiredService<CopilotSessionContext>(),
-    sp.GetRequiredService<CopilotOptions>(),
-    timeout: Timeout.InfiniteTimeSpan,
-    innerHandler: sp.GetService<HttpMessageHandler>()));
+builder.Services.AddSingleton(sp =>
+    CopilotHttpClientFactory.Create(
+        config.BaseUrl,
+        sp.GetRequiredService<ICopilotTokenProvider>(),
+        sp.GetRequiredService<CopilotSessionContext>(),
+        sp.GetRequiredService<CopilotOptions>(),
+        timeout: Timeout.InfiniteTimeSpan,
+        innerHandler: sp.GetService<HttpMessageHandler>()
+    )
+);
 
 var app = builder.Build();
 var logger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("CopilotAnthropicProxy");
@@ -90,70 +91,99 @@ catch (Exception ex) when (ex is InvalidOperationException or OperationCanceledE
 {
     logger.LogError(
         "No GitHub Copilot token could be resolved. Sign in with the GitHub Copilot CLI or `gh auth login`, "
-        + "or set GITHUB_COPILOT_TOKEN / GH_TOKEN, then restart. (set COPILOT_ANTHROPIC_ENABLE_DEVICE_FLOW=1 "
-        + "to allow an interactive device-flow login at startup.) Reason: {Reason}",
-        ex.Message);
+            + "or set GITHUB_COPILOT_TOKEN / GH_TOKEN, then restart. (set COPILOT_ANTHROPIC_ENABLE_DEVICE_FLOW=1 "
+            + "to allow an interactive device-flow login at startup.) Reason: {Reason}",
+        ex.Message
+    );
     return 1;
 }
 
-// 2) Resolve the outbound model id (env wins; else the Copilot `opus` Claude id; else fail fast).
-string resolvedModel;
+// 2) Resolve the outbound model catalog (env wins and pins a single model; else discover every
+//    /v1/messages-capable Copilot model and pick the `opus` Claude id as the default; else fail fast).
+ProxyModelCatalog catalog;
 try
 {
     using var modelCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-    resolvedModel = await ProxyModelResolver.ResolveAsync(
-        app.Services.GetRequiredService<HttpClient>(), config.ModelOverride, logger, modelCts.Token);
+    catalog = await ProxyModelResolver.ResolveAsync(
+        app.Services.GetRequiredService<HttpClient>(),
+        config.ModelOverride,
+        logger,
+        modelCts.Token
+    );
 }
 catch (Exception ex) when (ex is InvalidOperationException or HttpRequestException or OperationCanceledException)
 {
     logger.LogError(
         "Could not resolve a Copilot Opus Claude model. Set COPILOT_ANTHROPIC_MODEL to a model id exposed by "
-        + "GET {BaseUrl}/models. Reason: {Reason}",
-        config.BaseUrl, ex.Message);
+            + "GET {BaseUrl}/models. Reason: {Reason}",
+        config.BaseUrl,
+        ex.Message
+    );
     return 1;
 }
 
 logger.LogInformation(
-    "CopilotAnthropicProxy listening on http://127.0.0.1:{Port} -> {BaseUrl} (model: {Model})",
-    config.Port, config.BaseUrl, resolvedModel);
+    "CopilotAnthropicProxy listening on http://127.0.0.1:{Port} -> {BaseUrl} (default model: {Model}, "
+        + "{Count} available)",
+    config.Port,
+    config.BaseUrl,
+    catalog.Default,
+    catalog.Available.Count
+);
 
 // --- Pipeline ----------------------------------------------------------------
 // Host/loopback/cross-site guard runs FIRST.
-app.Use(async (ctx, next) =>
-{
-    if (!ProxyGuard.IsAllowed(
-        ctx.Connection.RemoteIpAddress,
-        ctx.Request.Headers.Host,
-        ctx.Request.Headers.Origin,
-        ctx.Request.Headers["Sec-Fetch-Site"],
-        config.Port))
+app.Use(
+    async (ctx, next) =>
     {
-        await ProxyHttp.WriteAnthropicErrorAsync(
-            ctx, StatusCodes.Status403Forbidden, "permission_error",
-            "This proxy only accepts loopback requests from a same-origin client.");
-        return;
+        if (
+            !ProxyGuard.IsAllowed(
+                ctx.Connection.RemoteIpAddress,
+                ctx.Request.Headers.Host,
+                ctx.Request.Headers.Origin,
+                ctx.Request.Headers["Sec-Fetch-Site"],
+                config.Port
+            )
+        )
+        {
+            await ProxyHttp.WriteAnthropicErrorAsync(
+                ctx,
+                StatusCodes.Status403Forbidden,
+                "permission_error",
+                "This proxy only accepts loopback requests from a same-origin client."
+            );
+            return;
+        }
+
+        await next(ctx);
     }
+);
 
-    await next(ctx);
-});
+app.MapGet("/health", () => Results.Ok(new { status = "healthy", model = catalog.Default }));
 
-app.MapGet("/health", () => Results.Ok(new { status = "healthy", model = resolvedModel }));
-
-// GET /v1/models — Anthropic-shaped stub advertising the single resolved model.
-app.MapGet("/v1/models", () => Results.Content(
-    ProxyHttp.BuildModelsStub(resolvedModel), "application/json", Encoding.UTF8));
+// GET /v1/models — Anthropic-shaped list of every available (/v1/messages-capable) model.
+app.MapGet(
+    "/v1/models",
+    () => Results.Content(ProxyHttp.BuildModelsStub(catalog.Available), "application/json", Encoding.UTF8)
+);
 
 // POST /v1/messages and /v1/messages/count_tokens — the forward path.
-app.MapPost("/v1/messages", ctx =>
-    ProxyHttp.ForwardAsync(ctx, resolvedModel, config.IdleTimeout, isCountTokens: false));
+app.MapPost("/v1/messages", ctx => ProxyHttp.ForwardAsync(ctx, catalog, config.IdleTimeout, isCountTokens: false));
 
-app.MapPost("/v1/messages/count_tokens", ctx =>
-    ProxyHttp.ForwardAsync(ctx, resolvedModel, config.IdleTimeout, isCountTokens: true));
+app.MapPost(
+    "/v1/messages/count_tokens",
+    ctx => ProxyHttp.ForwardAsync(ctx, catalog, config.IdleTimeout, isCountTokens: true)
+);
 
 // Unknown route -> Anthropic-shaped 404.
-app.MapFallback(ctx => ProxyHttp.WriteAnthropicErrorAsync(
-    ctx, StatusCodes.Status404NotFound, "not_found_error",
-    $"Unknown route: {ctx.Request.Method} {ctx.Request.Path}"));
+app.MapFallback(ctx =>
+    ProxyHttp.WriteAnthropicErrorAsync(
+        ctx,
+        StatusCodes.Status404NotFound,
+        "not_found_error",
+        $"Unknown route: {ctx.Request.Method} {ctx.Request.Path}"
+    )
+);
 
 await app.RunAsync();
 return 0;
@@ -176,10 +206,12 @@ internal sealed record ProxyConfig
         return new ProxyConfig
         {
             Port = ParseInt(Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_PORT"), 8787),
-            BaseUrl = NullIfBlank(Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_BASE_URL"))
+            BaseUrl =
+                NullIfBlank(Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_BASE_URL"))
                 ?? CopilotOptions.DefaultBaseUrl,
             IdleTimeout = TimeSpan.FromSeconds(
-                ParseInt(Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_IDLE_TIMEOUT_SECONDS"), 120)),
+                ParseInt(Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_IDLE_TIMEOUT_SECONDS"), 120)
+            ),
             EnableDeviceFlow = ParseBool(Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_ENABLE_DEVICE_FLOW")),
             ModelOverride = NullIfBlank(Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_MODEL")),
         };
@@ -194,9 +226,11 @@ internal sealed record ProxyConfig
 
     private static bool ParseBool(string? value) =>
         value is not null
-        && (value.Equals("1", StringComparison.OrdinalIgnoreCase)
+        && (
+            value.Equals("1", StringComparison.OrdinalIgnoreCase)
             || value.Equals("true", StringComparison.OrdinalIgnoreCase)
-            || value.Equals("yes", StringComparison.OrdinalIgnoreCase));
+            || value.Equals("yes", StringComparison.OrdinalIgnoreCase)
+        );
 }
 
 // =============================================================================
@@ -236,8 +270,9 @@ public static class ProxyGuard
             return false;
         }
 
-        if (!string.IsNullOrEmpty(secFetchSite)
-            && secFetchSite.Equals("cross-site", StringComparison.OrdinalIgnoreCase))
+        if (
+            !string.IsNullOrEmpty(secFetchSite) && secFetchSite.Equals("cross-site", StringComparison.OrdinalIgnoreCase)
+        )
         {
             return false;
         }
@@ -256,8 +291,10 @@ public static class ProxyGuard
         var portSuffix = ":" + port.ToString(CultureInfo.InvariantCulture);
         foreach (var allowed in LoopbackHostNames)
         {
-            if (host.Equals(allowed, StringComparison.OrdinalIgnoreCase)
-                || host.Equals(allowed + portSuffix, StringComparison.OrdinalIgnoreCase))
+            if (
+                host.Equals(allowed, StringComparison.OrdinalIgnoreCase)
+                || host.Equals(allowed + portSuffix, StringComparison.OrdinalIgnoreCase)
+            )
             {
                 return true;
             }
@@ -293,39 +330,83 @@ public static class ProxyGuard
 // Model resolution + request rewrite (pure where possible)
 // =============================================================================
 
-/// <summary>Resolves the outbound Copilot model id and rewrites the inbound request's model field.</summary>
+/// <summary>
+///     The resolved outbound model set: <see cref="Default"/> is used when a request's model is missing or
+///     unrecognized; <see cref="Available"/> lists every model the proxy will pass through unchanged.
+/// </summary>
+public sealed record ProxyModelCatalog(string Default, IReadOnlyList<string> Available);
+
+/// <summary>Resolves the outbound Copilot model catalog and rewrites the inbound request's model field.</summary>
 public static class ProxyModelResolver
 {
     /// <summary>
-    ///     Resolves the model id: <c>COPILOT_ANTHROPIC_MODEL</c> override wins; otherwise queries
-    ///     <c>GET /models</c> and picks the <c>opus</c> Claude id; otherwise throws (caller fails fast).
+    ///     Resolves the model catalog: <c>COPILOT_ANTHROPIC_MODEL</c> override wins and pins a single model
+    ///     (no discovery, no passthrough); otherwise queries <c>GET /models</c>, filters to the ids that
+    ///     support <c>/v1/messages</c>, and picks the <c>opus</c> Claude id as the default. Throws when no
+    ///     override is set and no opus Claude id is available (caller fails fast).
     /// </summary>
-    public static async Task<string> ResolveAsync(
-        HttpClient client, string? modelOverride, ILogger logger, CancellationToken cancellationToken)
+    public static async Task<ProxyModelCatalog> ResolveAsync(
+        HttpClient client,
+        string? modelOverride,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
     {
         ArgumentNullException.ThrowIfNull(client);
 
         if (!string.IsNullOrWhiteSpace(modelOverride))
         {
-            return modelOverride.Trim();
+            var pinned = modelOverride.Trim();
+            return new ProxyModelCatalog(pinned, [pinned]);
         }
 
         using var response = await client.GetAsync("/models", cancellationToken);
         _ = response.EnsureSuccessStatusCode();
         var json = await response.Content.ReadAsStringAsync(cancellationToken);
-        var ids = ParseModelIds(json);
+        var availableIds = ParseMessagesCapableModelIds(json);
 
-        var claudeIds = ids.Where(id => id.Contains("claude", StringComparison.OrdinalIgnoreCase)).ToList();
-        var opus = claudeIds.FirstOrDefault(id => id.Contains("opus", StringComparison.OrdinalIgnoreCase));
+        var claudeIds = availableIds.Where(id => id.Contains("claude", StringComparison.OrdinalIgnoreCase)).ToList();
+        var opus = PickHighestVersionOpusId(claudeIds);
         if (opus is not null)
         {
-            return opus;
+            return new ProxyModelCatalog(opus, availableIds);
         }
 
         throw new InvalidOperationException(
             "No Copilot 'opus' Claude model was found. Available Claude models: "
-            + (claudeIds.Count > 0 ? string.Join(", ", claudeIds) : "(none)")
-            + ". Set COPILOT_ANTHROPIC_MODEL to the exact id you want.");
+                + (claudeIds.Count > 0 ? string.Join(", ", claudeIds) : "(none)")
+                + ". Set COPILOT_ANTHROPIC_MODEL to the exact id you want."
+        );
+    }
+
+    /// <summary>
+    ///     Picks the <c>opus</c> Claude id with the numerically highest version suffix (e.g.
+    ///     <c>claude-opus-4.8</c> over <c>claude-opus-4.6</c>), rather than relying on upstream list
+    ///     order — Copilot has shipped multiple concurrent opus versions, and list order is not
+    ///     guaranteed to be oldest/newest-first.
+    /// </summary>
+    public static string? PickHighestVersionOpusId(IReadOnlyList<string> claudeIds)
+    {
+        return claudeIds
+            .Where(id => id.Contains("opus", StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(ExtractOpusVersion)
+            .FirstOrDefault();
+    }
+
+    private static readonly Regex OpusVersionSuffixPattern = new(@"^\d+(?:\.\d+)*", RegexOptions.Compiled);
+
+    private static Version ExtractOpusVersion(string id)
+    {
+        var opusIndex = id.IndexOf("opus", StringComparison.OrdinalIgnoreCase);
+        var rest = id[(opusIndex + "opus".Length)..].TrimStart('-', '_', '.');
+        var match = OpusVersionSuffixPattern.Match(rest);
+        if (!match.Success)
+        {
+            return new Version(0, 0);
+        }
+
+        var versionText = match.Value.Contains('.') ? match.Value : match.Value + ".0";
+        return Version.Parse(versionText);
     }
 
     /// <summary>Extracts model ids from an OpenAI-shaped (<c>{"data":[{"id":...}]}</c>) or bare-array list.</summary>
@@ -340,9 +421,11 @@ public static class ProxyModelResolver
         {
             foreach (var item in list.EnumerateArray())
             {
-                if (item.ValueKind == JsonValueKind.Object
+                if (
+                    item.ValueKind == JsonValueKind.Object
                     && item.TryGetProperty("id", out var idEl)
-                    && idEl.ValueKind == JsonValueKind.String)
+                    && idEl.ValueKind == JsonValueKind.String
+                )
                 {
                     var id = idEl.GetString();
                     if (!string.IsNullOrWhiteSpace(id))
@@ -354,6 +437,109 @@ public static class ProxyModelResolver
         }
 
         return ids;
+    }
+
+    /// <summary>
+    ///     Extracts ids for models whose <c>supported_endpoints</c> includes <c>/v1/messages</c> — the only
+    ///     ones this Anthropic-Messages-shaped proxy can forward to. Copilot also serves GPT/Gemini models
+    ///     that only support <c>/responses</c> or <c>/chat/completions</c>; those are excluded.
+    /// </summary>
+    public static IReadOnlyList<string> ParseMessagesCapableModelIds(string json)
+    {
+        var ids = new List<string>();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        var list = root.ValueKind == JsonValueKind.Object && root.TryGetProperty("data", out var data) ? data : root;
+
+        if (list.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in list.EnumerateArray())
+            {
+                if (
+                    item.ValueKind != JsonValueKind.Object
+                    || !item.TryGetProperty("id", out var idEl)
+                    || idEl.ValueKind != JsonValueKind.String
+                )
+                {
+                    continue;
+                }
+
+                var id = idEl.GetString();
+                if (string.IsNullOrWhiteSpace(id))
+                {
+                    continue;
+                }
+
+                if (
+                    item.TryGetProperty("supported_endpoints", out var endpoints)
+                    && endpoints.ValueKind == JsonValueKind.Array
+                    && endpoints
+                        .EnumerateArray()
+                        .Any(e =>
+                            e.ValueKind == JsonValueKind.String
+                            && string.Equals(e.GetString(), "/v1/messages", StringComparison.OrdinalIgnoreCase)
+                        )
+                )
+                {
+                    ids.Add(id);
+                }
+            }
+        }
+
+        return ids;
+    }
+
+    /// <summary>
+    ///     Picks the outbound model for a single request: <paramref name="incomingModel"/> passes through
+    ///     unchanged (normalized to the catalog's exact casing) when it matches one of
+    ///     <paramref name="catalog"/>'s available ids; otherwise falls back to the catalog's default.
+    /// </summary>
+    public static string SelectOutboundModel(string? incomingModel, ProxyModelCatalog catalog)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+
+        if (!string.IsNullOrWhiteSpace(incomingModel))
+        {
+            var match = catalog.Available.FirstOrDefault(id =>
+                string.Equals(id, incomingModel, StringComparison.OrdinalIgnoreCase)
+            );
+            if (match is not null)
+            {
+                return match;
+            }
+        }
+
+        return catalog.Default;
+    }
+
+    /// <summary>Peeks at the JSON body's <c>model</c> field without mutating it. Null on any parse failure.</summary>
+    public static string? PeekModel(byte[] body)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+
+        if (body.Length == 0)
+        {
+            return null;
+        }
+
+        try
+        {
+            if (
+                JsonNode.Parse(body) is JsonObject obj
+                && obj.TryGetPropertyValue("model", out var existing)
+                && existing is JsonValue value
+                && value.TryGetValue<string>(out var modelString)
+            )
+            {
+                return modelString;
+            }
+        }
+        catch (JsonException)
+        {
+            // Malformed body — ForwardAsync's TryRewriteModel call will surface the 400.
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -390,9 +576,11 @@ public static class ProxyModelResolver
             return false;
         }
 
-        if (obj.TryGetPropertyValue("model", out var existing)
+        if (
+            obj.TryGetPropertyValue("model", out var existing)
             && existing is JsonValue value
-            && value.TryGetValue<string>(out var modelString))
+            && value.TryGetValue<string>(out var modelString)
+        )
         {
             incomingModel = modelString;
         }
@@ -416,12 +604,26 @@ internal static class ProxyHttp
     // Content-Type is copied separately from the content headers.
     private static readonly HashSet<string> ExcludedResponseHeaders = new(StringComparer.OrdinalIgnoreCase)
     {
-        "Content-Length", "Transfer-Encoding", "Connection", "Keep-Alive", "Upgrade", "TE",
-        "Trailer", "Proxy-Authenticate", "Proxy-Authorization", "Content-Encoding", "Content-Type",
+        "Content-Length",
+        "Transfer-Encoding",
+        "Connection",
+        "Keep-Alive",
+        "Upgrade",
+        "TE",
+        "Trailer",
+        "Proxy-Authenticate",
+        "Proxy-Authorization",
+        "Content-Encoding",
+        "Content-Type",
     };
 
     /// <summary>Forwards POST /v1/messages (and count_tokens) to Copilot and streams the response back.</summary>
-    public static async Task ForwardAsync(HttpContext ctx, string model, TimeSpan idleTimeout, bool isCountTokens)
+    public static async Task ForwardAsync(
+        HttpContext ctx,
+        ProxyModelCatalog catalog,
+        TimeSpan idleTimeout,
+        bool isCountTokens
+    )
     {
         var services = ctx.RequestServices;
         var httpClient = services.GetRequiredService<HttpClient>();
@@ -436,12 +638,20 @@ internal static class ProxyHttp
             inboundBody = memory.ToArray();
         }
 
-        // 2) Rewrite the model field (raw JSON). Parse failure -> 400 (do NOT call upstream).
-        if (!ProxyModelResolver.TryRewriteModel(inboundBody, model, out var outboundBody, out var incomingModel))
+        // 2) Pass the requested model through unchanged when it's one of the available ids; otherwise fall
+        //    back to the catalog's default. Then rewrite the body (raw JSON). Parse failure -> 400 (do NOT
+        //    call upstream).
+        var outboundModel = ProxyModelResolver.SelectOutboundModel(ProxyModelResolver.PeekModel(inboundBody), catalog);
+        if (
+            !ProxyModelResolver.TryRewriteModel(inboundBody, outboundModel, out var outboundBody, out var incomingModel)
+        )
         {
             await WriteAnthropicErrorAsync(
-                ctx, StatusCodes.Status400BadRequest, "invalid_request_error",
-                "Request body must be a non-empty JSON object.");
+                ctx,
+                StatusCodes.Status400BadRequest,
+                "invalid_request_error",
+                "Request body must be a non-empty JSON object."
+            );
             return;
         }
 
@@ -464,7 +674,10 @@ internal static class ProxyHttp
         try
         {
             upstream = await httpClient.SendAsync(
-                upstreamRequest, HttpCompletionOption.ResponseHeadersRead, linked.Token);
+                upstreamRequest,
+                HttpCompletionOption.ResponseHeadersRead,
+                linked.Token
+            );
         }
         catch (OperationCanceledException) when (ctx.RequestAborted.IsCancellationRequested)
         {
@@ -473,8 +686,11 @@ internal static class ProxyHttp
         catch (OperationCanceledException) when (idleCts.IsCancellationRequested)
         {
             await WriteAnthropicErrorAsync(
-                ctx, StatusCodes.Status504GatewayTimeout, "api_error",
-                "Timed out waiting for the upstream Copilot API to respond.");
+                ctx,
+                StatusCodes.Status504GatewayTimeout,
+                "api_error",
+                "Timed out waiting for the upstream Copilot API to respond."
+            );
             return;
         }
         catch (InvalidOperationException ex)
@@ -482,30 +698,43 @@ internal static class ProxyHttp
             // Token acquisition failure surfaces from CopilotHeadersHandler before the first byte.
             logger.LogError("Copilot token acquisition failed: {Reason}", ex.Message);
             await WriteAnthropicErrorAsync(
-                ctx, StatusCodes.Status401Unauthorized, "authentication_error",
+                ctx,
+                StatusCodes.Status401Unauthorized,
+                "authentication_error",
                 "Failed to acquire a GitHub Copilot token. Re-authenticate with the GitHub Copilot CLI or "
-                + "`gh auth login`, or set GITHUB_COPILOT_TOKEN / GH_TOKEN.");
+                    + "`gh auth login`, or set GITHUB_COPILOT_TOKEN / GH_TOKEN."
+            );
             return;
         }
         catch (HttpRequestException ex)
         {
             logger.LogError("Upstream connection failed: {Reason}", ex.Message);
             await WriteAnthropicErrorAsync(
-                ctx, StatusCodes.Status502BadGateway, "api_error",
-                "Failed to reach the upstream Copilot API.");
+                ctx,
+                StatusCodes.Status502BadGateway,
+                "api_error",
+                "Failed to reach the upstream Copilot API."
+            );
             return;
         }
 
         using (upstream)
         {
             // count_tokens: normalize an unsupported endpoint (404/405) to an Anthropic not_found_error.
-            if (isCountTokens
-                && (upstream.StatusCode == HttpStatusCode.NotFound
-                    || upstream.StatusCode == HttpStatusCode.MethodNotAllowed))
+            if (
+                isCountTokens
+                && (
+                    upstream.StatusCode == HttpStatusCode.NotFound
+                    || upstream.StatusCode == HttpStatusCode.MethodNotAllowed
+                )
+            )
             {
                 await WriteAnthropicErrorAsync(
-                    ctx, StatusCodes.Status404NotFound, "not_found_error",
-                    "The upstream Copilot API does not support /v1/messages/count_tokens.");
+                    ctx,
+                    StatusCodes.Status404NotFound,
+                    "not_found_error",
+                    "The upstream Copilot API does not support /v1/messages/count_tokens."
+                );
                 return;
             }
 
@@ -532,8 +761,14 @@ internal static class ProxyHttp
 
             logger.LogInformation(
                 "{Method} {Path} model {IncomingModel} -> {ResolvedModel} stream={Stream} upstream={Status} {Elapsed}ms",
-                ctx.Request.Method, upstreamPath, incomingModel ?? "(none)", model, isSse,
-                (int)upstream.StatusCode, stopwatch.ElapsedMilliseconds);
+                ctx.Request.Method,
+                upstreamPath,
+                incomingModel ?? "(none)",
+                outboundModel,
+                isSse,
+                (int)upstream.StatusCode,
+                stopwatch.ElapsedMilliseconds
+            );
         }
     }
 
@@ -544,7 +779,8 @@ internal static class ProxyHttp
         TimeSpan idleTimeout,
         CancellationTokenSource idleCts,
         CancellationTokenSource linked,
-        ILogger logger)
+        ILogger logger
+    )
     {
         var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
         try
@@ -583,8 +819,11 @@ internal static class ProxyHttp
                         if (!ctx.Response.HasStarted)
                         {
                             await WriteAnthropicErrorAsync(
-                                ctx, StatusCodes.Status502BadGateway, "api_error",
-                                "The upstream Copilot stream failed before any data was received.");
+                                ctx,
+                                StatusCodes.Status502BadGateway,
+                                "api_error",
+                                "The upstream Copilot stream failed before any data was received."
+                            );
                         }
 
                         return;
@@ -674,35 +913,36 @@ internal static class ProxyHttp
 
         ctx.Response.StatusCode = status;
         ctx.Response.ContentType = "application/json";
-        var payload = JsonSerializer.SerializeToUtf8Bytes(new
-        {
-            type = "error",
-            error = new { type, message },
-        });
+        var payload = JsonSerializer.SerializeToUtf8Bytes(new { type = "error", error = new { type, message } });
         await ctx.Response.Body.WriteAsync(payload, ctx.RequestAborted);
     }
 
-    /// <summary>Builds the Anthropic-shaped GET /v1/models stub advertising the single resolved model.</summary>
-    public static string BuildModelsStub(string model)
+    /// <summary>
+    ///     Builds the Anthropic-shaped GET /v1/models response listing every available model.
+    ///     <paramref name="models"/> must be non-empty (the catalog always resolves at least one).
+    /// </summary>
+    public static string BuildModelsStub(IReadOnlyList<string> models)
     {
-        return JsonSerializer.Serialize(new
-        {
-            data = new[]
+        var data = models
+            .Select(model => new
             {
-                new
-                {
-                    type = "model",
-                    id = model,
-                    display_name = model,
-                    created_at = "2025-01-01T00:00:00Z",
-                },
-            },
-            has_more = false,
-            first_id = model,
-            last_id = model,
-        });
-    }
+                type = "model",
+                id = model,
+                display_name = model,
+                created_at = "2025-01-01T00:00:00Z",
+            })
+            .ToArray();
 
+        return JsonSerializer.Serialize(
+            new
+            {
+                data,
+                has_more = false,
+                first_id = models[0],
+                last_id = models[^1],
+            }
+        );
+    }
 }
 
 /// <summary>Exposed so <c>WebApplicationFactory&lt;Program&gt;</c> can boot this host in tests.</summary>

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -15,9 +15,11 @@ using Microsoft.Extensions.Primitives;
 // CopilotAnthropicProxy.Sample
 //
 // A thin, loopback-only reverse proxy that accepts the Anthropic Messages API
-// and forwards it to GitHub Copilot. It rewrites ONLY the JSON `model` field to a
-// configured Copilot Claude (Opus) id, attaches Copilot auth/headers via the proven
-// GithubCopilotProvider transport, and streams the SSE response back as raw bytes.
+// and forwards it to GitHub Copilot. It rewrites the JSON `model` field to a
+// configured Copilot Claude (Opus) id, strips the `context_management` field and the
+// `anthropic-beta` header (both unsupported by Copilot's backend), attaches Copilot
+// auth/headers via the proven GithubCopilotProvider transport, and streams the SSE
+// response back as raw bytes.
 // It also exposes Copilot's MCP server (Streamable HTTP transport) as a transparent
 // byte-level proxy on /mcp and /mcp/readonly, with Copilot auth attached the same way.
 //
@@ -549,9 +551,11 @@ public static class ProxyModelResolver
     }
 
     /// <summary>
-    ///     Raw <see cref="JsonNode"/> rewrite of the <c>model</c> field (overwrite or inject). Never
-    ///     deserializes to a typed DTO, so <c>cache_control</c>, <c>thinking</c>, <c>system</c> blocks,
-    ///     betas, and unknown fields are preserved verbatim.
+    ///     Raw <see cref="JsonNode"/> rewrite of the request body: sets/injects <c>model</c> and strips
+    ///     the top-level <c>context_management</c> field (Copilot's backend rejects it outright with
+    ///     <c>"context_management: Extra inputs are not permitted"</c>, so it can never be forwarded).
+    ///     Never deserializes to a typed DTO, so <c>cache_control</c>, <c>thinking</c>, <c>system</c>
+    ///     blocks, and every other unknown field are preserved verbatim.
     /// </summary>
     /// <returns>True on success; false when the body is missing, not JSON, or not a JSON object.</returns>
     public static bool TryRewriteModel(byte[] body, string model, out byte[] rewritten, out string? incomingModel)
@@ -592,6 +596,7 @@ public static class ProxyModelResolver
         }
 
         obj["model"] = model;
+        _ = obj.Remove("context_management");
         rewritten = JsonSerializer.SerializeToUtf8Bytes(obj);
         return true;
     }
@@ -861,7 +866,14 @@ internal static class ProxyHttp
         }
     }
 
-    /// <summary>Copies the positive request-header allowlist (anthropic-version + anthropic-beta) only.</summary>
+    /// <summary>
+    ///     Copies the positive request-header allowlist: only <c>anthropic-version</c> is forwarded (a
+    ///     default is injected when absent). <c>anthropic-beta</c> is intentionally dropped, never
+    ///     forwarded — Copilot's backend rejects the whole request with a 400 if it doesn't recognize
+    ///     every single value in the header (e.g. Claude Code's evolving beta set routinely includes
+    ///     values Copilot hasn't caught up to), so passing it through breaks requests Copilot would
+    ///     otherwise serve fine.
+    /// </summary>
     public static void ApplyRequestHeaderAllowlist(IHeaderDictionary inbound, HttpRequestMessage upstream)
     {
         var version = inbound["anthropic-version"];
@@ -877,14 +889,6 @@ internal static class ProxyHttp
                 {
                     _ = upstream.Headers.TryAddWithoutValidation("anthropic-version", value);
                 }
-            }
-        }
-
-        foreach (var value in inbound["anthropic-beta"])
-        {
-            if (!string.IsNullOrEmpty(value))
-            {
-                _ = upstream.Headers.TryAddWithoutValidation("anthropic-beta", value);
             }
         }
     }

--- a/samples/CopilotAnthropicProxy.Sample/README.md
+++ b/samples/CopilotAnthropicProxy.Sample/README.md
@@ -22,6 +22,8 @@ What it does, end to end:
    terminal frames: it returns a `502` when nothing has been sent yet, otherwise it stops and closes
    the (now incomplete) stream — the client detects the truncation from the missing `message_stop`,
    exactly as it would if the upstream connection had dropped directly.
+5. Also transparently exposes Copilot's **MCP server** on `/mcp` and `/mcp/readonly` — see
+   "Exposing Copilot's MCP server" below.
 
 > [!WARNING]
 > **Local development only.** This proxy has **no inbound authentication** but attaches **your**
@@ -106,6 +108,33 @@ dotnet run --project samples/LmStreaming.Sample
 value is honored when `COPILOT_ANTHROPIC_MODEL` is unset and it matches one of the models the proxy
 discovered from Copilot (see "Choosing the model"); otherwise it's rewritten to the resolved default.
 
+## Exposing Copilot's MCP server
+
+The same proxy also transparently exposes GitHub Copilot's **MCP server** (Streamable HTTP
+transport) on:
+
+- `GET` / `POST` / `DELETE` `/mcp` — the full read/write toolset
+- `GET` / `POST` / `DELETE` `/mcp/readonly` — the read-only toolset
+
+This is a **byte-level reverse proxy**, not an MCP-aware reimplementation: there's no JSON-RPC
+parsing and no proxy-side session bookkeeping. Point any MCP Streamable-HTTP client at
+`http://127.0.0.1:8787/mcp` (or `/mcp/readonly`) exactly as you would point it at
+`https://api.enterprise.githubcopilot.com/mcp` (or `/mcp/readonly`) directly — request/response
+bodies, status codes, and headers are relayed verbatim, including SSE responses (same raw-byte
+streaming as `/v1/messages`).
+
+**Header policy**: every inbound header is forwarded verbatim **except** `Authorization` (the
+proxy attaches its own Copilot bearer token instead, via the same `CopilotHeadersHandler` used for
+`/v1/messages`) and a handful of hop-by-hop/framing headers .NET's `HttpClient` must own
+(`Host`, `Content-Length`, `Content-Type`, `Connection`, `Transfer-Encoding`, `Keep-Alive`,
+`Upgrade`, `TE`, `Trailer`, `Accept-Encoding`). This means `Mcp-Session-Id`,
+`Mcp-Protocol-Version`, `Last-Event-ID`, and Copilot's `X-MCP-*` tool-filtering headers
+(`X-MCP-Readonly`, `X-MCP-Toolsets`, `X-MCP-Tools`, `X-MCP-Exclude-Tools`, `X-MCP-Features`,
+`X-MCP-Lockdown`, `X-MCP-Insiders`, `X-MCP-Host`, and any future ones) all pass through untouched
+— the proxy never needs to know Copilot's MCP header vocabulary in advance. Like the rest of the
+proxy, no inbound auth is required to reach `/mcp*`; it's covered by the same loopback +
+host/cross-site guard described in the warning above.
+
 ### Troubleshooting the base URL
 
 | Symptom (request that reaches the proxy) | Cause | Fix |
@@ -151,3 +180,6 @@ list**: `ModeToolFilter.FilterBuiltInTools` returns `null` for an empty tool set
 - **No synthetic `count_tokens` estimator.** `count_tokens` is best-effort pass-through; an
   unsupported upstream (404/405) is normalized to an Anthropic `not_found_error`.
 - **No inbound auth, TLS, or CORS** beyond the loopback + host/cross-site guard.
+- **No MCP session bookkeeping or resumability logic.** The proxy relays `Mcp-Session-Id` and
+  `Last-Event-ID` verbatim but never inspects, persists, or validates them — session lifecycle is
+  entirely between the client and Copilot.

--- a/samples/CopilotAnthropicProxy.Sample/README.md
+++ b/samples/CopilotAnthropicProxy.Sample/README.md
@@ -9,9 +9,11 @@ What it does, end to end:
 
 1. Accepts `POST /v1/messages` (streaming and non-streaming), `POST /v1/messages/count_tokens`, and
    `GET /v1/models`.
-2. Rewrites **only** the JSON `model` field of the request body to a configured Copilot Claude (Opus)
-   id. Everything else — `system` blocks, `cache_control`, `thinking`, `tools`, betas, and unknown
-   fields — is preserved verbatim (raw `JsonNode` swap, never a typed DTO).
+2. Rewrites **only** the JSON `model` field of the request body: if it names a model the proxy knows
+   about (see "Choosing the model" below), it passes through unchanged; otherwise it's rewritten to
+   the resolved default Copilot Claude (Opus) id. Everything else — `system` blocks, `cache_control`,
+   `thinking`, `tools`, betas, and unknown fields — is preserved verbatim (raw `JsonNode` swap, never
+   a typed DTO).
 3. Attaches Copilot auth + tracking headers using the proven `GithubCopilotProvider` transport
    (`CopilotHttpClientFactory` / `CopilotHeadersHandler` / the CLI credential token provider).
 4. Streams the upstream Server-Sent-Events response straight back to the client as **raw bytes**
@@ -42,22 +44,36 @@ What it does, end to end:
 dotnet run --project samples/CopilotAnthropicProxy.Sample
 ```
 
-On startup the proxy logs the resolved model and the listen address, e.g.:
+On startup the proxy logs the resolved default model, how many models are available, and the listen
+address, e.g.:
 
 ```
-CopilotAnthropicProxy listening on http://127.0.0.1:8787 -> https://api.enterprise.githubcopilot.com (model: <resolved-opus-id>)
+CopilotAnthropicProxy listening on http://127.0.0.1:8787 -> https://api.enterprise.githubcopilot.com (default model: <resolved-opus-id>, 7 available)
 ```
 
 ### Choosing the model
 
-The outbound model id is resolved at startup in this order:
+The proxy resolves an outbound **model catalog** (a default id plus the full set of available ids)
+at startup in one of two modes:
 
-1. `COPILOT_ANTHROPIC_MODEL` if set (wins outright).
-2. Otherwise the proxy queries Copilot `GET /models` and picks the Claude id containing `opus`.
-3. Otherwise it **fails fast** and logs the available Claude model ids so you can pick one and set
-   `COPILOT_ANTHROPIC_MODEL` explicitly.
+1. **Pinned** — `COPILOT_ANTHROPIC_MODEL` is set. The catalog is just that one id (both default and
+   only available entry); Copilot's `/models` endpoint is never queried, and **every** request is
+   rewritten to it regardless of what `model` the client sent — this matches the proxy's original
+   single-model behavior.
+2. **Discovered** — `COPILOT_ANTHROPIC_MODEL` is unset. The proxy queries Copilot `GET /models` and
+   keeps every model whose `supported_endpoints` includes `/v1/messages` (the only ones this
+   Anthropic-Messages-shaped proxy can forward to — Copilot's GPT/Gemini models are excluded). The
+   default is the Claude id containing `opus`; if none is found, the proxy **fails fast** and logs
+   the available Claude ids so you can set `COPILOT_ANTHROPIC_MODEL` explicitly. Copilot can expose
+   multiple concurrent `opus` ids at once (e.g. `claude-opus-4.6`, `claude-opus-4.7`,
+   `claude-opus-4.8`); the proxy picks the one with the numerically highest version suffix — not
+   just the first one Copilot happens to list — so the default always tracks the newest opus model.
+   In this mode, a request whose `model` field exactly matches (case-insensitively) one of the
+   discovered ids is forwarded **unchanged** (normalized to the catalog's casing); anything else
+   falls back to the default.
 
-`GET /v1/models` on the proxy returns an Anthropic-shaped stub advertising the single resolved id.
+`GET /v1/models` on the proxy returns an Anthropic-shaped list of every id in the catalog (one entry
+in pinned mode, every discovered `/v1/messages`-capable id in discovered mode).
 
 ## Point a client at the proxy
 
@@ -87,7 +103,8 @@ dotnet run --project samples/LmStreaming.Sample
 
 `ANTHROPIC_API_KEY` is required by clients but ignored by the proxy (the inbound `x-api-key` /
 `Authorization` are **not** forwarded; Copilot auth is attached outbound). The `ANTHROPIC_MODEL`
-value is also ignored — the proxy always rewrites it to the configured Copilot model.
+value is honored when `COPILOT_ANTHROPIC_MODEL` is unset and it matches one of the models the proxy
+discovered from Copilot (see "Choosing the model"); otherwise it's rewritten to the resolved default.
 
 ### Troubleshooting the base URL
 
@@ -102,7 +119,7 @@ value is also ignored — the proxy always rewrites it to the configured Copilot
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `COPILOT_ANTHROPIC_MODEL` | (resolved from `/models`) | Outbound Copilot model id. Wins over `/models` resolution. |
+| `COPILOT_ANTHROPIC_MODEL` | (discovered from `/models`) | Pins every request to this single Copilot model id and skips discovery entirely. Unset to discover the full `/v1/messages`-capable catalog instead (see "Choosing the model"). |
 | `COPILOT_ANTHROPIC_PORT` | `8787` | Loopback listen port. |
 | `COPILOT_ANTHROPIC_BASE_URL` | `https://api.enterprise.githubcopilot.com` | Copilot host root (for non-enterprise hosts). |
 | `COPILOT_ANTHROPIC_IDLE_TIMEOUT_SECONDS` | `120` | Per-request idle timeout, reset after each streamed read. The total exchange has no deadline, so long generations are not cut off. |
@@ -122,8 +139,10 @@ list**: `ModeToolFilter.FilterBuiltInTools` returns `null` for an empty tool set
 
 ## Non-goals (intentionally not implemented)
 
-- **No response-body rewriting.** The response body and the SSE `message_start` event carry the
-  rewritten (Opus) model id, not the requested id. This is accepted for raw-passthrough fidelity.
+- **No response-body rewriting.** The response body and the SSE `message_start` event carry whatever
+  model id was actually sent upstream (the passed-through id, or the resolved default when the
+  request's model wasn't recognized) — never rewritten back to the client's requested id. This is
+  accepted for raw-passthrough fidelity.
 - **No `anthropic-beta` allowlist filter.** Beta values are forwarded as-is; an unknown beta that
   Copilot rejects surfaces as an upstream 400 passthrough.
 - **No 200K → 1M context fallback / model routing.** Context-length errors pass through unchanged.

--- a/samples/CopilotAnthropicProxy.Sample/README.md
+++ b/samples/CopilotAnthropicProxy.Sample/README.md
@@ -9,20 +9,23 @@ What it does, end to end:
 
 1. Accepts `POST /v1/messages` (streaming and non-streaming), `POST /v1/messages/count_tokens`, and
    `GET /v1/models`.
-2. Rewrites **only** the JSON `model` field of the request body: if it names a model the proxy knows
-   about (see "Choosing the model" below), it passes through unchanged; otherwise it's rewritten to
-   the resolved default Copilot Claude (Opus) id. Everything else — `system` blocks, `cache_control`,
-   `thinking`, `tools`, betas, and unknown fields — is preserved verbatim (raw `JsonNode` swap, never
-   a typed DTO).
-3. Attaches Copilot auth + tracking headers using the proven `GithubCopilotProvider` transport
+2. Rewrites the JSON `model` field of the request body: if it names a model the proxy knows about
+   (see "Choosing the model" below), it passes through unchanged; otherwise it's rewritten to the
+   resolved default Copilot Claude (Opus) id. The top-level `context_management` field is stripped
+   (Copilot's backend rejects it outright — see "Known request incompatibilities" below). Everything
+   else — `system` blocks, `cache_control`, `thinking`, `tools`, and unknown fields — is preserved
+   verbatim (raw `JsonNode` swap, never a typed DTO).
+3. Drops the inbound `anthropic-beta` header entirely — it is never forwarded (see "Known request
+   incompatibilities" below).
+4. Attaches Copilot auth + tracking headers using the proven `GithubCopilotProvider` transport
    (`CopilotHttpClientFactory` / `CopilotHeadersHandler` / the CLI credential token provider).
-4. Streams the upstream Server-Sent-Events response straight back to the client as **raw bytes**
+5. Streams the upstream Server-Sent-Events response straight back to the client as **raw bytes**
    (no parsing, no buffering, incremental flush) and passes status codes and rate-limit headers
    through unchanged. If the upstream stream fails mid-flight the proxy does **not** fabricate any
    terminal frames: it returns a `502` when nothing has been sent yet, otherwise it stops and closes
    the (now incomplete) stream — the client detects the truncation from the missing `message_stop`,
    exactly as it would if the upstream connection had dropped directly.
-5. Also transparently exposes Copilot's **MCP server** on `/mcp` and `/mcp/readonly` — see
+6. Also transparently exposes Copilot's **MCP server** on `/mcp` and `/mcp/readonly` — see
    "Exposing Copilot's MCP server" below.
 
 > [!WARNING]
@@ -166,14 +169,25 @@ that in `LmStreaming.Sample` is to select (or define) a chat **mode with an empt
 list**: `ModeToolFilter.FilterBuiltInTools` returns `null` for an empty tool set
 (`Services/ModeToolFilter.cs`), which strips `AnthropicWebSearchTool` before the request is built.
 
+## Known request incompatibilities (stripped before forwarding)
+
+Copilot's backend rejects two things Claude Code routinely sends. Both are stripped unconditionally
+— the client never sees a 400 for either:
+
+- **`anthropic-beta` header.** Copilot's backend rejects the *entire* request if even one value in a
+  comma-separated `anthropic-beta` header is one it doesn't recognize (`"unsupported beta header(s):
+  <name>"`). Claude Code's beta list changes frequently and routinely includes values ahead of what
+  Copilot supports, so the header is dropped entirely rather than allowlisted value-by-value.
+- **`context_management` body field.** Copilot's backend rejects the request outright
+  (`"context_management: Extra inputs are not permitted"`) if this top-level field is present. It is
+  removed from the JSON body (alongside the `model` rewrite) before forwarding.
+
 ## Non-goals (intentionally not implemented)
 
 - **No response-body rewriting.** The response body and the SSE `message_start` event carry whatever
   model id was actually sent upstream (the passed-through id, or the resolved default when the
   request's model wasn't recognized) — never rewritten back to the client's requested id. This is
   accepted for raw-passthrough fidelity.
-- **No `anthropic-beta` allowlist filter.** Beta values are forwarded as-is; an unknown beta that
-  Copilot rejects surfaces as an upstream 400 passthrough.
 - **No 200K → 1M context fallback / model routing.** Context-length errors pass through unchanged.
 - **No refresh-on-401 / token invalidation.** A request-path token failure maps to a local
   `authentication_error`; re-authenticate out of band.

--- a/tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj
+++ b/tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj
@@ -29,4 +29,7 @@
   <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Fixtures\**\*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/tests/CopilotAnthropicProxy.Tests/Fixtures/copilot-models-real-response.json
+++ b/tests/CopilotAnthropicProxy.Tests/Fixtures/copilot-models-real-response.json
@@ -1,0 +1,2032 @@
+{
+  "data": [
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "individual_trial",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 50,
+            "cache_write_price": 625,
+            "input_price": 500,
+            "max_prompt_tokens": 200000,
+            "output_price": 2500
+          },
+          "long_context": {
+            "cache_read_price": 50,
+            "cache_write_price": 625,
+            "input_price": 500,
+            "max_prompt_tokens": 936000,
+            "output_price": 2500
+          }
+        }
+      },
+      "capabilities": {
+        "family": "claude-opus-4.6",
+        "limits": {
+          "max_context_window_tokens": 1000000,
+          "max_non_streaming_output_tokens": 16000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 936000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "adaptive_thinking": true,
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 1024,
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high",
+            "max"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "claude-opus-4.6",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "high",
+      "name": "Claude Opus 4.6",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Claude Opus 4.6 model from Anthropic. [Learn more about how GitHub Copilot serves Claude Opus 4.6](https://gh.io/copilot-claude-opus)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/v1/messages",
+        "/chat/completions"
+      ],
+      "vendor": "Anthropic",
+      "version": "claude-opus-4.6"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro_plus",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 50,
+            "cache_write_price": 625,
+            "input_price": 500,
+            "max_prompt_tokens": 200000,
+            "output_price": 2500
+          },
+          "long_context": {
+            "cache_read_price": 50,
+            "cache_write_price": 625,
+            "input_price": 500,
+            "max_prompt_tokens": 936000,
+            "output_price": 2500
+          }
+        }
+      },
+      "capabilities": {
+        "family": "claude-opus-4.7",
+        "limits": {
+          "max_context_window_tokens": 1000000,
+          "max_non_streaming_output_tokens": 16000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 936000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "adaptive_thinking": true,
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 1024,
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "claude-opus-4.7",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "high",
+      "name": "Claude Opus 4.7",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Claude Opus 4.7 model from Anthropic. [Learn more about how GitHub Copilot serves Claude Opus 4.7](https://gh.io/copilot-claude-opus)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/v1/messages",
+        "/chat/completions"
+      ],
+      "vendor": "Anthropic",
+      "version": "claude-opus-4.7"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro_plus",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 50,
+            "cache_write_price": 625,
+            "input_price": 500,
+            "max_prompt_tokens": 200000,
+            "output_price": 2500
+          },
+          "long_context": {
+            "cache_read_price": 50,
+            "cache_write_price": 625,
+            "input_price": 500,
+            "max_prompt_tokens": 936000,
+            "output_price": 2500
+          }
+        }
+      },
+      "capabilities": {
+        "family": "claude-opus-4.8",
+        "limits": {
+          "max_context_window_tokens": 1000000,
+          "max_non_streaming_output_tokens": 16000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 936000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "adaptive_thinking": true,
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 1024,
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "claude-opus-4.8",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "high",
+      "name": "Claude Opus 4.8",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Claude Opus 4.8 model from Anthropic. [Learn more about how GitHub Copilot serves Claude Opus 4.8](https://gh.io/copilot-claude-opus)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/v1/messages",
+        "/chat/completions"
+      ],
+      "vendor": "Anthropic",
+      "version": "claude-opus-4.8"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "individual_trial",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 30,
+            "cache_write_price": 375,
+            "input_price": 300,
+            "max_prompt_tokens": 200000,
+            "output_price": 1500
+          },
+          "long_context": {
+            "cache_read_price": 30,
+            "cache_write_price": 375,
+            "input_price": 300,
+            "max_prompt_tokens": 936000,
+            "output_price": 1500
+          }
+        }
+      },
+      "capabilities": {
+        "family": "claude-sonnet-4.6",
+        "limits": {
+          "max_context_window_tokens": 1000000,
+          "max_non_streaming_output_tokens": 16000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 936000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 5,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "adaptive_thinking": true,
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 1024,
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high",
+            "max"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "claude-sonnet-4.6",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "versatile",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "medium",
+      "name": "Claude Sonnet 4.6",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Claude Sonnet 4.6 model from Anthropic. [Learn more about how GitHub Copilot serves Claude Sonnet 4.6](https://gh.io/copilot-claude-opus)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/chat/completions",
+        "/v1/messages"
+      ],
+      "vendor": "Anthropic",
+      "version": "claude-sonnet-4.6"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 20,
+            "cache_write_price": 250,
+            "input_price": 200,
+            "max_prompt_tokens": 200000,
+            "output_price": 1000
+          },
+          "long_context": {
+            "cache_read_price": 20,
+            "cache_write_price": 250,
+            "input_price": 200,
+            "max_prompt_tokens": 936000,
+            "output_price": 1000
+          }
+        }
+      },
+      "capabilities": {
+        "family": "claude-sonnet-5",
+        "limits": {
+          "max_context_window_tokens": 1000000,
+          "max_non_streaming_output_tokens": 16000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 936000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 5,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "adaptive_thinking": true,
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 1024,
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "claude-sonnet-5",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "versatile",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "medium",
+      "name": "Claude Sonnet 5",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Claude model from Anthropic. [Learn more about how GitHub Copilot serves Claude](https://gh.io/copilot-claude-opus)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/v1/messages",
+        "/chat/completions"
+      ],
+      "vendor": "Anthropic",
+      "version": "claude-sonnet-5"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "edu",
+          "pro",
+          "pro_plus",
+          "individual_trial",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 20,
+            "cache_write_price": 0,
+            "input_price": 200,
+            "max_prompt_tokens": 200000,
+            "output_price": 1200
+          },
+          "long_context": {
+            "cache_read_price": 40,
+            "cache_write_price": 0,
+            "input_price": 400,
+            "max_prompt_tokens": 936000,
+            "output_price": 1800
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gemini-3.1-pro-preview",
+        "limits": {
+          "max_context_window_tokens": 1000000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 936000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 10,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/heic",
+              "image/heif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 256,
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "streaming": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gemini-3.1-pro-preview",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "medium",
+      "name": "Gemini 3.1 Pro",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Gemini 3 Pro model from Google. [Learn more about how GitHub Copilot serves Gemini 3 Pro](https://docs.github.com/en/copilot/reference/ai-models/model-hosting#google-models)."
+      },
+      "preview": true,
+      "supported_endpoints": [
+        "/chat/completions"
+      ],
+      "vendor": "Google",
+      "version": "gemini-3.1-pro-preview"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 15,
+            "cache_write_price": 0,
+            "input_price": 150,
+            "max_prompt_tokens": 200000,
+            "output_price": 900
+          },
+          "long_context": {
+            "cache_read_price": 15,
+            "cache_write_price": 0,
+            "input_price": 150,
+            "max_prompt_tokens": 936000,
+            "output_price": 900
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gemini-3.5-flash",
+        "limits": {
+          "max_context_window_tokens": 1000000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 936000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 10,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/heic",
+              "image/heif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "max_thinking_budget": 24000,
+          "min_thinking_budget": 256,
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ],
+          "streaming": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gemini-3.5-flash",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "lightweight",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "medium",
+      "name": "Gemini 3.5 Flash",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Gemini 3.5 Flash model from Google. [Learn more about how GitHub Copilot serves Gemini 3.5 Flash](https://docs.github.com/en/copilot/reference/ai-models/model-hosting#google-models)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/chat/completions"
+      ],
+      "vendor": "Google",
+      "version": "gemini-3.5-flash"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "edu",
+          "pro_plus",
+          "individual_trial",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 17,
+            "cache_write_price": 0,
+            "input_price": 175,
+            "max_prompt_tokens": 272000,
+            "output_price": 1400
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-5.3-codex",
+        "limits": {
+          "max_context_window_tokens": 400000,
+          "max_output_tokens": 128000,
+          "max_prompt_tokens": 272000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-5.3-codex",
+      "is_chat_default": true,
+      "is_chat_fallback": true,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "medium",
+      "name": "GPT-5.3-Codex",
+      "object": "model",
+      "preview": false,
+      "supported_endpoints": [
+        "/responses",
+        "ws:/responses"
+      ],
+      "vendor": "OpenAI",
+      "version": "gpt-5.3-codex"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "individual_trial",
+          "edu",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 7,
+            "cache_write_price": 0,
+            "input_price": 75,
+            "max_prompt_tokens": 272000,
+            "output_price": 450
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-5.4-mini",
+        "limits": {
+          "max_context_window_tokens": 400000,
+          "max_output_tokens": 128000,
+          "max_prompt_tokens": 272000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-5.4-mini",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "lightweight",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "low",
+      "name": "GPT-5.4 mini",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest GPT-5.4 mini model from OpenAI. [Learn more about how GitHub Copilot serves GPT-5.4 mini](https://gh.io/copilot-openai)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/responses",
+        "ws:/responses"
+      ],
+      "vendor": "OpenAI",
+      "version": "gpt-5.4-mini"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "individual_trial",
+          "edu",
+          "business",
+          "enterprise",
+          "max",
+          "free"
+        ],
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-5.4-nano",
+        "limits": {
+          "max_context_window_tokens": 400000,
+          "max_output_tokens": 128000,
+          "max_prompt_tokens": 272000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-5.4-nano",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "versatile",
+      "model_picker_enabled": false,
+      "model_picker_price_category": "low",
+      "name": "GPT-5.4 nano",
+      "object": "model",
+      "preview": false,
+      "supported_endpoints": [
+        "/responses",
+        "ws:/responses"
+      ],
+      "vendor": "OpenAI",
+      "version": "gpt-5.4-nano"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "individual_trial",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 25,
+            "cache_write_price": 0,
+            "input_price": 250,
+            "max_prompt_tokens": 272000,
+            "output_price": 1500
+          },
+          "long_context": {
+            "cache_read_price": 50,
+            "cache_write_price": 0,
+            "input_price": 500,
+            "max_prompt_tokens": 922000,
+            "output_price": 2250
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-5.4",
+        "limits": {
+          "max_context_window_tokens": 1050000,
+          "max_output_tokens": 128000,
+          "max_prompt_tokens": 922000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-5.4",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "medium",
+      "name": "GPT-5.4",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest GPT-5.4 model from OpenAI. [Learn more about how GitHub Copilot serves GPT-5.4](https://gh.io/copilot-openai)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/responses",
+        "/chat/completions",
+        "ws:/responses"
+      ],
+      "vendor": "OpenAI",
+      "version": "gpt-5.4"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro_plus",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 50,
+            "cache_write_price": 0,
+            "input_price": 500,
+            "max_prompt_tokens": 272000,
+            "output_price": 3000
+          },
+          "long_context": {
+            "cache_read_price": 100,
+            "cache_write_price": 0,
+            "input_price": 1000,
+            "max_prompt_tokens": 922000,
+            "output_price": 4500
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-5.5",
+        "limits": {
+          "max_context_window_tokens": 1050000,
+          "max_output_tokens": 128000,
+          "max_prompt_tokens": 922000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-5.5",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "high",
+      "name": "GPT-5.5",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest GPT-5.5 model from OpenAI. [Learn more about how GitHub Copilot serves GPT-5.5](https://gh.io/copilot-openai)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/responses",
+        "ws:/responses"
+      ],
+      "vendor": "OpenAI",
+      "version": "gpt-5.5"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "free",
+          "edu",
+          "pro",
+          "pro_plus",
+          "max",
+          "business",
+          "enterprise"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 7,
+            "cache_write_price": 0,
+            "input_price": 75,
+            "max_prompt_tokens": 128000,
+            "output_price": 450
+          }
+        }
+      },
+      "capabilities": {
+        "family": "oswe-vscode-modelD",
+        "limits": {
+          "max_context_window_tokens": 256000,
+          "max_output_tokens": 128000,
+          "max_prompt_tokens": 128000
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "mai-code-1-flash-picker",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "versatile",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "low",
+      "name": "MAI-Code-1-Flash",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": ""
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/responses"
+      ],
+      "vendor": "Microsoft",
+      "version": "mai-code-1-flash-picker"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 2,
+            "cache_write_price": 0,
+            "input_price": 25,
+            "output_price": 200
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-5-mini",
+        "limits": {
+          "max_context_window_tokens": 264000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 128000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-5-mini",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "lightweight",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "low",
+      "name": "GPT-5 mini",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest GPT-5 mini model from OpenAI. [Learn more about how GitHub Copilot serves GPT-5 mini](https://gh.io/copilot-openai)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/chat/completions",
+        "/responses",
+        "ws:/responses"
+      ],
+      "vendor": "Azure OpenAI",
+      "version": "gpt-5-mini"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4o-mini",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 64000
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4o-mini-2024-07-18",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "low",
+      "name": "GPT-4o mini",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4o-mini-2024-07-18"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4o",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 16384,
+          "max_prompt_tokens": 64000
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4o-2024-11-20",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT-4o",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4o-2024-11-20"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4o",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 16384,
+          "max_prompt_tokens": 64000
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4o-2024-08-06",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "high",
+      "name": "GPT-4o",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4o-2024-08-06"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "text-embedding-3-small",
+        "limits": {
+          "max_inputs": 512
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "dimensions": true
+        },
+        "tokenizer": "cl100k_base",
+        "type": "embeddings"
+      },
+      "id": "text-embedding-3-small",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "name": "Embedding V3 small",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "text-embedding-3-small"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "text-embedding-3-small",
+        "object": "model_capabilities",
+        "supports": {
+          "dimensions": true
+        },
+        "tokenizer": "cl100k_base",
+        "type": "embeddings"
+      },
+      "id": "text-embedding-3-small-inference",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "name": "Embedding V3 small (Inference)",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "text-embedding-3-small"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "max",
+          "business",
+          "enterprise"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 30,
+            "cache_write_price": 375,
+            "input_price": 300,
+            "output_price": 1500
+          }
+        }
+      },
+      "capabilities": {
+        "family": "claude-sonnet-4.5",
+        "limits": {
+          "max_context_window_tokens": 200000,
+          "max_non_streaming_output_tokens": 16000,
+          "max_output_tokens": 32000,
+          "max_prompt_tokens": 168000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 5,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 1024,
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "claude-sonnet-4.5",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "versatile",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "medium",
+      "name": "Claude Sonnet 4.5",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Claude Sonnet 4.5 model from Anthropic. [Learn more about how GitHub Copilot serves Claude Sonnet 4.5](https://docs.github.com/en/copilot/using-github-copilot/ai-models/using-claude-sonnet-in-github-copilot)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/chat/completions",
+        "/v1/messages"
+      ],
+      "vendor": "Anthropic",
+      "version": "claude-sonnet-4.5"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 10,
+            "cache_write_price": 125,
+            "input_price": 100,
+            "output_price": 500
+          }
+        }
+      },
+      "capabilities": {
+        "family": "claude-haiku-4.5",
+        "limits": {
+          "max_context_window_tokens": 200000,
+          "max_non_streaming_output_tokens": 16000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 136000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 5,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 1024,
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "claude-haiku-4.5",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "lightweight",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "low",
+      "name": "Claude Haiku 4.5",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Claude Haiku 4.5 model from Anthropic. [Learn more about how GitHub Copilot serves Claude Haiku 4.5](https://gh.io/copilot-anthropic)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/chat/completions",
+        "/v1/messages"
+      ],
+      "vendor": "Anthropic",
+      "version": "claude-haiku-4.5"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "max",
+          "business",
+          "enterprise",
+          "individual_trial",
+          "edu"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 12,
+            "cache_write_price": 0,
+            "input_price": 125,
+            "output_price": 1000
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gemini-2.5-pro",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 128000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 10,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/heic",
+              "image/heif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "max_thinking_budget": 32768,
+          "min_thinking_budget": 128,
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gemini-2.5-pro",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "medium",
+      "name": "Gemini 2.5 Pro",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Gemini 2.5 Pro model from Google. [Learn more about how GitHub Copilot serves Gemini 2.5 Pro](https://docs.github.com/en/copilot/using-github-copilot/ai-models/choosing-the-right-ai-model-for-your-task#gemini-25-pro)."
+      },
+      "preview": false,
+      "vendor": "Google",
+      "version": "gemini-2.5-pro"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4.1",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 16384,
+          "max_prompt_tokens": 64000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4.1-2025-04-14",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT-4.1",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest GPT-4.1 model from OpenAI. [Learn more about how GitHub Copilot serves GPT-4.1](https://docs.github.com/en/copilot/using-github-copilot/ai-models/choosing-the-right-ai-model-for-your-task#gpt-41)."
+      },
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4.1-2025-04-14"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 50,
+            "cache_write_price": 0,
+            "input_price": 200,
+            "output_price": 800
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4.1",
+        "object": "model_capabilities",
+        "supports": {
+          "streaming": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "completion"
+      },
+      "id": "gpt-41-copilot",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "versatile",
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT-4.1 Copilot",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-41-copilot"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-3.5-turbo",
+        "limits": {
+          "max_context_window_tokens": 16384,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 16384
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "cl100k_base",
+        "type": "chat"
+      },
+      "id": "gpt-3.5-turbo-0613",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT 3.5 Turbo",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-3.5-turbo-0613"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 125,
+            "cache_write_price": 0,
+            "input_price": 250,
+            "output_price": 1000
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4",
+        "limits": {
+          "max_context_window_tokens": 32768,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 32768
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "cl100k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT 4",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4-0613"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 125,
+            "cache_write_price": 0,
+            "input_price": 250,
+            "output_price": 1000
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4",
+        "limits": {
+          "max_context_window_tokens": 32768,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 32768
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "cl100k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4-0613",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT 4",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4-0613"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4o",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 64000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4o-2024-05-13",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT-4o",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4o-2024-05-13"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4o",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 64000
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4-o-preview",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "high",
+      "name": "GPT-4o",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4o-2024-05-13"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4.1",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 16384,
+          "max_prompt_tokens": 64000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4.1",
+      "info_messages": [
+        {
+          "code": "model_pending_deprecation",
+          "message": "GPT-4.1 has a planned deprecation date of 2026-06-01."
+        }
+      ],
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "versatile",
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT-4.1",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest GPT-4.1 model from OpenAI. [Learn more about how GitHub Copilot serves GPT-4.1](https://docs.github.com/en/copilot/using-github-copilot/ai-models/choosing-the-right-ai-model-for-your-task#gpt-41)."
+      },
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4.1-2025-04-14"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "max",
+          "business",
+          "enterprise",
+          "individual_trial",
+          "edu"
+        ],
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-3.5-turbo",
+        "limits": {
+          "max_context_window_tokens": 16384,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 16384
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "cl100k_base",
+        "type": "chat"
+      },
+      "id": "gpt-3.5-turbo",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT 3.5 Turbo",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-3.5-turbo-0613"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4o-mini",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 64000
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4o-mini",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "low",
+      "name": "GPT-4o mini",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4o-mini-2024-07-18"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4o",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 64000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4o",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT-4o",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4o-2024-11-20"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "text-embedding-ada-002",
+        "limits": {
+          "max_inputs": 512
+        },
+        "object": "model_capabilities",
+        "supports": {},
+        "tokenizer": "cl100k_base",
+        "type": "embeddings"
+      },
+      "id": "text-embedding-ada-002",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "name": "Embedding V2 Ada",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "text-embedding-3-small"
+    }
+  ],
+  "object": "list"
+}

--- a/tests/CopilotAnthropicProxy.Tests/HeaderAllowlistTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/HeaderAllowlistTests.cs
@@ -3,14 +3,14 @@ using FluentAssertions;
 
 namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
 
-/// <summary>Verifies the positive request-header allowlist (anthropic-version + anthropic-beta only).</summary>
+/// <summary>Verifies the positive request-header allowlist (anthropic-version only; anthropic-beta is dropped).</summary>
 public sealed class HeaderAllowlistTests
 {
     private static StringContent Body() =>
         new("{\"model\":\"x\",\"max_tokens\":5}", Encoding.UTF8, "application/json");
 
     [Fact]
-    public async Task Forwards_anthropic_version_and_beta_but_not_other_inbound_headers()
+    public async Task Forwards_anthropic_version_but_not_beta_or_other_inbound_headers()
     {
         HttpRequestMessage? forwarded = null;
         await using var factory = new ProxyWebAppFactory((req, ct) =>
@@ -34,7 +34,9 @@ public sealed class HeaderAllowlistTests
         forwarded.Should().NotBeNull();
 
         forwarded!.Headers.GetValues("anthropic-version").Should().ContainSingle().Which.Should().Be("2099-01-01");
-        forwarded.Headers.GetValues("anthropic-beta").Should().BeEquivalentTo("feature-a", "feature-b");
+        forwarded.Headers.Contains("anthropic-beta")
+            .Should()
+            .BeFalse("Copilot rejects the whole request if any beta value is unrecognized");
 
         forwarded.Headers.Contains("x-api-key").Should().BeFalse("inbound x-api-key must not be forwarded");
         // Authorization is force-set by CopilotHeadersHandler to the Copilot bearer, never the inbound value.

--- a/tests/CopilotAnthropicProxy.Tests/HostGuardTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/HostGuardTests.cs
@@ -74,6 +74,15 @@ public sealed class HostGuardTests
     }
 
     [Fact]
+    public void Loopback_origin_on_a_different_port_is_rejected()
+    {
+        // A page on another local port (another dev server, or something malicious) is still "loopback"
+        // but must not be treated as same-origin with this proxy.
+        ProxyGuard.IsAllowed(
+            IPAddress.Loopback, "127.0.0.1:8787", "http://127.0.0.1:3000", null, Port).Should().BeFalse();
+    }
+
+    [Fact]
     public async Task Foreign_host_header_is_rejected_with_403_permission_error()
     {
         await using var factory = new ProxyWebAppFactory((req, ct) => Task.FromResult(TestUpstream.Json("{}")));

--- a/tests/CopilotAnthropicProxy.Tests/McpProxyTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/McpProxyTests.cs
@@ -240,7 +240,8 @@ public sealed class McpProxyTests
         using var request = new HttpRequestMessage(HttpMethod.Put, "/mcp/readonly") { Content = JsonRpc("{}") };
         using var response = await client.SendAsync(request);
 
-        // Falls through to the shared Anthropic-shaped fallback 404, same as any other unmatched route/method.
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("\"jsonrpc\":\"2.0\"", "MCP-origin errors should be JSON-RPC-shaped, not the Anthropic fallback");
     }
 }

--- a/tests/CopilotAnthropicProxy.Tests/McpProxyTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/McpProxyTests.cs
@@ -6,9 +6,9 @@ namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
 
 /// <summary>
 ///     Verifies the transparent MCP (Streamable HTTP) reverse proxy on <c>/mcp</c> and
-///     <c>/mcp/readonly</c>: raw body/method/path forwarding, that every inbound header passes
-///     through verbatim except <c>Authorization</c> (which the proxy overrides with its own
-///     Copilot credentials), and session-id passthrough.
+///     <c>/mcp/readonly</c>: raw body/method/path forwarding, that inbound headers pass through
+///     verbatim except credentials (<c>Authorization</c>, <c>x-api-key</c>) and the Copilot
+///     transport/tracking headers owned by <c>CopilotHeadersHandler</c>, and session-id passthrough.
 /// </summary>
 public sealed class McpProxyTests
 {
@@ -114,7 +114,7 @@ public sealed class McpProxyTests
     }
 
     [Fact]
-    public async Task Inbound_authorization_is_overridden_but_arbitrary_custom_headers_pass_through()
+    public async Task Credentials_and_copilot_owned_headers_are_stripped_but_arbitrary_custom_headers_pass_through()
     {
         HttpRequestMessage? forwarded = null;
         await using var factory = new ProxyWebAppFactory(
@@ -129,6 +129,9 @@ public sealed class McpProxyTests
         using var request = new HttpRequestMessage(HttpMethod.Post, "/mcp/readonly") { Content = JsonRpc("{}") };
         request.Headers.TryAddWithoutValidation("Authorization", "Bearer inbound-token");
         request.Headers.TryAddWithoutValidation("x-api-key", "secret-key");
+        request.Headers.TryAddWithoutValidation("User-Agent", "inbound-agent/1.0");
+        request.Headers.TryAddWithoutValidation("copilot-integration-id", "spoofed-integration");
+        request.Headers.TryAddWithoutValidation("x-interaction-id", "spoofed-interaction");
         request.Headers.TryAddWithoutValidation("X-Some-Future-Mcp-Header", "anything");
         request.Headers.TryAddWithoutValidation("Accept-Encoding", "gzip");
 
@@ -137,8 +140,17 @@ public sealed class McpProxyTests
         response.IsSuccessStatusCode.Should().BeTrue();
         // Authorization is force-set by CopilotHeadersHandler to the Copilot bearer, never the inbound value.
         forwarded!.Headers.Authorization!.Parameter.Should().NotBe("inbound-token");
-        // Everything else passes through verbatim — no curated allowlist for MCP.
-        forwarded.Headers.GetValues("x-api-key").Should().ContainSingle().Which.Should().Be("secret-key");
+        // Credentials and Copilot-owned transport/tracking headers must never be caller-controlled.
+        forwarded.Headers.Contains("x-api-key").Should().BeFalse("inbound x-api-key must not be forwarded");
+        forwarded.Headers.UserAgent.ToString().Should().NotContain("inbound-agent");
+        // The header is still present (CopilotHeadersHandler sets its own real value when absent), but
+        // the spoofed inbound value must never survive.
+        forwarded
+            .Headers.GetValues("copilot-integration-id")
+            .Should()
+            .NotContain("spoofed-integration");
+        forwarded.Headers.GetValues("x-interaction-id").Should().NotContain("spoofed-interaction");
+        // Everything else still passes through verbatim — no curated allowlist beyond credentials/Copilot headers.
         forwarded.Headers.GetValues("X-Some-Future-Mcp-Header").Should().ContainSingle().Which.Should().Be("anything");
         forwarded
             .Headers.Contains("Accept-Encoding")
@@ -147,6 +159,25 @@ public sealed class McpProxyTests
                 "upstream never negotiates compression and Content-Encoding is stripped on the way back, "
                     + "so forwarding this would risk an undecodable body"
             );
+    }
+
+    [Fact]
+    public async Task Mid_stream_upstream_failure_before_any_byte_returns_a_json_rpc_shaped_error()
+    {
+        // The shared CopyBodyAsync helper must write a JSON-RPC-shaped error here, not the Anthropic
+        // "type":"error" envelope the /v1/messages path uses.
+        var upstreamStream = new ThrowingStream("");
+        await using var factory = new ProxyWebAppFactory(
+            (req, ct) => Task.FromResult(TestUpstream.SseStream(upstreamStream))
+        );
+        using var client = factory.CreateClient();
+
+        using var response = await client.PostAsync("/mcp/readonly", JsonRpc("{}"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("\"jsonrpc\":\"2.0\"");
+        body.Should().NotContain("\"type\":\"error\"", "this is the /v1/messages-shaped envelope, not JSON-RPC");
     }
 
     [Fact]

--- a/tests/CopilotAnthropicProxy.Tests/McpProxyTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/McpProxyTests.cs
@@ -1,0 +1,215 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+/// <summary>
+///     Verifies the transparent MCP (Streamable HTTP) reverse proxy on <c>/mcp</c> and
+///     <c>/mcp/readonly</c>: raw body/method/path forwarding, that every inbound header passes
+///     through verbatim except <c>Authorization</c> (which the proxy overrides with its own
+///     Copilot credentials), and session-id passthrough.
+/// </summary>
+public sealed class McpProxyTests
+{
+    private static StringContent JsonRpc(string body) => new(body, Encoding.UTF8, "application/json");
+
+    [Theory]
+    [InlineData("/mcp")]
+    [InlineData("/mcp/readonly")]
+    public async Task Post_forwards_the_raw_json_rpc_body_verbatim_to_the_same_upstream_path(string path)
+    {
+        HttpRequestMessage? forwarded = null;
+        string? forwardedBody = null;
+        await using var factory = new ProxyWebAppFactory(
+            async (req, ct) =>
+            {
+                forwarded = req;
+                forwardedBody = await req.Content!.ReadAsStringAsync(ct);
+                return TestUpstream.Json(
+                    "{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"protocolVersion\":\"2025-06-18\"}}",
+                    headers: new Dictionary<string, string>
+                    {
+                        ["mcp-session-id"] = "19d9ea76-c0b5-44bd-b554-f6e5e6127461",
+                    }
+                );
+            }
+        );
+        using var client = factory.CreateClient();
+
+        const string requestBody = "{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"initialize\",\"params\":{}}";
+        using var response = await client.PostAsync(path, JsonRpc(requestBody));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        forwarded.Should().NotBeNull();
+        forwarded!.Method.Should().Be(HttpMethod.Post);
+        forwarded.RequestUri!.AbsolutePath.Should().Be(path);
+        forwardedBody.Should().Be(requestBody);
+        response
+            .Headers.GetValues("mcp-session-id")
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be("19d9ea76-c0b5-44bd-b554-f6e5e6127461");
+    }
+
+    [Fact]
+    public async Task Session_id_and_protocol_version_headers_are_forwarded()
+    {
+        HttpRequestMessage? forwarded = null;
+        await using var factory = new ProxyWebAppFactory(
+            (req, ct) =>
+            {
+                forwarded = req;
+                return Task.FromResult(TestUpstream.Json("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}"));
+            }
+        );
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/mcp/readonly") { Content = JsonRpc("{}") };
+        request.Headers.TryAddWithoutValidation("Mcp-Session-Id", "19d9ea76-c0b5-44bd-b554-f6e5e6127461");
+        request.Headers.TryAddWithoutValidation("Mcp-Protocol-Version", "2025-06-18");
+
+        using var response = await client.SendAsync(request);
+
+        response.IsSuccessStatusCode.Should().BeTrue();
+        forwarded!
+            .Headers.GetValues("Mcp-Session-Id")
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be("19d9ea76-c0b5-44bd-b554-f6e5e6127461");
+        forwarded.Headers.GetValues("Mcp-Protocol-Version").Should().ContainSingle().Which.Should().Be("2025-06-18");
+    }
+
+    [Fact]
+    public async Task X_mcp_control_headers_are_forwarded()
+    {
+        HttpRequestMessage? forwarded = null;
+        await using var factory = new ProxyWebAppFactory(
+            (req, ct) =>
+            {
+                forwarded = req;
+                return Task.FromResult(TestUpstream.Json("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}"));
+            }
+        );
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/mcp/readonly") { Content = JsonRpc("{}") };
+        request.Headers.TryAddWithoutValidation("X-MCP-Tools", "get_file_contents,search_code");
+        request.Headers.TryAddWithoutValidation("X-MCP-Readonly", "true");
+        request.Headers.TryAddWithoutValidation("X-MCP-Host", "copilot-cli");
+
+        using var response = await client.SendAsync(request);
+
+        response.IsSuccessStatusCode.Should().BeTrue();
+        forwarded!
+            .Headers.GetValues("X-MCP-Tools")
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be("get_file_contents,search_code");
+        forwarded.Headers.GetValues("X-MCP-Readonly").Should().ContainSingle().Which.Should().Be("true");
+        forwarded.Headers.GetValues("X-MCP-Host").Should().ContainSingle().Which.Should().Be("copilot-cli");
+    }
+
+    [Fact]
+    public async Task Inbound_authorization_is_overridden_but_arbitrary_custom_headers_pass_through()
+    {
+        HttpRequestMessage? forwarded = null;
+        await using var factory = new ProxyWebAppFactory(
+            (req, ct) =>
+            {
+                forwarded = req;
+                return Task.FromResult(TestUpstream.Json("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}"));
+            }
+        );
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/mcp/readonly") { Content = JsonRpc("{}") };
+        request.Headers.TryAddWithoutValidation("Authorization", "Bearer inbound-token");
+        request.Headers.TryAddWithoutValidation("x-api-key", "secret-key");
+        request.Headers.TryAddWithoutValidation("X-Some-Future-Mcp-Header", "anything");
+        request.Headers.TryAddWithoutValidation("Accept-Encoding", "gzip");
+
+        using var response = await client.SendAsync(request);
+
+        response.IsSuccessStatusCode.Should().BeTrue();
+        // Authorization is force-set by CopilotHeadersHandler to the Copilot bearer, never the inbound value.
+        forwarded!.Headers.Authorization!.Parameter.Should().NotBe("inbound-token");
+        // Everything else passes through verbatim — no curated allowlist for MCP.
+        forwarded.Headers.GetValues("x-api-key").Should().ContainSingle().Which.Should().Be("secret-key");
+        forwarded.Headers.GetValues("X-Some-Future-Mcp-Header").Should().ContainSingle().Which.Should().Be("anything");
+        forwarded
+            .Headers.Contains("Accept-Encoding")
+            .Should()
+            .BeFalse(
+                "upstream never negotiates compression and Content-Encoding is stripped on the way back, "
+                    + "so forwarding this would risk an undecodable body"
+            );
+    }
+
+    [Fact]
+    public async Task Get_opens_a_standalone_stream_and_forwards_last_event_id()
+    {
+        HttpRequestMessage? forwarded = null;
+        const string sse = "event: message\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/ping\"}\n\n";
+        await using var factory = new ProxyWebAppFactory(
+            (req, ct) =>
+            {
+                forwarded = req;
+                return Task.FromResult(TestUpstream.Sse(sse));
+            }
+        );
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/mcp");
+        request.Headers.TryAddWithoutValidation("Last-Event-ID", "42");
+
+        using var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        forwarded!.Method.Should().Be(HttpMethod.Get);
+        forwarded.Content.Should().BeNull("GET carries no body");
+        forwarded.Headers.GetValues("Last-Event-ID").Should().ContainSingle().Which.Should().Be("42");
+        (await response.Content.ReadAsStringAsync()).Should().Be(sse);
+    }
+
+    [Fact]
+    public async Task Delete_forwards_session_termination_and_the_upstream_status_code()
+    {
+        HttpRequestMessage? forwarded = null;
+        await using var factory = new ProxyWebAppFactory(
+            (req, ct) =>
+            {
+                forwarded = req;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.MethodNotAllowed));
+            }
+        );
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Delete, "/mcp/readonly");
+        request.Headers.TryAddWithoutValidation("Mcp-Session-Id", "19d9ea76-c0b5-44bd-b554-f6e5e6127461");
+
+        using var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+        forwarded!.Method.Should().Be(HttpMethod.Delete);
+        forwarded.Content.Should().BeNull("DELETE carries no body");
+    }
+
+    [Fact]
+    public async Task Unsupported_http_method_is_rejected_before_reaching_the_upstream()
+    {
+        await using var factory = new ProxyWebAppFactory(
+            (req, ct) => throw new InvalidOperationException("upstream must not be called for an unsupported method")
+        );
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Put, "/mcp/readonly") { Content = JsonRpc("{}") };
+        using var response = await client.SendAsync(request);
+
+        // Falls through to the shared Anthropic-shaped fallback 404, same as any other unmatched route/method.
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/CopilotAnthropicProxy.Tests/ModelDiscoveryPassthroughTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ModelDiscoveryPassthroughTests.cs
@@ -1,0 +1,156 @@
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+/// <summary>
+///     End-to-end coverage for the no-override discovery path: GET /v1/models lists every
+///     /v1/messages-capable Copilot model, and POST /v1/messages passes a recognized model through
+///     unchanged instead of always rewriting to the default.
+/// </summary>
+public sealed class ModelDiscoveryPassthroughTests
+{
+    private const string DiscoveryJson = """
+        {"data":[
+            {"id":"claude-opus-4.8","supported_endpoints":["/v1/messages","/chat/completions"]},
+            {"id":"claude-sonnet-4.5","supported_endpoints":["/v1/messages"]},
+            {"id":"gpt-5.4","supported_endpoints":["/responses","ws:/responses"]}
+        ]}
+        """;
+
+    /// <summary>
+    ///     A real (sanitized) <c>GET /models</c> response body captured from
+    ///     <c>api.enterprise.githubcopilot.com</c> — 34 models, of which 7 support <c>/v1/messages</c>,
+    ///     including three concurrent <c>claude-opus-*</c> versions (4.6, 4.7, 4.8).
+    /// </summary>
+    private static string RealModelsResponseJson =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "copilot-models-real-response.json"));
+
+    /// <summary>
+    ///     A factory with <c>COPILOT_ANTHROPIC_MODEL</c> unset (discovery mode). The fake upstream answers
+    ///     the startup <c>GET /models</c> call itself; <paramref name="onMessages"/> handles everything else.
+    /// </summary>
+    private static ProxyWebAppFactory DiscoveryFactory(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> onMessages
+    )
+    {
+        return new ProxyWebAppFactory(
+            (req, ct) =>
+                req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/models"
+                    ? Task.FromResult(TestUpstream.Json(DiscoveryJson))
+                    : onMessages(req, ct),
+            model: null
+        );
+    }
+
+    [Fact]
+    public async Task Models_endpoint_lists_the_real_captured_copilot_response_messages_capable_models()
+    {
+        await using var factory = new ProxyWebAppFactory(
+            (req, ct) =>
+                req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/models"
+                    ? Task.FromResult(TestUpstream.Json(RealModelsResponseJson))
+                    : Task.FromResult(TestUpstream.Json("{}")),
+            model: null
+        );
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/v1/models");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var node = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var ids = node["data"]!.AsArray().Select(m => m!["id"]!.GetValue<string>());
+        ids.Should()
+            .Equal(
+                "claude-opus-4.6",
+                "claude-opus-4.7",
+                "claude-opus-4.8",
+                "claude-sonnet-4.6",
+                "claude-sonnet-5",
+                "claude-sonnet-4.5",
+                "claude-haiku-4.5"
+            );
+    }
+
+    [Fact]
+    public async Task Models_endpoint_lists_only_messages_capable_models_when_discovering()
+    {
+        await using var factory = DiscoveryFactory((req, ct) => Task.FromResult(TestUpstream.Json("{}")));
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/v1/models");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var node = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var ids = node["data"]!.AsArray().Select(m => m!["id"]!.GetValue<string>());
+        ids.Should().BeEquivalentTo(["claude-opus-4.8", "claude-sonnet-4.5"], "gpt-5.4 does not support /v1/messages");
+    }
+
+    [Fact]
+    public async Task Passthrough_keeps_a_recognized_non_default_model_unchanged()
+    {
+        string? forwardedBody = null;
+        await using var factory = DiscoveryFactory(
+            async (req, ct) =>
+            {
+                forwardedBody = await req.Content!.ReadAsStringAsync(ct);
+                return TestUpstream.Json("{\"type\":\"message\"}");
+            }
+        );
+        using var client = factory.CreateClient();
+
+        using var response = await client.PostAsync(
+            "/v1/messages",
+            new StringContent("{\"model\":\"claude-sonnet-4.5\",\"max_tokens\":5}", Encoding.UTF8, "application/json")
+        );
+
+        response.IsSuccessStatusCode.Should().BeTrue();
+        JsonNode.Parse(forwardedBody!)!["model"]!.GetValue<string>().Should().Be("claude-sonnet-4.5");
+    }
+
+    [Fact]
+    public async Task Unrecognized_model_falls_back_to_the_discovered_default()
+    {
+        string? forwardedBody = null;
+        await using var factory = DiscoveryFactory(
+            async (req, ct) =>
+            {
+                forwardedBody = await req.Content!.ReadAsStringAsync(ct);
+                return TestUpstream.Json("{\"type\":\"message\"}");
+            }
+        );
+        using var client = factory.CreateClient();
+
+        using var response = await client.PostAsync(
+            "/v1/messages",
+            new StringContent("{\"model\":\"not-a-known-model\",\"max_tokens\":5}", Encoding.UTF8, "application/json")
+        );
+
+        response.IsSuccessStatusCode.Should().BeTrue();
+        JsonNode.Parse(forwardedBody!)!["model"]!.GetValue<string>().Should().Be("claude-opus-4.8");
+    }
+
+    [Fact]
+    public async Task Passthrough_match_is_case_insensitive_and_normalizes_to_the_catalog_casing()
+    {
+        string? forwardedBody = null;
+        await using var factory = DiscoveryFactory(
+            async (req, ct) =>
+            {
+                forwardedBody = await req.Content!.ReadAsStringAsync(ct);
+                return TestUpstream.Json("{\"type\":\"message\"}");
+            }
+        );
+        using var client = factory.CreateClient();
+
+        using var response = await client.PostAsync(
+            "/v1/messages",
+            new StringContent("{\"model\":\"CLAUDE-SONNET-4.5\",\"max_tokens\":5}", Encoding.UTF8, "application/json")
+        );
+
+        response.IsSuccessStatusCode.Should().BeTrue();
+        JsonNode.Parse(forwardedBody!)!["model"]!.GetValue<string>().Should().Be("claude-sonnet-4.5");
+    }
+}

--- a/tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs
@@ -10,6 +10,14 @@ namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
 /// </summary>
 public sealed class ModelResolverTests
 {
+    /// <summary>
+    ///     A real (sanitized) <c>GET /models</c> response body captured from
+    ///     <c>api.enterprise.githubcopilot.com</c> — 34 models, of which 7 support <c>/v1/messages</c>,
+    ///     including three concurrent <c>claude-opus-*</c> versions (4.6, 4.7, 4.8) in that upstream order.
+    /// </summary>
+    private static string RealModelsResponseJson =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "copilot-models-real-response.json"));
+
     private static HttpClient UpstreamReturning(string modelsJson)
     {
         var handler = new FakeHttpMessageHandler((req, ct) => Task.FromResult(TestUpstream.Json(modelsJson)));
@@ -19,8 +27,10 @@ public sealed class ModelResolverTests
     [Fact]
     public void ParseModelIds_reads_openai_shaped_data_array()
     {
-        ProxyModelResolver.ParseModelIds("{\"data\":[{\"id\":\"claude-sonnet-4.5\"},{\"id\":\"claude-opus-4.8\"}]}")
-            .Should().Equal("claude-sonnet-4.5", "claude-opus-4.8");
+        ProxyModelResolver
+            .ParseModelIds("{\"data\":[{\"id\":\"claude-sonnet-4.5\"},{\"id\":\"claude-opus-4.8\"}]}")
+            .Should()
+            .Equal("claude-sonnet-4.5", "claude-opus-4.8");
     }
 
     [Fact]
@@ -32,44 +42,224 @@ public sealed class ModelResolverTests
     [Fact]
     public void ParseModelIds_ignores_entries_without_a_string_id()
     {
-        ProxyModelResolver.ParseModelIds("{\"data\":[{\"id\":\"keep\"},{\"name\":\"no-id\"},{\"id\":123},{\"id\":\"\"}]}")
-            .Should().Equal("keep");
+        ProxyModelResolver
+            .ParseModelIds("{\"data\":[{\"id\":\"keep\"},{\"name\":\"no-id\"},{\"id\":123},{\"id\":\"\"}]}")
+            .Should()
+            .Equal("keep");
+    }
+
+    [Fact]
+    public void ParseMessagesCapableModelIds_keeps_only_ids_whose_supported_endpoints_include_v1_messages()
+    {
+        const string json = """
+            {"data":[
+                {"id":"claude-opus-4.8","supported_endpoints":["/v1/messages","/chat/completions"]},
+                {"id":"claude-sonnet-4.5","supported_endpoints":["/v1/messages"]},
+                {"id":"gpt-5.4","supported_endpoints":["/responses","ws:/responses"]},
+                {"id":"gemini-2.5-pro","supported_endpoints":["/chat/completions"]},
+                {"id":"gpt-4o"}
+            ]}
+            """;
+
+        ProxyModelResolver.ParseMessagesCapableModelIds(json).Should().Equal("claude-opus-4.8", "claude-sonnet-4.5");
     }
 
     [Fact]
     public async Task ResolveAsync_returns_override_without_calling_upstream()
     {
-        var handler = new FakeHttpMessageHandler((req, ct) =>
-            throw new InvalidOperationException("upstream must not be called when an override is set"));
+        var handler = new FakeHttpMessageHandler(
+            (req, ct) => throw new InvalidOperationException("upstream must not be called when an override is set")
+        );
         using var client = new HttpClient(handler) { BaseAddress = new Uri("https://upstream.test") };
 
-        var model = await ProxyModelResolver.ResolveAsync(
-            client, modelOverride: "my-pinned-model", NullLogger.Instance, CancellationToken.None);
+        var catalog = await ProxyModelResolver.ResolveAsync(
+            client,
+            modelOverride: "my-pinned-model",
+            NullLogger.Instance,
+            CancellationToken.None
+        );
 
-        model.Should().Be("my-pinned-model");
+        catalog.Default.Should().Be("my-pinned-model");
+        catalog.Available.Should().Equal("my-pinned-model");
     }
 
     [Fact]
     public async Task ResolveAsync_picks_the_opus_claude_id_from_models()
     {
         using var client = UpstreamReturning(
-            "{\"data\":[{\"id\":\"gpt-4o\"},{\"id\":\"claude-sonnet-4.5\"},{\"id\":\"claude-opus-4.8\"}]}");
+            "{\"data\":["
+                + "{\"id\":\"gpt-4o\",\"supported_endpoints\":[\"/chat/completions\"]},"
+                + "{\"id\":\"claude-sonnet-4.5\",\"supported_endpoints\":[\"/v1/messages\"]},"
+                + "{\"id\":\"claude-opus-4.8\",\"supported_endpoints\":[\"/v1/messages\"]}"
+                + "]}"
+        );
 
-        var model = await ProxyModelResolver.ResolveAsync(
-            client, modelOverride: null, NullLogger.Instance, CancellationToken.None);
+        var catalog = await ProxyModelResolver.ResolveAsync(
+            client,
+            modelOverride: null,
+            NullLogger.Instance,
+            CancellationToken.None
+        );
 
-        model.Should().Be("claude-opus-4.8");
+        catalog.Default.Should().Be("claude-opus-4.8");
+        catalog.Available.Should().Equal("claude-sonnet-4.5", "claude-opus-4.8");
     }
 
     [Fact]
     public async Task ResolveAsync_throws_when_no_opus_model_is_available()
     {
-        using var client = UpstreamReturning("{\"data\":[{\"id\":\"claude-sonnet-4.5\"},{\"id\":\"gpt-4o\"}]}");
+        using var client = UpstreamReturning(
+            "{\"data\":["
+                + "{\"id\":\"claude-sonnet-4.5\",\"supported_endpoints\":[\"/v1/messages\"]},"
+                + "{\"id\":\"gpt-4o\",\"supported_endpoints\":[\"/chat/completions\"]}"
+                + "]}"
+        );
 
-        var act = () => ProxyModelResolver.ResolveAsync(
-            client, modelOverride: null, NullLogger.Instance, CancellationToken.None);
+        var act = () =>
+            ProxyModelResolver.ResolveAsync(client, modelOverride: null, NullLogger.Instance, CancellationToken.None);
 
         (await act.Should().ThrowAsync<InvalidOperationException>())
-            .Which.Message.Should().Contain("claude-sonnet-4.5", "the error lists the available Claude ids to pick from");
+            .Which.Message.Should()
+            .Contain("claude-sonnet-4.5", "the error lists the available Claude ids to pick from");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_excludes_messages_incapable_models_from_the_opus_search_even_if_named_opus()
+    {
+        // A hypothetical "opus" model that only supports /chat/completions must NOT be picked as default,
+        // since this proxy can only forward Anthropic-Messages-shaped requests.
+        using var client = UpstreamReturning(
+            "{\"data\":["
+                + "{\"id\":\"claude-opus-chat-only\",\"supported_endpoints\":[\"/chat/completions\"]},"
+                + "{\"id\":\"claude-sonnet-4.5\",\"supported_endpoints\":[\"/v1/messages\"]}"
+                + "]}"
+        );
+
+        var act = () =>
+            ProxyModelResolver.ResolveAsync(client, modelOverride: null, NullLogger.Instance, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Theory]
+    [InlineData(new[] { "claude-opus-4.6", "claude-opus-4.7", "claude-opus-4.8" }, "claude-opus-4.8")]
+    [InlineData(new[] { "claude-opus-4.8", "claude-opus-4.7", "claude-opus-4.6" }, "claude-opus-4.8")]
+    [InlineData(new[] { "claude-opus-4.7", "claude-opus-4.6" }, "claude-opus-4.7")]
+    [InlineData(new[] { "claude-opus-4.9", "claude-opus-4.10" }, "claude-opus-4.10")]
+    public void PickHighestVersionOpusId_picks_the_numerically_highest_version_regardless_of_list_order(
+        string[] claudeIds,
+        string expectedDefault
+    )
+    {
+        // claude-opus-4.10 must beat claude-opus-4.9 numerically (not "4.10" < "4.9" as a string compare).
+        ProxyModelResolver.PickHighestVersionOpusId(claudeIds).Should().Be(expectedDefault);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_picks_the_highest_version_opus_when_multiple_are_available()
+    {
+        // Real Copilot data ships three concurrent opus versions; the oldest (4.6) must NOT win just
+        // because it appears first in the upstream list.
+        using var client = UpstreamReturning(
+            "{\"data\":["
+                + "{\"id\":\"claude-opus-4.6\",\"supported_endpoints\":[\"/v1/messages\"]},"
+                + "{\"id\":\"claude-opus-4.7\",\"supported_endpoints\":[\"/v1/messages\"]},"
+                + "{\"id\":\"claude-opus-4.8\",\"supported_endpoints\":[\"/v1/messages\"]}"
+                + "]}"
+        );
+
+        var catalog = await ProxyModelResolver.ResolveAsync(
+            client,
+            modelOverride: null,
+            NullLogger.Instance,
+            CancellationToken.None
+        );
+
+        catalog.Default.Should().Be("claude-opus-4.8");
+    }
+
+    [Fact]
+    public void ParseMessagesCapableModelIds_matches_the_real_captured_copilot_response()
+    {
+        ProxyModelResolver
+            .ParseMessagesCapableModelIds(RealModelsResponseJson)
+            .Should()
+            .Equal(
+                "claude-opus-4.6",
+                "claude-opus-4.7",
+                "claude-opus-4.8",
+                "claude-sonnet-4.6",
+                "claude-sonnet-5",
+                "claude-sonnet-4.5",
+                "claude-haiku-4.5"
+            );
+    }
+
+    [Fact]
+    public async Task ResolveAsync_picks_claude_opus_4_8_as_default_from_the_real_captured_copilot_response()
+    {
+        using var client = UpstreamReturning(RealModelsResponseJson);
+
+        var catalog = await ProxyModelResolver.ResolveAsync(
+            client,
+            modelOverride: null,
+            NullLogger.Instance,
+            CancellationToken.None
+        );
+
+        catalog.Default.Should().Be("claude-opus-4.8");
+        catalog
+            .Available.Should()
+            .Equal(
+                "claude-opus-4.6",
+                "claude-opus-4.7",
+                "claude-opus-4.8",
+                "claude-sonnet-4.6",
+                "claude-sonnet-5",
+                "claude-sonnet-4.5",
+                "claude-haiku-4.5"
+            );
+    }
+
+    [Theory]
+    [InlineData("claude-opus-4.8", "claude-opus-4.8")]
+    [InlineData("CLAUDE-OPUS-4.8", "claude-opus-4.8")]
+    [InlineData(null, "claude-opus-4.8")]
+    [InlineData("", "claude-opus-4.8")]
+    [InlineData("some-unknown-model", "claude-opus-4.8")]
+    public void SelectOutboundModel_passes_through_matches_and_falls_back_to_default_otherwise(
+        string? incoming,
+        string expected
+    )
+    {
+        var catalog = new ProxyModelCatalog("claude-opus-4.8", ["claude-sonnet-4.5", "claude-opus-4.8"]);
+
+        ProxyModelResolver.SelectOutboundModel(incoming, catalog).Should().Be(expected);
+    }
+
+    [Fact]
+    public void SelectOutboundModel_passes_through_a_non_default_available_model()
+    {
+        var catalog = new ProxyModelCatalog("claude-opus-4.8", ["claude-sonnet-4.5", "claude-opus-4.8"]);
+
+        ProxyModelResolver.SelectOutboundModel("claude-sonnet-4.5", catalog).Should().Be("claude-sonnet-4.5");
+    }
+
+    [Fact]
+    public void PeekModel_reads_the_model_field_without_mutating_the_body()
+    {
+        var body = System.Text.Encoding.UTF8.GetBytes("{\"model\":\"claude-sonnet-4.5\",\"max_tokens\":5}");
+
+        ProxyModelResolver.PeekModel(body).Should().Be("claude-sonnet-4.5");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not json")]
+    [InlineData("{\"max_tokens\":5}")]
+    [InlineData("[1,2,3]")]
+    public void PeekModel_returns_null_when_the_model_field_is_absent_or_body_is_unparsable(string body)
+    {
+        ProxyModelResolver.PeekModel(System.Text.Encoding.UTF8.GetBytes(body)).Should().BeNull();
     }
 }

--- a/tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs
@@ -65,6 +65,19 @@ public sealed class ModelResolverTests
     }
 
     [Fact]
+    public void ParseMessagesCapableModelIds_falls_back_to_id_only_when_no_entry_has_endpoint_metadata()
+    {
+        const string json = """
+            {"data":[
+                {"id":"claude-opus-4.8"},
+                {"id":"claude-sonnet-4.5"}
+            ]}
+            """;
+
+        ProxyModelResolver.ParseMessagesCapableModelIds(json).Should().Equal("claude-opus-4.8", "claude-sonnet-4.5");
+    }
+
+    [Fact]
     public async Task ResolveAsync_returns_override_without_calling_upstream()
     {
         var handler = new FakeHttpMessageHandler(
@@ -103,6 +116,26 @@ public sealed class ModelResolverTests
 
         catalog.Default.Should().Be("claude-opus-4.8");
         catalog.Available.Should().Equal("claude-sonnet-4.5", "claude-opus-4.8");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_picks_the_opus_claude_id_from_a_legacy_models_response_without_endpoint_metadata()
+    {
+        // Older/alternative Copilot-compatible /models shape: id-only entries, no supported_endpoints at
+        // all. Startup must not fail just because this metadata is absent.
+        using var client = UpstreamReturning(
+            "{\"data\":[{\"id\":\"gpt-4o\"},{\"id\":\"claude-sonnet-4.5\"},{\"id\":\"claude-opus-4.8\"}]}"
+        );
+
+        var catalog = await ProxyModelResolver.ResolveAsync(
+            client,
+            modelOverride: null,
+            NullLogger.Instance,
+            CancellationToken.None
+        );
+
+        catalog.Default.Should().Be("claude-opus-4.8");
+        catalog.Available.Should().Equal("gpt-4o", "claude-sonnet-4.5", "claude-opus-4.8");
     }
 
     [Fact]

--- a/tests/CopilotAnthropicProxy.Tests/ModelRewriteTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ModelRewriteTests.cs
@@ -72,6 +72,38 @@ public sealed class ModelRewriteTests
     }
 
     [Fact]
+    public void TryRewriteModel_strips_context_management_field()
+    {
+        const string json = """
+        {
+          "model": "claude-3-5-haiku",
+          "max_tokens": 5,
+          "context_management": { "edits": [ { "type": "clear_tool_uses_20250919" } ] }
+        }
+        """;
+
+        var ok = ProxyModelResolver.TryRewriteModel(
+            Encoding.UTF8.GetBytes(json), "opus-x", out var rewritten, out _);
+
+        ok.Should().BeTrue();
+        var node = JsonNode.Parse(rewritten)!.AsObject();
+        node.ContainsKey("context_management").Should().BeFalse();
+        node["model"]!.GetValue<string>().Should().Be("opus-x");
+        node["max_tokens"]!.GetValue<int>().Should().Be(5);
+    }
+
+    [Fact]
+    public void TryRewriteModel_is_a_no_op_when_context_management_is_absent()
+    {
+        var body = Encoding.UTF8.GetBytes("{\"model\":\"x\",\"max_tokens\":5}");
+
+        var ok = ProxyModelResolver.TryRewriteModel(body, "opus-x", out var rewritten, out _);
+
+        ok.Should().BeTrue();
+        JsonNode.Parse(rewritten)!.AsObject().ContainsKey("context_management").Should().BeFalse();
+    }
+
+    [Fact]
     public async Task Forwarded_request_body_has_the_configured_model()
     {
         string? forwardedBody = null;

--- a/tests/CopilotAnthropicProxy.Tests/ModelRewriteTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ModelRewriteTests.cs
@@ -103,6 +103,56 @@ public sealed class ModelRewriteTests
         JsonNode.Parse(rewritten)!.AsObject().ContainsKey("context_management").Should().BeFalse();
     }
 
+    [Theory]
+    [InlineData("/v1/messages")]
+    [InlineData("/v1/messages/count_tokens")]
+    public async Task Forwarded_request_strips_beta_header_and_context_management_but_preserves_other_fields(
+        string path)
+    {
+        HttpRequestMessage? forwarded = null;
+        string? forwardedBody = null;
+        await using var factory = new ProxyWebAppFactory(async (req, ct) =>
+        {
+            forwarded = req;
+            forwardedBody = req.Content is null ? null : await req.Content.ReadAsStringAsync(ct);
+            return TestUpstream.Json(path.EndsWith("count_tokens") ? "{\"input_tokens\":7}" : "{\"type\":\"message\"}");
+        });
+        using var client = factory.CreateClient();
+
+        const string json = """
+        {
+          "model": "claude-3-5-haiku-20241022",
+          "max_tokens": 100,
+          "thinking": { "type": "enabled", "budget_tokens": 1024 },
+          "context_management": { "edits": [ { "type": "clear_tool_uses_20250919" } ] },
+          "system": [ { "type": "text", "text": "sys", "cache_control": { "type": "ephemeral" } } ],
+          "tools": [ { "name": "get_weather", "input_schema": { "type": "object" } } ],
+          "messages": [ { "role": "user", "content": "hi" } ],
+          "anthropic_unknown": { "nested": [1, 2, 3] }
+        }
+        """;
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, path)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+        request.Headers.TryAddWithoutValidation("anthropic-beta", "context-management-2025-06-27");
+
+        using var response = await client.SendAsync(request);
+
+        response.IsSuccessStatusCode.Should().BeTrue();
+        forwarded!.Headers.Contains("anthropic-beta")
+            .Should()
+            .BeFalse("Copilot rejects the whole request if any beta value is unrecognized");
+
+        var node = JsonNode.Parse(forwardedBody!)!.AsObject();
+        node.ContainsKey("context_management").Should().BeFalse();
+        node["thinking"]!["budget_tokens"]!.GetValue<int>().Should().Be(1024);
+        node["system"]![0]!["cache_control"]!["type"]!.GetValue<string>().Should().Be("ephemeral");
+        node["tools"]![0]!["name"]!.GetValue<string>().Should().Be("get_weather");
+        node["anthropic_unknown"]!["nested"]!.AsArray().Should().HaveCount(3);
+    }
+
     [Fact]
     public async Task Forwarded_request_body_has_the_configured_model()
     {

--- a/tests/CopilotAnthropicProxy.Tests/ProxyWebAppFactory.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ProxyWebAppFactory.cs
@@ -31,7 +31,12 @@ public sealed class ProxyWebAppFactory : WebApplicationFactory<Program>
     /// <summary>Creates a factory whose upstream is driven by <paramref name="upstream"/>.</summary>
     /// <param name="upstream">Fake upstream handler invoked for every forwarded request.</param>
     /// <param name="tokenProvider">Token provider to inject; defaults to a fixed fake token.</param>
-    /// <param name="model">The model id the proxy is configured to rewrite every request to.</param>
+    /// <param name="model">
+    ///     The model id the proxy is configured to pin every request to. Pass <c>null</c> to leave
+    ///     <c>COPILOT_ANTHROPIC_MODEL</c> unset, exercising the discovery path instead (the proxy then
+    ///     calls <c>GET /models</c> on <paramref name="upstream"/> at startup) — the caller's
+    ///     <paramref name="upstream"/> must handle that request too in that mode.
+    /// </param>
     /// <param name="idleTimeoutSeconds">
     ///     Optional per-request idle timeout for the proxy (sets <c>COPILOT_ANTHROPIC_IDLE_TIMEOUT_SECONDS</c>);
     ///     used by the 504 test to make a stalled upstream time out quickly.
@@ -39,8 +44,9 @@ public sealed class ProxyWebAppFactory : WebApplicationFactory<Program>
     public ProxyWebAppFactory(
         Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> upstream,
         ICopilotTokenProvider? tokenProvider = null,
-        string model = ConfiguredModel,
-        int? idleTimeoutSeconds = null)
+        string? model = ConfiguredModel,
+        int? idleTimeoutSeconds = null
+    )
     {
         ArgumentNullException.ThrowIfNull(upstream);
 
@@ -51,7 +57,8 @@ public sealed class ProxyWebAppFactory : WebApplicationFactory<Program>
         {
             Environment.SetEnvironmentVariable(
                 "COPILOT_ANTHROPIC_IDLE_TIMEOUT_SECONDS",
-                idleTimeoutSeconds.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                idleTimeoutSeconds.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
Three incremental hardening fixes to the `CopilotAnthropicProxy.Sample` reverse proxy so real Claude Code sessions work reliably against GitHub Copilot's Anthropic-compatible backend:
- Model discovery now picks the highest-version `claude-opus-*` id instead of the first match when Copilot lists multiple concurrent opus variants.
- Transparent MCP (Streamable HTTP) passthrough added on `/mcp` and `/mcp/readonly`, reusing the existing Copilot-authenticated transport.
- The `anthropic-beta` header and `context_management` body field are now stripped before forwarding — Copilot's backend 400s the whole request if it doesn't recognize every beta value, and 400s outright if `context_management` is present at all. Both are sent routinely by Claude Code.

## Changes
- Opus model resolver: parse and compare version suffixes so the numerically highest opus id always wins; added tests driven off a sanitized real Copilot `/models` response.
- MCP passthrough: byte-level reverse proxy for GET/POST/DELETE on `/mcp` and `/mcp/readonly`, forwarding inbound headers verbatim except `Authorization` (overridden with Copilot credentials) and a small hop-by-hop set.
- Request compatibility: `ApplyRequestHeaderAllowlist` no longer forwards `anthropic-beta`; `ProxyModelResolver.TryRewriteModel` now also strips `context_management` from the JSON body alongside the existing `model` rewrite.
- README updated to document the new "Known request incompatibilities" behavior and MCP exposure; removed the now-inaccurate "no anthropic-beta filter" non-goal.

## Testing
- `dotnet test tests/CopilotAnthropicProxy.Tests` — 82/82 passing.
- MCP passthrough verified live against the real Copilot MCP server (initialize, session-scoped `tools/list`, session termination, unsupported-method passthrough).
- anthropic-beta/context_management stripping verified against the exact failing request captures that motivated the fix (Copilot previously 400'd with `"unsupported beta header(s): ..."` and `"context_management: Extra inputs are not permitted"`).

## Related Issues
Fixes #126