### PR TITLE
feat(daemon): config-driven multi-provider reviewer (Copilot Anthropic + OpenAI Responses)

### DIFF
--- a/samples/CodeReviewDaemon.Sample/Agents/LiveReviewAgentLoopFactory.cs
+++ b/samples/CodeReviewDaemon.Sample/Agents/LiveReviewAgentLoopFactory.cs
@@ -17,9 +17,11 @@ using ModelContextProtocol.Client;
 namespace CodeReviewDaemon.Sample.Agents;
 
 /// <summary>
-/// The production <see cref="IReviewAgentLoopFactory"/>: assembles an Anthropic Messages
-/// <see cref="MultiTurnAgentLoop"/> routed through the GitHub Copilot backend (mirrors the Copilot-backed
-/// Anthropic wiring in <c>LmStreaming.Sample</c>). The bearer token comes from the local GitHub Copilot /
+/// The production <see cref="IReviewAgentLoopFactory"/>: assembles either a Copilot <b>Anthropic Messages</b>
+/// or Copilot <b>OpenAI Responses</b> <see cref="MultiTurnAgentLoop"/> — selected by the configured
+/// <see cref="CodeReviewDaemonOptions.ReviewModelId"/>'s vendor (<c>claude-*</c> → Anthropic, <c>gpt-*</c>/
+/// <c>o1|o3|o4</c> → OpenAI Responses) — routed through the GitHub Copilot backend (mirrors the Copilot-backed
+/// wiring in <c>LmStreaming.Sample</c>). The bearer token comes from the local GitHub Copilot /
 /// <c>gh</c> CLI login via <see cref="CliCredentialCopilotTokenProvider"/> — no API key / base URL config
 /// knob. When <see cref="Create"/> is called without a <see cref="ReviewToolContext"/> the registry stays
 /// empty — the daemon's agents are collect-only text agents that reason over the diff the executor
@@ -31,12 +33,13 @@ namespace CodeReviewDaemon.Sample.Agents;
 /// (lazy per run), so registering it cannot affect daemon boot or the route surface.
 /// </para>
 /// <para>
-/// <b>Lifetime.</b> The Copilot-backed <see cref="AnthropicAgent"/> (and the transport
-/// <see cref="System.Net.Http.HttpClient"/> it owns) is created once on first use and <b>shared</b> across
-/// every loop, then disposed with this singleton. <see cref="MultiTurnAgentLoop"/> disposal does not dispose
-/// its provider agent, so a fresh agent per run would leak one client per run; sharing avoids that. The
-/// daemon drives runs serially (the <c>ReviewStore</c> singleton is documented single-accessor), so one
-/// shared agent across the per-run loops is safe.
+/// <b>Lifetime.</b> The Copilot-backed provider agent (the vendor-matched <see cref="AnthropicAgent"/> or
+/// <see cref="OpenAiResponsesAgent"/>, and the transport <see cref="System.Net.Http.HttpClient"/> it owns) is
+/// created once on first use and <b>shared</b> across every loop, then disposed with this singleton.
+/// <see cref="MultiTurnAgentLoop"/> disposal does not dispose its provider agent, so a fresh agent per run
+/// would leak one client per run; sharing avoids that. The daemon drives runs serially (the
+/// <c>ReviewStore</c> singleton is documented single-accessor), so one shared agent across the per-run loops
+/// is safe.
 /// </para>
 /// </summary>
 internal sealed class LiveReviewAgentLoopFactory : IReviewAgentLoopFactory, IDisposable

--- a/samples/CodeReviewDaemon.Sample/Agents/LiveReviewAgentLoopFactory.cs
+++ b/samples/CodeReviewDaemon.Sample/Agents/LiveReviewAgentLoopFactory.cs
@@ -18,8 +18,9 @@ namespace CodeReviewDaemon.Sample.Agents;
 
 /// <summary>
 /// The production <see cref="IReviewAgentLoopFactory"/>: assembles either a Copilot <b>Anthropic Messages</b>
