### PR TITLE
feat(workflow): author & run LmWorkflow in Workspace Agent mode

### DIFF
--- a/samples/LmStreaming.Sample/LmStreaming.Sample.csproj
+++ b/samples/LmStreaming.Sample/LmStreaming.Sample.csproj
@@ -64,6 +64,7 @@
     <ProjectReference Include="..\..\src\LmStreaming.AspNetCore\AchieveAi.LmDotnetTools.LmStreaming.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\LmAgentInfra\AchieveAi.LmDotnetTools.LmAgentInfra.csproj" />
     <ProjectReference Include="..\..\src\LmMultiTurn\AchieveAi.LmDotnetTools.LmMultiTurn.csproj" />
+    <ProjectReference Include="..\..\src\LmWorkflow\AchieveAi.LmDotnetTools.LmWorkflow.csproj" />
     <ProjectReference Include="..\..\src\Misc\AchieveAi.LmDotnetTools.Misc.csproj" />
     <ProjectReference Include="..\..\src\OpenAIProvider\AchieveAi.LmDotnetTools.OpenAIProvider.csproj" />
     <ProjectReference Include="..\..\src\AnthropicProvider\AchieveAi.LmDotnetTools.AnthropicProvider.csproj" />

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -694,8 +694,23 @@ try
                     // same conversation loop (no separate WorkflowSession-owned loop) — the runtime
                     // observes the loop's own message stream (see ownedResources wiring below) to
                     // correlate Agent tool-call spawns back into workflow state.
-                    workflowRuntime = new WorkflowRuntime(logger: loggerFactory.CreateLogger<WorkflowRuntime>());
-                    _ = filteredRegistry.AddProvider(new WorkflowToolProvider(workflowRuntime));
+                    //
+                    // On by default, but disable-able per deployment WITHOUT a redeploy via
+                    // WORKSPACE_AGENT_LMWORKFLOW_ENABLED=false. This one flag gates all three behaviors as a
+                    // unit — the workflow tool surface (here), the appended controller prompt (below), and the
+                    // correlation observer (further below, which is already gated on `workflowRuntime`).
+                    var workflowEnabled = !string.Equals(
+                        Environment.GetEnvironmentVariable("WORKSPACE_AGENT_LMWORKFLOW_ENABLED"),
+                        "false",
+                        StringComparison.OrdinalIgnoreCase
+                    );
+                    if (workflowEnabled)
+                    {
+                        workflowRuntime = new WorkflowRuntime(
+                            logger: loggerFactory.CreateLogger<WorkflowRuntime>()
+                        );
+                        _ = filteredRegistry.AddProvider(new WorkflowToolProvider(workflowRuntime));
+                    }
 
                     // Workspace Agent mode: expose the sandbox file/shell tools via the gateway's
                     // MCP endpoint, bound to this agent's sandbox session by the X-Session-ID header.
@@ -741,11 +756,17 @@ try
                     }
 
                     // Append last, off whatever effectiveMode currently is (default or the
-                    // degraded-sandbox notice above) so the controller prompt survives either path.
-                    effectiveMode = effectiveMode with
+                    // degraded-sandbox notice above) so the controller prompt survives either path. Gated on
+                    // the workflow runtime (i.e. WORKSPACE_AGENT_LMWORKFLOW_ENABLED) so disabling the feature
+                    // also drops the extra controller instructions from the prompt.
+                    if (workflowRuntime is not null)
                     {
-                        SystemPrompt = effectiveMode.SystemPrompt + "\n\n" + ControllerSystemPrompt.Default,
-                    };
+                        effectiveMode = effectiveMode with
+                        {
+                            SystemPrompt =
+                                effectiveMode.SystemPrompt + "\n\n" + ControllerSystemPrompt.Default,
+                        };
+                    }
                 }
 
                 // WebFetch/WebSearch fallback tools for providers without a native web capability.
@@ -903,8 +924,23 @@ try
                                     }
                                 }
                             }
-                            catch (OperationCanceledException)
+                            catch (OperationCanceledException) when (observerCts.IsCancellationRequested)
                             { /* expected on shutdown */
+                            }
+                            catch (Exception ex)
+                            {
+                                // This background task is the critical path that correlates Agent
+                                // tool-call spawns/results back into the workflow runtime. If it faults, the
+                                // agent keeps serving workflow tools but joins never settle — so surface the
+                                // first failure loudly (disposal below would otherwise swallow it).
+                                loggerFactory
+                                    .CreateLogger<WorkflowRuntime>()
+                                    .LogError(
+                                        ex,
+                                        "Workflow observer for thread {ThreadId} failed; Agent-result "
+                                            + "correlation is now disabled for this conversation",
+                                        threadId
+                                    );
                             }
                             finally
                             {
@@ -1288,9 +1324,9 @@ public partial class Program
         return CopilotAnthropicAgentFactory.Create(
             name,
             s_copilotTokenProvider.Value,
-            s_copilotSession.Value,
-            logger: loggerFactory.CreateLogger<AnthropicAgent>(),
-            timeout: CopilotResponseTimeout
+            timeout: CopilotResponseTimeout,
+            session: s_copilotSession.Value,
+            logger: loggerFactory.CreateLogger<AnthropicAgent>()
         );
     }
 

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -21,6 +21,9 @@ using AchieveAi.LmDotnetTools.LmMultiTurn;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using AchieveAi.LmDotnetTools.LmStreaming.AspNetCore.Extensions;
+using AchieveAi.LmDotnetTools.LmWorkflow.Prompts;
+using AchieveAi.LmDotnetTools.LmWorkflow.Runtime;
+using AchieveAi.LmDotnetTools.LmWorkflow.Tools;
 using AchieveAi.LmDotnetTools.LmTestUtils;
 using AchieveAi.LmDotnetTools.McpMiddleware.Extensions;
 using AchieveAi.LmDotnetTools.McpServer.AspNetCore.Extensions;
@@ -663,6 +666,7 @@ try
                 // Add LlmQuery book search MCP tools — only for medical knowledge mode
                 // Track MCP clients for proper disposal alongside the agent
                 List<IAsyncDisposable>? ownedResources = null;
+                WorkflowRuntime? workflowRuntime = null;
                 if (!string.IsNullOrEmpty(mcpBaseUrl))
                 {
                     var (_, mcpClients) = ConnectLlmQueryMcpClients(
@@ -685,6 +689,13 @@ try
                     // is independent of the sandbox, so add it here unconditionally; it stays usable
                     // even when the sandbox MCP endpoint is offline (degraded mode below).
                     _ = filteredRegistry.AddFunctionsFromObject(new TaskManager(), providerName: "TaskManager");
+
+                    // Let the controller LLM author and drive an LmWorkflow workflow inside this
+                    // same conversation loop (no separate WorkflowSession-owned loop) — the runtime
+                    // observes the loop's own message stream (see ownedResources wiring below) to
+                    // correlate Agent tool-call spawns back into workflow state.
+                    workflowRuntime = new WorkflowRuntime(logger: loggerFactory.CreateLogger<WorkflowRuntime>());
+                    _ = filteredRegistry.AddProvider(new WorkflowToolProvider(workflowRuntime));
 
                     // Workspace Agent mode: expose the sandbox file/shell tools via the gateway's
                     // MCP endpoint, bound to this agent's sandbox session by the X-Session-ID header.
@@ -728,6 +739,13 @@ try
                                 threadId
                             );
                     }
+
+                    // Append last, off whatever effectiveMode currently is (default or the
+                    // degraded-sandbox notice above) so the controller prompt survives either path.
+                    effectiveMode = effectiveMode with
+                    {
+                        SystemPrompt = effectiveMode.SystemPrompt + "\n\n" + ControllerSystemPrompt.Default,
+                    };
                 }
 
                 // WebFetch/WebSearch fallback tools for providers without a native web capability.
@@ -858,6 +876,47 @@ try
                         subAgentTemplateSource: sharedSubAgentSource,
                         loggerFactory: loggerFactory
                     );
+
+                    if (workflowRuntime is not null)
+                    {
+                        // Correlate sub-agent spawn results back into the workflow runtime via a
+                        // second, independent subscriber to this loop's own message stream (tool
+                        // handlers above cover the synchronous SetWorkflow/SetCurrentNode/etc. path;
+                        // this covers the async Agent-tool-call/result correlation). The first
+                        // MoveNextAsync() is primed synchronously here — before this factory returns
+                        // "agent" to the caller — so the per-subscriber channel is registered before
+                        // any SendAsync can occur on this conversation.
+                        var observerCts = new CancellationTokenSource();
+                        var enumerator = agent.SubscribeAsync(observerCts.Token)
+                            .GetAsyncEnumerator(observerCts.Token);
+                        var pendingFirstMoveNext = enumerator.MoveNextAsync();
+                        var observerTask = Task.Run(async () =>
+                        {
+                            try
+                            {
+                                if (await pendingFirstMoveNext)
+                                {
+                                    workflowRuntime.ObserveMessage(enumerator.Current);
+                                    while (await enumerator.MoveNextAsync())
+                                    {
+                                        workflowRuntime.ObserveMessage(enumerator.Current);
+                                    }
+                                }
+                            }
+                            catch (OperationCanceledException)
+                            { /* expected on shutdown */
+                            }
+                            finally
+                            {
+                                await enumerator.DisposeAsync();
+                            }
+                        });
+                        ownedResources =
+                        [
+                            .. ownedResources ?? [],
+                            new WorkflowObserverDisposable(observerCts, observerTask),
+                        ];
+                    }
 
                     return new MultiTurnAgentPool.AgentCreationResult(agent, ownedResources);
                 }
