### PR TITLE
fix(daemon): don't post an empty review — it poisons the head's dedup slot

### DIFF
--- a/samples/CodeReviewDaemon.Sample/Orchestration/DaemonReviewStageExecutor.cs
+++ b/samples/CodeReviewDaemon.Sample/Orchestration/DaemonReviewStageExecutor.cs
@@ -1057,60 +1057,79 @@ internal sealed class DaemonReviewStageExecutor : IReviewStageExecutor
 
         var poster = new ReviewPoster(publisher, _store, _loggerFactory.CreateLogger<ReviewPoster>());
 
-        // ReviewPoster requires a non-blank body even on the collect-only path (it still builds the
-        // idempotency key and records the outbox row), so fall back when the agent produced nothing.
+        // A review that produced NO content must post NOTHING. A "_No review content was produced._"
+        // placeholder would go through the full idempotency path and leave a marked comment on the provider;
+        // the backstop scan (ReviewPoster.FindPostedCommentAsync) later ADOPTS that placeholder and
+        // permanently suppresses a real review of the same head_sha — e.g. a re-run on a model that does
+        // produce content. So skip both the post and the retention when the review is empty. The run still
+        // reaches its terminal stage below (and its review_run row prevents re-review), and the slot/session
+        // are still freed, so nothing is leaked or looped.
         var reviewText = ReadReviewText(run.Id);
-        var body = string.IsNullOrWhiteSpace(reviewText) ? "_No review content was produced._" : reviewText;
-        // The POSTED comment is prefixed with "[BotName]" so a reader knows the content was authored by
-        // the bot on behalf of whichever OAuth app/person's credential actually posted it — the retained
-        // artifact (CommitPooledNotesAsync / PublishToReviewBotAsync below) keeps the raw, unprefixed body.
-        var postedBody = $"[{_options.BotName}]\n\n{body}";
+        var hasContent = !string.IsNullOrWhiteSpace(reviewText);
+        if (hasContent)
+        {
+            // The POSTED comment is prefixed with "[BotName]" so a reader knows the content was authored by
+            // the bot on behalf of whichever OAuth app/person's credential actually posted it — the retained
+            // artifact (CommitPooledNotesAsync / PublishToReviewBotAsync below) keeps the raw, unprefixed body.
+            var postedBody = $"[{_options.BotName}]\n\n{reviewText}";
 
-        var key = new IdempotencyKeyComponents(
-            Provider: provider,
-            OrgOrOwner: repo.OrgOrOwner,
-            Project: repo.Project,
-            // RepoStableId must be non-blank and ':'-free; fall back to the colon-free normalized key.
-            RepoStableId: string.IsNullOrWhiteSpace(repo.RepoStableId) ? repo.NormalizedKey : repo.RepoStableId,
-            PrId: run.PrId,
-            Operation: ReviewPoster.PostReviewCommentOperation,
-            ArtifactKind: ReviewArtifactKind,
-            ArtifactSubject: "summary",
-            // Scope the key to the reviewed COMMIT. head_sha is stable across re-polls and — unlike the PR
-            // updated_at — is not mutated by posting the comment, so a re-poll of the same commit resolves
-            // to the same key and the backstop scan recognizes the already-posted comment (no duplicate).
-            HeadSha: run.HeadSha,
-            VariantId: run.VariantId);
+            var key = new IdempotencyKeyComponents(
+                Provider: provider,
+                OrgOrOwner: repo.OrgOrOwner,
+                Project: repo.Project,
+                // RepoStableId must be non-blank and ':'-free; fall back to the colon-free normalized key.
+                RepoStableId: string.IsNullOrWhiteSpace(repo.RepoStableId) ? repo.NormalizedKey : repo.RepoStableId,
+                PrId: run.PrId,
+                Operation: ReviewPoster.PostReviewCommentOperation,
+                ArtifactKind: ReviewArtifactKind,
+                ArtifactSubject: "summary",
+                // Scope the key to the reviewed COMMIT. head_sha is stable across re-polls and — unlike the PR
+                // updated_at — is not mutated by posting the comment, so a re-poll of the same commit resolves
+                // to the same key and the backstop scan recognizes the already-posted comment (no duplicate).
+                HeadSha: run.HeadSha,
+                VariantId: run.VariantId);
 
-        var request = new PostReviewRequest(
-            run.Id,
-            key,
-            new ReviewCommentTarget(repo, run.PrId),
-            postedBody,
-            LivePostingAuthorized: _options.EnableCommentPosting);
+            var request = new PostReviewRequest(
+                run.Id,
+                key,
+                new ReviewCommentTarget(repo, run.PrId),
+                postedBody,
+                LivePostingAuthorized: _options.EnableCommentPosting);
 
-        _ = await poster.PostReviewAsync(request, cancellationToken).ConfigureAwait(false);
+            _ = await poster.PostReviewAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Run {RunId}: review produced no content; not posting a comment or claiming the head's dedup "
+                    + "slot (a placeholder would block a later real review of the same commit).",
+                run.Id);
+        }
 