-/// or Copilot <b>OpenAI Responses</b> <see cref="MultiTurnAgentLoop"/> — selected by the configured
-/// <see cref="CodeReviewDaemonOptions.ReviewModelId"/>'s vendor (<c>claude-*</c> → Anthropic, <c>gpt-*</c>/
+/// or Copilot <b>OpenAI Responses</b> <see cref="MultiTurnAgentLoop"/> — selected per run by the effective
+/// review model's vendor (the per-call model override, else the configured
+/// <see cref="CodeReviewDaemonOptions.ReviewModelId"/>: <c>claude-*</c> → Anthropic, <c>gpt-*</c>/
 /// <c>o1|o3|o4</c> → OpenAI Responses) — routed through the GitHub Copilot backend (mirrors the Copilot-backed
 /// wiring in <c>LmStreaming.Sample</c>). The bearer token comes from the local GitHub Copilot /
 /// <c>gh</c> CLI login via <see cref="CliCredentialCopilotTokenProvider"/> — no API key / base URL config
@@ -33,13 +34,15 @@ namespace CodeReviewDaemon.Sample.Agents;
 /// (lazy per run), so registering it cannot affect daemon boot or the route surface.
 /// </para>
 /// <para>
-/// <b>Lifetime.</b> The Copilot-backed provider agent (the vendor-matched <see cref="AnthropicAgent"/> or
-/// <see cref="OpenAiResponsesAgent"/>, and the transport <see cref="System.Net.Http.HttpClient"/> it owns) is
-/// created once on first use and <b>shared</b> across every loop, then disposed with this singleton.
+/// <b>Lifetime.</b> Each Copilot-backed provider agent (the <see cref="AnthropicAgent"/> and/or
+/// <see cref="OpenAiResponsesAgent"/>, and the transport <see cref="System.Net.Http.HttpClient"/> it owns)
+/// is created once on first use <b>for its vendor</b> and <b>shared</b> across every loop of that vendor,
+/// then disposed with this singleton. A single factory instance can serve both vendors (a claude primary
+/// with a gpt variant, or the reverse), so up to two agents are cached — one per backend.
 /// <see cref="MultiTurnAgentLoop"/> disposal does not dispose its provider agent, so a fresh agent per run
 /// would leak one client per run; sharing avoids that. The daemon drives runs serially (the
-/// <c>ReviewStore</c> singleton is documented single-accessor), so one shared agent across the per-run loops
-/// is safe.
+/// <c>ReviewStore</c> singleton is documented single-accessor), so one shared agent per vendor across the
+/// per-run loops is safe.
 /// </para>
 /// </summary>
 internal sealed class LiveReviewAgentLoopFactory : IReviewAgentLoopFactory, IDisposable
@@ -49,7 +52,8 @@ internal sealed class LiveReviewAgentLoopFactory : IReviewAgentLoopFactory, IDis
     private readonly ICopilotTokenProvider _tokenProvider = new CliCredentialCopilotTokenProvider();
     private readonly CopilotSessionContext _session = new();
     private readonly object _agentGate = new();
-    private IStreamingAgent? _agent;
+    private IStreamingAgent? _anthropicAgent;
+    private IStreamingAgent? _openAiAgent;
 
     public LiveReviewAgentLoopFactory(ILoggerFactory loggerFactory, CodeReviewDaemonOptions options)
     {
@@ -58,12 +62,12 @@ internal sealed class LiveReviewAgentLoopFactory : IReviewAgentLoopFactory, IDis
     }
 
     /// <summary>
-    /// The same shared, lazily-created Copilot-backed agent every review loop is given (see the Lifetime
-    /// remarks on this type), exposed as an <see cref="IStreamingAgent"/> factory so a discovered
-    /// <c>code-reviewer:*</c> sub-agent (Task 12) is driven by the identical provider agent instead of
-    /// standing up a second one.
+    /// The shared, lazily-created Copilot-backed agent for the primary configured
+    /// <see cref="CodeReviewDaemonOptions.ReviewModelId"/>'s vendor (see the Lifetime remarks on this type),
+    /// exposed as an <see cref="IStreamingAgent"/> factory so a discovered <c>code-reviewer:*</c> sub-agent
+    /// (Task 12) is driven by that same provider agent instead of standing up a second one.
     /// </summary>
