### PR TITLE
fix(daemon): don't crash the PR-lifecycle sweep when a git workdir is missing

### DIFF
--- a/samples/CodeReviewDaemon.Sample/Workspace/Sandbox/HostGitCommandRunner.cs
+++ b/samples/CodeReviewDaemon.Sample/Workspace/Sandbox/HostGitCommandRunner.cs
@@ -20,6 +20,21 @@ internal sealed class HostGitCommandRunner(
             throw new ArgumentException("Argv must be non-empty.", nameof(command));
         }
 
+        // Process.Start throws Win32Exception(267) if WorkingDirectory is set but doesn't exist yet — e.g.
+        // the sweeper's first-ever probe of a checkout dir that hasn't been cloned. Fail gracefully instead
+        // of crashing so callers like ReviewBotCheckout can fall through from "probe" to "clone" (which
+        // creates the directory) rather than aborting the whole sweep.
+        if (!string.IsNullOrWhiteSpace(command.WorkingDirectory) && !Directory.Exists(command.WorkingDirectory))
+        {
+            var missingDirResult = new SandboxCommandResult(
+                1,
+                string.Empty,
+                $"working directory '{command.WorkingDirectory}' does not exist");
+            logger.LogDebug("Host git '{Argv}' exited {Exit}: {Stderr}",
+                string.Join(' ', command.Argv), missingDirResult.ExitCode, missingDirResult.Stderr);
+            return missingDirResult;
+        }
+
         var psi = new ProcessStartInfo
         {
             FileName = command.Argv[0],

--- a/tests/CodeReviewDaemon.Sample.Tests/Workspace/HostGitCommandRunnerTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Workspace/HostGitCommandRunnerTests.cs
@@ -22,6 +22,22 @@ public class HostGitCommandRunnerTests : IDisposable
     }
 
     [Fact]
+    public async Task RunAsync_WorkingDirectoryMissing_FailsGracefullyInsteadOfThrowing()
+    {
+        // Reproduces the sweeper's first-run probe: the checkout dir doesn't exist yet, so
+        // Process.Start (which requires an existing WorkingDirectory) must never be reached.
+        var missingDir = Path.Combine(_dir, "not-yet-cloned");
+        var runner = new HostGitCommandRunner(_ => Task.FromResult<string?>("t"), NullLogger<HostGitCommandRunner>.Instance);
+
+        var result = await runner.RunAsync(
+            new SandboxCommand(["git", "rev-parse", "--is-inside-work-tree"], missingDir),
+            default);
+
+        result.Succeeded.Should().BeFalse();
+        result.Stderr.Should().Contain(missingDir);
+    }
+
+    [Fact]
     public async Task HostFileSystem_WriteThenRead_RoundTrips()
     {
         var fs = new HostFileSystem();


### PR DESCRIPTION
## Problem

The Code-Review Daemon's PR-lifecycle sweeper crashed on **every** poll with:

```
System.ComponentModel.Win32Exception (267): An error occurred trying to start process 'git'
with working directory '.../review-pool/sweeper-store'. The directory name is invalid.
```

`HostGitCommandRunner.RunAsync` set `ProcessStartInfo.WorkingDirectory` and called `Process.Start`, which throws `Win32Exception(267)` when that directory doesn't exist yet. The sweeper's first-run probe (`git rev-parse --is-inside-work-tree` in the not-yet-cloned `sweeper-store`, via `ReviewBotCheckout.EnsureCheckoutAsync` → `Program.cs`) hit this at `PrLifecycleSweeper.SweepAsync` — **outside** the per-PR try/catch — so the whole sweep aborted before the intended graceful clone-or-skip path could run. Net effect: **Layer-2's at-close knowledge extraction never fired**, because the sweep that detects merged PRs died every cycle.

This was found during live bring-up on the merged #156 daemon; the fix was held out of #156 to avoid churning that PR and is landed here as a focused follow-up.

## Fix

Guard `HostGitCommandRunner.RunAsync`: when `WorkingDirectory` is set but missing, return a failed `SandboxCommandResult` (exit 1 + a clear stderr) instead of throwing. `ReviewBotCheckout.EnsureCheckoutAsync`'s existing `if (probe.Succeeded)` then falls through to `git clone` (run with `workingDirectory: null`), which creates the directory and its parents.

## Why one runner-level guard is sufficient

- `HostGitCommandRunner` is the **only** `Process.Start`/`ProcessStartInfo` site in the sample; every other git call goes through the sandbox's PosixShell-wrapped `cd -- '<dir>' && ...` (fails at the shell level, never crashes the process) or plain .NET `Directory`/`File` APIs.
- No caller depended on the old throw — they all inspect `.Succeeded`/`.ExitCode`.
- `git clone` recursively creates missing ancestor directories, so `review-pool` need not pre-exist: even on a cold daemon the sweep flow becomes probe(fails clean) → clone(auto-creates `review-pool/sweeper-store`) → succeeds.

## Tests

New `RunAsync_WorkingDirectoryMissing_FailsGracefullyInsteadOfThrowing` (RED reproduced the exact `Win32Exception`; GREEN after the guard). Build clean (0 warnings), full daemon suite **443 passed / 0 failed**.