### PR TITLE
feat(sandbox): authenticate clients to the gateway with per-app bearer (ADR 0029)

### DIFF
--- a/samples/CodeReviewDaemon.Sample/Agents/LiveReviewAgentLoopFactory.cs
+++ b/samples/CodeReviewDaemon.Sample/Agents/LiveReviewAgentLoopFactory.cs
@@ -4,6 +4,7 @@ using AchieveAi.LmDotnetTools.AnthropicProvider.Models;
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Agents;
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
 using AchieveAi.LmDotnetTools.LmAgentInfra;
+using AchieveAi.LmDotnetTools.LmAgentInfra.Sandbox;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
@@ -106,7 +107,7 @@ internal sealed class LiveReviewAgentLoopFactory : IReviewAgentLoopFactory, IDis
             {
                 Name = "sandbox",
                 Endpoint = new Uri($"{toolContext.GatewayBaseUrl}/mcp"),
-                AdditionalHeaders = new Dictionary<string, string> { ["X-Session-ID"] = toolContext.SessionId },
+                AdditionalHeaders = GatewayAuthHeaders.ForMcp(toolContext.SessionId, toolContext.AppId, toolContext.AppKey),
             });
             var client = McpClient.CreateAsync(transport).GetAwaiter().GetResult();
             ownedClients = [client];

--- a/samples/CodeReviewDaemon.Sample/Agents/ReviewToolContext.cs
+++ b/samples/CodeReviewDaemon.Sample/Agents/ReviewToolContext.cs
@@ -22,7 +22,9 @@ internal sealed record ReviewToolContext(
     bool EnableReviewerWrites = false,
     IReadOnlyList<string>? WritableToolAllowList = null,
     string? NotesDir = null,
-    string? ScratchDir = null);
+    string? ScratchDir = null,
+    string? AppId = null,
+    string? AppKey = null);
 
 /// <summary>
 /// Copies ONLY the allow-listed tool contracts+handlers from a source registry into the loop's registry.

--- a/samples/CodeReviewDaemon.Sample/Orchestration/DaemonReviewStageExecutor.cs
+++ b/samples/CodeReviewDaemon.Sample/Orchestration/DaemonReviewStageExecutor.cs
@@ -223,7 +223,11 @@ internal sealed class DaemonReviewStageExecutor : IReviewStageExecutor
                 EnableReviewerWrites: writeScope.Enabled,
                 WritableToolAllowList: writeScope.WritableAllow,
                 NotesDir: writeScope.NotesDir,
-                ScratchDir: writeScope.ScratchDir);
+                ScratchDir: writeScope.ScratchDir,
+                // Per-app bearer identity for the agent's MCP calls to the gateway (ADR 0029), read from the
+                // same env as GatewayBaseUrl so the tool-assisted session authenticates as the daemon.
+                AppId: Environment.GetEnvironmentVariable("CRD_SANDBOX_APP_ID") ?? "code-review-daemon",
+                AppKey: Environment.GetEnvironmentVariable("CRD_SANDBOX_APP_KEY"));
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/samples/CodeReviewDaemon.Sample/Program.cs
+++ b/samples/CodeReviewDaemon.Sample/Program.cs
@@ -111,11 +111,18 @@ builder.Services.AddSingleton(_ => new ReviewStore(dbConnectionString));
 // Sandbox: all deterministic git/fs work runs in the gateway, driven as a direct MCP client. The
 // connection is lazy (opened on first command), so registering it does no work at boot and the daemon
 // stays inert until a repo is allow-listed. The gateway base URL / session come from the environment.
+// Per-app bearer identity for the sandbox gateway (ADR 0029): sent as X-Sbx-App-Id/X-Sbx-App-Key on every
+// gateway request when a key is configured, so an AUTH_ENFORCE gateway authenticates the daemon and scopes
+// its sessions to it. No key configured → no bearer headers (works unchanged against an unenforced gateway).
+var sandboxAppId = Environment.GetEnvironmentVariable("CRD_SANDBOX_APP_ID") ?? "code-review-daemon";
+var sandboxAppKey = Environment.GetEnvironmentVariable("CRD_SANDBOX_APP_KEY");
 builder.Services.AddSingleton<ISandboxCommandRunner>(sp => new SandboxOrchestrator(
     Environment.GetEnvironmentVariable("CRD_SANDBOX_GATEWAY") ?? "http://127.0.0.1:8080",
     Environment.GetEnvironmentVariable("CRD_SANDBOX_SESSION") ?? Guid.NewGuid().ToString("N"),
     sp.GetRequiredService<ILogger<SandboxOrchestrator>>(),
-    daemonOptions.Limits));
+    daemonOptions.Limits,
+    appId: sandboxAppId,
+    appKey: sandboxAppKey));
 builder.Services.AddSingleton<ISandboxFileSystem>(sp =>
     new SandboxFileSystem(sp.GetRequiredService<ISandboxCommandRunner>()));
 
