### PR TITLE
Extract shared Copilot /models parsing (#132) + provider-dropdown scroll E2E (#133)

### DIFF
--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Primitives;
 using Serilog;
@@ -475,27 +476,15 @@ public static class ProxyModelResolver
     /// <summary>Extracts model ids from an OpenAI-shaped (<c>{"data":[{"id":...}]}</c>) or bare-array list.</summary>
     public static IReadOnlyList<string> ParseModelIds(string json)
     {
-        var ids = new List<string>();
         using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
-        var list = root.ValueKind == JsonValueKind.Object && root.TryGetProperty("data", out var data) ? data : root;
 
-        if (list.ValueKind == JsonValueKind.Array)
+        var ids = new List<string>();
+        foreach (var item in CopilotModelsResponse.EnumerateModelEntries(doc.RootElement))
         {
-            foreach (var item in list.EnumerateArray())
+            var id = CopilotModelsResponse.GetString(item, "id");
+            if (!string.IsNullOrWhiteSpace(id))
             {
-                if (
-                    item.ValueKind == JsonValueKind.Object
-                    && item.TryGetProperty("id", out var idEl)
-                    && idEl.ValueKind == JsonValueKind.String
-                )
-                {
-                    var id = idEl.GetString();
-                    if (!string.IsNullOrWhiteSpace(id))
-                    {
-                        ids.Add(id);
-                    }
-                }
+                ids.Add(id);
             }
         }
 
@@ -513,51 +502,27 @@ public static class ProxyModelResolver
     public static IReadOnlyList<string> ParseMessagesCapableModelIds(string json)
     {
         using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
-        var list = root.ValueKind == JsonValueKind.Object && root.TryGetProperty("data", out var data) ? data : root;
+        var entries = CopilotModelsResponse.EnumerateModelEntries(doc.RootElement).ToList();
 
-        if (list.ValueKind != JsonValueKind.Array)
-        {
-            return [];
-        }
-
-        var items = list.EnumerateArray().ToList();
-        var anyEndpointMetadata = items.Any(item =>
-            item.ValueKind == JsonValueKind.Object && item.TryGetProperty("supported_endpoints", out _)
-        );
-        if (!anyEndpointMetadata)
+        // The fallback is per RESPONSE, not per entry: if NO entry carries supported_endpoints metadata
+        // at all (an older/alternative Copilot-compatible /models shape), fall back to id-only rather
+        // than treating every model as unsupported and failing startup. If ANY entry declares it, filter
+        // the whole response to the /v1/messages-capable ids.
+        if (!entries.Any(CopilotModelsResponse.HasSupportedEndpoints))
         {
             return ParseModelIds(json);
         }
 
         var ids = new List<string>();
-        foreach (var item in items)
+        foreach (var item in entries)
         {
-            if (
-                item.ValueKind != JsonValueKind.Object
-                || !item.TryGetProperty("id", out var idEl)
-                || idEl.ValueKind != JsonValueKind.String
-            )
-            {
-                continue;
-            }
-
-            var id = idEl.GetString();
+            var id = CopilotModelsResponse.GetString(item, "id");
             if (string.IsNullOrWhiteSpace(id))
             {
                 continue;
             }
 
-            if (
-                item.TryGetProperty("supported_endpoints", out var endpoints)
-                && endpoints.ValueKind == JsonValueKind.Array
-                && endpoints
-                    .EnumerateArray()
-                    .Any(e =>
-                        e.ValueKind == JsonValueKind.String
-                        && string.Equals(e.GetString(), "/v1/messages", StringComparison.OrdinalIgnoreCase)
-                    )
-            )
+            if (CopilotModelsResponse.SupportsEndpoint(item, CopilotModelsResponse.MessagesEndpoint))
             {
                 ids.Add(id);
             }

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ProviderSelector.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ProviderSelector.vue
@@ -128,7 +128,7 @@ watch(
       <span class="dropdown-arrow">{{ dropdownOpen ? '▲' : '▼' }}</span>
     </button>
 
-    <div v-if="dropdownOpen" class="dropdown-menu">
+    <div v-if="dropdownOpen" class="dropdown-menu" data-testid="provider-selector-menu">
       <template v-for="group in groupedProviders" :key="group.label ?? '__ungrouped__'">
         <div
           v-if="group.label"

--- a/samples/LmStreaming.Sample/Services/ProviderRegistry.cs
+++ b/samples/LmStreaming.Sample/Services/ProviderRegistry.cs
@@ -70,11 +70,14 @@ public sealed class ProviderRegistry : AchieveAi.LmDotnetTools.LmAgentInfra.IPro
     }
 
     // Test-only constructor: lets tests inject a stub IsRunning probe without standing up a
-    // real Kestrel host. Marked internal so it stays out of the public surface.
+    // real Kestrel host, and inject the Copilot token gate (copilotTokenAvailable) so discovered
+    // Copilot models can render available without a real gh/Copilot login. Marked internal so it
+    // stays out of the public surface.
     internal ProviderRegistry(
         IFileSystemProbe? probe,
         Func<bool> mockHostIsRunning,
-        IReadOnlyList<CopilotModelInfo>? copilotModels = null)
+        IReadOnlyList<CopilotModelInfo>? copilotModels = null,
+        Func<bool>? copilotTokenAvailable = null)
     {
         ArgumentNullException.ThrowIfNull(mockHostIsRunning);
 
@@ -93,8 +96,9 @@ public sealed class ProviderRegistry : AchieveAi.LmDotnetTools.LmAgentInfra.IPro
         var hasOpenAiKey = HasEnvVar("OPENAI_API_KEY");
         var hasAnthropicKey = HasEnvVar("ANTHROPIC_API_KEY");
         // Copilot-backed providers route through the Copilot API using the developer's existing
-        // Copilot/gh login, so they are available whenever a token can be resolved.
-        var hasCopilotToken = new CliCredentialCopilotTokenProvider().ResolveToken() is not null;
+        // Copilot/gh login, so they are available whenever a token can be resolved. The check is
+        // delegated (defaulting to the real CLI-credential probe) so tests can force it without a login.
+        var hasCopilotToken = (copilotTokenAvailable ?? DefaultCopilotTokenAvailable)();
 
         foreach (var entry in CatalogEntries)
         {
@@ -231,6 +235,14 @@ public sealed class ProviderRegistry : AchieveAi.LmDotnetTools.LmAgentInfra.IPro
     private static bool IsMockProvider(string normalizedId)
     {
         return normalizedId.EndsWith("-mock", StringComparison.Ordinal);
+    }
+
+    // Production default for the Copilot token gate: a token resolves from the developer's existing
+    // gh/Copilot CLI credentials. Overridable via the internal ctor's copilotTokenAvailable delegate
+    // so tests need no real login.
+    private static bool DefaultCopilotTokenAvailable()
+    {
+        return new CliCredentialCopilotTokenProvider().ResolveToken() is not null;
     }
 
     private static bool HasEnvVar(string name)

--- a/src/GithubCopilotProvider/Models/CopilotModelCatalogParser.cs
+++ b/src/GithubCopilotProvider/Models/CopilotModelCatalogParser.cs
@@ -11,7 +11,9 @@ namespace AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
 /// <remarks>
 ///     Pure and side-effect free so it can be unit-tested against the captured real response fixture.
 ///     The response shape is <c>{ "data": [ { "id", "name", "vendor", "supported_endpoints": [...] } ] }</c>;
-///     a bare top-level array is also accepted.
+///     a bare top-level array is also accepted. Response unwrap and endpoint reads are shared with the
+///     CopilotAnthropicProxy resolver via <see cref="CopilotModelsResponse"/>; this parser layers the
+///     vendor partition, transport ranking, and adaptive-thinking projection on top.
 /// </remarks>
 public static class CopilotModelCatalogParser
 {
@@ -24,18 +26,9 @@ public static class CopilotModelCatalogParser
         ArgumentNullException.ThrowIfNull(json);
 
         using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
-        var list = root.ValueKind == JsonValueKind.Object && root.TryGetProperty("data", out var data)
-            ? data
-            : root;
-
-        if (list.ValueKind != JsonValueKind.Array)
-        {
-            return [];
-        }
 
         var models = new List<CopilotModelInfo>();
-        foreach (var item in list.EnumerateArray())
+        foreach (var item in CopilotModelsResponse.EnumerateModelEntries(doc.RootElement))
         {
             if (TryParseModel(item, out var model))
             {
@@ -50,18 +43,13 @@ public static class CopilotModelCatalogParser
     {
         model = null!;
 
-        if (item.ValueKind != JsonValueKind.Object)
-        {
-            return false;
-        }
-
-        var id = GetString(item, "id");
+        var id = CopilotModelsResponse.GetString(item, "id");
         if (string.IsNullOrWhiteSpace(id))
         {
             return false;
         }
 
-        if (!TryNormalizeVendor(GetString(item, "vendor"), out var vendor))
+        if (!TryNormalizeVendor(CopilotModelsResponse.GetString(item, "vendor"), out var vendor))
         {
             return false;
         }
@@ -72,7 +60,7 @@ public static class CopilotModelCatalogParser
             return false;
         }
 
-        var displayName = GetString(item, "name");
+        var displayName = CopilotModelsResponse.GetString(item, "name");
         displayName = string.IsNullOrWhiteSpace(displayName) ? id! : displayName!;
 
         model = new CopilotModelInfo(id!, displayName, vendor, transport, SupportsAdaptiveThinking(item));
@@ -126,46 +114,23 @@ public static class CopilotModelCatalogParser
 
     /// <summary>
     ///     Chooses the routable transport from <c>supported_endpoints</c>. <c>/v1/messages</c> wins
-    ///     (Anthropic Messages), else <c>/responses</c> (or its <c>ws:/responses</c> variant) selects
-    ///     the Responses transport. Absent metadata or only <c>/chat/completions</c> yields
-    ///     <see cref="CopilotModelTransport.Unsupported"/>.
+    ///     (Anthropic Messages) regardless of list order, else <c>/responses</c> (or its
+    ///     <c>ws:/responses</c> variant) selects the Responses transport. Absent metadata or only
+    ///     <c>/chat/completions</c> yields <see cref="CopilotModelTransport.Unsupported"/>.
     /// </summary>
     private static CopilotModelTransport DeriveTransport(JsonElement item)
     {
-        if (!item.TryGetProperty("supported_endpoints", out var endpoints)
-            || endpoints.ValueKind != JsonValueKind.Array)
+        if (CopilotModelsResponse.SupportsEndpoint(item, CopilotModelsResponse.MessagesEndpoint))
         {
-            return CopilotModelTransport.Unsupported;
+            return CopilotModelTransport.Anthropic;
         }
 
-        var hasResponses = false;
-        foreach (var endpoint in endpoints.EnumerateArray())
+        if (CopilotModelsResponse.SupportsEndpoint(item, CopilotModelsResponse.ResponsesEndpoint)
+            || CopilotModelsResponse.SupportsEndpoint(item, CopilotModelsResponse.ResponsesWebSocketEndpoint))
         {
-            if (endpoint.ValueKind != JsonValueKind.String)
-            {
-                continue;
-            }
-
-            var value = endpoint.GetString();
-            if (string.Equals(value, "/v1/messages", StringComparison.OrdinalIgnoreCase))
-            {
-                return CopilotModelTransport.Anthropic;
-            }
-
-            if (string.Equals(value, "/responses", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(value, "ws:/responses", StringComparison.OrdinalIgnoreCase))
-            {
-                hasResponses = true;
-            }
+            return CopilotModelTransport.Responses;
         }
 
-        return hasResponses ? CopilotModelTransport.Responses : CopilotModelTransport.Unsupported;
-    }
-
-    private static string? GetString(JsonElement item, string propertyName)
-    {
-        return item.TryGetProperty(propertyName, out var el) && el.ValueKind == JsonValueKind.String
-            ? el.GetString()
-            : null;
+        return CopilotModelTransport.Unsupported;
     }
 }

--- a/src/GithubCopilotProvider/Models/CopilotModelsResponse.cs
+++ b/src/GithubCopilotProvider/Models/CopilotModelsResponse.cs
@@ -1,0 +1,121 @@
+using System.Text.Json;
+
+namespace AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+
+/// <summary>
+///     Low-level plumbing for the GitHub Copilot <c>GET /models</c> response shape — the response
+///     unwrap, the endpoint-name spellings, and the <c>supported_endpoints</c> / string-property
+///     reads that <see cref="CopilotModelCatalogParser"/> (this assembly) and the CopilotAnthropicProxy
+///     sample's model resolver both need. Extracted so those two callers can't drift on the mechanics
+///     while keeping their own projection/filtering local.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Visibility:</b> <c>public</c> because the CopilotAnthropicProxy sample lives in a separate
+///         assembly and consumes these primitives too; it is otherwise internal-grade plumbing, not a
+///         curated API.
+///     </para>
+///     <para>
+///         <b>JsonElement lifetime:</b> the returned <see cref="JsonElement"/> entries are views over the
+///         caller's <see cref="JsonDocument"/>. Enumerate and read them while that document is still
+///         alive (inside the caller's <c>using</c> scope); they are invalid once it is disposed.
+///     </para>
+/// </remarks>
+public static class CopilotModelsResponse
+{
+    /// <summary><c>POST /v1/messages</c> — the Anthropic Messages transport.</summary>
+    public const string MessagesEndpoint = "/v1/messages";
+
+    /// <summary><c>POST /responses</c> — the OpenAI Responses transport.</summary>
+    public const string ResponsesEndpoint = "/responses";
+
+    /// <summary><c>ws:/responses</c> — the WebSocket variant of the Responses transport.</summary>
+    public const string ResponsesWebSocketEndpoint = "ws:/responses";
+
+    /// <summary>
+    ///     Unwraps the response to its model list and yields the object entries in upstream order.
+    ///     Accepts both the <c>{ "data": [ ... ] }</c> envelope and a bare top-level array; any other
+    ///     shape (missing/ non-array <c>data</c>, non-array root) yields nothing. Non-object array
+    ///     entries are skipped so callers never see them.
+    /// </summary>
+    public static IEnumerable<JsonElement> EnumerateModelEntries(JsonElement root)
+    {
+        var list = root.ValueKind == JsonValueKind.Object && root.TryGetProperty("data", out var data)
+            ? data
+            : root;
+
+        if (list.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        foreach (var item in list.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.Object)
+            {
+                yield return item;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Whether the entry <em>declares</em> a <c>supported_endpoints</c> property at all, regardless of
+    ///     its value kind. Callers use this to distinguish a response that carries endpoint metadata
+    ///     (filter by transport) from an older/alternative shape that carries none (fall back to id-only).
+    /// </summary>
+    public static bool HasSupportedEndpoints(JsonElement item)
+    {
+        return item.ValueKind == JsonValueKind.Object && item.TryGetProperty("supported_endpoints", out _);
+    }
+
+    /// <summary>
+    ///     Returns the entry's <c>supported_endpoints</c> array element, or a default
+    ///     (<see cref="JsonValueKind.Undefined"/>) element when the property is absent or not an array.
+    /// </summary>
+    public static JsonElement GetSupportedEndpoints(JsonElement item)
+    {
+        return item.ValueKind == JsonValueKind.Object
+            && item.TryGetProperty("supported_endpoints", out var endpoints)
+            && endpoints.ValueKind == JsonValueKind.Array
+            ? endpoints
+            : default;
+    }
+
+    /// <summary>
+    ///     Whether the entry's <c>supported_endpoints</c> contains <paramref name="endpoint"/> (exact,
+    ///     case-insensitive match). Non-string array values are skipped; absent/ non-array metadata is
+    ///     treated as "not supported".
+    /// </summary>
+    public static bool SupportsEndpoint(JsonElement item, string endpoint)
+    {
+        var endpoints = GetSupportedEndpoints(item);
+        if (endpoints.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        foreach (var value in endpoints.EnumerateArray())
+        {
+            if (value.ValueKind == JsonValueKind.String
+                && string.Equals(value.GetString(), endpoint, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     Reads a string property from a model entry, or <c>null</c> when the property is absent, not a
+    ///     string, or the element is not an object.
+    /// </summary>
+    public static string? GetString(JsonElement item, string propertyName)
+    {
+        return item.ValueKind == JsonValueKind.Object
+            && item.TryGetProperty(propertyName, out var el)
+            && el.ValueKind == JsonValueKind.String
+            ? el.GetString()
+            : null;
+    }
+}

--- a/tests/GithubCopilotProvider.Tests/Models/CopilotModelsResponseTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Models/CopilotModelsResponseTests.cs
@@ -1,0 +1,158 @@
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.GithubCopilotProvider.Tests.Models;
+
+/// <summary>
+///     Directly exercises the shared <see cref="CopilotModelsResponse"/> primitives that
+///     <see cref="CopilotModelCatalogParser"/> and the CopilotAnthropicProxy resolver both build on —
+///     response unwrap, endpoint-spelling constants, <c>supported_endpoints</c> reads, and string reads —
+///     across the malformed/partial shapes both callers must tolerate.
+/// </summary>
+public sealed class CopilotModelsResponseTests
+{
+    // Each helper takes a JsonElement view over a JsonDocument the caller owns; parse inside the test
+    // and read within scope so the element stays valid (mirrors how both real callers use it).
+    private static JsonElement Root(string json)
+    {
+        return JsonDocument.Parse(json).RootElement;
+    }
+
+    [Fact]
+    public void Endpoint_constants_use_the_exact_wire_spellings()
+    {
+        CopilotModelsResponse.MessagesEndpoint.Should().Be("/v1/messages");
+        CopilotModelsResponse.ResponsesEndpoint.Should().Be("/responses");
+        CopilotModelsResponse.ResponsesWebSocketEndpoint.Should().Be("ws:/responses");
+    }
+
+    [Fact]
+    public void EnumerateModelEntries_unwraps_data_envelope()
+    {
+        const string json = """{ "data": [ { "id": "a" }, { "id": "b" } ] }""";
+
+        var ids = CopilotModelsResponse.EnumerateModelEntries(Root(json))
+            .Select(e => CopilotModelsResponse.GetString(e, "id"))
+            .ToList();
+
+        ids.Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public void EnumerateModelEntries_accepts_bare_array()
+    {
+        const string json = """[ { "id": "a" }, { "id": "b" } ]""";
+
+        CopilotModelsResponse.EnumerateModelEntries(Root(json)).Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void EnumerateModelEntries_skips_non_object_entries()
+    {
+        const string json = """[ { "id": "a" }, 5, "s", null, { "id": "b" } ]""";
+
+        var ids = CopilotModelsResponse.EnumerateModelEntries(Root(json))
+            .Select(e => CopilotModelsResponse.GetString(e, "id"))
+            .ToList();
+
+        ids.Should().Equal("a", "b");
+    }
+
+    [Theory]
+    [InlineData("{}")]                       // object, no data property
+    [InlineData("""{ "data": {} }""")]      // data is an object, not an array
+    [InlineData("""{ "data": 123 }""")]     // data is a scalar
+    [InlineData("""{ "data": null }""")]    // data is null
+    [InlineData("123")]                       // bare scalar root
+    [InlineData("\"hello\"")]                // bare string root
+    [InlineData("""{ "data": [] }""")]      // empty list
+    public void EnumerateModelEntries_yields_nothing_for_non_list_shapes(string json)
+    {
+        CopilotModelsResponse.EnumerateModelEntries(Root(json)).Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("""{ "supported_endpoints": ["/v1/messages"] }""")] // present, array
+    [InlineData("""{ "supported_endpoints": null }""")]              // present, null
+    [InlineData("""{ "supported_endpoints": "x" }""")]              // present, string
+    public void HasSupportedEndpoints_is_true_whenever_property_present(string json)
+    {
+        CopilotModelsResponse.HasSupportedEndpoints(Root(json)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasSupportedEndpoints_is_false_when_absent()
+    {
+        CopilotModelsResponse.HasSupportedEndpoints(Root("""{ "id": "a" }""")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SupportsEndpoint_matches_exact_spelling_case_insensitively()
+    {
+        var item = Root("""{ "supported_endpoints": ["/V1/Messages"] }""");
+
+        CopilotModelsResponse.SupportsEndpoint(item, CopilotModelsResponse.MessagesEndpoint).Should().BeTrue();
+    }
+
+    [Fact]
+    public void SupportsEndpoint_distinguishes_transports()
+    {
+        var item = Root("""{ "supported_endpoints": ["/responses", "ws:/responses"] }""");
+
+        CopilotModelsResponse.SupportsEndpoint(item, CopilotModelsResponse.MessagesEndpoint).Should().BeFalse();
+        CopilotModelsResponse.SupportsEndpoint(item, CopilotModelsResponse.ResponsesEndpoint).Should().BeTrue();
+        CopilotModelsResponse.SupportsEndpoint(item, CopilotModelsResponse.ResponsesWebSocketEndpoint).Should().BeTrue();
+    }
+
+    [Fact]
+    public void SupportsEndpoint_does_not_match_a_similar_but_unequal_endpoint()
+    {
+        // A superstring must not count as a match — endpoint comparison is exact, not prefix/contains.
+        var item = Root("""{ "supported_endpoints": ["/v1/messages/count_tokens"] }""");
+
+        CopilotModelsResponse.SupportsEndpoint(item, CopilotModelsResponse.MessagesEndpoint).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SupportsEndpoint_skips_non_string_values_but_still_finds_the_match()
+    {
+        var item = Root("""{ "supported_endpoints": [123, true, "/v1/messages"] }""");
+
+        CopilotModelsResponse.SupportsEndpoint(item, CopilotModelsResponse.MessagesEndpoint).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("""{ "id": "a" }""")]                       // property absent
+    [InlineData("""{ "supported_endpoints": "x" }""")]     // property present but not an array
+    [InlineData("""{ "supported_endpoints": [123] }""")]   // array of non-strings only
+    public void SupportsEndpoint_is_false_for_absent_or_malformed_metadata(string json)
+    {
+        CopilotModelsResponse.SupportsEndpoint(Root(json), CopilotModelsResponse.MessagesEndpoint).Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetSupportedEndpoints_returns_undefined_when_absent_or_not_array()
+    {
+        CopilotModelsResponse.GetSupportedEndpoints(Root("""{ "id": "a" }""")).ValueKind
+            .Should().Be(JsonValueKind.Undefined);
+        CopilotModelsResponse.GetSupportedEndpoints(Root("""{ "supported_endpoints": "x" }""")).ValueKind
+            .Should().Be(JsonValueKind.Undefined);
+    }
+
+    [Fact]
+    public void GetString_reads_present_string_property()
+    {
+        CopilotModelsResponse.GetString(Root("""{ "id": "claude-opus-4.8" }"""), "id")
+            .Should().Be("claude-opus-4.8");
+    }
+
+    [Theory]
+    [InlineData("""{ "id": 123 }""")]     // present but not a string
+    [InlineData("""{ "name": "x" }""")]   // different property absent
+    [InlineData("[]")]                       // not an object at all
+    public void GetString_returns_null_for_missing_non_string_or_non_object(string json)
+    {
+        CopilotModelsResponse.GetString(Root(json), "id").Should().BeNull();
+    }
+}

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/BrowserWebAppFactory.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/BrowserWebAppFactory.cs
@@ -1,3 +1,4 @@
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
 using LmStreaming.Sample.Persistence;
 using LmStreaming.Sample.Services;
@@ -43,6 +44,7 @@ public sealed class BrowserWebAppFactory : WebApplicationFactory<Program>
     private readonly IMarketplaceCatalogClient? _catalogClient;
     private readonly HttpMessageHandler? _sandboxGatewayHandler;
     private readonly SandboxGatewayOptions? _sandboxOptions;
+    private readonly IReadOnlyList<CopilotModelInfo>? _copilotModels;
     private IHost? _kestrelHost;
     private string? _serverAddress;
 
@@ -70,13 +72,21 @@ public sealed class BrowserWebAppFactory : WebApplicationFactory<Program>
     /// (a temp <c>WorkspaceBasePath</c>, a closed-port <c>BaseUrl</c> so the gateway MCP transport
     /// fails fast and degrades, etc.). Required when a handler is supplied; ignored otherwise.
     /// </param>
+    /// <param name="copilotModels">
+    /// Optional stub GitHub Copilot models. When set, the <see cref="ProviderRegistry"/> singleton is
+    /// rebuilt from these entries with the Copilot token gate forced on (no real gh/Copilot login), so
+    /// the discovered models render as <em>available</em> providers. Used by the provider-dropdown
+    /// overflow regression to deterministically fill the selector. Left null for every other scenario
+    /// (the real startup discovery applies, which yields nothing without a token).
+    /// </param>
     public BrowserWebAppFactory(
         string providerMode,
         ITestAgentBuilder? builder,
         int? fixedPort = null,
         IMarketplaceCatalogClient? catalogClient = null,
         HttpMessageHandler? sandboxGatewayHandler = null,
-        SandboxGatewayOptions? sandboxOptions = null)
+        SandboxGatewayOptions? sandboxOptions = null,
+        IReadOnlyList<CopilotModelInfo>? copilotModels = null)
     {
         // Scripted SSE modes ('test' / 'test-anthropic') drive a fake handler via ITestAgentBuilder.
         // 'claude-mock' (and other *-mock providers) drive the real CLI against the in-process
@@ -116,6 +126,7 @@ public sealed class BrowserWebAppFactory : WebApplicationFactory<Program>
         _catalogClient = catalogClient;
         _sandboxGatewayHandler = sandboxGatewayHandler;
         _sandboxOptions = sandboxOptions;
+        _copilotModels = copilotModels;
         _conversationPath = Path.Combine(
             Path.GetTempPath(),
             "lm-streaming-browser-e2e",
@@ -168,6 +179,21 @@ public sealed class BrowserWebAppFactory : WebApplicationFactory<Program>
             {
                 services.RemoveAll<IMarketplaceCatalogClient>();
                 services.AddSingleton(_catalogClient);
+            }
+
+            // Swap the discovery-backed ProviderRegistry for one seeded with stub Copilot models and
+            // the Copilot token gate forced on, so the discovered models render as *available* providers
+            // without a real gh/Copilot login. Registered only as the concrete type (ProvidersController
+            // and the agent factory both resolve ProviderRegistry directly), so RemoveAll + AddSingleton
+            // last-wins fully replaces it. Left untouched when null (every non-dropdown scenario).
+            if (_copilotModels is not null)
+            {
+                services.RemoveAll<ProviderRegistry>();
+                services.AddSingleton(new ProviderRegistry(
+                    probe: null,
+                    mockHostIsRunning: () => false,
+                    copilotModels: _copilotModels,
+                    copilotTokenAvailable: () => true));
             }
 
             // Stand-in sandbox gateway: rebuild the gateway lifetime + registry around the capturing

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/ScriptedScenario.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/ScriptedScenario.cs
@@ -1,3 +1,4 @@
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using AchieveAi.LmDotnetTools.LmTestUtils;
@@ -40,7 +41,8 @@ public static class ScriptedScenario
         int? fixedPort = null,
         IMarketplaceCatalogClient? catalogClient = null,
         HttpMessageHandler? sandboxGatewayHandler = null,
-        SandboxGatewayOptions? sandboxOptions = null
+        SandboxGatewayOptions? sandboxOptions = null,
+        IReadOnlyList<CopilotModelInfo>? copilotModels = null
     )
     {
         return fixture.OpenWithBuilderAsync(
@@ -49,7 +51,8 @@ public static class ScriptedScenario
             fixedPort,
             catalogClient,
             sandboxGatewayHandler,
-            sandboxOptions);
+            sandboxOptions,
+            copilotModels);
     }
 
     /// <summary>
@@ -66,7 +69,8 @@ public static class ScriptedScenario
         int? fixedPort = null,
         IMarketplaceCatalogClient? catalogClient = null,
         HttpMessageHandler? sandboxGatewayHandler = null,
-        SandboxGatewayOptions? sandboxOptions = null
+        SandboxGatewayOptions? sandboxOptions = null,
+        IReadOnlyList<CopilotModelInfo>? copilotModels = null
     )
     {
         return fixture.OpenWithBuilderAsync(
@@ -75,7 +79,8 @@ public static class ScriptedScenario
             fixedPort,
             catalogClient,
             sandboxGatewayHandler,
-            sandboxOptions);
+            sandboxOptions,
+            copilotModels);
     }
 
     private static async Task<ScenarioSession> OpenWithBuilderAsync(
@@ -85,7 +90,8 @@ public static class ScriptedScenario
         int? fixedPort,
         IMarketplaceCatalogClient? catalogClient,
         HttpMessageHandler? sandboxGatewayHandler,
-        SandboxGatewayOptions? sandboxOptions
+        SandboxGatewayOptions? sandboxOptions,
+        IReadOnlyList<CopilotModelInfo>? copilotModels = null
     )
     {
         var factory = new BrowserWebAppFactory(
@@ -94,7 +100,8 @@ public static class ScriptedScenario
             fixedPort,
             catalogClient,
             sandboxGatewayHandler,
-            sandboxOptions);
+            sandboxOptions,
+            copilotModels);
         IBrowserContext? context = null;
         try
         {

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs
@@ -142,6 +142,12 @@ public static class UiHelpers
         return page.GetByTestId("provider-selector-button");
     }
 
+    /// <summary>The opened provider-selector dropdown menu (the scrollable, capped-height container).</summary>
+    public static ILocator ProviderSelectorMenu(this IPage page)
+    {
+        return page.GetByTestId("provider-selector-menu");
+    }
+
     /// <summary>Provider option menu item. Pass the provider id (e.g., <c>test</c>, <c>test-anthropic</c>).</summary>
     public static ILocator ProviderOption(this IPage page, string providerId)
     {

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/ProviderDropdownScrollTests.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/ProviderDropdownScrollTests.cs
@@ -78,17 +78,37 @@ public sealed class ProviderDropdownScrollTests
         (await page.ProviderOption("copilot-model-00").IsEnabledAsync()).Should().BeTrue(
             "injected Copilot models render available when the token gate is forced on");
 
-        // The menu must actually be scrollable — its content exceeds the capped visible height.
-        (await menu.EvaluateAsync<bool>("el => el.scrollHeight > el.clientHeight")).Should().BeTrue(
-            "the overflowing Copilot list must scroll inside the capped-height menu, not run off-screen");
+        // The menu must actually be scrollable via CSS — `scrollHeight > clientHeight` alone proves the
+        // content overflows, but that would hold even if `overflow-y` regressed back to the default
+        // `visible` (content would simply spill out unclipped instead of scrolling).
+        (await menu.EvaluateAsync<string>("el => getComputedStyle(el).overflowY")).Should().BeOneOf(
+            ["auto", "scroll"],
+            "the overflowing Copilot list must scroll inside the capped-height menu, not spill out unclipped");
 
-        // The last option starts below the fold; scrolling must bring it fully into view, and it must be
-        // enabled/reachable. We stop here — selecting it is intentionally out of scope.
+        // Prove the menu is actually scrollable, not merely eligible per its computed style: driving
+        // scrollTop to scrollHeight must move the offset off zero (the browser clamps to the real max).
+        await menu.EvaluateAsync("el => { el.scrollTop = el.scrollHeight; }");
+        (await menu.EvaluateAsync<double>("el => el.scrollTop")).Should().BeGreaterThan(
+            0,
+            "scrolling the menu to its content height must move the scroll offset off zero");
+
+        // The last option must be enabled, and — after scrolling — its bounding box must actually fall
+        // within the menu's clipped viewport. IsVisibleAsync alone does not prove containment within a
+        // scrollable ancestor's viewport, so we stop at bounding-box containment; selecting it remains
+        // out of scope.
         var lastOption = options.Last;
         (await lastOption.IsEnabledAsync()).Should().BeTrue();
-        await lastOption.ScrollIntoViewIfNeededAsync();
-        (await lastOption.IsVisibleAsync()).Should().BeTrue(
-            "the last option must be reachable by scrolling the menu");
+
+        var menuBox = await menu.BoundingBoxAsync();
+        var lastOptionBox = await lastOption.BoundingBoxAsync();
+        menuBox.Should().NotBeNull("the menu must be laid out to assert reachability against it");
+        lastOptionBox.Should().NotBeNull("the last option must be laid out to assert reachability against it");
+        lastOptionBox!.Y.Should().BeGreaterThanOrEqualTo(
+            menuBox!.Y,
+            "the last option must be reachable within the menu's top edge after scrolling");
+        (lastOptionBox.Y + lastOptionBox.Height).Should().BeLessThanOrEqualTo(
+            menuBox.Y + menuBox.Height,
+            "the last option must be fully reachable within the menu's clipped bottom edge, not scrolled past it");
 
         await session.SaveSuccessScreenshotAsync("ProviderDropdownScroll.overflow_reaches_last_option");
     }

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/ProviderDropdownScrollTests.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/ProviderDropdownScrollTests.cs
@@ -1,0 +1,95 @@
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using FluentAssertions;
+using LmStreaming.Sample.Browser.E2E.Tests.Infrastructure;
+
+namespace LmStreaming.Sample.Browser.E2E.Tests.Scenarios;
+
+/// <summary>
+/// Regression for the provider-dropdown scroll fix (issue #133, originally shipped in #129): when the
+/// dynamically discovered Copilot model list overflows the menu's capped height
+/// (<c>max-height: min(60vh, 320px)</c>), the menu must actually scroll so every option — including the
+/// last — stays reachable. PR #129 guarded this only with a source-level CSS assertion; this drives a
+/// real browser.
+///
+/// The Copilot list is token-gated and empty in CI, so a stub <see cref="CopilotModelInfo"/> list is
+/// injected through <see cref="BrowserWebAppFactory"/> with the Copilot token gate forced on, making the
+/// discovered models render as <em>available</em> providers without a real gh/Copilot login. The test
+/// proves the overflowed last option is present, enabled, and reachable by scrolling — it deliberately
+/// does NOT select it (the selection flow is covered elsewhere; changing the provider is out of scope
+/// for a scroll regression).
+/// </summary>
+[Collection(PlaywrightCollection.Name)]
+public sealed class ProviderDropdownScrollTests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public ProviderDropdownScrollTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    // Enough entries that the two Copilot partitions alone dwarf the 320px cap under CI fonts —
+    // ~20 items × ~35px each + the base providers is well over 320px, so overflow is deterministic
+    // rather than dependent on incidental viewport/font sizing.
+    private static IReadOnlyList<CopilotModelInfo> StubCopilotModels(int count = 20)
+    {
+        return
+        [
+            .. Enumerable.Range(0, count)
+                .Select(i => new CopilotModelInfo(
+                    $"copilot-model-{i:D2}",
+                    $"Copilot Model {i:D2}",
+                    i % 2 == 0 ? CopilotModelVendor.Anthropic : CopilotModelVendor.OpenAI,
+                    i % 2 == 0 ? CopilotModelTransport.Anthropic : CopilotModelTransport.Responses))
+        ];
+    }
+
+    [Fact]
+    public async Task Overflowing_provider_dropdown_scrolls_and_reaches_the_last_option()
+    {
+        // A no-op responder: the test never sends a message, it only inspects the provider dropdown.
+        var responder = ScriptedSseResponder
+            .New()
+            .ForRole("parent", ctx => ctx.SystemPromptContains("assistant"))
+            .Turn(t => t.Text("noop"))
+            .Build();
+
+        var copilotModels = StubCopilotModels();
+
+        await using var session = await _fixture.OpenAsync("test", responder, copilotModels: copilotModels);
+        var page = session.Page;
+
+        // Pin the viewport so the 60vh/320px cap and thus the overflow are deterministic across machines.
+        await page.SetViewportSizeAsync(1280, 720);
+
+        // Open the dropdown and wait for the menu to actually render before measuring it.
+        await page.ProviderSelectorButton().ClickAsync();
+        var menu = page.Locator(".dropdown-menu");
+        await menu.WaitForAsync();
+
+        // Setup assertion: the injected Copilot options are present and enabled. This fails loudly if the
+        // DI replacement (or the token-gate seam) regressed, before we ever measure scroll behavior.
+        var options = page.Locator("[data-testid^='provider-option-']");
+        (await options.CountAsync()).Should().BeGreaterThan(
+            copilotModels.Count,
+            "the base providers plus every injected Copilot model should be rendered");
+        await page.ProviderOption("copilot-model-00").WaitForAsync();
+        (await page.ProviderOption("copilot-model-00").IsEnabledAsync()).Should().BeTrue(
+            "injected Copilot models render available when the token gate is forced on");
+
+        // The menu must actually be scrollable — its content exceeds the capped visible height.
+        (await menu.EvaluateAsync<bool>("el => el.scrollHeight > el.clientHeight")).Should().BeTrue(
+            "the overflowing Copilot list must scroll inside the capped-height menu, not run off-screen");
+
+        // The last option starts below the fold; scrolling must bring it fully into view, and it must be
+        // enabled/reachable. We stop here — selecting it is intentionally out of scope.
+        var lastOption = options.Last;
+        (await lastOption.IsEnabledAsync()).Should().BeTrue();
+        await lastOption.ScrollIntoViewIfNeededAsync();
+        (await lastOption.IsVisibleAsync()).Should().BeTrue(
+            "the last option must be reachable by scrolling the menu");
+
+        await session.SaveSuccessScreenshotAsync("ProviderDropdownScroll.overflow_reaches_last_option");
+    }
+}

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/ProviderDropdownScrollTests.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/ProviderDropdownScrollTests.cs
@@ -65,7 +65,7 @@ public sealed class ProviderDropdownScrollTests
 
         // Open the dropdown and wait for the menu to actually render before measuring it.
         await page.ProviderSelectorButton().ClickAsync();
-        var menu = page.Locator(".dropdown-menu");
+        var menu = page.ProviderSelectorMenu();
         await menu.WaitForAsync();
 
         // Setup assertion: the injected Copilot options are present and enabled. This fails loudly if the

--- a/tests/LmStreaming.Sample.Tests/Services/ProviderRegistryTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ProviderRegistryTests.cs
@@ -250,6 +250,28 @@ public class ProviderRegistryTests
     }
 
     [Fact]
+    public void IsAvailable_CopilotModel_TracksInjectedTokenDelegate()
+    {
+        // The copilotTokenAvailable seam lets tests (and the browser E2E harness) make discovered
+        // Copilot models available without a real gh/Copilot login. It governs only the token gate:
+        // the model is known either way, but only available when the delegate reports a token.
+        using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");
+        var copilotModels = new[]
+        {
+            new CopilotModelInfo("claude-opus-4.8", "Claude Opus 4.8", CopilotModelVendor.Anthropic, CopilotModelTransport.Anthropic),
+        };
+
+        var withToken = new ProviderRegistry(
+            new FakeFileSystemProbe(), () => false, copilotModels, copilotTokenAvailable: () => true);
+        var withoutToken = new ProviderRegistry(
+            new FakeFileSystemProbe(), () => false, copilotModels, copilotTokenAvailable: () => false);
+
+        withToken.IsAvailable("claude-opus-4.8").Should().BeTrue();
+        withoutToken.IsAvailable("claude-opus-4.8").Should().BeFalse();
+        withoutToken.IsKnown("claude-opus-4.8").Should().BeTrue();
+    }
+
+    [Fact]
     public void IsAvailable_ClaudeMock_RequiresCliAndRunningHost()
     {
         using var _ = EnvScope.Set("LM_PROVIDER_MODE", "test");


### PR DESCRIPTION
## Summary

Two follow-ups deferred from #129, shipped together on one branch.

- **#132** extracts the drift-prone GitHub Copilot `GET /models` mechanics — response unwrap (`data[]`/bare-array), endpoint-name constants, and `supported_endpoints`/string reads — into a shared `CopilotModelsResponse` helper in `GithubCopilotProvider`, consumed by both `CopilotModelCatalogParser` and the CopilotAnthropicProxy `ProxyModelResolver`. Pure refactor; each caller keeps its own projection.
- **#133** adds a real browser regression proving the provider dropdown scrolls when the dynamically discovered Copilot list overflows its capped height (`max-height: min(60vh, 320px)`). #129 guarded this only with a source-level CSS assertion.

## Changes

- **#132** New `CopilotModelsResponse` (unwrap + endpoint constants + `supported_endpoints`/string readers). `CopilotModelCatalogParser` and `ProxyModelResolver` consume it; the proxy's **per-response (not per-entry)** id-only fallback and the parser's `messages > responses` transport ranking are preserved byte-for-byte. Adds `CopilotModelsResponseTests`.
- **#133** `ProviderRegistry` gains an optional `copilotTokenAvailable` delegate seam (default = the real CLI-credential check, so production behavior is unchanged). `BrowserWebAppFactory` + `ScriptedScenario` thread an optional stub `CopilotModelInfo` list. New `ProviderDropdownScrollTests` overflows the dropdown, asserts it actually scrolls (`scrollHeight > clientHeight`) and the last option is reachable + enabled — it does **not** select it. Adds a `ProviderRegistryTests` case for the seam. The #129 CSS smoke test is kept.

## Testing

- `GithubCopilotProvider.Tests`: 83/83 (new `CopilotModelsResponseTests` + refactored parser tests)
- `CopilotAnthropicProxy.Tests`: 89/89 (`ModelResolverTests`/`ModelRewriteTests` unchanged — behavior preserved)
- `LmStreaming.Sample.Tests`: 376/376 (incl. new seam test)
- E2E `ProviderDropdownScrollTests`: 1/1
- Vitest: 292/292 (incl. #129 `ProviderSelector` CSS smoke test)
- Independent code review: no material findings.

## Key Decisions

- **Shared low-level primitives, not a shared DTO** — each caller keeps its own projection/filtering (avoids over-generalizing; YAGNI).
- `CopilotModelsResponse` is `public` because the CopilotAnthropicProxy sample is a separate assembly that consumes it; documented as low-level `/models` plumbing.
- Proxy fallback kept **per-response** (any entry declaring `supported_endpoints` → filter to `/v1/messages`-capable ids; none → id-only) — the behavior most likely to drift during extraction.
- #133 seam mirrors the existing `mockHostIsRunning` delegate; the regression asserts scroll-reachability only and does **not** change the selected provider (per review).

## Related Issues

Fixes #132
Fixes #133