### PR TITLE
Switch a conversation's provider after its run completes

### DIFF
--- a/samples/LmStreaming.Sample/CLAUDE.md
+++ b/samples/LmStreaming.Sample/CLAUDE.md
@@ -33,17 +33,38 @@ There are **two** Playwright surfaces. Keep them aligned; do not invent a third.
    - `Scenarios/*.cs` — `MultiTurnConversationTests`, `ModeSwitchingTests`, `ClaudeMockProviderTests`,
      `CancellationTests`, `ErrorHandlingTests`, … `dotnet test` runs them all (no exclusions).
 
-2. **Manual / exploratory (Claude MCP Playwright) — `PlaywrightTestingGuide.md`.**
-   Ready-to-run MCP scripts for ad-hoc checks. See its "Rationalization & fastest browser control"
-   section for the canonical fast patterns and the selector cross-reference.
+2. **Manual / exploratory (Claude MCP Playwright).**
+   **MANDATORY: drive the UI with a single self-contained Playwright script, NOT snapshot→act→screenshot
+   loops.** Ad-hoc snapshot/click/screenshot round-trips are slow and burn tokens (an ad-hoc agent run
+   cost ~140k tokens / 68 tool calls for what one script does in one call). Instead:
+   - **Reuse / add a script in [`playwright-scripts/`](playwright-scripts/).** Each is a self-contained
+     `async (page) => { … return { pass, failures, steps } }` that drives the WHOLE flow and returns
+     structured JSON. Run it in ONE call:
+     `browser_run_code_unsafe({ filename: "samples/LmStreaming.Sample/playwright-scripts/<name>.mjs" })`.
+     Existing: `provider-switch.mjs` (switch provider when idle / locked while streaming),
+     `queue-button.mjs` (blue Queue button while streaming). Add a new `.mjs` per recurring manual case
+     — do not re-drive it by hand next time. (No trailing `;` after the arrow function — the runner
+     wraps the file as an expression.)
+   - **Assert only DETERMINISTIC, browser-observable state** in scripts (DOM/testids, `/api/*` reads).
+     Exact HTTP codes / timing-sensitive races (e.g. 409-while-streaming) belong in the deterministic
+     C# suite (`ConversationsControllerTests`), not a browser race against the fast mock.
+   - **Prompts come from [`PromptExamples.md`](PromptExamples.md)** (mock instruction-chain format). If a
+     new scenario needs a new prompt, ADD it there (see "Manual UI test prompts (conversation UX)") and
+     reference it from the script — don't invent throwaway prompts inline.
+   - [`PlaywrightTestingGuide.md`](PlaywrightTestingGuide.md) holds the selector cross-reference and the
+     older prose recipes; prefer promoting any keeper prose recipe into a runnable `.mjs`.
 
 ### Control the browser the FASTEST way possible
+- **Prefer a whole-flow script over individual round-trips.** One `browser_run_code_unsafe({filename})`
+  that drives the flow and returns `{ pass, failures, steps }` beats a dozen snapshot/click/evaluate
+  calls (see point 2 above). Iterate by editing the `.mjs` file and re-running the one call.
 - **Select by `data-testid`, never by brittle CSS classes.** The stable contract (see `UiHelpers.cs`):
-  `chat-input-textarea`, `send-button`, `stop-button`, `clear-button`, `error-banner`,
+  `chat-input-textarea`, `send-button`, `stop-button`, `queue-button`, `clear-button`, `error-banner`,
   `message-list`, `user-message-group`, `assistant-message-group`, `assistant-text` (the answer
   bubble — equals the `.text-bubble` element), `metadata-pill`, `thinking-pill`, `tool-call-pill`
   (carries `data-tool-name`), `mode-selector-button` / `mode-option-{id}`,