@@ -130,6 +137,10 @@ var sandboxGatewayOptions = new SandboxGatewayOptions
     BaseUrl = Environment.GetEnvironmentVariable("CRD_SANDBOX_GATEWAY") ?? "http://127.0.0.1:3000",
     AutoSpawn = false,
     Marketplaces = string.Join(",", daemonOptions.Marketplaces),
+    // Per-app bearer identity (ADR 0029) — distinct from LmStreaming.Sample so the daemon's sandbox
+    // sessions are scoped to their own app tree under an AUTH_ENFORCE gateway.
+    AppId = sandboxAppId,
+    AppKey = sandboxAppKey,
     // Host base directory the (already-running) gateway maps to its container WORKSPACE_BASE_PATH. The
     // per-run provisioner mounts a distinct leaf (review-run-{id}) under this base, so it MUST be set or
     // session-create fails with "no workspace base path is configured". Sourced from env/config so it
@@ -141,11 +152,15 @@ builder.Services.AddSingleton(sp => new SandboxSessionRegistry(
     new SandboxGatewayLifetime(
         sandboxGatewayOptions,
         sp.GetRequiredService<ILogger<SandboxGatewayLifetime>>(),
-        new HttpClient()),
+        new HttpClient(new GatewayAuthHandler(sandboxAppId, sandboxAppKey) { InnerHandler = new HttpClientHandler() })),
     sandboxGatewayOptions,
     sp.GetRequiredService<ILogger<SandboxSessionRegistry>>(),
-    // Bounds the gateway create/destroy calls (mirrors LmStreaming.Sample's registration).
-    new HttpClient { Timeout = TimeSpan.FromSeconds(30) },
+    // Bounds the gateway create/destroy calls (mirrors LmStreaming.Sample's registration); the handler
+    // attaches the per-app bearer headers to every gateway REST call.
+    new HttpClient(new GatewayAuthHandler(sandboxAppId, sandboxAppKey) { InnerHandler = new HttpClientHandler() })
+    {
+        Timeout = TimeSpan.FromSeconds(30),
+    },
     authOptions,
     sp.GetRequiredService<AuthSharedSecret>()));
 builder.Services.AddSingleton<ISandboxSessionSource>(sp =>

--- a/samples/CodeReviewDaemon.Sample/Workspace/Sandbox/SandboxOrchestrator.cs
+++ b/samples/CodeReviewDaemon.Sample/Workspace/Sandbox/SandboxOrchestrator.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using AchieveAi.LmDotnetTools.LmAgentInfra.Sandbox;
 using CodeReviewDaemon.Sample.Configuration;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
@@ -33,6 +34,8 @@ internal sealed class SandboxOrchestrator : ISandboxCommandRunner, IAsyncDisposa
 
     private readonly Uri _endpoint;
     private readonly string _sessionId;
+    private readonly string? _appId;
+    private readonly string? _appKey;
     private readonly SandboxLimits _limits;
     private readonly ILogger<SandboxOrchestrator> _logger;
     private readonly SemaphoreSlim _connectGate = new(1, 1);
@@ -43,13 +46,17 @@ internal sealed class SandboxOrchestrator : ISandboxCommandRunner, IAsyncDisposa
         string gatewayBaseUrl,
         string sessionId,
         ILogger<SandboxOrchestrator> logger,
-        SandboxLimits? limits = null
+        SandboxLimits? limits = null,
+        string? appId = null,
+        string? appKey = null
     )
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(gatewayBaseUrl);
         ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
         _endpoint = new Uri($"{gatewayBaseUrl.TrimEnd('/')}/mcp");
         _sessionId = sessionId;
