### PR TITLE
feat(samples): expose Copilot models in dropdown, partitioned by vendor (#128)

### DIFF
--- a/docs/superpowers/specs/2026-07-01-copilot-models-partition-design.md
+++ b/docs/superpowers/specs/2026-07-01-copilot-models-partition-design.md
@@ -1,0 +1,58 @@
+# Expose GitHub Copilot models in the sample model list, partitioned by vendor
+
+**Date:** 2026-07-01
+**Status:** Approved via goal directive + HITL scope answers
+**Target repo:** `B:/sources/LmDotnetTools` (main checkout; feature branch off `main`)
+
+## Goal
+Expose all models available through the GitHub Copilot-based provider in the
+LmStreaming.Sample model list, clearly partitioned into **Anthropic** and **OpenAI** groups.
+
+## Locked decisions (from HITL)
+1. **Which list:** LmStreaming.Sample provider dropdown (`ProviderRegistry` → `/api/providers` → `ProviderSelector.vue`). NOT LmConfig `models.json`.
+2. **Source:** Dynamic discovery — call Copilot `GET /models` at startup and build the list from the live response.
+3. **Scope:** Only models whose `vendor ∈ {Anthropic, OpenAI}` (normalizing `Azure OpenAI` → `OpenAI`) **and** that are routable via an existing factory (`/v1/messages` → Anthropic, `/responses` → Responses). Google/Gemini and `/chat/completions`-only models excluded.
+4. **UI:** Grouped dropdown with non-selectable headers (`Copilot · Anthropic`, `Copilot · OpenAI`).
+5. **Curated entries:** Remove the 4 hardcoded Copilot entries (`sonnet`, `haiku`, `gpt-5.5`, `gpt-5.5-mini`); the discovered list is the single source. Generalize the dispatch to route by discovered transport instead of those literal ids.
+
+## Current state (grounding)
+- `samples/LmStreaming.Sample/Services/ProviderRegistry.cs:20-41` — hardcoded catalog incl. the 4 Copilot entries; availability gated on `hasCopilotToken` (:73, :86).
+- `ProviderDescriptor(Id, DisplayName, Available, KnownLimitation?)` — flat, no group field.
+- Dispatch: `Func<string,IStreamingAgent>` switch `Program.cs:314-328` (`sonnet`/`haiku` → `CopilotAnthropicAgentFactory`; `gpt-5.5*` → `CopilotResponsesAgentFactory`).
+- Model id: `GetModelIdForProvider` switch `Program.cs:1496-1512` → `GenerateReplyOptions.ModelId` (`:757`, `:839`).
+- Copilot `/models` real response: `tests/CopilotAnthropicProxy.Tests/Fixtures/copilot-models-real-response.json` — each entry has `id`, `name`, `vendor`, `supported_endpoints`, `capabilities.family`.
+- Auth/HTTP to reuse: `CopilotHttpClientFactory.Create(host, tokenProvider, session, options)`; token via `CliCredentialCopilotTokenProvider`; host `CopilotOptions.DefaultBaseUrl`.
+- Existing endpoint-filter/parse precedent (not reused directly): `ProxyModelResolver.ParseMessagesCapableModelIds` in `samples/CopilotAnthropicProxy.Sample/Program.cs`.
+
+## Design
+
+### Component 1 — Discovery (`src/GithubCopilotProvider/Models/`)
+- `CopilotModelInfo` record: `Id`, `DisplayName`, `Vendor` (normalized), `SupportedEndpoints`, derived `Transport` enum { `Anthropic`, `Responses`, `Unsupported` }.
+- `CopilotVendor`/`CopilotModelTransport` — small enums or normalized strings.
+- `CopilotModelCatalogParser.Parse(json)` — **pure**. Parses `{"data":[...]}`, normalizes vendor, derives transport from `supported_endpoints`, keeps only `Vendor ∈ {Anthropic, OpenAI}` and `Transport ∈ {Anthropic, Responses}`. Unit-tested against the real fixture.
+- `CopilotModelsClient.GetModelsAsync(ct)` — `CopilotHttpClientFactory.Create(...)` → `GET /models` → `Parse`. Returns empty list on failure.
+
+### Component 2 — Sample wiring
+- `ProviderDescriptor` gains `string? Group` (null → flat render). Add `Vendor`/`RawModelId` only if needed for dispatch; prefer a separate lookup map `id → CopilotModelInfo`.
+- `ProviderRegistry` accepts injected `IReadOnlyList<CopilotModelInfo>`; builds one descriptor per model, **id = raw model id**, `Group = "Copilot · Anthropic" | "Copilot · OpenAI"`, `Available = hasCopilotToken`. Removes the 4 curated entries. Non-Copilot entries unchanged (`Group = null`).
+- Startup resolve in `Program.cs` (sync-over-async at registration, same pattern as `:796`). Token absent → empty list → no Copilot models. Token present + discovery fails → small built-in Anthropic+OpenAI fallback set so the app still runs.
+- Dispatch generalization: factory switch + model-id resolution look up the discovered `CopilotModelInfo` by id → `Transport` picks the factory; raw id → `GenerateReplyOptions.ModelId`. Direct (`openai`/`anthropic`) and CLI (`claude`/`codex`/`copilot`) branches unchanged.
+
+### Component 3 — UI
+- `types/providers.ts` `ProviderDescriptor` gains `group?: string | null`.
+- `ProviderSelector.vue`: group entries by `group`; `group == null` render flat first (unchanged look), grouped entries under non-selectable headers. Preserve availability/limitation/active rendering.
+
+### Testing (TDD, RED→GREEN)
+- Parser unit tests vs real fixture: Anthropic→Anthropic partition/Transport; GPT→OpenAI/Responses; Gemini/Google + `/chat/completions`-only excluded; `Azure OpenAI`→`OpenAI`.
+- `ProviderRegistry` tests: stub list → descriptors+groups; empty/no-token → no Copilot entries; non-Copilot entries unchanged.
+- Dispatch tests: `claude-*` id → Anthropic factory; `gpt-*` id → Responses factory; raw id flows to `ModelId`.
+
+## Out of scope (YAGNI)
+- `CopilotAnthropicProxy.Sample`, `src/LmConfig/models.json`, real Anthropic/OpenAI providers.
+- Caching/refresh beyond the single startup resolve.
+- Live network in tests (fixture-driven).
+
+## Risks
+- Overlap of discovered `gpt-5.5` with a former curated id — resolved by "replace" decision (single source).
+- `Azure OpenAI` vendor drift — handled by normalization.
+- Startup network dependency — handled by graceful fallback.

--- a/docs/superpowers/specs/2026-07-01-copilot-models-partition-design.md
+++ b/docs/superpowers/specs/2026-07-01-copilot-models-partition-design.md
@@ -35,7 +35,7 @@ LmStreaming.Sample model list, clearly partitioned into **Anthropic** and **Open
 ### Component 2 — Sample wiring
 - `ProviderDescriptor` gains `string? Group` (null → flat render). Add `Vendor`/`RawModelId` only if needed for dispatch; prefer a separate lookup map `id → CopilotModelInfo`.
 - `ProviderRegistry` accepts injected `IReadOnlyList<CopilotModelInfo>`; builds one descriptor per model, **id = raw model id**, `Group = "Copilot · Anthropic" | "Copilot · OpenAI"`, `Available = hasCopilotToken`. Removes the 4 curated entries. Non-Copilot entries unchanged (`Group = null`).
-- Startup resolve in `Program.cs` (sync-over-async at registration, same pattern as `:796`). Token absent → empty list → no Copilot models. Token present + discovery fails → small built-in Anthropic+OpenAI fallback set so the app still runs.
+- Startup resolve in `Program.cs` (sync-over-async at registration, same pattern as `:796`). Token absent → empty list → no Copilot models. Token present + discovery fails (or the bounded startup timeout elapses) → empty list → no Copilot models; the app still boots with the direct/CLI/test providers. (No built-in fallback set is used — the accepted behavior is to leave the Copilot sections empty.)
 - Dispatch generalization: factory switch + model-id resolution look up the discovered `CopilotModelInfo` by id → `Transport` picks the factory; raw id → `GenerateReplyOptions.ModelId`. Direct (`openai`/`anthropic`) and CLI (`claude`/`codex`/`copilot`) branches unchanged.
 
 ### Component 3 — UI
@@ -55,4 +55,4 @@ LmStreaming.Sample model list, clearly partitioned into **Anthropic** and **Open
 ## Risks
 - Overlap of discovered `gpt-5.5` with a former curated id — resolved by "replace" decision (single source).
 - `Azure OpenAI` vendor drift — handled by normalization.
-- Startup network dependency — handled by graceful fallback.
+- Startup network dependency — handled by degrading to an empty Copilot catalog (bounded timeout).

--- a/samples/LmStreaming.Sample/CLAUDE.md
+++ b/samples/LmStreaming.Sample/CLAUDE.md
@@ -13,9 +13,11 @@ dotnet run --project samples/LmStreaming.Sample        # serves API + /ws on :50
 npm --prefix samples/LmStreaming.Sample/ClientApp install
 npm --prefix samples/LmStreaming.Sample/ClientApp run dev   # http://localhost:5173
 ```
-Provider is chosen in the UI (header dropdown, `GET /api/providers`). Copilot-backed providers
-("GPT-5.5 (Copilot)", "Sonnet/Haiku (Copilot)") need a resolvable Copilot/`gh` token, no API key.
-Add `?record=1` to the URL to dump the WebSocket stream + LLM request/response to `recordings/`.
+Provider is chosen in the UI (header dropdown, `GET /api/providers`). GitHub Copilot models are
+**discovered dynamically** at startup from the Copilot `/models` API and listed by their raw model
+id (e.g. `claude-opus-4.8`, `gpt-5.5`), partitioned into "Copilot · Anthropic" / "Copilot · OpenAI"
+dropdown sections. They need a resolvable Copilot/`gh` token, no API key; with no token the sections
+are empty. Add `?record=1` to the URL to dump the WebSocket stream + LLM request/response to `recordings/`.
 
 ## UI / browser testing — READ THIS BEFORE WRITING BROWSER TESTS
 

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ProviderSelector.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ProviderSelector.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { mount } from '@vue/test-utils';
 import ProviderSelector from '@/components/ProviderSelector.vue';
+// Raw component source, used to assert the scoped stylesheet rules (scoped <style> is not
+// injected into the jsdom DOM by @vue/test-utils, so we verify the CSS at the source level).
+import providerSelectorSource from '@/components/ProviderSelector.vue?raw';
 import type { ProviderDescriptor } from '@/types/providers';
 
 const providers: ProviderDescriptor[] = [
@@ -67,5 +70,24 @@ describe('ProviderSelector grouping', () => {
 
     expect(wrapper.findAll('.menu-group-header')).toHaveLength(0);
     expect(wrapper.findAll('.menu-item')).toHaveLength(2);
+  });
+});
+
+describe('ProviderSelector dropdown scroll', () => {
+  // Extract the `.dropdown-menu { ... }` rule body from the scoped stylesheet source.
+  const menuRule = (() => {
+    const start = providerSelectorSource.indexOf('.dropdown-menu {');
+    expect(start).toBeGreaterThanOrEqual(0);
+    const end = providerSelectorSource.indexOf('}', start);
+    return providerSelectorSource.slice(start, end);
+  })();
+
+  it('caps the dropdown height so a long list does not run off-screen', () => {
+    // max-height keeps the menu bounded; a bare `max-height` without a value would not.
+    expect(menuRule).toMatch(/max-height:\s*[^;]+;/);
+  });
+
+  it('enables vertical scrolling for overflowing content', () => {
+    expect(menuRule).toMatch(/overflow-y:\s*auto\s*;/);
   });
 });

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ProviderSelector.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ProviderSelector.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ProviderSelector from '@/components/ProviderSelector.vue';
+import type { ProviderDescriptor } from '@/types/providers';
+
+const providers: ProviderDescriptor[] = [
+  { id: 'openai', displayName: 'OpenAI', available: true },
+  { id: 'anthropic', displayName: 'Anthropic', available: true },
+  { id: 'claude-opus-4.8', displayName: 'Claude Opus 4.8', available: true, group: 'Copilot · Anthropic' },
+  { id: 'claude-sonnet-5', displayName: 'Claude Sonnet 5', available: true, group: 'Copilot · Anthropic' },
+  { id: 'gpt-5.5', displayName: 'GPT-5.5', available: true, group: 'Copilot · OpenAI' },
+];
+
+function open() {
+  const wrapper = mount(ProviderSelector, {
+    props: { providers, selectedProviderId: 'openai' },
+  });
+  return wrapper.get('.selector-btn').trigger('click').then(() => wrapper);
+}
+
+describe('ProviderSelector grouping', () => {
+  it('renders a section header per partition group', async () => {
+    const wrapper = await open();
+
+    const headers = wrapper.findAll('.menu-group-header').map((h) => h.text());
+    expect(headers).toEqual(['Copilot · Anthropic', 'Copilot · OpenAI']);
+  });
+
+  it('renders ungrouped providers ahead of the grouped sections', async () => {
+    const wrapper = await open();
+
+    // Ungrouped providers (openai/anthropic) have no header; the first header appears only after them.
+    const menu = wrapper.get('.dropdown-menu');
+    const html = menu.html();
+    const firstHeaderIndex = html.indexOf('menu-group-header');
+    const openAiIndex = html.indexOf('provider-option-openai');
+    expect(openAiIndex).toBeGreaterThanOrEqual(0);
+    expect(openAiIndex).toBeLessThan(firstHeaderIndex);
+  });
+
+  it('renders every provider as a selectable option under its group', async () => {
+    const wrapper = await open();
+
+    for (const provider of providers) {
+      expect(wrapper.find(`[data-testid="provider-option-${provider.id}"]`).exists()).toBe(true);
+    }
+  });
+
+  it('emits select-provider with the model id when a grouped option is clicked', async () => {
+    const wrapper = await open();
+
+    await wrapper.get('[data-testid="provider-option-gpt-5.5"]').trigger('click');
+    expect(wrapper.emitted('select-provider')?.[0]).toEqual(['gpt-5.5']);
+  });
+
+  it('renders a flat list with no headers when no provider has a group', async () => {
+    const wrapper = mount(ProviderSelector, {
+      props: {
+        providers: [
+          { id: 'openai', displayName: 'OpenAI', available: true },
+          { id: 'test', displayName: 'Test', available: true },
+        ],
+        selectedProviderId: 'openai',
+      },
+    });
+    await wrapper.get('.selector-btn').trigger('click');
+
+    expect(wrapper.findAll('.menu-group-header')).toHaveLength(0);
+    expect(wrapper.findAll('.menu-item')).toHaveLength(2);
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ProviderSelector.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ProviderSelector.vue
@@ -245,12 +245,13 @@ watch(
   right: 0;
   margin-top: 4px;
   min-width: 200px;
+  max-height: 320px;
+  overflow-y: auto;
   background: white;
   border: 1px solid #ddd;
   border-radius: 8px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   z-index: 100;
-  overflow: hidden;
   padding: 4px 0;
 }
 
@@ -269,6 +270,9 @@ watch(
 }
 
 .menu-group-header {
+  position: sticky;
+  top: 0;
+  background: white;
   padding: 6px 12px 2px;
   font-size: 11px;
   font-weight: 600;

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ProviderSelector.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ProviderSelector.vue
@@ -38,6 +38,44 @@ const selectedProvider = computed<ProviderDescriptor | null>(() =>
   props.providers.find((p) => p.id === props.selectedProviderId) ?? null
 );
 
+/**
+ * Renders the dropdown as ungrouped entries first (in server order) followed by one section per
+ * partition group (e.g. "Copilot · Anthropic", "Copilot · OpenAI"). Group order follows first
+ * appearance in the provider list, so the server controls partition ordering.
+ */
+interface ProviderGroup {
+  label: string | null;
+  providers: ProviderDescriptor[];
+}
+
+const groupedProviders = computed<ProviderGroup[]>(() => {
+  const ungrouped: ProviderDescriptor[] = [];
+  const groups = new Map<string, ProviderDescriptor[]>();
+
+  for (const provider of props.providers) {
+    const group = provider.group;
+    if (!group) {
+      ungrouped.push(provider);
+      continue;
+    }
+    const bucket = groups.get(group);
+    if (bucket) {
+      bucket.push(provider);
+    } else {
+      groups.set(group, [provider]);
+    }
+  }
+
+  const result: ProviderGroup[] = [];
+  if (ungrouped.length > 0) {
+    result.push({ label: null, providers: ungrouped });
+  }
+  for (const [label, providers] of groups) {
+    result.push({ label, providers });
+  }
+  return result;
+});
+
 function toggleDropdown(): void {
   if (props.disabled || props.isLoading || isLocked.value) {
     return;
@@ -115,26 +153,36 @@ watch(
       </button>
 
       <div v-if="dropdownOpen" class="dropdown-menu">
-        <button
-          v-for="provider in providers"
-          :key="provider.id"
-          class="menu-item"
-          :class="{ active: provider.id === selectedProviderId, unavailable: !provider.available }"
-          :data-testid="`provider-option-${provider.id}`"
-          :disabled="disabled || !provider.available"
-          :title="provider.knownLimitation ?? undefined"
-          @click="handleSelect(provider.id)"
-        >
-          <span class="item-name">{{ provider.displayName }}</span>
-          <span
-            v-if="provider.available && provider.knownLimitation"
-            class="item-warning"
-            :data-testid="`provider-warning-${provider.id}`"
-            aria-label="known limitation"
-          >⚠</span>
-          <span v-if="!provider.available" class="item-status">unavailable</span>
-          <span v-else-if="provider.id === selectedProviderId" class="check-mark">✓</span>
-        </button>
+        <template v-for="group in groupedProviders" :key="group.label ?? '__ungrouped__'">
+          <div
+            v-if="group.label"
+            class="menu-group-header"
+            :data-testid="`provider-group-${group.label}`"
+            role="presentation"
+          >
+            {{ group.label }}
+          </div>
+          <button
+            v-for="provider in group.providers"
+            :key="provider.id"
+            class="menu-item"
+            :class="{ active: provider.id === selectedProviderId, unavailable: !provider.available }"
+            :data-testid="`provider-option-${provider.id}`"
+            :disabled="disabled || !provider.available"
+            :title="provider.knownLimitation ?? undefined"
+            @click="handleSelect(provider.id)"
+          >
+            <span class="item-name">{{ provider.displayName }}</span>
+            <span
+              v-if="provider.available && provider.knownLimitation"
+              class="item-warning"
+              :data-testid="`provider-warning-${provider.id}`"
+              aria-label="known limitation"
+            >⚠</span>
+            <span v-if="!provider.available" class="item-status">unavailable</span>
+            <span v-else-if="provider.id === selectedProviderId" class="check-mark">✓</span>
+          </button>
+        </template>
       </div>
     </template>
   </div>
@@ -218,6 +266,22 @@ watch(
   text-align: left;
   cursor: pointer;
   transition: background 0.15s;
+}
+
+.menu-group-header {
+  padding: 6px 12px 2px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6c757d;
+  user-select: none;
+}
+
+.menu-group-header:not(:first-child) {
+  margin-top: 4px;
+  border-top: 1px solid #eee;
+  padding-top: 8px;
 }
 
 .menu-item:hover:not(:disabled) {

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ProviderSelector.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ProviderSelector.vue
@@ -245,8 +245,12 @@ watch(
   right: 0;
   margin-top: 4px;
   min-width: 200px;
-  max-height: 320px;
+  /* Cap the height so a long (dynamically discovered) model list scrolls instead of
+     running off-screen. Viewport-relative with a fixed upper bound so it adapts to
+     short viewports too. */
+  max-height: min(60vh, 320px);
   overflow-y: auto;
+  overscroll-behavior: contain;
   background: white;
   border: 1px solid #ddd;
   border-radius: 8px;

--- a/samples/LmStreaming.Sample/ClientApp/src/types/providers.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/types/providers.ts
@@ -11,6 +11,12 @@ export interface ProviderDescriptor {
    * issue). Rendered next to the entry in the dropdown.
    */
   knownLimitation?: string | null;
+  /**
+   * Optional partition label rendered as a non-selectable section header in the dropdown
+   * (e.g. "Copilot · Anthropic", "Copilot · OpenAI"). Entries without a group are rendered
+   * as a flat list ahead of the grouped sections.
+   */
+  group?: string | null;
 }
 
 /**

--- a/samples/LmStreaming.Sample/ClientApp/vite.config.ts
+++ b/samples/LmStreaming.Sample/ClientApp/vite.config.ts
@@ -2,6 +2,14 @@ import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { resolve } from 'path';
 
+// Dev-server port and backend proxy target are configurable so an isolated instance can run
+// alongside another without colliding on 5173/5000. VITE_DEV_PORT sets the dev-server port;
+// VITE_BACKEND_ORIGIN (e.g. http://localhost:5098) points the /api and /ws proxies at the paired
+// backend. Both default to the standard single-instance values.
+const devPort = Number(process.env.VITE_DEV_PORT) || 5173;
+const backendOrigin = process.env.VITE_BACKEND_ORIGIN || 'http://localhost:5000';
+const wsOrigin = backendOrigin.replace(/^http/, 'ws');
+
 export default defineConfig({
   plugins: [vue()],
   base: '/dist/',
@@ -14,15 +22,15 @@ export default defineConfig({
     },
   },
   server: {
-    port: 5173,
+    port: devPort,
     strictPort: true,
     proxy: {
       '/api': {
-        target: 'http://localhost:5000',
+        target: backendOrigin,
         changeOrigin: true,
       },
       '/ws': {
-        target: 'ws://localhost:5000',
+        target: wsOrigin,
         ws: true,
         changeOrigin: true,
       },

--- a/samples/LmStreaming.Sample/ManualTesting.md
+++ b/samples/LmStreaming.Sample/ManualTesting.md
@@ -16,6 +16,22 @@ LM_PROVIDER_MODE=test-anthropic dotnet run --project samples/LmStreaming.Sample
 LM_PROVIDER_MODE=codex dotnet run --project samples/LmStreaming.Sample
 ```
 
+### Running a second, isolated instance
+
+The default instance binds the app to `:5000` and its Vite dev server to `:5173`. To run another
+instance alongside it without port collisions, override the app URL plus the Vite dev-server port
+(`VITE_DEV_PORT`) and backend origin (`VITE_BACKEND_ORIGIN`):
+
+```bash
+ASPNETCORE_ENVIRONMENT=Development LM_PROVIDER_MODE=test \
+  VITE_DEV_PORT=5273 VITE_BACKEND_ORIGIN=http://localhost:5098 \
+  dotnet run --project samples/LmStreaming.Sample --urls http://localhost:5098
+```
+
+`VITE_DEV_PORT` is read by both the ASP.NET Vite middleware and `vite.config.ts`, so the two agree
+on the dev-server port; `VITE_BACKEND_ORIGIN` points the Vite `/api` + `/ws` proxies at the paired
+backend. Both default to the standard single-instance values when unset.
+
 Provider modes:
 | Mode | Description | Server Tools |
 |------|-------------|--------------|

--- a/samples/LmStreaming.Sample/ManualTesting.md
+++ b/samples/LmStreaming.Sample/ManualTesting.md
@@ -28,9 +28,10 @@ Provider modes:
 ### Fallback web tools (Jina-backed `WebFetch` / `WebSearch`)
 
 Providers **without** a native web capability receive the Jina-backed function tools `WebFetch`
-(read a page as Markdown) and `WebSearch` (ranked results as Markdown) as a fallback. Only the
-no-native providers get them: `openai`, `sonnet`, `haiku`, `gpt-5.5`, `gpt-5.5-mini` (the last four
-are Copilot-routed provider ids). Providers with native web — `anthropic`/`test-anthropic`
+(read a page as Markdown) and `WebSearch` (ranked results as Markdown) as a fallback. The no-native
+providers that get them are `openai` and every dynamically discovered GitHub Copilot model (the
+"Copilot · Anthropic" / "Copilot · OpenAI" dropdown entries, keyed by raw model id such as
+`claude-opus-4.8` or `gpt-5.5`). Providers with native web — `anthropic`/`test-anthropic`
 (`web_search`), the Claude/Codex CLIs, plain `copilot`, and the `*-mock`/`test` providers — do
 **not** get them, so a conversation never has both native web and the Jina fallback. `WebSearch` is
 only registered when `JINA_API_KEY` is set; `WebFetch` works without a key. Both are also gated by

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -113,13 +113,18 @@ try
     _ = builder.Services.AddControllers();
     _ = builder.Services.AddEndpointsApiExplorer();
 
-    // Add Vite services for frontend integration
+    // Add Vite services for frontend integration. The dev-server port is configurable via
+    // VITE_DEV_PORT so an isolated instance can run alongside another without colliding on 5173
+    // (the paired vite.config.ts reads the same env var). Defaults to 5173.
+    var viteDevPort = ushort.TryParse(Environment.GetEnvironmentVariable("VITE_DEV_PORT"), out var parsedVitePort)
+        ? parsedVitePort
+        : (ushort)5173;
     _ = builder.Services.AddViteServices(options =>
     {
         options.Base = "/dist/";
         options.Server.AutoRun = true;
         options.Server.PackageDirectory = "ClientApp";
-        options.Server.Port = 5173;
+        options.Server.Port = viteDevPort;
     });
 
     var providerMode = Environment.GetEnvironmentVariable("LM_PROVIDER_MODE") ?? "test";

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -1271,7 +1271,18 @@ public partial class Program
 
         var client = new CopilotModelsClient(s_copilotTokenProvider.Value, s_copilotSession.Value, logger: logger);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        return client.GetModelsAsync(cts.Token).GetAwaiter().GetResult();
+        try
+        {
+            return client.GetModelsAsync(cts.Token).GetAwaiter().GetResult();
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            // The bounded discovery timeout elapsed — degrade to no Copilot models rather than
+            // blocking startup. (The client propagates genuine cancellation; the sample owns the
+            // timeout-to-empty fallback.)
+            logger.LogWarning("Copilot model discovery timed out; exposing no Copilot models.");
+            return [];
+        }
     }
 
     /// <summary>