-  `provider-selector-button` / `provider-option-{id}`.
+  `provider-selector-button` / `provider-option-{id}`. (`conversation-item` carries `data-thread-id`;
+  the pending "Waiting to send…" list is `.pending-queue`.)
 - **Bulk-extract DOM state in ONE `browser_evaluate` call** instead of many snapshot/locator
   round-trips. e.g. count answer bubbles (the duplicate-bubble check):
   ```js

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ChatLayout.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ChatLayout.test.ts
@@ -25,7 +25,9 @@ const sharedMocks = vi.hoisted(() => ({
   switchMode: vi.fn(),
   disconnectWebSocket: vi.fn(),
   selectProvider: vi.fn(),
+  switchProvider: vi.fn(async () => {}),
   selectWorkspace: vi.fn(),
+  addOrUpdateConversation: vi.fn(),
   resumeStreamIfActive: vi.fn(async () => {}),
 }));
 
@@ -40,7 +42,7 @@ vi.mock('@/composables/useConversations', async () => {
       createNewConversation: vi.fn(() => 'thread-new'),
       selectConversation: vi.fn(),
       removeConversation: vi.fn(async () => {}),
-      addOrUpdateConversation: vi.fn(),
+      addOrUpdateConversation: sharedMocks.addOrUpdateConversation,
     }),
   };
 });
@@ -140,6 +142,7 @@ vi.mock('@/composables/useProviders', async () => {
       isLoading: ref(false),
       loadProviders: vi.fn(async () => {}),
       selectProvider: sharedMocks.selectProvider,
+      switchProvider: sharedMocks.switchProvider,
     }),
   };
 });
@@ -300,6 +303,84 @@ describe('ChatLayout handleSelectMode start-gating regression', () => {
 
     expect(sharedMocks.switchMode).toHaveBeenCalledWith('thread-1', 'math-helper');
     expect(sharedMocks.selectMode).not.toHaveBeenCalled();
+  });
+});
+
+// Provider is mutable while the conversation is idle and locked only while streaming (mirrors mode).
+// A messageless thread applies the pick locally; a started conversation switches the backend provider
+// and reflects it in the sidebar summary; while streaming the selector is disabled and does neither.
+describe('ChatLayout handleSelectProvider start-gating', () => {
+  const mountWithProviderSelector = () =>
+    mount(ChatLayout, {
+      global: {
+        stubs: {
+          ConversationSidebar: true,
+          MessageList: true,
+          PendingMessageQueue: true,
+          ChatInput: true,
+          ProviderSelector: {
+            props: ['disabled'],
+            template:
+              '<button data-test="provider-select" :disabled="disabled" @click="$emit(\'select-provider\', \'openai\')">Provider</button>',
+          },
+        },
+      },
+    });
+
+  beforeEach(() => {
+    sharedMocks.chatLoading = false;
+    sharedMocks.isSending = false;
+    sharedMocks.selectProvider.mockReset();
+    sharedMocks.switchProvider.mockReset();
+    sharedMocks.disconnectWebSocket.mockReset();
+    sharedMocks.addOrUpdateConversation.mockReset();
+  });
+
+  it('applies the provider locally (no backend switch) on a messageless thread', async () => {
+    sharedMocks.currentThreadId = 'thread-new';
+    sharedMocks.conversations = [];
+
+    const wrapper = mountWithProviderSelector();
+    await flushPromises();
+    await wrapper.get('[data-test="provider-select"]').trigger('click');
+    await flushPromises();
+
+    expect(sharedMocks.selectProvider).toHaveBeenCalledWith('openai');
+    expect(sharedMocks.switchProvider).not.toHaveBeenCalled();
+    expect(sharedMocks.disconnectWebSocket).not.toHaveBeenCalled();
+  });
+
+  it('switches the provider on the backend once the thread has started, and updates the summary', async () => {
+    sharedMocks.currentThreadId = 'thread-1';
+    sharedMocks.conversations = [{ threadId: 'thread-1', provider: 'test' } as ConversationSummary];
+
+    const wrapper = mountWithProviderSelector();
+    await flushPromises();
+    await wrapper.get('[data-test="provider-select"]').trigger('click');
+    await flushPromises();
+
+    expect(sharedMocks.disconnectWebSocket).toHaveBeenCalled();
+    expect(sharedMocks.switchProvider).toHaveBeenCalledWith('thread-1', 'openai');
+    expect(sharedMocks.selectProvider).not.toHaveBeenCalled();
+    // The sidebar summary is updated to the new provider so restore-on-refresh reflects it.
+    expect(sharedMocks.addOrUpdateConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: 'thread-1', provider: 'openai' })
+    );
+  });
+
+  it('does nothing while a run is streaming (selector disabled)', async () => {
+    sharedMocks.currentThreadId = 'thread-1';
+    sharedMocks.conversations = [{ threadId: 'thread-1', provider: 'test' } as ConversationSummary];
+    sharedMocks.chatLoading = true; // streaming
+
+    const wrapper = mountWithProviderSelector();
+    await flushPromises();
+    // The stubbed selector button is disabled; invoking the handler directly must also no-op.
+    await wrapper.get('[data-test="provider-select"]').trigger('click');
+    await flushPromises();
+
+    expect(sharedMocks.switchProvider).not.toHaveBeenCalled();
+    expect(sharedMocks.selectProvider).not.toHaveBeenCalled();
   });
 });
 

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ProviderSelector.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ProviderSelector.test.ts
@@ -73,6 +73,43 @@ describe('ProviderSelector grouping', () => {
   });
 });
 
+describe('ProviderSelector disabled state', () => {
+  // While a run streams the parent passes disabled=true; provider is editable only when idle.
+  it('disables the selector button when disabled is true', () => {
+    const wrapper = mount(ProviderSelector, {
+      props: { providers, selectedProviderId: 'openai', disabled: true },
+    });
+    expect(wrapper.get('.selector-btn').attributes('disabled')).toBeDefined();
+  });
+
+  it('does not open the dropdown when disabled is true', async () => {
+    const wrapper = mount(ProviderSelector, {
+      props: { providers, selectedProviderId: 'openai', disabled: true },
+    });
+    await wrapper.get('.selector-btn').trigger('click');
+    expect(wrapper.find('.dropdown-menu').exists()).toBe(false);
+  });
+
+  it('does not emit select-provider when disabled', async () => {
+    const wrapper = mount(ProviderSelector, {
+      props: { providers, selectedProviderId: 'openai', disabled: true },
+    });
+    await wrapper.get('.selector-btn').trigger('click');
+    expect(wrapper.emitted('select-provider')).toBeUndefined();
+  });
+
+  it('renders an editable dropdown (no permanent lock badge) when idle', async () => {
+    const wrapper = mount(ProviderSelector, {
+      props: { providers, selectedProviderId: 'openai' },
+    });
+    // The old immutable-provider badge is gone; the selector is always a dropdown button.
+    expect(wrapper.find('[data-testid="provider-locked-badge"]').exists()).toBe(false);
+    expect(wrapper.get('.selector-btn').attributes('disabled')).toBeUndefined();
+    await wrapper.get('.selector-btn').trigger('click');
+    expect(wrapper.find('.dropdown-menu').exists()).toBe(true);
+  });
+});
+
 describe('ProviderSelector dropdown scroll', () => {
   // Extract the `.dropdown-menu { ... }` rule body from the scoped stylesheet source.
   const menuRule = (() => {

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useProviders.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useProviders.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { useProviders } from '@/composables/useProviders';
+
+function mockFetchOnce(ok: boolean, body: unknown, status = ok ? 200 : 409) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Conflict',
+    json: async () => body,
+  } as Response);
+}
+
+describe('useProviders.switchProvider', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('POSTs the provider endpoint and reflects the new provider on success', async () => {
+    const fetchSpy = mockFetchOnce(true, { providerId: 'openai' });
+    const p = useProviders();
+
+    await p.switchProvider('thread-1', 'openai');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/conversations/thread-1/provider',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ providerId: 'openai' }),
+      })
+    );
+    expect(p.selectedProviderId.value).toBe('openai');
+    expect(p.error.value).toBeNull();
+  });
+
+  it('re-throws and sets error without changing the selection on failure (409 while streaming)', async () => {
+    mockFetchOnce(false, { error: 'Cannot switch provider while response is streaming.' }, 409);
+    const p = useProviders();
+    p.selectedProviderId.value = 'test';
+
+    await expect(p.switchProvider('thread-1', 'openai')).rejects.toThrow(/streaming/);
+
+    expect(p.selectedProviderId.value).toBe('test'); // selection unchanged on failure
+    expect(p.error.value).toMatch(/streaming/);
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/api/providersApi.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/api/providersApi.ts
@@ -1,4 +1,4 @@
-import type { ProvidersResponse } from '@/types/providers';
+import type { ProvidersResponse, SwitchProviderResponse } from '@/types/providers';
 
 /**
  * Fetches the list of providers available in the current process and the default
@@ -8,6 +8,29 @@ export async function listProviders(): Promise<ProvidersResponse> {
   const response = await fetch('/api/providers');
   if (!response.ok) {
     throw new Error(`Failed to fetch providers: ${response.statusText}`);
+  }
+  return response.json();
+}
+
+/**
+ * Switches a conversation's provider. Allowed only while the conversation is idle: the backend
+ * answers 409 while a run streams and 503 when the target provider is unavailable.
+ */
+export async function switchConversationProvider(
+  threadId: string,
+  providerId: string
+): Promise<SwitchProviderResponse> {
+  const response = await fetch(
+    `/api/conversations/${encodeURIComponent(threadId)}/provider`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ providerId }),
+    }
+  );
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || `Failed to switch provider: ${response.statusText}`);
   }
   return response.json();
 }

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
@@ -52,6 +52,7 @@ const {
   isLoading: providersLoading,
   loadProviders,
   selectProvider,
+  switchProvider,
 } = useProviders();
 
 // Workspace catalog + per-process selection for new conversations.
@@ -102,33 +103,53 @@ provide('getResultForToolCall', getResultForToolCall);
 
 const sidebarCollapsed = ref(false);
 const isSwitchingMode = ref(false);
+const isSwitchingProvider = ref(false);
 const marketplaceModalOpen = ref(false);
 const modeSwitchDisabled = computed(
   () => modesLoading.value || chatLoading.value || isSending.value || isSwitchingMode.value
 );
 
 /**
- * Provider id locked to the current thread, derived from the conversation summary
- * (populated from <c>ThreadMetadata.Properties["provider"]</c>). A thread becomes
- * "locked" the moment it appears in the sidebar — i.e. after its first message —
- * and stays locked for the rest of its life. New conversations have no sidebar
- * entry yet, so this resolves to <c>null</c> and the dropdown stays editable.
+ * The provider selector is editable while the conversation is idle and locked ONLY while a run is
+ * streaming (mirrors mode). A brand-new, messageless thread applies the pick locally; a started
+ * conversation switches the backend provider (which recreates the agent). There is no permanent
+ * per-thread lock — provider is mutable once the run completes.
  */
-const lockedProviderId = computed<string | null>(() => {
-  if (!currentThreadId.value) return null;
-  const conversation = conversations.value.find((c) => c.threadId === currentThreadId.value);
-  return conversation?.provider ?? null;
-});
-
 const providerSelectorDisabled = computed(
-  () => providersLoading.value || chatLoading.value || isSending.value || isSwitchingMode.value
+  () => providersLoading.value || chatLoading.value || isSending.value || isSwitchingProvider.value
 );
 
-function handleSelectProvider(providerId: string): void {
-  if (providerSelectorDisabled.value || lockedProviderId.value) {
+async function handleSelectProvider(providerId: string): Promise<void> {
+  if (providerSelectorDisabled.value) {
     return;
   }
-  selectProvider(providerId);
+
+  // Mirror handleSelectMode: only switch on the backend once the conversation has actually started
+  // (has a sidebar entry). A messageless thread just records the pick locally for the first send.
+  const started =
+    !!currentThreadId.value &&
+    conversations.value.some((c) => c.threadId === currentThreadId.value);
+
+  if (started) {
+    isSwitchingProvider.value = true;
+    try {
+      await disconnectWebSocket();
+      await switchProvider(currentThreadId.value!, providerId);
+      // Reflect the switched-to provider in the sidebar summary so the Bug-3 restore path
+      // (restoreBindingsFromConversation on select / refresh) shows the new provider.
+      const existing = conversations.value.find((c) => c.threadId === currentThreadId.value);
+      if (existing) {
+        addOrUpdateConversation({ ...existing, provider: providerId });
+      }
+    } catch (e) {
+      console.error('Failed to switch provider:', e);
+    } finally {
+      isSwitchingProvider.value = false;
+    }
+  } else {
+    // Messageless thread: defer agent creation to the first send.
+    selectProvider(providerId);
+  }
 }
 
 /**
@@ -447,7 +468,6 @@ onBeforeUnmount(() => {
             <ProviderSelector
               :providers="providers"
               :selected-provider-id="selectedProviderId"
-              :locked-provider-id="lockedProviderId"
               :is-loading="providersLoading"
               :disabled="providerSelectorDisabled"
               @select-provider="handleSelectProvider"

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ProviderSelector.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ProviderSelector.vue
@@ -5,12 +5,12 @@ import type { ProviderDescriptor } from '@/types/providers';
 const props = defineProps<{
   providers: ProviderDescriptor[];
   selectedProviderId: string | null;
-  /**
-   * Provider id locked to the current thread (set after the first message). When
-   * provided, the selector renders as a read-only badge instead of a dropdown.
-   */
-  lockedProviderId?: string | null;
   isLoading?: boolean;
+  /**
+   * Disables the selector. The parent sets this while a run is streaming (provider is mutable only
+   * when the conversation is idle); when idle the dropdown is editable and a pick switches the
+   * conversation's provider on the backend.
+   */
   disabled?: boolean;
 }>();
 
@@ -20,19 +20,6 @@ const emit = defineEmits<{
 
 const dropdownOpen = ref(false);
 const dropdownRef = ref<HTMLElement | null>(null);
-
-const isLocked = computed(() => !!props.lockedProviderId);
-
-const lockedProvider = computed<ProviderDescriptor | null>(() => {
-  if (!props.lockedProviderId) return null;
-  return (
-    props.providers.find((p) => p.id === props.lockedProviderId) ?? {
-      id: props.lockedProviderId,
-      displayName: props.lockedProviderId,
-      available: false,
-    }
-  );
-});
 
 const selectedProvider = computed<ProviderDescriptor | null>(() =>
   props.providers.find((p) => p.id === props.selectedProviderId) ?? null
@@ -77,7 +64,7 @@ const groupedProviders = computed<ProviderGroup[]>(() => {
 });
 
 function toggleDropdown(): void {
-  if (props.disabled || props.isLoading || isLocked.value) {
+  if (props.disabled || props.isLoading) {
     return;
   }
   dropdownOpen.value = !dropdownOpen.value;
@@ -88,7 +75,7 @@ function closeDropdown(): void {
 }
 
 function handleSelect(providerId: string): void {
-  if (props.disabled || isLocked.value) {
+  if (props.disabled) {
     return;
   }
   emit('select-provider', providerId);
@@ -118,9 +105,9 @@ onUnmounted(() => {
 });
 
 watch(
-  () => [props.disabled, props.lockedProviderId] as const,
-  ([isDisabled, locked]) => {
-    if (isDisabled || locked) {
+  () => props.disabled,
+  (isDisabled) => {
+    if (isDisabled) {
       closeDropdown();
     }
   }
@@ -129,62 +116,50 @@ watch(
 
 <template>
   <div class="provider-selector" ref="dropdownRef" data-testid="provider-selector">
-    <span
-      v-if="isLocked"
-      class="provider-badge"
-      data-testid="provider-locked-badge"
-      :title="`This conversation is locked to ${lockedProvider?.displayName ?? lockedProviderId}`"
+    <button
+      class="selector-btn"
+      :class="{ open: dropdownOpen }"
+      data-testid="provider-selector-button"
+      @click="toggleDropdown"
+      :disabled="isLoading || disabled"
     >
-      <span class="badge-label">Provider:</span>
-      <span class="badge-name">{{ lockedProvider?.displayName ?? lockedProviderId }}</span>
-      <span class="badge-lock" aria-hidden="true">🔒</span>
-    </span>
-    <template v-else>
-      <button
-        class="selector-btn"
-        :class="{ open: dropdownOpen }"
-        data-testid="provider-selector-button"
-        @click="toggleDropdown"
-        :disabled="isLoading || disabled"
-      >
-        <span class="provider-label">Provider:</span>
-        <span class="provider-name">{{ selectedProvider?.displayName ?? 'Loading...' }}</span>
-        <span class="dropdown-arrow">{{ dropdownOpen ? '\u25B2' : '\u25BC' }}</span>
-      </button>
+      <span class="provider-label">Provider:</span>
+      <span class="provider-name">{{ selectedProvider?.displayName ?? 'Loading...' }}</span>
+      <span class="dropdown-arrow">{{ dropdownOpen ? '▲' : '▼' }}</span>
+    </button>
 
-      <div v-if="dropdownOpen" class="dropdown-menu">
-        <template v-for="group in groupedProviders" :key="group.label ?? '__ungrouped__'">
-          <div
-            v-if="group.label"
-            class="menu-group-header"
-            :data-testid="`provider-group-${group.label}`"
-            role="presentation"
-          >
-            {{ group.label }}
-          </div>
-          <button
-            v-for="provider in group.providers"
-            :key="provider.id"
-            class="menu-item"
-            :class="{ active: provider.id === selectedProviderId, unavailable: !provider.available }"
-            :data-testid="`provider-option-${provider.id}`"
-            :disabled="disabled || !provider.available"
-            :title="provider.knownLimitation ?? undefined"
-            @click="handleSelect(provider.id)"
-          >
-            <span class="item-name">{{ provider.displayName }}</span>
-            <span
-              v-if="provider.available && provider.knownLimitation"
-              class="item-warning"
-              :data-testid="`provider-warning-${provider.id}`"
-              aria-label="known limitation"
-            >⚠</span>
-            <span v-if="!provider.available" class="item-status">unavailable</span>
-            <span v-else-if="provider.id === selectedProviderId" class="check-mark">✓</span>
-          </button>
-        </template>
-      </div>
-    </template>
+    <div v-if="dropdownOpen" class="dropdown-menu">
+      <template v-for="group in groupedProviders" :key="group.label ?? '__ungrouped__'">
+        <div
+          v-if="group.label"
+          class="menu-group-header"
+          :data-testid="`provider-group-${group.label}`"
+          role="presentation"
+        >
+          {{ group.label }}
+        </div>
+        <button
+          v-for="provider in group.providers"
+          :key="provider.id"
+          class="menu-item"
+          :class="{ active: provider.id === selectedProviderId, unavailable: !provider.available }"
+          :data-testid="`provider-option-${provider.id}`"
+          :disabled="disabled || !provider.available"
+          :title="provider.knownLimitation ?? undefined"
+          @click="handleSelect(provider.id)"
+        >
+          <span class="item-name">{{ provider.displayName }}</span>
+          <span
+            v-if="provider.available && provider.knownLimitation"
+            class="item-warning"
+            :data-testid="`provider-warning-${provider.id}`"
+            aria-label="known limitation"
+          >⚠</span>
+          <span v-if="!provider.available" class="item-status">unavailable</span>
+          <span v-else-if="provider.id === selectedProviderId" class="check-mark">✓</span>
+        </button>
+      </template>
+    </div>
   </div>
 </template>
 
@@ -336,31 +311,5 @@ watch(
   font-weight: bold;
   flex-shrink: 0;
   margin-left: 8px;
-}
-
-.provider-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  background: #eef1f5;
-  border: 1px solid #d0d7de;
-  border-radius: 6px;
-  font-size: 13px;
-  color: #444;
-}
-
-.badge-label {
-  color: #666;
-}
-
-.badge-name {
-  color: #333;
-  font-weight: 500;
-}
-
-.badge-lock {
-  font-size: 12px;
-  opacity: 0.8;
 }
 </style>

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useProviders.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useProviders.ts
@@ -1,15 +1,16 @@
 import { ref, computed } from 'vue';
 import type { ProviderDescriptor } from '@/types/providers';
-import { listProviders } from '@/api/providersApi';
+import { listProviders, switchConversationProvider } from '@/api/providersApi';
 
 /**
  * Composable that loads the provider catalog from the backend and exposes the
- * user's currently-selected provider for the next new conversation.
+ * user's currently-selected provider.
  *
- * The selection is intentionally process-local: the backend treats a thread's
- * provider as immutable once the thread has its first message, so this state
- * only matters until that point. After the first message we read the locked
- * value from the conversation's metadata instead.
+ * For a NEW (messageless) conversation the selection is process-local and simply
+ * chooses the provider the first message will bind. Once a conversation has started
+ * its provider is mutable ONLY while idle: switching it calls {@link switchProvider}
+ * (POST .../provider), which recreates the agent on the backend. While a run streams
+ * the selector is locked (the backend answers 409).
  */
 export function useProviders() {
   const providers = ref<ProviderDescriptor[]>([]);
@@ -66,6 +67,23 @@ export function useProviders() {
   }
 
   /**
+   * Switches the given (started) conversation's provider on the backend, then reflects it locally.
+   * Mirrors useChatModes.switchMode. Re-throws so the caller (ChatLayout) can surface the failure
+   * and leave the selection unchanged — the backend answers 409 while streaming and 503 when the
+   * target provider is unavailable.
+   */
+  async function switchProvider(threadId: string, providerId: string): Promise<void> {
+    try {
+      await switchConversationProvider(threadId, providerId);
+      selectedProviderId.value = providerId;
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to switch provider';
+      console.error('Failed to switch provider:', e);
+      throw e;
+    }
+  }
+
+  /**
    * Look up a descriptor by id. Returns null if the id is unknown — useful for
    * rendering a locked-thread badge when the persisted provider has since been
    * removed from the registry.
@@ -84,6 +102,7 @@ export function useProviders() {
     error,
     loadProviders,
     selectProvider,
+    switchProvider,
     getProviderById,
   };
 }

--- a/samples/LmStreaming.Sample/ClientApp/src/types/providers.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/types/providers.ts
@@ -26,3 +26,10 @@ export interface ProvidersResponse {
   providers: ProviderDescriptor[];
   default: string;
 }
+
+/**
+ * Response body for POST /api/conversations/{threadId}/provider.
+ */
+export interface SwitchProviderResponse {
+  providerId: string;
+}

--- a/samples/LmStreaming.Sample/Controllers/ConversationsController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ConversationsController.cs
@@ -236,6 +236,99 @@ public class ConversationsController(
     }
 
     /// <summary>
+    /// Switches a conversation's provider. Mirrors <see cref="SwitchMode"/>: the provider is mutable
+    /// while the conversation is idle (its run has completed) and locked only while a run streams.
+    /// The thread's current mode and persisted workspace are preserved. An unavailable/unknown target
+    /// provider answers a clean 503 rather than evicting the working agent.
+    /// </summary>
+    [HttpPost("{threadId}/provider")]
+    public async Task<IActionResult> SwitchProvider(
+        string threadId,
+        [FromBody] SwitchProviderRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var runState = agentPool.GetRunStateInfo(threadId);
+        if (runState.IsInProgress)
+        {
+            logger.LogWarning(
+                "Blocked provider switch for thread {ThreadId} to provider {ProviderId} because a run is in progress. CurrentRunId={CurrentRunId}, AgentIsRunning={AgentIsRunning}, RunTaskCompleted={RunTaskCompleted}, IsStale={IsStale}",
+                threadId,
+                request.ProviderId,
+                runState.CurrentRunId,
+                runState.AgentIsRunning,
+                runState.RunTaskCompleted,
+                runState.IsStale);
+            return Conflict(
+                new
+                {
+                    error = "Cannot switch provider while response is streaming.",
+                    code = "provider_switch_while_streaming",
+                    threadId,
+                });
+        }
+
+        // Preserve the thread's current mode across the provider swap. Prefer the live agent's mode;
+        // fall back to the persisted mode id (then the system default) if the agent was evicted.
+        var currentMode = agentPool.GetAgentMode(threadId);
+        if (currentMode == null)
+        {
+            var metadata = await store.LoadMetadataAsync(threadId, ct);
+            var persistedModeId =
+                metadata?.Properties?.TryGetValue(MultiTurnAgentPool.ModePropertyKey, out var modeObj) == true
+                    ? modeObj?.ToString()
+                    : null;
+            var chatMode =
+                await modeStore.GetModeAsync(persistedModeId ?? SystemChatModes.DefaultModeId, ct)
+                ?? await modeStore.GetModeAsync(SystemChatModes.DefaultModeId, ct);
+            if (chatMode != null)
+            {
+                currentMode = chatMode; // implicit ChatMode -> AgentProfile (non-null)
+            }
+        }
+
+        if (currentMode == null)
+        {
+            return StatusCode(
+                StatusCodes.Status500InternalServerError,
+                new { error = "Could not resolve the conversation's current mode.", threadId });
+        }
+
+        // Switching to a sandbox-backed provider eagerly reprovisions; a gateway rejection or an
+        // unavailable/unknown provider must answer a clean 503, not crash the request with a 500.
+        try
+        {
+            _ = await agentPool.RecreateAgentWithProviderAsync(threadId, request.ProviderId, currentMode);
+        }
+        catch (ProviderUnavailableException ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Provider switch to {ProviderId} for thread {ThreadId} failed: provider unavailable",
+                request.ProviderId,
+                threadId);
+            return StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                new { error = "provider_unavailable", code = "provider_unavailable", providerId = ex.ProviderId, detail = ex.Message, threadId });
+        }
+        catch (SandboxSessionUnavailableException ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Provider switch to {ProviderId} for thread {ThreadId} failed: sandbox unavailable (gateway status {StatusCode})",
+                request.ProviderId,
+                threadId,
+                ex.StatusCode);
+            return StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                new { error = "sandbox_unavailable", code = "sandbox_unavailable", detail = ex.Message, threadId });
+        }
+
+        return Ok(new { providerId = request.ProviderId });
+    }
+
+    /// <summary>
     /// Fixes legacy persisted messages where content_block_start leaked "{}" into FunctionArgs,
     /// producing invalid JSON like {}{"query":"..."}.
     /// </summary>

--- a/samples/LmStreaming.Sample/Models/ConversationDtos.cs
+++ b/samples/LmStreaming.Sample/Models/ConversationDtos.cs
@@ -62,3 +62,12 @@ public record SwitchModeRequest
 {
     public required string ModeId { get; init; }
 }
+
+/// <summary>
+/// DTO for switching a conversation's provider. Unlike workspace (bound for life), a conversation's
+/// provider is mutable once its run is idle — this carries the target provider id.
+/// </summary>
+public record SwitchProviderRequest
+{
+    public required string ProviderId { get; init; }
+}

--- a/samples/LmStreaming.Sample/PlaywrightTestingGuide.md
+++ b/samples/LmStreaming.Sample/PlaywrightTestingGuide.md
@@ -3,6 +3,14 @@
 This guide provides ready-to-use Playwright scripts for **manual exploratory testing** of the
 LmStreaming Chat Client via the MCP Playwright tools in Claude Code.
 
+> **⚡ Prefer single-call runnable scripts.** For recurring manual checks, use / add a self-contained
+> script in [`playwright-scripts/`](playwright-scripts/) and run the WHOLE flow in ONE call:
+> `browser_run_code_unsafe({ filename: "samples/LmStreaming.Sample/playwright-scripts/<name>.mjs" })`.
+> It returns `{ pass, failures, steps }`. Do **not** drive the UI with snapshot→act→screenshot loops —
+> that is slow and token-heavy. The prose recipes below remain a **selector/pattern reference**; when a
+> recipe is worth keeping, promote it into a runnable `.mjs`. Prompts live in
+> [`PromptExamples.md`](PromptExamples.md). Full policy: `CLAUDE.md` → "UI / browser testing".
+
 > **Automated browser E2E tests** live in
 > [`tests/LmStreaming.Sample.Browser.E2E.Tests/`](../../tests/LmStreaming.Sample.Browser.E2E.Tests/)
 > and run the same chat client under headless Chromium + a scripted SSE backend (no real

--- a/samples/LmStreaming.Sample/PromptExamples.md
+++ b/samples/LmStreaming.Sample/PromptExamples.md
@@ -334,6 +334,47 @@ src/LmTestUtils/TestMode/InstructionChainParser.cs
 
 ---
 
+## Manual UI test prompts (conversation UX)
+
+Prompts for the **manual/exploratory Playwright smoke checks** in
+[`playwright-scripts/`](playwright-scripts/) (run one-shot via
+`browser_run_code_unsafe({ filename: … })` — see CLAUDE.md "UI / browser testing"). These target the
+conversation-UX features (provider switch, Queue button, conversation switching, streaming resume)
+rather than a specific tool. Use two MOCK providers so there are no real LLM calls:
+`test-anthropic` (streams text — the client keeps rendering, giving a **wide, reliable streaming
+window**) and `claude-mock` (completes silently — proves a recreated agent runs a new turn).
+
+### Long streamed reply (wide streaming window)
+
+A ~300-word text reply keeps the composer in the streaming state for a few seconds — long enough to
+observe "disabled while streaming", type a Queue follow-up, or attempt a mid-stream action. **Do not
+use much larger lengths** (e.g. 2000): the client renders every word and the run can take >60s to go
+idle, tripping wait timeouts.
+<|instruction_start|>{"instruction_chain":[{"id":"long-text","id_message":"Long response","messages":[{"text_message":{"length":300}}]}]}<|instruction_end|>
+
+### Short reply (fast completion)
+
+For a quick turn (e.g. proving a switched-to provider runs a new turn):
+<|instruction_start|>{"instruction_chain":[{"id":"short","id_message":"Short","messages":[{"text_message":{"length":20}}]}]}<|instruction_end|>
+
+### Queue follow-up (plain text)
+
+Any plain (non-instruction) text typed mid-stream is what the blue **Queue** button queues. The scripts
+use a literal string, e.g. `a queued follow-up typed mid-stream`.
+
+### What the scripts assert (deterministic, browser-observable)
+- **provider-switch.mjs** — streaming ⇒ provider selector DISABLED + no `provider-locked-badge`; idle ⇒
+  editable dropdown; switch when idle ⇒ `/api/conversations` shows the new `provider` + the label
+  updates; a new turn runs on the recreated agent. (The 409-while-streaming / 503-unavailable HTTP
+  codes are covered deterministically by `ConversationsControllerTests`, not the browser.)
+- **queue-button.mjs** — streaming + empty box ⇒ red `stop-button`; streaming + typed text ⇒ blue
+  `queue-button` replaces Stop; click Queue ⇒ box clears + message enters the `.pending-queue`
+  "Waiting to send…" list + reverts to Stop.
+
+> If a new manual scenario needs a new prompt, add it in this section and reference it from the script.
+
+---
+
 ## Codex Mode Prompt Examples
 
 These prompts are for `LM_PROVIDER_MODE=codex`.

--- a/samples/LmStreaming.Sample/playwright-scripts/README.md
+++ b/samples/LmStreaming.Sample/playwright-scripts/README.md
@@ -1,0 +1,41 @@
+# Playwright manual smoke scripts
+
+Single-call Playwright scripts for **manual/exploratory** UI verification of the LmStreaming chat
+client. Each script drives a whole flow and returns structured JSON — **run it in ONE call**, do NOT
+re-drive the UI with snapshot→act→screenshot loops (that is slow and token-heavy).
+
+## Run
+
+With the app running (dev instance: backend `:5098` + Vite `:5273` — adjust `BASE` in the script if
+your ports differ), invoke via the Playwright MCP:
+
+```
+browser_run_code_unsafe({ filename: "samples/LmStreaming.Sample/playwright-scripts/provider-switch.mjs" })
+```
+
+The result is `{ pass, failures, steps }`. `pass:true` means every assertion held; otherwise `failures`
+lists the failing step names and each `steps[].detail` has the observed values.
+
+## Scripts
+
+| Script | Feature under test |
+|--------|--------------------|
+| `provider-switch.mjs` | Switch a conversation's provider when idle; selector locked (disabled) while streaming; no permanent lock badge; switch persists + recreates the agent. |
+| `queue-button.mjs` | Blue **Queue** button replaces red Stop while streaming when the composer has text; clicking Queue clears the box and enqueues the message. |
+
+## Conventions (so these stay fast + reliable)
+
+- **File format:** a single self-contained `async (page) => { … return { pass, failures, steps } }`
+  arrow function. **No trailing `;`** after it — the runner wraps the file as an expression.
+- **Assert only DETERMINISTIC, browser-observable state** (DOM/`data-testid`, `/api/*` reads). Exact
+  HTTP status codes and timing-sensitive races (e.g. 409-while-streaming) belong in the deterministic
+  C# suite (`tests/LmStreaming.Sample.Tests`), not a browser race against the fast mock.
+- **Wait on state, not time** (`stop-button` visible = streaming; `send-button` visible = idle).
+- **Mock providers only** (`test-anthropic` streams text with a wide window; `claude-mock` completes
+  silently) — no real LLM calls.
+- **Prompts live in [`../PromptExamples.md`](../PromptExamples.md)** → "Manual UI test prompts
+  (conversation UX)". Add new prompts there, not inline.
+- **Add a script per recurring manual case** instead of re-driving by hand. Promote any keeper check
+  into `tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/*.cs` when it should run in CI.
+
+See `../CLAUDE.md` → "UI / browser testing" for the full policy and the `data-testid` selector contract.

--- a/samples/LmStreaming.Sample/playwright-scripts/provider-switch.mjs
+++ b/samples/LmStreaming.Sample/playwright-scripts/provider-switch.mjs
@@ -1,0 +1,117 @@
+// provider-switch.mjs — single-call Playwright smoke check for "switch a conversation's provider
+// when idle" (locked while streaming). Runs the WHOLE flow in ONE call and returns structured JSON:
+//
+//   browser_run_code_unsafe({ filename: "samples/LmStreaming.Sample/playwright-scripts/provider-switch.mjs" })
+//
+// Returns { pass, failures, steps }. Do NOT drive this with snapshot->act->screenshot loops — that is
+// slow and token-heavy. Assert only DETERMINISTIC, browser-observable states here; the exact HTTP
+// codes (409 while streaming / 503 unavailable) are covered deterministically by
+// tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerTests.cs (a browser race against
+// the fast mock is unreliable for those).
+//
+// Prereqs: app running (adjust BASE). Uses MOCK providers only (no real LLM):
+//   A = "test-anthropic" (mock, streams text — client keeps rendering, so "disabled while streaming"
+//       has a wide, reliable window)
+//   B = "claude-mock"    (mock, completes silently — proves the recreated agent runs a new turn)
+// Prompts come from PromptExamples.md → "Manual UI test prompts (conversation UX)".
+async (page) => {
+  const BASE = 'http://localhost:5273';
+  const LONG =
+    '<|instruction_start|>{"instruction_chain":[{"id":"long-text","id_message":"Long response","messages":[{"text_message":{"length":300}}]}]}<|instruction_end|>';
+  const SHORT =
+    '<|instruction_start|>{"instruction_chain":[{"id":"short","id_message":"Short","messages":[{"text_message":{"length":20}}]}]}<|instruction_end|>';
+  const PROVIDER_A = 'test-anthropic';
+  const PROVIDER_B = 'claude-mock';
+
+  const steps = [];
+  const record = (name, pass, detail) => steps.push({ name, pass, detail });
+  const tid = (id) => page.locator(`[data-testid="${id}"]`);
+  const waitStreaming = () => tid('stop-button').waitFor({ state: 'visible', timeout: 15000 });
+  const waitIdle = async () => {
+    await tid('stop-button').waitFor({ state: 'hidden', timeout: 60000 });
+    await tid('send-button').waitFor({ state: 'visible', timeout: 60000 });
+  };
+  const send = async (text) => {
+    await tid('chat-input-textarea').fill(text);
+    await tid('send-button').click();
+  };
+  const threadId = () =>
+    page.evaluate(() =>
+      document.querySelector('[data-testid=conversation-item]')?.getAttribute('data-thread-id') ?? null
+    );
+
+  try {
+    // 1. Fresh chat; pick the streaming mock provider BEFORE the first send.
+    await page.goto(BASE);
+    await tid('chat-input-textarea').waitFor({ timeout: 20000 });
+    await page.getByRole('button', { name: '+ New Chat' }).click();
+    await tid('provider-selector-button').click();
+    await tid(`provider-option-${PROVIDER_A}`).click();
+
+    // 2. Streaming -> the selector is DISABLED and there is NO permanent lock badge (client-side gate).
+    await send(LONG);
+    await waitStreaming();
+    const midDom = await page.evaluate(() => ({
+      streaming: !!document.querySelector('[data-testid=stop-button]'),
+      providerBtnDisabled: document.querySelector('[data-testid=provider-selector-button]')?.disabled === true,
+      hasLockedBadge: !!document.querySelector('[data-testid=provider-locked-badge]'),
+    }));
+    record(
+      'disabled-while-streaming (no lock badge)',
+      midDom.streaming && midDom.providerBtnDisabled && !midDom.hasLockedBadge,
+      midDom
+    );
+
+    // 3. Idle -> the selector is an editable dropdown (no lock badge, button enabled).
+    await waitIdle();
+    await tid('provider-selector-button').click();
+    const idleDom = await page.evaluate(() => ({
+      dropdownOpen: !!document.querySelector('.dropdown-menu'),
+      hasLockedBadge: !!document.querySelector('[data-testid=provider-locked-badge]'),
+      btnDisabled: document.querySelector('[data-testid=provider-selector-button]')?.disabled === true,
+    }));
+    record(
+      'editable-when-idle (dropdown, no badge)',
+      idleDom.dropdownOpen && !idleDom.hasLockedBadge && !idleDom.btnDisabled,
+      idleDom
+    );
+
+    // 4. Switch provider while idle -> persisted in /api/conversations + label updates (POST 200).
+    const id = await threadId();
+    await tid(`provider-option-${PROVIDER_B}`).click();
+    await waitIdle();
+    const afterSwitch = await page.evaluate(async (t) => {
+      const deadline = Date.now() + 8000;
+      let c;
+      while (Date.now() < deadline) {
+        const list = await (await fetch('/api/conversations')).json();
+        c = (list.conversations || list).find((x) => x.threadId === t);
+        if (c?.provider === 'claude-mock') break;
+        await new Promise((res) => setTimeout(res, 200));
+      }
+      return {
+        persistedProvider: c?.provider,
+        label: document.querySelector('[data-testid=provider-selector-button]')?.textContent?.trim(),
+      };
+    }, id);
+    record(
+      'switch-when-idle (persisted + label)',
+      afterSwitch.persistedProvider === 'claude-mock' && /claude/i.test(afterSwitch.label ?? ''),
+      afterSwitch
+    );
+
+    // 5. A new turn runs on the recreated (switched) agent — the run reaches idle and the user turn is
+    //    recorded (claude-mock completes silently, so we assert completion, not assistant text).
+    const userBefore = await tid('user-message-group').count();
+    await send(SHORT);
+    await waitStreaming().catch(() => {});
+    await waitIdle();
+    const userAfter = await tid('user-message-group').count();
+    record('new-turn-on-switched-provider (completes)', userAfter > userBefore, { userBefore, userAfter });
+  } catch (e) {
+    record('exception', false, String((e && e.stack) || e));
+  }
+
+  const failures = steps.filter((s) => !s.pass).map((s) => s.name);
+  return { pass: failures.length === 0, failures, steps };
+}

--- a/samples/LmStreaming.Sample/playwright-scripts/queue-button.mjs
+++ b/samples/LmStreaming.Sample/playwright-scripts/queue-button.mjs
@@ -1,0 +1,77 @@
+// queue-button.mjs — single-call Playwright smoke check for the "Queue button while streaming" feature
+// (Bug 4). Runs the WHOLE flow in ONE call, returns { pass, failures, steps }:
+//
+//   browser_run_code_unsafe({ filename: "samples/LmStreaming.Sample/playwright-scripts/queue-button.mjs" })
+//
+// Do NOT drive this with snapshot->act->screenshot loops. Deterministic browser-observable states only.
+// Prereqs: app running (adjust BASE). Uses the test-anthropic MOCK (no real LLM). The 300-word reply
+// keeps the client rendering long enough that the composer stays in the streaming state while we type.
+async (page) => {
+  const BASE = 'http://localhost:5273';
+  const LONG =
+    '<|instruction_start|>{"instruction_chain":[{"id":"long-text","id_message":"Long response","messages":[{"text_message":{"length":300}}]}]}<|instruction_end|>';
+  const FOLLOW_UP = 'a queued follow-up typed mid-stream';
+  const PROVIDER = 'test-anthropic';
+
+  const steps = [];
+  const record = (name, pass, detail) => steps.push({ name, pass, detail });
+  const tid = (id) => page.locator(`[data-testid="${id}"]`);
+  const waitStreaming = () => tid('stop-button').waitFor({ state: 'visible', timeout: 15000 });
+
+  try {
+    // 1. Fresh chat on the streaming mock; start a long run.
+    await page.goto(BASE);
+    await tid('chat-input-textarea').waitFor({ timeout: 20000 });
+    await page.getByRole('button', { name: '+ New Chat' }).click();
+    await tid('provider-selector-button').click();
+    await tid(`provider-option-${PROVIDER}`).click();
+    await tid('chat-input-textarea').fill(LONG);
+    await tid('send-button').click();
+    await waitStreaming();
+
+    // 2. Streaming + empty box -> red Stop, no Queue.
+    const empty = await page.evaluate(() => ({
+      hasStop: !!document.querySelector('[data-testid=stop-button]'),
+      hasQueue: !!document.querySelector('[data-testid=queue-button]'),
+    }));
+    record('streaming-empty-box (Stop, no Queue)', empty.hasStop && !empty.hasQueue, empty);
+
+    // 3. Streaming + text typed -> blue Queue replaces Stop.
+    await tid('chat-input-textarea').fill(FOLLOW_UP);
+    await tid('queue-button').waitFor({ state: 'visible', timeout: 5000 });
+    const typed = await page.evaluate(() => ({
+      hasQueue: !!document.querySelector('[data-testid=queue-button]'),
+      hasStop: !!document.querySelector('[data-testid=stop-button]'),
+      queueLabel: document.querySelector('[data-testid=queue-button]')?.textContent?.trim(),
+    }));
+    record(
+      'streaming-with-text (Queue replaces Stop)',
+      typed.hasQueue && !typed.hasStop && /queue/i.test(typed.queueLabel ?? ''),
+      typed
+    );
+
+    // 4. Click Queue -> box clears, message enters the pending "Waiting to send…" list, button reverts
+    //    to Stop (the run is still streaming and the box is now empty).
+    await tid('queue-button').click();
+    await tid('stop-button').waitFor({ state: 'visible', timeout: 5000 });
+    const afterQueue = await page.evaluate(() => ({
+      textareaEmpty: (document.querySelector('[data-testid=chat-input-textarea]')?.value ?? 'x') === '',
+      hasStop: !!document.querySelector('[data-testid=stop-button]'),
+      hasQueue: !!document.querySelector('[data-testid=queue-button]'),
+      pendingText: [...document.querySelectorAll('.pending-queue')].map((n) => n.textContent.trim()).join(' '),
+    }));
+    record(
+      'click-Queue (box clears, pending, reverts to Stop)',
+      afterQueue.textareaEmpty &&
+        afterQueue.hasStop &&
+        !afterQueue.hasQueue &&
+        afterQueue.pendingText.includes('queued follow-up'),
+      afterQueue
+    );
+  } catch (e) {
+    record('exception', false, String((e && e.stack) || e));
+  }
+
+  const failures = steps.filter((s) => !s.pass).map((s) => s.name);
+  return { pass: failures.length === 0, failures, steps };
+}

--- a/src/LmAgentInfra/Agents/MultiTurnAgentPool.cs
+++ b/src/LmAgentInfra/Agents/MultiTurnAgentPool.cs
@@ -15,16 +15,19 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
 {
     /// <summary>
     /// Property key in <see cref="ThreadMetadata.Properties"/> that stores the provider
-    /// id chosen for a thread. Once set, the value is treated as immutable for the
-    /// lifetime of that thread (a thread is "locked" to a single provider).
+    /// id chosen for a thread. Seeded on first creation and treated as immutable for plain
+    /// reconnects (a persisted value wins over a later requested one in
+    /// <see cref="ResolveProviderId"/>), but MUTABLE via a deliberate provider switch on an idle
+    /// conversation (<see cref="RecreateAgentWithProviderAsync"/>), which overwrites it so a later
+    /// refresh restores the switched-to provider.
     /// </summary>
     public const string ProviderPropertyKey = "provider";
 
     /// <summary>
     /// Property key in <see cref="ThreadMetadata.Properties"/> that stores the workspace id
     /// chosen for a thread. Persisted on first creation, then treated as immutable for the
-    /// lifetime of that thread (persisted value wins over a later requested value), mirroring
-    /// <see cref="ProviderPropertyKey"/>.
+    /// lifetime of that thread (persisted value wins over a later requested value) and — unlike
+    /// the provider — never changed by a switch: a thread stays bound to its workspace for life.
     /// </summary>
     public const string WorkspacePropertyKey = "workspace";
 
@@ -533,43 +536,9 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
     /// Overwrites the persisted mode for a thread (a deliberate, mutable mode switch). Provider and
     /// workspace are left untouched.
     /// </summary>
-    private async Task PersistModeAsync(string threadId, string? modeId)
+    private Task PersistModeAsync(string threadId, string? modeId)
     {
-        if (_conversationStore == null || string.IsNullOrWhiteSpace(modeId))
-        {
-            return;
-        }
-
-        try
-        {
-            await _conversationStore.UpdateMetadataAsync(
-                threadId,
-                existing =>
-                {
-                    var properties = (existing?.Properties ?? ImmutableDictionary<string, object>.Empty)
-                        .SetItem(ModePropertyKey, modeId);
-
-                    return (
-                        existing
-                        ?? new ThreadMetadata
-                        {
-                            ThreadId = threadId,
-                            LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                        }
-                    ) with
-                    {
-                        Properties = properties,
-                        LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                    };
-                }
-            ).ConfigureAwait(false);
-
-            _logger.LogInformation("Persisted mode {ModeId} for thread {ThreadId}", modeId, threadId);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to persist mode {ModeId} for thread {ThreadId}", modeId, threadId);
-        }
+        return PersistThreadPropertyAsync(threadId, ModePropertyKey, modeId, label: "mode");
     }
 
     /// <summary>
@@ -578,9 +547,26 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
     /// <see cref="PersistThreadBindingsIfNeededAsync"/> (seed-only), this unconditionally sets the
     /// value so a later refresh restores the switched-to provider.
     /// </summary>
-    private async Task PersistProviderAsync(string threadId, string? providerId)
+    private Task PersistProviderAsync(string threadId, string? providerId)
     {
-        if (_conversationStore == null || string.IsNullOrWhiteSpace(providerId))
+        return PersistThreadPropertyAsync(threadId, ProviderPropertyKey, providerId, label: "provider");
+    }
+
+    /// <summary>
+    /// Unconditionally overwrites a single <see cref="ThreadMetadata.Properties"/> entry via a
+    /// read-modify-write (<see cref="IConversationStore.UpdateMetadataAsync"/>). Shared by the
+    /// deliberate, mutable mode- and provider-switch persist paths. A no-op when there is no store or
+    /// the value is blank; persistence failures are logged and swallowed — the in-memory swap already
+    /// succeeded, so a failed persist only forfeits the restore-after-refresh, not the live switch.
+    /// </summary>
+    private async Task PersistThreadPropertyAsync(
+        string threadId,
+        string propertyKey,
+        string? value,
+        string label
+    )
+    {
+        if (_conversationStore == null || string.IsNullOrWhiteSpace(value))
         {
             return;
         }
@@ -592,7 +578,7 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
                 existing =>
                 {
                     var properties = (existing?.Properties ?? ImmutableDictionary<string, object>.Empty)
-                        .SetItem(ProviderPropertyKey, providerId);
+                        .SetItem(propertyKey, value);
 
                     return (
                         existing
@@ -609,11 +595,22 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
                 }
             ).ConfigureAwait(false);
 
-            _logger.LogInformation("Persisted provider {ProviderId} for thread {ThreadId}", providerId, threadId);
+            _logger.LogInformation(
+                "Persisted {Label} {Value} for thread {ThreadId}",
+                label,
+                value,
+                threadId
+            );
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to persist provider {ProviderId} for thread {ThreadId}", providerId, threadId);
+            _logger.LogWarning(
+                ex,
+                "Failed to persist {Label} {Value} for thread {ThreadId}",
+                label,
+                value,
+                threadId
+            );
         }
     }
 
@@ -834,44 +831,16 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
         var resolvedProviderId = ResolveProviderId(threadId, requestedProviderId: null);
         var resolvedWorkspaceId = ResolveWorkspaceId(threadId, requestedWorkspaceId: null);
 
-        // Acquire the per-key lock to prevent races with concurrent GetOrCreateAgent calls.
-        var lockObj = _creationLocks.GetOrAdd(threadId, _ => new object());
-        AgentEntry? oldEntry = null;
-        AgentEntry entry;
-        lock (lockObj)
-        {
-            _ = _agents.TryRemove(threadId, out oldEntry);
-            entry = CreateAgentEntry(
-                threadId,
-                mode,
-                resolvedProviderId,
-                requestResponseDumpFileName: null,
-                resolvedWorkspaceId
-            );
-            _agents[threadId] = entry;
-        }
-
-        // Dispose old entry outside the lock to avoid blocking concurrent operations. The new agent is
-        // already swapped in, so a failure tearing down the OLD one must NOT fail the mode switch.
-        if (oldEntry != null)
-        {
-            _logger.LogInformation("Removing agent for thread {ThreadId}", threadId);
-            try
-            {
-                await oldEntry.DisposeAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(
-                    ex,
-                    "Failed to dispose the previous agent for thread {ThreadId} after a mode switch; the new agent is already active",
-                    threadId
-                );
-            }
-        }
+        var entry = await SwapAgentUnderLockAsync(
+            threadId,
+            mode,
+            resolvedProviderId,
+            resolvedWorkspaceId,
+            switchKind: "mode"
+        );
 
         // A mode switch is deliberate and mutable: overwrite the persisted mode so a later refresh
-        // restores the switched-to mode (provider/workspace stay untouched — they are immutable).
+        // restores the switched-to mode (provider/workspace are untouched by a mode switch).
         await PersistModeAsync(threadId, mode.Id);
 
         return entry.Agent;
@@ -916,19 +885,56 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
         // the lock to avoid blocking other threadIds on file I/O.
         var resolvedWorkspaceId = ResolveWorkspaceId(threadId, requestedWorkspaceId: null);
 
+        var entry = await SwapAgentUnderLockAsync(
+            threadId,
+            currentMode,
+            newProviderId,
+            resolvedWorkspaceId,
+            switchKind: "provider"
+        );
+
+        // A provider switch is deliberate and mutable: overwrite the persisted provider so a later
+        // refresh restores it (mode/workspace untouched).
+        await PersistProviderAsync(threadId, newProviderId);
+
+        return entry.Agent;
+    }
+
+    /// <summary>
+    /// Swaps a thread's pooled agent for a freshly-built one under the per-thread creation lock,
+    /// transactionally. The replacement is constructed FIRST: if construction throws (e.g. a provider
+    /// or Workspace-Agent sandbox session fails to start), the existing agent stays registered and the
+    /// thread is left untouched — the failure surfaces as a clean 503 upstream instead of a broken
+    /// conversation with no pooled agent. Only once the new entry is built is the old one evicted,
+    /// swapped in, and disposed — outside the lock and non-fatally, because the new agent is already
+    /// active, so a failure tearing down the OLD one must not fail the switch. Shared by the
+    /// mode-switch (<see cref="RecreateAgentWithModeAsync"/>) and provider-switch
+    /// (<see cref="RecreateAgentWithProviderAsync"/>) recreate paths.
+    /// </summary>
+    private async Task<AgentEntry> SwapAgentUnderLockAsync(
+        string threadId,
+        AgentProfile mode,
+        string providerId,
+        string? workspaceId,
+        string switchKind
+    )
+    {
+        // Acquire the per-key lock to prevent races with concurrent GetOrCreateAgent calls.
         var lockObj = _creationLocks.GetOrAdd(threadId, _ => new object());
-        AgentEntry? oldEntry = null;
+        AgentEntry? oldEntry;
         AgentEntry entry;
         lock (lockObj)
         {
-            _ = _agents.TryRemove(threadId, out oldEntry);
+            // Construct BEFORE evicting — a throw here leaves the current agent registered (the thread
+            // is untouched) rather than stranding the conversation with no pooled agent.
             entry = CreateAgentEntry(
                 threadId,
-                currentMode,
-                newProviderId,
+                mode,
+                providerId,
                 requestResponseDumpFileName: null,
-                resolvedWorkspaceId
+                workspaceId
             );
+            _ = _agents.TryRemove(threadId, out oldEntry);
             _agents[threadId] = entry;
         }
 
@@ -947,17 +953,14 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
             {
                 _logger.LogWarning(
                     ex,
-                    "Failed to dispose the previous agent for thread {ThreadId} after a provider switch; the new agent is already active",
-                    threadId
+                    "Failed to dispose the previous agent for thread {ThreadId} after a {SwitchKind} switch; the new agent is already active",
+                    threadId,
+                    switchKind
                 );
             }
         }
 
-        // A provider switch is deliberate and mutable: overwrite the persisted provider so a later
-        // refresh restores it (mode/workspace untouched).
-        await PersistProviderAsync(threadId, newProviderId);
-
-        return entry.Agent;
+        return entry;
     }
 
     private AgentEntry CreateAgentEntry(

--- a/src/LmAgentInfra/Agents/MultiTurnAgentPool.cs
+++ b/src/LmAgentInfra/Agents/MultiTurnAgentPool.cs
@@ -572,6 +572,51 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Overwrites the persisted provider for a thread (a deliberate provider switch on an idle
+    /// conversation). Mode and workspace are left untouched. Unlike
+    /// <see cref="PersistThreadBindingsIfNeededAsync"/> (seed-only), this unconditionally sets the
+    /// value so a later refresh restores the switched-to provider.
+    /// </summary>
+    private async Task PersistProviderAsync(string threadId, string? providerId)
+    {
+        if (_conversationStore == null || string.IsNullOrWhiteSpace(providerId))
+        {
+            return;
+        }
+
+        try
+        {
+            await _conversationStore.UpdateMetadataAsync(
+                threadId,
+                existing =>
+                {
+                    var properties = (existing?.Properties ?? ImmutableDictionary<string, object>.Empty)
+                        .SetItem(ProviderPropertyKey, providerId);
+
+                    return (
+                        existing
+                        ?? new ThreadMetadata
+                        {
+                            ThreadId = threadId,
+                            LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                        }
+                    ) with
+                    {
+                        Properties = properties,
+                        LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    };
+                }
+            ).ConfigureAwait(false);
+
+            _logger.LogInformation("Persisted provider {ProviderId} for thread {ThreadId}", providerId, threadId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to persist provider {ProviderId} for thread {ThreadId}", providerId, threadId);
+        }
+    }
+
     private string? LoadPersistedProviderId(string threadId)
     {
         if (_conversationStore == null)
@@ -806,16 +851,111 @@ public sealed class MultiTurnAgentPool : IAsyncDisposable
             _agents[threadId] = entry;
         }
 
-        // Dispose old entry outside the lock to avoid blocking concurrent operations
+        // Dispose old entry outside the lock to avoid blocking concurrent operations. The new agent is
+        // already swapped in, so a failure tearing down the OLD one must NOT fail the mode switch.
         if (oldEntry != null)
         {
             _logger.LogInformation("Removing agent for thread {ThreadId}", threadId);
-            await oldEntry.DisposeAsync();
+            try
+            {
+                await oldEntry.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to dispose the previous agent for thread {ThreadId} after a mode switch; the new agent is already active",
+                    threadId
+                );
+            }
         }
 
         // A mode switch is deliberate and mutable: overwrite the persisted mode so a later refresh
         // restores the switched-to mode (provider/workspace stay untouched — they are immutable).
         await PersistModeAsync(threadId, mode.Id);
+
+        return entry.Agent;
+    }
+
+    /// <summary>
+    /// Tears down a thread's agent and recreates it against a DIFFERENT provider, preserving the
+    /// thread's current mode and persisted workspace. Used when the user switches a conversation's
+    /// provider after its run has completed (provider is mutable when idle; workspace stays bound for
+    /// life). The new provider is validated up-front (an unavailable/unknown id throws
+    /// <see cref="ProviderUnavailableException"/>), used directly for the new agent, then persisted
+    /// (overwrite) so a later refresh restores it — deliberately bypassing the "persisted wins"
+    /// immutability that <see cref="ResolveProviderId"/> enforces for plain reconnects.
+    /// </summary>
+    /// <param name="threadId">The thread identifier</param>
+    /// <param name="newProviderId">The provider to switch to</param>
+    /// <param name="currentMode">The thread's current mode, preserved across the switch</param>
+    /// <returns>The new agent for this thread</returns>
+    public async Task<IMultiTurnAgent> RecreateAgentWithProviderAsync(
+        string threadId,
+        string newProviderId,
+        AgentProfile currentMode
+    )
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentException.ThrowIfNullOrEmpty(threadId);
+        ArgumentException.ThrowIfNullOrEmpty(newProviderId);
+        ArgumentNullException.ThrowIfNull(currentMode);
+
+        // Validate the target BEFORE tearing down the existing agent — a bad id must leave the thread
+        // untouched (and surface as a clean 503 at the controller), not evict a working agent.
+        EnsureAvailableOrThrow(newProviderId, source: "requested");
+
+        _logger.LogInformation(
+            "Recreating agent for thread {ThreadId} with provider {ProviderId} (mode {ModeId} preserved)",
+            threadId,
+            newProviderId,
+            currentMode.Id
+        );
+
+        // Provider is the switch; workspace stays bound (resolve the persisted one). Resolved before
+        // the lock to avoid blocking other threadIds on file I/O.
+        var resolvedWorkspaceId = ResolveWorkspaceId(threadId, requestedWorkspaceId: null);
+
+        var lockObj = _creationLocks.GetOrAdd(threadId, _ => new object());
+        AgentEntry? oldEntry = null;
+        AgentEntry entry;
+        lock (lockObj)
+        {
+            _ = _agents.TryRemove(threadId, out oldEntry);
+            entry = CreateAgentEntry(
+                threadId,
+                currentMode,
+                newProviderId,
+                requestResponseDumpFileName: null,
+                resolvedWorkspaceId
+            );
+            _agents[threadId] = entry;
+        }
+
+        // Dispose old entry outside the lock to avoid blocking concurrent operations. The new agent is
+        // already swapped in, so a failure tearing down the OLD one (e.g. its provider's CLI is missing,
+        // or its StopAsync throws) must NOT fail the switch — log and move on, otherwise the endpoint
+        // leaks a 500 for a swap that actually succeeded.
+        if (oldEntry != null)
+        {
+            _logger.LogInformation("Removing agent for thread {ThreadId}", threadId);
+            try
+            {
+                await oldEntry.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to dispose the previous agent for thread {ThreadId} after a provider switch; the new agent is already active",
+                    threadId
+                );
+            }
+        }
+
+        // A provider switch is deliberate and mutable: overwrite the persisted provider so a later
+        // refresh restores it (mode/workspace untouched).
+        await PersistProviderAsync(threadId, newProviderId);
 
         return entry.Agent;
     }

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/ScriptedScenario.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/ScriptedScenario.cs
@@ -32,7 +32,7 @@ public static class ScriptedScenario
     /// A <see cref="ScenarioSession"/> that owns the factory, context, and page. Callers
     /// dispose it with <c>await using</c>.
     /// </returns>
-    public static async Task<ScenarioSession> OpenAsync(
+    public static Task<ScenarioSession> OpenAsync(
         this PlaywrightFixture fixture,
         string providerMode,
         HttpMessageHandler handler,
@@ -43,7 +43,51 @@ public static class ScriptedScenario
         SandboxGatewayOptions? sandboxOptions = null
     )
     {
-        var builder = new ScriptedBuilder(handler, subAgentFactory);
+        return fixture.OpenWithBuilderAsync(
+            providerMode,
+            new ScriptedBuilder(handler, subAgentFactory),
+            fixedPort,
+            catalogClient,
+            sandboxGatewayHandler,
+            sandboxOptions);
+    }
+
+    /// <summary>
+    /// Provider-switch overload: takes the <see cref="ScriptedSseResponder"/> itself (not a single
+    /// wire-committed handler) so the agent can be recreated on EITHER scripted wire mid-session —
+    /// required to exercise a runtime provider switch between <c>test</c> (OpenAI) and
+    /// <c>test-anthropic</c> (Anthropic). <paramref name="providerMode"/> is the initial selection.
+    /// </summary>
+    public static Task<ScenarioSession> OpenAsync(
+        this PlaywrightFixture fixture,
+        string providerMode,
+        ScriptedSseResponder responder,
+        Func<ILoggerFactory, Func<IStreamingAgent>, SubAgentOptions?>? subAgentFactory = null,
+        int? fixedPort = null,
+        IMarketplaceCatalogClient? catalogClient = null,
+        HttpMessageHandler? sandboxGatewayHandler = null,
+        SandboxGatewayOptions? sandboxOptions = null
+    )
+    {
+        return fixture.OpenWithBuilderAsync(
+            providerMode,
+            new ScriptedBuilder(responder, subAgentFactory),
+            fixedPort,
+            catalogClient,
+            sandboxGatewayHandler,
+            sandboxOptions);
+    }
+
+    private static async Task<ScenarioSession> OpenWithBuilderAsync(
+        this PlaywrightFixture fixture,
+        string providerMode,
+        ITestAgentBuilder builder,
+        int? fixedPort,
+        IMarketplaceCatalogClient? catalogClient,
+        HttpMessageHandler? sandboxGatewayHandler,
+        SandboxGatewayOptions? sandboxOptions
+    )
+    {
         var factory = new BrowserWebAppFactory(
             providerMode,
             builder,

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs
@@ -136,6 +136,18 @@ public static class UiHelpers
         return page.GetByTestId($"mode-option-{modeId}");
     }
 
+    /// <summary>Provider selector button in the header (a dropdown when idle; disabled while streaming).</summary>
+    public static ILocator ProviderSelectorButton(this IPage page)
+    {
+        return page.GetByTestId("provider-selector-button");
+    }
+
+    /// <summary>Provider option menu item. Pass the provider id (e.g., <c>test</c>, <c>test-anthropic</c>).</summary>
+    public static ILocator ProviderOption(this IPage page, string providerId)
+    {
+        return page.GetByTestId($"provider-option-{providerId}");
+    }
+
     /// <summary>
     /// Type a message into the chat input and click the send button. Returns after the
     /// click — does not wait for the response.

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/ProviderSwitchTests.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/ProviderSwitchTests.cs
@@ -1,0 +1,75 @@
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using FluentAssertions;
+using LmStreaming.Sample.Browser.E2E.Tests.Infrastructure;
+
+namespace LmStreaming.Sample.Browser.E2E.Tests.Scenarios;
+
+/// <summary>
+/// Runtime PROVIDER switch between the two scripted mock providers — <c>test</c> (OpenAI wire) and
+/// <c>test-anthropic</c> (Anthropic wire) — inside a single page session. Turn 1 streams on the boot
+/// provider; the header dropdown switches the provider while idle (POST
+/// <c>/api/conversations/{threadId}/provider</c> → the pool recreates the agent on the OTHER wire);
+/// turn 2 must then stream on the recreated agent. Both turns come from ONE
+/// <see cref="ScriptedSseResponder"/> whose two wire handlers share a plan queue, so this proves the
+/// switch rebuilds the agent against a different provider and the next turn is served correctly.
+///
+/// The exact HTTP codes (409 while streaming, 503 unavailable) are covered deterministically by
+/// <c>ConversationsControllerTests</c>; this browser test asserts UI + streamed content only.
+/// </summary>
+[Collection(PlaywrightCollection.Name)]
+public sealed class ProviderSwitchTests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public ProviderSwitchTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Theory]
+    [InlineData("test", "test-anthropic", "Test (Anthropic)")]
+    [InlineData("test-anthropic", "test", "Test (Mock)")]
+    public async Task Provider_dropdown_switches_between_scripted_mocks_and_next_turn_streams(
+        string bootProvider,
+        string targetProvider,
+        string targetLabel)
+    {
+        // ONE responder, two turns. The role matches on the system prompt, which both the OpenAI and
+        // Anthropic extractors surface, so either wire pops the next plan.
+        var responder = ScriptedSseResponder
+            .New()
+            .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
+            .Turn(t => t.Text("First turn answer."))
+            .Turn(t => t.Text("Second turn answer."))
+            .Build();
+
+        // Boot on bootProvider (its own wire). The provider-aware ScriptedBuilder overload lets the
+        // agent be recreated on EITHER wire when the provider is switched.
+        await using var session = await _fixture.OpenAsync(bootProvider, responder);
+        var page = session.Page;
+
+        // Turn 1 on the boot provider — establishes the (started) conversation.
+        await page.SendMessageAsync("first");
+        await page.WaitForStreamIdleAsync();
+        string.Join(" ", await page.AssistantText().AllInnerTextsAsync())
+            .Should().Contain("First turn answer");
+
+        // Switch the provider while idle: header dropdown → target option. This fires the backend
+        // switch (recreate on the other wire). Wait for the button label to reflect the new provider.
+        await page.ProviderSelectorButton().ClickAsync();
+        await page.ProviderOption(targetProvider).ClickAsync();
+        await page.ProviderSelectorButton().WaitForTextContainsAsync(targetLabel);
+
+        // Turn 2 must stream on the RECREATED agent (the other wire). If the switch didn't rebuild the
+        // agent against the target provider, the scripted handler would 404 the mismatched wire and
+        // this would never render / go idle.
+        await page.SendMessageAsync("second");
+        await page.WaitForStreamIdleAsync();
+        string.Join(" ", await page.AssistantText().AllInnerTextsAsync())
+            .Should().Contain("Second turn answer");
+
+        responder.RemainingTurns["parent"].Should().Be(0, "both turns ran to completion across the switch");
+        await session.SaveSuccessScreenshotAsync(
+            $"ProviderSwitch.{bootProvider}_to_{targetProvider}");
+    }
+}

--- a/tests/LmStreaming.Sample.E2E.Tests/Infrastructure/ScriptedBuilder.cs
+++ b/tests/LmStreaming.Sample.E2E.Tests/Infrastructure/ScriptedBuilder.cs
@@ -1,5 +1,6 @@
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
 using LmStreaming.Sample.Services;
 
 namespace LmStreaming.Sample.E2E.Tests.Infrastructure;
@@ -12,7 +13,8 @@ namespace LmStreaming.Sample.E2E.Tests.Infrastructure;
 /// </summary>
 public sealed class ScriptedBuilder : ITestAgentBuilder
 {
-    private readonly HttpMessageHandler _handler;
+    private readonly HttpMessageHandler? _handler;
+    private readonly ScriptedSseResponder? _responder;
     private readonly Func<ILoggerFactory, Func<IStreamingAgent>, SubAgentOptions?>? _subAgentFactory;
 
     public ScriptedBuilder(
@@ -23,9 +25,32 @@ public sealed class ScriptedBuilder : ITestAgentBuilder
         _subAgentFactory = subAgentFactory;
     }
 
+    /// <summary>
+    /// Provider-aware overload: derives the per-wire handler from the requested provider mode, so a
+    /// conversation can SWITCH between the scripted <c>test</c> (OpenAI wire) and <c>test-anthropic</c>
+    /// (Anthropic wire) providers at runtime. Both handlers come from the SAME responder and share its
+    /// plan queue, so a single scripted plan serves whichever wire the current provider uses. The
+    /// single-handler ctor above pins one wire and cannot switch.
+    /// </summary>
+    public ScriptedBuilder(
+        ScriptedSseResponder responder,
+        Func<ILoggerFactory, Func<IStreamingAgent>, SubAgentOptions?>? subAgentFactory = null)
+    {
+        _responder = responder ?? throw new ArgumentNullException(nameof(responder));
+        _subAgentFactory = subAgentFactory;
+    }
+
     public HttpMessageHandler CreateHandler(string providerMode, ILoggerFactory loggerFactory)
     {
-        return _handler;
+        if (_responder != null)
+        {
+            // Mirror DefaultTestAgentBuilder: honor the requested provider mode's wire format.
+            return string.Equals(providerMode, "test-anthropic", StringComparison.OrdinalIgnoreCase)
+                ? _responder.AsAnthropicHandler()
+                : _responder.AsOpenAiHandler();
+        }
+
+        return _handler!;
     }
 
     public SubAgentOptions? CreateSubAgentOptions(

--- a/tests/LmStreaming.Sample.Tests/Agents/MultiTurnAgentPoolTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Agents/MultiTurnAgentPoolTests.cs
@@ -497,6 +497,119 @@ public class MultiTurnAgentPoolTests
     }
 
     [Fact]
+    public async Task RecreateAgentWithProviderAsync_OverwritesPersistedProvider_AndPreservesModeAndWorkspace()
+    {
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test", "openai", "anthropic"]);
+        var store = new InMemoryConversationStore();
+        var created = new List<(string Provider, string? Workspace, string Mode)>();
+
+        await using var pool = new MultiTurnAgentPool(
+            context =>
+            {
+                created.Add((context.ProviderId, context.WorkspaceId, context.Mode.Id));
+                return new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(context.ThreadId));
+            },
+            registry.ToReal(),
+            store,
+            NullLogger<MultiTurnAgentPool>.Instance
+        );
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        _ = pool.GetOrCreateAgent(
+            "thread-prov-swap",
+            mode,
+            requestedProviderId: "test",
+            requestResponseDumpFileName: null,
+            requestedWorkspaceId: "ws-1"
+        );
+        (await WaitForPersistedProviderAsync(store, "thread-prov-swap")).Should().Be("test");
+
+        _ = await pool.RecreateAgentWithProviderAsync("thread-prov-swap", "openai", mode);
+
+        // The recreated agent used the NEW provider and preserved the thread's mode + workspace.
+        created.Should().HaveCount(2);
+        created[1].Provider.Should().Be("openai");
+        created[1].Workspace.Should().Be("ws-1");
+        created[1].Mode.Should().Be(mode.Id);
+
+        // The switch is persisted (overwrite) so a later refresh restores it.
+        (await WaitForPersistedProviderAsync(store, "thread-prov-swap")).Should().Be("openai");
+        pool.GetEffectiveProviderId("thread-prov-swap", null).Should().Be("openai");
+    }
+
+    [Fact]
+    public async Task RecreateAgentWithProviderAsync_Throws_AndLeavesThreadUntouched_WhenProviderUnavailable()
+    {
+        // "openai" is NOT available — the validation must happen BEFORE teardown so the working agent
+        // and its persisted provider are left intact (the controller maps this to a clean 503).
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test"]);
+        var store = new InMemoryConversationStore();
+
+        await using var pool = new MultiTurnAgentPool(
+            context => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(context.ThreadId)),
+            registry.ToReal(),
+            store,
+            NullLogger<MultiTurnAgentPool>.Instance
+        );
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        var original = pool.GetOrCreateAgent("thread-prov-bad", mode, requestedProviderId: "test", requestResponseDumpFileName: null);
+        (await WaitForPersistedProviderAsync(store, "thread-prov-bad")).Should().Be("test");
+
+        var act = async () => await pool.RecreateAgentWithProviderAsync("thread-prov-bad", "openai", mode);
+        await act.Should().ThrowAsync<ProviderUnavailableException>();
+
+        // Untouched: same agent instance still pooled, persisted provider still "test".
+        ReferenceEquals(pool.GetOrCreateAgent("thread-prov-bad", mode), original).Should().BeTrue();
+        pool.GetEffectiveProviderId("thread-prov-bad", null).Should().Be("test");
+    }
+
+    [Fact]
+    public async Task ThreadRemoved_DoesNotFire_OnRecreateAgentWithProviderAsync()
+    {
+        // Provider-switch preserves threadId (same as mode-switch), so the session→thread map must
+        // stay intact — ThreadRemoved must not fire.
+        await using var pool = CreatePool();
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        _ = pool.GetOrCreateAgent("thread-prov-noremove", mode);
+
+        var notifications = new List<string>();
+        pool.ThreadRemoved += id => notifications.Add(id);
+
+        _ = await pool.RecreateAgentWithProviderAsync("thread-prov-noremove", "test", mode);
+
+        notifications.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RecreateAgentWithProviderAsync_SucceedsAndPersists_WhenOldAgentDisposeThrows()
+    {
+        // Tearing down the PREVIOUS agent can fail (e.g. its provider's CLI is missing / StopAsync
+        // throws). The new agent is already swapped in, so the switch must still succeed and persist —
+        // not leak the dispose exception as a 500.
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test", "openai"]);
+        var store = new InMemoryConversationStore();
+
+        await using var pool = new MultiTurnAgentPool(
+            context => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(context.ThreadId)),
+            registry.ToReal(),
+            store,
+            NullLogger<MultiTurnAgentPool>.Instance
+        );
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        var old = (FakeMultiTurnAgent)pool.GetOrCreateAgent(
+            "thread-dispose-throw", mode, requestedProviderId: "test", requestResponseDumpFileName: null);
+        old.ThrowOnDispose = true; // tearing down the old agent will throw
+
+        var newAgent = await pool.RecreateAgentWithProviderAsync("thread-dispose-throw", "openai", mode);
+
+        newAgent.Should().NotBeSameAs(old);
+        (await WaitForPersistedProviderAsync(store, "thread-dispose-throw")).Should().Be("openai");
+        pool.GetEffectiveProviderId("thread-dispose-throw", null).Should().Be("openai");
+    }
+
+    [Fact]
     public async Task ThreadRemoved_SubscriberException_DoesNotPoisonOtherSubscribers()
     {
         // Defensive: a buggy subscriber must not strand subsequent listeners. The pool wraps

--- a/tests/LmStreaming.Sample.Tests/Agents/MultiTurnAgentPoolTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Agents/MultiTurnAgentPoolTests.cs
@@ -610,6 +610,50 @@ public class MultiTurnAgentPoolTests
     }
 
     [Fact]
+    public async Task RecreateAgentWithProviderAsync_LeavesExistingAgentPooled_WhenNewAgentConstructionThrows()
+    {
+        // The target provider is available (validation passes), but BUILDING the replacement agent can
+        // still throw AFTER validation — e.g. a Workspace-Agent sandbox session or provider CLI fails to
+        // start. The switch must be transactional: a construction failure must leave the existing working
+        // agent pooled (and the persisted provider untouched), not evict it and strand the conversation
+        // with no agent. Surfaces upstream as a clean 503 for a switch that never happened.
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test", "openai"]);
+        var store = new InMemoryConversationStore();
+        var creations = 0;
+
+        await using var pool = new MultiTurnAgentPool(
+            context =>
+            {
+                creations++;
+                if (creations >= 2)
+                {
+                    // Second creation = the recreate. Simulate replacement construction failing.
+                    throw new InvalidOperationException("sandbox session failed to start");
+                }
+                return new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(context.ThreadId));
+            },
+            registry.ToReal(),
+            store,
+            NullLogger<MultiTurnAgentPool>.Instance
+        );
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        var original = pool.GetOrCreateAgent(
+            "thread-prov-construct-throws", mode, requestedProviderId: "test", requestResponseDumpFileName: null);
+        (await WaitForPersistedProviderAsync(store, "thread-prov-construct-throws")).Should().Be("test");
+
+        var act = async () =>
+            await pool.RecreateAgentWithProviderAsync("thread-prov-construct-throws", "openai", mode);
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        // Untouched: the SAME original agent is still pooled (a re-fetch does NOT hit the factory again —
+        // proving it was never evicted), and the persisted provider is still the original "test".
+        ReferenceEquals(pool.GetOrCreateAgent("thread-prov-construct-throws", mode), original).Should().BeTrue();
+        creations.Should().Be(2, "the failed recreate is the only extra factory call; the re-fetch reused the pooled agent");
+        pool.GetEffectiveProviderId("thread-prov-construct-throws", null).Should().Be("test");
+    }
+
+    [Fact]
     public async Task ThreadRemoved_SubscriberException_DoesNotPoisonOtherSubscribers()
     {
         // Defensive: a buggy subscriber must not strand subsequent listeners. The pool wraps

--- a/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using LmStreaming.Sample.Tests.Agents;
 using LmStreaming.Sample.Tests.TestDoubles;
 
@@ -249,5 +250,79 @@ public class ConversationsControllerTests
 
         result.Should().BeOfType<OkObjectResult>();
         pool.GetEffectiveProviderId(threadId, null).Should().Be("openai");
+    }
+
+    [Fact]
+    public async Task SwitchProvider_ReturnsOk_ViaPersistedModeFallback_WhenAgentNotPooled()
+    {
+        // The real-world switch-after-refresh path: the agent was evicted from the pool
+        // (GetAgentMode == null), but the thread's mode was persisted. The controller must recover the
+        // mode from metadata + the mode store and preserve it across the provider swap. This exercises
+        // the fallback chain (metadata → mode store) that the live-agent tests never reach.
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test", "openai"]);
+        var store = new InMemoryConversationStore();
+        await store.SaveMetadataAsync(
+            "thread-prov-refresh",
+            new ThreadMetadata
+            {
+                ThreadId = "thread-prov-refresh",
+                LastUpdated = 1,
+                Properties = ImmutableDictionary<string, object>.Empty
+                    .SetItem(MultiTurnAgentPool.ModePropertyKey, "math-helper")
+                    .SetItem(MultiTurnAgentPool.ProviderPropertyKey, "test"),
+            });
+        await using var pool = CreatePoolWithRegistry(registry, store);
+
+        var modeStore = new Mock<IChatModeStore>();
+        modeStore.Setup(m => m.GetModeAsync("math-helper", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SystemChatModes.GetById("math-helper"));
+
+        // No live agent for this thread → forces the persisted-mode fallback chain in the controller.
+        var controller = new ConversationsController(
+            store, pool, modeStore.Object, NullLogger<ConversationsController>.Instance);
+
+        var result = await controller.SwitchProvider(
+            "thread-prov-refresh",
+            new SwitchProviderRequest { ProviderId = "openai" },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        JsonSerializer.Serialize(ok.Value).Should().Contain("\"providerId\":\"openai\"");
+        // Provider switched AND the recovered mode was preserved on the recreated agent.
+        pool.GetEffectiveProviderId("thread-prov-refresh", null).Should().Be("openai");
+        pool.GetAgentMode("thread-prov-refresh")!.Id.Should().Be("math-helper");
+    }
+
+    [Fact]
+    public async Task SwitchProvider_Returns500_WhenNoModeCanBeResolved()
+    {
+        // Agent evicted from the pool (GetAgentMode == null) AND the mode store resolves nothing —
+        // neither a persisted mode nor the system default. The controller cannot preserve a mode across
+        // the swap, so it answers a clean 500 rather than recreating the agent with an unknown mode.
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test", "openai"]);
+        var store = new InMemoryConversationStore();
+        await using var pool = CreatePoolWithRegistry(registry, store);
+
+        var modeStore = new Mock<IChatModeStore>();
+        // GetById on an unknown id returns null (typed ChatMode?), so every resolution attempt fails.
+        modeStore.Setup(m => m.GetModeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SystemChatModes.GetById("__no_such_mode__"));
+
+        // No agent is created for this thread and no metadata is persisted → GetAgentMode is null and
+        // the fallback chain resolves nothing.
+        var controller = new ConversationsController(
+            store, pool, modeStore.Object, NullLogger<ConversationsController>.Instance);
+
+        var result = await controller.SwitchProvider(
+            "thread-prov-nomode",
+            new SwitchProviderRequest { ProviderId = "openai" },
+            CancellationToken.None);
+
+        var obj = Assert.IsType<ObjectResult>(result);
+        obj.StatusCode.Should().Be(500);
+        JsonSerializer.Serialize(obj.Value)
+            .Should().Contain("Could not resolve the conversation");
+        // The failed switch left the thread's persisted provider untouched.
+        pool.GetEffectiveProviderId("thread-prov-nomode", null).Should().Be("test");
     }
 }

--- a/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerTests.cs
@@ -1,3 +1,4 @@
+using LmStreaming.Sample.Tests.Agents;
 using LmStreaming.Sample.Tests.TestDoubles;
 
 namespace LmStreaming.Sample.Tests.Controllers;
@@ -125,5 +126,128 @@ public class ConversationsControllerTests
         return new MultiTurnAgentPool(
             (threadId, _, _) => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId)),
             NullLogger<MultiTurnAgentPool>.Instance);
+    }
+
+    private static MultiTurnAgentPool CreatePoolWithRegistry(
+        FakeProviderRegistry registry,
+        InMemoryConversationStore store)
+    {
+        return new MultiTurnAgentPool(
+            context => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(context.ThreadId)),
+            registry.ToReal(),
+            store,
+            NullLogger<MultiTurnAgentPool>.Instance);
+    }
+
+    [Fact]
+    public async Task SwitchProvider_ReturnsConflict_WhenRunIsInProgress()
+    {
+        await using var pool = CreatePool();
+        var threadId = "thread-prov-conflict";
+        var currentMode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        var agent = (FakeMultiTurnAgent)pool.GetOrCreateAgent(threadId, currentMode);
+        agent.CurrentRunId = "run-active";
+
+        var controller = new ConversationsController(
+            Mock.Of<IConversationStore>(),
+            pool,
+            Mock.Of<IChatModeStore>(),
+            NullLogger<ConversationsController>.Instance);
+
+        var result = await controller.SwitchProvider(
+            threadId,
+            new SwitchProviderRequest { ProviderId = "openai" },
+            CancellationToken.None);
+
+        var conflict = Assert.IsType<ConflictObjectResult>(result);
+        conflict.StatusCode.Should().Be(409);
+        var payload = JsonSerializer.Serialize(conflict.Value);
+        payload.Should().Contain("provider_switch_while_streaming");
+        payload.Should().Contain(threadId);
+
+        // No recreate happened — the agent (and its mode) is still pooled.
+        pool.GetAgentMode(threadId)!.Id.Should().Be(SystemChatModes.DefaultModeId);
+    }
+
+    [Fact]
+    public async Task SwitchProvider_ReturnsOk_AndPersistsProvider_WhenRunIsIdle()
+    {
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test", "openai"]);
+        var store = new InMemoryConversationStore();
+        await using var pool = CreatePoolWithRegistry(registry, store);
+
+        var threadId = "thread-prov-idle";
+        var currentMode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        _ = (FakeMultiTurnAgent)pool.GetOrCreateAgent(
+            threadId, currentMode, requestedProviderId: "test", requestResponseDumpFileName: null);
+
+        var controller = new ConversationsController(
+            store, pool, Mock.Of<IChatModeStore>(), NullLogger<ConversationsController>.Instance);
+
+        var result = await controller.SwitchProvider(
+            threadId,
+            new SwitchProviderRequest { ProviderId = "openai" },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        JsonSerializer.Serialize(ok.Value).Should().Contain("\"providerId\":\"openai\"");
+        pool.GetEffectiveProviderId(threadId, null).Should().Be("openai"); // persisted overwrite
+        pool.GetAgentMode(threadId)!.Id.Should().Be(SystemChatModes.DefaultModeId); // mode preserved
+    }
+
+    [Fact]
+    public async Task SwitchProvider_Returns503_WhenProviderUnavailable()
+    {
+        // "openai" is NOT in the registry's available set → RecreateAgentWithProviderAsync throws
+        // ProviderUnavailableException → the controller maps it to a clean 503.
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test"]);
+        var store = new InMemoryConversationStore();
+        await using var pool = CreatePoolWithRegistry(registry, store);
+
+        var threadId = "thread-prov-503";
+        var currentMode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        _ = (FakeMultiTurnAgent)pool.GetOrCreateAgent(
+            threadId, currentMode, requestedProviderId: "test", requestResponseDumpFileName: null);
+
+        var controller = new ConversationsController(
+            store, pool, Mock.Of<IChatModeStore>(), NullLogger<ConversationsController>.Instance);
+
+        var result = await controller.SwitchProvider(
+            threadId,
+            new SwitchProviderRequest { ProviderId = "openai" },
+            CancellationToken.None);
+
+        var obj = Assert.IsType<ObjectResult>(result);
+        obj.StatusCode.Should().Be(503);
+        var payload = JsonSerializer.Serialize(obj.Value);
+        payload.Should().Contain("provider_unavailable");
+        payload.Should().Contain("openai");
+        pool.GetEffectiveProviderId(threadId, null).Should().Be("test"); // untouched
+    }
+
+    [Fact]
+    public async Task SwitchProvider_ReturnsOk_WhenRunStateIsStale()
+    {
+        var registry = new FakeProviderRegistry(defaultProviderId: "test", available: ["test", "openai"]);
+        var store = new InMemoryConversationStore();
+        await using var pool = CreatePoolWithRegistry(registry, store);
+
+        var threadId = "thread-prov-stale";
+        var currentMode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        var agent = (FakeMultiTurnAgent)pool.GetOrCreateAgent(
+            threadId, currentMode, requestedProviderId: "test", requestResponseDumpFileName: null);
+        agent.CurrentRunId = "run-stale";
+        agent.IsRunning = false;
+
+        var controller = new ConversationsController(
+            store, pool, Mock.Of<IChatModeStore>(), NullLogger<ConversationsController>.Instance);
+
+        var result = await controller.SwitchProvider(
+            threadId,
+            new SwitchProviderRequest { ProviderId = "openai" },
+            CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>();
+        pool.GetEffectiveProviderId(threadId, null).Should().Be("openai");
     }
 }

--- a/tests/LmStreaming.Sample.Tests/TestDoubles/FakeMultiTurnAgent.cs
+++ b/tests/LmStreaming.Sample.Tests/TestDoubles/FakeMultiTurnAgent.cs
@@ -13,6 +13,10 @@ internal sealed class FakeMultiTurnAgent : IMultiTurnAgent
 
     public bool IsRunning { get; set; } = true;
 
+    /// <summary>When true, <see cref="DisposeAsync"/> throws — used to prove a switch tolerates a
+    /// failure tearing down the PREVIOUS agent (the new one is already swapped in).</summary>
+    public bool ThrowOnDispose { get; set; }
+
     public ValueTask<SendReceipt> SendAsync(
         List<IMessage> messages,
         string? inputId = null,
@@ -58,6 +62,11 @@ internal sealed class FakeMultiTurnAgent : IMultiTurnAgent
 
     public ValueTask DisposeAsync()
     {
+        if (ThrowOnDispose)
+        {
+            throw new InvalidOperationException("Simulated dispose failure for the previous agent.");
+        }
+
         return ValueTask.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary
Makes a conversation's **provider** switchable after its run completes — mirroring **mode**. Provider is
now editable while the conversation is idle and locked only while a run streams; workspace stays bound
for life. Also fixes a robustness gap surfaced during testing (a 500 leaking on old-agent disposal) and
adds reusable single-call Playwright manual-test tooling. Scoped to the LmStreaming.Sample app + its test
infra; no wire-protocol or DTO breaking changes.

## Changes
- **Backend** — `POST /api/conversations/{threadId}/provider` (`SwitchProviderRequest`) mirroring
  `SwitchMode` (409 while streaming, 503 unavailable, 200 idle); `MultiTurnAgentPool
  .RecreateAgentWithProviderAsync` + `PersistProviderAsync` (validate target, preserve mode + persisted
  workspace, recreate, overwrite persisted provider). **Old-agent disposal is now non-fatal** in both
  `RecreateAgentWith{Provider,Mode}Async` — a failed teardown of the already-replaced agent no longer
  leaks a 500 for a swap that succeeded.
- **Client** — `switchConversationProvider` + `useProviders.switchProvider`;
  `ChatLayout.handleSelectProvider` started-vs-messageless split (+ sidebar summary update); dropped the
  permanent provider lock — `ProviderSelector` is an always-dropdown **disabled while streaming**
  (mirrors `ModeSelector`).
- **Manual-test tooling** — `playwright-scripts/` single-call scripts (`provider-switch.mjs`,
  `queue-button.mjs`) run via `browser_run_code_unsafe({filename})` returning `{ pass, failures, steps }`,
  replacing snapshot→act→screenshot loops; mandated in `CLAUDE.md`, prompts in `PromptExamples.md`.

## Testing
- **Backend unit:** pool (4) + controller (4) — incl. dispose-throws-still-succeeds and 409/503/idle/stale.
- **Client unit:** `useProviders.switchProvider` (2), `ChatLayout` start-gating (3), `ProviderSelector`
  disabled-state (4).
- **Browser E2E:** new `ProviderSwitchTests` switches `test` ⇄ `test-anthropic` **both directions** and
  asserts the next turn streams on the recreated agent (required making `ScriptedBuilder` provider-aware
  so a scripted↔scripted switch no longer 404s the mismatched wire).
- Green: backend **372**, client **292** + `vue-tsc`, full Browser.E2E (aside from a pre-existing
  machine-load flake in `StreamingResumeToolPillsTests` that passes in isolation).
- Live: both `.mjs` smoke scripts pass; Husky `format-verify` passed on both commits.

## Related Issues
Fixes #136