@@ -1130,6 +1189,28 @@ public partial class Program
     }
 
     /// <summary>
+    ///     Cancels and awaits the background workflow-observer task on disposal, mirroring the same
+    ///     cancel→await/swallow→dispose idiom <c>MultiTurnAgentPool.AgentEntry.DisposeAsync</c>
+    ///     already uses for the agent's own run loop.
+    /// </summary>
+    private sealed class WorkflowObserverDisposable(CancellationTokenSource cts, Task observerTask)
+        : IAsyncDisposable
+    {
+        public async ValueTask DisposeAsync()
+        {
+            await cts.CancelAsync();
+            try
+            {
+                await observerTask;
+            }
+            catch
+            { /* best-effort shutdown */
+            }
+            cts.Dispose();
+        }
+    }
+
+    /// <summary>
     ///     Creates a test-mode agent using an <see cref="ITestAgentBuilder"/>-supplied handler.
     /// </summary>
     private static IStreamingAgent CreateTestAgent(ILoggerFactory loggerFactory, ITestAgentBuilder testAgentBuilder)
@@ -1208,9 +1289,27 @@ public partial class Program
             name,
             s_copilotTokenProvider.Value,
             s_copilotSession.Value,
-            logger: loggerFactory.CreateLogger<AnthropicAgent>()
+            logger: loggerFactory.CreateLogger<AnthropicAgent>(),
+            timeout: CopilotResponseTimeout
         );
     }
+
+    /// <summary>
+    ///     Time-to-first-response ceiling for Copilot-backed streaming agents. Because the streaming
+    ///     clients read with <c>ResponseHeadersRead</c>, this bounds how long a stuck/dead upstream
+    ///     connection blocks before it surfaces as a timeout — it does NOT cap a healthy stream's length.
+    ///     A tight-but-generous default (120s) keeps a hung backend from freezing a whole run (including a
+    ///     blocking sub-agent spawn) for the full 5-minute HTTP default. Override with
+    ///     <c>COPILOT_RESPONSE_TIMEOUT_SECONDS</c>.
+    /// </summary>
+    private static TimeSpan CopilotResponseTimeout =>
+        int.TryParse(
+            Environment.GetEnvironmentVariable("COPILOT_RESPONSE_TIMEOUT_SECONDS"),
+            out var seconds
+        )
+        && seconds > 0
+            ? TimeSpan.FromSeconds(seconds)
+            : TimeSpan.FromSeconds(120);
 
     /// <summary>
     ///     Creates an OpenAI Responses agent (GPT-5.5 / GPT-5.5 mini) routed through the GitHub Copilot

--- a/src/GithubCopilotProvider/Agents/CopilotAnthropicAgentFactory.cs
+++ b/src/GithubCopilotProvider/Agents/CopilotAnthropicAgentFactory.cs
@@ -31,6 +31,13 @@ public static class CopilotAnthropicAgentFactory
     /// <param name="performanceTracker">Optional performance tracker.</param>
     /// <param name="logger">Optional logger.</param>
     /// <param name="retryOptions">Optional retry configuration.</param>
+    /// <param name="timeout">
+    ///     Optional HTTP timeout. Because the streaming client reads with
+    ///     <see cref="System.Net.Http.HttpCompletionOption.ResponseHeadersRead"/>, this bounds the
+    ///     time-to-first-response (a dead/stuck connection), NOT the length of a healthy stream — so a
+    ///     shorter value makes an unresponsive backend surface promptly instead of hanging for the full
+    ///     default. Defaults to the shared 5-minute HTTP default.
+    /// </param>
     public static AnthropicAgent Create(
         string name,
         ICopilotTokenProvider tokenProvider,
@@ -38,7 +45,8 @@ public static class CopilotAnthropicAgentFactory
         CopilotOptions? options = null,
         IPerformanceTracker? performanceTracker = null,
         ILogger<AnthropicAgent>? logger = null,
-        RetryOptions? retryOptions = null
+        RetryOptions? retryOptions = null,
+        TimeSpan? timeout = null
     )
     {
         ArgumentNullException.ThrowIfNull(name);
@@ -54,7 +62,7 @@ public static class CopilotAnthropicAgentFactory
         var context = session ?? new CopilotSessionContext();
         var host = copilotOptions.BaseUrl.TrimEnd('/');
 
-        var httpClient = CopilotHttpClientFactory.Create(host, tokenProvider, context, copilotOptions);
+        var httpClient = CopilotHttpClientFactory.Create(host, tokenProvider, context, copilotOptions, timeout);
 
         // The client appends "/messages", so the base URL must carry the "/v1" prefix to hit
         // {host}/v1/messages.

--- a/src/GithubCopilotProvider/Agents/CopilotAnthropicAgentFactory.cs
+++ b/src/GithubCopilotProvider/Agents/CopilotAnthropicAgentFactory.cs
@@ -24,6 +24,11 @@ public static class CopilotAnthropicAgentFactory
     /// <summary>
     ///     Creates an <see cref="AnthropicAgent"/> routed through GitHub Copilot.
     /// </summary>
+    /// <remarks>
+    ///     This is the original signature, preserved verbatim for binary compatibility: already-compiled
+    ///     SDK consumers bound to this 7-parameter method keep resolving to it. It delegates to the
+    ///     timeout-aware overload with the default (5-minute) HTTP timeout.
+    /// </remarks>
     /// <param name="name">Agent name.</param>
     /// <param name="tokenProvider">Source of the GitHub OAuth bearer token.</param>
     /// <param name="session">Optional shared tracking ids; a new context is created when omitted.</param>
@@ -31,13 +36,6 @@ public static class CopilotAnthropicAgentFactory
     /// <param name="performanceTracker">Optional performance tracker.</param>
     /// <param name="logger">Optional logger.</param>
     /// <param name="retryOptions">Optional retry configuration.</param>
-    /// <param name="timeout">
-    ///     Optional HTTP timeout. Because the streaming client reads with
-    ///     <see cref="System.Net.Http.HttpCompletionOption.ResponseHeadersRead"/>, this bounds the
-    ///     time-to-first-response (a dead/stuck connection), NOT the length of a healthy stream — so a
-    ///     shorter value makes an unresponsive backend surface promptly instead of hanging for the full
-    ///     default. Defaults to the shared 5-minute HTTP default.
-    /// </param>
     public static AnthropicAgent Create(
         string name,
         ICopilotTokenProvider tokenProvider,
@@ -45,8 +43,48 @@ public static class CopilotAnthropicAgentFactory
         CopilotOptions? options = null,
         IPerformanceTracker? performanceTracker = null,
         ILogger<AnthropicAgent>? logger = null,
-        RetryOptions? retryOptions = null,
-        TimeSpan? timeout = null
+        RetryOptions? retryOptions = null
+    ) =>
+        Create(
+            name,
+            tokenProvider,
+            timeout: null,
+            session: session,
+            options: options,
+            performanceTracker: performanceTracker,
+            logger: logger,
+            retryOptions: retryOptions
+        );
+
+    /// <summary>
+    ///     Creates an <see cref="AnthropicAgent"/> routed through GitHub Copilot, with an explicit HTTP
+    ///     timeout. <paramref name="timeout"/> is required (with no default) purely so this overload can
+    ///     never be ambiguous with the binary-compatible timeout-less overload above — pass <c>null</c> for
+    ///     the default. The remaining parameters keep their defaults for caller ergonomics.
+    /// </summary>
+    /// <param name="name">Agent name.</param>
+    /// <param name="tokenProvider">Source of the GitHub OAuth bearer token.</param>
+    /// <param name="timeout">
+    ///     HTTP timeout (<c>null</c> = the shared 5-minute default). Because the streaming client reads with
+    ///     <see cref="System.Net.Http.HttpCompletionOption.ResponseHeadersRead"/>, this bounds the
+    ///     time-to-first-response (a dead/stuck connection), NOT the length of a healthy stream — so a
+    ///     shorter value makes an unresponsive backend surface promptly instead of hanging for the full
+    ///     default.
+    /// </param>
+    /// <param name="session">Optional shared tracking ids; a new context is created when omitted.</param>
+    /// <param name="options">Optional Copilot header options; defaults target the enterprise host.</param>
+    /// <param name="performanceTracker">Optional performance tracker.</param>
+    /// <param name="logger">Optional logger.</param>
+    /// <param name="retryOptions">Optional retry configuration.</param>
+    public static AnthropicAgent Create(
+        string name,
+        ICopilotTokenProvider tokenProvider,
+        TimeSpan? timeout,
+        CopilotSessionContext? session = null,
+        CopilotOptions? options = null,
+        IPerformanceTracker? performanceTracker = null,
+        ILogger<AnthropicAgent>? logger = null,
+        RetryOptions? retryOptions = null
     )
     {
         ArgumentNullException.ThrowIfNull(name);

--- a/src/LmWorkflow/Model/WorkflowJson.cs
+++ b/src/LmWorkflow/Model/WorkflowJson.cs
@@ -14,12 +14,38 @@ public static class WorkflowJson
     /// <summary>The shared serializer options that define the workflow wire contract.</summary>
     public static JsonSerializerOptions Options { get; } = CreateOptions();
 
+    /// <summary>
+    ///     Strict variant of <see cref="Options"/> used only when an LLM AUTHORS a definition through the
+    ///     workflow tools. It adds <see cref="JsonUnmappedMemberHandling.Disallow"/> so a misspelled or
+    ///     invented field (e.g. <c>tasks</c> instead of <c>taskList</c>, <c>agentType</c> instead of
+    ///     <c>subagent_type</c>) throws a <see cref="JsonException"/> naming the offending property instead
+    ///     of being silently dropped — which used to leave the field null and produce a workflow that
+    ///     validated clean yet did nothing. Persistence deliberately keeps using the lenient
+    ///     <see cref="Options"/> so already-saved snapshots stay loadable across shape changes.
+    /// </summary>
+    public static JsonSerializerOptions StrictOptions { get; } = CreateStrictOptions();
+
     /// <summary>Deserializes a workflow definition from its JSON form.</summary>
     /// <exception cref="JsonException">The JSON is invalid or deserializes to a null definition.</exception>
     public static WorkflowDefinition Deserialize(string json)
     {
         ArgumentException.ThrowIfNullOrEmpty(json);
         return JsonSerializer.Deserialize<WorkflowDefinition>(json, Options)
+            ?? throw new JsonException("Workflow JSON deserialized to a null definition.");
+    }
+
+    /// <summary>
+    ///     Deserializes a workflow definition, rejecting unknown/misspelled fields (see
+    ///     <see cref="StrictOptions"/>). Use for the LLM authoring path so wrong field names surface as an
+    ///     actionable error rather than silently vanishing.
+    /// </summary>
+    /// <exception cref="JsonException">
+    ///     The JSON is invalid, contains an unmapped property, or deserializes to a null definition.
+    /// </exception>
+    public static WorkflowDefinition DeserializeStrict(string json)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(json);
+        return JsonSerializer.Deserialize<WorkflowDefinition>(json, StrictOptions)
             ?? throw new JsonException("Workflow JSON deserialized to a null definition.");
     }
 
@@ -41,6 +67,13 @@ public static class WorkflowJson
         options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
         options.Converters.Add(new WorkflowNodeJsonConverter());
         options.Converters.Add(new ConditionJsonConverter());
+        return options;
+    }
+
+    private static JsonSerializerOptions CreateStrictOptions()
+    {
+        var options = CreateOptions();
+        options.UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow;
         return options;
     }
 }