+        _appId = appId;
+        _appKey = appKey;
         _limits = limits ?? new SandboxLimits();
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -114,10 +121,7 @@ internal sealed class SandboxOrchestrator : ISandboxCommandRunner, IAsyncDisposa
                     {
                         Name = "sandbox",
                         Endpoint = _endpoint,
-                        AdditionalHeaders = new Dictionary<string, string>
-                        {
-                            ["X-Session-ID"] = _sessionId,
-                        },
+                        AdditionalHeaders = GatewayAuthHeaders.ForMcp(_sessionId, _appId, _appKey),
                     });
 
                 _client = await McpClient.CreateAsync(transport, cancellationToken: cancellationToken)

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -176,10 +176,26 @@ try
         builder.Configuration.GetSection(SandboxGatewayOptions.SectionName).Get<SandboxGatewayOptions>()
         ?? new SandboxGatewayOptions();
     _ = builder.Services.AddSingleton(sandboxOptions);
+
+    // Every gateway-bound HttpClient gets the per-app bearer handler (ADR 0029) so its REST calls carry
+    // X-Sbx-App-Id/X-Sbx-App-Key under an AUTH_ENFORCE gateway. No-op when no AppKey is configured, so an
+    // unenforced gateway is unaffected.
+    HttpClient GatewayHttpClient(TimeSpan? timeout = null)
+    {
+        var client = new HttpClient(
+            new GatewayAuthHandler(sandboxOptions.AppId, sandboxOptions.AppKey) { InnerHandler = new HttpClientHandler() });
+        if (timeout is { } t)
+        {
+            client.Timeout = t;
+        }
+
+        return client;
+    }
+
     _ = builder.Services.AddSingleton(sp => new SandboxGatewayLifetime(
         sandboxOptions,
         sp.GetRequiredService<ILogger<SandboxGatewayLifetime>>(),
-        new HttpClient()
+        GatewayHttpClient()
     ));
     _ = builder.Services.AddHostedService(sp => sp.GetRequiredService<SandboxGatewayLifetime>());
 
@@ -190,7 +206,7 @@ try
         sandboxOptions,
         // The gateway is frequently offline; a short timeout fails fast instead of holding the
         // request for the default 100s while the catalog is a best-effort, read-only browse.
-        new HttpClient { Timeout = TimeSpan.FromSeconds(10) },
+        GatewayHttpClient(TimeSpan.FromSeconds(10)),
         sp.GetRequiredService<ILogger<MarketplaceCatalogClient>>()
     ));
 
@@ -262,7 +278,7 @@ try
         sp.GetRequiredService<ILogger<SandboxSessionRegistry>>(),
         // Bounds the gateway create/destroy calls; the create-POST runs sync-over-async on the
         // WebSocket request thread, so the 100s default could stall it indefinitely.
-        new HttpClient { Timeout = TimeSpan.FromSeconds(30) },
+        GatewayHttpClient(TimeSpan.FromSeconds(30)),
         authOptions,
         sp.GetRequiredService<AuthSharedSecret>()
     ));
@@ -670,7 +686,7 @@ try
                                 ? BuildHttpMcpServer(
                                     "sandbox",
                                     $"{sandboxLifetime.GatewayBaseUrl}/mcp",
-                                    new Dictionary<string, string> { ["X-Session-ID"] = sandboxSession!.SessionId }
+                                    GatewayAuthHeaders.ForMcp(sandboxSession!.SessionId, sandboxOptions.AppId, sandboxOptions.AppKey)
                                 )
                                 : null,
                             workingDirectoryOverride: isWorkspaceMode ? sandboxSession!.HostPath : null
@@ -767,7 +783,7 @@ try
                         filteredRegistry,
                         "sandbox",
                         $"{sandboxLifetime.GatewayBaseUrl}/mcp",
-                        new Dictionary<string, string> { ["X-Session-ID"] = sandboxSession!.SessionId },
+                        GatewayAuthHeaders.ForMcp(sandboxSession!.SessionId, sandboxOptions.AppId, sandboxOptions.AppKey),
                         loggerFactory,
                         // Expose sandbox tools under their natural names (bash, edit, …) rather than
                         // sandbox-bash; the gateway is the sole MCP server here, so no collisions.

--- a/samples/LmStreaming.Sample/SandboxWorkspaceGuide.md
+++ b/samples/LmStreaming.Sample/SandboxWorkspaceGuide.md
@@ -69,7 +69,8 @@ Workspace Agent mode is configured through the **`SandboxGateway`** section of
 | `Workspace` | — | Workspace path **relative to `WorkspaceBasePath`**, mounted as the sandbox workspace. |
 | `WorkspaceBasePath` | — | Host base directory the gateway resolves the workspace under (becomes `WORKSPACE_BASE_PATH` when the gateway is spawned). |
 | `WorkspacePath` | — | **Optional absolute path** to the workspace dir. When set it **overrides** `WorkspaceBasePath` + `Workspace`: the app uses its parent as `WORKSPACE_BASE_PATH` and its folder name as the workspace, and creates it if missing. The simplest way to point the sandbox at any folder (see below). |