@@ -1281,9 +1292,15 @@ public partial class Program
     /// </summary>
     private static IStreamingAgent CreateCopilotModelAgent(CopilotModelInfo model, ILoggerFactory loggerFactory)
     {
-        return model.Transport == CopilotModelTransport.Anthropic
-            ? CreateCopilotAnthropicAgent(model.DisplayName, loggerFactory)
-            : CreateCopilotResponsesAgent(model.DisplayName, loggerFactory);
+        return model.Transport switch
+        {
+            CopilotModelTransport.Anthropic => CreateCopilotAnthropicAgent(model.DisplayName, loggerFactory),
+            CopilotModelTransport.Responses => CreateCopilotResponsesAgent(model.DisplayName, loggerFactory),
+            _ => throw new ProviderUnavailableException(
+                model.Id,
+                $"unsupported Copilot transport {model.Transport}"
+            ),
+        };
     }
 
     /// <summary>

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -7,6 +7,7 @@ using AchieveAi.LmDotnetTools.AnthropicProvider.Models;
 using AchieveAi.LmDotnetTools.ClaudeAgentSdkProvider.Configuration;
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Agents;
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
 using AchieveAi.LmDotnetTools.LmCore.AgentRuntime;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
@@ -135,7 +136,19 @@ try
     _ = builder.Services.AddSingleton<MockProviderHostLifetime>();
     _ = builder.Services.AddHostedService(sp => sp.GetRequiredService<MockProviderHostLifetime>());
 