--- a/src/LmWorkflow/Prompts/ControllerSystemPrompt.cs
+++ b/src/LmWorkflow/Prompts/ControllerSystemPrompt.cs
@@ -9,8 +9,7 @@ namespace AchieveAi.LmDotnetTools.LmWorkflow.Prompts;
 /// </summary>
 public static class ControllerSystemPrompt
 {
-    /// <summary>The default controller system prompt. See the type remarks for what it covers.</summary>
-    public const string Default = """
+    private const string Body = """
         You are the CONTROLLER of a workflow. You first (optionally) AUTHOR a workflow and then DRIVE it
         to completion. Understand the division of labour clearly:
 
@@ -79,4 +78,32 @@ public static class ControllerSystemPrompt
 
         Keep going — spawn, observe, route — until you reach a terminal node and the workflow completes.
         """;
+
+    // The authoring guide is appended to the body. It names the exact, easily-mistyped field names and
+    // embeds a verbatim worked example (the same string the tests prove authors cleanly), so the model
+    // reads the shape rather than guessing it. SetWorkflow rejects unknown/misspelled fields by name.
+    private static readonly string AuthoringGuide =
+        """
+        AUTHORING A WORKFLOW (the SetWorkflow definition shape)
+        A definition is an object with an "objective" (string) and a "nodes" array. Each node has an
+        "id", a "type" (start | procedural | conditional | terminal), and a "title". Use these EXACT
+        field names — SetWorkflow rejects unknown or misspelled fields by name, so do not invent
+        synonyms:
+        - A node's onward edges go in "next" (an array of node ids). start has exactly one; procedural
+          has at least one.
+        - A procedural node's tasks go in "taskList" (NOT "tasks", "task", or "units").
+        - Each task needs "id", "subagent_type" (snake_case — NOT "agentType"/"agent_type"), and
+          "promptTemplate". Optionally "writes": { "to": "state.<path>", "mode": "set|append|merge" }.
+        - A conditional node needs "branches" (each { "when": <cond>, "to": <nodeId> }) and a non-empty
+          "else". A terminal node may carry a "resultTemplate".
+
+        Worked example — a start → procedural (one agent task) → terminal workflow. Copy this shape:
+
+        """
+        + WorkflowExamples.MinimalProcedural;
+
+    /// <summary>The default controller system prompt. See the type remarks for what it covers.</summary>
+    // Declared last: static field initializers run in textual order, so both Body and AuthoringGuide
+    // must be initialized before this composes them (otherwise AuthoringGuide would still be null here).
+    public static readonly string Default = Body + "\n\n" + AuthoringGuide;
 }

--- a/src/LmWorkflow/Prompts/WorkflowExamples.cs
+++ b/src/LmWorkflow/Prompts/WorkflowExamples.cs
@@ -1,0 +1,42 @@
+namespace AchieveAi.LmDotnetTools.LmWorkflow.Prompts;
+
+/// <summary>
+///     Canonical, copy-pasteable workflow-definition examples shown to the controller LLM. Kept as a
+///     single source of truth so the JSON the model is taught with is the exact JSON the tests prove
+///     authors cleanly (see <c>WorkflowAuthoringErgonomicsTests</c>) — the example can never drift from a
+///     working definition.
+/// </summary>
+public static class WorkflowExamples
+{
+    /// <summary>
+    ///     The smallest useful workflow: a start node routing into one procedural node that runs a single
+    ///     sub-agent task, then a terminal. It deliberately shows the exact field names the runtime
+    ///     requires — <c>taskList</c>, and within a task <c>subagent_type</c> (snake_case) and
+    ///     <c>promptTemplate</c> — because these are the ones an LLM most often guesses wrong.
+    /// </summary>
+    public const string MinimalProcedural = """
+        {
+          "schemaVersion": 1,
+          "objective": "Research a topic and write a short brief.",
+          "nodes": [
+            { "id": "start", "type": "start", "title": "Start", "next": ["work"] },
+            {
+              "id": "work",
+              "type": "procedural",
+              "title": "Research the topic",
+              "joinPolicy": { "mode": "all" },
+              "taskList": [
+                {
+                  "id": "research",
+                  "subagent_type": "general-purpose",
+                  "promptTemplate": "Research {{objective}} and return a concise brief.",
+                  "writes": { "to": "state.brief", "mode": "set" }
+                }
+              ],
+              "next": ["done"]
+            },
+            { "id": "done", "type": "terminal", "title": "Done" }
+          ]
+        }
+        """;
+}

--- a/src/LmWorkflow/Runtime/TaskCoordinator.cs
+++ b/src/LmWorkflow/Runtime/TaskCoordinator.cs
@@ -175,14 +175,25 @@ internal sealed class TaskCoordinator
 
     /// <summary>
     ///     Correlates an observed <c>Agent</c> tool call (by its <paramref name="toolCallId"/>) to the expected
-    ///     unit named <paramref name="name"/> and marks the task in-flight. No-ops when the name is not an
-    ///     expected unit (so the caller can pass through every <c>Agent</c> call unconditionally).
+    ///     unit named <paramref name="name"/> and marks the task in-flight. If the name is not yet a known unit
+    ///     — because the controller spawned the task WITHOUT first polling <c>GetWorkflow</c> to compose the
+    ///     active node's units — the active node's authored units are composed on demand (idempotent) and the
+    ///     lookup retried, so correlation never depends on the controller's call order. Genuinely no-ops only
+    ///     when the name still does not match an authored unit of the active node.
     /// </summary>
     public void RegisterSpawn(string toolCallId, string name)
     {
         if (!_tasksByName.TryGetValue(name, out var taskRef))
         {
-            return;
+            // The controller can issue the Agent call before any GetWorkflow/projection has composed the
+            // active node's units (observed live: SetCurrentNode -> Agent -> GetWorkflow). Compose now so a
+            // legitimate authored-task spawn still correlates; Compose is idempotent, so this cannot double
+            // up already-registered units.
+            _ = Compose();
+            if (!_tasksByName.TryGetValue(name, out taskRef))
+            {
+                return;
+            }
         }
 
         // A unit that has already validated or terminally failed is SETTLED. A controller re-issuing an Agent

--- a/src/LmWorkflow/Runtime/WorkflowRuntime.cs
+++ b/src/LmWorkflow/Runtime/WorkflowRuntime.cs
@@ -50,7 +50,9 @@ public sealed class WorkflowRuntime
     // Per-tool-call reassembly buffer for STREAMING Agent-call args. ObserveMessage runs on the host's
     // out-of-band observer thread (not under _lock), and a real provider delivers the Agent call's args as
     // incremental fragments across many ToolCallUpdateMessages; this concurrent map reassembles them by
-    // tool-call id until the spawn name is parseable. Cleared per id once the spawn result settles.
+    // tool-call id until the spawn name is parseable. Dropped as soon as the args parse, capped for a stream
+    // that never parses, and cleared on the tool result — so it cannot leak in a long-lived conversation.
+    private const int MaxSpawnArgBufferChars = 256 * 1024;
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, string> _spawnArgBuffers =
         new(StringComparer.Ordinal);
 
@@ -450,10 +452,16 @@ public sealed class WorkflowRuntime
                 AccumulateAndRegisterSpawn(updateId, update.FunctionArgs);
                 break;
 
-            case ToolCallResultMessage { ToolCallId: { } resultId } result when IsRegisteredSpawn(resultId):
-                ObserveSpawnResult(resultId, result.Result, result.IsError);
-                // The spawn is settled; drop its arg buffer so a re-used id can't append onto stale bytes.
+            case ToolCallResultMessage { ToolCallId: { } resultId } result:
+                // Any tool result SETTLES its call: drop the streamed-args buffer unconditionally, whether or
+                // not the spawn correlated. Non-workflow Agent calls, malformed streams, and names that never
+                // matched a workflow unit must not retain fragments for the life of a long conversation.
                 _ = _spawnArgBuffers.TryRemove(resultId, out _);
+                if (IsRegisteredSpawn(resultId))
+                {
+                    ObserveSpawnResult(resultId, result.Result, result.IsError);
+                }
+
                 break;
 
             // Injected <sub-agent> completion (DORMANT / forward-built in V1): MultiTurnAgentLoop does not
@@ -495,6 +503,12 @@ public sealed class WorkflowRuntime
     ///     is parseable — only the reassembled buffer is. Idempotent: <see cref="RegisterSpawn"/> keys on
     ///     tool-call id, so repeated parses after the name first appears are harmless.
     /// </summary>
+    /// <remarks>
+    ///     Buffer lifecycle is bounded so a long-lived Workspace Agent conversation cannot leak: the buffer is
+    ///     dropped the moment the args become parseable (the name is then known — later fragments are noise),
+    ///     is capped at <see cref="MaxSpawnArgBufferChars"/> for a stream that never parses, and is cleared on
+    ///     the tool result (see <see cref="ObserveMessage"/>).
+    /// </remarks>
     private void AccumulateAndRegisterSpawn(string toolCallId, string? fragment)
     {
         if (string.IsNullOrEmpty(fragment))
@@ -508,10 +522,20 @@ public sealed class WorkflowRuntime
             (_, existing) => existing + fragment
         );
 
-        var name = TryReadSpawnName(buffer);
-        if (name is not null)
+        if (TryReadSpawnName(buffer) is { } name)
         {
             RegisterSpawn(toolCallId, name);
+            // The args are complete enough to parse — the name is known and further fragments are noise.
+            // Drop the buffer now (before the sub-agent even finishes) rather than waiting for the result.
+            _ = _spawnArgBuffers.TryRemove(toolCallId, out _);
+            return;
+        }
+
+        // A well-formed Agent call yields a parseable name well within the cap; a stream that blows past it
+        // without ever parsing is malformed or not a workflow spawn — drop it so it cannot grow unbounded.
+        if (buffer.Length > MaxSpawnArgBufferChars)
+        {
+            _ = _spawnArgBuffers.TryRemove(toolCallId, out _);
         }
     }
 

--- a/src/LmWorkflow/Runtime/WorkflowRuntime.cs
+++ b/src/LmWorkflow/Runtime/WorkflowRuntime.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using System.Text.Json.Nodes;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Utils;
 using AchieveAi.LmDotnetTools.LmWorkflow.Binding;
 using AchieveAi.LmDotnetTools.LmWorkflow.Ingest;
@@ -44,6 +46,13 @@ public sealed class WorkflowRuntime
     // status/attempt/error bookkeeping are owned by the coordinator. It holds no lock of its own: the runtime
     // invokes every coordinator method while holding _lock, so all its state is mutated under the one lock.
     private readonly TaskCoordinator _coordinator;
+
+    // Per-tool-call reassembly buffer for STREAMING Agent-call args. ObserveMessage runs on the host's
+    // out-of-band observer thread (not under _lock), and a real provider delivers the Agent call's args as
+    // incremental fragments across many ToolCallUpdateMessages; this concurrent map reassembles them by
+    // tool-call id until the spawn name is parseable. Cleared per id once the spawn result settles.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, string> _spawnArgBuffers =
+        new(StringComparer.Ordinal);
 
     private readonly Dictionary<string, int> _visits = new(StringComparer.Ordinal);
 
@@ -411,6 +420,120 @@ public sealed class WorkflowRuntime
         }
 
         Persist(snapshot);
+    }
+
+    /// <summary>
+    ///     Correlates the stream events that matter to a run observer: an <c>Agent</c> tool call (registers
+    ///     the spawn by the runtime-surfaced unit name); its tool result (a blocking answer is
+    ///     validated/recorded, a background spawn receipt is failed fast — unsupported in V1); and an injected
+    ///     <c>&lt;sub-agent&gt;</c> user message (dormant / forward-built). Every other message is ignored.
+    ///     This is the single entry point a host wires a <c>MultiTurnAgentLoop</c>'s message stream
+    ///     into to drive workflow correlation from outside a dedicated <c>WorkflowSession</c>.
+    /// </summary>
+    public void ObserveMessage(IMessage message)
+    {
+        switch (message)
+        {
+            // A finalized Agent tool call (what ExecuteRunAsync / a mocked agent yields as one message).
+            case ToolCallMessage { FunctionName: "Agent", ToolCallId: { } toolCallId } call:
+                RegisterSpawnByName(toolCallId, call.FunctionArgs);
+                break;
+
+            // A streaming Agent tool-call update. A REAL provider publishes the Agent call to subscribers
+            // ONLY as these updates (the finalized ToolCallMessage is added to loop history but NOT published
+            // to the subscriber stream, so the sample's out-of-band observer never sees it). Critically, each
+            // update carries an INCREMENTAL args FRAGMENT, not the full accumulated args — verified live: the
+            // fragments arrive as {"subagent_t / ype": "gen / eral-pu / ... / "name": "work:1:task1"}. So the
+            // spawn name only becomes readable after the fragments are reassembled; accumulate per toolCallId
+            // and retry the parse on each fragment.
+            case ToolCallUpdateMessage { FunctionName: "Agent", ToolCallId: { } updateId } update:
+                AccumulateAndRegisterSpawn(updateId, update.FunctionArgs);
+                break;
+
+            case ToolCallResultMessage { ToolCallId: { } resultId } result when IsRegisteredSpawn(resultId):
+                ObserveSpawnResult(resultId, result.Result, result.IsError);
+                // The spawn is settled; drop its arg buffer so a re-used id can't append onto stale bytes.
+                _ = _spawnArgBuffers.TryRemove(resultId, out _);
+                break;
+
+            // Injected <sub-agent> completion (DORMANT / forward-built in V1): MultiTurnAgentLoop does not
+            // publish injected sub-agent completions to its subscribers, so this case does not fire in V1.
+            // Even if it did, the background receipt path now fails fast (ObserveSpawnResult) and never records
+            // an agent_id correlation, so ObserveInjectedResult would find no mapping and surface the result as
+            // harmless "unmatched". Re-enabled in the follow-up that makes injected completions observable.
+            case TextMessage { Role: Role.User, Text: { } text }
+                when text.TrimStart().StartsWith("<sub-agent", StringComparison.Ordinal):
+                if (SubAgentResultParser.TryParse(text, out var agentId, out var payload, out var isError))
+                {
+                    ObserveInjectedResult(agentId, payload, isError);
+                }
+
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    /// <summary>
+    ///     Reads the spawn <c>name</c> from a FINALIZED Agent tool call's complete args and registers the
+    ///     correlation. No-ops when the args do not name a known unit.
+    /// </summary>
+    private void RegisterSpawnByName(string toolCallId, string? functionArgs)
+    {
+        var name = TryReadSpawnName(functionArgs);
+        if (name is not null)
+        {
+            RegisterSpawn(toolCallId, name);
+        }
+    }
+
+    /// <summary>
+    ///     Appends a streaming Agent-call args fragment to this tool call's buffer and, once the accumulated
+    ///     buffer parses as JSON carrying a <c>name</c>, registers the spawn. Fragments arrive as raw byte
+    ///     slices of the args JSON (e.g. <c>{"subagent_t</c> then <c>ype": "gen</c> …), so no single fragment
+    ///     is parseable — only the reassembled buffer is. Idempotent: <see cref="RegisterSpawn"/> keys on
+    ///     tool-call id, so repeated parses after the name first appears are harmless.
+    /// </summary>
+    private void AccumulateAndRegisterSpawn(string toolCallId, string? fragment)
+    {
+        if (string.IsNullOrEmpty(fragment))
+        {
+            return;
+        }
+
+        var buffer = _spawnArgBuffers.AddOrUpdate(
+            toolCallId,
+            fragment,
+            (_, existing) => existing + fragment
+        );
+
+        var name = TryReadSpawnName(buffer);
+        if (name is not null)
+        {
+            RegisterSpawn(toolCallId, name);
+        }
+    }
+
+    private static string? TryReadSpawnName(string? functionArgs)
+    {
+        if (string.IsNullOrEmpty(functionArgs))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(functionArgs);
+            return doc.RootElement.TryGetProperty("name", out var name)
+                && name.ValueKind == JsonValueKind.String
+                ? name.GetString()
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/LmWorkflow/Tools/WorkflowToolProvider.cs
+++ b/src/LmWorkflow/Tools/WorkflowToolProvider.cs
@@ -45,7 +45,7 @@ public sealed class WorkflowToolProvider : IFunctionProvider
         yield return Descriptor(
             "SetWorkflow",
             "Author (or replace) the workflow definition and position the controller at the start node.",
-            [Param("definition", "The full workflow definition object.", ObjectSchema(), required: true)],
+            [Param("definition", "The full workflow definition object.", DefinitionSchema(), required: true)],
             HandleSetWorkflowAsync
         );
 
@@ -129,7 +129,11 @@ public sealed class WorkflowToolProvider : IFunctionProvider
             WorkflowDefinition definition;
             try
             {
-                definition = WorkflowJson.Deserialize(definitionElement.GetRawText());
+                // Strict deserialize so a misspelled or invented field (e.g. 'tasks' for 'taskList',
+                // 'agentType' for 'subagent_type') is rejected by name instead of silently dropped —
+                // a silently-dropped task field used to yield a workflow that validated clean yet ran
+                // nothing, giving the authoring LLM no signal to correct.
+                definition = WorkflowJson.DeserializeStrict(definitionElement.GetRawText());
             }
             catch (JsonException ex)
             {
@@ -327,6 +331,116 @@ public sealed class WorkflowToolProvider : IFunctionProvider
         };
 
     private static JsonSchemaObject ObjectSchema() => new() { Type = new("object") };
+
+    /// <summary>
+    ///     A machine-readable schema for the <c>SetWorkflow</c> <c>definition</c> parameter. It advertises
+    ///     the fields an authoring LLM most needs — <c>objective</c>, <c>nodes[]</c>, and within a
+    ///     procedural node the <c>taskList[]</c> with <c>subagent_type</c> / <c>promptTemplate</c> — so the
+    ///     model reads the field names off the tool schema instead of guessing them. The node/task shapes
+    ///     vary by <c>type</c>, so their objects keep <c>additionalProperties</c> open; the strict authoring
+    ///     deserializer (<see cref="WorkflowJson.DeserializeStrict"/>) is what actually rejects misspelled
+    ///     fields, and this schema is the reference the model uses to get them right in the first place.
+    /// </summary>
+    private static JsonSchemaObject DefinitionSchema()
+    {
+        var task = JsonSchemaObject
+            .Create("object")
+            .WithDescription("An authored sub-agent task within a procedural node.")
+            .WithProperty("id", JsonSchemaObject.String("Task id, unique within the node."), required: true)
+            .WithProperty(
+                "subagent_type",
+                JsonSchemaObject.String(
+                    "The sub-agent template to spawn (snake_case field name). "
+                        + "Passed as the Agent tool's subagent_type. Required."
+                ),
+                required: true
+            )
+            .WithProperty(
+                "promptTemplate",
+                JsonSchemaObject.String("The prompt handed to the spawned agent. Required."),
+                required: true
+            )
+            .WithProperty("label", JsonSchemaObject.String("Optional human-readable label."))
+            .WithProperty(
+                "writes",
+                JsonSchemaObject
+                    .Create("object")
+                    .WithDescription("Optional: where to write the validated task output.")
+                    .WithProperty(
+                        "to",
+                        JsonSchemaObject.String("Destination state path; must start with 'state.'."),
+                        required: true
+                    )
+                    .WithProperty(
+                        "mode",
+                        new JsonSchemaObject
+                        {
+                            Type = new("string"),
+                            Description = "Merge mode.",
+                            Enum = ["set", "append", "merge"],
+                        }
+                    )
+                    .AllowAdditionalProperties(true)
+                    .Build()
+            )
+            .AllowAdditionalProperties(true)
+            .Build();
+
+        var node = JsonSchemaObject
+            .Create("object")
+            .WithDescription("A workflow node. The fields used depend on 'type'.")
+            .WithProperty("id", JsonSchemaObject.String("Globally-unique node id."), required: true)
+            .WithProperty(
+                "type",
+                new JsonSchemaObject
+                {
+                    Type = new("string"),
+                    Description = "The node kind.",
+                    Enum = ["start", "procedural", "conditional", "terminal"],
+                },
+                required: true
+            )
+            .WithProperty("title", JsonSchemaObject.String("Human-readable node title."), required: true)
+            .WithProperty(
+                "next",
+                JsonSchemaObject.StringArray(
+                    "Target node id(s). start: exactly one; procedural: at least one."
+                )
+            )
+            .WithProperty(
+                "taskList",
+                JsonSchemaObject.Array(
+                    task,
+                    "procedural only: the authored sub-agent tasks this node runs. "
+                        + "This is the field name — NOT 'tasks'."
+                )
+            )
+            .AllowAdditionalProperties(true)
+            .Build();
+
+        return JsonSchemaObject
+            .Create("object")
+            .WithDescription(
+                "A workflow definition: an objective plus a graph of nodes. See the worked example in the "
+                    + "system prompt for the exact shape."
+            )
+            .WithProperty(
+                "objective",
+                JsonSchemaObject.String("The high-level objective the workflow pursues."),
+                required: true
+            )
+            .WithProperty(
+                "nodes",
+                JsonSchemaObject.Array(node, "The workflow nodes: one start, >=1 terminal, and the rest."),
+                required: true
+            )
+            .WithProperty(
+                "schemaVersion",
+                JsonSchemaObject.Integer("The workflow schema version (use 1).")
+            )
+            .AllowAdditionalProperties(true)
+            .Build();
+    }
 
     /// <summary>
     ///     Parses a handler's raw JSON arguments, returning a structured <c>invalid_args</c> error result

--- a/src/LmWorkflow/WorkflowSession.cs
+++ b/src/LmWorkflow/WorkflowSession.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using System.Text.Json.Nodes;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
@@ -249,69 +248,8 @@ public static class WorkflowSession
         }
     }
 
-    /// <summary>
-    ///     Correlates the stream events that matter: an <c>Agent</c> tool call (registers the spawn by the
-    ///     runtime-surfaced unit name); its tool result (a blocking answer is validated/recorded, a background
-    ///     spawn receipt is failed fast — unsupported in V1); and an injected <c>&lt;sub-agent&gt;</c> user
-    ///     message (dormant / forward-built — see the case comment). Every other message is ignored.
-    /// </summary>
-    private static void Observe(WorkflowRuntime runtime, IMessage message)
-    {
-        switch (message)
-        {
-            case ToolCallMessage { FunctionName: "Agent", ToolCallId: { } toolCallId } call:
-                var name = TryReadSpawnName(call.FunctionArgs);
-                if (name is not null)
-                {
-                    runtime.RegisterSpawn(toolCallId, name);
-                }
-
-                break;
-
-            case ToolCallResultMessage { ToolCallId: { } resultId } result
-                when runtime.IsRegisteredSpawn(resultId):
-                runtime.ObserveSpawnResult(resultId, result.Result, result.IsError);
-                break;
-
-            // Injected <sub-agent> completion (DORMANT / forward-built in V1): MultiTurnAgentLoop does not
-            // publish injected sub-agent completions to its subscribers, so this case does not fire in V1.
-            // Even if it did, the background receipt path now fails fast (ObserveSpawnResult) and never records
-            // an agent_id correlation, so ObserveInjectedResult would find no mapping and surface the result as
-            // harmless "unmatched". Re-enabled in the follow-up that makes injected completions observable.
-            case TextMessage { Role: Role.User, Text: { } text }
-                when text.TrimStart().StartsWith("<sub-agent", StringComparison.Ordinal):
-                if (SubAgentResultParser.TryParse(text, out var agentId, out var payload, out var isError))
-                {
-                    runtime.ObserveInjectedResult(agentId, payload, isError);
-                }
-
-                break;
-
-            default:
-                break;
-        }
-    }
-
-    private static string? TryReadSpawnName(string? functionArgs)
-    {
-        if (string.IsNullOrEmpty(functionArgs))
-        {
-            return null;
-        }
-
-        try
-        {
-            using var doc = JsonDocument.Parse(functionArgs);
-            return doc.RootElement.TryGetProperty("name", out var name)
-                && name.ValueKind == JsonValueKind.String
-                ? name.GetString()
-                : null;
-        }
-        catch (JsonException)
-        {
-            return null;
-        }
-    }
+    /// <summary>Delegates stream-event correlation to the runtime's own observer entry point.</summary>
+    private static void Observe(WorkflowRuntime runtime, IMessage message) => runtime.ObserveMessage(message);
 }
 
 /// <summary>

--- a/tests/GithubCopilotProvider.Tests/Agents/CopilotAnthropicAgentFactoryTimeoutTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Agents/CopilotAnthropicAgentFactoryTimeoutTests.cs
@@ -1,0 +1,86 @@
+using AchieveAi.LmDotnetTools.AnthropicProvider.Agents;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Agents;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.GithubCopilotProvider.Tests.Agents;
+
+/// <summary>
+///     Guards the time-to-first-response ceiling on the Copilot-backed Anthropic agent: a caller-supplied
+///     timeout must reach the underlying <see cref="System.Net.Http.HttpClient"/>, and omitting it must
+///     leave the 5-minute default intact. Because the streaming client reads with
+///     <c>ResponseHeadersRead</c>, this timeout bounds a dead/stuck upstream connection (the blocking
+///     sub-agent hang we fixed) without capping a healthy stream's duration.
+/// </summary>
+public sealed class CopilotAnthropicAgentFactoryTimeoutTests
+{
+    private sealed class StubTokenProvider : ICopilotTokenProvider
+    {
+        public Task<string> GetTokenAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult("gho_test_token");
+    }
+
+    [Fact]
+    public void Create_ForwardsSuppliedTimeout_OntoTheHttpClient()
+    {
+        var agent = CopilotAnthropicAgentFactory.Create(
+            "Sonnet",
+            new StubTokenProvider(),
+            timeout: TimeSpan.FromSeconds(42)
+        );
+
+        HttpClientOf(agent).Timeout.Should().Be(TimeSpan.FromSeconds(42));
+    }
+
+    [Fact]
+    public void Create_WithoutTimeout_KeepsTheFiveMinuteDefault()
+    {
+        var agent = CopilotAnthropicAgentFactory.Create("Sonnet", new StubTokenProvider());
+
+        HttpClientOf(agent).Timeout.Should().Be(TimeSpan.FromMinutes(5));
+    }
+
+    // The AnthropicAgent -> AnthropicClient -> HttpClient chain is private; reflect through it so the test
+    // asserts on the REAL client the factory built rather than a re-derived value.
+    private static HttpClient HttpClientOf(AnthropicAgent agent)
+    {
+        var client = GetPrivateField(agent, "_client")
+            ?? throw new InvalidOperationException("AnthropicAgent._client not found.");
+        var httpClient = GetPrivateField(client, "HttpClient") ?? GetPrivateField(client, "_httpClient")
+            ?? throw new InvalidOperationException("AnthropicClient HttpClient not found.");
+        return (HttpClient)httpClient;
+    }
+
+    private static object? GetPrivateField(object instance, string name)
+    {
+        var type = instance.GetType();
+        while (type is not null)
+        {
+            var field = type.GetField(
+                name,
+                System.Reflection.BindingFlags.Instance
+                    | System.Reflection.BindingFlags.NonPublic
+                    | System.Reflection.BindingFlags.Public
+            );
+            if (field is not null)
+            {
+                return field.GetValue(instance);
+            }
+
+            var prop = type.GetProperty(
+                name,
+                System.Reflection.BindingFlags.Instance
+                    | System.Reflection.BindingFlags.NonPublic
+                    | System.Reflection.BindingFlags.Public
+            );
+            if (prop is not null)
+            {
+                return prop.GetValue(instance);
+            }
+
+            type = type.BaseType;
+        }
+
+        return null;
+    }
+}

--- a/tests/LmWorkflow.Tests/ObserveMessageCorrelationTests.cs
+++ b/tests/LmWorkflow.Tests/ObserveMessageCorrelationTests.cs
@@ -1,0 +1,148 @@
+using System.Text.Json.Nodes;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmWorkflow.Model;
+using AchieveAi.LmDotnetTools.LmWorkflow.Runtime;
+using FluentAssertions;
+using Xunit;
+
+namespace AchieveAi.LmDotnetTools.LmWorkflow.Tests;
+
+/// <summary>
+///     Reproduces, through the SAME public entry point the host observer uses
+///     (<see cref="WorkflowRuntime.ObserveMessage"/>), the live sequence that left a successful blocking
+///     sub-agent's task stuck at <c>pending</c>: the controller routed into the procedural node, then
+///     issued the <c>Agent</c> tool call and its result flowed back. The result must correlate to the task
+///     and validate the join — the task must become <c>validated</c>, never remain <c>pending</c>.
+/// </summary>
+public class ObserveMessageCorrelationTests
+{
+    private const string Unit = "analyze:1:task";
+
+    // The analyze task validates against a {summary} schema; a conforming result must validate the join.
+    private static WorkflowRuntime RuntimeAtAnalyze()
+    {
+        var runtime = new WorkflowRuntime();
+        runtime.LoadDefinition(WorkflowJson.Deserialize(Phase3Fixtures.LinearBlockingAgent));
+        runtime.AdvanceTo("start", "analyze", null);
+        return runtime;
+    }
+
+    private static ToolCallMessage AgentCall(string toolCallId, string name) =>
+        new()
+        {
+            FunctionName = "Agent",
+            FunctionArgs = new JsonObject
+            {
+                ["subagent_type"] = "general-purpose",
+                ["prompt"] = "do it",
+                ["name"] = name,
+            }.ToJsonString(),
+            ToolCallId = toolCallId,
+            Role = Role.Assistant,
+        };
+
+    private static ToolCallResultMessage AgentResult(string toolCallId, string result, bool isError = false) =>
+        new()
+        {
+            ToolCallId = toolCallId,
+            Result = result,
+            ToolName = "Agent",
+            IsError = isError,
+            Role = Role.User,
+        };
+
+    // A REAL provider publishes the Agent tool call to subscribers as a sequence of streaming
+    // ToolCallUpdateMessages whose FunctionArgs are INCREMENTAL FRAGMENTS (raw byte slices of the args
+    // JSON), NOT the full accumulated args — verified live. The finalized ToolCallMessage is added to loop
+    // history but never published to the subscriber stream. The observer must reassemble the fragments.
+    private static ToolCallUpdateMessage AgentCallFragment(string toolCallId, string argsFragment) =>
+        new()
+        {
+            FunctionName = "Agent",
+            FunctionArgs = argsFragment,
+            ToolCallId = toolCallId,
+            Role = Role.Assistant,
+        };
+
+    // Splits a complete args JSON into the kind of ragged fragments a provider streams (mid-token, mid-key),
+    // so the test proves reassembly — not a lucky per-fragment parse.
+    private static IEnumerable<ToolCallUpdateMessage> AgentCallStream(string toolCallId, string name)
+    {
+        var full = new JsonObject
+        {
+            ["subagent_type"] = "general-purpose",
+            ["prompt"] = "do it",
+            ["name"] = name,
+        }.ToJsonString();
+
+        // Chunk into 7-char slices to mimic the observed mid-token fragmentation.
+        for (var i = 0; i < full.Length; i += 7)
+        {
+            yield return AgentCallFragment(toolCallId, full.Substring(i, Math.Min(7, full.Length - i)));
+        }
+    }
+
+    private static string StatusOf(WorkflowRuntime runtime) =>
+        runtime.GetProjection(null)["tasks"]![Unit]!.GetValue<string>();
+
+    /// <summary>
+    ///     The REAL live path: the Agent call reaches the subscriber stream ONLY as streaming
+    ///     <see cref="ToolCallUpdateMessage"/> fragments (each a raw slice of the args JSON), followed by the
+    ///     finalized <see cref="ToolCallResultMessage"/>. The observer must reassemble the fragments, read the
+    ///     spawn name, correlate the result, and validate the task. This is the exact case the live workspace
+    ///     run failed — the task stayed <c>pending</c> because no single fragment was parseable.
+    /// </summary>
+    [Fact]
+    public void ObserveMessage_StreamingFragmentedAgentCall_ThenResult_ValidatesTheTask()
+    {
+        var runtime = RuntimeAtAnalyze();
+
+        foreach (var fragment in AgentCallStream("tc_agent", Unit))
+        {
+            runtime.ObserveMessage(fragment);
+        }
+
+        runtime.ObserveMessage(AgentResult("tc_agent", """{ "summary": "done" }"""));
+
+        StatusOf(runtime)
+            .Should()
+            .Be("validated", because: "the observer must reassemble the streamed args fragments to read the spawn name");
+    }
+
+    /// <summary>
+    ///     The exact live ordering: the controller surfaced the unit (GetWorkflow/projection composes it),
+    ///     then the Agent call and its blocking result are OBSERVED. The task must end validated.
+    /// </summary>
+    [Fact]
+    public void ObserveMessage_AgentCallThenResult_AfterProjection_ValidatesTheTask()
+    {
+        var runtime = RuntimeAtAnalyze();
+
+        // The controller reads the node (this composes + registers the unit into the runtime's task map).
+        _ = runtime.GetProjection(null);
+
+        runtime.ObserveMessage(AgentCall("tc_agent", Unit));
+        runtime.ObserveMessage(AgentResult("tc_agent", """{ "summary": "done" }"""));
+
+        StatusOf(runtime).Should().Be("validated", because: "an observed blocking result must correlate to the task");
+    }
+
+    /// <summary>
+    ///     The failure the live run actually hit: the controller issued the Agent call WITHOUT first calling
+    ///     GetWorkflow, so no projection had composed the unit when the call was observed. The correlation
+    ///     must still succeed — the runtime already knows the active node's authored tasks, so it must be
+    ///     able to register the spawn regardless of whether the controller polled the projection first.
+    /// </summary>
+    [Fact]
+    public void ObserveMessage_AgentCallThenResult_WithoutPriorProjection_StillValidatesTheTask()
+    {
+        var runtime = RuntimeAtAnalyze();
+
+        // NOTE: no GetProjection / ComposeNextExpectedAction call here — mirror the live pill order
+        // SetCurrentNode -> Agent -> GetWorkflow, where the Agent call is observed before any GetWorkflow.
+        runtime.ObserveMessage(AgentCall("tc_agent", Unit));
+        runtime.ObserveMessage(AgentResult("tc_agent", """{ "summary": "done" }"""));
+
+        StatusOf(runtime).Should().Be("validated", because: "correlation must not depend on the controller polling GetWorkflow first");
+    }
+}

--- a/tests/LmWorkflow.Tests/ObserveMessageCorrelationTests.cs
+++ b/tests/LmWorkflow.Tests/ObserveMessageCorrelationTests.cs
@@ -145,4 +145,37 @@ public class ObserveMessageCorrelationTests
 
         StatusOf(runtime).Should().Be("validated", because: "correlation must not depend on the controller polling GetWorkflow first");
     }
+
+    /// <summary>
+    ///     A non-workflow Agent call (a name that matches no authored unit — the common case in a
+    ///     Workspace Agent conversation) must be handled gracefully: its streamed fragments and its result
+    ///     do not correlate, do not throw, and — critically — do not contaminate a subsequent REAL workflow
+    ///     spawn. This exercises the hardened buffer lifecycle (drop-on-parse / clear-on-any-result).
+    /// </summary>
+    [Fact]
+    public void ObserveMessage_NonWorkflowAgentCall_IsHarmless_AndDoesNotBreakLaterCorrelation()
+    {
+        var runtime = RuntimeAtAnalyze();
+
+        // An Agent spawn whose name is NOT an authored unit of the active node.
+        foreach (var fragment in AgentCallStream("tc_other", "some:other:spawn"))
+        {
+            runtime.ObserveMessage(fragment);
+        }
+
+        runtime.ObserveMessage(AgentResult("tc_other", "arbitrary non-workflow output"));
+
+        // The real workflow unit is untouched by the unrelated spawn.
+        StatusOf(runtime).Should().Be("pending");
+
+        // A genuine spawn for the authored unit still correlates and validates afterward.
+        foreach (var fragment in AgentCallStream("tc_agent", Unit))
+        {
+            runtime.ObserveMessage(fragment);
+        }
+
+        runtime.ObserveMessage(AgentResult("tc_agent", """{ "summary": "done" }"""));
+
+        StatusOf(runtime).Should().Be("validated");
+    }
 }

--- a/tests/LmWorkflow.Tests/WorkflowAuthoringErgonomicsTests.cs
+++ b/tests/LmWorkflow.Tests/WorkflowAuthoringErgonomicsTests.cs
@@ -1,0 +1,207 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmCore.Models;
+using AchieveAi.LmDotnetTools.LmWorkflow.Model;
+using AchieveAi.LmDotnetTools.LmWorkflow.Prompts;
+using AchieveAi.LmDotnetTools.LmWorkflow.Runtime;
+using AchieveAi.LmDotnetTools.LmWorkflow.Tools;
+using FluentAssertions;
+using Xunit;
+
+namespace AchieveAi.LmDotnetTools.LmWorkflow.Tests;
+
+/// <summary>
+///     Ergonomics tests that lock in the three fixes that make workflows authorable by an LLM working
+///     only from the tool schema + system prompt:
+///     <list type="number">
+///         <item>SetWorkflow's <c>definition</c> parameter advertises a real nested schema (nodes and,
+///             crucially, a procedural node's <c>taskList</c>), not a bare <c>{"type":"object"}</c>.</item>
+///         <item>A misspelled task-list field (e.g. <c>tasks</c> instead of <c>taskList</c>) is rejected
+///             LOUDLY, naming the offending field, rather than silently deserializing to an empty node
+///             that validates clean and walks with zero tasks.</item>
+///         <item>The worked example embedded in <see cref="ControllerSystemPrompt"/> is real: it
+///             deserializes, validates, and actually registers a spawnable task.</item>
+///     </list>
+///     Strict authoring deserialization must still accept every valid fixture — including the derived
+///     get-only <c>type</c> discriminator and polymorphic node shapes.
+/// </summary>
+public class WorkflowAuthoringErgonomicsTests
+{
+    // ---- Fix A: SetWorkflow advertises a usable nested schema ----------------------------------
+
+    [Fact]
+    public void SetWorkflow_DefinitionParameter_ExposesNestedNodeAndTaskListSchema()
+    {
+        var definition = SetWorkflowDefinitionSchema();
+
+        // The definition is an object with named properties (not an opaque bag).
+        JsonSchemaObject.GetJsonPrimaryType(definition).Should().Be("object");
+        definition.Properties.Should().NotBeNull("the LLM needs a machine-readable field list");
+        definition.Properties!.Should().ContainKey("objective");
+        definition.Properties.Should().ContainKey("nodes");
+
+        // Drill into nodes[].taskList[] — the exact path the model kept guessing wrong.
+        var nodeSchema = definition.Properties!["nodes"].Items;
+        nodeSchema.Should().NotBeNull("nodes must advertise an item schema");
+        nodeSchema!.Properties.Should().NotBeNull();
+        nodeSchema.Properties!.Should().ContainKey("taskList");
+
+        var taskSchema = nodeSchema.Properties!["taskList"].Items;
+        taskSchema.Should().NotBeNull("taskList must advertise its task item schema");
+        taskSchema!.Properties.Should().NotBeNull();
+        taskSchema.Properties!.Should().ContainKey("subagent_type");
+        taskSchema.Properties.Should().ContainKey("promptTemplate");
+    }
+
+    // ---- Fix C: a misspelled task field is rejected loudly, naming the field -------------------
+
+    [Fact]
+    public async Task SetWorkflow_MisspelledTaskListField_IsRejected_NamingTheField()
+    {
+        // 'tasks' instead of the real 'taskList'. Before the fix this silently produced a procedural
+        // node with TaskList == null, validated clean, and returned success with zero tasks.
+        const string misspelled = """
+            {
+              "schemaVersion": 1,
+              "objective": "one agent task",
+              "nodes": [
+                { "id": "s", "type": "start", "title": "Start", "next": ["p"] },
+                {
+                  "id": "p", "type": "procedural", "title": "Work", "next": ["t"],
+                  "tasks": [
+                    { "id": "a", "subagent_type": "general-purpose", "promptTemplate": "Do the thing." }
+                  ]
+                },
+                { "id": "t", "type": "terminal", "title": "Done" }
+              ]
+            }
+            """;
+
+        var args = new JsonObject { ["definition"] = JsonNode.Parse(misspelled) };
+        var result = await Invoke(Tool(new WorkflowRuntime(), "SetWorkflow"), args.ToJsonString());
+
+        result.Payload.IsError.Should().BeTrue("a wrong field name must not silently succeed");
+        result.Payload.ErrorCode.Should().Be("invalid_workflow");
+        result
+            .Payload.Text.Should()
+            .Contain("tasks", "the error must name the offending field so the model can correct it");
+    }
+
+    [Fact]
+    public async Task SetWorkflow_MisspelledSubagentField_IsRejected_NamingTheField()
+    {
+        // 'agentType' — the classic guess born of the snake_case subagent_type exception.
+        const string misspelled = """
+            {
+              "schemaVersion": 1,
+              "objective": "one agent task",
+              "nodes": [
+                { "id": "s", "type": "start", "title": "Start", "next": ["p"] },
+                {
+                  "id": "p", "type": "procedural", "title": "Work", "next": ["t"],
+                  "taskList": [
+                    { "id": "a", "agentType": "general-purpose", "promptTemplate": "Do the thing." }
+                  ]
+                },
+                { "id": "t", "type": "terminal", "title": "Done" }
+              ]
+            }
+            """;
+
+        var args = new JsonObject { ["definition"] = JsonNode.Parse(misspelled) };
+        var result = await Invoke(Tool(new WorkflowRuntime(), "SetWorkflow"), args.ToJsonString());
+
+        result.Payload.IsError.Should().BeTrue();
+        result.Payload.ErrorCode.Should().Be("invalid_workflow");
+        result.Payload.Text.Should().Contain("agentType");
+    }
+
+    // ---- Fix B: the prompt's worked example is real and drives a task --------------------------
+
+    [Fact]
+    public async Task ControllerPrompt_EmbedsTheWorkedExample_Verbatim()
+    {
+        // The example the model is shown must be the same string the tests prove works — no drift.
+        ControllerSystemPrompt.Default.Should().Contain(WorkflowExamples.MinimalProcedural);
+        ControllerSystemPrompt.Default.Should().Contain("taskList");
+        ControllerSystemPrompt.Default.Should().Contain("subagent_type");
+        ControllerSystemPrompt.Default.Should().Contain("promptTemplate");
+
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task WorkedExample_AuthorsCleanly_AndRegistersASpawnableTask()
+    {
+        var runtime = new WorkflowRuntime();
+        var args = new JsonObject
+        {
+            ["definition"] = JsonNode.Parse(WorkflowExamples.MinimalProcedural),
+        };
+
+        var result = await Invoke(Tool(runtime, "SetWorkflow"), args.ToJsonString());
+        result.Payload.IsError.Should().BeFalse(because: result.Payload.Text);
+
+        // Drive to the procedural node and confirm the runtime actually surfaces a spawn unit —
+        // i.e. the task list parsed, which was the whole point.
+        runtime.AdvanceTo("start", "work", null);
+        var units = runtime.ComposeNextExpectedAction();
+        units.Should().NotBeEmpty("the authored task must be surfaced as a ready-to-spawn unit");
+    }
+
+    // ---- Strict authoring deserialize still accepts every valid shape --------------------------
+
+    [Fact]
+    public void StrictDeserialize_AcceptsAllValidFixtures_IncludingPolymorphicNodesAndTypeDiscriminator()
+    {
+        // The 'type' discriminator is a derived get-only property, not a settable member; strict
+        // unmapped-member handling must not choke on it, nor on any node/task field in the rich fixture.
+        var act = () =>
+        {
+            _ = WorkflowJson.DeserializeStrict(WorkflowFixtures.ValidWorkflow);
+            _ = WorkflowJson.DeserializeStrict(WorkflowFixtures.MinimalValid);
+        };
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void StrictDeserialize_RejectsUnknownTaskField_WithJsonException()
+    {
+        const string json = """
+            {
+              "schemaVersion": 1, "objective": "x",
+              "nodes": [
+                { "id": "s", "type": "start", "title": "S", "next": ["p"] },
+                {
+                  "id": "p", "type": "procedural", "title": "P", "next": ["t"],
+                  "taskList": [ { "id": "a", "subagent_type": "x", "promptTemplate": "y", "bogusField": 1 } ]
+                },
+                { "id": "t", "type": "terminal", "title": "T" }
+              ]
+            }
+            """;
+
+        var act = () => WorkflowJson.DeserializeStrict(json);
+        act.Should().Throw<JsonException>().WithMessage("*bogusField*");
+    }
+
+    private static JsonSchemaObject SetWorkflowDefinitionSchema() =>
+        new WorkflowToolProvider(new WorkflowRuntime())
+            .GetFunctions()
+            .Single(f => f.Contract.Name == "SetWorkflow")
+            .Contract.Parameters!.Single(p => p.Name == "definition")
+            .ParameterType;
+
+    private static FunctionDescriptor Tool(WorkflowRuntime runtime, string name) =>
+        new WorkflowToolProvider(runtime).GetFunctions().Single(f => f.Contract.Name == name);
+
+    private static async Task<ToolHandlerResult.Resolved> Invoke(
+        FunctionDescriptor tool,
+        string argsJson
+    ) =>
+        (ToolHandlerResult.Resolved)
+            await tool.Handler(argsJson, new ToolCallContext(), CancellationToken.None);
+}

--- a/tests/LmWorkflow.Tests/WorkflowEndToEndTests.cs
+++ b/tests/LmWorkflow.Tests/WorkflowEndToEndTests.cs
@@ -109,6 +109,170 @@ public class WorkflowEndToEndTests
     }
 
     /// <summary>
+    ///     The "runs to completion even when a sub-agent fails" property that the live hang exposed as
+    ///     untested at the session level: a blocking sub-agent returns schema-INVALID output, so the runtime
+    ///     terminally fails the task (maxValidationRetries=0) and surfaces the node's onFailure route; the
+    ///     controller follows it into the failure terminal and the workflow still reaches completion. A
+    ///     workflow must not deadlock just because a delegated agent failed.
+    /// </summary>
+    [Fact]
+    public async Task BlockingAgentFailsSchemaValidation_RoutesOnFailure_AndStillCompletes()
+    {
+        // The sub-agent returns a well-formed JSON object that does NOT match the {summary} schema, so
+        // validation fails and — with maxValidationRetries=0 — the task is terminally failed.
+        var subAgentMock = new Mock<IStreamingAgent>();
+        subAgentMock
+            .Setup(a =>
+                a.GenerateReplyStreamingAsync(
+                    It.IsAny<IEnumerable<IMessage>>(),
+                    It.IsAny<GenerateReplyOptions>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(
+                Task.FromResult(
+                    ToAsyncEnumerable(
+                        [
+                            new TextMessage
+                            {
+                                Text = """{ "not_summary": "schema-miss" }""",
+                                Role = Role.Assistant,
+                            },
+                        ]
+                    )
+                )
+            );
+
+        var controllerMock = new Mock<IStreamingAgent>();
+        var turn = 0;
+        controllerMock
+            .Setup(a =>
+                a.GenerateReplyStreamingAsync(
+                    It.IsAny<IEnumerable<IMessage>>(),
+                    It.IsAny<GenerateReplyOptions>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(() => Task.FromResult(ToAsyncEnumerable([NextFailureDriveMessage(ref turn)])));
+
+        var subAgentOptions = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate>
+            {
+                ["general-purpose"] = new SubAgentTemplate
+                {
+                    Name = "general-purpose",
+                    SystemPrompt = "You are a general-purpose analysis agent.",
+                    AgentFactory = () => subAgentMock.Object,
+                },
+            },
+        };
+
+        await using var handle = await WorkflowSession.StartAsync(
+            objective: "Analyze the topic and finish.",
+            inputs: null,
+            definition: null,
+            subAgentOptions: subAgentOptions,
+            controllerAgent: controllerMock.Object,
+            threadId: "wf-e2e-fail-thread"
+        );
+
+        await handle.Completion.WaitAsync(TimeSpan.FromSeconds(30));
+
+        var runtime = handle.Runtime;
+
+        // The workflow reached its FAILURE terminal — it did not deadlock on the failed task.
+        runtime.IsComplete.Should().BeTrue();
+        runtime.CurrentNodeId.Should().Be("fail");
+
+        // The task is recorded as failed (not validated, not stuck pending).
+        runtime.GetProjection(null)["tasks"]!["analyze:1:task"]!.GetValue<string>()
+            .Should()
+            .Be("failed");
+    }
+
+    /// <summary>
+    ///     Produces the controller's turn-by-turn drive for the failure path: author → route to analyze →
+    ///     read → spawn (which fails validation) → route the surfaced onFailure into the failure terminal.
+    /// </summary>
+    private static IMessage NextFailureDriveMessage(ref int turn)
+    {
+        turn++;
+        return turn switch
+        {
+            1 => ToolCall(
+                "SetWorkflow",
+                new JsonObject { ["definition"] = JsonNode.Parse(OnFailureWorkflow) },
+                "tc_setwf"
+            ),
+            2 => ToolCall(
+                "SetCurrentNode",
+                new JsonObject { ["completedNodeId"] = "start", ["nextNodeId"] = "analyze" },
+                "tc_route_analyze"
+            ),
+            3 => ToolCall("GetWorkflow", [], "tc_get"),
+            4 => ToolCall(
+                "Agent",
+                new JsonObject
+                {
+                    ["subagent_type"] = "general-purpose",
+                    ["prompt"] = "Spawn the analysis task.",
+                    ["name"] = "analyze:1:task",
+                },
+                "tc_agent"
+            ),
+            5 => ToolCall(
+                "SetCurrentNode",
+                new JsonObject { ["completedNodeId"] = "analyze", ["nextNodeId"] = "fail" },
+                "tc_route_fail"
+            ),
+            _ => new TextMessage { Text = "Workflow failed and finished.", Role = Role.Assistant },
+        };
+    }
+
+    /// <summary>
+    ///     A single-task workflow whose procedural node declares an onFailure terminal: the task validates
+    ///     against a {summary} schema with maxValidationRetries=0, so a schema-miss fails it immediately.
+    /// </summary>
+    private const string OnFailureWorkflow = """
+        {
+          "schemaVersion": 1,
+          "objective": "Analyze the topic and finish.",
+          "state": {},
+          "maxStepBudget": 50,
+          "nodes": [
+            { "id": "start", "type": "start", "title": "Start", "next": ["analyze"] },
+            {
+              "id": "analyze",
+              "type": "procedural",
+              "title": "Analyze",
+              "tasksMode": "authored",
+              "joinPolicy": { "mode": "all" },
+              "onFailure": "fail",
+              "taskList": [
+                {
+                  "id": "task",
+                  "delegate": "agent",
+                  "subagent_type": "general-purpose",
+                  "promptTemplate": "Analyze the topic.",
+                  "outputSchema": {
+                    "type": "object",
+                    "required": ["summary"],
+                    "properties": { "summary": { "type": "string" } }
+                  },
+                  "onFailure": "fail",
+                  "maxValidationRetries": 0
+                }
+              ],
+              "next": ["done"]
+            },
+            { "id": "done", "type": "terminal", "title": "Done" },
+            { "id": "fail", "type": "terminal", "title": "Failed" }
+          ]
+        }
+        """;
+
+    /// <summary>
     ///     Produces the controller's tool call for the current turn (incremented per provider call). Each
     ///     turn issues exactly one tool call until the final plain-text turn ends the run.
     /// </summary>


### PR DESCRIPTION
## Summary
Wires `LmWorkflow` into the sample's existing **Workspace Agent** `MultiTurnAgentLoop` so a real Copilot-backed LLM can author and drive a workflow end-to-end through the chat UI, and fixes the three defects that prevented that from working. Verified live (authored first-try, task validated, join satisfied, `isComplete`) and covered by new tests.

## Changes
**Wire-in**
- Register `WorkflowRuntime` + `WorkflowToolProvider` in Workspace Agent mode; add the `LmWorkflow` project reference.
- Extract a public `WorkflowRuntime.ObserveMessage` from `WorkflowSession` (pure code move); add a race-safe second stream subscriber for sub-agent-spawn correlation.

**Authoring ergonomics** — the LLM could not author a valid workflow
- Real nested JSON schema for `SetWorkflow.definition` (was a bare `{"type":"object"}`).
- Worked example + exact field names in `ControllerSystemPrompt`, sourced from a single **test-enforced** `WorkflowExamples.MinimalProcedural` constant (no prompt drift).
- Strict authoring deserialize (`UnmappedMemberHandling.Disallow`) so a misspelled field is rejected **by name** instead of silently dropped (which used to yield a valid-but-empty procedural node with no feedback). Persistence stays lenient.

**Robustness** — the workflow could not run to completion
- Bound Copilot agents' time-to-first-response (`COPILOT_RESPONSE_TIMEOUT_SECONDS`, default 120s) so a dead upstream connection surfaces fast instead of freezing the run for the full 5-minute HTTP default. Safe because `ResponseHeadersRead` means this bounds only connect/headers, not stream length.
- Compose the active node's units **on demand** in `TaskCoordinator.RegisterSpawn` so correlation no longer depends on the controller polling `GetWorkflow` before spawning.
- Reassemble streamed `ToolCallUpdateMessage` args fragments in `ObserveMessage`: a real provider publishes the `Agent` call to subscribers as fragmented update deltas (never a finalized `ToolCallMessage`), so the spawn name must be reassembled before the sub-agent result can correlate to the join.

## Testing
- New: `WorkflowAuthoringErgonomicsTests`, `ObserveMessageCorrelationTests` (incl. fragment-reassembly), `CopilotAnthropicAgentFactoryTimeoutTests`, and a sub-agent-failure E2E in `WorkflowEndToEndTests` (workflow still reaches a terminal via `onFailure`).
- Suites green: **LmWorkflow 194/194, GithubCopilotProvider 35/35, LmStreaming.Sample 359/359, LmMultiTurn 285/285.** Solution builds clean.
- **Live-verified** with real Copilot Sonnet through the UI: authored first-try, task `validated`, join `{validated:1, satisfied:true}`, `isComplete:true`.

## Related Issues
Fixes #130