-    public Func<IStreamingAgent> SharedAgentFactory => GetSharedAgent;
+    public Func<IStreamingAgent> SharedAgentFactory => () => GetSharedAgent(IsOpenAiModel(_options.ReviewModelId));
 
     public IMultiTurnAgent Create(
         AgentProfile profile,
@@ -75,31 +79,20 @@ internal sealed class LiveReviewAgentLoopFactory : IReviewAgentLoopFactory, IDis
         ArgumentNullException.ThrowIfNull(profile);
         ArgumentException.ThrowIfNullOrWhiteSpace(threadId);
 
-        // Anthropic Messages agent (claude-*) or OpenAI Responses agent (gpt-*/o-series) over the Copilot
-        // backend, chosen by the configured model's vendor; shared across loops. The model id is supplied
-        // per run via defaultOptions below.
-        var providerAgent = GetSharedAgent();
-
-        // Resolve the reasoning effort and attach the request shape matching the model's backend: the
-        // Copilot Anthropic Messages agent takes an adaptive-thinking output_config.effort (and a
+        // Route by the EFFECTIVE per-call model (the per-run override callers pass — run.ModelId for the
+        // primary/knowledge/judge paths, VariantModelId for the A/B B arm — else the configured
+        // ReviewModelId), not the configured model, so a claude variant under a gpt-* primary (or the
+        // reverse) is driven by the matching backend with the matching request shape. The reasoning shape:
+        // the Copilot Anthropic Messages agent takes an adaptive-thinking output_config.effort (and a
         // non-adaptive model like haiku REJECTS an effort it does not support, so it is omitted when empty);
         // the Copilot OpenAI Responses agent (gpt-5.5) takes a reasoning request (effort + summary).
         var effort = reasoningEffort ?? _options.ReviewReasoningEffort;
-        var extraProperties = ImmutableDictionary<string, object?>.Empty;
-        if (IsOpenAiModel(_options.ReviewModelId))
-        {
-            extraProperties = extraProperties.Add(
-                "Reasoning",
-                new ResponseReasoningOptions
-                {
-                    Effort = string.IsNullOrWhiteSpace(effort) ? null : effort,
-                    Summary = "auto",
-                });
-        }
-        else if (!string.IsNullOrWhiteSpace(effort))
-        {
-            extraProperties = extraProperties.Add("OutputConfig", new AnthropicOutputConfig { Effort = effort });
-        }
+        var (isOpenAi, extraProperties) = ResolveReasoning(modelId, _options.ReviewModelId, effort);
+
+        // Anthropic Messages agent (claude-*) or OpenAI Responses agent (gpt-*/o-series) over the Copilot
+        // backend, chosen by that same effective-model vendor; one shared agent per vendor across loops. The
+        // model id is supplied per run via defaultOptions below.
+        var providerAgent = GetSharedAgent(isOpenAi);
 
         // Only on the tool-assisted path (toolContext is not null) do we connect the gateway MCP client and
         // filter its tools down to the read-only allow-list — the diff-only path keeps today's empty
@@ -162,33 +155,73 @@ internal sealed class LiveReviewAgentLoopFactory : IReviewAgentLoopFactory, IDis
         return ownedClients.Count > 0 ? new ToolScopedReviewLoop(loop, ownedClients) : loop;
     }
 
-    private IStreamingAgent GetSharedAgent()
+    /// <summary>
+    /// The shared Copilot-backed provider agent for the requested vendor, lazily created on first use and
+    /// reused thereafter. A single factory instance can serve both a claude and a gpt run, so the two vendors
+    /// get independent cache slots (guarded by <see cref="_agentGate"/>); each is disposed with this singleton.
+    /// </summary>
+    private IStreamingAgent GetSharedAgent(bool isOpenAi)
     {
-        if (_agent is not null)
+        var cached = isOpenAi ? _openAiAgent : _anthropicAgent;
+        if (cached is not null)
         {
-            return _agent;
+            return cached;
         }
 
         lock (_agentGate)
         {
-            _agent ??= IsOpenAiModel(_options.ReviewModelId)
-                ? CopilotResponsesAgentFactory.Create(
+            if (isOpenAi)
+            {
+                return _openAiAgent ??= CopilotResponsesAgentFactory.Create(
                     "CopilotResponses",
                     _tokenProvider,
                     CopilotResponsesTransport.Sse,
                     _session,
-                    logger: _loggerFactory.CreateLogger<OpenAiResponsesAgent>())
-                : CopilotAnthropicAgentFactory.Create(
-                    "CopilotAnthropic",
-                    _tokenProvider,
-                    _session,
-                    logger: _loggerFactory.CreateLogger<AnthropicAgent>());
-            return _agent;
+                    logger: _loggerFactory.CreateLogger<OpenAiResponsesAgent>());
+            }
+
+            return _anthropicAgent ??= CopilotAnthropicAgentFactory.Create(
+                "CopilotAnthropic",
+                _tokenProvider,
+                _session,
+                logger: _loggerFactory.CreateLogger<AnthropicAgent>());
         }
     }
 
     /// <summary>
