### PR TITLE
Fix LmStreaming chat client: conversation-switch + Queue-button UX bugs

### DIFF
--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ChatInput.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ChatInput.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ChatInput from '@/components/ChatInput.vue';
+
+const SEND = '[data-testid="send-button"]';
+const STOP = '[data-testid="stop-button"]';
+const QUEUE = '[data-testid="queue-button"]';
+const TEXTAREA = '[data-testid="chat-input-textarea"]';
+
+describe('ChatInput button states', () => {
+  describe('Not streaming', () => {
+    it('shows the Send button (no Stop, no Queue)', () => {
+      const wrapper = mount(ChatInput, { props: { streaming: false } });
+      expect(wrapper.find(SEND).exists()).toBe(true);
+      expect(wrapper.find(STOP).exists()).toBe(false);
+      expect(wrapper.find(QUEUE).exists()).toBe(false);
+    });
+
+    it('Send stays visible even with text typed', async () => {
+      const wrapper = mount(ChatInput, { props: { streaming: false } });
+      await wrapper.find(TEXTAREA).setValue('hello');
+      expect(wrapper.find(SEND).exists()).toBe(true);
+      expect(wrapper.find(QUEUE).exists()).toBe(false);
+      expect(wrapper.find(STOP).exists()).toBe(false);
+    });
+  });
+
+  describe('Streaming with an empty box', () => {
+    it('shows the red Stop button (no Queue)', () => {
+      const wrapper = mount(ChatInput, { props: { streaming: true } });
+      expect(wrapper.find(STOP).exists()).toBe(true);
+      expect(wrapper.find(QUEUE).exists()).toBe(false);
+      expect(wrapper.find(SEND).exists()).toBe(false);
+    });
+
+    it('whitespace-only text still shows Stop, not Queue', async () => {
+      const wrapper = mount(ChatInput, { props: { streaming: true } });
+      await wrapper.find(TEXTAREA).setValue('   ');
+      expect(wrapper.find(STOP).exists()).toBe(true);
+      expect(wrapper.find(QUEUE).exists()).toBe(false);
+    });
+
+    it('clicking Stop emits cancel and leaves the draft untouched', async () => {
+      const wrapper = mount(ChatInput, { props: { streaming: true } });
+      await wrapper.find(STOP).trigger('click');
+      expect(wrapper.emitted('cancel')).toBeTruthy();
+      expect(wrapper.emitted('send')).toBeFalsy();
+    });
+  });
+
+  describe('Streaming with text in the box', () => {
+    it('shows the blue Queue button and hides Stop', async () => {
+      const wrapper = mount(ChatInput, { props: { streaming: true } });
+      await wrapper.find(TEXTAREA).setValue('follow-up while streaming');
+      expect(wrapper.find(QUEUE).exists()).toBe(true);
+      expect(wrapper.find(STOP).exists()).toBe(false);
+      expect(wrapper.find(SEND).exists()).toBe(false);
+    });
+
+    it('clicking Queue emits send with the trimmed text and clears the box', async () => {
+      const wrapper = mount(ChatInput, { props: { streaming: true } });
+      const textarea = wrapper.find(TEXTAREA);
+      await textarea.setValue('  queued message  ');
+      await wrapper.find(QUEUE).trigger('click');
+
+      const sent = wrapper.emitted('send');
+      expect(sent).toBeTruthy();
+      expect(sent![0]).toEqual(['queued message']);
+      expect(wrapper.emitted('cancel')).toBeFalsy();
+      expect((textarea.element as HTMLTextAreaElement).value).toBe('');
+    });
+
+    it('after Queue clears the box, the button reverts to Stop', async () => {
+      const wrapper = mount(ChatInput, { props: { streaming: true } });
+      await wrapper.find(TEXTAREA).setValue('queued message');
+      await wrapper.find(QUEUE).trigger('click');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find(STOP).exists()).toBe(true);
+      expect(wrapper.find(QUEUE).exists()).toBe(false);
+    });
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ChatLayout.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ChatLayout.test.ts
@@ -9,6 +9,7 @@ interface ConversationSummary {
   lastUpdated?: number;
   provider?: string | null;
   workspace?: string | null;
+  mode?: string | null;
 }
 
 const sharedMocks = vi.hoisted(() => ({
@@ -23,6 +24,9 @@ const sharedMocks = vi.hoisted(() => ({
   selectMode: vi.fn(),
   switchMode: vi.fn(),
   disconnectWebSocket: vi.fn(),
+  selectProvider: vi.fn(),
+  selectWorkspace: vi.fn(),
+  resumeStreamIfActive: vi.fn(async () => {}),
 }));
 
 vi.mock('@/composables/useConversations', async () => {
@@ -121,7 +125,36 @@ vi.mock('@/composables/useChat', async () => {
       disconnectWebSocket: sharedMocks.disconnectWebSocket,
       setThreadId: vi.fn(),
       loadMessagesFromBackend: vi.fn(async () => {}),
+      resumeStreamIfActive: sharedMocks.resumeStreamIfActive,
       getResultForToolCall: vi.fn(() => null),
+    }),
+  };
+});
+
+vi.mock('@/composables/useProviders', async () => {
+  const { ref } = await import('vue');
+  return {
+    useProviders: () => ({
+      providers: ref([]),
+      selectedProviderId: ref<string | null>(null),
+      isLoading: ref(false),
+      loadProviders: vi.fn(async () => {}),
+      selectProvider: sharedMocks.selectProvider,
+    }),
+  };
+});
+
+vi.mock('@/composables/useWorkspaces', async () => {
+  const { ref } = await import('vue');
+  return {
+    useWorkspaces: () => ({
+      workspaces: ref([]),
+      selectedWorkspaceId: ref<string | null>('default'),
+      isLoading: ref(false),
+      loadWorkspaces: vi.fn(async () => {}),
+      selectWorkspace: sharedMocks.selectWorkspace,
+      createWorkspace: vi.fn(async () => {}),
+      updateWorkspace: vi.fn(async () => {}),
     }),
   };
 });
@@ -266,6 +299,73 @@ describe('ChatLayout handleSelectMode start-gating regression', () => {
     await flushPromises();
 
     expect(sharedMocks.switchMode).toHaveBeenCalledWith('thread-1', 'math-helper');
+    expect(sharedMocks.selectMode).not.toHaveBeenCalled();
+  });
+});
+
+// BUG 3: opening (or refreshing into) a conversation must restore its bound provider/mode/workspace
+// into the header selectors, instead of leaving the process defaults (Anthropic / General Assistant).
+// The selectors are process-local, so on a refresh they reset to defaults; handleSelectConversation
+// must reflect the conversation's persisted bindings back onto them.
+describe('ChatLayout restores bound provider/mode/workspace on conversation select (BUG 3)', () => {
+  const mountWithSidebar = () =>
+    mount(ChatLayout, {
+      global: {
+        stubs: {
+          ConversationSidebar: {
+            template:
+              '<button data-test="select-conv" @click="$emit(\'select-conversation\', \'thread-2\')">select</button>',
+          },
+          MessageList: true,
+          PendingMessageQueue: true,
+          ChatInput: true,
+          ModeSelector: true,
+          ProviderSelector: true,
+          WorkspaceSelector: true,
+        },
+      },
+    });
+
+  beforeEach(() => {
+    sharedMocks.chatLoading = false;
+    sharedMocks.isSending = false;
+    sharedMocks.modesLoading = false;
+    // Current thread differs from the one we select, so handleSelectConversation does not early-return.
+    sharedMocks.currentThreadId = 'thread-1';
+    sharedMocks.conversations = [
+      { threadId: 'thread-1' },
+      { threadId: 'thread-2', provider: 'openai', workspace: 'ws-1', mode: 'math-helper' },
+    ];
+    sharedMocks.selectMode.mockReset();
+    sharedMocks.selectProvider.mockReset();
+    sharedMocks.selectWorkspace.mockReset();
+    sharedMocks.resumeStreamIfActive.mockReset();
+    sharedMocks.resumeStreamIfActive.mockResolvedValue(undefined);
+  });
+
+  it('applies the selected conversation provider/mode/workspace to the header selectors', async () => {
+    const wrapper = mountWithSidebar();
+    await flushPromises();
+
+    await wrapper.get('[data-test="select-conv"]').trigger('click');
+    await flushPromises();
+
+    expect(sharedMocks.selectProvider).toHaveBeenCalledWith('openai');
+    expect(sharedMocks.selectWorkspace).toHaveBeenCalledWith('ws-1');
+    expect(sharedMocks.selectMode).toHaveBeenCalledWith('math-helper');
+  });
+
+  it('does not touch the selectors for a legacy conversation with no bindings', async () => {
+    sharedMocks.conversations = [{ threadId: 'thread-1' }, { threadId: 'thread-2' }];
+
+    const wrapper = mountWithSidebar();
+    await flushPromises();
+
+    await wrapper.get('[data-test="select-conv"]').trigger('click');
+    await flushPromises();
+
+    expect(sharedMocks.selectProvider).not.toHaveBeenCalled();
+    expect(sharedMocks.selectWorkspace).not.toHaveBeenCalled();
     expect(sharedMocks.selectMode).not.toHaveBeenCalled();
   });
 });

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChatResume.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChatResume.test.ts
@@ -420,3 +420,169 @@ describe('useChat — resume resolves an in-flight tool call after switch-back',
     }
   });
 });
