### PR TITLE
Make sandbox WorkspaceBasePath optional; client never FS-accesses the workspace (#164)

### DIFF
--- a/src/LmAgentInfra/Sandbox/SandboxGatewayOptions.cs
+++ b/src/LmAgentInfra/Sandbox/SandboxGatewayOptions.cs
@@ -77,12 +77,13 @@ public sealed class SandboxGatewayOptions
     /// Resolves a per-workspace directory leaf into base/leaf/full-path. When
     /// <paramref name="relPathOverride"/> is null/whitespace this is identical to
     /// <see cref="ResolveWorkspace()"/>. Otherwise <paramref name="relPathOverride"/> is treated as
-    /// the workspace leaf. A rooted override is always rejected (via
-    /// <see cref="InvalidOperationException"/>) — a workspace identifier is never an absolute path.
+    /// the workspace leaf. A rooted override, or one containing a <c>..</c> traversal segment, is
+    /// always rejected (via <see cref="InvalidOperationException"/>) regardless of whether a base is
+    /// configured — a workspace identifier is never an absolute path and never traverses upward.
     /// <para>
     /// If a local base is configured (<see cref="WorkspaceBasePath"/>/<see cref="WorkspacePath"/>),
-    /// the leaf is resolved under it and rejected when it escapes the base (e.g. <c>"../evil"</c>), so
-    /// a chosen workspace can never mount a directory outside the configured base. If NO base is
+    /// the leaf is resolved under it and additionally rejected if it escapes the base, so a chosen
+    /// workspace can never mount a directory outside the configured base. If NO base is
     /// configured, resolution returns just the leaf with a null base and null full path: the gateway
     /// may be remote, or root the workspace under its own per-app base (ADR 0029), so the client
     /// forwards the leaf and lets the gateway own directory creation instead of resolving/creating a
@@ -102,6 +103,18 @@ public sealed class SandboxGatewayOptions
         {
             throw new InvalidOperationException(
                 $"Workspace directory '{relPathOverride}' must be relative to the workspace base."
+            );
+        }
+
+        // Defense-in-depth: a workspace identifier never legitimately contains a parent-directory
+        // traversal segment. Reject '..' regardless of whether a base is configured — on the no-base
+        // path the leaf is forwarded straight to the (possibly remote/permissive) gateway, so this is
+        // the client's only containment guard there; with a base, it fails fast before the escape
+        // check below would catch the same thing.
+        if (Array.Exists(relPathOverride.Split('/', '\\'), segment => segment == ".."))
+        {
+            throw new InvalidOperationException(
+                $"Workspace directory '{relPathOverride}' must not contain '..' path segments."
             );
         }
 

--- a/src/LmAgentInfra/Sandbox/SandboxGatewayOptions.cs
+++ b/src/LmAgentInfra/Sandbox/SandboxGatewayOptions.cs
@@ -29,6 +29,13 @@ public sealed class SandboxGatewayOptions
     /// <summary>
     /// Host base directory the gateway resolves the workspace under.
     /// Becomes <c>WORKSPACE_BASE_PATH</c> when the gateway is spawned.
+    /// <para>
+    /// OPTIONAL. Needed only for the same-host <b>spawn</b> path (and the same-host adopt
+    /// optimization where the client pre-creates the workspace directory). When it is unset, the
+    /// client forwards the workspace leaf to the gateway and lets the gateway own directory
+    /// creation — so a workspace-backed session works against a REMOTE or per-app-rooting gateway
+    /// (ADR 0029) with no local base configured. See <see cref="ResolveWorkspace(string)"/>.
+    /// </para>
     /// </summary>
     public string? WorkspaceBasePath { get; set; }
 
@@ -69,11 +76,18 @@ public sealed class SandboxGatewayOptions
     /// <summary>
     /// Resolves a per-workspace directory leaf into base/leaf/full-path. When
     /// <paramref name="relPathOverride"/> is null/whitespace this is identical to
-    /// <see cref="ResolveWorkspace()"/>. Otherwise the configured base from
-    /// <see cref="ResolveWorkspace()"/> is reused and <paramref name="relPathOverride"/> is treated
-    /// as the workspace leaf. The override is rejected (via <see cref="InvalidOperationException"/>)
-    /// when it is rooted or escapes the base directory (e.g. <c>"../evil"</c>), so a chosen
-    /// workspace can never mount a directory outside the configured base.
+    /// <see cref="ResolveWorkspace()"/>. Otherwise <paramref name="relPathOverride"/> is treated as
+    /// the workspace leaf. A rooted override is always rejected (via
+    /// <see cref="InvalidOperationException"/>) — a workspace identifier is never an absolute path.
+    /// <para>
+    /// If a local base is configured (<see cref="WorkspaceBasePath"/>/<see cref="WorkspacePath"/>),
+    /// the leaf is resolved under it and rejected when it escapes the base (e.g. <c>"../evil"</c>), so
+    /// a chosen workspace can never mount a directory outside the configured base. If NO base is
+    /// configured, resolution returns just the leaf with a null base and null full path: the gateway
+    /// may be remote, or root the workspace under its own per-app base (ADR 0029), so the client
+    /// forwards the leaf and lets the gateway own directory creation instead of resolving/creating a
+    /// local path. A base is thus OPTIONAL — required only for the same-host spawn optimization.
+    /// </para>
     /// </summary>
     public (string? BasePath, string? Leaf, string? FullPath) ResolveWorkspace(string? relPathOverride)
     {
@@ -82,19 +96,25 @@ public sealed class SandboxGatewayOptions
             return ResolveWorkspace();
         }
 
-        var (basePath, _, _) = ResolveWorkspace();
-        if (string.IsNullOrWhiteSpace(basePath))
-        {
-            throw new InvalidOperationException(
-                "Cannot resolve a workspace override because no workspace base path is configured."
-            );
-        }
-
+        // A workspace override is always a RELATIVE leaf (a workspace identifier), never an absolute
+        // path — reject a rooted value up front, independent of whether a local base is configured.
         if (Path.IsPathRooted(relPathOverride))
         {
             throw new InvalidOperationException(
                 $"Workspace directory '{relPathOverride}' must be relative to the workspace base."
             );
+        }
+
+        var (basePath, _, _) = ResolveWorkspace();
+        if (string.IsNullOrWhiteSpace(basePath))
+        {
+            // No local base is configured — e.g. the client adopts a gateway that may be REMOTE, or
+            // that roots the workspace under its own per-app base (ADR 0029). The client neither
+            // resolves an absolute path nor pre-creates the directory on a filesystem it may not even
+            // share: it forwards the leaf (the workspace identifier) and lets the gateway own
+            // creation. WorkspaceBasePath / WorkspacePath is therefore OPTIONAL, needed only for the
+            // same-host spawn path where the client pre-creates the workspace dir as an optimization.
+            return (null, relPathOverride, null);
         }
 
         var baseFull = Path.TrimEndingDirectorySeparator(Path.GetFullPath(basePath));

--- a/src/LmAgentInfra/Sandbox/SandboxSessionRegistry.cs
+++ b/src/LmAgentInfra/Sandbox/SandboxSessionRegistry.cs
@@ -384,23 +384,14 @@ public sealed partial class SandboxSessionRegistry : IAsyncDisposable
             throw new SandboxSessionUnavailableException(workspaceId, statusCode: null, ex.Message, ex);
         }
 