-    /// Whether the configured review model is served by the Copilot <b>OpenAI Responses</b> backend
+    /// The provider routing decision for one review turn: resolves the effective model (the per-call
+    /// <paramref name="modelId"/> override, else the configured <paramref name="configuredModelId"/>), picks
+    /// the vendor, and builds the matching reasoning-request shape — an OpenAI Responses <c>Reasoning</c>
+    /// (effort + summary) for <c>gpt-*</c>/<c>o1|o3|o4</c>, or an Anthropic Messages <c>OutputConfig</c>
+    /// (effort, omitted when empty for a non-adaptive model like haiku) for <c>claude-*</c>. Both the provider
+    /// agent selection and the request shape are driven off this single decision so they can never diverge.
+    /// </summary>
+    internal static (bool IsOpenAi, ImmutableDictionary<string, object?> ExtraProperties) ResolveReasoning(
+        string? modelId, string? configuredModelId, string? effort)
+    {
+        var effectiveModelId = string.IsNullOrWhiteSpace(modelId) ? configuredModelId : modelId;
+        var isOpenAi = IsOpenAiModel(effectiveModelId);
+        var extraProperties = ImmutableDictionary<string, object?>.Empty;
+        if (isOpenAi)
+        {
+            extraProperties = extraProperties.Add(
+                "Reasoning",
+                new ResponseReasoningOptions
+                {
+                    Effort = string.IsNullOrWhiteSpace(effort) ? null : effort,
+                    Summary = "auto",
+                });
+        }
+        else if (!string.IsNullOrWhiteSpace(effort))
+        {
+            extraProperties = extraProperties.Add("OutputConfig", new AnthropicOutputConfig { Effort = effort });
+        }
+
+        return (isOpenAi, extraProperties);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="modelId"/> is served by the Copilot <b>OpenAI Responses</b> backend
     /// (<c>gpt-*</c>, <c>o1/o3/o4</c>) rather than the Anthropic Messages backend (<c>claude-*</c>). Drives
     /// both which provider agent is created and which reasoning-request shape is attached.
     /// </summary>
@@ -199,5 +232,9 @@ internal sealed class LiveReviewAgentLoopFactory : IReviewAgentLoopFactory, IDis
             || modelId.StartsWith("o3", StringComparison.OrdinalIgnoreCase)
             || modelId.StartsWith("o4", StringComparison.OrdinalIgnoreCase));
 
-    public void Dispose() => (_agent as IDisposable)?.Dispose();
+    public void Dispose()
+    {
+        (_anthropicAgent as IDisposable)?.Dispose();
+        (_openAiAgent as IDisposable)?.Dispose();
+    }
 }

--- a/samples/CodeReviewDaemon.Sample/Agents/LiveReviewAgentLoopFactory.cs
+++ b/samples/CodeReviewDaemon.Sample/Agents/LiveReviewAgentLoopFactory.cs
@@ -9,6 +9,8 @@ using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmMultiTurn;
 using AchieveAi.LmDotnetTools.McpMiddleware.Extensions;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
 using CodeReviewDaemon.Sample.Configuration;
 using ModelContextProtocol.Client;
 
@@ -44,7 +46,7 @@ internal sealed class LiveReviewAgentLoopFactory : IReviewAgentLoopFactory, IDis
     private readonly ICopilotTokenProvider _tokenProvider = new CliCredentialCopilotTokenProvider();
     private readonly CopilotSessionContext _session = new();
     private readonly object _agentGate = new();