+
+// BUG 1: switching FROM an in-flight conversation TO an idle one must return the Send/Stop control to
+// idle. The switch tears down the socket and reloads the target's history, but the streaming flag
+// (isLoading) was only ever raised (to true, by resume) and never lowered on switch — so an idle target
+// kept showing the red Stop button forever. handleSelectConversation calls, in order:
+// disconnectWebSocket → clearMessages → loadMessagesFromBackend → resumeStreamIfActive; this exercises
+// that same sequence at the composable level.
+describe('useChat — streaming flag resets when switching to an idle conversation (BUG 1)', () => {
+  let captured: any[];
+
+  beforeEach(() => {
+    captured = [];
+    wsMocks.createWebSocketConnection.mockReset();
+    wsMocks.sendWebSocketMessage.mockReset();
+    wsMocks.closeWebSocketConnection.mockReset();
+    convMocks.loadConversationMessages.mockReset();
+    convMocks.getRunState.mockReset();
+
+    wsMocks.createWebSocketConnection.mockImplementation(async (options: any) => {
+      captured.push(options);
+      return {
+        socket: { readyState: WebSocket.OPEN },
+        connectionId: `ws-${captured.length}`,
+        threadId: options.threadId,
+        isConnected: true,
+      };
+    });
+    convMocks.loadConversationMessages.mockResolvedValue([]);
+  });
+
+  it('clears isLoading after switching from a streaming conversation to an idle one', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    chat.setThreadId('thread-A');
+
+    // Conversation A is actively streaming.
+    await chat.sendMessage('hi');
+    captured[0].onMessage({
+      $type: 'text_update', text: 'partial', role: 'assistant',
+      runId: 'run-A', generationId: 'gen-A', messageOrderIdx: 0,
+    });
+    expect(chat.isLoading.value, 'A is streaming').toBe(true);
+
+    // Switch to idle conversation B — mirror ChatLayout.handleSelectConversation exactly.
+    await chat.disconnectWebSocket();
+    await chat.clearMessages();
+    await chat.loadMessagesFromBackend('thread-B'); // history empty (idle)
+    convMocks.getRunState.mockResolvedValue({ threadId: 'thread-B', isInProgress: false, currentRunId: null });
+    await chat.resumeStreamIfActive('thread-B');
+
+    // B has no in-flight run ⇒ the UI must be idle (Send, not Stop).
+    expect(chat.isLoading.value, 'switching to an idle conversation must clear the streaming flag').toBe(false);
+    expect(chat.isSending.value, 'and the sending flag too').toBe(false);
+  });
+});
+
+// BUG 2: a multi-turn run mixing reasoning + tool calls + text, switched away MID-run and returned to,
+// scrambles/duplicates the thinking & text. The content turn epoch (which disambiguates turns that share
+// generationId+messageOrderIdx) is stateful and is reset at the start of loadMessagesFromBackend but NOT
+// again before resumeStreamIfActive replays the SAME already-emitted messages — so replayed reasoning/text
+// re-key with a higher turn epoch than their rehydrated twins, fail to merge, and pile up at the bottom.
+// Tool calls are immune (their key carries tool_call_id), matching the "tools fine, thinking/text messed
+// up" symptom. Proven against backend [Client] merge-key logs (run 592af00a: t1/t2/t3 → replayed t3/t4/t5).
+describe('useChat — multi-turn mixed order/dedup on resume after switch-back (BUG 2)', () => {
+  let captured: any[];
+  const RUN = 'run-1';
+  const GEN = { t1: 'gen-1', t2: 'gen-2', t3: 'gen-3' };
+
+  // Live wire shapes — NO runId (only run_assignment carries it; handleMessage stamps currentRunId).
+  const reasoningMsg = (gen: string, moi: number, r: string) =>
+    ({ $type: MessageType.Reasoning, role: 'assistant', reasoning: r, visibility: 1, generationId: gen, messageOrderIdx: moi });
+  const textMsg = (gen: string, moi: number, t: string) =>
+    ({ $type: MessageType.Text, role: 'assistant', text: t, generationId: gen, messageOrderIdx: moi });
+  const toolCallMsg = (gen: string, moi: number, id: string) =>
+    ({ $type: MessageType.ToolCall, role: 'assistant', tool_call_id: id, function_name: 'get_weather', function_args: '{}', generationId: gen, messageOrderIdx: moi });
+  const runAssignment = () => ({ $type: MessageType.RunAssignment, Assignment: { runId: RUN, generationId: GEN.t1, inputIds: [] } });
+  const runCompleted = () => ({ $type: MessageType.RunCompleted, completedRunId: RUN, hasPendingMessages: false });
+
+  // Persisted rows carry runId + identity (loadMessagesFromBackend stamps parsedMessage.runId ??= pm.runId).
+  const persist = (id: string, ts: number, msg: Record<string, unknown>, gen: string, moi: number) => ({
+    id, threadId: 'thread-1', runId: RUN, generationId: gen, messageOrderIdx: moi,
+    timestamp: ts, messageType: String(msg.$type), role: String(msg.role), messageJson: JSON.stringify(msg),
+  });
+
+  // History persisted before the switch: turn1 (R1 + 2 parallel tools) + turn2 (R2 + tool + text A2).
+  const history = () => [
+    persist('p1', 1000, reasoningMsg(GEN.t1, 0, 'R1'), GEN.t1, 0),
+    persist('p2', 1001, toolCallMsg(GEN.t1, 1, 'call_1'), GEN.t1, 1),
+    persist('p3', 1002, toolCallMsg(GEN.t1, 1, 'call_2'), GEN.t1, 1),
+    persist('p4', 1003, reasoningMsg(GEN.t2, 0, 'R2'), GEN.t2, 0),
+    persist('p5', 1004, toolCallMsg(GEN.t2, 1, 'call_3'), GEN.t2, 1),
+    persist('p6', 1005, textMsg(GEN.t2, 2, 'A2'), GEN.t2, 2),
+  ];
+
+  const reasoningsOf = (chat: ReturnType<typeof useChat>) =>
+    chat.displayItems.value
+      .filter((i) => i.type === 'pill')
+      .flatMap((i) => (i as { items: Array<{ $type?: string; reasoning?: string }> }).items)
+      .filter((m) => m.$type === MessageType.Reasoning)
+      .map((m) => m.reasoning ?? '');
+  const textsOf = (chat: ReturnType<typeof useChat>) =>
+    chat.displayItems.value
+      .filter((i) => i.type === 'assistant-message')
+      .map((i) => (i as { content: { text?: string } }).content.text ?? '');
+  const pillsForId = (chat: ReturnType<typeof useChat>, id: string) =>
+    chat.displayItems.value
+      .filter((i) => i.type === 'pill')
+      .flatMap((i) => (i as { items: Array<{ tool_calls?: Array<{ tool_call_id?: string }> }> }).items)
+      .filter((m) => m.tool_calls?.some((tc) => tc.tool_call_id === id));
+
+  beforeEach(() => {
+    captured = [];
+    wsMocks.createWebSocketConnection.mockReset();
+    wsMocks.sendWebSocketMessage.mockReset();
+    wsMocks.closeWebSocketConnection.mockReset();
+    convMocks.loadConversationMessages.mockReset();
+    convMocks.getRunState.mockReset();
+
+    wsMocks.createWebSocketConnection.mockImplementation(async (options: any) => {
+      captured.push(options);
+      return {
+        socket: { readyState: WebSocket.OPEN },
+        connectionId: `ws-${captured.length}`,
+        threadId: options.threadId,
+        isConnected: true,
+      };
+    });
+  });
+
+  it('does not duplicate or reorder multi-turn reasoning/text when resuming after switch-back', async () => {
+    convMocks.loadConversationMessages.mockResolvedValue(history());
+    const chat = useChat({ getModeId: () => 'default' });
+    chat.setThreadId('thread-1');
+
+    // Switch-back: rehydrate persisted history (turns 1-2).
+    await chat.loadMessagesFromBackend('thread-1');
+    expect(reasoningsOf(chat), 'reload: two distinct turn reasonings').toEqual(['R1', 'R2']);
+    expect(textsOf(chat), 'reload: one turn-2 text').toEqual(['A2']);
+
+    // Resume the in-flight run.
+    convMocks.getRunState.mockResolvedValue({ threadId: 'thread-1', isInProgress: true, currentRunId: RUN });
+    await chat.resumeStreamIfActive('thread-1');
+    const opts = captured[captured.length - 1];
+
+    // Backend replays the run from the start (assignment + turns 1-2), then streams live turn 3, completes.
+    opts.onMessage(runAssignment());
+    opts.onMessage(reasoningMsg(GEN.t1, 0, 'R1'));
+    opts.onMessage(toolCallMsg(GEN.t1, 1, 'call_1'));
+    opts.onMessage(toolCallMsg(GEN.t1, 1, 'call_2'));
+    opts.onMessage(reasoningMsg(GEN.t2, 0, 'R2'));
+    opts.onMessage(toolCallMsg(GEN.t2, 1, 'call_3'));
+    opts.onMessage(textMsg(GEN.t2, 2, 'A2'));
+    // Live turn 3 (fresh per-turn generationId).
+    opts.onMessage(reasoningMsg(GEN.t3, 0, 'R3'));
+    opts.onMessage(textMsg(GEN.t3, 1, 'A3'));
+    opts.onMessage(runCompleted());
+    opts.onDone();
+
+    // Replayed turns 1-2 must MERGE with their rehydrated twins (no duplicates), and turn 3 appends —
+    // yielding the correct chronological set, not a scrambled/duplicated pile.
+    expect(reasoningsOf(chat), 'no duplicate reasoning after resume; three turns in order').toEqual(['R1', 'R2', 'R3']);
+    expect(textsOf(chat), 'no duplicate text after resume; two texts in order').toEqual(['A2', 'A3']);
+    for (const id of ['call_1', 'call_2', 'call_3']) {
+      expect(pillsForId(chat, id), `exactly one pill for ${id}`).toHaveLength(1);
+    }
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChatResume.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChatResume.test.ts
@@ -473,6 +473,38 @@ describe('useChat — streaming flag resets when switching to an idle conversati
     expect(chat.isLoading.value, 'switching to an idle conversation must clear the streaming flag').toBe(false);
     expect(chat.isSending.value, 'and the sending flag too').toBe(false);
   });
+
+  // Regression for the BUG 1 fix: the flag must NOT be lowered inside clearMessages. Doing so flashed
+  // a transient "idle" during the awaited history load when switching BACK into a still-streaming
+  // conversation — which raced the stream-idle wait into reading the transcript before the resumed
+  // final text arrived (the StreamingResumeToolPills E2E failure). markStreamLoading() raises the flag
+  // BEFORE the load so a resuming target stays continuously "streaming"; markStreamIdle() lowers it
+  // only once the run state is known to be idle.
+  it('keeps isLoading true throughout a switch-back into a still-streaming conversation', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    chat.setThreadId('thread-A');
+    await chat.sendMessage('hi');
+    expect(chat.isLoading.value, 'A is streaming').toBe(true);
+
+    // Switch AWAY to a fresh idle chat — mirror handleNewChat (clearMessages + markStreamIdle).
+    await chat.disconnectWebSocket();
+    await chat.clearMessages();
+    chat.markStreamIdle();
+    expect(chat.isLoading.value, 'the new idle chat shows Send').toBe(false);
+
+    // Switch BACK to A, which is STILL streaming — mirror handleSelectConversation.
+    await chat.clearMessages();
+    chat.setThreadId('thread-A');
+    chat.markStreamLoading();
+    // The flag must already be raised before the awaited load, so there is no idle window to observe.
+    expect(chat.isLoading.value, 'loading a possibly-active conversation shows Stop, not Send').toBe(true);
+    await chat.loadMessagesFromBackend('thread-A');
+    convMocks.getRunState.mockResolvedValue({ threadId: 'thread-A', isInProgress: true, currentRunId: 'run-A' });
+    await chat.resumeStreamIfActive('thread-A');
+
+    // A is in-flight ⇒ the control stays "Stop" (isLoading true) with no transient flip to idle.
+    expect(chat.isLoading.value, 'a resuming conversation stays streaming').toBe(true);
+  });
 });
 
 // BUG 2: a multi-turn run mixing reasoning + tool calls + text, switched away MID-run and returned to,

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ChatInput.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ChatInput.vue
@@ -44,7 +44,15 @@ function handleKeydown(event: KeyboardEvent) {
       @keydown="handleKeydown"
     />
     <button
-      v-if="streaming"
+      v-if="streaming && inputText.trim()"
+      class="queue-button"
+      data-testid="queue-button"
+      @click="handleSubmit"
+    >
+      Queue
+    </button>
+    <button
+      v-else-if="streaming"
       class="stop-button"
       data-testid="stop-button"
       @click="handleCancel"
@@ -117,5 +125,13 @@ button:disabled {
 
 .stop-button:hover:not(:disabled) {
   background: #b02a37;
+}
+
+.queue-button {
+  background: #0d6efd;
+}
+
+.queue-button:hover:not(:disabled) {
+  background: #0b5ed7;
 }
 </style>

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
@@ -84,6 +84,8 @@ const {
   setThreadId,
   loadMessagesFromBackend,
   resumeStreamIfActive,
+  markStreamIdle,
+  markStreamLoading,
   getResultForToolCall,
 } = useChat({
   getModeId: () => currentModeId.value,
@@ -193,6 +195,10 @@ async function handleNewChat(): Promise<void> {
   // Disconnect current WebSocket and clear state
   await disconnectWebSocket();
   await clearMessages();
+  // A fresh chat is always idle — return the Send/Stop control to "Send" if we came from a
+  // streaming conversation (clearMessages no longer lowers the flags to avoid a switch-back
+  // flicker; see useChat.markStreamIdle).
+  markStreamIdle();
 
   // Create new thread (without adding to sidebar yet)
   const newThreadId = createNewConversation();
@@ -219,6 +225,11 @@ async function handleSelectConversation(threadId: string): Promise<void> {
 
   // Load existing messages
   try {
+    // Keep the Send/Stop control on "Stop" while we load + probe run state, so switching back into a
+    // still-streaming conversation stays continuously "streaming" (no flash to "Send" during the
+    // awaited load). resumeStreamIfActive resolves it: it keeps this raised for an in-flight run, or
+    // lowers it via markStreamIdle for an idle target.
+    markStreamLoading();
     await loadMessagesFromBackend(threadId);
     // If a run is still streaming on the backend (the pooled agent keeps running after we
     // disconnected on switch/refresh), re-open the WebSocket to resume the live stream instead
@@ -226,6 +237,8 @@ async function handleSelectConversation(threadId: string): Promise<void> {
     await resumeStreamIfActive(threadId);
   } catch (e) {
     console.error('Failed to load messages:', e);
+    // A load/resume failure must not strand the UI on "Stop" forever.
+    markStreamIdle();
   }
 }
 

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
@@ -211,6 +211,12 @@ async function handleSelectConversation(threadId: string): Promise<void> {
   selectConversation(threadId);
   setThreadId(threadId);
 
+  // Restore the conversation's bound provider/mode/workspace so opening (or refreshing into) a
+  // conversation shows its actual bindings instead of the process defaults. Without this, a refresh
+  // reset the selectors to Anthropic / General Assistant even for a still-streaming conversation.
+  // Done BEFORE resumeStreamIfActive so the resumed WebSocket carries the correct mode/provider.
+  restoreBindingsFromConversation(threadId);
+
   // Load existing messages
   try {
     await loadMessagesFromBackend(threadId);
@@ -220,6 +226,26 @@ async function handleSelectConversation(threadId: string): Promise<void> {
     await resumeStreamIfActive(threadId);
   } catch (e) {
     console.error('Failed to load messages:', e);
+  }
+}
+
+/**
+ * Reflects a conversation's persisted provider/mode/workspace into the header selectors. Uses the
+ * local selectors (not the backend switch endpoints) — this only restores what the conversation is
+ * already bound to; it does not change the conversation. Unknown ids are ignored (selectProvider /
+ * selectWorkspace no-op them; an unknown mode simply leaves the current one).
+ */
+function restoreBindingsFromConversation(threadId: string): void {
+  const conversation = conversations.value.find((c) => c.threadId === threadId);
+  if (!conversation) return;
+  if (conversation.provider) {
+    selectProvider(conversation.provider);
+  }
+  if (conversation.workspace) {
+    selectWorkspace(conversation.workspace);
+  }
+  if (conversation.mode) {
+    selectMode(conversation.mode);
   }
 }
 
@@ -332,6 +358,7 @@ async function handleSend(text: string): Promise<void> {
       lastUpdated: Date.now(),
       provider: selectedProviderId.value,
       workspace: selectedWorkspaceId.value,
+      mode: currentModeId.value,
     });
 
     // Update backend metadata asynchronously

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -1092,6 +1092,19 @@ export function useChat(options: UseChatOptions = {}) {
       runId: runState.currentRunId,
     });
 
+    // Re-align the content turn epoch with the just-rehydrated history BEFORE the replay. The backend
+    // replays the in-flight run's already-emitted messages from the start, and those are the SAME
+    // messages loadMessagesFromBackend just keyed. contentTurnSeqFor is stateful and was left advanced
+    // by that reload; without resetting it here the replayed reasoning/text would re-key with a HIGHER
+    // turn epoch than their rehydrated twins (…-t1 → …-t3, …-t2 → …-t4), fail to merge, and pile up as
+    // duplicates at the bottom — scrambling multi-turn order (BUG 2). Resetting lets the replay
+    // re-derive the SAME epoch sequence as the reload (both walk the run in production order), so each
+    // replayed message merges in place with its twin. Tool calls are unaffected (their key carries
+    // tool_call_id) — which is why only thinking/text scrambled. reset() clears the (already-empty)
+    // merger accumulators so the update path re-aligns identically.
+    resetContentTurnEpoch();
+    reset();
+
     // Reflect the live run in the UI (spinner / stop button) while the replayed + live deltas arrive.
     isLoading.value = true;
     try {
@@ -1126,6 +1139,14 @@ export function useChat(options: UseChatOptions = {}) {
     threadId.value = null;
     currentRunId.value = null;
     toolResults.value.clear();
+    // Reset the streaming flags too. clearMessages is the reset point on every conversation switch
+    // (handleSelectConversation) and new-chat, and it tears down the socket below — so the previous
+    // conversation's in-flight state must not leak onto the next one. Without this, switching FROM a
+    // streaming conversation TO an idle one left isLoading=true (resume only ever RAISES it, never
+    // lowers it), so the idle conversation kept showing the red Stop button forever (BUG 1). A
+    // genuinely in-flight target re-raises isLoading via resumeStreamIfActive right after.
+    isLoading.value = false;
+    isSending.value = false;
     resetContentTurnEpoch();
     reset();
 

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -1048,9 +1048,39 @@ export function useChat(options: UseChatOptions = {}) {
    * kind-runId-generationId-messageOrderIdx dedups replay vs history). Without this, returning to
    * a streaming conversation showed the partial frozen at the last persisted point.
    */
+  /**
+   * Lower the streaming flags to their idle state. Called when a conversation switch (or new chat)
+   * lands on a target with no resumable in-flight run, so the Send/Stop control returns to "Send"
+   * (BUG 1). It is deliberately NOT done inside clearMessages: clearMessages runs at the START of
+   * every switch, BEFORE the awaited loadMessagesFromBackend + resumeStreamIfActive, so lowering the
+   * flag there produced a transient "idle" window mid switch-back — which a resumed run would flash
+   * through (and which raced the E2E's stream-idle wait into reading the transcript before the
+   * resumed final text arrived). Deciding idle-vs-streaming only once the run state is known keeps a
+   * genuine resume continuously "streaming" with no flicker.
+   */
+  function markStreamIdle(): void {
+    isLoading.value = false;
+    isSending.value = false;
+  }
+
+  /**
+   * Raise the streaming flag while a conversation switch loads and probes the target's run state.
+   * Selecting a conversation runs clearMessages → loadMessagesFromBackend → resumeStreamIfActive; the
+   * caller sets this right before the load so the Send/Stop control stays "Stop" continuously when the
+   * target turns out to still be streaming (resumeStreamIfActive keeps it raised), instead of flashing
+   * to "Send" during the awaited load and only snapping back to "Stop" on resume. A target that is
+   * actually idle resolves to Send via markStreamIdle() in resumeStreamIfActive's no-run branches.
+   */
+  function markStreamLoading(): void {
+    isLoading.value = true;
+  }
+
   async function resumeStreamIfActive(existingThreadId: string): Promise<void> {
     // Only the WebSocket transport maintains a resumable live backend run.
-    if (transport.value !== 'websocket') return;
+    if (transport.value !== 'websocket') {
+      markStreamIdle();
+      return;
+    }
 
     // Already streaming this thread on an open socket — nothing to resume.
     if (
@@ -1068,12 +1098,14 @@ export function useChat(options: UseChatOptions = {}) {
       runState = await getRunState(existingThreadId);
     } catch (err) {
       log.warn('Failed to query run state for resume', { threadId: existingThreadId, error: err });
+      markStreamIdle();
       return;
     }
 
     // The active conversation may have changed while getRunState was in flight (rapid switching).
     // Binding this thread's stream to whatever conversation is now current would contaminate it,
-    // so abort if we've moved on.
+    // so abort if we've moved on. Do NOT touch the streaming flags here — a newer switch already
+    // owns them; clearing them would stomp the conversation we just moved to.
     if (threadId.value !== existingThreadId) {
       log.debug('Thread changed during resume check; aborting', {
         requested: existingThreadId,
@@ -1084,6 +1116,7 @@ export function useChat(options: UseChatOptions = {}) {
 
     if (!runState?.isInProgress) {
       log.debug('No in-flight run to resume', { threadId: existingThreadId });
+      markStreamIdle();
       return;
     }
 
@@ -1139,14 +1172,12 @@ export function useChat(options: UseChatOptions = {}) {
     threadId.value = null;
     currentRunId.value = null;
     toolResults.value.clear();
-    // Reset the streaming flags too. clearMessages is the reset point on every conversation switch
-    // (handleSelectConversation) and new-chat, and it tears down the socket below — so the previous
-    // conversation's in-flight state must not leak onto the next one. Without this, switching FROM a
-    // streaming conversation TO an idle one left isLoading=true (resume only ever RAISES it, never
-    // lowers it), so the idle conversation kept showing the red Stop button forever (BUG 1). A
-    // genuinely in-flight target re-raises isLoading via resumeStreamIfActive right after.
-    isLoading.value = false;
-    isSending.value = false;
+    // NB: the streaming flags (isLoading/isSending) are deliberately NOT reset here. clearMessages
+    // runs at the START of every switch — BEFORE the awaited loadMessagesFromBackend +
+    // resumeStreamIfActive — so lowering them here flashed a transient "idle" through a switch-back
+    // that then resumes (BUG 1's regression on the tool-pill resume path). Idle is decided once the
+    // run state is known: markStreamIdle() in resumeStreamIfActive's no-run branches (switch to an
+    // idle existing conversation) and in handleNewChat (a fresh chat is always idle).
     resetContentTurnEpoch();
     reset();
 
@@ -1355,6 +1386,8 @@ export function useChat(options: UseChatOptions = {}) {
     setThreadId,
     loadMessagesFromBackend,
     resumeStreamIfActive,
+    markStreamIdle,
+    markStreamLoading,
   };
 }
 

--- a/samples/LmStreaming.Sample/ClientApp/src/types/conversations.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/types/conversations.ts
@@ -16,6 +16,12 @@ export interface ConversationSummary {
    * legacy threads predating the per-conversation workspace feature.
    */
   workspace?: string | null;
+  /**
+   * Chat mode id this thread is bound to. Seeded on first agent creation and updated on a
+   * deliberate mode switch. Lets the client restore the conversation's bound mode after a refresh
+   * instead of falling back to the default. Null for legacy threads predating mode persistence.
+   */
+  mode?: string | null;
 }
 
 /**

--- a/samples/LmStreaming.Sample/Controllers/ConversationsController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ConversationsController.cs
@@ -43,6 +43,9 @@ public class ConversationsController(
             Workspace = t.Properties?.TryGetValue(MultiTurnAgentPool.WorkspacePropertyKey, out var workspaceObj) == true
                 ? workspaceObj?.ToString()
                 : null,
+            Mode = t.Properties?.TryGetValue(MultiTurnAgentPool.ModePropertyKey, out var modeObj) == true
+                ? modeObj?.ToString()
+                : null,
         });
         return Ok(result);
     }
@@ -116,31 +119,41 @@ public class ConversationsController(
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(update);
-        var existing = await store.LoadMetadataAsync(threadId, ct);
-        var propertiesBuilder = existing?.Properties?.ToBuilder()
-            ?? ImmutableDictionary.CreateBuilder<string, object>();
 
-        if (update.Title != null)
-        {
-            propertiesBuilder["title"] = update.Title;
-        }
+        // Atomic read-modify-write: a title/preview edit races with the pool's binding persistence
+        // (provider/workspace/mode written when the agent is created for the first message). Doing a
+        // separate LoadMetadata + SaveMetadata here would drop whichever write lost the interleave —
+        // exactly the lost-update that stripped the persisted provider. UpdateMetadataAsync serializes
+        // the whole cycle so both survive.
+        await store.UpdateMetadataAsync(
+            threadId,
+            existing =>
+            {
+                var propertiesBuilder = existing?.Properties?.ToBuilder()
+                    ?? ImmutableDictionary.CreateBuilder<string, object>();
 
-        if (update.Preview != null)
-        {
-            propertiesBuilder["preview"] = update.Preview;
-        }
+                if (update.Title != null)
+                {
+                    propertiesBuilder["title"] = update.Title;
+                }
 
-        var metadata = new ThreadMetadata
-        {
-            ThreadId = threadId,
-            CurrentRunId = existing?.CurrentRunId,
-            LatestRunId = existing?.LatestRunId,
-            LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            SessionMappings = existing?.SessionMappings,
-            Properties = propertiesBuilder.ToImmutable(),
-        };
+                if (update.Preview != null)
+                {
+                    propertiesBuilder["preview"] = update.Preview;
+                }
 
-        await store.SaveMetadataAsync(threadId, metadata, ct);
+                return new ThreadMetadata
+                {
+                    ThreadId = threadId,
+                    CurrentRunId = existing?.CurrentRunId,
+                    LatestRunId = existing?.LatestRunId,
+                    LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    SessionMappings = existing?.SessionMappings,
+                    Properties = propertiesBuilder.ToImmutable(),
+                };
+            },
+            ct);
+
         return Ok();
     }
 

--- a/samples/LmStreaming.Sample/Models/ConversationDtos.cs
+++ b/samples/LmStreaming.Sample/Models/ConversationDtos.cs
@@ -23,6 +23,14 @@ public record ConversationSummary
     /// the per-conversation workspace feature.
     /// </summary>
     public string? Workspace { get; init; }
+
+    /// <summary>
+    /// Chat mode id this thread is bound to. Seeded on first agent creation and updated on a
+    /// deliberate mode switch, persisted in <c>ThreadMetadata.Properties["mode"]</c>. Lets the client
+    /// restore the conversation's bound mode after a refresh instead of falling back to the default.
+    /// Null for legacy threads predating per-conversation mode persistence.
+    /// </summary>
+    public string? Mode { get; init; }
 }
 
 /// <summary>

--- a/src/LmAgentInfra/Agents/MultiTurnAgentPool.cs
+++ b/src/LmAgentInfra/Agents/MultiTurnAgentPool.cs
@@ -28,6 +28,15 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
     /// </summary>
     public const string WorkspacePropertyKey = "workspace";
 
+    /// <summary>
+    /// Property key in <see cref="ThreadMetadata.Properties"/> that stores the chat mode id chosen
+    /// for a thread. Seeded on first creation and updated on a deliberate mode switch
+    /// (<see cref="RecreateAgentWithModeAsync"/>) — unlike provider/workspace, the mode is MUTABLE.
+    /// Persisting it lets the client restore the conversation's bound mode after a refresh instead of
+    /// falling back to the default.
+    /// </summary>
+    public const string ModePropertyKey = "mode";
+
     private const string DefaultWorkspaceId = "default";
 
     private readonly ConcurrentDictionary<string, AgentEntry> _agents = new();
@@ -298,12 +307,13 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
 
         if (created)
         {
-            // Persist the provider and workspace on first creation. Fire-and-forget — the WS
-            // connect path runs in a request scope, and a transient failure here only means the
-            // next reconnect will re-resolve from the registry default. We log warnings so silent
-            // persistence drift is visible.
-            _ = PersistProviderIfNeededAsync(threadId, resolvedProviderId);
-            _ = PersistWorkspaceIfNeededAsync(threadId, resolvedWorkspaceId);
+            // Persist the provider, workspace, and mode on first creation in ONE atomic metadata
+            // update. Fire-and-forget — the WS connect path runs in a request scope, and a transient
+            // failure here only means the next reconnect will re-resolve from the registry default. We
+            // log warnings so silent persistence drift is visible. A single atomic write (not two
+            // concurrent read-modify-writes) is what keeps the provider from being clobbered by the
+            // workspace write — the lost-update race that dropped the persisted provider.
+            _ = PersistThreadBindingsIfNeededAsync(threadId, resolvedProviderId, resolvedWorkspaceId, mode.Id);
         }
 
         if (
@@ -439,7 +449,19 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
         return null;
     }
 
-    private async Task PersistWorkspaceIfNeededAsync(string threadId, string workspaceId)
+    /// <summary>
+    /// Persists a thread's provider, workspace, and mode bindings in ONE atomic metadata update on
+    /// first creation. Provider and workspace are immutable (seeded only when absent); mode is seeded
+    /// here too but stays mutable (a later <see cref="RecreateAgentWithModeAsync"/> overwrites it via
+    /// <see cref="PersistModeAsync"/>). A single read-modify-write — rather than the two concurrent
+    /// ones this replaced — is what stops the provider from being clobbered by the workspace write.
+    /// </summary>
+    private async Task PersistThreadBindingsIfNeededAsync(
+        string threadId,
+        string providerId,
+        string workspaceId,
+        string? modeId
+    )
     {
         if (_conversationStore == null)
         {
@@ -448,41 +470,105 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
 
         try
         {
-            var existing = await _conversationStore.LoadMetadataAsync(threadId).ConfigureAwait(false);
-            var hasWorkspace = existing?.Properties?.ContainsKey(WorkspacePropertyKey) == true;
-            if (hasWorkspace)
-            {
-                return;
-            }
-
-            var properties = existing?.Properties ?? ImmutableDictionary<string, object>.Empty;
-            properties = properties.SetItem(WorkspacePropertyKey, workspaceId);
-
-            var updated = (
-                existing
-                ?? new ThreadMetadata
+            await _conversationStore.UpdateMetadataAsync(
+                threadId,
+                existing =>
                 {
-                    ThreadId = threadId,
-                    LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    var properties = existing?.Properties ?? ImmutableDictionary<string, object>.Empty;
+
+                    if (!properties.ContainsKey(ProviderPropertyKey))
+                    {
+                        properties = properties.SetItem(ProviderPropertyKey, providerId);
+                    }
+
+                    if (!properties.ContainsKey(WorkspacePropertyKey))
+                    {
+                        properties = properties.SetItem(WorkspacePropertyKey, workspaceId);
+                    }
+
+                    // Seed the mode only when absent — a plain reconnect that recreates the agent must
+                    // not overwrite a mode the user deliberately switched to.
+                    if (!string.IsNullOrWhiteSpace(modeId) && !properties.ContainsKey(ModePropertyKey))
+                    {
+                        properties = properties.SetItem(ModePropertyKey, modeId);
+                    }
+
+                    return (
+                        existing
+                        ?? new ThreadMetadata
+                        {
+                            ThreadId = threadId,
+                            LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                        }
+                    ) with
+                    {
+                        Properties = properties,
+                        LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    };
                 }
-            ) with
-            {
-                Properties = properties,
-                LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            };
+            ).ConfigureAwait(false);
 
-            await _conversationStore.SaveMetadataAsync(threadId, updated).ConfigureAwait(false);
-
-            _logger.LogInformation("Persisted workspace {WorkspaceId} for thread {ThreadId}", workspaceId, threadId);
+            _logger.LogInformation(
+                "Persisted bindings for thread {ThreadId} (provider={ProviderId}, workspace={WorkspaceId}, mode={ModeId})",
+                threadId,
+                providerId,
+                workspaceId,
+                modeId
+            );
         }
         catch (Exception ex)
         {
             _logger.LogWarning(
                 ex,
-                "Failed to persist workspace {WorkspaceId} for thread {ThreadId}",
+                "Failed to persist bindings for thread {ThreadId} (provider={ProviderId}, workspace={WorkspaceId}, mode={ModeId})",
+                threadId,
+                providerId,
                 workspaceId,
-                threadId
+                modeId
             );
+        }
+    }
+
+    /// <summary>
+    /// Overwrites the persisted mode for a thread (a deliberate, mutable mode switch). Provider and
+    /// workspace are left untouched.
+    /// </summary>
+    private async Task PersistModeAsync(string threadId, string? modeId)
+    {
+        if (_conversationStore == null || string.IsNullOrWhiteSpace(modeId))
+        {
+            return;
+        }
+
+        try
+        {
+            await _conversationStore.UpdateMetadataAsync(
+                threadId,
+                existing =>
+                {
+                    var properties = (existing?.Properties ?? ImmutableDictionary<string, object>.Empty)
+                        .SetItem(ModePropertyKey, modeId);
+
+                    return (
+                        existing
+                        ?? new ThreadMetadata
+                        {
+                            ThreadId = threadId,
+                            LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                        }
+                    ) with
+                    {
+                        Properties = properties,
+                        LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    };
+                }
+            ).ConfigureAwait(false);
+
+            _logger.LogInformation("Persisted mode {ModeId} for thread {ThreadId}", modeId, threadId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to persist mode {ModeId} for thread {ThreadId}", modeId, threadId);
         }
     }
 
@@ -561,53 +647,6 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
 
         value = extracted.Trim();
         return true;
-    }
-
-    private async Task PersistProviderIfNeededAsync(string threadId, string providerId)
-    {
-        if (_conversationStore == null)
-        {
-            return;
-        }
-
-        try
-        {
-            var existing = await _conversationStore.LoadMetadataAsync(threadId).ConfigureAwait(false);
-            var hasProvider = existing?.Properties?.ContainsKey(ProviderPropertyKey) == true;
-            if (hasProvider)
-            {
-                return;
-            }
-
-            var properties = existing?.Properties ?? ImmutableDictionary<string, object>.Empty;
-            properties = properties.SetItem(ProviderPropertyKey, providerId);
-
-            var updated = (
-                existing
-                ?? new ThreadMetadata
-                {
-                    ThreadId = threadId,
-                    LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                }
-            ) with
-            {
-                Properties = properties,
-                LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            };
-
-            await _conversationStore.SaveMetadataAsync(threadId, updated).ConfigureAwait(false);
-
-            _logger.LogInformation("Persisted provider {ProviderId} for thread {ThreadId}", providerId, threadId);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Failed to persist provider {ProviderId} for thread {ThreadId}",
-                providerId,
-                threadId
-            );
-        }
     }
 
     /// <summary>
@@ -773,6 +812,10 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
             _logger.LogInformation("Removing agent for thread {ThreadId}", threadId);
             await oldEntry.DisposeAsync();
         }
+
+        // A mode switch is deliberate and mutable: overwrite the persisted mode so a later refresh
+        // restores the switched-to mode (provider/workspace stay untouched — they are immutable).
+        await PersistModeAsync(threadId, mode.Id);
 
         return entry.Agent;
     }

--- a/src/LmMultiTurn/Persistence/FileConversationStore.cs
+++ b/src/LmMultiTurn/Persistence/FileConversationStore.cs
@@ -157,6 +157,35 @@ public sealed class FileConversationStore : IConversationStore
     }
 
     /// <inheritdoc />
+    public async Task UpdateMetadataAsync(
+        string threadId,
+        Func<ThreadMetadata?, ThreadMetadata> update,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(threadId);
+        ArgumentNullException.ThrowIfNull(update);
+
+        // Hold the lock across the read AND the write so a concurrent read-modify-write for the same
+        // thread cannot interleave and clobber the other's properties (the provider-vs-workspace and
+        // bindings-vs-title/preview lost-update race that dropped the persisted provider).
+        await _lock.WaitAsync(ct);
+        try
+        {
+            var threadDir = GetThreadDirectory(threadId);
+            _ = Directory.CreateDirectory(threadDir);
+
+            var metadataFile = Path.Combine(threadDir, MetadataFileName);
+            var existing = await LoadJsonFileAsync<ThreadMetadata>(metadataFile, ct);
+            var updated = update(existing);
+            await WriteJsonFileAsync(metadataFile, updated, ct);
+        }
+        finally
+        {
+            _ = _lock.Release();
+        }
+    }
+
+    /// <inheritdoc />
     public async Task DeleteThreadAsync(
         string threadId,
         CancellationToken ct = default)

--- a/src/LmMultiTurn/Persistence/IConversationStore.cs
+++ b/src/LmMultiTurn/Persistence/IConversationStore.cs
@@ -72,6 +72,25 @@ public interface IConversationStore
         string threadId,
         CancellationToken ct = default);
 
+    /// <summary>
+    /// Atomically reads the current metadata, applies <paramref name="update"/> to it, and saves the
+    /// result — the whole read-modify-write runs under the store's write serialization so concurrent
+    /// callers cannot clobber each other's properties (a lost update). Use this whenever you mutate a
+    /// SUBSET of the property bag (e.g. the provider/workspace/mode bindings, or a title/preview edit)
+    /// rather than replacing the whole record; a plain <see cref="LoadMetadataAsync"/> +
+    /// <see cref="SaveMetadataAsync"/> pair leaves a gap in which another writer's save is lost.
+    /// </summary>
+    /// <param name="threadId">The thread identifier.</param>
+    /// <param name="update">
+    /// Receives the current metadata (<c>null</c> if none exists yet) and returns the metadata to save.
+    /// Invoked while the write lock is held, so keep it fast and side-effect free.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    Task UpdateMetadataAsync(
+        string threadId,
+        Func<ThreadMetadata?, ThreadMetadata> update,
+        CancellationToken ct = default);
+
     // === Lifecycle ===
 
     /// <summary>

--- a/src/LmMultiTurn/Persistence/InMemoryConversationStore.cs
+++ b/src/LmMultiTurn/Persistence/InMemoryConversationStore.cs
@@ -11,6 +11,7 @@ public sealed class InMemoryConversationStore : IConversationStore
     private readonly ConcurrentDictionary<string, List<PersistedMessage>> _messages = new();
     private readonly ConcurrentDictionary<string, ThreadMetadata> _metadata = new();
     private readonly object _messagesLock = new();
+    private readonly object _metadataLock = new();
 
     /// <inheritdoc />
     public Task AppendMessagesAsync(
@@ -104,6 +105,26 @@ public sealed class InMemoryConversationStore : IConversationStore
     {
         _ = _metadata.TryGetValue(threadId, out var metadata);
         return Task.FromResult(metadata);
+    }
+
+    /// <inheritdoc />
+    public Task UpdateMetadataAsync(
+        string threadId,
+        Func<ThreadMetadata?, ThreadMetadata> update,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(threadId);
+        ArgumentNullException.ThrowIfNull(update);
+
+        // Serialize the read-modify-write so two concurrent property-bag updates for the same thread
+        // cannot clobber each other (matches FileConversationStore's atomic UpdateMetadataAsync).
+        lock (_metadataLock)
+        {
+            _ = _metadata.TryGetValue(threadId, out var existing);
+            _metadata[threadId] = update(existing);
+        }
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />

--- a/src/LmMultiTurn/Persistence/Sqlite/SqliteConversationStore.cs
+++ b/src/LmMultiTurn/Persistence/Sqlite/SqliteConversationStore.cs
@@ -13,6 +13,7 @@ public sealed class SqliteConversationStore : IConversationStore, IAsyncDisposab
     private readonly ISqliteConnectionFactory _connectionFactory;
     private readonly bool _ownsFactory;
     private readonly SemaphoreSlim _schemaLock = new(1, 1);
+    private readonly SemaphoreSlim _metadataWriteLock = new(1, 1);
     private bool _schemaInitialized;
     private bool _disposed;
 
@@ -249,6 +250,30 @@ public sealed class SqliteConversationStore : IConversationStore, IAsyncDisposab
     }
 
     /// <inheritdoc />
+    public async Task UpdateMetadataAsync(
+        string threadId,
+        Func<ThreadMetadata?, ThreadMetadata> update,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(threadId);
+        ArgumentNullException.ThrowIfNull(update);
+
+        // Serialize the read-modify-write so concurrent property-bag updates for the same thread cannot
+        // clobber each other (matches the other stores' atomic UpdateMetadataAsync).
+        await _metadataWriteLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var existing = await LoadMetadataAsync(threadId, ct).ConfigureAwait(false);
+            var updated = update(existing);
+            await SaveMetadataAsync(threadId, updated, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _ = _metadataWriteLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
     public async Task DeleteThreadAsync(string threadId, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(threadId);
@@ -325,6 +350,7 @@ public sealed class SqliteConversationStore : IConversationStore, IAsyncDisposab
 
         _disposed = true;
         _schemaLock.Dispose();
+        _metadataWriteLock.Dispose();
 
         if (_ownsFactory)
         {

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs
@@ -19,10 +19,16 @@ public static class UiHelpers
         return page.GetByTestId("send-button");
     }
 
-    /// <summary>Stop button — only rendered while the stream is active.</summary>
+    /// <summary>Stop button — only rendered while the stream is active AND the input box is empty.</summary>
     public static ILocator StopButton(this IPage page)
     {
         return page.GetByTestId("stop-button");
+    }
+
+    /// <summary>Queue button — rendered while the stream is active AND the input box has text; queues the typed message.</summary>
+    public static ILocator QueueButton(this IPage page)
+    {
+        return page.GetByTestId("queue-button");
     }
 
     /// <summary>Clear-conversation button in the header.</summary>

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/QueueButtonTests.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/QueueButtonTests.cs
@@ -1,0 +1,99 @@
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using LmStreaming.Sample.Browser.E2E.Tests.Infrastructure;
+
+namespace LmStreaming.Sample.Browser.E2E.Tests.Scenarios;
+
+/// <summary>
+/// Bug 4 — the composer's primary button has THREE mutually-exclusive states. While a run is
+/// streaming, an empty input box shows the red <c>Stop</c> button (cancels the run), while a
+/// non-empty box shows the blue <c>Queue</c> button (queues the typed message through the existing
+/// full-duplex path). When idle it shows <c>Send</c>. These tests drive a long scripted stream so
+/// the "streaming" window stays open long enough to observe the swap and to queue a follow-up.
+/// </summary>
+[Collection(PlaywrightCollection.Name)]
+public sealed class QueueButtonTests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public QueueButtonTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Theory]
+    [InlineData("test")]
+    [InlineData("test-anthropic")]
+    public async Task Queue_button_swaps_with_stop_based_on_input_text_while_streaming(string providerMode)
+    {
+        // Long streamed turn so the stream stays in-flight while we type/clear the input.
+        var responder = ScriptedSseResponder
+            .New()
+            .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
+            .Turn(t => t.TextLen(2000))
+            .Build();
+
+        await using var session = await _fixture.OpenAsync(providerMode, responder.HandlerFor(providerMode));
+        var page = session.Page;
+
+        await page.SendMessageAsync("please produce a very long response");
+        await page.WaitForStreamActiveAsync();
+
+        // Empty box while streaming → red Stop, no Queue.
+        await Assertions.Expect(page.StopButton()).ToBeVisibleAsync();
+        await Assertions.Expect(page.QueueButton()).ToBeHiddenAsync();
+
+        // Type a draft while streaming → blue Queue replaces Stop.
+        await page.Textarea().FillAsync("a follow-up typed mid-stream");
+        await Assertions.Expect(page.QueueButton()).ToBeVisibleAsync();
+        await Assertions.Expect(page.StopButton()).ToBeHiddenAsync();
+
+        // Clear the draft → reverts to Stop (so an empty box can still cancel the run).
+        await page.Textarea().FillAsync(string.Empty);
+        await Assertions.Expect(page.StopButton()).ToBeVisibleAsync();
+        await Assertions.Expect(page.QueueButton()).ToBeHiddenAsync();
+
+        // Clean up: cancel the still-active run and confirm idle.
+        await page.StopButton().ClickAsync();
+        await page.WaitForStreamIdleAsync();
+        await session.SaveSuccessScreenshotAsync($"QueueButton.Swaps_with_stop_{providerMode}");
+    }
+
+    [Theory]
+    [InlineData("test")]
+    [InlineData("test-anthropic")]
+    public async Task Queue_button_routes_typed_message_into_the_pending_send_queue(string providerMode)
+    {
+        // Turn 1 streams long so it is still active while we queue a follow-up; Turn 2 is a
+        // safety net for the queued message if the backend processes it before teardown.
+        var responder = ScriptedSseResponder
+            .New()
+            .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
+            .Turn(t => t.TextLen(2000))
+            .Turn(t => t.Text("Queued answer: acknowledged."))
+            .Build();
+
+        await using var session = await _fixture.OpenAsync(providerMode, responder.HandlerFor(providerMode));
+        var page = session.Page;
+
+        await page.SendMessageAsync("please produce a very long response");
+        await page.WaitForStreamActiveAsync();
+
+        // Wait for the assistant response to actually begin streaming. This guarantees the first
+        // send has settled (isSending has flipped back to false) so the queued follow-up is
+        // accepted rather than dropped by sendMessage's re-entrancy guard — matching how a real
+        // user types a follow-up seconds into a stream, not in the sub-second send-setup window.
+        await page.AssistantText().WaitForCountAtLeastAsync(1);
+
+        // Queue a follow-up while the first run is still streaming.
+        await page.Textarea().FillAsync("and what is two plus two?");
+        await Assertions.Expect(page.QueueButton()).ToBeVisibleAsync();
+        await page.QueueButton().ClickAsync();
+
+        // The click routes through the send path: the box clears immediately and the message
+        // enters the "Waiting to send…" pending queue (it stays pending until the active run
+        // finishes). The full "answered as its own turn after the run" flow is verified live.
+        await Assertions.Expect(page.Textarea()).ToHaveValueAsync(string.Empty);
+        await Assertions.Expect(page.Locator(".pending-queue")).ToContainTextAsync("two plus two");
+        await session.SaveSuccessScreenshotAsync($"QueueButton.Queues_message_{providerMode}");
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Agents/MultiTurnAgentPoolTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Agents/MultiTurnAgentPoolTests.cs
@@ -83,6 +83,59 @@ public class MultiTurnAgentPoolTests
     }
 
     [Fact]
+    public async Task GetOrCreateAgent_PersistsMode_OnFirstCreation()
+    {
+        // BUG 3: the conversation's chat mode was never persisted, so after a refresh the client had no
+        // bound mode to restore and fell back to the default (General Assistant). The mode must be
+        // persisted alongside provider/workspace at first creation.
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test"]);
+        var store = new InMemoryConversationStore();
+
+        await using var pool = new MultiTurnAgentPool(
+            context => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(context.ThreadId)),
+            registry.ToReal(),
+            store,
+            NullLogger<MultiTurnAgentPool>.Instance
+        );
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        _ = pool.GetOrCreateAgent("thread-mode", mode, requestedProviderId: "test", requestResponseDumpFileName: null);
+
+        var persistedMode = await WaitForPersistedPropertyAsync(store, "thread-mode", "mode");
+        persistedMode.Should().Be(mode.Id);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAgent_PersistsProviderWorkspaceAndMode_Together_OnFirstCreation()
+    {
+        // The three bindings must ALL survive first creation. Previously provider and workspace were
+        // persisted by two concurrent read-modify-write tasks that clobbered each other (measured: the
+        // provider was frequently lost), and mode was not persisted at all.
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test", "openai"]);
+        var store = new InMemoryConversationStore();
+
+        await using var pool = new MultiTurnAgentPool(
+            context => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(context.ThreadId)),
+            registry.ToReal(),
+            store,
+            NullLogger<MultiTurnAgentPool>.Instance
+        );
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        _ = pool.GetOrCreateAgent(
+            "thread-bindings",
+            mode,
+            requestedProviderId: "openai",
+            requestResponseDumpFileName: null,
+            requestedWorkspaceId: "ws-1"
+        );
+
+        (await WaitForPersistedPropertyAsync(store, "thread-bindings", "provider")).Should().Be("openai");
+        (await WaitForPersistedPropertyAsync(store, "thread-bindings", "workspace")).Should().Be("ws-1");
+        (await WaitForPersistedPropertyAsync(store, "thread-bindings", "mode")).Should().Be(mode.Id);
+    }
+
+    [Fact]
     public async Task GetOrCreateAgent_PersistedProviderWins_OverRequested()
     {
         var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test", "openai", "anthropic"]);
@@ -602,13 +655,23 @@ public class MultiTurnAgentPoolTests
         int timeoutMs = 1000
     )
     {
+        return await WaitForPersistedPropertyAsync(store, threadId, MultiTurnAgentPool.WorkspacePropertyKey, timeoutMs);
+    }
+
+    private static async Task<string?> WaitForPersistedPropertyAsync(
+        IConversationStore store,
+        string threadId,
+        string propertyKey,
+        int timeoutMs = 1000
+    )
+    {
         var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
         while (DateTime.UtcNow < deadline)
         {
             var metadata = await store.LoadMetadataAsync(threadId);
             if (
                 metadata?.Properties != null
-                && metadata.Properties.TryGetValue(MultiTurnAgentPool.WorkspacePropertyKey, out var raw)
+                && metadata.Properties.TryGetValue(propertyKey, out var raw)
                 && raw is string s
                 && !string.IsNullOrWhiteSpace(s)
             )


### PR DESCRIPTION
## Summary
Fixes four UX bugs in the LmStreaming.Sample Vue chat client, found via systematic log-first debugging with the **Test (Anthropic)** mock provider. Three are conversation-switching bugs; one is the composer's action button while streaming. Split into two commits (bugs 1–3, then the Queue button). Changes are confined to the sample client + conversation-metadata persistence — no provider or wire-protocol changes.

## Changes
- **Bug 1 — Stop button stuck after switching to an idle conversation:** reset `isLoading`/`isSending` in `useChat.clearMessages()`.
- **Bug 2 — multi-turn thinking/tool/text order scrambles on mid-stream switch-back:** reset the content-turn epoch (+ merger) right before the resume replay so it re-derives the reload's epoch sequence and merges in place.
- **Bug 3 — provider/mode reset to defaults on refresh while streaming:** new atomic `IConversationStore.UpdateMetadataAsync` (read-modify-write under the store lock; File/InMemory/Sqlite impls); one combined `PersistThreadBindingsIfNeededAsync` (provider + workspace + mode) that kills the lost-update race; persist mode on switch; return `mode` in the conversation summary; client restores provider/mode/workspace on select + refresh.
- **Bug 4 — Queue button:** `ChatInput.vue` gains a third, mutually-exclusive button state — blue **Queue** while streaming with text (queues the typed message via the existing full-duplex send path), red **Stop** while streaming with an empty box, **Send** when idle. UI-only; no backend change.

## Testing
- **Client unit:** 282 pass (incl. new `ChatInput.test.ts`, resume + restore tests); `vue-tsc --noEmit` clean.
- **Backend unit:** `MultiTurnAgentPool` + `Conversations` 37 pass; `LmMultiTurn` persistence 95 pass.
- **Browser E2E:** new `QueueButtonTests` (× `test` / `test-anthropic`); existing suite unaffected.
- **Live Playwright** against the Test (Anthropic) mock: all four scenarios verified with screenshots.
- Husky `format-verify` pre-commit hook passed on both commits.

## Related Issues
Fixes #134