-        var (_, workspaceLeaf, workspaceFullPath) = _options.ResolveWorkspace(workspaceRef.DirectoryRelPath);
+        // Resolve only the workspace LEAF — the identifier sent to the gateway as the `workspace`
+        // field. The client deliberately does NOT touch the workspace filesystem here: the sandbox
+        // gateway may be on a remote machine, and it owns workspace directory creation
+        // (create-if-missing) and mounting. A local WorkspaceBasePath/WorkspacePath is used only by
+        // the spawn path to provision a LOCAL gateway (SandboxGatewayLifetime.EnsureWorkspaceDirectory)
+        // — it is neither required nor resolved to a local path when adopting a (possibly remote) gateway.
+        var (_, workspaceLeaf, _) = _options.ResolveWorkspace(workspaceRef.DirectoryRelPath);
         var workspaceRelPath = workspaceLeaf ?? string.Empty;
-
-        // Ensure the workspace directory exists before the gateway mounts it — the gateway rejects a
-        // leaf that doesn't exist under WORKSPACE_BASE_PATH. Idempotent with the spawn-time creation;
-        // this also covers the adopt-an-existing-gateway path (no spawn ran).
-        if (!string.IsNullOrWhiteSpace(workspaceFullPath))
-        {
-            try
-            {
-                _ = Directory.CreateDirectory(workspaceFullPath);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Could not create workspace directory '{WorkspacePath}'", workspaceFullPath);
-            }
-        }
 
         var requestUri = $"{_gateway.GatewayBaseUrl}/api/v1/sandboxes";
         var (authProviders, network) = BuildAuthProviders();

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxGatewayOptionsTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxGatewayOptionsTests.cs
@@ -173,6 +173,19 @@ public class SandboxGatewayOptionsTests
     }
 
     [Fact]