-    private AnthropicAgent? _agent;
+    private IStreamingAgent? _agent;
 
     public LiveReviewAgentLoopFactory(ILoggerFactory loggerFactory, CodeReviewDaemonOptions options)
     {
@@ -70,19 +72,31 @@ internal sealed class LiveReviewAgentLoopFactory : IReviewAgentLoopFactory, IDis
         ArgumentNullException.ThrowIfNull(profile);
         ArgumentException.ThrowIfNullOrWhiteSpace(threadId);
 
-        // Anthropic Messages agent over the Copilot backend (POST {copilot-host}/v1/messages); shared across
-        // loops. The model id (e.g. claude-sonnet-5) is supplied per run via defaultOptions below.
+        // Anthropic Messages agent (claude-*) or OpenAI Responses agent (gpt-*/o-series) over the Copilot
+        // backend, chosen by the configured model's vendor; shared across loops. The model id is supplied
+        // per run via defaultOptions below.
         var providerAgent = GetSharedAgent();
 
-        // Resolve the adaptive-thinking effort: an explicit per-call value wins, else the configured
-        // default. Attach output_config ONLY when the effort is non-empty — an adaptive model (sonnet)
-        // needs it to keep reasoning bounded, but a non-adaptive model (haiku) REJECTS an effort it does
-        // not support, so it must be omitted for those.
+        // Resolve the reasoning effort and attach the request shape matching the model's backend: the
+        // Copilot Anthropic Messages agent takes an adaptive-thinking output_config.effort (and a
+        // non-adaptive model like haiku REJECTS an effort it does not support, so it is omitted when empty);
+        // the Copilot OpenAI Responses agent (gpt-5.5) takes a reasoning request (effort + summary).
         var effort = reasoningEffort ?? _options.ReviewReasoningEffort;
-        var extraProperties = string.IsNullOrWhiteSpace(effort)
-            ? ImmutableDictionary<string, object?>.Empty
-            : ImmutableDictionary<string, object?>.Empty.Add(
-                "OutputConfig", new AnthropicOutputConfig { Effort = effort });
+        var extraProperties = ImmutableDictionary<string, object?>.Empty;
+        if (IsOpenAiModel(_options.ReviewModelId))
+        {
+            extraProperties = extraProperties.Add(
+                "Reasoning",
+                new ResponseReasoningOptions
+                {
+                    Effort = string.IsNullOrWhiteSpace(effort) ? null : effort,
+                    Summary = "auto",
+                });
+        }
+        else if (!string.IsNullOrWhiteSpace(effort))
+        {
+            extraProperties = extraProperties.Add("OutputConfig", new AnthropicOutputConfig { Effort = effort });
+        }
 
         // Only on the tool-assisted path (toolContext is not null) do we connect the gateway MCP client and
         // filter its tools down to the read-only allow-list — the diff-only path keeps today's empty
@@ -145,7 +159,7 @@ internal sealed class LiveReviewAgentLoopFactory : IReviewAgentLoopFactory, IDis
         return ownedClients.Count > 0 ? new ToolScopedReviewLoop(loop, ownedClients) : loop;
     }
 
-    private AnthropicAgent GetSharedAgent()
+    private IStreamingAgent GetSharedAgent()
     {
         if (_agent is not null)
         {
@@ -154,14 +168,33 @@ internal sealed class LiveReviewAgentLoopFactory : IReviewAgentLoopFactory, IDis
 
         lock (_agentGate)
         {
-            _agent ??= CopilotAnthropicAgentFactory.Create(
-                "CopilotAnthropic",
-                _tokenProvider,
-                _session,
-                logger: _loggerFactory.CreateLogger<AnthropicAgent>());
+            _agent ??= IsOpenAiModel(_options.ReviewModelId)
+                ? CopilotResponsesAgentFactory.Create(
+                    "CopilotResponses",
+                    _tokenProvider,
+                    CopilotResponsesTransport.Sse,
+                    _session,
+                    logger: _loggerFactory.CreateLogger<OpenAiResponsesAgent>())
+                : CopilotAnthropicAgentFactory.Create(
+                    "CopilotAnthropic",
+                    _tokenProvider,
+                    _session,
+                    logger: _loggerFactory.CreateLogger<AnthropicAgent>());
             return _agent;
         }
     }
 
-    public void Dispose() => _agent?.Dispose();
+    /// <summary>
+    /// Whether the configured review model is served by the Copilot <b>OpenAI Responses</b> backend
+    /// (<c>gpt-*</c>, <c>o1/o3/o4</c>) rather than the Anthropic Messages backend (<c>claude-*</c>). Drives
+    /// both which provider agent is created and which reasoning-request shape is attached.
+    /// </summary>
+    private static bool IsOpenAiModel(string? modelId) =>
+        !string.IsNullOrWhiteSpace(modelId)
+        && (modelId.StartsWith("gpt", StringComparison.OrdinalIgnoreCase)
+            || modelId.StartsWith("o1", StringComparison.OrdinalIgnoreCase)
+            || modelId.StartsWith("o3", StringComparison.OrdinalIgnoreCase)
+            || modelId.StartsWith("o4", StringComparison.OrdinalIgnoreCase));
+
+    public void Dispose() => (_agent as IDisposable)?.Dispose();
 }

