### PR TITLE
feat(triggers): generic Wait/CancelWait/ListWaits primitive (#107)

### DIFF
--- a/docs/features/wait-trigger-primitive/README.md
+++ b/docs/features/wait-trigger-primitive/README.md
@@ -1,0 +1,126 @@
+# Wait / Trigger Primitive
+
+## What it is
+
+A generic way for an LLM, mid multi-turn conversation, to **wait for a background or scheduled
+event** and resume with a self-describing result — layered on the existing
+[deferred tool execution](../deferred-tool-execution/motivation.md) park/wake core.
+
+The model calls a single tool:
+
+```jsonc
+Wait({
+  kind,      // required — a registered trigger kind (this release ships "timer")
+  args,      // optional — per-kind options object
+  timeout,   // required — duration ("10m", "30s") or absolute ISO-8601 time; the safety ceiling
+  label,     // optional — short, self-describing; shown in ListWaits
+})
+CancelWait({ id?, label?, kind? })   // total + idempotent
+ListWaits()                           // armed waits + registered kinds
+```
+
+`Wait` **parks the run** (returns a deferred tool result). When the event fires — or the `timeout`
+ceiling is reached — the run resumes automatically and the tool's result is a small JSON payload:
+
+```jsonc
+{ "status": "fired" | "timed_out" | "cancelled" | "failed", "kind": "timer", "label": "...", ... }
+```
+
+### Built-in `timer` source
+
+```jsonc
+Wait({ kind: "timer", args: { delay: "10m" }, timeout: "11m" })          // wake me in 10 minutes
+Wait({ kind: "timer", args: { deadline: "2026-07-31T12:00:00Z" }, timeout: "2026-07-31T12:05:00Z" })
+Wait({ kind: "timer", timeout: "5m" })                                     // no args → fire at the timeout
+```
+
+## Design
+
+### One extensibility seam
+
+Adding a new wake source is "implement `ITriggerSource` + register it" — no change to the agent loop
+or the tool surface. A source only **observes** its event and reports a raw fact to a runtime-owned
+sink; it holds no lifecycle policy:
+
+```csharp
+public interface ITriggerSource
+{
+    ValueTask<IArmedTrigger> ArmAsync(TriggerArmRequest request, ITriggerEventSink eventSink, CancellationToken ct);
+}
+
+public interface ITriggerEventSink   // implemented by the runtime, bound to one wait
+{
+    ValueTask FireAsync(TriggerFireEvent fire, CancellationToken ct);
+}
+
+public interface IArmedTrigger : IAsyncDisposable { string WaitId { get; } }  // a cancellable handle
+```
+
+Register a host source through `TriggerOptions`:
+
+```csharp
+var options = new TriggerOptions
+{
+    MaxConcurrentWaits = 16,
+    MaxBlockWaitDuration = TimeSpan.FromMinutes(15),
+    AdditionalRegistrations =
+    [
+        new TriggerSourceRegistration
+        {
+            Kind = "my_event",
+            Description = "wait for my custom event",
+            ArgsSchema = "{ ... }",
+            Capabilities = new TriggerCapabilities(SupportsBlock: true, SupportsNotify: false, SupportsRestore: false),
+            Source = new MyTriggerSource(),
+        },
+    ],
+};
+var loop = new MultiTurnAgentLoop(providerAgent, registry, threadId, triggerOptions: options);
+```
+
+### The runtime owns the lifecycle
+
+`TriggerRuntime` owns every state transition so behavior is identical across kinds:
+
+```
+Pending ──► Fired      (the source's event fired first)
+        ├─► TimedOut   (the ceiling elapsed first)
+        ├─► Cancelled  (CancelWait before any fire)
+        └─► Failed     (arm error, or trigger_lost_on_restart)
+```
+
+- **Exactly one terminal transition** per wait — a single-resolution latch (an atomic
+  compare-and-swap in the runtime, not in the source). A fire racing a timeout racing a cancel
+  produces exactly one delivery; the losers are no-ops.
+- **Ceiling timeout** is runtime-owned and applied to every wait. It fires a hair after the nominal
+  deadline so a time-based source whose fire coincides with the ceiling deterministically resolves
+  as `fired`, not `timed_out`.
+- **Cancellation** stops the underlying source (disposes the handle → no later fire) and resolves the
+  parked block wait with `cancelled`.
+- **Delivery** goes through the loop's existing public `ResolveToolCallAsync` — no new loop API.
+
+### One wait identity, one persistence model
+
+A block wait's identity **is** its deferred `tool_call_id`. It needs no new persisted record: the
+existing `IsDeferred=true` placeholder (plus `DeferredAt`) is the arming record. On restart,
+`OnHistoryRestoredAsync` reconciles each recovered wait:
+
+- a restorable source (e.g. `timer`) re-arms for its remaining delay — firing immediately if the
+  instant already elapsed while offline;
+- a non-restorable source resolves the wait with `trigger_lost_on_restart`.
+
+A restored block wait is **never left hanging**.
+
+### Safety
+
+- Mandatory `timeout` on every wait (clamped to `MaxBlockWaitDuration`) — no leaked waits.
+- Bounded concurrency (`MaxConcurrentWaits`); over-limit arms return a structured `rejected` result
+  (not an exception, not a park) so the model can react.
+- Source payloads are size-capped (`MaxPayloadBytes`) with a truncation marker.
+- `ListWaits` exposes only identity/kind/label/timing — never raw payloads or source internals.
+
+## Deferred to follow-ups
+
+Notify mode (keep working + injected `<trigger>` messages), file-tail / process / cron-interval /
+sub-agent-completion sources, durable notify-watcher restore, and any shared background-work base
+class are intentionally out of this first PR. The seam is designed so each is a drop-in.

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -9,6 +9,7 @@ using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Middleware;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
 using Microsoft.Extensions.Logging;
 
 namespace AchieveAi.LmDotnetTools.LmMultiTurn;
@@ -36,6 +37,9 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
     private readonly IStreamingAgent _agent;
     private readonly IDictionary<string, ToolHandler> _toolHandlers;
     private readonly SubAgentManager? _subAgentManager;
+
+    // Owns the Wait/trigger lifecycle when trigger options are supplied. Null otherwise.
+    private readonly TriggerRuntime? _triggerRuntime;
 
     // Deferred tool tracking. Keyed by ToolCallId. Concurrent because resolutions arrive on
     // arbitrary threads (UI callbacks, webhook handlers).
@@ -76,6 +80,12 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
     ///     (MessageTransformation, MessageUpdateJoiner) their own category loggers so their
     ///     ordering/de-dup decisions are visible in structured logs. When null they stay silent.
     /// </param>
+    /// <param name="triggerOptions">
+    ///     Optional Wait/trigger configuration. When provided, the loop enables the
+    ///     <c>Wait</c>/<c>CancelWait</c>/<c>ListWaits</c> tools backed by a <see cref="TriggerRuntime"/>
+    ///     (with the built-in one-shot <c>timer</c> source plus any host registrations). When null,
+    ///     no wait tools are exposed.
+    /// </param>
     public MultiTurnAgentLoop(
         IStreamingAgent providerAgent,
         FunctionRegistry functionRegistry,
@@ -89,7 +99,8 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         ILogger<MultiTurnAgentLoop>? logger = null,
         SubAgentOptions? subAgentOptions = null,
         MutableSubAgentTemplateSource? subAgentTemplateSource = null,
-        ILoggerFactory? loggerFactory = null)
+        ILoggerFactory? loggerFactory = null,
+        TriggerOptions? triggerOptions = null)
         : base(threadId, systemPrompt, defaultOptions, maxTurnsPerRun, inputChannelCapacity, outputChannelCapacity, store, logger)
     {
         ArgumentNullException.ThrowIfNull(providerAgent);
@@ -129,6 +140,26 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
             _ = functionRegistry.AddProvider(toolProvider);
         }
 
+        // When trigger options are supplied, stand up the Wait/trigger runtime and register the
+        // Wait/CancelWait/ListWaits tools. Registered AFTER the sub-agent snapshot so sub-agents
+        // don't inherit the wait surface. The runtime resolves parked block waits through the
+        // loop's existing public ResolveToolCallAsync — no new loop API is exposed.
+        if (triggerOptions != null)
+        {
+            _triggerRuntime = new TriggerRuntime(
+                triggerOptions,
+                resolve: (toolCallId, result, isError, ct) =>
+                    ResolveToolCallAsync(toolCallId, result, isError, contentBlocks: null, ct),
+                logger: logger);
+            _triggerRuntime.RegisterBuiltIns();
+            foreach (var registration in triggerOptions.AdditionalRegistrations)
+            {
+                _triggerRuntime.Register(registration);
+            }
+
+            _ = functionRegistry.AddProvider(new WaitToolProvider(_triggerRuntime));
+        }
+
         // Build tool call components from registry
         var (toolCallMiddleware, finalHandlers) = functionRegistry.BuildToolCallComponents(name: "MultiTurnAgentTools");
         _toolHandlers = finalHandlers;
@@ -155,6 +186,11 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         if (_subAgentManager != null)
         {
             await _subAgentManager.DisposeAsync();
+        }
+
+        if (_triggerRuntime != null)
+        {
+            await _triggerRuntime.DisposeAsync();
         }
     }
 
@@ -818,14 +854,14 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
     }
 
     /// <inheritdoc />
-    protected override Task OnHistoryRestoredAsync(IReadOnlyList<IMessage> messages, CancellationToken ct)
+    protected override async Task OnHistoryRestoredAsync(IReadOnlyList<IMessage> messages, CancellationToken ct)
     {
         // Rebuild the deferred registry from persisted history. Each ToolCallResultMessage
         // with IsDeferred=true gets re-registered so GetDeferredToolCallsAsync surfaces it
         // and ResolveToolCallAsync can complete it after restart.
         if (messages == null || messages.Count == 0)
         {
-            return Task.CompletedTask;
+            return;
         }
 
         // Index ToolCallMessages by ToolCallId so we can recover function name/args for
@@ -880,7 +916,22 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                 _deferred.Count);
         }
 
-        return Task.CompletedTask;
+        // Reconcile restored block waits so no parked Wait is left hanging: a restorable source
+        // (e.g. timer) re-arms for its remaining delay; a non-restorable one resolves as
+        // trigger_lost_on_restart. Runs after the deferred set is rebuilt so it sees every entry.
+        if (_triggerRuntime != null)
+        {
+            List<RestoredWait> restoredList =
+            [
+                .. _deferred.Values
+                    .Where(e => e.FunctionName == WaitToolProvider.WaitToolName)
+                    .Select(e => new RestoredWait(e.ToolCallId, e.FunctionArgs, e.DeferredAtUnixMs)),
+            ];
+            if (restoredList.Count > 0)
+            {
+                await _triggerRuntime.ReconcileRestoredAsync(restoredList, ct);
+            }
+        }
     }
 
     private bool HasUnresolvedDeferralsForGeneration(string generationId)

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -222,11 +222,6 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                 var realInputs = batch.Where(b => b.Resume == null).ToList();
                 var resumeSentinels = batch.Where(b => b.Resume != null).ToList();
 
-                if (realInputs.Count == 0 && resumeSentinels.Count == 0)
-                {
-                    continue;
-                }
-
                 if (resumeSentinels.Count > 0)
                 {
                     // Clear the scheduled flag now that we're consuming the sentinel; future
@@ -919,17 +914,31 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         // Reconcile restored block waits so no parked Wait is left hanging: a restorable source
         // (e.g. timer) re-arms for its remaining delay; a non-restorable one resolves as
         // trigger_lost_on_restart. Runs after the deferred set is rebuilt so it sees every entry.
+        List<DeferredEntry> restoredWaitEntries =
+            [.. _deferred.Values.Where(e => e.FunctionName == WaitToolProvider.WaitToolName)];
+
         if (_triggerRuntime != null)
         {
-            List<RestoredWait> restoredList =
-            [
-                .. _deferred.Values
-                    .Where(e => e.FunctionName == WaitToolProvider.WaitToolName)
-                    .Select(e => new RestoredWait(e.ToolCallId, e.FunctionArgs, e.DeferredAtUnixMs)),
-            ];
-            if (restoredList.Count > 0)
+            if (restoredWaitEntries.Count > 0)
             {
+                List<RestoredWait> restoredList =
+                    [.. restoredWaitEntries.Select(e => new RestoredWait(e.ToolCallId, e.FunctionArgs, e.DeferredAtUnixMs))];
                 await _triggerRuntime.ReconcileRestoredAsync(restoredList, ct);
+            }
+        }
+        else if (restoredWaitEntries.Count > 0)
+        {
+            // Triggers are disabled in this host (or were rolled back after these waits were
+            // persisted) — there is no runtime left to re-arm or fail them. Resolve each restored
+            // Wait with a terminal failure now rather than leaving the run parked forever.
+            foreach (var entry in restoredWaitEntries)
+            {
+                await ResolveToolCallAsync(
+                    entry.ToolCallId,
+                    JsonSerializer.Serialize(new { status = "failed", reason = "trigger_disabled", waitId = entry.ToolCallId }),
+                    isError: false,
+                    contentBlocks: null,
+                    ct);
             }
         }
     }

--- a/src/LmMultiTurn/Triggers/IArmedTrigger.cs
+++ b/src/LmMultiTurn/Triggers/IArmedTrigger.cs
@@ -1,0 +1,14 @@
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+
+/// <summary>
+/// Handle to a single armed trigger, returned by <see cref="ITriggerSource.ArmAsync"/>. It is a
+/// pure resource handle: disposing it stops the underlying watcher/timer and guarantees no
+/// further <see cref="ITriggerEventSink.FireAsync"/> callback occurs. All lifecycle policy
+/// (single-resolution latch, ceiling timeout, cancellation semantics, delivery) lives in the
+/// runtime, not here.
+/// </summary>
+public interface IArmedTrigger : IAsyncDisposable
+{
+    /// <summary>The wait this handle belongs to.</summary>
+    string WaitId { get; }
+}

--- a/src/LmMultiTurn/Triggers/ITriggerEventSink.cs
+++ b/src/LmMultiTurn/Triggers/ITriggerEventSink.cs
@@ -1,0 +1,12 @@
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+
+/// <summary>
+/// Runtime-owned callback a <see cref="ITriggerSource"/> invokes when its event fires. The sink
+/// handed to <see cref="ITriggerSource.ArmAsync"/> is already bound to the specific wait, so the
+/// source does not echo the wait id — it simply reports "my event happened".
+/// </summary>
+public interface ITriggerEventSink
+{
+    /// <summary>Report that the source's observed event occurred.</summary>
+    ValueTask FireAsync(TriggerFireEvent fire, CancellationToken cancellationToken);
+}

--- a/src/LmMultiTurn/Triggers/ITriggerSource.cs
+++ b/src/LmMultiTurn/Triggers/ITriggerSource.cs
@@ -10,7 +10,8 @@ namespace AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
 /// Implementations MUST be safe to reuse across many concurrent arms (each <see cref="ArmAsync"/>
 /// call returns an independent <see cref="IArmedTrigger"/> handle and must hold no per-wait state
 /// on the source itself). A source must never resolve tool calls, enforce timeouts, or count