-        // Retention (design §4.4, the commit gate). A run that leased a pooled slot commits its notes onto
-        // the slot's store checkout scoped to ONLY the PR notes dir, then returns the slot; every other run
-        // uses the host ReviewBot retention checkout exactly as before. The slot is returned even if the
-        // commit throws, and the atomic TryRemove guards against a double-return.
+        // Retention (design §4.4, the commit gate) — only when there is content to retain. A run that leased a
+        // pooled slot commits its notes onto the slot's store checkout scoped to ONLY the PR notes dir, then
+        // returns the slot; every other run uses the host ReviewBot retention checkout. The slot is ALWAYS
+        // returned (finally) and the session ALWAYS torn down (below), so an empty review still frees its
+        // resources; the atomic TryRemove guards against a double-return.
         if (_slotWorkspace is not null && _leasedReviews.TryRemove(run.Id, out var lease))
         {
             try
             {
-                await CommitPooledNotesAsync(run, repo, provider, body, lease, cancellationToken).ConfigureAwait(false);
+                if (hasContent)
+                {
+                    await CommitPooledNotesAsync(run, repo, provider, reviewText, lease, cancellationToken).ConfigureAwait(false);
+                }
             }
             finally
             {
                 await _slotWorkspace.Pool.ReturnAsync(lease.Slot, CancellationToken.None).ConfigureAwait(false);
             }
         }
-        else
+        else if (hasContent)
         {
             // Durably persist the primary review's artifacts to the ReviewBot repo (AC#6, plan §2). This is
             // the only path that writes to the ReviewBot remote; the collect-only B variant never reaches it.
-            await PublishToReviewBotAsync(run, repo, provider, body, cancellationToken).ConfigureAwait(false);
+            await PublishToReviewBotAsync(run, repo, provider, reviewText, cancellationToken).ConfigureAwait(false);
         }
 
         // Terminal-stage cleanup (Task 18, design §7): tear down the run's per-run sandbox session (and

--- a/tests/CodeReviewDaemon.Sample.Tests/Scenarios/DaemonReviewStageExecutorTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Scenarios/DaemonReviewStageExecutorTests.cs
@@ -625,17 +625,19 @@ public sealed class DaemonReviewStageExecutorTests : LoggingTestBase
     }
 
     [Fact]
-    public async Task Posted_substitutes_a_placeholder_body_when_the_review_is_empty()
+    public async Task Posted_does_not_post_a_comment_when_the_review_is_empty()
     {
         using var fixture = Fixture.GitHub(LoggerFactory, new CodeReviewDaemonOptions { EnableCommentPosting = true });
-        // The agent produces no review prose → ReadReviewText is empty → the poster needs a non-blank body.
+        // The agent produces no review prose. Posting a "_No review content was produced._" placeholder would
+        // claim the head_sha's idempotency slot on the provider — the backstop scan would then adopt that
+        // placeholder and permanently suppress a later REAL review of the same commit (e.g. a re-run on a
+        // model that actually produces content). So an empty review must post NOTHING.
         fixture.Factory.TextByProfileId[DaemonAgentFactory.ReviewProfileId] = string.Empty;
         var run = fixture.SeedRun(watermark: "2026-06-29T12:34:56Z");
 
         await RunAllStagesAsync(fixture, run);
 
-        fixture.GitHubPublisher.PostedBodies.Should().ContainSingle()
-            .Which.Should().Be("[Revobot]\n\n_No review content was produced._");
+        fixture.GitHubPublisher.PostedBodies.Should().BeEmpty("an empty review must not claim the head's dedup slot");
     }
 
     [Fact]


### PR DESCRIPTION
## Symptom

A real review never appears on a PR that previously received an empty one. Found live: a fresh **opus** daemon produced a real 4000-char review of #157 but the log showed `already posted as 4895617153 (found via backstop scan); not re-posting` — where `4895617153` is an **empty** `_No review content was produced._` comment a prior gpt-5.5 run had left.

## Root cause (not the old comment — the mechanism that created it)

`DaemonReviewStageExecutor.PostAsync` ran an empty-content review through the full idempotency path:

```csharp
var body = string.IsNullOrWhiteSpace(reviewText) ? "_No review content was produced._" : reviewText;
// ... posts `body` with a head_sha-scoped IdempotencyKey + marker
```

That places a **marked comment** on the provider for the review's `head_sha`. `ReviewPoster`'s backstop scan (`FindPostedCommentAsync`) later finds that marker and **adopts** it — so a subsequent run that *does* produce content (a re-run, or a different reviewer model) is treated as "already posted" and its real review is silently dropped. An empty review permanently claims the head's post slot.

## Fix

Skip the post **and** the retention when the review produced no content:
- No placeholder comment, no idempotency marker → a later real review of the same `head_sha` posts cleanly.
- The run still reaches its terminal stage (its `review_run` row prevents re-review), and the pooled slot + sandbox session are still freed — so nothing leaks or loops.

## Tests

The existing test `Posted_substitutes_a_placeholder_body_when_the_review_is_empty` **enshrined the buggy behavior** (asserted the placeholder was posted). Flipped it to `Posted_does_not_post_a_comment_when_the_review_is_empty` (asserts `PostedBodies` is empty) — RED against the old code, GREEN after the fix. Full daemon suite **442 green**, 0 warnings.

## Note on already-poisoned PRs

This prevents *future* poisoning. PRs that already carry an old empty comment (#157, #88) still need that stale comment deleted for a real review to post — handled operationally, separately from this code fix.