--- a/tests/CodeReviewDaemon.Sample.Tests/Agents/LiveReviewAgentRoutingTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Agents/LiveReviewAgentRoutingTests.cs
@@ -1,0 +1,121 @@
+using AchieveAi.LmDotnetTools.AnthropicProvider.Models;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+using CodeReviewDaemon.Sample.Agents;
+
+namespace CodeReviewDaemon.Sample.Tests.Agents;
+
+/// <summary>
+/// The provider-routing decision <see cref="LiveReviewAgentLoopFactory.ResolveReasoning"/> makes for one
+/// review turn. This is the seam <see cref="LiveReviewAgentLoopFactory.Create"/> drives both the provider
+/// agent selection AND the reasoning-request shape off, so asserting it here pins the per-call routing:
+/// <c>gpt-*</c>/<c>o1|o3|o4</c> → an OpenAI Responses <c>Reasoning</c>; <c>claude-*</c> → an Anthropic
+/// Messages <c>OutputConfig</c>; and, critically, the EFFECTIVE per-call model wins over the configured one
+/// (so an A/B claude variant under a gpt-* primary — or the reverse — is routed correctly). No live Copilot
+/// call is made — the decision is a pure function.
+/// </summary>
+public class LiveReviewAgentRoutingTests
+{
+    [Theory]
+    [InlineData("gpt-5.5")]
+    [InlineData("gpt-5.5-mini")]
+    [InlineData("o1")]
+    [InlineData("o3")]
+    [InlineData("o4")]
+    public void ResolveReasoning_OpenAiModel_AttachesReasoningWithEffortAndAutoSummary(string modelId)
+    {
+        var (isOpenAi, extra) = LiveReviewAgentLoopFactory.ResolveReasoning(
+            modelId, configuredModelId: "claude-sonnet-5", effort: "medium");
+
+        isOpenAi.Should().BeTrue();
+        extra.Should().NotContainKey("OutputConfig");
+        var reasoning = extra["Reasoning"].Should().BeOfType<ResponseReasoningOptions>().Subject;
+        reasoning.Effort.Should().Be("medium");
+        reasoning.Summary.Should().Be("auto");
+    }
+
+    [Theory]
+    [InlineData("claude-sonnet-5")]
+    [InlineData("claude-haiku-4.5")]
+    [InlineData("claude-opus-4-8")]
+    public void ResolveReasoning_ClaudeModel_AttachesOutputConfigEffort(string modelId)
+    {
+        var (isOpenAi, extra) = LiveReviewAgentLoopFactory.ResolveReasoning(
+            modelId, configuredModelId: "gpt-5.5", effort: "high");
+
+        isOpenAi.Should().BeFalse();
+        extra.Should().NotContainKey("Reasoning");
+        var outputConfig = extra["OutputConfig"].Should().BeOfType<AnthropicOutputConfig>().Subject;
+        outputConfig.Effort.Should().Be("high");
+    }
+
+    [Fact]
+    public void ResolveReasoning_PrimaryGptWithClaudeVariantOverride_RoutesToAnthropicShape()
+    {
+        // Regression: with gpt-5.5 configured as the primary, the A/B B arm passes VariantModelId
+        // (claude-haiku-4.5) per call. The effective model — not the configured one — must decide, so the
+        // claude variant is routed through the Anthropic Messages shape, never the OpenAI Responses one.
+        var (isOpenAi, extra) = LiveReviewAgentLoopFactory.ResolveReasoning(
+            modelId: "claude-haiku-4.5", configuredModelId: "gpt-5.5", effort: "");
+
+        isOpenAi.Should().BeFalse();
+        extra.Should().NotContainKey("Reasoning");
+    }
+
+    [Fact]
+    public void ResolveReasoning_PrimaryClaudeWithGptVariantOverride_RoutesToOpenAiShape()
+    {
+        // The reverse mix: a gpt-* per-call override under a claude primary must route to the OpenAI
+        // Responses reasoning shape.
+        var (isOpenAi, extra) = LiveReviewAgentLoopFactory.ResolveReasoning(
+            modelId: "gpt-5.5", configuredModelId: "claude-sonnet-5", effort: "low");
+
+        isOpenAi.Should().BeTrue();
+        extra.Should().NotContainKey("OutputConfig");
+        var reasoning = extra["Reasoning"].Should().BeOfType<ResponseReasoningOptions>().Subject;
+        reasoning.Effort.Should().Be("low");
+        reasoning.Summary.Should().Be("auto");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveReasoning_NoPerCallModel_FallsBackToConfiguredVendor(string? modelId)
+    {
+        var (openAiFromGpt, gptExtra) = LiveReviewAgentLoopFactory.ResolveReasoning(
+            modelId, configuredModelId: "gpt-5.5", effort: "medium");
+        openAiFromGpt.Should().BeTrue();
+        gptExtra.Should().ContainKey("Reasoning");
+
+        var (openAiFromClaude, claudeExtra) = LiveReviewAgentLoopFactory.ResolveReasoning(
+            modelId, configuredModelId: "claude-sonnet-5", effort: "medium");
+        openAiFromClaude.Should().BeFalse();
+        claudeExtra.Should().ContainKey("OutputConfig");
+    }
+
+    [Fact]
+    public void ResolveReasoning_ClaudeWithEmptyEffort_OmitsOutputConfig()
+    {
+        // A non-adaptive model (e.g. haiku) REJECTS an effort it does not support, so an empty effort must
+        // leave the request shape empty rather than attaching an OutputConfig.
+        var (isOpenAi, extra) = LiveReviewAgentLoopFactory.ResolveReasoning(
+            modelId: "claude-haiku-4.5", configuredModelId: "claude-sonnet-5", effort: "");
+
+        isOpenAi.Should().BeFalse();
+        extra.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ResolveReasoning_OpenAiWithEmptyEffort_AttachesReasoningWithNullEffort()
+    {
+        // The OpenAI Responses shape is always attached (summary="auto"); an empty effort maps to a null
+        // Effort so the provider applies its default rather than being sent a blank string.
+        var (isOpenAi, extra) = LiveReviewAgentLoopFactory.ResolveReasoning(
+            modelId: "gpt-5.5", configuredModelId: "gpt-5.5", effort: "");
+
+        isOpenAi.Should().BeTrue();
+        var reasoning = extra["Reasoning"].Should().BeOfType<ResponseReasoningOptions>().Subject;
+        reasoning.Effort.Should().BeNull();
+        reasoning.Summary.Should().Be("auto");
+    }
+}


### PR DESCRIPTION
## What

Makes the Code-Review Daemon's review provider **config-driven**. `LiveReviewAgentLoopFactory` now selects the Copilot-backed provider agent by the configured `ReviewModelId`'s vendor:

- `claude-*` → Copilot **Anthropic Messages** agent (`/v1/messages`) — the existing path
- `gpt-*` / `o1|o3|o4` → Copilot **OpenAI Responses** agent (`/responses`, SSE)

Each backend gets its matching reasoning-request shape (Anthropic `output_config.effort` vs OpenAI `reasoning` effort + summary), so switching the review model — e.g. `claude-opus-4.8` ↔ `gpt-5.5` — is a pure config change, no code edit.

## Why

The reviewer was hardwired to the Copilot Anthropic agent, so GPT models silently fell back to Claude. This unlocks reviewing with any Copilot-hosted model of either vendor via `CodeReviewDaemon:ReviewModelId`.

## How tested

Ran the daemon live (tool-assisted, post mode) with `ReviewModelId=gpt-5.5` against open PRs: the Responses agent, the MCP read-only tool loop, and the `code-reviewer:*` sub-agent fan-out all function (dispatched performance / architecture / schema-compatibility sub-agents). Claude models (`claude-opus-4.8`, `claude-sonnet-5`) continue to work unchanged.