-/// fires — those are runtime concerns.
+/// fires — those are runtime concerns. Fires MUST be asynchronous: a source must not invoke the
+/// sink synchronously from within <see cref="ArmAsync"/> (yield first if the event is already due).
 /// </remarks>
 public interface ITriggerSource
 {

--- a/src/LmMultiTurn/Triggers/ITriggerSource.cs
+++ b/src/LmMultiTurn/Triggers/ITriggerSource.cs
@@ -1,0 +1,26 @@
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+
+/// <summary>
+/// The one extensibility seam for the Wait/trigger primitive. A source knows how to observe one
+/// kind of event (a timer elapsing, a file line matching, a process exiting, …) and report it to
+/// a runtime-owned sink. Adding a new wake kind is "implement this interface + register it" — no
+/// change to the agent loop or the tool surface.
+/// </summary>
+/// <remarks>
+/// Implementations MUST be safe to reuse across many concurrent arms (each <see cref="ArmAsync"/>
+/// call returns an independent <see cref="IArmedTrigger"/> handle and must hold no per-wait state
+/// on the source itself). A source must never resolve tool calls, enforce timeouts, or count
+/// fires — those are runtime concerns.
+/// </remarks>
+public interface ITriggerSource
+{
+    /// <summary>
+    /// Arm one wait. Parse <see cref="TriggerArmRequest.ArgsJson"/>, begin observing, and invoke
+    /// <paramref name="eventSink"/> when the event fires. Return a handle whose disposal stops the
+    /// observation.
+    /// </summary>
+    ValueTask<IArmedTrigger> ArmAsync(
+        TriggerArmRequest request,
+        ITriggerEventSink eventSink,
+        CancellationToken cancellationToken);
+}

--- a/src/LmMultiTurn/Triggers/Sources/TimerTriggerSource.cs
+++ b/src/LmMultiTurn/Triggers/Sources/TimerTriggerSource.cs
@@ -115,6 +115,11 @@ public sealed class TimerTriggerSource : ITriggerSource
 
         private static async Task RunAsync(DateTimeOffset fireAt, ITriggerEventSink sink, CancellationToken ct)
         {
+            // Yield first so the fire is always asynchronous — never synchronous within ArmAsync,
+            // even when the instant has already elapsed (Task.Delay(0) would otherwise continue
+            // synchronously and fire before the runtime has finished registering the wait).
+            await Task.Yield();
+
             var remaining = fireAt - DateTimeOffset.UtcNow;
             if (remaining < TimeSpan.Zero)
             {

--- a/src/LmMultiTurn/Triggers/Sources/TimerTriggerSource.cs
+++ b/src/LmMultiTurn/Triggers/Sources/TimerTriggerSource.cs
@@ -45,19 +45,39 @@ public sealed class TimerTriggerSource : ITriggerSource
     /// Computes the absolute instant the timer should fire, relative to the arm time so restart
     /// re-arming yields the same wall-clock target.
     /// </summary>
+    /// <exception cref="ArgumentException">
+    /// The args are not a JSON object, supply both <c>delay</c> and <c>deadline</c>, or supply a
+    /// <c>delay</c>/<c>deadline</c> that does not parse. Invalid input is rejected rather than
+    /// silently falling back to the wait's ceiling, so the caller sees a structured rejection it
+    /// can correct instead of an unexpectedly-late fire.
+    /// </exception>
     private static DateTimeOffset ResolveFireInstant(TriggerArmRequest request)
     {
         var (delay, deadline) = ParseArgs(request.ArgsJson);
+        var hasDelay = !string.IsNullOrWhiteSpace(delay);
+        var hasDeadline = !string.IsNullOrWhiteSpace(deadline);
 
-        if (!string.IsNullOrWhiteSpace(deadline)
-            && TriggerDurations.TryResolveInstant(deadline, request.ArmedAt, out var absolute, out _))
+        if (hasDelay && hasDeadline)
         {
+            throw new ArgumentException("timer args must supply at most one of 'delay' or 'deadline', not both.");
+        }
+
+        if (hasDeadline)
+        {
+            if (!TriggerDurations.TryResolveInstant(deadline, request.ArmedAt, out var absolute, out var error))
+            {
+                throw new ArgumentException($"timer 'deadline' is invalid: {error}");
+            }
             return absolute;
         }
 
-        if (!string.IsNullOrWhiteSpace(delay)
-            && TriggerDurations.TryParseDuration(delay, out var relative))
+        if (hasDelay)
         {
+            if (!TriggerDurations.TryParseDuration(delay, out var relative))
+            {
+                throw new ArgumentException(
+                    $"timer 'delay' is invalid: '{delay}' is not a duration (e.g. \"10m\", \"30s\").");
+            }
             return request.ArmedAt + relative;
         }
 
@@ -72,27 +92,41 @@ public sealed class TimerTriggerSource : ITriggerSource
             return (null, null);
         }
 
+        JsonDocument doc;
         try
         {
-            using var doc = JsonDocument.Parse(argsJson);
+            doc = JsonDocument.Parse(argsJson);
+        }
+        catch (JsonException ex)
+        {
+            throw new ArgumentException($"timer args is not valid JSON: {ex.Message}", ex);
+        }
+
+        using (doc)
+        {
             var root = doc.RootElement;
             if (root.ValueKind != JsonValueKind.Object)
             {
-                return (null, null);
+                throw new ArgumentException("timer args must be a JSON object.");
             }
 
-            var delay = root.TryGetProperty("delay", out var d) && d.ValueKind == JsonValueKind.String
-                ? d.GetString()
-                : null;
-            var deadline = root.TryGetProperty("deadline", out var dl) && dl.ValueKind == JsonValueKind.String
-                ? dl.GetString()
-                : null;
-            return (delay, deadline);
+            return (GetOptionalString(root, "delay"), GetOptionalString(root, "deadline"));
         }
-        catch (JsonException)
+    }
+
+    private static string? GetOptionalString(JsonElement root, string name)
+    {
+        if (!root.TryGetProperty(name, out var el) || el.ValueKind == JsonValueKind.Null)
         {
-            return (null, null);
+            return null;
         }
+
+        if (el.ValueKind != JsonValueKind.String)
+        {
+            throw new ArgumentException($"timer '{name}' must be a string.");
+        }
+
+        return el.GetString();
     }
 
     /// <summary>

--- a/src/LmMultiTurn/Triggers/Sources/TimerTriggerSource.cs
+++ b/src/LmMultiTurn/Triggers/Sources/TimerTriggerSource.cs
@@ -1,0 +1,166 @@
+using System.Text.Json;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Triggers.Sources;
+
+/// <summary>
+/// Built-in one-shot timer source. Fires once when its configured instant is reached, then never
+/// again. The awaited instant comes from <c>args.deadline</c> (absolute) or <c>args.delay</c>
+/// (relative to when the wait was armed); if neither is supplied it defaults to the wait's own
+/// ceiling deadline (i.e. <c>Wait({kind:"timer", timeout:"10m"})</c> means "wake me in 10m").
+/// </summary>
+/// <remarks>
+/// Restartable: the fire instant is a pure function of the persisted arm time and args, so a
+/// restored wait re-arms for its remaining delay (or fires immediately if already elapsed). This
+/// source holds no per-wait state — each <see cref="ArmAsync"/> returns an independent handle.
+/// </remarks>
+public sealed class TimerTriggerSource : ITriggerSource
+{
+    /// <summary>The registered kind token.</summary>
+    public const string KindName = "timer";
+
+    /// <summary>Capabilities: block + restore. Notify is a future follow-up.</summary>
+    public static TriggerCapabilities Capabilities { get; } =
+        new(SupportsBlock: true, SupportsNotify: false, SupportsRestore: true);
+
+    /// <summary>Human-readable args hint for the tool contract.</summary>
+    public const string ArgsSchemaText =
+        "{ delay?: \"<duration e.g. 10m|30s|2h>\", deadline?: \"<ISO-8601 time>\" } "
+        + "— supply at most one; if omitted, fires at the wait's timeout.";
+
+    /// <inheritdoc />
+    public ValueTask<IArmedTrigger> ArmAsync(
+        TriggerArmRequest request,
+        ITriggerEventSink eventSink,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(eventSink);
+
+        var fireAt = ResolveFireInstant(request);
+        var handle = new TimerArmedTrigger(request.WaitId, fireAt, eventSink);
+        return ValueTask.FromResult<IArmedTrigger>(handle);
+    }
+
+    /// <summary>
+    /// Computes the absolute instant the timer should fire, relative to the arm time so restart
+    /// re-arming yields the same wall-clock target.
+    /// </summary>
+    private static DateTimeOffset ResolveFireInstant(TriggerArmRequest request)
+    {
+        var (delay, deadline) = ParseArgs(request.ArgsJson);
+
+        if (!string.IsNullOrWhiteSpace(deadline)
+            && TriggerDurations.TryResolveInstant(deadline, request.ArmedAt, out var absolute, out _))
+        {
+            return absolute;
+        }
+
+        if (!string.IsNullOrWhiteSpace(delay)
+            && TriggerDurations.TryParseDuration(delay, out var relative))
+        {
+            return request.ArmedAt + relative;
+        }
+
+        // No explicit fire time — fire at the wait's ceiling ("sleep until timeout").
+        return request.Deadline;
+    }
+
+    private static (string? Delay, string? Deadline) ParseArgs(string argsJson)
+    {
+        if (string.IsNullOrWhiteSpace(argsJson))
+        {
+            return (null, null);
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(argsJson);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return (null, null);
+            }
+
+            var delay = root.TryGetProperty("delay", out var d) && d.ValueKind == JsonValueKind.String
+                ? d.GetString()
+                : null;
+            var deadline = root.TryGetProperty("deadline", out var dl) && dl.ValueKind == JsonValueKind.String
+                ? dl.GetString()
+                : null;
+            return (delay, deadline);
+        }
+        catch (JsonException)
+        {
+            return (null, null);
+        }
+    }
+
+    /// <summary>
+    /// Per-arm handle. Runs a single <see cref="Task.Delay(TimeSpan, CancellationToken)"/> for the
+    /// remaining delay and reports one fire. Disposal cancels the delay so no fire occurs afterward.
+    /// </summary>
+    private sealed class TimerArmedTrigger : IArmedTrigger
+    {
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _timerTask;
+        private int _disposed;
+
+        public TimerArmedTrigger(string waitId, DateTimeOffset fireAt, ITriggerEventSink sink)
+        {
+            WaitId = waitId;
+            _timerTask = RunAsync(fireAt, sink, _cts.Token);
+        }
+
+        public string WaitId { get; }
+
+        private static async Task RunAsync(DateTimeOffset fireAt, ITriggerEventSink sink, CancellationToken ct)
+        {
+            var remaining = fireAt - DateTimeOffset.UtcNow;
+            if (remaining < TimeSpan.Zero)
+            {
+                remaining = TimeSpan.Zero;
+            }
+
+            try
+            {
+                await Task.Delay(remaining, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                return; // disposed/cancelled before firing — no fire.
+            }
+
+            await sink.FireAsync(new TriggerFireEvent(), ct);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            await _cts.CancelAsync();
+
+            // Do NOT await _timerTask here: disposal is normally invoked by the runtime from
+            // within the fire callback (fire → runtime finalize → source dispose), and awaiting
+            // our own still-running task would deadlock. Dispose the CTS once the task settles,
+            // off the current stack.
+            _ = _timerTask.ContinueWith(
+                _ =>
+                {
+                    try
+                    {
+                        _cts.Dispose();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // Already disposed — nothing to do.
+                    }
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+    }
+}

--- a/src/LmMultiTurn/Triggers/TriggerArmRequest.cs
+++ b/src/LmMultiTurn/Triggers/TriggerArmRequest.cs
@@ -1,0 +1,34 @@
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+
+/// <summary>
+/// Everything a <see cref="ITriggerSource"/> needs to arm a single wait. The runtime owns the
+/// wait lifecycle (latch, ceiling timeout, cancellation, delivery); a source only observes its
+/// event and reports it through the supplied <see cref="ITriggerEventSink"/>.
+/// </summary>
+public sealed record TriggerArmRequest
+{
+    /// <summary>Canonical wait identity. For a block wait this is the deferred tool_call_id.</summary>
+    public required string WaitId { get; init; }
+
+    /// <summary>The registered kind this arm targets (e.g. <c>"timer"</c>).</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>Raw per-kind arguments JSON (the <c>args</c> object from the <c>Wait</c> call).</summary>
+    public required string ArgsJson { get; init; }
+
+    /// <summary>Optional short, human-readable label echoed in <c>ListWaits</c>.</summary>
+    public string? Label { get; init; }
+
+    /// <summary>
+    /// Reference instant the wait was (re-)armed at. Fresh arms pass <c>now</c>; restart
+    /// reconciliation passes the original arm time so a source can compute the remaining delay
+    /// relative to when the wait was first created.
+    /// </summary>
+    public required DateTimeOffset ArmedAt { get; init; }
+
+    /// <summary>
+    /// Absolute ceiling for this wait. The runtime enforces this independently (a source need not
+    /// honor it); it is provided so time-based sources with no explicit fire time can default to it.
+    /// </summary>
+    public required DateTimeOffset Deadline { get; init; }
+}

--- a/src/LmMultiTurn/Triggers/TriggerCapabilities.cs
+++ b/src/LmMultiTurn/Triggers/TriggerCapabilities.cs
@@ -1,0 +1,22 @@
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+
+/// <summary>
+/// Declares what a <see cref="ITriggerSource"/> can do, so the <c>Wait</c> tool contract can
+/// describe each kind explicitly and stably rather than inferring capabilities at runtime.
+/// </summary>
+/// <param name="SupportsBlock">
+/// The source can back a block-mode wait (park the run, resolve with the fire payload).
+/// </param>
+/// <param name="SupportsNotify">
+/// The source can back a notify-mode wait (inject a message without parking). Reserved for a
+/// follow-up — no source ships notify support in this release.
+/// </param>
+/// <param name="SupportsRestore">
+/// A wait armed against this source can be safely re-armed after a process restart from its
+/// persisted arming record. Sources that cannot (e.g. a one-shot external event) return false,
+/// and a restored block wait against them resolves with <c>trigger_lost_on_restart</c>.
+/// </param>
+public sealed record TriggerCapabilities(
+    bool SupportsBlock,
+    bool SupportsNotify,
+    bool SupportsRestore);

--- a/src/LmMultiTurn/Triggers/TriggerDurations.cs
+++ b/src/LmMultiTurn/Triggers/TriggerDurations.cs
@@ -1,0 +1,119 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+
+/// <summary>
+/// Parses the compact duration / absolute-time strings the LLM supplies for <c>timeout</c> and
+/// timer <c>args</c> — e.g. <c>"30s"</c>, <c>"10m"</c>, <c>"2h"</c>, <c>"1d"</c>, or an absolute
+/// ISO-8601 instant like <c>"2026-07-31T12:00:00Z"</c>.
+/// </summary>
+internal static partial class TriggerDurations
+{
+    [GeneratedRegex(@"^\s*(?<value>\d+)\s*(?<unit>ms|s|m|h|d)\s*$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex DurationRegex();
+
+    /// <summary>
+    /// Parses a relative duration string ("10m", "500ms", …). Returns false for absolute times or
+    /// malformed input.
+    /// </summary>
+    public static bool TryParseDuration(string? spec, out TimeSpan duration)
+    {
+        duration = default;
+        if (string.IsNullOrWhiteSpace(spec))
+        {
+            return false;
+        }
+
+        var match = DurationRegex().Match(spec);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        if (!long.TryParse(match.Groups["value"].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+        {
+            return false;
+        }
+
+        duration = match.Groups["unit"].Value.ToLowerInvariant() switch
+        {
+            "ms" => TimeSpan.FromMilliseconds(value),
+            "s" => TimeSpan.FromSeconds(value),
+            "m" => TimeSpan.FromMinutes(value),
+            "h" => TimeSpan.FromHours(value),
+            "d" => TimeSpan.FromDays(value),
+            _ => TimeSpan.Zero,
+        };
+        return duration > TimeSpan.Zero;
+    }
+
+    /// <summary>
+    /// Resolves a spec that is EITHER a relative duration (added to <paramref name="from"/>) OR an
+    /// absolute ISO-8601 instant, into an absolute instant. Returns false with a reason otherwise.
+    /// </summary>
+    public static bool TryResolveInstant(
+        string? spec,
+        DateTimeOffset from,
+        out DateTimeOffset instant,
+        out string? error)
+    {
+        instant = default;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(spec))
+        {
+            error = "value is required";
+            return false;
+        }
+
+        if (TryParseDuration(spec, out var duration))
+        {
+            instant = from + duration;
+            return true;
+        }
+
+        if (DateTimeOffset.TryParse(
+                spec,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var parsed))
+        {
+            instant = parsed;
+            return true;
+        }
+
+        error = $"'{spec}' is not a valid duration (e.g. \"10m\") or ISO-8601 time";
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves a wait's ceiling deadline from a <c>timeout</c> spec relative to
+    /// <paramref name="from"/>, clamped so the deadline is never further out than
+    /// <paramref name="max"/> and never in the past.
+    /// </summary>
+    public static bool TryResolveDeadline(
+        string? spec,
+        DateTimeOffset from,
+        TimeSpan max,
+        out DateTimeOffset deadline,
+        out string? error)
+    {
+        deadline = default;
+
+        if (!TryResolveInstant(spec, from, out var instant, out error))
+        {
+            return false;
+        }
+
+        if (instant <= from)
+        {
+            error = "timeout must be in the future";
+            return false;
+        }
+
+        var maxDeadline = from + max;
+        deadline = instant > maxDeadline ? maxDeadline : instant;
+        return true;
+    }
+}

--- a/src/LmMultiTurn/Triggers/TriggerFireEvent.cs
+++ b/src/LmMultiTurn/Triggers/TriggerFireEvent.cs
@@ -1,0 +1,12 @@
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+
+/// <summary>
+/// A raw fact reported by a <see cref="ITriggerSource"/> when its observed event occurs. The
+/// runtime decides whether this is the winning terminal transition for the wait and how to
+/// deliver it — the source expresses no lifecycle policy.
+/// </summary>
+/// <param name="Payload">
+/// Optional source-specific detail merged into the delivered result (size-capped by the runtime).
+/// May be null when the fire itself is the only signal (e.g. a timer elapsing).
+/// </param>
+public sealed record TriggerFireEvent(string? Payload = null);

--- a/src/LmMultiTurn/Triggers/TriggerOptions.cs
+++ b/src/LmMultiTurn/Triggers/TriggerOptions.cs
@@ -1,0 +1,31 @@
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+
+/// <summary>
+/// Host-configurable limits and extra source registrations for the Wait/trigger primitive. Passed
+/// to <c>MultiTurnAgentLoop</c> to enable the <c>Wait</c> / <c>CancelWait</c> / <c>ListWaits</c>
+/// tools. When provided, the built-in one-shot <c>timer</c> source is registered automatically;
+/// <see cref="AdditionalRegistrations"/> adds host-specific kinds.
+/// </summary>
+public sealed record TriggerOptions
+{
+    /// <summary>
+    /// Maximum number of simultaneously-armed waits. Arming beyond this returns a structured
+    /// <c>rejected</c> result (not an exception, not a park) so the model can react.
+    /// </summary>
+    public int MaxConcurrentWaits { get; init; } = 16;
+
+    /// <summary>Maximum bytes of source-supplied payload merged into a delivered result; excess is truncated.</summary>
+    public int MaxPayloadBytes { get; init; } = 8 * 1024;
+
+    /// <summary>Hard ceiling on a block wait's duration. A requested timeout larger than this is clamped down.</summary>
+    public TimeSpan MaxBlockWaitDuration { get; init; } = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// How long an arm waits to acquire a concurrency slot before rejecting with
+    /// <c>max_concurrent_waits</c>. Kept small so a full gate rejects promptly.
+    /// </summary>
+    public TimeSpan GateAcquireTimeout { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>Host-specific trigger kinds to register in addition to the built-in <c>timer</c>.</summary>
+    public IReadOnlyList<TriggerSourceRegistration> AdditionalRegistrations { get; init; } = [];
+}

--- a/src/LmMultiTurn/Triggers/TriggerRuntime.cs
+++ b/src/LmMultiTurn/Triggers/TriggerRuntime.cs
@@ -45,9 +45,10 @@ public sealed class TriggerRuntime : IAsyncDisposable
 
     // The loop registers a deferral and appends its placeholder to history immediately AFTER the
     // handler returns Deferred; a fast fire can briefly precede that append. Tolerate it with a
-    // bounded retry rather than exposing loop internals to gate on.
-    private const int DeliverMaxAttempts = 50;
-    private const int DeliverRetryMs = 20;
+    // bounded retry (generous total budget for slow persistence) rather than exposing loop
+    // internals to gate on. ~200 * 50ms ≈ 10s worst case.
+    private const int DeliverMaxAttempts = 200;
+    private const int DeliverRetryMs = 50;
 
     private readonly TriggerOptions _options;
     private readonly TriggerResolveDelegate _resolve;
@@ -189,6 +190,17 @@ public sealed class TriggerRuntime : IAsyncDisposable
 
             var sink = new WaitSink(this, wait);
             wait.Source = await reg.Source.ArmAsync(request, sink, _shutdown.Token);
+
+            // Defensive: a well-behaved source fires asynchronously (never during ArmAsync), but if
+            // one fired synchronously the wait already reached a terminal state and FinalizeAsync ran
+            // before wait.Source was assigned (so it could not dispose the source). Complete that
+            // cleanup here and don't re-register or start a ceiling for an already-terminal wait.
+            if (wait.State != WaitState.Pending)
+            {
+                await wait.Source.DisposeAsync();
+                return WaitArmResult.Accept(waitId);
+            }
+
             _waits[waitId] = wait;
             StartCeilingTimer(wait);
 
@@ -219,7 +231,7 @@ public sealed class TriggerRuntime : IAsyncDisposable
         var cancelled = 0;
         foreach (var wait in matches)
         {
-            if (await FinalizeAsync(wait, WaitState.Cancelled, BuildTerminalPayload("cancelled", wait), isError: false, ct))
+            if (await FinalizeAsync(wait, WaitState.Cancelled, BuildTerminalPayload("cancelled", wait), isError: false))
             {
                 cancelled++;
             }
@@ -278,7 +290,7 @@ public sealed class TriggerRuntime : IAsyncDisposable
         {
             if (!WaitToolArgs.TryParse(r.FunctionArgs, out var parsed))
             {
-                await DeliverAsync(r.ToolCallId, BuildFailedPayload(r.ToolCallId, "unknown", null, "trigger_lost_on_restart"), isError: false, ct);
+                await DeliverAsync(r.ToolCallId, BuildFailedPayload(r.ToolCallId, "unknown", null, "trigger_lost_on_restart"), isError: false);
                 continue;
             }
 
@@ -287,33 +299,44 @@ public sealed class TriggerRuntime : IAsyncDisposable
                 await DeliverAsync(
                     r.ToolCallId,
                     BuildFailedPayload(r.ToolCallId, parsed.Kind, parsed.Label, "trigger_lost_on_restart"),
-                    isError: false,
-                    ct);
+                    isError: false);
                 continue;
             }
 
-            var armedAt = DateTimeOffset.FromUnixTimeMilliseconds(r.DeferredAtUnixMs);
+            // A missing arm timestamp (older/hand-authored data) would otherwise map to the Unix
+            // epoch and expire instantly — restart the clock from now instead.
+            var armedAt = r.DeferredAtUnixMs > 0
+                ? DateTimeOffset.FromUnixTimeMilliseconds(r.DeferredAtUnixMs)
+                : DateTimeOffset.UtcNow;
             if (!TriggerDurations.TryResolveDeadline(parsed.Timeout, armedAt, _options.MaxBlockWaitDuration, out var deadline, out _))
             {
                 // Ceiling already elapsed while offline (or unparseable) — resolve as timed out.
                 await DeliverAsync(
                     r.ToolCallId,
                     BuildTerminalPayload("timed_out", new ArmedWait { WaitId = r.ToolCallId, Kind = parsed.Kind, Label = parsed.Label, ArmedAt = armedAt, Deadline = armedAt }),
-                    isError: false,
-                    ct);
+                    isError: false);
                 continue;
             }
 
-            _ = await ArmCoreAsync(r.ToolCallId, reg, parsed.ArgsJson, parsed.Label, armedAt, deadline, ct);
+            var armResult = await ArmCoreAsync(r.ToolCallId, reg, parsed.ArgsJson, parsed.Label, armedAt, deadline, ct);
+            if (!armResult.IsArmed)
+            {
+                // Re-arm was rejected (e.g. concurrency limit, source arm failure). Do NOT leave the
+                // parked run hanging — resolve it as a restart failure.
+                await DeliverAsync(
+                    r.ToolCallId,
+                    BuildFailedPayload(r.ToolCallId, parsed.Kind, parsed.Label, armResult.Reason ?? "trigger_lost_on_restart"),
+                    isError: false);
+            }
         }
     }
 
     // ---- internal transition machinery -------------------------------------------------------
 
-    private async ValueTask OnSourceFiredAsync(ArmedWait wait, TriggerFireEvent fire, CancellationToken ct)
+    private async ValueTask OnSourceFiredAsync(ArmedWait wait, TriggerFireEvent fire)
     {
         var payload = BuildFiredPayload(wait, fire);
-        _ = await FinalizeAsync(wait, WaitState.Fired, payload, isError: false, ct);
+        _ = await FinalizeAsync(wait, WaitState.Fired, payload, isError: false);
     }
 
     /// <summary>
@@ -321,7 +344,7 @@ public sealed class TriggerRuntime : IAsyncDisposable
     /// ceiling timer, disposes the source (no fire after dispose), releases the concurrency slot,
     /// and delivers the one result. Returns true only for the winning caller.
     /// </summary>
-    private async Task<bool> FinalizeAsync(ArmedWait wait, WaitState state, string payload, bool isError, CancellationToken ct)
+    private async Task<bool> FinalizeAsync(ArmedWait wait, WaitState state, string payload, bool isError)
     {
         if (!wait.TryClaim(state))
         {
@@ -354,12 +377,16 @@ public sealed class TriggerRuntime : IAsyncDisposable
         _ = _waits.TryRemove(wait.WaitId, out _);
         ReleaseGate(wait);
 
-        await DeliverAsync(wait.WaitId, payload, isError, ct);
+        // Deliver with a fresh, uncancellable token: the terminal result must reach the loop even
+        // though disposing the source above cancels the source's own token, and even if the
+        // operation that triggered this transition (a CancelWait) carried a cancelled token.
+        await DeliverAsync(wait.WaitId, payload, isError);
         return true;
     }
 
-    private async Task DeliverAsync(string toolCallId, string payload, bool isError, CancellationToken ct)
+    private async Task DeliverAsync(string toolCallId, string payload, bool isError)
     {
+        var ct = CancellationToken.None;
         for (var attempt = 1; ; attempt++)
         {
             try
@@ -418,7 +445,7 @@ public sealed class TriggerRuntime : IAsyncDisposable
                 return; // wait already terminated another way.
             }
 
-            _ = await FinalizeAsync(wait, WaitState.TimedOut, BuildTerminalPayload("timed_out", wait), isError: false, CancellationToken.None);
+            _ = await FinalizeAsync(wait, WaitState.TimedOut, BuildTerminalPayload("timed_out", wait), isError: false);
         });
     }
 
@@ -426,7 +453,15 @@ public sealed class TriggerRuntime : IAsyncDisposable
     {
         if (Interlocked.Exchange(ref wait.GateReleased, 1) == 0)
         {
-            _ = _concurrencyGate.Release();
+            try
+            {
+                _ = _concurrencyGate.Release();
+            }
+            catch (ObjectDisposedException)
+            {
+                // A fire/timeout finalizing concurrently with runtime disposal may reach here after
+                // the gate is disposed. The slot no longer matters once the runtime is shutting down.
+            }
         }
     }
 
@@ -437,8 +472,10 @@ public sealed class TriggerRuntime : IAsyncDisposable
         var detail = fire.Payload;
         if (detail != null && Encoding.UTF8.GetByteCount(detail) > _options.MaxPayloadBytes)
         {
-            var truncated = TruncateUtf8(detail, _options.MaxPayloadBytes);
-            detail = truncated + $"\n[truncated to {_options.MaxPayloadBytes} bytes]";
+            // Reserve room for the marker so the resulting detail stays within MaxPayloadBytes.
+            var marker = $"\n[truncated to {_options.MaxPayloadBytes} bytes]";
+            var budget = Math.Max(0, _options.MaxPayloadBytes - Encoding.UTF8.GetByteCount(marker));
+            detail = TruncateUtf8(detail, budget) + marker;
         }
 
         return Serialize(new Dictionary<string, object?>
@@ -576,6 +613,6 @@ public sealed class TriggerRuntime : IAsyncDisposable
     private sealed class WaitSink(TriggerRuntime runtime, ArmedWait wait) : ITriggerEventSink
     {
         public ValueTask FireAsync(TriggerFireEvent fire, CancellationToken cancellationToken) =>
-            runtime.OnSourceFiredAsync(wait, fire, cancellationToken);
+            runtime.OnSourceFiredAsync(wait, fire);
     }
 }

--- a/src/LmMultiTurn/Triggers/TriggerRuntime.cs
+++ b/src/LmMultiTurn/Triggers/TriggerRuntime.cs
@@ -440,10 +440,16 @@ public sealed class TriggerRuntime : IAsyncDisposable
 
         _ = Task.Run(async () =>
         {
-            var delay = wait.Deadline + TimeSpan.FromMilliseconds(CeilingGraceMs) - DateTimeOffset.UtcNow;
-            if (delay < TimeSpan.Zero)
+            var grace = TimeSpan.FromMilliseconds(CeilingGraceMs);
+            var delay = wait.Deadline + grace - DateTimeOffset.UtcNow;
+            if (delay < grace)
             {
-                delay = TimeSpan.Zero;
+                // The deadline itself may already be in the past (e.g. a wait restored after the
+                // process was offline past its timeout). The source's own timer also clamps its
+                // remaining delay to "fire ASAP" in that case, so the ceiling must still wait the
+                // full grace period measured from now - clamping straight to zero here would erase
+                // the source's head start and turn the "fired vs timed_out" outcome into a race.
+                delay = grace;
             }
 
             try

--- a/src/LmMultiTurn/Triggers/TriggerRuntime.cs
+++ b/src/LmMultiTurn/Triggers/TriggerRuntime.cs
@@ -1,0 +1,581 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Triggers.Sources;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+
+/// <summary>
+/// Delivers a resolved wait payload back to the owning agent loop. Supplied by the loop so the
+/// runtime never references loop internals or grows public loop APIs — for a block wait this is
+/// simply <c>MultiTurnAgentLoop.ResolveToolCallAsync</c> partially applied.
+/// </summary>
+public delegate Task TriggerResolveDelegate(
+    string toolCallId,
+    string result,
+    bool isError,
+    CancellationToken cancellationToken);
+
+/// <summary>
+/// A block wait recovered from persisted history on restart. Carries the original <c>Wait</c>
+/// arguments and the instant it was armed so the runtime can re-arm (or expire) it.
+/// </summary>
+public sealed record RestoredWait(string ToolCallId, string FunctionArgs, long DeferredAtUnixMs);
+
+/// <summary>
+/// Owns the entire lifecycle of every armed wait: the single-resolution latch, the ceiling
+/// timeout, cancellation, bounded concurrency, resource cleanup, and delivery back to the loop.
+/// Trigger <see cref="ITriggerSource"/>s are dumb observers that only report fire events to a
+/// runtime-owned sink; every state transition and policy decision happens here so behavior is
+/// identical across all kinds.
+/// </summary>
+/// <remarks>
+/// State machine per wait: <c>Pending → { Fired | TimedOut | Cancelled | Failed }</c>, exactly one
+/// terminal transition, claimed atomically. Whoever wins the claim performs cleanup and delivers
+/// the single result; all other concurrent transitions (a fire racing the timeout racing a cancel)
+/// become no-ops.
+/// </remarks>
+public sealed class TriggerRuntime : IAsyncDisposable
+{
+    // Ceiling fires this much AFTER the nominal deadline so that, for time-based sources whose
+    // fire instant coincides with the ceiling, the source's "fired" outcome deterministically
+    // wins the latch over "timed_out".
+    private const int CeilingGraceMs = 50;
+
+    // The loop registers a deferral and appends its placeholder to history immediately AFTER the
+    // handler returns Deferred; a fast fire can briefly precede that append. Tolerate it with a
+    // bounded retry rather than exposing loop internals to gate on.
+    private const int DeliverMaxAttempts = 50;
+    private const int DeliverRetryMs = 20;
+
+    private readonly TriggerOptions _options;
+    private readonly TriggerResolveDelegate _resolve;
+    private readonly ILogger? _logger;
+    private readonly SemaphoreSlim _concurrencyGate;
+    private readonly ConcurrentDictionary<string, TriggerSourceRegistration> _registrations =
+        new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, ArmedWait> _waits = new(StringComparer.Ordinal);
+    private readonly CancellationTokenSource _shutdown = new();
+    private int _disposed;
+
+    public TriggerRuntime(TriggerOptions options, TriggerResolveDelegate resolve, ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(resolve);
+        _options = options;
+        _resolve = resolve;
+        _logger = logger;
+        _concurrencyGate = new SemaphoreSlim(options.MaxConcurrentWaits, options.MaxConcurrentWaits);
+    }
+
+    /// <summary>Registers the built-in one-shot <c>timer</c> source.</summary>
+    public void RegisterBuiltIns()
+    {
+        Register(new TriggerSourceRegistration
+        {
+            Kind = TimerTriggerSource.KindName,
+            Description = "Wait for a one-shot timer to elapse (a relative delay or an absolute deadline).",
+            ArgsSchema = TimerTriggerSource.ArgsSchemaText,
+            Capabilities = TimerTriggerSource.Capabilities,
+            Source = new TimerTriggerSource(),
+        });
+    }
+
+    /// <summary>Registers a trigger kind. The last registration for a kind wins.</summary>
+    public void Register(TriggerSourceRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+        _registrations[registration.Kind] = registration;
+    }
+
+    /// <summary>The kinds currently registered.</summary>
+    public IReadOnlyCollection<string> RegisteredKinds => [.. _registrations.Keys];
+
+    /// <summary>
+    /// Builds the stable, per-session catalog embedded in the <c>Wait</c> tool description so the
+    /// model can see every kind and its args shape.
+    /// </summary>
+    public string DescribeKindsForToolContract()
+    {
+        var sb = new StringBuilder();
+        _ = sb.Append("Registered wait kinds:");
+        foreach (var reg in _registrations.Values.OrderBy(r => r.Kind, StringComparer.Ordinal))
+        {
+            _ = sb.Append("\n- ").Append(reg.Kind).Append(": ").Append(reg.Description)
+                .Append("\n  args: ").Append(reg.ArgsSchema);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Arms a fresh block wait keyed by <paramref name="waitId"/> (the deferred tool_call_id).
+    /// Returns <see cref="WaitArmResult.Accept"/> when armed (caller parks the run) or a structured
+    /// rejection otherwise.
+    /// </summary>
+    public async Task<WaitArmResult> ArmAsync(
+        string waitId,
+        string kind,
+        string argsJson,
+        string timeout,
+        string? label,
+        CancellationToken ct)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            return WaitArmResult.Reject("shutting_down", "The trigger runtime is disposed.");
+        }
+
+        if (!_registrations.TryGetValue(kind, out var reg))
+        {
+            return WaitArmResult.Reject(
+                "unknown_kind",
+                $"No trigger kind '{kind}' is registered. Registered kinds: {string.Join(", ", RegisteredKinds)}.");
+        }
+
+        if (!reg.Capabilities.SupportsBlock)
+        {
+            return WaitArmResult.Reject("unsupported_mode", $"Kind '{kind}' does not support block waits.");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        if (!TriggerDurations.TryResolveDeadline(timeout, now, _options.MaxBlockWaitDuration, out var deadline, out var timeoutError))
+        {
+            return WaitArmResult.Reject("invalid_timeout", timeoutError ?? "invalid timeout");
+        }
+
+        return await ArmCoreAsync(waitId, reg, argsJson, label, now, deadline, ct);
+    }
+
+    private async Task<WaitArmResult> ArmCoreAsync(
+        string waitId,
+        TriggerSourceRegistration reg,
+        string argsJson,
+        string? label,
+        DateTimeOffset armedAt,
+        DateTimeOffset deadline,
+        CancellationToken ct)
+    {
+        // Bounded concurrency: acquire once here, release exactly once when the wait terminates
+        // (or in the failure path below if arming the source throws).
+        if (!await _concurrencyGate.WaitAsync(_options.GateAcquireTimeout, ct))
+        {
+            return WaitArmResult.Reject(
+                "max_concurrent_waits",
+                $"The maximum of {_options.MaxConcurrentWaits} concurrent waits is reached. "
+                + "Cancel a wait or wait for one to complete.");
+        }
+
+        var wait = new ArmedWait
+        {
+            WaitId = waitId,
+            Kind = reg.Kind,
+            Label = label,
+            ArmedAt = armedAt,
+            Deadline = deadline,
+        };
+
+        try
+        {
+            var request = new TriggerArmRequest
+            {
+                WaitId = waitId,
+                Kind = reg.Kind,
+                ArgsJson = string.IsNullOrWhiteSpace(argsJson) ? "{}" : argsJson,
+                Label = label,
+                ArmedAt = armedAt,
+                Deadline = deadline,
+            };
+
+            var sink = new WaitSink(this, wait);
+            wait.Source = await reg.Source.ArmAsync(request, sink, _shutdown.Token);
+            _waits[waitId] = wait;
+            StartCeilingTimer(wait);
+
+            _logger?.LogInformation(
+                "trigger.armed {WaitId} kind={Kind} deadline={Deadline:o}",
+                waitId, reg.Kind, deadline);
+
+            return WaitArmResult.Accept(waitId);
+        }
+        catch (Exception ex)
+        {
+            ReleaseGate(wait);
+            _ = _waits.TryRemove(waitId, out _);
+            _logger?.LogWarning(ex, "trigger.arm_failed {WaitId} kind={Kind}", waitId, reg.Kind);
+            return WaitArmResult.Reject("arm_failed", ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Cancels every armed wait matching the selector (by id, label, or kind). Total and
+    /// idempotent: unknown or already-terminal waits contribute nothing. Returns the number of
+    /// waits this call transitioned to <see cref="WaitState.Cancelled"/>.
+    /// </summary>
+    public async Task<int> CancelWaitsAsync(string? id, string? label, string? kind, CancellationToken ct)
+    {
+        List<ArmedWait> matches = [.. _waits.Values.Where(w => Matches(w, id, label, kind))];
+
+        var cancelled = 0;
+        foreach (var wait in matches)
+        {
+            if (await FinalizeAsync(wait, WaitState.Cancelled, BuildTerminalPayload("cancelled", wait), isError: false, ct))
+            {
+                cancelled++;
+            }
+        }
+        return cancelled;
+    }
+
+    private static bool Matches(ArmedWait wait, string? id, string? label, string? kind)
+    {
+        // A total selector (all null) matches nothing — CancelWait requires at least one filter.
+        if (id == null && label == null && kind == null)
+        {
+            return false;
+        }
+
+        if (id != null && !string.Equals(wait.WaitId, id, StringComparison.Ordinal))
+        {
+            return false;
+        }
+        if (label != null && !string.Equals(wait.Label, label, StringComparison.Ordinal))
+        {
+            return false;
+        }
+        if (kind != null && !string.Equals(wait.Kind, kind, StringComparison.Ordinal))
+        {
+            return false;
+        }
+        return true;
+    }
+
+    /// <summary>Read model of currently-armed waits (no payloads or source internals exposed).</summary>
+    public IReadOnlyList<WaitInfo> ListWaits() =>
+        [.. _waits.Values
+            .Where(w => w.State == WaitState.Pending)
+            .Select(w => new WaitInfo
+            {
+                WaitId = w.WaitId,
+                Kind = w.Kind,
+                Label = w.Label,
+                State = WaitState.Pending,
+                ArmedAt = w.ArmedAt.ToString("o"),
+                Deadline = w.Deadline.ToString("o"),
+            })];
+
+    /// <summary>
+    /// Reconciles block waits recovered from persisted history after a restart. A restorable kind
+    /// (e.g. timer) is re-armed for its remaining delay — firing immediately if already elapsed. A
+    /// non-restorable kind, or one whose original args no longer parse, resolves as
+    /// <c>trigger_lost_on_restart</c> so the parked run is never left hanging.
+    /// </summary>
+    public async Task ReconcileRestoredAsync(IReadOnlyList<RestoredWait> restored, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(restored);
+
+        foreach (var r in restored)
+        {
+            if (!WaitToolArgs.TryParse(r.FunctionArgs, out var parsed))
+            {
+                await DeliverAsync(r.ToolCallId, BuildFailedPayload(r.ToolCallId, "unknown", null, "trigger_lost_on_restart"), isError: false, ct);
+                continue;
+            }
+
+            if (!_registrations.TryGetValue(parsed.Kind, out var reg) || !reg.Capabilities.SupportsRestore)
+            {
+                await DeliverAsync(
+                    r.ToolCallId,
+                    BuildFailedPayload(r.ToolCallId, parsed.Kind, parsed.Label, "trigger_lost_on_restart"),
+                    isError: false,
+                    ct);
+                continue;
+            }
+
+            var armedAt = DateTimeOffset.FromUnixTimeMilliseconds(r.DeferredAtUnixMs);
+            if (!TriggerDurations.TryResolveDeadline(parsed.Timeout, armedAt, _options.MaxBlockWaitDuration, out var deadline, out _))
+            {
+                // Ceiling already elapsed while offline (or unparseable) — resolve as timed out.
+                await DeliverAsync(
+                    r.ToolCallId,
+                    BuildTerminalPayload("timed_out", new ArmedWait { WaitId = r.ToolCallId, Kind = parsed.Kind, Label = parsed.Label, ArmedAt = armedAt, Deadline = armedAt }),
+                    isError: false,
+                    ct);
+                continue;
+            }
+
+            _ = await ArmCoreAsync(r.ToolCallId, reg, parsed.ArgsJson, parsed.Label, armedAt, deadline, ct);
+        }
+    }
+
+    // ---- internal transition machinery -------------------------------------------------------
+
+    private async ValueTask OnSourceFiredAsync(ArmedWait wait, TriggerFireEvent fire, CancellationToken ct)
+    {
+        var payload = BuildFiredPayload(wait, fire);
+        _ = await FinalizeAsync(wait, WaitState.Fired, payload, isError: false, ct);
+    }
+
+    /// <summary>
+    /// Attempts the single terminal transition for <paramref name="wait"/>. The winner stops the
+    /// ceiling timer, disposes the source (no fire after dispose), releases the concurrency slot,
+    /// and delivers the one result. Returns true only for the winning caller.
+    /// </summary>
+    private async Task<bool> FinalizeAsync(ArmedWait wait, WaitState state, string payload, bool isError, CancellationToken ct)
+    {
+        if (!wait.TryClaim(state))
+        {
+            return false; // lost the race — already terminal.
+        }
+
+        _logger?.LogInformation("trigger.{State} {WaitId} kind={Kind}", state.ToString().ToLowerInvariant(), wait.WaitId, wait.Kind);
+
+        try
+        {
+            wait.CancelCeiling();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "trigger ceiling-timer teardown failed for {WaitId}", wait.WaitId);
+        }
+
+        if (wait.Source != null)
+        {
+            try
+            {
+                await wait.Source.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "trigger source dispose failed for {WaitId}", wait.WaitId);
+            }
+        }
+
+        _ = _waits.TryRemove(wait.WaitId, out _);
+        ReleaseGate(wait);
+
+        await DeliverAsync(wait.WaitId, payload, isError, ct);
+        return true;
+    }
+
+    private async Task DeliverAsync(string toolCallId, string payload, bool isError, CancellationToken ct)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                await _resolve(toolCallId, payload, isError, ct);
+                return;
+            }
+            catch (ObjectDisposedException)
+            {
+                return; // loop torn down — nothing to resolve into.
+            }
+            catch (InvalidOperationException ex)
+                when (attempt < DeliverMaxAttempts
+                    && !ex.Message.Contains("already been resolved", StringComparison.Ordinal))
+            {
+                // The deferred placeholder is not in history yet (handler just returned Deferred).
+                // Retry briefly until the loop finishes appending it.
+                try
+                {
+                    await Task.Delay(DeliverRetryMs, ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                // Conflict, or the placeholder never appeared after the retry budget — give up.
+                _logger?.LogWarning(ex, "trigger delivery failed for {ToolCallId}", toolCallId);
+                return;
+            }
+        }
+    }
+
+    private void StartCeilingTimer(ArmedWait wait)
+    {
+        var linked = CancellationTokenSource.CreateLinkedTokenSource(_shutdown.Token);
+        wait.CeilingCts = linked;
+        var token = linked.Token;
+
+        _ = Task.Run(async () =>
+        {
+            var delay = wait.Deadline + TimeSpan.FromMilliseconds(CeilingGraceMs) - DateTimeOffset.UtcNow;
+            if (delay < TimeSpan.Zero)
+            {
+                delay = TimeSpan.Zero;
+            }
+
+            try
+            {
+                await Task.Delay(delay, token);
+            }
+            catch (OperationCanceledException)
+            {
+                return; // wait already terminated another way.
+            }
+
+            _ = await FinalizeAsync(wait, WaitState.TimedOut, BuildTerminalPayload("timed_out", wait), isError: false, CancellationToken.None);
+        });
+    }
+
+    private void ReleaseGate(ArmedWait wait)
+    {
+        if (Interlocked.Exchange(ref wait.GateReleased, 1) == 0)
+        {
+            _ = _concurrencyGate.Release();
+        }
+    }
+
+    // ---- payload building --------------------------------------------------------------------
+
+    private string BuildFiredPayload(ArmedWait wait, TriggerFireEvent fire)
+    {
+        var detail = fire.Payload;
+        if (detail != null && Encoding.UTF8.GetByteCount(detail) > _options.MaxPayloadBytes)
+        {
+            var truncated = TruncateUtf8(detail, _options.MaxPayloadBytes);
+            detail = truncated + $"\n[truncated to {_options.MaxPayloadBytes} bytes]";
+        }
+
+        return Serialize(new Dictionary<string, object?>
+        {
+            ["status"] = "fired",
+            ["kind"] = wait.Kind,
+            ["label"] = wait.Label,
+            ["waitId"] = wait.WaitId,
+            ["firedAt"] = DateTimeOffset.UtcNow.ToString("o"),
+            ["detail"] = detail,
+        });
+    }
+
+    private static string BuildTerminalPayload(string status, ArmedWait wait) =>
+        Serialize(new Dictionary<string, object?>
+        {
+            ["status"] = status,
+            ["kind"] = wait.Kind,
+            ["label"] = wait.Label,
+            ["waitId"] = wait.WaitId,
+            ["deadline"] = wait.Deadline.ToString("o"),
+        });
+
+    private static string BuildFailedPayload(string waitId, string kind, string? label, string reason) =>
+        Serialize(new Dictionary<string, object?>
+        {
+            ["status"] = "failed",
+            ["reason"] = reason,
+            ["kind"] = kind,
+            ["label"] = label,
+            ["waitId"] = waitId,
+        });
+
+    private static string Serialize(Dictionary<string, object?> map)
+    {
+        // Drop null-valued keys for a compact, stable payload.
+        var pruned = map.Where(kv => kv.Value != null).ToDictionary(kv => kv.Key, kv => kv.Value);
+        return JsonSerializer.Serialize(pruned);
+    }
+
+    private static string TruncateUtf8(string value, int maxBytes)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        if (bytes.Length <= maxBytes)
+        {
+            return value;
+        }
+
+        // Trim to a valid UTF-8 boundary at or below maxBytes.
+        var count = maxBytes;
+        while (count > 0 && (bytes[count] & 0xC0) == 0x80)
+        {
+            count--;
+        }
+        return Encoding.UTF8.GetString(bytes, 0, count);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            await _shutdown.CancelAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "trigger runtime shutdown cancel failed");
+        }
+
+        foreach (var wait in _waits.Values)
+        {
+            try
+            {
+                wait.CancelCeiling();
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogDebug(ex, "trigger ceiling teardown failed for {WaitId} during dispose", wait.WaitId);
+            }
+
+            if (wait.Source != null)
+            {
+                try
+                {
+                    await wait.Source.DisposeAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex, "trigger source dispose failed for {WaitId} during dispose", wait.WaitId);
+                }
+            }
+        }
+
+        _waits.Clear();
+        _shutdown.Dispose();
+        _concurrencyGate.Dispose();
+    }
+
+    /// <summary>Runtime-owned mutable state for one armed wait. All transitions latch on <see cref="TryClaim"/>.</summary>
+    private sealed class ArmedWait
+    {
+        private int _state; // WaitState as int; 0 == Pending.
+        public int GateReleased; // 0 == not released.
+
+        public required string WaitId { get; init; }
+        public required string Kind { get; init; }
+        public string? Label { get; init; }
+        public required DateTimeOffset ArmedAt { get; init; }
+        public required DateTimeOffset Deadline { get; init; }
+        public IArmedTrigger? Source { get; set; }
+        public CancellationTokenSource? CeilingCts { get; set; }
+
+        public WaitState State => (WaitState)Volatile.Read(ref _state);
+
+        /// <summary>Atomically claim the single terminal transition. True only for the first caller.</summary>
+        public bool TryClaim(WaitState target) =>
+            Interlocked.CompareExchange(ref _state, (int)target, (int)WaitState.Pending) == (int)WaitState.Pending;
+
+        public void CancelCeiling()
+        {
+            var cts = CeilingCts;
+            if (cts != null)
+            {
+                cts.Cancel();
+                cts.Dispose();
+            }
+        }
+    }
+
+    /// <summary>Per-wait sink handed to a source; forwards fires to the runtime bound to one wait.</summary>
+    private sealed class WaitSink(TriggerRuntime runtime, ArmedWait wait) : ITriggerEventSink
+    {
+        public ValueTask FireAsync(TriggerFireEvent fire, CancellationToken cancellationToken) =>
+            runtime.OnSourceFiredAsync(wait, fire, cancellationToken);
+    }
+}

--- a/src/LmMultiTurn/Triggers/TriggerRuntime.cs
+++ b/src/LmMultiTurn/Triggers/TriggerRuntime.cs
@@ -210,6 +210,16 @@ public sealed class TriggerRuntime : IAsyncDisposable
 
             return WaitArmResult.Accept(waitId);
         }
+        catch (ArgumentException ex)
+        {
+            // The source rejected malformed/contradictory args (e.g. a timer given both `delay`
+            // and `deadline`). This is caller-correctable, so it gets its own reason distinct from
+            // an unexpected internal failure.
+            ReleaseGate(wait);
+            _ = _waits.TryRemove(waitId, out _);
+            _logger?.LogInformation("trigger.arm_rejected {WaitId} kind={Kind} reason={Message}", waitId, reg.Kind, ex.Message);
+            return WaitArmResult.Reject("invalid_args", ex.Message);
+        }
         catch (Exception ex)
         {
             ReleaseGate(wait);

--- a/src/LmMultiTurn/Triggers/TriggerSourceRegistration.cs
+++ b/src/LmMultiTurn/Triggers/TriggerSourceRegistration.cs
@@ -1,0 +1,27 @@
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+
+/// <summary>
+/// Host-side registration of a trigger kind: the kind name the LLM uses, human-readable docs and
+/// an args-schema hint surfaced in the <c>Wait</c> tool description, the source's capabilities,
+/// and the (stateless, reusable) source instance that arms waits of this kind.
+/// </summary>
+public sealed record TriggerSourceRegistration
+{
+    /// <summary>The kind token the LLM passes as <c>Wait({kind})</c>. Unique per runtime.</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>One-line description of what this kind waits for, shown in the tool contract.</summary>
+    public required string Description { get; init; }
+
+    /// <summary>
+    /// Human-readable hint describing the <c>args</c> object for this kind (e.g.
+    /// <c>{ delay?: "10m", deadline?: "2026-07-31T12:00:00Z" }</c>). Shown in the tool contract.
+    /// </summary>
+    public required string ArgsSchema { get; init; }
+
+    /// <summary>What this source supports (block / notify / restore).</summary>
+    public required TriggerCapabilities Capabilities { get; init; }
+
+    /// <summary>The stateless source instance that arms waits of this kind.</summary>
+    public required ITriggerSource Source { get; init; }
+}

--- a/src/LmMultiTurn/Triggers/WaitArmResult.cs
+++ b/src/LmMultiTurn/Triggers/WaitArmResult.cs
@@ -1,0 +1,29 @@
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+
+/// <summary>
+/// Outcome of an arm attempt. Either the wait was armed (and the caller should park the run), or
+/// it was rejected up front with a machine-readable reason the model can act on without parking.
+/// </summary>
+public sealed record WaitArmResult
+{
+    private WaitArmResult() { }
+
+    /// <summary>True when the wait was armed; the tool handler should return <c>Deferred()</c>.</summary>
+    public bool IsArmed { get; private init; }
+
+    /// <summary>The armed wait's id (present only when <see cref="IsArmed"/>).</summary>
+    public string? WaitId { get; private init; }
+
+    /// <summary>Machine-readable rejection reason (present only when not armed).</summary>
+    public string? Reason { get; private init; }
+
+    /// <summary>Human-readable rejection detail (present only when not armed).</summary>
+    public string? Message { get; private init; }
+
+    /// <summary>Builds an armed result.</summary>
+    public static WaitArmResult Accept(string waitId) => new() { IsArmed = true, WaitId = waitId };
+
+    /// <summary>Builds a rejected result.</summary>
+    public static WaitArmResult Reject(string reason, string message) =>
+        new() { IsArmed = false, Reason = reason, Message = message };
+}

--- a/src/LmMultiTurn/Triggers/WaitInfo.cs
+++ b/src/LmMultiTurn/Triggers/WaitInfo.cs
@@ -1,0 +1,49 @@
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+
+/// <summary>
+/// Lifecycle states of a single wait. A wait starts <see cref="Pending"/> and makes exactly one
+/// terminal transition — enforced by the runtime's single-resolution latch — to <see cref="Fired"/>,
+/// <see cref="TimedOut"/>, <see cref="Cancelled"/>, or <see cref="Failed"/>.
+/// </summary>
+public enum WaitState
+{
+    /// <summary>Armed and waiting.</summary>
+    Pending = 0,
+
+    /// <summary>The source's event fired first; the wait resolved with the fire payload.</summary>
+    Fired = 1,
+
+    /// <summary>The ceiling deadline elapsed before any fire; the wait resolved with a timed-out outcome.</summary>
+    TimedOut = 2,
+
+    /// <summary>Cancelled via <c>CancelWait</c> before any fire or timeout.</summary>
+    Cancelled = 3,
+
+    /// <summary>Arming/observation failed, or the wait could not be restored after restart.</summary>
+    Failed = 4,
+}
+
+/// <summary>
+/// Read model of a currently-armed wait, returned by <c>ListWaits</c>. Deliberately omits raw
+/// payloads and source internals — it exposes only identity, kind, model-authored label, and timing.
+/// </summary>
+public sealed record WaitInfo
+{
+    /// <summary>Canonical wait id (the deferred tool_call_id for a block wait).</summary>
+    public required string WaitId { get; init; }
+
+    /// <summary>The registered kind (e.g. <c>"timer"</c>).</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>Model-authored label, if any.</summary>
+    public string? Label { get; init; }
+
+    /// <summary>Lifecycle state. Armed waits report <see cref="WaitState.Pending"/>; terminal waits are removed.</summary>
+    public required WaitState State { get; init; }
+
+    /// <summary>When the wait was armed (ISO-8601).</summary>
+    public required string ArmedAt { get; init; }
+
+    /// <summary>Absolute ceiling after which the wait times out (ISO-8601).</summary>
+    public required string Deadline { get; init; }
+}

--- a/src/LmMultiTurn/Triggers/WaitToolArgs.cs
+++ b/src/LmMultiTurn/Triggers/WaitToolArgs.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+
+/// <summary>
+/// Parsed shape of a <c>Wait</c> tool call's arguments. Shared by the tool handler (fresh calls)
+/// and the runtime's restart reconciliation (re-parsing persisted args), so both interpret the
+/// wire format identically.
+/// </summary>
+internal sealed record WaitToolArgs(string Kind, string ArgsJson, string Timeout, string? Label)
+{
+    /// <summary>
+    /// Parses <c>{ kind, args?, timeout, label? }</c>. Returns false when <c>kind</c> or
+    /// <c>timeout</c> is missing/blank; <c>args</c> defaults to an empty object.
+    /// </summary>
+    public static bool TryParse(string? json, out WaitToolArgs result)
+    {
+        result = new WaitToolArgs(string.Empty, "{}", string.Empty, null);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            var kind = GetString(root, "kind");
+            var timeout = GetString(root, "timeout");
+            if (string.IsNullOrWhiteSpace(kind) || string.IsNullOrWhiteSpace(timeout))
+            {
+                return false;
+            }
+
+            var argsJson = root.TryGetProperty("args", out var argsEl) && argsEl.ValueKind == JsonValueKind.Object
+                ? argsEl.GetRawText()
+                : "{}";
+            var label = GetString(root, "label");
+
+            result = new WaitToolArgs(kind, argsJson, timeout, string.IsNullOrWhiteSpace(label) ? null : label);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static string? GetString(JsonElement root, string name) =>
+        root.TryGetProperty(name, out var el) && el.ValueKind == JsonValueKind.String
+            ? el.GetString()
+            : null;
+}

--- a/src/LmMultiTurn/Triggers/WaitToolProvider.cs
+++ b/src/LmMultiTurn/Triggers/WaitToolProvider.cs
@@ -1,0 +1,248 @@
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmCore.Models;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+
+/// <summary>
+/// Exposes the generic <c>Wait</c> / <c>CancelWait</c> / <c>ListWaits</c> tools, kind-dispatched
+/// onto a <see cref="TriggerRuntime"/>. Registered as an <see cref="IFunctionProvider"/> so the
+/// tools join the agent's function registry alongside everything else. <c>Wait</c> parks the run
+/// (returns <c>Deferred()</c>); <c>CancelWait</c>/<c>ListWaits</c> resolve synchronously.
+/// </summary>
+public sealed class WaitToolProvider : IFunctionProvider
+{
+    /// <summary>Tool name used for the block <c>Wait</c> — also the deferred-entry function name matched on restart.</summary>
+    public const string WaitToolName = "Wait";
+
+    private readonly TriggerRuntime _runtime;
+
+    public WaitToolProvider(TriggerRuntime runtime)
+    {
+        ArgumentNullException.ThrowIfNull(runtime);
+        _runtime = runtime;
+    }
+
+    public string ProviderName => "TriggerTools";
+
+    /// <summary>Low priority (high number) so domain tools take precedence on key conflicts.</summary>
+    public int Priority => 100;
+
+    public IEnumerable<FunctionDescriptor> GetFunctions()
+    {
+        yield return CreateWaitDescriptor();
+        yield return CreateCancelWaitDescriptor();
+        yield return CreateListWaitsDescriptor();
+    }
+
+    private FunctionDescriptor CreateWaitDescriptor()
+    {
+        var contract = new FunctionContract
+        {
+            Name = WaitToolName,
+            Description =
+                "Pause and wait for a background/scheduled event, then resume with its result. "
+                + "The run parks after this call and continues automatically once the event fires "
+                + "or the timeout is reached — the result becomes this tool's return value.\n\n"
+                + _runtime.DescribeKindsForToolContract(),
+            Parameters =
+            [
+                new FunctionParameterContract
+                {
+                    Name = "kind",
+                    Description = "Which registered trigger kind to wait on (see the list above).",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
+                    IsRequired = true,
+                },
+                new FunctionParameterContract
+                {
+                    Name = "args",
+                    Description = "Per-kind options object (see each kind's args shape above).",
+                    ParameterType = new JsonSchemaObject { Type = new("object") },
+                    IsRequired = false,
+                },
+                new FunctionParameterContract
+                {
+                    Name = "timeout",
+                    Description =
+                        "Required safety ceiling: a duration (e.g. \"10m\", \"30s\") or an absolute "
+                        + "ISO-8601 time. If reached before the event fires, the wait resolves with "
+                        + "status \"timed_out\".",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
+                    IsRequired = true,
+                },
+                new FunctionParameterContract
+                {
+                    Name = "label",
+                    Description = "Optional short, self-describing label shown in ListWaits.",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
+                    IsRequired = false,
+                },
+            ],
+        };
+
+        return new FunctionDescriptor
+        {
+            Contract = contract,
+            Handler = HandleWaitAsync,
+            ProviderName = ProviderName,
+        };
+    }
+
+    private FunctionDescriptor CreateCancelWaitDescriptor()
+    {
+        var contract = new FunctionContract
+        {
+            Name = "CancelWait",
+            Description =
+                "Cancel one or more armed waits by id, label, or kind. Total and idempotent — "
+                + "cancelling an unknown or already-finished wait is a no-op. A cancelled block "
+                + "wait resolves immediately with status \"cancelled\".",
+            Parameters =
+            [
+                new FunctionParameterContract
+                {
+                    Name = "id",
+                    Description = "The waitId to cancel (from ListWaits).",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
+                    IsRequired = false,
+                },
+                new FunctionParameterContract
+                {
+                    Name = "label",
+                    Description = "Cancel all waits with this label.",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
+                    IsRequired = false,
+                },
+                new FunctionParameterContract
+                {
+                    Name = "kind",
+                    Description = "Cancel all waits of this kind.",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
+                    IsRequired = false,
+                },
+            ],
+        };
+
+        return new FunctionDescriptor
+        {
+            Contract = contract,
+            Handler = HandleCancelWaitAsync,
+            ProviderName = ProviderName,
+        };
+    }
+
+    private FunctionDescriptor CreateListWaitsDescriptor()
+    {
+        var contract = new FunctionContract
+        {
+            Name = "ListWaits",
+            Description = "List all currently-armed waits (id, kind, label, state, timing) and the registered kinds.",
+            Parameters = [],
+        };
+
+        return new FunctionDescriptor
+        {
+            Contract = contract,
+            Handler = HandleListWaitsAsync,
+            ProviderName = ProviderName,
+        };
+    }
+
+    private async Task<ToolHandlerResult> HandleWaitAsync(
+        string argsJson,
+        ToolCallContext context,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(context.ToolCallId))
+        {
+            return ToolHandlerResult.FromError(
+                Reject("missing_tool_call_id", "Wait requires a tool_call_id to correlate the deferred result."),
+                "missing_tool_call_id");
+        }
+
+        if (!WaitToolArgs.TryParse(argsJson, out var parsed))
+        {
+            return ToolHandlerResult.FromError(
+                Reject("invalid_args", "Wait requires 'kind' and 'timeout'."),
+                "invalid_args");
+        }
+
+        var result = await _runtime.ArmAsync(
+            context.ToolCallId,
+            parsed.Kind,
+            parsed.ArgsJson,
+            parsed.Timeout,
+            parsed.Label,
+            cancellationToken);
+
+        if (result.IsArmed)
+        {
+            // Park the run; the runtime resolves this tool call when the wait terminates.
+            return new ToolHandlerResult.Deferred();
+        }
+
+        return ToolHandlerResult.FromError(
+            Reject(result.Reason ?? "rejected", result.Message ?? "Wait was rejected."),
+            result.Reason);
+    }
+
+    private async Task<ToolHandlerResult> HandleCancelWaitAsync(
+        string argsJson,
+        ToolCallContext context,
+        CancellationToken cancellationToken)
+    {
+        var (id, label, kind) = ParseCancelArgs(argsJson);
+        var cancelled = await _runtime.CancelWaitsAsync(id, label, kind, cancellationToken);
+        return ToolHandlerResult.FromText(
+            JsonSerializer.Serialize(new { status = "resolved", cancelled }));
+    }
+
+    private Task<ToolHandlerResult> HandleListWaitsAsync(
+        string argsJson,
+        ToolCallContext context,
+        CancellationToken cancellationToken)
+    {
+        var waits = _runtime.ListWaits();
+        var payload = JsonSerializer.Serialize(new
+        {
+            waits,
+            registeredKinds = _runtime.RegisteredKinds,
+        });
+        return Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText(payload));
+    }
+
+    private static (string? Id, string? Label, string? Kind) ParseCancelArgs(string argsJson)
+    {
+        if (string.IsNullOrWhiteSpace(argsJson))
+        {
+            return (null, null, null);
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(argsJson);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return (null, null, null);
+            }
+
+            return (Get(root, "id"), Get(root, "label"), Get(root, "kind"));
+        }
+        catch (JsonException)
+        {
+            return (null, null, null);
+        }
+
+        static string? Get(JsonElement root, string name) =>
+            root.TryGetProperty(name, out var el) && el.ValueKind == JsonValueKind.String
+                ? el.GetString()
+                : null;
+    }
+
+    private static string Reject(string reason, string message) =>
+        JsonSerializer.Serialize(new { status = "rejected", reason, message });
+}

--- a/tests/LmMultiTurn.Tests/DeferredToolExecutionTests.cs
+++ b/tests/LmMultiTurn.Tests/DeferredToolExecutionTests.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
@@ -6,6 +7,7 @@ using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmMultiTurn;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -673,6 +675,82 @@ public class DeferredToolExecutionTests
         info.RunId.Should().Be(runId);
         info.GenerationId.Should().Be(generationId);
         info.DeferredAtUnixMs.Should().Be(1_700_000_000_000);
+    }
+
+    [Fact]
+    public async Task OnHistoryRestoredAsync_ResolvesRestoredWait_AsTriggerDisabled_WhenNoTriggerRuntime()
+    {
+        // A Wait placeholder was persisted while triggers were enabled on some earlier process,
+        // but this recovering process has triggerOptions: null (disabled, or rolled back). There
+        // is no TriggerRuntime to re-arm or fail the restored Wait via ReconcileRestoredAsync, so
+        // OnHistoryRestoredAsync must resolve it directly instead of leaving it parked forever.
+        var threadId = "test-thread-restore-wait-disabled";
+        var runId = "run_prev";
+        var generationId = "gen_prev";
+
+        var store = new InMemoryConversationStore();
+
+        var toolCall = new ToolCallMessage
+        {
+            ToolCallId = "tc_wait_persisted",
+            FunctionName = WaitToolProvider.WaitToolName,
+            FunctionArgs = "{\"kind\":\"timer\",\"timeout\":\"10m\"}",
+            Role = Role.Assistant,
+            FromAgent = "test",
+            GenerationId = generationId,
+            RunId = runId,
+        };
+        var deferredResult = new ToolCallResultMessage
+        {
+            ToolCallId = "tc_wait_persisted",
+            ToolName = WaitToolProvider.WaitToolName,
+            Result = string.Empty,
+            IsDeferred = true,
+            DeferredAt = 1_700_000_000_000,
+            Role = Role.User,
+            GenerationId = generationId,
+            RunId = runId,
+        };
+
+        await store.AppendMessagesAsync(threadId,
+        [
+            MessagePersistenceConverter.ToPersistedMessage(toolCall, threadId, runId),
+            MessagePersistenceConverter.ToPersistedMessage(deferredResult, threadId, runId),
+        ]);
+        await store.SaveMetadataAsync(threadId, new ThreadMetadata
+        {
+            ThreadId = threadId,
+            LatestRunId = runId,
+            LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        });
+
+        // Recovering loop has no triggerOptions -> _triggerRuntime is null.
+        var registry = new FunctionRegistry();
+        await using var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            registry,
+            threadId,
+            store: store,
+            logger: _loggerMock.Object);
+
+        var recovered = await loop.RecoverAsync();
+        recovered.Should().BeTrue();
+
+        // The restored Wait must not be left parked.
+        var pending = await loop.GetDeferredToolCallsAsync();
+        pending.Should().BeEmpty();
+
+        // It must have resolved with a terminal trigger_disabled failure, persisted to the store.
+        var persisted = await store.LoadMessagesAsync(threadId);
+        var resolvedMessages = MessagePersistenceConverter.FromPersistedMessages(persisted);
+        var resolved = resolvedMessages.OfType<ToolCallResultMessage>()
+            .Should().ContainSingle(m => m.ToolCallId == "tc_wait_persisted").Subject;
+        resolved.IsDeferred.Should().BeFalse();
+        resolved.IsError.Should().BeFalse();
+
+        using var payload = JsonDocument.Parse(resolved.Result);
+        payload.RootElement.GetProperty("status").GetString().Should().Be("failed");
+        payload.RootElement.GetProperty("reason").GetString().Should().Be("trigger_disabled");
     }
 
     [Fact]

--- a/tests/LmMultiTurn.Tests/Triggers/TimerTriggerSourceTests.cs
+++ b/tests/LmMultiTurn.Tests/Triggers/TimerTriggerSourceTests.cs
@@ -91,4 +91,23 @@ public class TimerTriggerSourceTests
 
         (await sink.Fired.WaitAsync(TimeSpan.FromSeconds(5))).Should().NotBeNull();
     }