-    _ = builder.Services.AddSingleton<ProviderRegistry>();
+    // Discover the GitHub Copilot model catalog once at startup and register the provider
+    // registry from it. Discovery reuses the developer's existing Copilot/gh login; when no token
+    // resolves or the /models call fails, DiscoverCopilotModels returns an empty list and the
+    // registry simply exposes no Copilot models (the app still boots with the direct/CLI/test
+    // providers). Resolved eagerly here (sync-over-async on the no-SynchronizationContext startup
+    // path) so the registry — used on the request hot path — stays synchronous.
+    _ = builder.Services.AddSingleton(sp =>
+    {
+        var probe = sp.GetRequiredService<IFileSystemProbe>();
+        var mockHost = sp.GetRequiredService<MockProviderHostLifetime>();
+        var copilotModels = DiscoverCopilotModels(sp.GetRequiredService<ILoggerFactory>());
+        return new ProviderRegistry(copilotModels, probe, mockHost);
+    });
 
     // Register the FunctionRegistry with sample tools
     _ = builder.Services.AddSingleton(sp =>
@@ -311,14 +324,18 @@ try
         providerId =>
         {
             var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+
+            // Discovered Copilot models route by their transport (Anthropic Messages vs OpenAI
+            // Responses); everything else is a fixed provider handled by the switch below.
+            if (sp.GetRequiredService<ProviderRegistry>().TryGetCopilotModel(providerId, out var copilotModel))
+            {
+                return CreateCopilotModelAgent(copilotModel, loggerFactory);
+            }
+
             return providerId.ToLowerInvariant() switch
             {
                 "openai" => CreateOpenAiAgent(loggerFactory),
                 "anthropic" => CreateAnthropicAgent(loggerFactory),
-                "sonnet" => CreateCopilotAnthropicAgent("Sonnet", loggerFactory),
-                "haiku" => CreateCopilotAnthropicAgent("Haiku", loggerFactory),
-                "gpt-5.5" => CreateCopilotResponsesAgent("GPT-5.5", loggerFactory),
-                "gpt-5.5-mini" => CreateCopilotResponsesAgent("GPT-5.5 mini", loggerFactory),
                 "test-anthropic" => CreateAnthropicTestAgent(loggerFactory, sp.GetRequiredService<ITestAgentBuilder>()),
                 "test" => CreateTestAgent(loggerFactory, sp.GetRequiredService<ITestAgentBuilder>()),
                 _ => throw new ProviderUnavailableException(
@@ -735,13 +752,18 @@ try
                 // tool set. Gated by the provider allow-list and the mode's EnabledTools (function-tool
                 // list); the native built-in path (modeBuiltInAllowList, below) is governed separately
                 // and left untouched.
+                // Resolve the discovered Copilot model (if any) backing this provider once; its
+                // transport and raw id drive the model-id, reasoning, and web-tool wiring below.
+                var isCopilotBackedModel = providerRegistry.TryGetCopilotModel(normalizedProviderId, out var copilotModelInfo);
+
                 var webToolStatuses = WebToolRegistrationPolicy.Apply(
                     filteredRegistry,
                     normalizedProviderId,
                     mode.EnabledTools,
                     jinaWebProvider,
                     webToolsOptions,
-                    loggerFactory
+                    loggerFactory,
+                    isCopilotBackedModel
                 );
                 if (webToolStatuses.Count > 0)
                 {
@@ -754,7 +776,11 @@ try
 
                 try
                 {
-                    var modelId = GetModelIdForProvider(normalizedProviderId);
+                    // Discovered Copilot models use their raw model id verbatim; fixed providers keep
+                    // the curated per-provider id map.
+                    var modelId = isCopilotBackedModel
+                        ? copilotModelInfo.Id
+                        : GetModelIdForProvider(normalizedProviderId);
 
                     // Built-in (server-side) tools are selected by the MODE — never injected per
                     // provider or via a per-mode override. A mode declares its server-side built-ins in
@@ -770,8 +796,11 @@ try
 
                     // Surface model reasoning (provider→Thinking/Reasoning mapping). Extracted to a
                     // testable helper so the per-provider wiring is regression-guarded; see
-                    // ProgramReasoningExtraPropertiesTests.
-                    var extraProperties = BuildReasoningExtraProperties(normalizedProviderId);
+                    // ProgramReasoningExtraPropertiesTests. Discovered Copilot models map by transport.
+                    var extraProperties = BuildReasoningExtraProperties(
+                        normalizedProviderId,
+                        isCopilotBackedModel ? copilotModelInfo.Transport : null
+                    );
 
                     // Sub-agent orchestration options. Only the middleware providers reach this
                     // path — the CLI providers (codex/claude/copilot and their *-mock variants)
@@ -1092,22 +1121,25 @@ finally
 public partial class Program
 {
     /// <summary>
-    ///     Maps a normalized provider id to the reasoning/thinking request options that surface a
-    ///     model's reasoning. Anthropic-format providers (incl. the Copilot-backed sonnet/haiku — the
-    ///     Copilot proxy accepts the thinking parameter, verified by
-    ///     CopilotAnthropicLiveTests.Thinking_param_is_accepted_by_copilot_backend) get an extended-
-    ///     thinking budget; the OpenAI Responses providers (gpt-5.5/gpt-5.5-mini) get a reasoning-
-    ///     summary request (CopilotResponsesLiveTests confirms gpt-5.5 returns reasoning). Other
-    ///     providers get none. Without this wiring, Copilot-backed models return no thinking blocks.
+    ///     Maps a normalized provider id (plus, for discovered Copilot models, its transport) to the
+    ///     reasoning/thinking request options that surface a model's reasoning. Anthropic-format
+    ///     providers — the direct <c>anthropic</c>/<c>test-anthropic</c> providers and any Copilot model
+    ///     whose transport is <see cref="CopilotModelTransport.Anthropic"/> (the Copilot proxy accepts
+    ///     the thinking parameter, verified by
+    ///     CopilotAnthropicLiveTests.Thinking_param_is_accepted_by_copilot_backend) — get an extended-
+    ///     thinking budget; Copilot models on the OpenAI Responses transport get a reasoning-summary
+    ///     request (CopilotResponsesLiveTests confirms gpt-5.5 returns reasoning). Other providers get
+    ///     none. Without this wiring, Copilot-backed models return no thinking blocks.
     /// </summary>
-    internal static ImmutableDictionary<string, object?> BuildReasoningExtraProperties(string normalizedProviderId)
+    internal static ImmutableDictionary<string, object?> BuildReasoningExtraProperties(
+        string normalizedProviderId,
+        CopilotModelTransport? copilotTransport = null)
     {
         var extraProperties = ImmutableDictionary<string, object?>.Empty;
         if (
             string.Equals(normalizedProviderId, "anthropic", StringComparison.Ordinal)
             || string.Equals(normalizedProviderId, "test-anthropic", StringComparison.Ordinal)
-            || string.Equals(normalizedProviderId, "sonnet", StringComparison.Ordinal)
-            || string.Equals(normalizedProviderId, "haiku", StringComparison.Ordinal)
+            || copilotTransport == CopilotModelTransport.Anthropic
         )
         {
             var budgetTokens = int.TryParse(
@@ -1118,10 +1150,7 @@ public partial class Program
                 : 2048;
             extraProperties = extraProperties.Add("Thinking", new AnthropicThinking(budgetTokens));
         }
-        else if (
-            string.Equals(normalizedProviderId, "gpt-5.5", StringComparison.Ordinal)
-            || string.Equals(normalizedProviderId, "gpt-5.5-mini", StringComparison.Ordinal)
-        )
+        else if (copilotTransport == CopilotModelTransport.Responses)
         {
             extraProperties = extraProperties.Add("Reasoning", new ResponseReasoningOptions { Summary = "auto" });
         }
@@ -1196,6 +1225,45 @@ public partial class Program
     );
 
     private static readonly Lazy<CopilotSessionContext> s_copilotSession = new(() => new CopilotSessionContext());
+
+    /// <summary>
+    ///     Discovers the routable Anthropic/OpenAI GitHub Copilot models. Returns an empty list when no
+    ///     Copilot token resolves or the <c>/models</c> call fails/times out, so the sample degrades to
+    ///     exposing no Copilot models rather than failing. Runs synchronously — it is called from the
+    ///     <see cref="ProviderRegistry"/> DI factory (which resolves lazily on the first
+    ///     <c>GET /api/providers</c>); ASP.NET Core has no <c>SynchronizationContext</c> so the blocking
+    ///     wait cannot deadlock. A short discovery timeout bounds first-request latency if the Copilot
+    ///     host hangs, instead of blocking the request thread for the HttpClient default timeout.
+    /// </summary>
+    private static IReadOnlyList<CopilotModelInfo> DiscoverCopilotModels(ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("LmStreaming.Sample.CopilotModelDiscovery");
+
+        // Gate on a resolvable Copilot token first (same sync check ProviderRegistry uses for its
+        // availability flag) so we don't fire an unauthenticated /models request when the developer
+        // isn't logged in.
+        if (new CliCredentialCopilotTokenProvider().ResolveToken() is null)
+        {
+            logger.LogInformation("No GitHub Copilot token resolved; skipping Copilot model discovery.");
+            return [];
+        }
+
+        var client = new CopilotModelsClient(s_copilotTokenProvider.Value, s_copilotSession.Value, logger: logger);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        return client.GetModelsAsync(cts.Token).GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    ///     Maps a discovered Copilot model's transport to the matching agent factory. Anthropic-shaped
+    ///     models route through the Copilot Messages backend; OpenAI-shaped models through the Copilot
+    ///     Responses backend.
+    /// </summary>
+    private static IStreamingAgent CreateCopilotModelAgent(CopilotModelInfo model, ILoggerFactory loggerFactory)
+    {
+        return model.Transport == CopilotModelTransport.Anthropic
+            ? CreateCopilotAnthropicAgent(model.DisplayName, loggerFactory)
+            : CreateCopilotResponsesAgent(model.DisplayName, loggerFactory);
+    }
 
     /// <summary>
     ///     Creates an Anthropic Messages agent (Sonnet/Haiku) routed through the GitHub Copilot
@@ -1503,10 +1571,6 @@ public partial class Program
             "claude" or "claude-mock" => Environment.GetEnvironmentVariable("CLAUDE_MODEL") ?? "claude-sonnet-4-6",
             "codex" or "codex-mock" => Environment.GetEnvironmentVariable("CODEX_MODEL") ?? "gpt-5.3-codex",
             "copilot" or "copilot-mock" => Environment.GetEnvironmentVariable("COPILOT_MODEL") ?? "claude-sonnet-4.5",
-            "sonnet" => Environment.GetEnvironmentVariable("SONNET_MODEL") ?? "claude-sonnet-4.5",
-            "haiku" => Environment.GetEnvironmentVariable("HAIKU_MODEL") ?? "claude-haiku-4.5",
-            "gpt-5.5" => Environment.GetEnvironmentVariable("GPT55_MODEL") ?? "gpt-5.5",
-            "gpt-5.5-mini" => Environment.GetEnvironmentVariable("GPT55_MINI_MODEL") ?? "gpt-5-mini",
             _ => "test-model",
         };
     }

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -796,10 +796,12 @@ try
 
                     // Surface model reasoning (provider→Thinking/Reasoning mapping). Extracted to a
                     // testable helper so the per-provider wiring is regression-guarded; see
-                    // ProgramReasoningExtraPropertiesTests. Discovered Copilot models map by transport.
+                    // ProgramReasoningExtraPropertiesTests. Discovered Copilot models map by transport,
+                    // and adaptive-thinking models opt out of the classic thinking budget request.
                     var extraProperties = BuildReasoningExtraProperties(
                         normalizedProviderId,
-                        isCopilotBackedModel ? copilotModelInfo.Transport : null
+                        isCopilotBackedModel ? copilotModelInfo.Transport : null,
+                        isCopilotBackedModel && copilotModelInfo.SupportsAdaptiveThinking
                     );
 
                     // Sub-agent orchestration options. Only the middleware providers reach this
@@ -1130,10 +1132,18 @@ public partial class Program
     ///     thinking budget; Copilot models on the OpenAI Responses transport get a reasoning-summary
     ///     request (CopilotResponsesLiveTests confirms gpt-5.5 returns reasoning). Other providers get
     ///     none. Without this wiring, Copilot-backed models return no thinking blocks.
+    ///     <para>
+    ///     Copilot Claude models that advertise <c>adaptive_thinking</c> (opus 4.x, sonnet 4.6+, sonnet 5)
+    ///     REJECT the classic <c>thinking.type.enabled</c> budget request with HTTP 400 — they require
+    ///     the newer <c>thinking.type.adaptive</c> + <c>output_config.effort</c> API, which this provider
+    ///     does not model yet. For those we omit the classic thinking parameter rather than send an
+    ///     unsupported one; they still reason, just without an explicit budget request.
+    ///     </para>
     /// </summary>
     internal static ImmutableDictionary<string, object?> BuildReasoningExtraProperties(
         string normalizedProviderId,
-        CopilotModelTransport? copilotTransport = null)
+        CopilotModelTransport? copilotTransport = null,
+        bool copilotSupportsAdaptiveThinking = false)
     {
         var extraProperties = ImmutableDictionary<string, object?>.Empty;
         if (
@@ -1142,6 +1152,12 @@ public partial class Program
             || copilotTransport == CopilotModelTransport.Anthropic
         )
         {
+            // Adaptive-thinking Copilot models reject the classic budget request; skip it for them.
+            if (copilotSupportsAdaptiveThinking)
+            {
+                return extraProperties;
+            }
+
             var budgetTokens = int.TryParse(
                 Environment.GetEnvironmentVariable("ANTHROPIC_THINKING_BUDGET"),
                 out var parsed

--- a/samples/LmStreaming.Sample/Services/ProviderDescriptor.cs
+++ b/samples/LmStreaming.Sample/Services/ProviderDescriptor.cs
@@ -11,8 +11,14 @@ namespace LmStreaming.Sample.Services;
 /// available but has a documented limitation that prevents end-to-end use today (typically a
 /// link to a follow-up issue). <c>null</c> for providers without such a caveat.
 /// </param>
+/// <param name="Group">
+/// Optional partition label the client renders as a non-selectable section header (e.g.
+/// <c>Copilot · Anthropic</c>, <c>Copilot · OpenAI</c>). <c>null</c> for ungrouped providers, which
+/// the client renders as a flat list ahead of the grouped sections.
+/// </param>
 public sealed record ProviderDescriptor(
     string Id,
     string DisplayName,
     bool Available,
-    string? KnownLimitation = null);
+    string? KnownLimitation = null,
+    string? Group = null);

--- a/samples/LmStreaming.Sample/Services/ProviderRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/ProviderRegistry.cs
@@ -141,7 +141,10 @@ public sealed class ProviderRegistry : AchieveAi.LmDotnetTools.LmAgentInfra.IPro
             }
 
             var group = model.Vendor == CopilotModelVendor.Anthropic ? CopilotAnthropicGroup : CopilotOpenAiGroup;
-            builder[id] = new ProviderDescriptor(id, model.DisplayName, hasCopilotToken, Group: group);
+            // Suffix "(Copilot)" so the model is identifiable as Copilot-backed even in a client that
+            // renders a flat list without the group headers.
+            var displayName = $"{model.DisplayName} (Copilot)";
+            builder[id] = new ProviderDescriptor(id, displayName, hasCopilotToken, Group: group);
         }
 
         _byId = builder.ToImmutable();

--- a/samples/LmStreaming.Sample/Services/ProviderRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/ProviderRegistry.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
 
 namespace LmStreaming.Sample.Services;
 
@@ -15,8 +16,18 @@ namespace LmStreaming.Sample.Services;
 /// resolved through a delegate captured at construction time and re-evaluated on each
 /// <see cref="IsAvailable"/> / <see cref="ListAll"/> call.
 /// </remarks>
+/// <remarks>
+/// GitHub Copilot models are discovered dynamically at startup (see
+/// <see cref="AchieveAi.LmDotnetTools.GithubCopilotProvider.Models.CopilotModelsClient"/>) and injected
+/// as catalog entries keyed by their raw model id, partitioned into <c>Copilot · Anthropic</c> /
+/// <c>Copilot · OpenAI</c> groups. When no Copilot token resolves (or discovery fails) the injected
+/// list is empty and no Copilot models are exposed.
+/// </remarks>
 public sealed class ProviderRegistry : AchieveAi.LmDotnetTools.LmAgentInfra.IProviderResolver
 {
+    private const string CopilotAnthropicGroup = "Copilot · Anthropic";
+    private const string CopilotOpenAiGroup = "Copilot · OpenAI";
+
     private static readonly ImmutableArray<CatalogEntry> CatalogEntries =
         [
             new("openai", "OpenAI"),
@@ -26,10 +37,6 @@ public sealed class ProviderRegistry : AchieveAi.LmDotnetTools.LmAgentInfra.IPro
             new("claude", "Claude (CLI)"),
             new("codex", "Codex"),
             new("copilot", "Copilot (CLI)"),
-            new("sonnet", "Sonnet (Copilot)"),
-            new("haiku", "Haiku (Copilot)"),
-            new("gpt-5.5", "GPT-5.5 (Copilot)"),
-            new("gpt-5.5-mini", "GPT-5.5 mini (Copilot)"),
             new("claude-mock", "Claude (CLI, Mock)"),
             new("codex-mock", "Codex (Mock)"),
             new("copilot-mock", "Copilot (CLI, Mock)"),
@@ -41,6 +48,7 @@ public sealed class ProviderRegistry : AchieveAi.LmDotnetTools.LmAgentInfra.IPro
         string? KnownLimitation = null);
 
     private readonly ImmutableDictionary<string, ProviderDescriptor> _byId;
+    private readonly ImmutableDictionary<string, CopilotModelInfo> _copilotModelsById;
     private readonly ImmutableHashSet<string> _staticAvailability;
     private readonly Func<string, bool> _dynamicAvailability;
 
@@ -49,9 +57,24 @@ public sealed class ProviderRegistry : AchieveAi.LmDotnetTools.LmAgentInfra.IPro
     {
     }
 
+    /// <summary>
+    ///     Production constructor that injects the Copilot models discovered at startup. When the list is
+    ///     empty (no token, or discovery failed) no Copilot models are exposed.
+    /// </summary>
+    public ProviderRegistry(
+        IReadOnlyList<CopilotModelInfo> copilotModels,
+        IFileSystemProbe? probe = null,
+        MockProviderHostLifetime? mockHost = null)
+        : this(probe, mockHost is null ? () => false : () => mockHost.IsRunning, copilotModels)
+    {
+    }
+
     // Test-only constructor: lets tests inject a stub IsRunning probe without standing up a
     // real Kestrel host. Marked internal so it stays out of the public surface.
-    internal ProviderRegistry(IFileSystemProbe? probe, Func<bool> mockHostIsRunning)
+    internal ProviderRegistry(
+        IFileSystemProbe? probe,
+        Func<bool> mockHostIsRunning,
+        IReadOnlyList<CopilotModelInfo>? copilotModels = null)
     {
         ArgumentNullException.ThrowIfNull(mockHostIsRunning);
 
@@ -61,6 +84,7 @@ public sealed class ProviderRegistry : AchieveAi.LmDotnetTools.LmAgentInfra.IPro
 
         var builder = ImmutableDictionary.CreateBuilder<string, ProviderDescriptor>(StringComparer.OrdinalIgnoreCase);
         var staticBuilder = ImmutableHashSet.CreateBuilder<string>(StringComparer.OrdinalIgnoreCase);
+        var copilotBuilder = ImmutableDictionary.CreateBuilder<string, CopilotModelInfo>(StringComparer.OrdinalIgnoreCase);
 
         // Pre-compute the static availability of CLI gates and env-var gates once.
         // *-mock providers AND-on the runtime mock-host signal in the dynamic delegate below.
@@ -83,7 +107,6 @@ public sealed class ProviderRegistry : AchieveAi.LmDotnetTools.LmAgentInfra.IPro
                 "anthropic" => hasAnthropicKey,
                 "claude" => hasClaudeCli,
                 "copilot" => hasCopilotCli,
-                "sonnet" or "haiku" or "gpt-5.5" or "gpt-5.5-mini" => hasCopilotToken,
                 // *-mock providers need both their CLI prerequisite and the running mock host;
                 // codex-mock has no CLI prerequisite (codex availability is unconditional).
                 "claude-mock" => hasClaudeCli,
@@ -100,7 +123,29 @@ public sealed class ProviderRegistry : AchieveAi.LmDotnetTools.LmAgentInfra.IPro
             builder[id] = new ProviderDescriptor(id, displayName, isStatic, entry.KnownLimitation);
         }
 
+        // Dynamically discovered GitHub Copilot models — one entry per routable Anthropic/OpenAI
+        // model, keyed by its raw model id and partitioned into the two Copilot groups. Availability
+        // mirrors the Copilot token gate the former curated entries used.
+        foreach (var model in copilotModels ?? [])
+        {
+            var id = NormalizeId(model.Id);
+            if (id is null || builder.ContainsKey(id))
+            {
+                continue;
+            }
+
+            copilotBuilder[id] = model;
+            if (hasCopilotToken)
+            {
+                _ = staticBuilder.Add(id);
+            }
+
+            var group = model.Vendor == CopilotModelVendor.Anthropic ? CopilotAnthropicGroup : CopilotOpenAiGroup;
+            builder[id] = new ProviderDescriptor(id, model.DisplayName, hasCopilotToken, Group: group);
+        }
+
         _byId = builder.ToImmutable();
+        _copilotModelsById = copilotBuilder.ToImmutable();
         _staticAvailability = staticBuilder.ToImmutable();
         _dynamicAvailability = id => _staticAvailability.Contains(id)
             && (!IsMockProvider(id) || mockHostIsRunning());
@@ -142,6 +187,25 @@ public sealed class ProviderRegistry : AchieveAi.LmDotnetTools.LmAgentInfra.IPro
         // Re-evaluate availability so callers see the live mock-host status. The static
         // descriptor stored in the dictionary is only used as a name/display source.
         return descriptor with { Available = _dynamicAvailability(normalized) };
+    }
+
+    /// <summary>
+    ///     Resolves the discovered GitHub Copilot model backing a provider id, if any. Returns
+    ///     <c>false</c> for non-Copilot providers (openai/anthropic/CLI/test), letting callers keep
+    ///     their existing behavior and only branch into Copilot-specific wiring (transport, raw model
+    ///     id, reasoning options, web-tool fallback) when this returns <c>true</c>.
+    /// </summary>
+    public bool TryGetCopilotModel(string? providerId, out CopilotModelInfo model)
+    {
+        var normalized = NormalizeId(providerId);
+        if (normalized != null && _copilotModelsById.TryGetValue(normalized, out var found))
+        {
+            model = found;
+            return true;
+        }
+
+        model = null!;
+        return false;
     }
 
     /// <summary>

--- a/samples/LmStreaming.Sample/Services/WebToolRegistrationPolicy.cs
+++ b/samples/LmStreaming.Sample/Services/WebToolRegistrationPolicy.cs
@@ -17,16 +17,13 @@ internal static class WebToolRegistrationPolicy
     /// <see cref="ProviderRegistry" /> ids that have NO native web capability and therefore receive
     /// the Jina fallback tools. Plain <c>copilot</c> is intentionally excluded: it returns early on
     /// the <c>CopilotAgentLoop</c> (CLI) path before the per-conversation registry is built, so it
-    /// never reaches this seam. <c>sonnet</c>/<c>haiku</c>/<c>gpt-5.5</c>/<c>gpt-5.5-mini</c> route
-    /// through the normal middleware agent loop and so are included.
+    /// never reaches this seam. Dynamically discovered Copilot models (Anthropic/OpenAI) route through
+    /// the normal middleware agent loop and are included via the <c>isCopilotBackedModel</c> flag the
+    /// caller passes, not by literal id.
     /// </summary>
     private static readonly HashSet<string> FallbackProviderIds = new(StringComparer.OrdinalIgnoreCase)
     {
         "openai",
-        "sonnet",
-        "haiku",
-        "gpt-5.5",
-        "gpt-5.5-mini",
     };
 
     /// <summary>
@@ -44,6 +41,10 @@ internal static class WebToolRegistrationPolicy
     /// (invalid configuration). When <c>null</c>, nothing is registered.</param>
     /// <param name="options">Web tools configuration (used for the API-key gate and tool construction).</param>
     /// <param name="loggerFactory">Factory used to create tool/diagnostic loggers.</param>
+    /// <param name="isCopilotBackedModel">
+    /// <c>true</c> when the provider id resolves to a dynamically discovered Copilot model (Anthropic or
+    /// OpenAI). Those models lack a native web capability and so receive the Jina fallback tools,
+    /// alongside the statically allow-listed ids in <see cref="FallbackProviderIds" />.</param>
     /// <returns>A small list of human-readable status strings describing what was registered, skipped,
     /// or disabled (for diagnostics/logging). Never contains secret values.</returns>
     public static IReadOnlyList<string> Apply(
@@ -52,7 +53,8 @@ internal static class WebToolRegistrationPolicy
         IReadOnlyList<string>? enabledTools,
         JinaWebProvider? provider,
         WebToolsOptions options,
-        ILoggerFactory loggerFactory
+        ILoggerFactory loggerFactory,
+        bool isCopilotBackedModel = false
     )
     {
         ArgumentNullException.ThrowIfNull(registry);
@@ -71,7 +73,7 @@ internal static class WebToolRegistrationPolicy
         var normalized = string.IsNullOrWhiteSpace(providerId)
             ? string.Empty
             : providerId.Trim().ToLowerInvariant();
-        if (!FallbackProviderIds.Contains(normalized))
+        if (!isCopilotBackedModel && !FallbackProviderIds.Contains(normalized))
         {
             return statuses;
         }

--- a/src/GithubCopilotProvider/Models/CopilotModelCatalogParser.cs
+++ b/src/GithubCopilotProvider/Models/CopilotModelCatalogParser.cs
@@ -75,8 +75,23 @@ public static class CopilotModelCatalogParser
         var displayName = GetString(item, "name");
         displayName = string.IsNullOrWhiteSpace(displayName) ? id! : displayName!;
 
-        model = new CopilotModelInfo(id!, displayName, vendor, transport);
+        model = new CopilotModelInfo(id!, displayName, vendor, transport, SupportsAdaptiveThinking(item));
         return true;
+    }
+
+    /// <summary>
+    ///     Reads <c>capabilities.supports.adaptive_thinking</c>. Models that advertise it reject the
+    ///     classic <c>thinking.type.enabled</c> budget request, so the sample gates the classic thinking
+    ///     parameter on this flag being <c>false</c>/absent.
+    /// </summary>
+    private static bool SupportsAdaptiveThinking(JsonElement item)
+    {
+        return item.TryGetProperty("capabilities", out var capabilities)
+            && capabilities.ValueKind == JsonValueKind.Object
+            && capabilities.TryGetProperty("supports", out var supports)
+            && supports.ValueKind == JsonValueKind.Object
+            && supports.TryGetProperty("adaptive_thinking", out var adaptive)
+            && adaptive.ValueKind == JsonValueKind.True;
     }
 
     /// <summary>

--- a/src/GithubCopilotProvider/Models/CopilotModelCatalogParser.cs
+++ b/src/GithubCopilotProvider/Models/CopilotModelCatalogParser.cs
@@ -1,0 +1,156 @@
+using System.Text.Json;
+
+namespace AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+
+/// <summary>
+///     Parses the GitHub Copilot <c>GET /models</c> response into the subset of models the sample can
+///     list and route: those published by Anthropic or OpenAI <em>and</em> reachable via a supported
+///     transport (<c>/v1/messages</c> or <c>/responses</c>). Google/Microsoft models and
+///     <c>/chat/completions</c>-only models are dropped.
+/// </summary>
+/// <remarks>
+///     Pure and side-effect free so it can be unit-tested against the captured real response fixture.
+///     The response shape is <c>{ "data": [ { "id", "name", "vendor", "supported_endpoints": [...] } ] }</c>;
+///     a bare top-level array is also accepted.
+/// </remarks>
+public static class CopilotModelCatalogParser
+{
+    /// <summary>
+    ///     Projects the Copilot <c>/models</c> JSON to the routable Anthropic/OpenAI models, preserving
+    ///     upstream order. Malformed or partial entries are skipped rather than throwing.
+    /// </summary>
+    public static IReadOnlyList<CopilotModelInfo> Parse(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        var list = root.ValueKind == JsonValueKind.Object && root.TryGetProperty("data", out var data)
+            ? data
+            : root;
+
+        if (list.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var models = new List<CopilotModelInfo>();
+        foreach (var item in list.EnumerateArray())
+        {
+            if (TryParseModel(item, out var model))
+            {
+                models.Add(model);
+            }
+        }
+
+        return models;
+    }
+
+    private static bool TryParseModel(JsonElement item, out CopilotModelInfo model)
+    {
+        model = null!;
+
+        if (item.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        var id = GetString(item, "id");
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return false;
+        }
+
+        if (!TryNormalizeVendor(GetString(item, "vendor"), out var vendor))
+        {
+            return false;
+        }
+
+        var transport = DeriveTransport(item);
+        if (transport == CopilotModelTransport.Unsupported)
+        {
+            return false;
+        }
+
+        var displayName = GetString(item, "name");
+        displayName = string.IsNullOrWhiteSpace(displayName) ? id! : displayName!;
+
+        model = new CopilotModelInfo(id!, displayName, vendor, transport);
+        return true;
+    }
+
+    /// <summary>
+    ///     Maps the response <c>vendor</c> to a partition. Copilot reports newer GPTs as <c>OpenAI</c>
+    ///     but some hosted variants as <c>Azure OpenAI</c>; both collapse to <see cref="CopilotModelVendor.OpenAI"/>.
+    ///     Any other publisher (Google, Microsoft, ...) is not a partition we surface.
+    /// </summary>
+    private static bool TryNormalizeVendor(string? vendor, out CopilotModelVendor normalized)
+    {
+        normalized = default;
+        if (string.IsNullOrWhiteSpace(vendor))
+        {
+            return false;
+        }
+
+        var trimmed = vendor.Trim();
+        if (trimmed.Equals("Anthropic", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = CopilotModelVendor.Anthropic;
+            return true;
+        }
+
+        if (trimmed.Equals("OpenAI", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("Azure OpenAI", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = CopilotModelVendor.OpenAI;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     Chooses the routable transport from <c>supported_endpoints</c>. <c>/v1/messages</c> wins
+    ///     (Anthropic Messages), else <c>/responses</c> (or its <c>ws:/responses</c> variant) selects
+    ///     the Responses transport. Absent metadata or only <c>/chat/completions</c> yields
+    ///     <see cref="CopilotModelTransport.Unsupported"/>.
+    /// </summary>
+    private static CopilotModelTransport DeriveTransport(JsonElement item)
+    {
+        if (!item.TryGetProperty("supported_endpoints", out var endpoints)
+            || endpoints.ValueKind != JsonValueKind.Array)
+        {
+            return CopilotModelTransport.Unsupported;
+        }
+
+        var hasResponses = false;
+        foreach (var endpoint in endpoints.EnumerateArray())
+        {
+            if (endpoint.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var value = endpoint.GetString();
+            if (string.Equals(value, "/v1/messages", StringComparison.OrdinalIgnoreCase))
+            {
+                return CopilotModelTransport.Anthropic;
+            }
+
+            if (string.Equals(value, "/responses", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "ws:/responses", StringComparison.OrdinalIgnoreCase))
+            {
+                hasResponses = true;
+            }
+        }
+
+        return hasResponses ? CopilotModelTransport.Responses : CopilotModelTransport.Unsupported;
+    }
+
+    private static string? GetString(JsonElement item, string propertyName)
+    {
+        return item.TryGetProperty(propertyName, out var el) && el.ValueKind == JsonValueKind.String
+            ? el.GetString()
+            : null;
+    }
+}

--- a/src/GithubCopilotProvider/Models/CopilotModelInfo.cs
+++ b/src/GithubCopilotProvider/Models/CopilotModelInfo.cs
@@ -1,0 +1,46 @@
+namespace AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+
+/// <summary>
+///     The request transport a Copilot model is reachable through, derived from the model's
+///     <c>supported_endpoints</c>. Only <see cref="Anthropic"/> and <see cref="Responses"/> are
+///     routable by the sample today; everything else (e.g. <c>/chat/completions</c>-only models
+///     such as Gemini) is <see cref="Unsupported"/> and filtered out.
+/// </summary>
+public enum CopilotModelTransport
+{
+    /// <summary>No routable endpoint (e.g. only <c>/chat/completions</c>).</summary>
+    Unsupported = 0,
+
+    /// <summary>Reachable via <c>POST /v1/messages</c> (Anthropic Messages shape).</summary>
+    Anthropic = 1,
+
+    /// <summary>Reachable via <c>POST /responses</c> (OpenAI Responses shape).</summary>
+    Responses = 2,
+}
+
+/// <summary>
+///     A single GitHub Copilot model, projected from the Copilot <c>GET /models</c> response down to
+///     the fields the sample needs to list and route it.
+/// </summary>
+/// <param name="Id">Raw Copilot model id (e.g. <c>claude-opus-4.8</c>, <c>gpt-5.5</c>). Used verbatim as the request model id.</param>
+/// <param name="DisplayName">Human-friendly label from the response <c>name</c> (falls back to <see cref="Id"/>).</param>
+/// <param name="Vendor">Normalized publisher — <c>Anthropic</c> or <c>OpenAI</c> (<c>Azure OpenAI</c> collapses to <c>OpenAI</c>).</param>
+/// <param name="Transport">The routable transport derived from <c>supported_endpoints</c>.</param>
+public sealed record CopilotModelInfo(
+    string Id,
+    string DisplayName,
+    CopilotModelVendor Vendor,
+    CopilotModelTransport Transport);
+
+/// <summary>
+///     The normalized publisher partition a Copilot model belongs to. The sample only surfaces these
+///     two vendors; Google/Microsoft and any other publisher are excluded during parsing.
+/// </summary>
+public enum CopilotModelVendor
+{
+    /// <summary>Anthropic (Claude) models.</summary>
+    Anthropic = 1,
+
+    /// <summary>OpenAI (GPT/o-series) models, including Copilot's <c>Azure OpenAI</c>-hosted variants.</summary>
+    OpenAI = 2,
+}

--- a/src/GithubCopilotProvider/Models/CopilotModelInfo.cs
+++ b/src/GithubCopilotProvider/Models/CopilotModelInfo.cs
@@ -26,11 +26,18 @@ public enum CopilotModelTransport
 /// <param name="DisplayName">Human-friendly label from the response <c>name</c> (falls back to <see cref="Id"/>).</param>
 /// <param name="Vendor">Normalized publisher — <c>Anthropic</c> or <c>OpenAI</c> (<c>Azure OpenAI</c> collapses to <c>OpenAI</c>).</param>
 /// <param name="Transport">The routable transport derived from <c>supported_endpoints</c>.</param>
+/// <param name="SupportsAdaptiveThinking">
+///     <c>true</c> when the model advertises <c>capabilities.supports.adaptive_thinking</c>. Such
+///     models reject the classic <c>thinking.type.enabled</c> budget request (they require
+///     <c>thinking.type.adaptive</c> + <c>output_config.effort</c>), so the sample must not send the
+///     classic thinking parameter to them.
+/// </param>
 public sealed record CopilotModelInfo(
     string Id,
     string DisplayName,
     CopilotModelVendor Vendor,
-    CopilotModelTransport Transport);
+    CopilotModelTransport Transport,
+    bool SupportsAdaptiveThinking = false);
 
 /// <summary>
 ///     The normalized publisher partition a Copilot model belongs to. The sample only surfaces these

--- a/src/GithubCopilotProvider/Models/CopilotModelsClient.cs
+++ b/src/GithubCopilotProvider/Models/CopilotModelsClient.cs
@@ -1,0 +1,86 @@
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
+using Microsoft.Extensions.Logging;
+
+namespace AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+
+/// <summary>
+///     Discovers the GitHub Copilot model catalog by calling <c>GET /models</c> through the Copilot
+///     backend and projecting the response to the routable Anthropic/OpenAI models via
+///     <see cref="CopilotModelCatalogParser"/>.
+/// </summary>
+/// <remarks>
+///     Failures (no token, network error, non-success status, malformed body) are swallowed and
+///     surfaced as an empty list so a discovery outage never takes down the caller — the caller
+///     decides how to degrade (e.g. fall back to a built-in set).
+/// </remarks>
+public sealed class CopilotModelsClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger? _logger;
+
+    /// <summary>
+    ///     Creates a client that builds its own Copilot-authenticated <see cref="HttpClient"/> from the
+    ///     supplied token provider, session, and options.
+    /// </summary>
+    public CopilotModelsClient(
+        ICopilotTokenProvider tokenProvider,
+        CopilotSessionContext? session = null,
+        CopilotOptions? options = null,
+        ILogger? logger = null)
+        : this(BuildHttpClient(tokenProvider, session, options), logger)
+    {
+    }
+
+    /// <summary>
+    ///     Creates a client over a caller-supplied <see cref="HttpClient"/> (must target the Copilot host
+    ///     root). Primarily a test seam.
+    /// </summary>
+    public CopilotModelsClient(HttpClient httpClient, ILogger? logger = null)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _logger = logger;
+    }
+
+    /// <summary>
+    ///     Fetches and parses the routable Anthropic/OpenAI Copilot models. Returns an empty list on any
+    ///     failure.
+    /// </summary>
+    public async Task<IReadOnlyList<CopilotModelInfo>> GetModelsAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var response = await _httpClient.GetAsync("/models", cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger?.LogWarning(
+                    "Copilot model discovery returned {StatusCode}; treating catalog as empty.",
+                    (int)response.StatusCode);
+                return [];
+            }
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            var models = CopilotModelCatalogParser.Parse(json);
+            _logger?.LogInformation("Discovered {Count} routable Copilot models.", models.Count);
+            return models;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException or System.Text.Json.JsonException)
+        {
+            _logger?.LogWarning(ex, "Copilot model discovery failed; treating catalog as empty.");
+            return [];
+        }
+    }
+
+    private static HttpClient BuildHttpClient(
+        ICopilotTokenProvider tokenProvider,
+        CopilotSessionContext? session,
+        CopilotOptions? options)
+    {
+        ArgumentNullException.ThrowIfNull(tokenProvider);
+        var effectiveOptions = options ?? new CopilotOptions();
+        return CopilotHttpClientFactory.Create(
+            effectiveOptions.BaseUrl,
+            tokenProvider,
+            session ?? new CopilotSessionContext(),
+            effectiveOptions);
+    }
+}

--- a/src/GithubCopilotProvider/Models/CopilotModelsClient.cs
+++ b/src/GithubCopilotProvider/Models/CopilotModelsClient.cs
@@ -63,7 +63,14 @@ public sealed class CopilotModelsClient
             _logger?.LogInformation("Discovered {Count} routable Copilot models.", models.Count);
             return models;
         }
-        catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException or System.Text.Json.JsonException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Caller-requested cancellation is cooperative — let it propagate rather than masking it
+            // as an empty catalog. A bounded startup timeout is the caller's concern (see the sample's
+            // DiscoverCopilotModels).
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or System.Text.Json.JsonException)
         {
             _logger?.LogWarning(ex, "Copilot model discovery failed; treating catalog as empty.");
             return [];

--- a/tests/GithubCopilotProvider.Tests/AchieveAi.LmDotnetTools.GithubCopilotProvider.Tests.csproj
+++ b/tests/GithubCopilotProvider.Tests/AchieveAi.LmDotnetTools.GithubCopilotProvider.Tests.csproj
@@ -31,4 +31,7 @@
   <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Fixtures\**\*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/tests/GithubCopilotProvider.Tests/Fixtures/copilot-models-real-response.json
+++ b/tests/GithubCopilotProvider.Tests/Fixtures/copilot-models-real-response.json
@@ -1,0 +1,2032 @@
+{
+  "data": [
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "individual_trial",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 50,
+            "cache_write_price": 625,
+            "input_price": 500,
+            "max_prompt_tokens": 200000,
+            "output_price": 2500
+          },
+          "long_context": {
+            "cache_read_price": 50,
+            "cache_write_price": 625,
+            "input_price": 500,
+            "max_prompt_tokens": 936000,
+            "output_price": 2500
+          }
+        }
+      },
+      "capabilities": {
+        "family": "claude-opus-4.6",
+        "limits": {
+          "max_context_window_tokens": 1000000,
+          "max_non_streaming_output_tokens": 16000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 936000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "adaptive_thinking": true,
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 1024,
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high",
+            "max"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "claude-opus-4.6",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "high",
+      "name": "Claude Opus 4.6",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Claude Opus 4.6 model from Anthropic. [Learn more about how GitHub Copilot serves Claude Opus 4.6](https://gh.io/copilot-claude-opus)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/v1/messages",
+        "/chat/completions"
+      ],
+      "vendor": "Anthropic",
+      "version": "claude-opus-4.6"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro_plus",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 50,
+            "cache_write_price": 625,
+            "input_price": 500,
+            "max_prompt_tokens": 200000,
+            "output_price": 2500
+          },
+          "long_context": {
+            "cache_read_price": 50,
+            "cache_write_price": 625,
+            "input_price": 500,
+            "max_prompt_tokens": 936000,
+            "output_price": 2500
+          }
+        }
+      },
+      "capabilities": {
+        "family": "claude-opus-4.7",
+        "limits": {
+          "max_context_window_tokens": 1000000,
+          "max_non_streaming_output_tokens": 16000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 936000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "adaptive_thinking": true,
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 1024,
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "claude-opus-4.7",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "high",
+      "name": "Claude Opus 4.7",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Claude Opus 4.7 model from Anthropic. [Learn more about how GitHub Copilot serves Claude Opus 4.7](https://gh.io/copilot-claude-opus)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/v1/messages",
+        "/chat/completions"
+      ],
+      "vendor": "Anthropic",
+      "version": "claude-opus-4.7"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro_plus",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 50,
+            "cache_write_price": 625,
+            "input_price": 500,
+            "max_prompt_tokens": 200000,
+            "output_price": 2500
+          },
+          "long_context": {
+            "cache_read_price": 50,
+            "cache_write_price": 625,
+            "input_price": 500,
+            "max_prompt_tokens": 936000,
+            "output_price": 2500
+          }
+        }
+      },
+      "capabilities": {
+        "family": "claude-opus-4.8",
+        "limits": {
+          "max_context_window_tokens": 1000000,
+          "max_non_streaming_output_tokens": 16000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 936000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "adaptive_thinking": true,
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 1024,
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "claude-opus-4.8",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "high",
+      "name": "Claude Opus 4.8",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Claude Opus 4.8 model from Anthropic. [Learn more about how GitHub Copilot serves Claude Opus 4.8](https://gh.io/copilot-claude-opus)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/v1/messages",
+        "/chat/completions"
+      ],
+      "vendor": "Anthropic",
+      "version": "claude-opus-4.8"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "individual_trial",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 30,
+            "cache_write_price": 375,
+            "input_price": 300,
+            "max_prompt_tokens": 200000,
+            "output_price": 1500
+          },
+          "long_context": {
+            "cache_read_price": 30,
+            "cache_write_price": 375,
+            "input_price": 300,
+            "max_prompt_tokens": 936000,
+            "output_price": 1500
+          }
+        }
+      },
+      "capabilities": {
+        "family": "claude-sonnet-4.6",
+        "limits": {
+          "max_context_window_tokens": 1000000,
+          "max_non_streaming_output_tokens": 16000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 936000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 5,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "adaptive_thinking": true,
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 1024,
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high",
+            "max"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "claude-sonnet-4.6",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "versatile",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "medium",
+      "name": "Claude Sonnet 4.6",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Claude Sonnet 4.6 model from Anthropic. [Learn more about how GitHub Copilot serves Claude Sonnet 4.6](https://gh.io/copilot-claude-opus)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/chat/completions",
+        "/v1/messages"
+      ],
+      "vendor": "Anthropic",
+      "version": "claude-sonnet-4.6"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 20,
+            "cache_write_price": 250,
+            "input_price": 200,
+            "max_prompt_tokens": 200000,
+            "output_price": 1000
+          },
+          "long_context": {
+            "cache_read_price": 20,
+            "cache_write_price": 250,
+            "input_price": 200,
+            "max_prompt_tokens": 936000,
+            "output_price": 1000
+          }
+        }
+      },
+      "capabilities": {
+        "family": "claude-sonnet-5",
+        "limits": {
+          "max_context_window_tokens": 1000000,
+          "max_non_streaming_output_tokens": 16000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 936000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 5,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "adaptive_thinking": true,
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 1024,
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "claude-sonnet-5",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "versatile",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "medium",
+      "name": "Claude Sonnet 5",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Claude model from Anthropic. [Learn more about how GitHub Copilot serves Claude](https://gh.io/copilot-claude-opus)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/v1/messages",
+        "/chat/completions"
+      ],
+      "vendor": "Anthropic",
+      "version": "claude-sonnet-5"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "edu",
+          "pro",
+          "pro_plus",
+          "individual_trial",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 20,
+            "cache_write_price": 0,
+            "input_price": 200,
+            "max_prompt_tokens": 200000,
+            "output_price": 1200
+          },
+          "long_context": {
+            "cache_read_price": 40,
+            "cache_write_price": 0,
+            "input_price": 400,
+            "max_prompt_tokens": 936000,
+            "output_price": 1800
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gemini-3.1-pro-preview",
+        "limits": {
+          "max_context_window_tokens": 1000000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 936000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 10,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/heic",
+              "image/heif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 256,
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "streaming": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gemini-3.1-pro-preview",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "medium",
+      "name": "Gemini 3.1 Pro",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Gemini 3 Pro model from Google. [Learn more about how GitHub Copilot serves Gemini 3 Pro](https://docs.github.com/en/copilot/reference/ai-models/model-hosting#google-models)."
+      },
+      "preview": true,
+      "supported_endpoints": [
+        "/chat/completions"
+      ],
+      "vendor": "Google",
+      "version": "gemini-3.1-pro-preview"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 15,
+            "cache_write_price": 0,
+            "input_price": 150,
+            "max_prompt_tokens": 200000,
+            "output_price": 900
+          },
+          "long_context": {
+            "cache_read_price": 15,
+            "cache_write_price": 0,
+            "input_price": 150,
+            "max_prompt_tokens": 936000,
+            "output_price": 900
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gemini-3.5-flash",
+        "limits": {
+          "max_context_window_tokens": 1000000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 936000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 10,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/heic",
+              "image/heif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "max_thinking_budget": 24000,
+          "min_thinking_budget": 256,
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ],
+          "streaming": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gemini-3.5-flash",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "lightweight",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "medium",
+      "name": "Gemini 3.5 Flash",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Gemini 3.5 Flash model from Google. [Learn more about how GitHub Copilot serves Gemini 3.5 Flash](https://docs.github.com/en/copilot/reference/ai-models/model-hosting#google-models)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/chat/completions"
+      ],
+      "vendor": "Google",
+      "version": "gemini-3.5-flash"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "edu",
+          "pro_plus",
+          "individual_trial",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 17,
+            "cache_write_price": 0,
+            "input_price": 175,
+            "max_prompt_tokens": 272000,
+            "output_price": 1400
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-5.3-codex",
+        "limits": {
+          "max_context_window_tokens": 400000,
+          "max_output_tokens": 128000,
+          "max_prompt_tokens": 272000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-5.3-codex",
+      "is_chat_default": true,
+      "is_chat_fallback": true,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "medium",
+      "name": "GPT-5.3-Codex",
+      "object": "model",
+      "preview": false,
+      "supported_endpoints": [
+        "/responses",
+        "ws:/responses"
+      ],
+      "vendor": "OpenAI",
+      "version": "gpt-5.3-codex"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "individual_trial",
+          "edu",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 7,
+            "cache_write_price": 0,
+            "input_price": 75,
+            "max_prompt_tokens": 272000,
+            "output_price": 450
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-5.4-mini",
+        "limits": {
+          "max_context_window_tokens": 400000,
+          "max_output_tokens": 128000,
+          "max_prompt_tokens": 272000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-5.4-mini",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "lightweight",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "low",
+      "name": "GPT-5.4 mini",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest GPT-5.4 mini model from OpenAI. [Learn more about how GitHub Copilot serves GPT-5.4 mini](https://gh.io/copilot-openai)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/responses",
+        "ws:/responses"
+      ],
+      "vendor": "OpenAI",
+      "version": "gpt-5.4-mini"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "individual_trial",
+          "edu",
+          "business",
+          "enterprise",
+          "max",
+          "free"
+        ],
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-5.4-nano",
+        "limits": {
+          "max_context_window_tokens": 400000,
+          "max_output_tokens": 128000,
+          "max_prompt_tokens": 272000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-5.4-nano",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "versatile",
+      "model_picker_enabled": false,
+      "model_picker_price_category": "low",
+      "name": "GPT-5.4 nano",
+      "object": "model",
+      "preview": false,
+      "supported_endpoints": [
+        "/responses",
+        "ws:/responses"
+      ],
+      "vendor": "OpenAI",
+      "version": "gpt-5.4-nano"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "individual_trial",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 25,
+            "cache_write_price": 0,
+            "input_price": 250,
+            "max_prompt_tokens": 272000,
+            "output_price": 1500
+          },
+          "long_context": {
+            "cache_read_price": 50,
+            "cache_write_price": 0,
+            "input_price": 500,
+            "max_prompt_tokens": 922000,
+            "output_price": 2250
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-5.4",
+        "limits": {
+          "max_context_window_tokens": 1050000,
+          "max_output_tokens": 128000,
+          "max_prompt_tokens": 922000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-5.4",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "medium",
+      "name": "GPT-5.4",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest GPT-5.4 model from OpenAI. [Learn more about how GitHub Copilot serves GPT-5.4](https://gh.io/copilot-openai)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/responses",
+        "/chat/completions",
+        "ws:/responses"
+      ],
+      "vendor": "OpenAI",
+      "version": "gpt-5.4"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro_plus",
+          "business",
+          "enterprise",
+          "max"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 50,
+            "cache_write_price": 0,
+            "input_price": 500,
+            "max_prompt_tokens": 272000,
+            "output_price": 3000
+          },
+          "long_context": {
+            "cache_read_price": 100,
+            "cache_write_price": 0,
+            "input_price": 1000,
+            "max_prompt_tokens": 922000,
+            "output_price": 4500
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-5.5",
+        "limits": {
+          "max_context_window_tokens": 1050000,
+          "max_output_tokens": 128000,
+          "max_prompt_tokens": 922000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-5.5",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "high",
+      "name": "GPT-5.5",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest GPT-5.5 model from OpenAI. [Learn more about how GitHub Copilot serves GPT-5.5](https://gh.io/copilot-openai)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/responses",
+        "ws:/responses"
+      ],
+      "vendor": "OpenAI",
+      "version": "gpt-5.5"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "free",
+          "edu",
+          "pro",
+          "pro_plus",
+          "max",
+          "business",
+          "enterprise"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 7,
+            "cache_write_price": 0,
+            "input_price": 75,
+            "max_prompt_tokens": 128000,
+            "output_price": 450
+          }
+        }
+      },
+      "capabilities": {
+        "family": "oswe-vscode-modelD",
+        "limits": {
+          "max_context_window_tokens": 256000,
+          "max_output_tokens": 128000,
+          "max_prompt_tokens": 128000
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "mai-code-1-flash-picker",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "versatile",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "low",
+      "name": "MAI-Code-1-Flash",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": ""
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/responses"
+      ],
+      "vendor": "Microsoft",
+      "version": "mai-code-1-flash-picker"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 2,
+            "cache_write_price": 0,
+            "input_price": 25,
+            "output_price": 200
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-5-mini",
+        "limits": {
+          "max_context_window_tokens": 264000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 128000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "reasoning_effort": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-5-mini",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "lightweight",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "low",
+      "name": "GPT-5 mini",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest GPT-5 mini model from OpenAI. [Learn more about how GitHub Copilot serves GPT-5 mini](https://gh.io/copilot-openai)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/chat/completions",
+        "/responses",
+        "ws:/responses"
+      ],
+      "vendor": "Azure OpenAI",
+      "version": "gpt-5-mini"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4o-mini",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 64000
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4o-mini-2024-07-18",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "low",
+      "name": "GPT-4o mini",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4o-mini-2024-07-18"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4o",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 16384,
+          "max_prompt_tokens": 64000
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4o-2024-11-20",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT-4o",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4o-2024-11-20"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4o",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 16384,
+          "max_prompt_tokens": 64000
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4o-2024-08-06",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "high",
+      "name": "GPT-4o",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4o-2024-08-06"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "text-embedding-3-small",
+        "limits": {
+          "max_inputs": 512
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "dimensions": true
+        },
+        "tokenizer": "cl100k_base",
+        "type": "embeddings"
+      },
+      "id": "text-embedding-3-small",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "name": "Embedding V3 small",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "text-embedding-3-small"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "text-embedding-3-small",
+        "object": "model_capabilities",
+        "supports": {
+          "dimensions": true
+        },
+        "tokenizer": "cl100k_base",
+        "type": "embeddings"
+      },
+      "id": "text-embedding-3-small-inference",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "name": "Embedding V3 small (Inference)",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "text-embedding-3-small"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "max",
+          "business",
+          "enterprise"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 30,
+            "cache_write_price": 375,
+            "input_price": 300,
+            "output_price": 1500
+          }
+        }
+      },
+      "capabilities": {
+        "family": "claude-sonnet-4.5",
+        "limits": {
+          "max_context_window_tokens": 200000,
+          "max_non_streaming_output_tokens": 16000,
+          "max_output_tokens": 32000,
+          "max_prompt_tokens": 168000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 5,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 1024,
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "claude-sonnet-4.5",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "versatile",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "medium",
+      "name": "Claude Sonnet 4.5",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Claude Sonnet 4.5 model from Anthropic. [Learn more about how GitHub Copilot serves Claude Sonnet 4.5](https://docs.github.com/en/copilot/using-github-copilot/ai-models/using-claude-sonnet-in-github-copilot)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/chat/completions",
+        "/v1/messages"
+      ],
+      "vendor": "Anthropic",
+      "version": "claude-sonnet-4.5"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 10,
+            "cache_write_price": 125,
+            "input_price": 100,
+            "output_price": 500
+          }
+        }
+      },
+      "capabilities": {
+        "family": "claude-haiku-4.5",
+        "limits": {
+          "max_context_window_tokens": 200000,
+          "max_non_streaming_output_tokens": 16000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 136000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 5,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 1024,
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "claude-haiku-4.5",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "lightweight",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "low",
+      "name": "Claude Haiku 4.5",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Claude Haiku 4.5 model from Anthropic. [Learn more about how GitHub Copilot serves Claude Haiku 4.5](https://gh.io/copilot-anthropic)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/chat/completions",
+        "/v1/messages"
+      ],
+      "vendor": "Anthropic",
+      "version": "claude-haiku-4.5"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "max",
+          "business",
+          "enterprise",
+          "individual_trial",
+          "edu"
+        ],
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 12,
+            "cache_write_price": 0,
+            "input_price": 125,
+            "output_price": 1000
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gemini-2.5-pro",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 128000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 10,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/heic",
+              "image/heif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "max_thinking_budget": 32768,
+          "min_thinking_budget": 128,
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gemini-2.5-pro",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "model_picker_price_category": "medium",
+      "name": "Gemini 2.5 Pro",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Gemini 2.5 Pro model from Google. [Learn more about how GitHub Copilot serves Gemini 2.5 Pro](https://docs.github.com/en/copilot/using-github-copilot/ai-models/choosing-the-right-ai-model-for-your-task#gemini-25-pro)."
+      },
+      "preview": false,
+      "vendor": "Google",
+      "version": "gemini-2.5-pro"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4.1",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 16384,
+          "max_prompt_tokens": 64000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4.1-2025-04-14",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT-4.1",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest GPT-4.1 model from OpenAI. [Learn more about how GitHub Copilot serves GPT-4.1](https://docs.github.com/en/copilot/using-github-copilot/ai-models/choosing-the-right-ai-model-for-your-task#gpt-41)."
+      },
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4.1-2025-04-14"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 50,
+            "cache_write_price": 0,
+            "input_price": 200,
+            "output_price": 800
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4.1",
+        "object": "model_capabilities",
+        "supports": {
+          "streaming": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "completion"
+      },
+      "id": "gpt-41-copilot",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "versatile",
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT-4.1 Copilot",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-41-copilot"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-3.5-turbo",
+        "limits": {
+          "max_context_window_tokens": 16384,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 16384
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "cl100k_base",
+        "type": "chat"
+      },
+      "id": "gpt-3.5-turbo-0613",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT 3.5 Turbo",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-3.5-turbo-0613"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 125,
+            "cache_write_price": 0,
+            "input_price": 250,
+            "output_price": 1000
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4",
+        "limits": {
+          "max_context_window_tokens": 32768,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 32768
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "cl100k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT 4",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4-0613"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 1000000,
+          "default": {
+            "cache_read_price": 125,
+            "cache_write_price": 0,
+            "input_price": 250,
+            "output_price": 1000
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4",
+        "limits": {
+          "max_context_window_tokens": 32768,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 32768
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "cl100k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4-0613",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT 4",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4-0613"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4o",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 64000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4o-2024-05-13",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT-4o",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4o-2024-05-13"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4o",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 64000
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4-o-preview",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "high",
+      "name": "GPT-4o",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4o-2024-05-13"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4.1",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 16384,
+          "max_prompt_tokens": 64000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4.1",
+      "info_messages": [
+        {
+          "code": "model_pending_deprecation",
+          "message": "GPT-4.1 has a planned deprecation date of 2026-06-01."
+        }
+      ],
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "versatile",
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT-4.1",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest GPT-4.1 model from OpenAI. [Learn more about how GitHub Copilot serves GPT-4.1](https://docs.github.com/en/copilot/using-github-copilot/ai-models/choosing-the-right-ai-model-for-your-task#gpt-41)."
+      },
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4.1-2025-04-14"
+    },
+    {
+      "billing": {
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "max",
+          "business",
+          "enterprise",
+          "individual_trial",
+          "edu"
+        ],
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-3.5-turbo",
+        "limits": {
+          "max_context_window_tokens": 16384,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 16384
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "cl100k_base",
+        "type": "chat"
+      },
+      "id": "gpt-3.5-turbo",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT 3.5 Turbo",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-3.5-turbo-0613"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4o-mini",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 64000
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4o-mini",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "low",
+      "name": "GPT-4o mini",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4o-mini-2024-07-18"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "gpt-4o",
+        "limits": {
+          "max_context_window_tokens": 128000,
+          "max_output_tokens": 4096,
+          "max_prompt_tokens": 64000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "streaming": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-4o",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "model_picker_price_category": "medium",
+      "name": "GPT-4o",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "gpt-4o-2024-11-20"
+    },
+    {
+      "billing": {
+        "token_prices": {
+          "batch_size": 0,
+          "default": {
+            "cache_read_price": 0,
+            "cache_write_price": 0,
+            "input_price": 0,
+            "output_price": 0
+          }
+        }
+      },
+      "capabilities": {
+        "family": "text-embedding-ada-002",
+        "limits": {
+          "max_inputs": 512
+        },
+        "object": "model_capabilities",
+        "supports": {},
+        "tokenizer": "cl100k_base",
+        "type": "embeddings"
+      },
+      "id": "text-embedding-ada-002",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_enabled": false,
+      "name": "Embedding V2 Ada",
+      "object": "model",
+      "preview": false,
+      "vendor": "Azure OpenAI",
+      "version": "text-embedding-3-small"
+    }
+  ],
+  "object": "list"
+}

--- a/tests/GithubCopilotProvider.Tests/Models/CopilotModelCatalogParserTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Models/CopilotModelCatalogParserTests.cs
@@ -1,0 +1,157 @@
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.GithubCopilotProvider.Tests.Models;
+
+public sealed class CopilotModelCatalogParserTests
+{
+    private static string RealResponseJson =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "copilot-models-real-response.json"));
+
+    [Fact]
+    public void Parse_real_response_keeps_only_routable_anthropic_and_openai_models()
+    {
+        var models = CopilotModelCatalogParser.Parse(RealResponseJson);
+
+        // 34 models upstream → 13 routable Anthropic/OpenAI (7 Claude + 5 OpenAI + 1 Azure-OpenAI).
+        models.Should().HaveCount(13);
+        models.Should().OnlyContain(m =>
+            m.Vendor == CopilotModelVendor.Anthropic || m.Vendor == CopilotModelVendor.OpenAI);
+        models.Should().OnlyContain(m =>
+            m.Transport == CopilotModelTransport.Anthropic || m.Transport == CopilotModelTransport.Responses);
+    }
+
+    [Fact]
+    public void Parse_maps_claude_models_to_anthropic_partition_with_messages_transport()
+    {
+        var models = CopilotModelCatalogParser.Parse(RealResponseJson);
+
+        var anthropic = models.Where(m => m.Vendor == CopilotModelVendor.Anthropic).ToList();
+
+        anthropic.Should().HaveCount(7);
+        anthropic.Should().OnlyContain(m => m.Transport == CopilotModelTransport.Anthropic);
+        anthropic.Select(m => m.Id).Should().Contain(
+            ["claude-opus-4.8", "claude-sonnet-5", "claude-haiku-4.5"]);
+    }
+
+    [Fact]
+    public void Parse_maps_gpt_models_to_openai_partition_with_responses_transport()
+    {
+        var models = CopilotModelCatalogParser.Parse(RealResponseJson);
+
+        var openAi = models.Where(m => m.Vendor == CopilotModelVendor.OpenAI).ToList();
+
+        openAi.Should().HaveCount(6);
+        openAi.Should().OnlyContain(m => m.Transport == CopilotModelTransport.Responses);
+        openAi.Select(m => m.Id).Should().Contain("gpt-5.5");
+    }
+
+    [Fact]
+    public void Parse_normalizes_azure_openai_vendor_to_openai()
+    {
+        var models = CopilotModelCatalogParser.Parse(RealResponseJson);
+
+        // gpt-5-mini is reported as vendor "Azure OpenAI" in the real response.
+        var mini = models.SingleOrDefault(m => m.Id == "gpt-5-mini");
+
+        mini.Should().NotBeNull();
+        mini!.Vendor.Should().Be(CopilotModelVendor.OpenAI);
+    }
+
+    [Fact]
+    public void Parse_excludes_google_and_chat_completions_only_models()
+    {
+        var models = CopilotModelCatalogParser.Parse(RealResponseJson);
+
+        models.Select(m => m.Id).Should().NotContain(
+            ["gemini-3.1-pro-preview", "gemini-3.5-flash", "gemini-2.5-pro"]);
+    }
+
+    [Fact]
+    public void Parse_excludes_non_partition_vendors_even_when_transport_is_routable()
+    {
+        var models = CopilotModelCatalogParser.Parse(RealResponseJson);
+
+        // mai-code-1-flash-picker supports /responses but is vendor "Microsoft" — vendor filtering
+        // is independent of transport, so it must not appear.
+        models.Select(m => m.Id).Should().NotContain("mai-code-1-flash-picker");
+    }
+
+    [Fact]
+    public void Parse_uses_name_as_display_name()
+    {
+        var models = CopilotModelCatalogParser.Parse(RealResponseJson);
+
+        var opus = models.Single(m => m.Id == "claude-opus-4.6");
+
+        opus.DisplayName.Should().Be("Claude Opus 4.6");
+    }
+
+    [Fact]
+    public void Parse_accepts_bare_array_shape()
+    {
+        const string json = """
+            [
+              { "id": "claude-sonnet-5", "name": "Claude Sonnet 5", "vendor": "Anthropic", "supported_endpoints": ["/v1/messages"] },
+              { "id": "gpt-5.5", "name": "GPT-5.5", "vendor": "OpenAI", "supported_endpoints": ["/responses"] }
+            ]
+            """;
+
+        var models = CopilotModelCatalogParser.Parse(json);
+
+        models.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Parse_treats_responses_websocket_endpoint_as_responses_transport()
+    {
+        const string json = """
+            { "data": [
+              { "id": "gpt-x", "name": "GPT X", "vendor": "OpenAI", "supported_endpoints": ["ws:/responses"] }
+            ] }
+            """;
+
+        var models = CopilotModelCatalogParser.Parse(json);
+
+        models.Should().ContainSingle()
+            .Which.Transport.Should().Be(CopilotModelTransport.Responses);
+    }
+
+    [Fact]
+    public void Parse_skips_entries_without_supported_endpoints_metadata()
+    {
+        // Endpoint metadata is required to decide a transport; an entry lacking it can't be routed.
+        const string json = """
+            { "data": [
+              { "id": "mystery", "name": "Mystery", "vendor": "OpenAI" }
+            ] }
+            """;
+
+        var models = CopilotModelCatalogParser.Parse(json);
+
+        models.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_falls_back_to_id_when_name_missing()
+    {
+        const string json = """
+            { "data": [
+              { "id": "claude-sonnet-5", "vendor": "Anthropic", "supported_endpoints": ["/v1/messages"] }
+            ] }
+            """;
+
+        var models = CopilotModelCatalogParser.Parse(json);
+
+        models.Should().ContainSingle().Which.DisplayName.Should().Be("claude-sonnet-5");
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("""{ "data": {} }""")]
+    [InlineData("""{ "data": [] }""")]
+    public void Parse_returns_empty_for_missing_or_empty_lists(string json)
+    {
+        CopilotModelCatalogParser.Parse(json).Should().BeEmpty();
+    }
+}

--- a/tests/GithubCopilotProvider.Tests/Models/CopilotModelCatalogParserTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Models/CopilotModelCatalogParserTests.cs
@@ -88,6 +88,19 @@ public sealed class CopilotModelCatalogParserTests
     }
 
     [Fact]
+    public void Parse_flags_adaptive_thinking_from_capabilities()
+    {
+        var models = CopilotModelCatalogParser.Parse(RealResponseJson);
+
+        // Newer Claude models advertise capabilities.supports.adaptive_thinking=true and reject the
+        // classic thinking.type.enabled budget API; the older ones don't advertise it.
+        models.Single(m => m.Id == "claude-sonnet-5").SupportsAdaptiveThinking.Should().BeTrue();
+        models.Single(m => m.Id == "claude-opus-4.8").SupportsAdaptiveThinking.Should().BeTrue();
+        models.Single(m => m.Id == "claude-sonnet-4.5").SupportsAdaptiveThinking.Should().BeFalse();
+        models.Single(m => m.Id == "claude-haiku-4.5").SupportsAdaptiveThinking.Should().BeFalse();
+    }
+
+    [Fact]
     public void Parse_accepts_bare_array_shape()
     {
         const string json = """

--- a/tests/GithubCopilotProvider.Tests/Models/CopilotModelsClientTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Models/CopilotModelsClientTests.cs
@@ -80,15 +80,15 @@ public sealed class CopilotModelsClientTests
     }
 
     [Fact]
-    public async Task GetModelsAsync_returns_empty_when_cancelled()
+    public async Task GetModelsAsync_propagates_caller_requested_cancellation()
     {
+        // Caller cancellation is cooperative and must NOT be masked as an empty catalog — the
+        // caller (e.g. a bounded startup timeout) decides how to degrade.
         var handler = new FakeHttpMessageHandler((_, ct) => throw new OperationCanceledException(ct));
         var client = new CopilotModelsClient(ClientOver(handler));
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        var models = await client.GetModelsAsync(cts.Token);
-
-        models.Should().BeEmpty();
+        _ = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.GetModelsAsync(cts.Token));
     }
 }

--- a/tests/GithubCopilotProvider.Tests/Models/CopilotModelsClientTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Models/CopilotModelsClientTests.cs
@@ -1,0 +1,94 @@
+using System.Net;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+using AchieveAi.LmDotnetTools.LmTestUtils;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.GithubCopilotProvider.Tests.Models;
+
+public sealed class CopilotModelsClientTests
+{
+    private static HttpClient ClientOver(FakeHttpMessageHandler handler) =>
+        new(handler) { BaseAddress = new Uri("https://api.enterprise.githubcopilot.com") };
+
+    [Fact]
+    public async Task GetModelsAsync_requests_the_models_endpoint()
+    {
+        string? requestedPath = null;
+        var handler = new FakeHttpMessageHandler((request, _) =>
+        {
+            requestedPath = request.RequestUri?.AbsolutePath;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{ "data": [] }"""),
+            });
+        });
+
+        var client = new CopilotModelsClient(ClientOver(handler));
+        _ = await client.GetModelsAsync();
+
+        requestedPath.Should().Be("/models");
+    }
+
+    [Fact]
+    public async Task GetModelsAsync_parses_successful_response()
+    {
+        const string json = """
+            { "data": [
+              { "id": "claude-sonnet-5", "name": "Claude Sonnet 5", "vendor": "Anthropic", "supported_endpoints": ["/v1/messages"] },
+              { "id": "gpt-5.5", "name": "GPT-5.5", "vendor": "OpenAI", "supported_endpoints": ["/responses"] },
+              { "id": "gemini-3.5-flash", "name": "Gemini", "vendor": "Google", "supported_endpoints": ["/chat/completions"] }
+            ] }
+            """;
+        var client = new CopilotModelsClient(ClientOver(FakeHttpMessageHandler.CreateSimpleJsonHandler(json)));
+
+        var models = await client.GetModelsAsync();
+
+        models.Select(m => m.Id).Should().BeEquivalentTo("claude-sonnet-5", "gpt-5.5");
+    }
+
+    [Fact]
+    public async Task GetModelsAsync_returns_empty_on_non_success_status()
+    {
+        var handler = FakeHttpMessageHandler.CreateSimpleJsonHandler("unauthorized", HttpStatusCode.Unauthorized);
+        var client = new CopilotModelsClient(ClientOver(handler));
+
+        var models = await client.GetModelsAsync();
+
+        models.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetModelsAsync_returns_empty_on_transport_failure()
+    {
+        var handler = new FakeHttpMessageHandler((_, _) => throw new HttpRequestException("boom"));
+        var client = new CopilotModelsClient(ClientOver(handler));
+
+        var models = await client.GetModelsAsync();
+
+        models.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetModelsAsync_returns_empty_on_malformed_json()
+    {
+        var handler = FakeHttpMessageHandler.CreateSimpleJsonHandler("{ not json ");
+        var client = new CopilotModelsClient(ClientOver(handler));
+
+        var models = await client.GetModelsAsync();
+
+        models.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetModelsAsync_returns_empty_when_cancelled()
+    {
+        var handler = new FakeHttpMessageHandler((_, ct) => throw new OperationCanceledException(ct));
+        var client = new CopilotModelsClient(ClientOver(handler));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var models = await client.GetModelsAsync(cts.Token);
+
+        models.Should().BeEmpty();
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/ProgramReasoningExtraPropertiesTests.cs
+++ b/tests/LmStreaming.Sample.Tests/ProgramReasoningExtraPropertiesTests.cs
@@ -18,7 +18,8 @@ public sealed class ProgramReasoningExtraPropertiesTests
 {
     private static ImmutableDictionary<string, object?> Build(
         string normalizedProviderId,
-        CopilotModelTransport? copilotTransport = null)
+        CopilotModelTransport? copilotTransport = null,
+        bool copilotSupportsAdaptiveThinking = false)
     {
         var programType = typeof(LmStreaming.Sample.Controllers.DiagnosticsController)
             .Assembly.GetType("Program");
@@ -28,7 +29,10 @@ public sealed class ProgramReasoningExtraPropertiesTests
             BindingFlags.NonPublic | BindingFlags.Static
         );
         method.Should().NotBeNull("Program must expose the provider→reasoning extra-properties helper");
-        return (ImmutableDictionary<string, object?>)method!.Invoke(null, [normalizedProviderId, copilotTransport])!;
+        return (ImmutableDictionary<string, object?>)method!.Invoke(
+            null,
+            [normalizedProviderId, copilotTransport, copilotSupportsAdaptiveThinking]
+        )!;
     }
 
     [Theory]
@@ -45,10 +49,21 @@ public sealed class ProgramReasoningExtraPropertiesTests
     [Fact]
     public void Copilot_anthropic_transport_models_get_thinking_budget()
     {
-        var props = Build("claude-sonnet-5", CopilotModelTransport.Anthropic);
+        var props = Build("claude-sonnet-4.5", CopilotModelTransport.Anthropic);
 
         props.Should().ContainKey("Thinking");
         props["Thinking"].Should().BeOfType<AnthropicThinking>();
+    }
+
+    [Fact]
+    public void Copilot_adaptive_thinking_models_omit_classic_thinking_budget()
+    {
+        // Models advertising adaptive_thinking (e.g. claude-sonnet-5) reject thinking.type.enabled with
+        // HTTP 400, so the classic budget request must NOT be sent for them.
+        var props = Build("claude-sonnet-5", CopilotModelTransport.Anthropic, copilotSupportsAdaptiveThinking: true);
+
+        props.Should().NotContainKey("Thinking");
+        props.Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/ProgramReasoningExtraPropertiesTests.cs
+++ b/tests/LmStreaming.Sample.Tests/ProgramReasoningExtraPropertiesTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Reflection;
 using AchieveAi.LmDotnetTools.AnthropicProvider.Models;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
 
 namespace LmStreaming.Sample.Tests;
@@ -8,13 +9,16 @@ namespace LmStreaming.Sample.Tests;
 /// <summary>
 ///     Regression coverage for the provider → reasoning/thinking extra-properties wiring in Program.
 ///     This is what makes thinking blocks appear for Copilot-backed models: the Anthropic-format
-///     providers (incl. sonnet/haiku via Copilot) must get a "Thinking" budget, and the OpenAI
-///     Responses providers (gpt-5.5/gpt-5.5-mini) must get a "Reasoning" summary request. Without
-///     this test, deleting either provider-id branch would silently turn thinking back off.
+///     providers (the direct anthropic/test-anthropic providers and any discovered Copilot model on
+///     the Anthropic transport) must get a "Thinking" budget, and Copilot models on the OpenAI
+///     Responses transport must get a "Reasoning" summary request. Without this test, deleting either
+///     branch would silently turn thinking back off.
 /// </summary>
 public sealed class ProgramReasoningExtraPropertiesTests
 {
-    private static ImmutableDictionary<string, object?> Build(string normalizedProviderId)
+    private static ImmutableDictionary<string, object?> Build(
+        string normalizedProviderId,
+        CopilotModelTransport? copilotTransport = null)
     {
         var programType = typeof(LmStreaming.Sample.Controllers.DiagnosticsController)
             .Assembly.GetType("Program");
@@ -24,14 +28,12 @@ public sealed class ProgramReasoningExtraPropertiesTests
             BindingFlags.NonPublic | BindingFlags.Static
         );
         method.Should().NotBeNull("Program must expose the provider→reasoning extra-properties helper");
-        return (ImmutableDictionary<string, object?>)method!.Invoke(null, [normalizedProviderId])!;
+        return (ImmutableDictionary<string, object?>)method!.Invoke(null, [normalizedProviderId, copilotTransport])!;
     }
 
     [Theory]
     [InlineData("anthropic")]
     [InlineData("test-anthropic")]
-    [InlineData("sonnet")]
-    [InlineData("haiku")]
     public void Anthropic_format_providers_get_thinking_budget(string providerId)
     {
         var props = Build(providerId);
@@ -40,12 +42,19 @@ public sealed class ProgramReasoningExtraPropertiesTests
         props["Thinking"].Should().BeOfType<AnthropicThinking>();
     }
 
-    [Theory]
-    [InlineData("gpt-5.5")]
-    [InlineData("gpt-5.5-mini")]
-    public void OpenAi_responses_providers_get_reasoning_summary(string providerId)
+    [Fact]
+    public void Copilot_anthropic_transport_models_get_thinking_budget()
     {
-        var props = Build(providerId);
+        var props = Build("claude-sonnet-5", CopilotModelTransport.Anthropic);
+
+        props.Should().ContainKey("Thinking");
+        props["Thinking"].Should().BeOfType<AnthropicThinking>();
+    }
+
+    [Fact]
+    public void Copilot_responses_transport_models_get_reasoning_summary()
+    {
+        var props = Build("gpt-5.5", CopilotModelTransport.Responses);
 
         props.Should().ContainKey("Reasoning");
         props["Reasoning"].Should().BeOfType<ResponseReasoningOptions>().Which.Summary.Should().Be("auto");

--- a/tests/LmStreaming.Sample.Tests/Services/ProviderRegistryTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ProviderRegistryTests.cs
@@ -1,3 +1,4 @@
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
 using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Tests.TestDoubles;
 
@@ -183,10 +184,68 @@ public class ProviderRegistryTests
         catalog.Select(p => p.Id).Should().BeEquivalentTo(
             [
                 "anthropic", "claude", "claude-mock", "codex", "codex-mock",
-                "copilot", "copilot-mock", "gpt-5.5", "gpt-5.5-mini", "haiku",
-                "openai", "sonnet", "test", "test-anthropic",
+                "copilot", "copilot-mock", "openai", "test", "test-anthropic",
             ],
             options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void ListAll_IncludesDiscoveredCopilotModels_PartitionedByVendor()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        var copilotModels = new[]
+        {
+            new CopilotModelInfo("claude-opus-4.8", "Claude Opus 4.8", CopilotModelVendor.Anthropic, CopilotModelTransport.Anthropic),
+            new CopilotModelInfo("gpt-5.5", "GPT-5.5", CopilotModelVendor.OpenAI, CopilotModelTransport.Responses),
+        };
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe(), () => false, copilotModels);
+        var byId = registry.ListAll().ToDictionary(p => p.Id);
+
+        byId["claude-opus-4.8"].Group.Should().Be("Copilot · Anthropic");
+        byId["claude-opus-4.8"].DisplayName.Should().Be("Claude Opus 4.8");
+        byId["gpt-5.5"].Group.Should().Be("Copilot · OpenAI");
+    }
+
+    [Fact]
+    public void FixedProviders_HaveNoGroup()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe());
+        var byId = registry.ListAll().ToDictionary(p => p.Id);
+
+        byId["openai"].Group.Should().BeNull();
+        byId["anthropic"].Group.Should().BeNull();
+        byId["test"].Group.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGetCopilotModel_ResolvesDiscoveredModel_AndRejectsFixedProviders()
+    {
+        using var env = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        var copilotModels = new[]
+        {
+            new CopilotModelInfo("claude-opus-4.8", "Claude Opus 4.8", CopilotModelVendor.Anthropic, CopilotModelTransport.Anthropic),
+        };
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe(), () => false, copilotModels);
+
+        registry.TryGetCopilotModel("claude-opus-4.8", out var model).Should().BeTrue();
+        model.Transport.Should().Be(CopilotModelTransport.Anthropic);
+        registry.TryGetCopilotModel("openai", out _).Should().BeFalse();
+        registry.TryGetCopilotModel("does-not-exist", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void DiscoveredCopilotModels_AreOmitted_WhenListEmpty()
+    {
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+
+        var registry = new ProviderRegistry(new FakeFileSystemProbe(), () => false, copilotModels: []);
+
+        // No entry carries a Copilot partition group when discovery yields nothing.
+        registry.ListAll().Should().OnlyContain(p => p.Group == null);
     }
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/Services/ProviderRegistryTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ProviderRegistryTests.cs
@@ -203,8 +203,9 @@ public class ProviderRegistryTests
         var byId = registry.ListAll().ToDictionary(p => p.Id);
 
         byId["claude-opus-4.8"].Group.Should().Be("Copilot · Anthropic");
-        byId["claude-opus-4.8"].DisplayName.Should().Be("Claude Opus 4.8");
+        byId["claude-opus-4.8"].DisplayName.Should().Be("Claude Opus 4.8 (Copilot)");
         byId["gpt-5.5"].Group.Should().Be("Copilot · OpenAI");
+        byId["gpt-5.5"].DisplayName.Should().Be("GPT-5.5 (Copilot)");
     }
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/Services/WebToolRegistrationPolicyTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/WebToolRegistrationPolicyTests.cs
@@ -21,13 +21,30 @@ public class WebToolRegistrationPolicyTests
 
     // ---- Provider matrix: allow-listed providers (with key) receive both tools ----
 
+    [Fact]
+    public void Apply_RegistersBothTools_ForOpenAi_WhenKeyPresent()
+    {
+        var registry = new FunctionRegistry();
+        var (provider, options) = Backend(ApiKey);
+
+        _ = WebToolRegistrationPolicy.Apply(
+            registry,
+            "openai",
+            enabledTools: null,
+            provider,
+            options,
+            NullLoggerFactory.Instance
+        );
+
+        RegisteredNames(registry).Should().Contain("WebFetch").And.Contain("WebSearch");
+    }
+
     [Theory]
-    [InlineData("openai")]
-    [InlineData("sonnet")]
-    [InlineData("haiku")]
+    [InlineData("claude-sonnet-5")]
+    [InlineData("claude-haiku-4.5")]
     [InlineData("gpt-5.5")]
-    [InlineData("gpt-5.5-mini")]
-    public void Apply_RegistersBothTools_ForAllowListedProvider_WhenKeyPresent(string providerId)
+    [InlineData("gpt-5.4-mini")]
+    public void Apply_RegistersBothTools_ForDiscoveredCopilotModel_WhenKeyPresent(string providerId)
     {
         var registry = new FunctionRegistry();
         var (provider, options) = Backend(ApiKey);
@@ -38,7 +55,8 @@ public class WebToolRegistrationPolicyTests
             enabledTools: null,
             provider,
             options,
-            NullLoggerFactory.Instance
+            NullLoggerFactory.Instance,
+            isCopilotBackedModel: true
         );
 
         RegisteredNames(registry).Should().Contain("WebFetch").And.Contain("WebSearch");


### PR DESCRIPTION
## Summary

Expose all GitHub Copilot provider models in the LmStreaming.Sample provider dropdown, discovered dynamically from the Copilot `/models` API at startup and clearly partitioned into **Copilot · Anthropic** and **Copilot · OpenAI** sections. This replaces the four hardcoded Copilot entries (`sonnet`/`haiku`/`gpt-5.5`/`gpt-5.5-mini`) with the live, routable catalog.

## Changes

- **Discovery (`src/GithubCopilotProvider/Models/`)** — new `CopilotModelInfo`, a pure `CopilotModelCatalogParser`, and `CopilotModelsClient`. The parser keeps only models whose vendor is Anthropic or OpenAI (normalizing `Azure OpenAI` → OpenAI) and that are routable via `/v1/messages` (Anthropic) or `/responses` (OpenAI Responses); Google/Gemini and `/chat/completions`-only models are dropped.
- **`ProviderRegistry`** — injects the discovered models, keys each by its raw model id, tags it with a partition group, and exposes `TryGetCopilotModel`. The four curated Copilot entries are removed; the discovered list is the single source.
- **`Program.cs`** — dispatch (agent transport), model-id resolution, reasoning/thinking options, and web-tool fallback are now driven by the discovered model's transport/vendor instead of literal ids. Discovery runs sync-over-async in the registry DI factory with a 10s timeout and degrades to an empty list (no token / failure / timeout) so the app still boots.
- **UI** — `ProviderDescriptor` / `providers.ts` gain a `Group` field; `ProviderSelector.vue` renders non-selectable section headers with ungrouped providers listed first.
- **Docs** — `CLAUDE.md` / `ManualTesting.md` updated to describe the dynamic, partitioned list.

## Testing

- New unit tests for the parser and client against the real captured `/models` fixture (34 models → 13 routable: 7 Claude + 6 GPT incl. one `Azure OpenAI`).
- Registry grouping/availability, reasoning-props and web-tool policy by transport, and Vue grouping/selection tests.
- Verified green: full solution build (0 errors), format gate (`dotnet format whitespace --verify-no-changes`), GithubCopilotProvider.Tests (20 new + 52 total), LmStreaming.Sample.Tests (361), ClientApp vitest (268).
- Not yet live-verified against a real Copilot token — tests are fixture-driven.

## Risks

- Behavior change: conversations previously locked to `sonnet`/`haiku`/`gpt-5.5`/`gpt-5.5-mini` will show those ids as unavailable (intended replacement).
- First `GET /api/providers` request triggers the one-time discovery call (bounded by a 10s timeout).

## Related Issues

Fixes #128

---

## Additional infrastructure

- **Configurable Vite dev-server port** (`VITE_DEV_PORT` / `VITE_BACKEND_ORIGIN`) — manual-validation infra, not part of #128 proper. It removes the hardcoded 5173 collision so a second sample instance can boot alongside a running one for live UI verification. Both env vars default to the standard single-instance values, so existing runs are unchanged.

## Follow-ups (deferred from review)

- #132 — extract a shared Copilot `/models` parsing helper between the provider and the proxy sample.
- #133 — add a browser E2E regression for provider-dropdown scroll/overflow (needs a DI seam to inject stub Copilot models into the token-gated registry).