+    public void ResolveWorkspace_WithTraversalOverride_Throws_EvenWithNoBaseConfigured()
+    {
+        // Defense-in-depth (PR #165 review): a '..' traversal segment is never a valid workspace
+        // identifier, so it is rejected even with no base configured — the no-base path forwards the
+        // leaf straight to the gateway, so this is the client's only containment guard there.
+        var options = new SandboxGatewayOptions();
+
+        var act = () => options.ResolveWorkspace(Path.Combine("..", "evil"));
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
     public void ResolveWorkspace_WithEscapingOverride_Throws()
     {
         var basePath = Path.Combine(Path.GetTempPath(), "ws-base");

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxGatewayOptionsTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxGatewayOptionsTests.cs
@@ -143,6 +143,36 @@ public class SandboxGatewayOptionsTests
     }
 
     [Fact]
+    public void ResolveWorkspace_WithOverride_ReturnsLeafWithoutBaseOrFullPath_WhenNoBaseConfigured()
+    {
+        // A remote gateway (or one that roots the workspace under its own per-app base, ADR 0029) has
+        // no local filesystem the client can resolve against or pre-create in. WorkspaceBasePath is
+        // therefore OPTIONAL: with no base configured, resolving an override must NOT throw — it yields
+        // just the leaf (the workspace identifier the gateway needs), with a null base and null full
+        // path so the registry skips local directory pre-creation and lets the gateway own creation.
+        var options = new SandboxGatewayOptions(); // no WorkspaceBasePath, no WorkspacePath
+
+        var (resolvedBase, leaf, full) = options.ResolveWorkspace("projA");
+
+        resolvedBase.Should().BeNull();
+        leaf.Should().Be("projA");
+        full.Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveWorkspace_WithRootedOverride_Throws_EvenWithNoBaseConfigured()
+    {
+        // The "override must be relative" invariant is independent of whether a base is configured —
+        // a rooted value is never a valid workspace leaf.
+        var options = new SandboxGatewayOptions();
+
+        var rooted = Path.Combine(Path.GetTempPath(), "elsewhere");
+        var act = () => options.ResolveWorkspace(rooted);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
     public void ResolveWorkspace_WithEscapingOverride_Throws()
     {
         var basePath = Path.Combine(Path.GetTempPath(), "ws-base");

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxGatewayOptionsTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxGatewayOptionsTests.cs
@@ -169,7 +169,9 @@ public class SandboxGatewayOptionsTests
         var rooted = Path.Combine(Path.GetTempPath(), "elsewhere");
         var act = () => options.ResolveWorkspace(rooted);
 
-        act.Should().Throw<InvalidOperationException>();
+        // Pin WHICH guard fires: the rooted check must run ahead of the no-base return (pre-PR the
+        // no-base guard threw first with a different message), so this stays sensitive to the reorder.
+        act.Should().Throw<InvalidOperationException>().WithMessage("*must be relative to the workspace base*");
     }
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryWorkspaceTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryWorkspaceTests.cs
@@ -58,6 +58,23 @@ public class SandboxSessionRegistryWorkspaceTests
         second.WorkspaceRelPath.Should().Be("projA");
     }
 
+    [Fact]
+    public async Task GetOrCreateSession_DoesNotCreateWorkspaceDirectoryOnDisk_GatewayOwnsIt()
+    {
+        // The client must NEVER touch the workspace filesystem — the gateway may be on a remote
+        // machine and owns workspace directory creation (create-if-missing) and mounting. Even with a
+        // local base configured, creating a session forwards the leaf WITHOUT the client mkdir-ing it.
+        using var baseDir = new TempWorkspaceBase();
+        await using var registry = CreateRegistry(baseDir.Path, out var captured);
+
+        var session = await registry.GetOrCreateSessionAsync(new WorkspaceRef("ws-fs", "projFS"));
+
+        session.WorkspaceRelPath.Should().Be("projFS");
+        captured.LastWorkspace.Should().Be("projFS"); // leaf still forwarded to the gateway
+        Directory.Exists(System.IO.Path.Combine(baseDir.Path, "projFS"))
+            .Should().BeFalse("the client must not create the workspace directory — the gateway owns it");
+    }
+
     private static SandboxSessionRegistry CreateRegistry(string workspaceBasePath, out CapturedRequest captured)
     {
         var capturedRequest = new CapturedRequest();
@@ -115,8 +132,8 @@ public class SandboxSessionRegistryWorkspaceTests
     }
 
     /// <summary>Creates (and deletes) a real temp directory to serve as the workspace base, so the
-    /// <c>ResolveWorkspace</c> containment check passes and the registry's idempotent
-    /// <c>Directory.CreateDirectory</c> succeeds.</summary>
+    /// <c>ResolveWorkspace</c> containment check has a real parent to resolve leaves under. The
+    /// registry itself never creates the per-workspace leaf (the gateway owns that).</summary>
     private sealed class TempWorkspaceBase : IDisposable
     {
         public string Path { get; } =

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryWorkspaceTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryWorkspaceTests.cs
@@ -75,7 +75,26 @@ public class SandboxSessionRegistryWorkspaceTests
             .Should().BeFalse("the client must not create the workspace directory — the gateway owns it");
     }
 
-    private static SandboxSessionRegistry CreateRegistry(string workspaceBasePath, out CapturedRequest captured)
+    [Fact]
+    public async Task GetOrCreateSession_NoBaseConfigured_DoesNotThrow_AndForwardsLeaf()
+    {
+        // #164 end-to-end regression THROUGH the registry: adopting a gateway with NO WorkspaceBasePath
+        // must NOT throw (pre-fix the throw became a 500 -> WebSocket crash). The client forwards the
+        // leaf and the gateway owns creation. This is the thesis of the PR — covered here at the
+        // registry level, not just in ResolveWorkspace in isolation.
+        await using var registry = CreateRegistryNoBase(out var captured);
+
+        var act = async () => await registry.GetOrCreateSessionAsync(new WorkspaceRef("ws-nobase", "projRemote"));
+
+        var session = (await act.Should().NotThrowAsync()).Subject;
+        session.WorkspaceRelPath.Should().Be("projRemote");
+        captured.LastWorkspace.Should().Be("projRemote"); // leaf forwarded to the gateway
+    }
+
+    private static SandboxSessionRegistry CreateRegistryNoBase(out CapturedRequest captured) =>
+        CreateRegistry(workspaceBasePath: null, out captured);
+
+    private static SandboxSessionRegistry CreateRegistry(string? workspaceBasePath, out CapturedRequest captured)
     {
         var capturedRequest = new CapturedRequest();
         captured = capturedRequest;


### PR DESCRIPTION
## Summary
Makes the sandbox client treat the workspace as a **remote-owned resource**: it forwards the workspace *identifier* (leaf) to the gateway and never touches the workspace filesystem itself. `WorkspaceBasePath` becomes **optional**.

Fixes #164.

## Why
The client assumed the workspace was on a shared local filesystem:
- `ResolveWorkspace(override)` threw when no `WorkspaceBasePath` was configured.
- `SandboxSessionRegistry` pre-created the workspace dir via `Directory.CreateDirectory` on every session-create.

Both break when the gateway is on a **remote machine**, and the enforcing gateway (ADR 0029) already owns creation (per-app rooting + create-if-missing) — so the client's `mkdir` only produced an orphan directory.

## Changes
- `SandboxGatewayOptions.ResolveWorkspace(override)` — returns the leaf with a null base/full-path when no base is configured (no throw). A rooted override, or one containing a `..` traversal segment, is rejected **regardless of base** (FS-free string check); the escape check still applies when a base IS set.
- `SandboxSessionRegistry` — removed the per-session `Directory.CreateDirectory`; forwards the leaf, gateway owns creation/mounting.
- Docs updated to mark `WorkspaceBasePath` optional.

## Client/gateway boundary now
| Path | Client workspace FS access |
|---|---|
| Adopt a gateway (local or **remote**) | **None** — sends the leaf; gateway owns everything |
| Spawn a **local** gateway (`AutoSpawn=true`) | `EnsureWorkspaceDirectory` still pre-creates locally (client owns the gateway it launches) |

## Tests
- `ResolveWorkspace(override)` resolves the leaf with no base (no throw); rooted + `..`-traversal overrides throw regardless of base.
- Registry: **no-base** session create does not throw and forwards the leaf (#164 repro through `GetOrCreateSessionAsync`); and the client does **not** create the workspace dir on disk (`Directory.Exists(base/leaf) == false`).

## Notes
- **Rebased onto current `main`**; the earlier Scriban bump was dropped as redundant — `main` already remediated the NU1903 advisory (7.2.0 → 7.2.2, `658f7c92`), so this PR inherits that. #166 closed accordingly.
- Deliberately separate from #157 (auth) — different concern, based on `main`.
- The spawn-path `EnsureWorkspaceDirectory` is the one remaining client-side workspace `mkdir` (only runs when the client spawns a local gateway) — could be delegated to the gateway too; noted for discussion.