-| `AppId` | `lmstreaming-sample` | App id sent in the sandbox-create request. |
+| `AppId` | `lmstreaming-sample` | App id sent in the sandbox-create request and, under gateway auth enforcement, as the `X-Sbx-App-Id` bearer header. |
+| `AppKey` | — | Base64 per-app secret (`openssl rand -base64 32`). When set it is sent as `X-Sbx-App-Key` on every gateway request so an `AUTH_ENFORCE` gateway can authenticate this app (see [Gateway authentication](#gateway-authentication)). Leave empty for an unenforced gateway. **SECRET — do not commit a real value.** |
 | `AutoSpawn` | `true` | If a healthy gateway is already running at `BaseUrl`, adopt it; otherwise spawn `GatewayExePath`. |
 | `GatewayExePath` | — | Absolute path to the built `mcp-gateway.exe`, used for auto-spawn. |
 | `AgentCliPath` | — | Absolute path to the built `agent-cli.exe` (becomes `LOCAL_AGENT_CLI_PATH` when the gateway is spawned). |
@@ -98,6 +99,26 @@ With the example above, the mounted workspace is `WorkspaceBasePath` + `Workspac
 `B:\sandbox-workspaces\demo` (the app **creates the directory if it does not exist**).
 Point `Workspace`/`WorkspaceBasePath` at a **dedicated** folder rather than a real source repo —
 the local backend runs unsandboxed, so the agent has read/write access to whatever you mount.
+
+### Gateway authentication
+
+Recent gateways enforce **per-app bearer authentication** (gateway ADR 0029). When `AUTH_ENFORCE` is on
+(the gateway's default), every request must carry `X-Sbx-App-Id` + `X-Sbx-App-Key`; the gateway binds the
+app identity from the credential and scopes each sandbox session to that app. This sample sends those
+headers automatically on **all** gateway calls (REST + MCP) whenever `AppKey` is set — set both `AppId` and
+`AppKey`, or neither.
+
+To run against an enforcing gateway:
+
+1. Generate a secret: `openssl rand -base64 32`.
+2. Register it on the **gateway** under this app's id — e.g. `APP_SECRETS=lmstreaming-sample=<base64>` (or an
+   `APP_SECRETS_FILE` JSON `{ "lmstreaming-sample": "<base64>" }`).
+3. Set the same value on this app: `SandboxGateway:AppKey` in config, or the `SandboxGateway__AppKey` env var
+   (keep the real secret out of committed files).
+
+Leave `AppKey` empty to talk to an `AUTH_ENFORCE=off` gateway — the sample then sends no bearer headers, exactly
+as before. (The gateway↔egress-proxy `PROXY_SERVICE_CRED` and its "deploy the proxy first" ordering are
+operator concerns configured on the gateway side, not here.)
 
 ### Use any folder as the workspace
 

--- a/samples/LmStreaming.Sample/appsettings.Development.json
+++ b/samples/LmStreaming.Sample/appsettings.Development.json
@@ -21,6 +21,8 @@
     "_WorkspacePath_comment": "Optional: set to ANY absolute folder to use it as the sandbox workspace (auto-created if missing). When non-empty it overrides WorkspaceBasePath+Workspace. Only applied when the app SPAWNS the gateway (stop any gateway already on :3000 first). Example: B:\\\\sources\\\\my-repo",
     "WorkspacePath": "",
     "AppId": "lmstreaming-sample",
+    "_AppKey_comment": "Base64 per-app secret (openssl rand -base64 32). Leave empty for an AUTH_ENFORCE=off gateway; set it (and register the same app id+secret in the gateway's APP_SECRETS) to authenticate under enforcement. SECRET — do not commit a real value.",
+    "AppKey": "",
     "AutoSpawn": true,
     "GatewayExePath": "B:\\sources\\SandboxedOstoolsMcpServer\\target\\release\\mcp-gateway.exe",
     "AgentCliPath": "B:\\sources\\SandboxedOstoolsMcpServer\\target\\release\\agent-cli.exe",

--- a/src/LmAgentInfra/Sandbox/GatewayAuthHandler.cs
+++ b/src/LmAgentInfra/Sandbox/GatewayAuthHandler.cs
@@ -1,0 +1,50 @@
+namespace AchieveAi.LmDotnetTools.LmAgentInfra.Sandbox;
+
+/// <summary>
+/// A <see cref="DelegatingHandler"/> that attaches the sandbox gateway's per-app bearer headers
+/// (<c>X-Sbx-App-Id</c> + <c>X-Sbx-App-Key</c>, gateway ADR 0029) to every outbound REST request, so the
+/// gateway's session-lifecycle clients (<c>SandboxSessionRegistry</c>, <c>SandboxGatewayLifetime</c>,
+/// <c>MarketplaceCatalogClient</c>) authenticate under <c>AUTH_ENFORCE</c> without each call site setting the
+/// headers itself. Mirrors the daemon's <c>OperationPolicyHandler</c> pattern (constructor-injected values,
+/// mutate <c>request.Headers</c>, continue via <see cref="DelegatingHandler.SendAsync"/>).
+/// <para>
+/// No-op when no app key is configured, so an unenforced gateway keeps working unchanged. Existing headers
+/// are never overwritten (a hand-built request that already carries the bearer wins).
+/// </para>
+/// </summary>
+public sealed class GatewayAuthHandler : DelegatingHandler
+{
+    private readonly string? _appId;
+    private readonly string? _appKey;
+
+    /// <summary>Creates the handler with the app identity + base64 secret (either may be null when unenforced).</summary>
+    public GatewayAuthHandler(string? appId, string? appKey)
+    {
+        _appId = appId;
+        _appKey = appKey;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (GatewayAuthHeaders.IsConfigured(_appId, _appKey))
+        {
+            // TryAddWithoutValidation is a no-op when the header is already present, so a caller that
+            // pre-set the bearer (or a retried request) is never duplicated.
+            if (!request.Headers.Contains(GatewayAuthHeaders.AppIdHeader))
+            {
+                _ = request.Headers.TryAddWithoutValidation(GatewayAuthHeaders.AppIdHeader, _appId);
+            }
+
+            if (!request.Headers.Contains(GatewayAuthHeaders.AppKeyHeader))
+            {
+                _ = request.Headers.TryAddWithoutValidation(GatewayAuthHeaders.AppKeyHeader, _appKey);
+            }
+        }
+
+        return base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/LmAgentInfra/Sandbox/GatewayAuthHeaders.cs
+++ b/src/LmAgentInfra/Sandbox/GatewayAuthHeaders.cs
@@ -1,0 +1,61 @@
+namespace AchieveAi.LmDotnetTools.LmAgentInfra.Sandbox;
+
+/// <summary>
+/// Builds the per-app bearer headers the sandbox gateway requires under auth enforcement (gateway
+/// ADR 0029 / work-item #109): <c>X-Sbx-App-Id</c> + <c>X-Sbx-App-Key</c>. A single place owns the header
+/// names and the "attach only when a key is configured" rule so the REST path
+/// (<see cref="GatewayAuthHandler"/>) and the MCP transport path (<c>HttpClientTransportOptions.AdditionalHeaders</c>)
+/// can never drift.
+/// <para>
+/// Backward-compatible by design: with no <c>AppKey</c> configured the app headers are omitted, so a client
+/// keeps talking to an <c>AUTH_ENFORCE=off</c> gateway exactly as it did before this existed.
+/// </para>
+/// </summary>
+public static class GatewayAuthHeaders
+{
+    /// <summary>Header carrying the authenticated app identity.</summary>
+    public const string AppIdHeader = "X-Sbx-App-Id";
+
+    /// <summary>Header carrying the app's base64 shared secret. SECRET — never log its value.</summary>
+    public const string AppKeyHeader = "X-Sbx-App-Key";
+
+    /// <summary>The session-binding header the gateway already required before app auth existed.</summary>
+    public const string SessionHeader = "X-Session-ID";
+
+    /// <summary>
+    /// True when both an app id and a non-blank app key are present — the only case in which the bearer
+    /// headers are sent (both go together or not at all).
+    /// </summary>
+    public static bool IsConfigured(string? appId, string? appKey) =>
+        !string.IsNullOrWhiteSpace(appId) && !string.IsNullOrWhiteSpace(appKey);
+
+    /// <summary>
+    /// Adds <see cref="AppIdHeader"/>/<see cref="AppKeyHeader"/> to <paramref name="headers"/> when
+    /// <see cref="IsConfigured"/> holds; a no-op otherwise. Overwrites any existing values so a caller can
+    /// call this idempotently.
+    /// </summary>
+    public static void Apply(IDictionary<string, string> headers, string? appId, string? appKey)
+    {
+        ArgumentNullException.ThrowIfNull(headers);
+        if (!IsConfigured(appId, appKey))
+        {
+            return;
+        }
+
+        headers[AppIdHeader] = appId!;
+        headers[AppKeyHeader] = appKey!;
+    }
+
+    /// <summary>
+    /// Builds the header dictionary an MCP <c>HttpClientTransport</c> should carry: the session header
+    /// always, plus the two app-bearer headers when configured. Replaces the inline
+    /// <c>new Dictionary { ["X-Session-ID"] = sessionId }</c> at every sandbox MCP transport site.
+    /// </summary>
+    public static Dictionary<string, string> ForMcp(string sessionId, string? appId, string? appKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        var headers = new Dictionary<string, string> { [SessionHeader] = sessionId };
+        Apply(headers, appId, appKey);
+        return headers;
+    }
+}

--- a/src/LmAgentInfra/Sandbox/SandboxGatewayOptions.cs
+++ b/src/LmAgentInfra/Sandbox/SandboxGatewayOptions.cs
@@ -145,9 +145,19 @@ public sealed class SandboxGatewayOptions
     }
 
     /// <summary>
-    /// App id sent in the sandbox-create request.
+    /// App id sent in the sandbox-create request and, under gateway auth enforcement, in the
+    /// <c>X-Sbx-App-Id</c> bearer header (see <see cref="GatewayAuthHeaders"/>).
     /// </summary>
     public string AppId { get; set; } = "lmstreaming-sample";
+
+    /// <summary>
+    /// Base64-encoded per-app shared secret paired with <see cref="AppId"/>. When set, it is sent as the
+    /// <c>X-Sbx-App-Key</c> header on every gateway request so an <c>AUTH_ENFORCE</c> gateway can verify the
+    /// app identity (gateway ADR 0029). Left null/blank when the gateway runs unenforced — the client then
+    /// sends no bearer headers, exactly as before.
+    /// <para>SECRET — never log this value.</para>
+    /// </summary>
+    public string? AppKey { get; set; }
 
     /// <summary>
     /// When <c>true</c> and the gateway is not already healthy, spawn it.

--- a/tests/LmStreaming.Sample.Tests/Services/GatewayAppAuthWiringTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/GatewayAppAuthWiringTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Text;
+using LmStreaming.Sample.Services;
+using Microsoft.Extensions.Configuration;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// Wiring tests for LmStreaming's sandbox gateway app-auth (ADR 0029): that <c>AppKey</c> binds from the
+/// <c>SandboxGateway</c> config section, and that a gateway REST client built the production way (its
+/// <see cref="HttpClient"/> wrapped in a <see cref="GatewayAuthHandler"/>) actually emits the two bearer
+/// headers on its outbound calls — verified through the real <see cref="MarketplaceCatalogClient"/> path.
+/// </summary>
+public class GatewayAppAuthWiringTests
+{
+    private const string GatewayBaseUrl = "http://localhost:3000";
+    private const string EmptyCatalog = """{"selected":[],"marketplaces":[]}""";
+
+    [Fact]
+    public void AppKey_binds_from_the_SandboxGateway_config_section()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["SandboxGateway:AppId"] = "lmstreaming-sample",
+                ["SandboxGateway:AppKey"] = "c2VjcmV0",
+            })
+            .Build();
+
+        var options = config.GetSection(SandboxGatewayOptions.SectionName).Get<SandboxGatewayOptions>();
+
+        options!.AppId.Should().Be("lmstreaming-sample");
+        options.AppKey.Should().Be("c2VjcmV0");
+    }
+
+    [Fact]
+    public async Task Catalog_client_sends_both_bearer_headers_when_configured()
+    {
+        var capture = new CapturingHandler(EmptyCatalog);
+        var http = new HttpClient(new GatewayAuthHandler("lmstreaming-sample", "c2VjcmV0") { InnerHandler = capture });
+        var client = new MarketplaceCatalogClient(
+            new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl, AppId = "lmstreaming-sample", AppKey = "c2VjcmV0" },
+            http,
+            NullLogger<MarketplaceCatalogClient>.Instance);
+
+        _ = await client.GetCatalogAsync();
+
+        capture.LastRequest!.Headers.GetValues(GatewayAuthHeaders.AppIdHeader).Should().ContainSingle()
+            .Which.Should().Be("lmstreaming-sample");
+        capture.LastRequest!.Headers.GetValues(GatewayAuthHeaders.AppKeyHeader).Should().ContainSingle()
+            .Which.Should().Be("c2VjcmV0");
+    }
+
+    [Fact]
+    public async Task Catalog_client_sends_no_bearer_headers_when_key_is_unset()
+    {
+        var capture = new CapturingHandler(EmptyCatalog);
+        var http = new HttpClient(new GatewayAuthHandler("lmstreaming-sample", appKey: null) { InnerHandler = capture });
+        var client = new MarketplaceCatalogClient(
+            new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl },
+            http,
+            NullLogger<MarketplaceCatalogClient>.Instance);
+
+        _ = await client.GetCatalogAsync();
+
+        capture.LastRequest!.Headers.Contains(GatewayAuthHeaders.AppIdHeader).Should().BeFalse();
+        capture.LastRequest!.Headers.Contains(GatewayAuthHeaders.AppKeyHeader).Should().BeFalse();
+    }
+
+    private sealed class CapturingHandler(string body) : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/GatewayAuthHandlerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/GatewayAuthHandlerTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="GatewayAuthHandler"/> — the REST-path <see cref="DelegatingHandler"/> that attaches
+/// the gateway's per-app bearer headers. It attaches both headers when configured, neither when the key is
+/// absent (so an unenforced gateway is unaffected), and never overwrites a header the caller already set.
+/// </summary>
+public class GatewayAuthHandlerTests
+{
+    private static (HttpClient Client, CapturingHandler Inner) BuildClient(string? appId, string? appKey)
+    {
+        var inner = new CapturingHandler();
+        var handler = new GatewayAuthHandler(appId, appKey) { InnerHandler = inner };
+        return (new HttpClient(handler), inner);
+    }
+
+    [Fact]
+    public async Task Attaches_both_bearer_headers_when_configured()
+    {
+        var (client, inner) = BuildClient("code-review-daemon", "c2VjcmV0");
+
+        _ = await client.GetAsync("http://localhost:3000/api/v1/sandboxes");
+
+        inner.LastRequest!.Headers.GetValues(GatewayAuthHeaders.AppIdHeader).Should().ContainSingle()
+            .Which.Should().Be("code-review-daemon");
+        inner.LastRequest!.Headers.GetValues(GatewayAuthHeaders.AppKeyHeader).Should().ContainSingle()
+            .Which.Should().Be("c2VjcmV0");
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("code-review-daemon", null)]
+    [InlineData("code-review-daemon", "")]
+    public async Task Attaches_no_bearer_headers_when_key_is_missing(string? appId, string? appKey)
+    {
+        var (client, inner) = BuildClient(appId, appKey);
+
+        _ = await client.GetAsync("http://localhost:3000/api/v1/sandboxes");
+
+        inner.LastRequest!.Headers.Contains(GatewayAuthHeaders.AppIdHeader).Should().BeFalse();
+        inner.LastRequest!.Headers.Contains(GatewayAuthHeaders.AppKeyHeader).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Does_not_overwrite_a_header_the_caller_already_set()
+    {
+        var (client, inner) = BuildClient("code-review-daemon", "c2VjcmV0");
+        using var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost:3000/api/v1/sandboxes");
+        _ = request.Headers.TryAddWithoutValidation(GatewayAuthHeaders.AppIdHeader, "preset-app");
+
+        _ = await client.SendAsync(request);
+
+        inner.LastRequest!.Headers.GetValues(GatewayAuthHeaders.AppIdHeader).Should().ContainSingle()
+            .Which.Should().Be("preset-app");
+        inner.LastRequest!.Headers.GetValues(GatewayAuthHeaders.AppKeyHeader).Should().ContainSingle()
+            .Which.Should().Be("c2VjcmV0");
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/GatewayAuthHeadersTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/GatewayAuthHeadersTests.cs
@@ -1,0 +1,51 @@
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="GatewayAuthHeaders"/> — the single owner of the gateway's per-app bearer
+/// header names and the "attach only when a key is configured" rule (gateway ADR 0029). The session
+/// header is always present; the two app headers appear together or not at all.
+/// </summary>
+public class GatewayAuthHeadersTests
+{
+    [Fact]
+    public void ForMcp_always_carries_the_session_header()
+    {
+        var headers = GatewayAuthHeaders.ForMcp("sess-1", appId: null, appKey: null);
+
+        headers.Should().ContainKey(GatewayAuthHeaders.SessionHeader).WhoseValue.Should().Be("sess-1");
+    }
+
+    [Fact]
+    public void ForMcp_adds_both_app_headers_when_a_key_is_configured()
+    {
+        var headers = GatewayAuthHeaders.ForMcp("sess-1", "code-review-daemon", "c2VjcmV0");
+
+        headers[GatewayAuthHeaders.SessionHeader].Should().Be("sess-1");
+        headers[GatewayAuthHeaders.AppIdHeader].Should().Be("code-review-daemon");
+        headers[GatewayAuthHeaders.AppKeyHeader].Should().Be("c2VjcmV0");
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("code-review-daemon", null)]
+    [InlineData("code-review-daemon", "")]
+    [InlineData("code-review-daemon", "   ")]
+    [InlineData(null, "c2VjcmV0")]
+    public void ForMcp_omits_both_app_headers_when_id_or_key_is_missing(string? appId, string? appKey)
+    {
+        var headers = GatewayAuthHeaders.ForMcp("sess-1", appId, appKey);
+
+        headers.Should().ContainKey(GatewayAuthHeaders.SessionHeader);
+        headers.Should().NotContainKey(GatewayAuthHeaders.AppIdHeader);
+        headers.Should().NotContainKey(GatewayAuthHeaders.AppKeyHeader);
+    }
+
+    [Fact]
+    public void IsConfigured_requires_both_id_and_non_blank_key()
+    {
+        GatewayAuthHeaders.IsConfigured("app", "key").Should().BeTrue();
+        GatewayAuthHeaders.IsConfigured("app", null).Should().BeFalse();
+        GatewayAuthHeaders.IsConfigured("app", "  ").Should().BeFalse();
+        GatewayAuthHeaders.IsConfigured(null, "key").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Context

The sandbox gateway added **per-app bearer authentication** (gateway work-item #109 / ADR 0029). Under `AUTH_ENFORCE` (default **on**), every app-facing request must carry `X-Sbx-App-Id` + `X-Sbx-App-Key`; the gateway binds `app.id` from the credential and scopes each sandbox session to that app (foreign/absent session → `404`, bad/missing creds → `401`).

LmDotnetTools' gateway clients only sent `X-Session-ID` — they work today solely because the gateway they hit runs `AUTH_ENFORCE=off`. This change makes them authenticate under enforcement, with a **distinct app id per client**.

## What changed

**Shared primitives (`src/LmAgentInfra/Sandbox`)**
- `SandboxGatewayOptions.AppKey` — base64 per-app secret (SECRET-doc'd), companion to the existing `AppId`.
- `GatewayAuthHeaders` — single owner of the header names + the "attach only when a key is configured" rule; `ForMcp(sessionId, appId, appKey)` builds the MCP transport header map, `Apply(...)` for the REST path.
- `GatewayAuthHandler : DelegatingHandler` — attaches the two headers to every REST call (mirrors the existing `OperationPolicyHandler`).

**Code-Review Daemon** (app id `code-review-daemon`, env `CRD_SANDBOX_APP_ID` / `CRD_SANDBOX_APP_KEY`)
- REST clients (session registry + gateway lifetime) wrapped with `GatewayAuthHandler`; the two MCP transports (`SandboxOrchestrator` diff-only path, `LiveReviewAgentLoopFactory` tool-assisted path via new `ReviewToolContext.AppId/AppKey`) build headers with `ForMcp`.

**LmStreaming.Sample** (app id `lmstreaming-sample`, `SandboxGateway__AppKey`)
- The three gateway REST clients wrapped via a small local factory; both MCP header maps use `ForMcp`; `AppKey` knob added to `appsettings.Development.json` and documented in `SandboxWorkspaceGuide.md`.

## Backward compatible

Both headers attach **only when `AppKey` is non-empty**. With no key configured the clients send exactly what they did before, so existing `AUTH_ENFORCE=off` deployments are unaffected. Enabling enforcement is an operator step (register the app id + `openssl rand -base64 32` secret in the gateway's `APP_SECRETS*`, set the matching key here).

## Tests

- `GatewayAuthHeadersTests` / `GatewayAuthHandlerTests` — header logic + the DelegatingHandler (attach-when-configured, omit-when-unset, don't-overwrite).
- `GatewayAppAuthWiringTests` — `AppKey` binds from the `SandboxGateway` config section; a handler-wrapped `MarketplaceCatalogClient` emits both headers.
- Full solution builds **0 warnings / 0 errors**; daemon suite **442 green**, LmStreaming suite **502 green**.

## Scope

Client-side only. The gateway/operator side (`APP_SECRETS*`, `AUTH_ENFORCE`, proxy `PROXY_SERVICE_CRED`, deploy order) is configured out-of-band.