+
+    [Theory]
+    [InlineData("{\"delay\":\"soon\"}")] // malformed relative duration
+    [InlineData("{\"deadline\":\"not-a-date\"}")] // malformed absolute instant
+    [InlineData("{\"delay\":\"10m\",\"deadline\":\"2026-01-01T00:00:00Z\"}")] // contradictory: both supplied
+    [InlineData("not json")] // not JSON at all
+    [InlineData("[1,2,3]")] // valid JSON, but not an object
+    [InlineData("{\"delay\":123}")] // wrong JSON value type
+    public async Task ArmAsync_RejectsInvalidArgs_InsteadOfSilentlyFallingBackToCeiling(string argsJson)
+    {
+        var source = new TimerTriggerSource();
+        var sink = new CapturingSink();
+        var now = DateTimeOffset.UtcNow;
+
+        var act = () => source.ArmAsync(Request(argsJson, now, now.AddMinutes(10)), sink, CancellationToken.None).AsTask();
+
+        await act.Should().ThrowAsync<ArgumentException>(
+            "malformed or contradictory timer args must be rejected, not silently armed against the wait's ceiling");
+    }
 }

--- a/tests/LmMultiTurn.Tests/Triggers/TimerTriggerSourceTests.cs
+++ b/tests/LmMultiTurn.Tests/Triggers/TimerTriggerSourceTests.cs
@@ -1,0 +1,94 @@
+using AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Triggers.Sources;
+using FluentAssertions;
+using Xunit;
+
+namespace LmMultiTurn.Tests.Triggers;
+
+/// <summary>
+/// Unit tests for the built-in one-shot <see cref="TimerTriggerSource"/>: it fires exactly once at
+/// the resolved instant (from <c>delay</c>, <c>deadline</c>, or the wait ceiling) and disposal
+/// before firing suppresses the fire.
+/// </summary>
+public class TimerTriggerSourceTests
+{
+    private sealed class CapturingSink : ITriggerEventSink
+    {
+        private readonly TaskCompletionSource<TriggerFireEvent> _fired =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<TriggerFireEvent> Fired => _fired.Task;
+
+        public ValueTask FireAsync(TriggerFireEvent fire, CancellationToken cancellationToken)
+        {
+            _fired.TrySetResult(fire);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static TriggerArmRequest Request(string argsJson, DateTimeOffset armedAt, DateTimeOffset deadline) => new()
+    {
+        WaitId = "tc",
+        Kind = TimerTriggerSource.KindName,
+        ArgsJson = argsJson,
+        ArmedAt = armedAt,
+        Deadline = deadline,
+    };
+
+    [Fact]
+    public async Task Fires_AfterDelay()
+    {
+        var source = new TimerTriggerSource();
+        var sink = new CapturingSink();
+        var now = DateTimeOffset.UtcNow;
+
+        await using var handle = await source.ArmAsync(
+            Request("{\"delay\":\"200ms\"}", now, now.AddMinutes(10)), sink, CancellationToken.None);
+
+        (await sink.Fired.WaitAsync(TimeSpan.FromSeconds(5))).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Fires_AtCeiling_WhenNoArgs()
+    {
+        var source = new TimerTriggerSource();
+        var sink = new CapturingSink();
+        var now = DateTimeOffset.UtcNow;
+
+        // Empty args → the timer defaults to firing at the wait's ceiling deadline.
+        await using var handle = await source.ArmAsync(
+            Request("{}", now, now.AddMilliseconds(200)), sink, CancellationToken.None);
+
+        (await sink.Fired.WaitAsync(TimeSpan.FromSeconds(5))).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DoesNotFire_WhenDisposedBeforeDeadline()
+    {
+        var source = new TimerTriggerSource();
+        var sink = new CapturingSink();
+        var now = DateTimeOffset.UtcNow;
+
+        var handle = await source.ArmAsync(
+            Request("{\"delay\":\"5s\"}", now, now.AddMinutes(10)), sink, CancellationToken.None);
+
+        await handle.DisposeAsync();
+
+        var fired = await Task.WhenAny(sink.Fired, Task.Delay(400));
+        (fired == sink.Fired).Should().BeFalse("a disposed timer must not fire");
+    }
+
+    [Fact]
+    public async Task Fires_Immediately_WhenDelayAlreadyElapsed()
+    {
+        var source = new TimerTriggerSource();
+        var sink = new CapturingSink();
+        // Armed 30 minutes ago with a 5-minute delay → already elapsed → fires ~immediately.
+        var armedAt = DateTimeOffset.UtcNow.AddMinutes(-30);
+
+        await using var handle = await source.ArmAsync(
+            Request("{\"delay\":\"5m\"}", armedAt, armedAt.AddMinutes(10)), sink, CancellationToken.None);
+
+        (await sink.Fired.WaitAsync(TimeSpan.FromSeconds(5))).Should().NotBeNull();
+    }
+}

--- a/tests/LmMultiTurn.Tests/Triggers/TriggerRuntimeTests.cs
+++ b/tests/LmMultiTurn.Tests/Triggers/TriggerRuntimeTests.cs
@@ -1,0 +1,331 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+using FluentAssertions;
+using Xunit;
+
+namespace LmMultiTurn.Tests.Triggers;
+
+/// <summary>
+/// Unit tests for <see cref="TriggerRuntime"/>: the lifecycle state machine, single-resolution
+/// latch, ceiling timeout, cancellation cleanup, bounded concurrency, payload caps, and restart
+/// reconciliation — exercised directly against a controllable dummy source, no agent loop.
+/// </summary>
+public class TriggerRuntimeTests
+{
+    private static string ReadStatus(string payloadJson)
+    {
+        using var doc = JsonDocument.Parse(payloadJson);
+        return doc.RootElement.GetProperty("status").GetString()!;
+    }
+
+    private static TriggerOptions FastOptions(int maxConcurrent = 16) => new()
+    {
+        MaxConcurrentWaits = maxConcurrent,
+        GateAcquireTimeout = TimeSpan.FromMilliseconds(150),
+        MaxBlockWaitDuration = TimeSpan.FromMinutes(15),
+    };
+
+    [Fact]
+    public async Task Fire_ResolvesWait_WithFiredStatus_ViaDummySource()
+    {
+        var resolver = new RecordingResolver();
+        var source = new ManualTriggerSource();
+        await using var runtime = new TriggerRuntime(FastOptions(), resolver.Resolve);
+        runtime.Register(Registration("dummy", source));
+
+        var armed = await runtime.ArmAsync("tc1", "dummy", "{}", "10m", "wait-a", CancellationToken.None);
+        armed.IsArmed.Should().BeTrue("an external source registered through the seam must arm");
+
+        await source.FireAsync("hello");
+
+        var payload = await resolver.FirstPayload.WaitAsync(TimeSpan.FromSeconds(5));
+        ReadStatus(payload).Should().Be("fired");
+        payload.Should().Contain("hello");
+        resolver.Count.Should().Be(1);
+        runtime.ListWaits().Should().BeEmpty("a fired wait is removed from the armed set");
+    }
+
+    [Fact]
+    public async Task Timeout_ResolvesWait_WithTimedOutStatus_WhenSourceNeverFires()
+    {
+        var resolver = new RecordingResolver();
+        var source = new ManualTriggerSource();
+        await using var runtime = new TriggerRuntime(FastOptions(), resolver.Resolve);
+        runtime.Register(Registration("dummy", source));
+
+        // Never fire; the runtime ceiling timer must resolve the wait as timed_out.
+        await runtime.ArmAsync("tc-timeout", "dummy", "{}", "300ms", null, CancellationToken.None);
+
+        var payload = await resolver.FirstPayload.WaitAsync(TimeSpan.FromSeconds(5));
+        ReadStatus(payload).Should().Be("timed_out");
+        resolver.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Cancel_ResolvesWait_WithCancelledStatus_AndDisposesSource_NoLaterFire()
+    {
+        var resolver = new RecordingResolver();
+        var source = new ManualTriggerSource();
+        await using var runtime = new TriggerRuntime(FastOptions(), resolver.Resolve);
+        runtime.Register(Registration("dummy", source));
+
+        await runtime.ArmAsync("tc-cancel", "dummy", "{}", "10m", "cancel-me", CancellationToken.None);
+
+        var cancelled = await runtime.CancelWaitsAsync("tc-cancel", null, null, CancellationToken.None);
+        cancelled.Should().Be(1);
+
+        var payload = await resolver.FirstPayload.WaitAsync(TimeSpan.FromSeconds(5));
+        ReadStatus(payload).Should().Be("cancelled");
+        source.Disposed.Should().BeTrue("cancellation must dispose the underlying source");
+
+        // A fire arriving after cancellation must be a no-op (source already disposed / latch closed).
+        await source.FireAsync("late");
+        await Task.Delay(100);
+        resolver.Count.Should().Be(1, "no delivery may occur after a terminal cancellation");
+    }
+
+    [Fact]
+    public async Task CancelWait_IsIdempotent_ForUnknownAndAlreadyTerminal()
+    {
+        var resolver = new RecordingResolver();
+        var source = new ManualTriggerSource();
+        await using var runtime = new TriggerRuntime(FastOptions(), resolver.Resolve);
+        runtime.Register(Registration("dummy", source));
+
+        // Unknown id/label/kind → nothing cancelled, no throw.
+        (await runtime.CancelWaitsAsync("nope", null, null, CancellationToken.None)).Should().Be(0);
+
+        await runtime.ArmAsync("tc-idem", "dummy", "{}", "10m", null, CancellationToken.None);
+        (await runtime.CancelWaitsAsync("tc-idem", null, null, CancellationToken.None)).Should().Be(1);
+        // Second cancel of an already-terminal wait → 0.
+        (await runtime.CancelWaitsAsync("tc-idem", null, null, CancellationToken.None)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CancelWait_BySelector_CancelsAllMatching_ByKind()
+    {
+        var resolver = new RecordingResolver();
+        var source = new ManualTriggerSource();
+        await using var runtime = new TriggerRuntime(FastOptions(), resolver.Resolve);
+        runtime.Register(Registration("dummy", source));
+
+        await runtime.ArmAsync("a", "dummy", "{}", "10m", "batch", CancellationToken.None);
+        await runtime.ArmAsync("b", "dummy", "{}", "10m", "batch", CancellationToken.None);
+
+        var byLabel = await runtime.CancelWaitsAsync(null, "batch", null, CancellationToken.None);
+        byLabel.Should().Be(2);
+        runtime.ListWaits().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ConcurrentFireAndCancel_ResolveExactlyOnce()
+    {
+        // The single-resolution latch must ensure exactly one terminal transition even when a
+        // fire and a cancel race.
+        for (var i = 0; i < 25; i++)
+        {
+            var resolver = new RecordingResolver();
+            var source = new ManualTriggerSource();
+            await using var runtime = new TriggerRuntime(FastOptions(), resolver.Resolve);
+            runtime.Register(Registration("dummy", source));
+
+            await runtime.ArmAsync($"race-{i}", "dummy", "{}", "10m", null, CancellationToken.None);
+
+            var fire = Task.Run(() => source.FireAsync("x"));
+            var cancel = Task.Run(() => runtime.CancelWaitsAsync($"race-{i}", null, null, CancellationToken.None));
+            await Task.WhenAll(fire, cancel);
+
+            await resolver.FirstPayload.WaitAsync(TimeSpan.FromSeconds(5));
+            await Task.Delay(30);
+            resolver.Count.Should().Be(1, "fire/cancel race must produce exactly one resolution");
+        }
+    }
+
+    [Fact]
+    public async Task Arm_Rejects_WhenMaxConcurrentWaitsReached()
+    {
+        var resolver = new RecordingResolver();
+        var source = new ManualTriggerSource();
+        await using var runtime = new TriggerRuntime(FastOptions(maxConcurrent: 1), resolver.Resolve);
+        runtime.Register(Registration("dummy", source));
+
+        (await runtime.ArmAsync("one", "dummy", "{}", "10m", null, CancellationToken.None)).IsArmed.Should().BeTrue();
+
+        var second = await runtime.ArmAsync("two", "dummy", "{}", "10m", null, CancellationToken.None);
+        second.IsArmed.Should().BeFalse();
+        second.Reason.Should().Be("max_concurrent_waits");
+    }
+
+    [Fact]
+    public async Task Arm_Rejects_UnknownKind()
+    {
+        var resolver = new RecordingResolver();
+        await using var runtime = new TriggerRuntime(FastOptions(), resolver.Resolve);
+        runtime.RegisterBuiltIns();
+
+        var result = await runtime.ArmAsync("x", "no-such-kind", "{}", "10m", null, CancellationToken.None);
+        result.IsArmed.Should().BeFalse();
+        result.Reason.Should().Be("unknown_kind");
+    }
+
+    [Fact]
+    public async Task Arm_Rejects_InvalidTimeout()
+    {
+        var resolver = new RecordingResolver();
+        var source = new ManualTriggerSource();
+        await using var runtime = new TriggerRuntime(FastOptions(), resolver.Resolve);
+        runtime.Register(Registration("dummy", source));
+
+        var result = await runtime.ArmAsync("x", "dummy", "{}", "not-a-time", null, CancellationToken.None);
+        result.IsArmed.Should().BeFalse();
+        result.Reason.Should().Be("invalid_timeout");
+    }
+
+    [Fact]
+    public async Task Fire_Payload_IsTruncated_AtCap()
+    {
+        var resolver = new RecordingResolver();
+        var source = new ManualTriggerSource();
+        var options = FastOptions() with { MaxPayloadBytes = 64 };
+        await using var runtime = new TriggerRuntime(options, resolver.Resolve);
+        runtime.Register(Registration("dummy", source));
+
+        await runtime.ArmAsync("tc-cap", "dummy", "{}", "10m", null, CancellationToken.None);
+        await source.FireAsync(new string('A', 10_000));
+
+        var payload = await resolver.FirstPayload.WaitAsync(TimeSpan.FromSeconds(5));
+        payload.Should().Contain("[truncated to 64 bytes]");
+        payload.Length.Should().BeLessThan(10_000);
+    }
+
+    [Fact]
+    public async Task Deliver_RetriesTransientMissingPlaceholder_ThenSucceeds()
+    {
+        // Simulates the register-window race: the deferred placeholder isn't in history for the
+        // first few resolve attempts. The runtime must retry rather than drop the resolution.
+        var attempts = 0;
+        var delivered = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task Resolve(string id, string payload, bool isError, CancellationToken ct)
+        {
+            if (Interlocked.Increment(ref attempts) < 3)
+            {
+                throw new InvalidOperationException($"no matching deferred call for '{id}'");
+            }
+            delivered.TrySetResult(payload);
+            return Task.CompletedTask;
+        }
+
+        var source = new ManualTriggerSource();
+        await using var runtime = new TriggerRuntime(FastOptions(), Resolve);
+        runtime.Register(Registration("dummy", source));
+
+        await runtime.ArmAsync("tc-retry", "dummy", "{}", "10m", null, CancellationToken.None);
+        await source.FireAsync("x");
+
+        var payload = await delivered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        ReadStatus(payload).Should().Be("fired");
+        attempts.Should().BeGreaterThanOrEqualTo(3);
+    }
+
+    [Fact]
+    public async Task ReconcileRestored_ExpiredTimer_ResolvesImmediately()
+    {
+        var resolver = new RecordingResolver();
+        await using var runtime = new TriggerRuntime(FastOptions(), resolver.Resolve);
+        runtime.RegisterBuiltIns(); // timer supports restore
+
+        // A block timer wait armed long ago with a short timeout: on restart it has elapsed.
+        var longAgo = DateTimeOffset.UtcNow.AddMinutes(-30).ToUnixTimeMilliseconds();
+        var waitArgs = JsonSerializer.Serialize(new { kind = "timer", args = new { }, timeout = "5m" });
+        await runtime.ReconcileRestoredAsync(
+            [new RestoredWait("tc-restore", waitArgs, longAgo)],
+            CancellationToken.None);
+
+        var payload = await resolver.FirstPayload.WaitAsync(TimeSpan.FromSeconds(5));
+        // Elapsed-while-offline timer fires as soon as it is re-armed.
+        ReadStatus(payload).Should().Be("fired");
+    }
+
+    [Fact]
+    public async Task ReconcileRestored_NonRestorableKind_ResolvesTriggerLostOnRestart()
+    {
+        var resolver = new RecordingResolver();
+        var source = new ManualTriggerSource();
+        await using var runtime = new TriggerRuntime(FastOptions(), resolver.Resolve);
+        runtime.Register(Registration("volatile", source, supportsRestore: false));
+
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var waitArgs = JsonSerializer.Serialize(new { kind = "volatile", args = new { }, timeout = "10m" });
+        await runtime.ReconcileRestoredAsync(
+            [new RestoredWait("tc-lost", waitArgs, now)],
+            CancellationToken.None);
+
+        var payload = await resolver.FirstPayload.WaitAsync(TimeSpan.FromSeconds(5));
+        ReadStatus(payload).Should().Be("failed");
+        payload.Should().Contain("trigger_lost_on_restart");
+    }
+
+    private static TriggerSourceRegistration Registration(string kind, ITriggerSource source, bool supportsRestore = true) => new()
+    {
+        Kind = kind,
+        Description = $"test source {kind}",
+        ArgsSchema = "{}",
+        Capabilities = new TriggerCapabilities(SupportsBlock: true, SupportsNotify: false, SupportsRestore: supportsRestore),
+        Source = source,
+    };
+
+    /// <summary>Records every resolve delegate invocation and signals the first payload.</summary>
+    private sealed class RecordingResolver
+    {
+        private readonly ConcurrentQueue<(string, string, bool)> _calls = new();
+        private readonly TaskCompletionSource<string> _first = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<string> FirstPayload => _first.Task;
+        public int Count => _calls.Count;
+
+        public Task Resolve(string toolCallId, string payload, bool isError, CancellationToken ct)
+        {
+            _calls.Enqueue((toolCallId, payload, isError));
+            _first.TrySetResult(payload);
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>A source whose single fire is triggered manually by the test.</summary>
+    private sealed class ManualTriggerSource : ITriggerSource
+    {
+        private volatile ITriggerEventSink? _sink;
+        private readonly Handle _handle = new();
+
+        public bool Disposed => _handle.Disposed;
+
+        public ValueTask<IArmedTrigger> ArmAsync(TriggerArmRequest request, ITriggerEventSink eventSink, CancellationToken cancellationToken)
+        {
+            _sink = eventSink;
+            _handle.WaitId = request.WaitId;
+            return ValueTask.FromResult<IArmedTrigger>(_handle);
+        }
+
+        public async Task FireAsync(string? payload)
+        {
+            var sink = _sink;
+            if (sink != null && !_handle.Disposed)
+            {
+                await sink.FireAsync(new TriggerFireEvent(payload), CancellationToken.None);
+            }
+        }
+
+        private sealed class Handle : IArmedTrigger
+        {
+            public string WaitId { get; set; } = string.Empty;
+            public bool Disposed { get; private set; }
+
+            public ValueTask DisposeAsync()
+            {
+                Disposed = true;
+                return ValueTask.CompletedTask;
+            }
+        }
+    }
+}

--- a/tests/LmMultiTurn.Tests/Triggers/TriggerRuntimeTests.cs
+++ b/tests/LmMultiTurn.Tests/Triggers/TriggerRuntimeTests.cs
@@ -266,6 +266,77 @@ public class TriggerRuntimeTests
         payload.Should().Contain("trigger_lost_on_restart");
     }
 
+    [Fact]
+    public async Task ReconcileRestored_ExpiredTimer_LeavesNoZombieWait()
+    {
+        // Regression: an already-elapsed restored timer must fire cleanly and leave no armed entry
+        // (an earlier version fired synchronously inside ArmAsync, re-inserting a terminal zombie).
+        var resolver = new RecordingResolver();
+        await using var runtime = new TriggerRuntime(FastOptions(), resolver.Resolve);
+        runtime.RegisterBuiltIns();
+
+        var longAgo = DateTimeOffset.UtcNow.AddMinutes(-30).ToUnixTimeMilliseconds();
+        var waitArgs = JsonSerializer.Serialize(new { kind = "timer", args = new { }, timeout = "5m" });
+        await runtime.ReconcileRestoredAsync(
+            [new RestoredWait("tc-zombie", waitArgs, longAgo)],
+            CancellationToken.None);
+
+        await resolver.FirstPayload.WaitAsync(TimeSpan.FromSeconds(5));
+        await Task.Delay(100);
+        runtime.ListWaits().Should().BeEmpty("an expired restored timer must not leave an armed entry");
+    }
+
+    [Fact]
+    public async Task ReconcileRestored_RejectedReArm_ResolvesInsteadOfHanging()
+    {
+        // Regression: if re-arming a restored wait is rejected (e.g. concurrency limit), the wait
+        // must be resolved (failed), never left parked forever.
+        var resolver = new RecordingResolver();
+        var source = new ManualTriggerSource();
+        // One slot, already taken by a live wait, so the restored re-arm cannot acquire it.
+        await using var runtime = new TriggerRuntime(FastOptions(maxConcurrent: 1), resolver.Resolve);
+        runtime.Register(Registration("dummy", source));
+        await runtime.ArmAsync("live", "dummy", "{}", "10m", null, CancellationToken.None);
+
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var waitArgs = JsonSerializer.Serialize(new { kind = "dummy", args = new { }, timeout = "10m" });
+        await runtime.ReconcileRestoredAsync(
+            [new RestoredWait("tc-reject", waitArgs, now)],
+            CancellationToken.None);
+
+        var payload = await resolver.FirstPayload.WaitAsync(TimeSpan.FromSeconds(5));
+        ReadStatus(payload).Should().Be("failed");
+    }
+
+    [Fact]
+    public async Task Fire_Delivers_EvenWhenSourceTokenCancelsOnDispose_AndDeliveryRetries()
+    {
+        // Regression for the fire-path token bug: disposing the source (which cancels the source's
+        // token) must not abort delivery, even when the first resolve attempt is transiently
+        // rejected (the register-window). Delivery uses an uncancellable token.
+        var attempts = 0;
+        var delivered = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task Resolve(string id, string payload, bool isError, CancellationToken ct)
+        {
+            if (Interlocked.Increment(ref attempts) < 3)
+            {
+                throw new InvalidOperationException($"no matching deferred call for '{id}'");
+            }
+            delivered.TrySetResult(payload);
+            return Task.CompletedTask;
+        }
+
+        var source = new TokenCancellingSource();
+        await using var runtime = new TriggerRuntime(FastOptions(), Resolve);
+        runtime.Register(Registration("cancel_on_dispose", source));
+
+        await runtime.ArmAsync("tc-token", "cancel_on_dispose", "{}", "10m", null, CancellationToken.None);
+        await source.FireAsync();
+
+        var payload = await delivered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        ReadStatus(payload).Should().Be("fired");
+    }
+
     private static TriggerSourceRegistration Registration(string kind, ITriggerSource source, bool supportsRestore = true) => new()
     {
         Kind = kind,
@@ -324,6 +395,50 @@ public class TriggerRuntimeTests
             public ValueTask DisposeAsync()
             {
                 Disposed = true;
+                return ValueTask.CompletedTask;
+            }
+        }
+    }
+
+    /// <summary>
+    /// A source that fires with a token it cancels on disposal — mimics the built-in timer, whose
+    /// DisposeAsync cancels the token the fire callback carries. Used to prove delivery is robust to
+    /// that cancellation.
+    /// </summary>
+    private sealed class TokenCancellingSource : ITriggerSource
+    {
+        private readonly Handle _handle = new();
+        private volatile ITriggerEventSink? _sink;
+
+        public ValueTask<IArmedTrigger> ArmAsync(TriggerArmRequest request, ITriggerEventSink eventSink, CancellationToken cancellationToken)
+        {
+            _sink = eventSink;
+            return ValueTask.FromResult<IArmedTrigger>(_handle);
+        }
+
+        public async Task FireAsync()
+        {
+            var sink = _sink;
+            if (sink != null)
+            {
+                // Fire carries the source's own token, exactly as the timer source does.
+                await sink.FireAsync(new TriggerFireEvent("payload"), _handle.Token);
+            }
+        }
+
+        private sealed class Handle : IArmedTrigger
+        {
+            private readonly CancellationTokenSource _cts = new();
+
+            public string WaitId { get; } = "tc-token";
+            public CancellationToken Token => _cts.Token;
+
+            public ValueTask DisposeAsync()
+            {
+                // Cancels the token the in-flight fire callback is carrying — the runtime must not
+                // let this abort delivery.
+                _cts.Cancel();
+                _cts.Dispose();
                 return ValueTask.CompletedTask;
             }
         }

--- a/tests/LmMultiTurn.Tests/Triggers/WaitToolProviderTests.cs
+++ b/tests/LmMultiTurn.Tests/Triggers/WaitToolProviderTests.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+using FluentAssertions;
+using Xunit;
+
+namespace LmMultiTurn.Tests.Triggers;
+
+/// <summary>
+/// Provider-level tests for <see cref="WaitToolProvider"/>'s <c>ListWaits</c> and <c>CancelWait</c>
+/// handlers against a real <see cref="TriggerRuntime"/>. Invokes the <see cref="FunctionDescriptor"/>
+/// handlers directly (bypassing <c>MultiTurnAgentLoop</c>, whose send-guard rejects a new turn while
+/// a <c>Wait</c> is parked, making a full loop-driven second-turn test awkward for this purpose) so
+/// the JSON args parsing and serialized response shapes are exercised end-to-end.
+/// </summary>
+public class WaitToolProviderTests : IAsyncLifetime
+{
+    private TriggerRuntime _runtime = null!;
+    private FunctionDescriptor _wait = null!;
+    private FunctionDescriptor _cancelWait = null!;
+    private FunctionDescriptor _listWaits = null!;
+
+    public Task InitializeAsync()
+    {
+        _runtime = new TriggerRuntime(new TriggerOptions(), (_, _, _, _) => Task.CompletedTask);
+        _runtime.RegisterBuiltIns();
+        var provider = new WaitToolProvider(_runtime);
+
+        var functions = provider.GetFunctions().ToDictionary(f => f.Contract.Name);
+        _wait = functions[WaitToolProvider.WaitToolName];
+        _cancelWait = functions["CancelWait"];
+        _listWaits = functions["ListWaits"];
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync() => await _runtime.DisposeAsync();
+
+    private static string WaitArgs() =>
+        JsonSerializer.Serialize(new { kind = "timer", args = new { }, timeout = "10m" });
+
+    private async Task<JsonDocument> ListAsync() =>
+        JsonDocument.Parse((await _listWaits.Handler("{}", new ToolCallContext(), CancellationToken.None)).ResultText);
+
+    [Fact]
+    public async Task ListWaits_ShowsArmedWait_ThenEmpty_AfterCancelWait()
+    {
+        // Arm a long-timeout timer wait directly through the Wait handler; it parks (Deferred) and
+        // stays pending for the rest of this test since nothing fires it.
+        var waitResult = await _wait.Handler(WaitArgs(), new ToolCallContext { ToolCallId = "tc_1" }, CancellationToken.None);
+        waitResult.Should().BeOfType<ToolHandlerResult.Deferred>();
+
+        using (var listed = await ListAsync())
+        {
+            var waits = listed.RootElement.GetProperty("waits");
+            waits.GetArrayLength().Should().Be(1);
+            // WaitInfo is serialized with default System.Text.Json naming (no camelCase policy
+            // applied), so its properties keep their declared PascalCase names.
+            waits[0].GetProperty("WaitId").GetString().Should().Be("tc_1");
+            waits[0].GetProperty("Kind").GetString().Should().Be("timer");
+
+            listed.RootElement.GetProperty("registeredKinds")
+                .EnumerateArray().Select(e => e.GetString())
+                .Should().Contain("timer");
+        }
+
+        var cancelArgs = JsonSerializer.Serialize(new { id = "tc_1" });
+        var cancelResult = await _cancelWait.Handler(cancelArgs, new ToolCallContext(), CancellationToken.None);
+        using (var cancelled = JsonDocument.Parse(cancelResult.ResultText))
+        {
+            cancelled.RootElement.GetProperty("status").GetString().Should().Be("resolved");
+            cancelled.RootElement.GetProperty("cancelled").GetInt32().Should().Be(1);
+        }
+
+        using var listedAfter = await ListAsync();
+        listedAfter.RootElement.GetProperty("waits").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CancelWait_ByKind_CancelsAllMatchingWaits()
+    {
+        await _wait.Handler(WaitArgs(), new ToolCallContext { ToolCallId = "tc_a" }, CancellationToken.None);
+        await _wait.Handler(WaitArgs(), new ToolCallContext { ToolCallId = "tc_b" }, CancellationToken.None);
+
+        var cancelArgs = JsonSerializer.Serialize(new { kind = "timer" });
+        var cancelResult = await _cancelWait.Handler(cancelArgs, new ToolCallContext(), CancellationToken.None);
+        using (var cancelled = JsonDocument.Parse(cancelResult.ResultText))
+        {
+            cancelled.RootElement.GetProperty("cancelled").GetInt32().Should().Be(2);
+        }
+
+        using var listed = await ListAsync();
+        listed.RootElement.GetProperty("waits").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CancelWait_WithNoSelector_IsNoOp()
+    {
+        // A totally-unfiltered CancelWait matches nothing (TriggerRuntime.Matches requires at
+        // least one of id/label/kind) — it must not cancel every armed wait by accident.
+        await _wait.Handler(WaitArgs(), new ToolCallContext { ToolCallId = "tc_solo" }, CancellationToken.None);
+
+        var cancelResult = await _cancelWait.Handler("{}", new ToolCallContext(), CancellationToken.None);
+        using (var cancelled = JsonDocument.Parse(cancelResult.ResultText))
+        {
+            cancelled.RootElement.GetProperty("cancelled").GetInt32().Should().Be(0);
+        }
+
+        using var listed = await ListAsync();
+        listed.RootElement.GetProperty("waits").GetArrayLength().Should().Be(1);
+    }
+}

--- a/tests/LmMultiTurn.Tests/Triggers/WaitTriggerLoopIntegrationTests.cs
+++ b/tests/LmMultiTurn.Tests/Triggers/WaitTriggerLoopIntegrationTests.cs
@@ -1,0 +1,377 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace LmMultiTurn.Tests.Triggers;
+
+/// <summary>
+/// End-to-end tests wiring the Wait/trigger primitive through <see cref="MultiTurnAgentLoop"/>:
+/// the LLM calls <c>Wait</c>, the run parks on the deferral, the trigger fires, the run
+/// auto-resumes, and the LLM's next turn sees the resolved payload. Covers the built-in timer,
+/// a host-registered external source (via the seam), and restart reconciliation.
+/// </summary>
+public class WaitTriggerLoopIntegrationTests
+{
+    private readonly Mock<IStreamingAgent> _mockAgent = new();
+    private readonly Mock<ILogger<MultiTurnAgentLoop>> _loggerMock = new();
+
+    private static string WaitArgs(object body) => JsonSerializer.Serialize(body);
+
+    [Fact]
+    public async Task Wait_Timer_ParksThenAutoResumes_WithFiredPayload()
+    {
+        // Turn 1: the LLM asks to wait on a short one-shot timer. Turn 2 (after the timer fires and
+        // the run auto-resumes) returns final text and must see the resolved "fired" payload.
+        var waitCall = new ToolCallMessage
+        {
+            FunctionName = WaitToolProvider.WaitToolName,
+            FunctionArgs = WaitArgs(new { kind = "timer", args = new { delay = "150ms" }, timeout = "10m" }),
+            ToolCallId = "tc_wait",
+            Role = Role.Assistant,
+        };
+        var finalText = new TextMessage { Text = "resumed", Role = Role.Assistant };
+
+        var callCount = 0;
+        IEnumerable<IMessage>? secondCallMessages = null;
+        _mockAgent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>((msgs, _, _) =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    return Task.FromResult(ToAsyncEnumerable([waitCall]));
+                }
+                secondCallMessages = [.. msgs];
+                return Task.FromResult(ToAsyncEnumerable([finalText]));
+            });
+
+        await using var loop = BuildLoop(new TriggerOptions());
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+
+        var (firstDone, secondDone) = SubscribeForTwoRuns(loop, cts.Token);
+
+        await loop.SendAsync([new TextMessage { Text = "sleep then continue", Role = Role.User }]);
+        await firstDone.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Parked: exactly one LLM call so far, and the Wait is registered as deferred.
+        callCount.Should().Be(1);
+        (await loop.GetDeferredToolCallsAsync()).Should().ContainSingle(p => p.ToolCallId == "tc_wait");
+
+        // The timer fires (~150ms) and auto-resumes the run.
+        await secondDone.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        callCount.Should().Be(2);
+
+        var resolved = ExtractResults(secondCallMessages!).Single(m => m.ToolCallId == "tc_wait");
+        ReadStatus(resolved.Result).Should().Be("fired");
+        (await loop.GetDeferredToolCallsAsync()).Should().BeEmpty();
+
+        await cts.CancelAsync();
+    }
+
+    [Fact]
+    public async Task Wait_ExternalHostSource_ArmsAndFires_ThroughTheSeam()
+    {
+        // Proves a host can register a brand-new trigger kind with no loop change: the LLM waits on
+        // it, the host fires it out-of-band, and the run resumes with the fired payload.
+        var manual = new ManualLoopTriggerSource();
+        var options = new TriggerOptions
+        {
+            AdditionalRegistrations =
+            [
+                new TriggerSourceRegistration
+                {
+                    Kind = "host_event",
+                    Description = "wait for a host-fired event",
+                    ArgsSchema = "{}",
+                    Capabilities = new TriggerCapabilities(true, false, false),
+                    Source = manual,
+                },
+            ],
+        };
+
+        var waitCall = new ToolCallMessage
+        {
+            FunctionName = WaitToolProvider.WaitToolName,
+            FunctionArgs = WaitArgs(new { kind = "host_event", args = new { }, timeout = "10m" }),
+            ToolCallId = "tc_host",
+            Role = Role.Assistant,
+        };
+        var finalText = new TextMessage { Text = "done", Role = Role.Assistant };
+
+        var callCount = 0;
+        IEnumerable<IMessage>? secondCallMessages = null;
+        _mockAgent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>((msgs, _, _) =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    return Task.FromResult(ToAsyncEnumerable([waitCall]));
+                }
+                secondCallMessages = [.. msgs];
+                return Task.FromResult(ToAsyncEnumerable([finalText]));
+            });
+
+        await using var loop = BuildLoop(options);
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+
+        var (firstDone, secondDone) = SubscribeForTwoRuns(loop, cts.Token);
+
+        await loop.SendAsync([new TextMessage { Text = "wait for host", Role = Role.User }]);
+        await firstDone.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        (await loop.GetDeferredToolCallsAsync()).Should().ContainSingle(p => p.ToolCallId == "tc_host");
+
+        // Host fires the external event; the parked run resumes.
+        await manual.FireAsync("host-payload");
+
+        await secondDone.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var resolved = ExtractResults(secondCallMessages!).Single(m => m.ToolCallId == "tc_host");
+        ReadStatus(resolved.Result).Should().Be("fired");
+        resolved.Result.Should().Contain("host-payload");
+
+        await cts.CancelAsync();
+    }
+
+    [Fact]
+    public async Task Wait_Timer_RejectedKind_DoesNotPark()
+    {
+        // An unknown kind is a fail-fast Resolved error (not a park): the run continues in the same
+        // turn and the LLM sees the rejection so it can self-correct.
+        var waitCall = new ToolCallMessage
+        {
+            FunctionName = WaitToolProvider.WaitToolName,
+            FunctionArgs = WaitArgs(new { kind = "does_not_exist", args = new { }, timeout = "10m" }),
+            ToolCallId = "tc_bad",
+            Role = Role.Assistant,
+        };
+        var finalText = new TextMessage { Text = "recovered", Role = Role.Assistant };
+
+        var callCount = 0;
+        _mockAgent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>((_, _, _) =>
+            {
+                callCount++;
+                return callCount == 1
+                    ? Task.FromResult(ToAsyncEnumerable([waitCall]))
+                    : Task.FromResult(ToAsyncEnumerable([finalText]));
+            });
+
+        await using var loop = BuildLoop(new TriggerOptions());
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+
+        var messages = new List<IMessage>();
+        await foreach (var msg in loop.ExecuteRunAsync(
+            new UserInput([new TextMessage { Text = "go", Role = Role.User }]), cts.Token))
+        {
+            messages.Add(msg);
+        }
+
+        // No deferral: the rejection resolved inline and the run ran to a normal completion.
+        (await loop.GetDeferredToolCallsAsync()).Should().BeEmpty();
+        var result = messages.OfType<ToolCallResultMessage>().Single(m => m.ToolCallId == "tc_bad");
+        result.IsError.Should().BeTrue();
+        result.Result.Should().Contain("unknown_kind");
+
+        await cts.CancelAsync();
+    }
+
+    [Fact]
+    public async Task RestoredTimerWait_ExpiredWhileOffline_ResolvesOnRecover()
+    {
+        // A previous process parked on a timer Wait then exited. On restart the reconcile pass must
+        // resolve it (never leave the deferred tool call hanging).
+        var threadId = "trigger-restore";
+        var runId = "run_prev";
+        var generationId = "gen_prev";
+        var store = new InMemoryConversationStore();
+
+        var toolCall = new ToolCallMessage
+        {
+            ToolCallId = "tc_restore",
+            FunctionName = WaitToolProvider.WaitToolName,
+            FunctionArgs = WaitArgs(new { kind = "timer", args = new { }, timeout = "1m" }),
+            Role = Role.Assistant,
+            FromAgent = "test",
+            GenerationId = generationId,
+            RunId = runId,
+        };
+        var deferred = new ToolCallResultMessage
+        {
+            ToolCallId = "tc_restore",
+            ToolName = WaitToolProvider.WaitToolName,
+            Result = string.Empty,
+            IsDeferred = true,
+            // Armed 30 minutes ago with a 1-minute timeout → long elapsed.
+            DeferredAt = DateTimeOffset.UtcNow.AddMinutes(-30).ToUnixTimeMilliseconds(),
+            Role = Role.User,
+            GenerationId = generationId,
+            RunId = runId,
+        };
+
+        await store.AppendMessagesAsync(threadId,
+        [
+            MessagePersistenceConverter.ToPersistedMessage(toolCall, threadId, runId),
+            MessagePersistenceConverter.ToPersistedMessage(deferred, threadId, runId),
+        ]);
+        await store.SaveMetadataAsync(threadId, new ThreadMetadata
+        {
+            ThreadId = threadId,
+            LatestRunId = runId,
+            LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        });
+
+        // Any auto-resumed run just returns final text.
+        _mockAgent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(ToAsyncEnumerable([new TextMessage { Text = "back", Role = Role.Assistant }])));
+
+        await using var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            new FunctionRegistry(),
+            threadId,
+            store: store,
+            logger: _loggerMock.Object,
+            triggerOptions: new TriggerOptions());
+
+        (await loop.RecoverAsync()).Should().BeTrue();
+
+        // The reconcile re-armed an already-elapsed timer; it resolves the parked wait shortly after.
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if ((await loop.GetDeferredToolCallsAsync()).Count == 0)
+            {
+                break;
+            }
+            await Task.Delay(50);
+        }
+
+        (await loop.GetDeferredToolCallsAsync()).Should().BeEmpty("a restored timer wait must not be left hanging");
+    }
+
+    private MultiTurnAgentLoop BuildLoop(TriggerOptions options) => new(
+        _mockAgent.Object,
+        new FunctionRegistry(),
+        "trigger-thread",
+        logger: _loggerMock.Object,
+        triggerOptions: options);
+
+    private static (TaskCompletionSource<bool> First, TaskCompletionSource<bool> Second) SubscribeForTwoRuns(
+        MultiTurnAgentLoop loop, CancellationToken ct)
+    {
+        var first = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var second = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completed = 0;
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var msg in loop.SubscribeAsync(ct))
+                {
+                    if (msg is RunCompletedMessage)
+                    {
+                        completed++;
+                        if (completed == 1)
+                        {
+                            first.TrySetResult(true);
+                        }
+                        else if (completed == 2)
+                        {
+                            second.TrySetResult(true);
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException) { }
+        }, ct);
+        return (first, second);
+    }
+
+    private static string ReadStatus(string payloadJson)
+    {
+        using var doc = JsonDocument.Parse(payloadJson);
+        return doc.RootElement.GetProperty("status").GetString()!;
+    }
+
+    private static List<ToolCallResultMessage> ExtractResults(IEnumerable<IMessage> messages) =>
+    [
+        .. messages.OfType<ToolCallResultMessage>()
+            .Concat(messages.OfType<ToolsCallResultMessage>()
+                .SelectMany(m => m.ToolCallResults.Select(r => new ToolCallResultMessage
+                {
+                    ToolCallId = r.ToolCallId,
+                    Result = r.Result,
+                    IsError = r.IsError,
+                }))),
+    ];
+
+    private static async IAsyncEnumerable<IMessage> ToAsyncEnumerable(
+        IEnumerable<IMessage> messages,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        foreach (var msg in messages)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return msg;
+            await Task.Yield();
+        }
+    }
+
+    /// <summary>A host-registered source whose fire the test triggers out-of-band.</summary>
+    private sealed class ManualLoopTriggerSource : ITriggerSource
+    {
+        private volatile ITriggerEventSink? _sink;
+
+        public ValueTask<IArmedTrigger> ArmAsync(TriggerArmRequest request, ITriggerEventSink eventSink, CancellationToken cancellationToken)
+        {
+            _sink = eventSink;
+            return ValueTask.FromResult<IArmedTrigger>(new Handle(request.WaitId));
+        }
+
+        public async Task FireAsync(string payload)
+        {
+            var sink = _sink;
+            if (sink != null)
+            {
+                await sink.FireAsync(new TriggerFireEvent(payload), CancellationToken.None);
+            }
+        }
+
+        private sealed class Handle(string waitId) : IArmedTrigger
+        {
+            public string WaitId { get; } = waitId;
+
+            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a generic **Wait / CancelWait / ListWaits** primitive that lets an LLM, mid multi-turn conversation, **park a run on a background or scheduled event and resume with a self-describing payload** — layered on the existing [deferred tool-call](docs/features/deferred-tool-execution/motivation.md) park/wake core. Implements the approved **plan v3** on #107 (block-mode only; one one-shot `timer` source).

```jsonc
Wait({ kind, args?, timeout, label? })   // parks the run; resumes with {status: fired|timed_out|cancelled|failed, ...}
CancelWait({ id?, label?, kind? })       // total + idempotent
ListWaits()                              // armed waits + registered kinds
```

Adding a new wake source is "implement `ITriggerSource` + register it" — no change to the agent loop or the tool surface.

## What's included

- **`ITriggerSource` seam** — a source only observes its event and reports a raw fact to a runtime-owned `ITriggerEventSink`; `IArmedTrigger` is a cancellable handle. Lifecycle policy lives entirely in the runtime.
- **`TriggerRuntime`** — owns the whole lifecycle: single-resolution latch (`Pending → Fired | TimedOut | Cancelled | Failed`), ceiling timeout, cancellation with source cleanup, bounded concurrency, payload caps, and restart reconciliation.
- **`WaitToolProvider`** — the `Wait`/`CancelWait`/`ListWaits` tools; block waits park via the loop's **existing public** `ResolveToolCallAsync` (no new loop API).
- **Built-in one-shot `timer` source** — `delay` | `deadline` | default-to-`timeout`; restartable.
- **Loop wiring** — `TriggerOptions` ctor param, `WaitToolProvider` registration, and an `OnHistoryRestoredAsync` reconcile pass so a restored block wait is **never left hanging**.
- **Docs** — `docs/features/wait-trigger-primitive/README.md`.
- **25 tests** — latch races, cancel cleanup, timeout, restart reconcile (re-arm / expired / non-restorable / rejected re-arm), limits, unknown-kind / invalid-timeout rejection, payload cap, register-window retry + fire-path token robustness, and end-to-end park→fire→resume through the loop for both the built-in timer and a host-registered external source.

## Key decisions

1. **Narrowed to the minimum proving slice** (per the plan-v3 review): block-mode only, one one-shot `timer` source, a dummy/external-source test proving the seam. File-tail, process, cron/interval, sub-agent-completion, notify-mode, and any shared `BackgroundWorkBase` are deferred to follow-ups.
2. **Runtime owns the lifecycle; sources are dumb observers.** A single-resolution latch guarantees exactly one terminal transition even when a fire races a timeout races a cancel. This resolves the review's CRITICAL race-semantics finding without per-source policy.
3. **One wait identity, one persistence model.** A block wait's identity *is* its deferred `tool_call_id`; the existing `IsDeferred` placeholder (+ `DeferredAt`) is the arming record — no new persisted type. On restart, a restorable source re-arms for its remaining delay; a non-restorable one resolves `trigger_lost_on_restart`.
4. **No new public loop API.** Block delivery reuses the existing public `ResolveToolCallAsync` and internal auto-resume; the v2-proposed `HasUnresolvedDeferrals`/`DeferralResolved` were dropped. (Notify mode, when it lands, will use the loop's existing internal `EnqueueRawAsync` sentinel gate.)
5. **Deterministic fire-vs-timeout** via a small ceiling grace so a timer's `fired` wins over `timed_out` when they coincide; terminal delivery uses an uncancellable token so disposing the source can't drop the result.

## Testing

- `dotnet test tests/LmMultiTurn.Tests` → **309 passing** (28 new + 281 existing), 0 failures.
- Full solution builds clean (0 errors).

Fixes #107.
