### PR TITLE
refactor(daemon): {repo}-{pr} review-store naming + reconcile orphaned notes branches

### DIFF
--- a/samples/CodeReviewDaemon.Sample/Orchestration/DaemonReviewStageExecutor.cs
+++ b/samples/CodeReviewDaemon.Sample/Orchestration/DaemonReviewStageExecutor.cs
@@ -404,8 +404,8 @@ internal sealed class DaemonReviewStageExecutor : IReviewStageExecutor
                 return false;
             }
 
-            var branch = BuildNotesBranchName(hostGit, hostFileSystem, provider, repo, run);
-            var notesRelPath = BuildNotesRelPath(provider, repo, run.PrId);
+            var branch = BuildNotesBranchName(hostGit, hostFileSystem, repo, run);
+            var notesRelPath = BuildNotesRelPath(repo, run.PrId);
             var policy = DaemonOperationPolicy.BuildForRun(
                 repo, _options.ReviewBotRepoUrl, allowWriteOperations: false,
                 allowedSubmodules: BuildStoreSubmoduleAllowList(run, repo));
@@ -498,18 +498,18 @@ internal sealed class DaemonReviewStageExecutor : IReviewStageExecutor
         return entry?.Path;
     }
 
-    /// <summary>The PR's persistent notes branch name (<c>review/{provider}/{owner-repo}/{pr}</c>) — resolved
+    /// <summary>The PR's persistent notes branch name (<c>review/{repo}-{pr}</c>) — resolved
     /// through <see cref="ReviewBranchManager.BuildReviewBranchName(ReviewBotPublishRequest)"/> so the preparer,
     /// the commit-notes step, and the sweeper all name the branch identically.</summary>
     private string BuildNotesBranchName(
-        GitRunner hostGit, ISandboxFileSystem hostFileSystem, string provider, RepoIdentity repo, ReviewRun run) =>
-        new ReviewBranchManager(hostGit, hostFileSystem, provider, _loggerFactory.CreateLogger<ReviewBranchManager>())
+        GitRunner hostGit, ISandboxFileSystem hostFileSystem, RepoIdentity repo, ReviewRun run) =>
+        new ReviewBranchManager(hostGit, hostFileSystem, _loggerFactory.CreateLogger<ReviewBranchManager>())
             .BuildReviewBranchName(BuildNotesRequest(repo, run, []));
 
-    /// <summary>The PR's persistent notes directory under the store (<c>PRs/{provider}/{owner-repo}/{pr}</c>,
-    /// design §4.3 D3 — one accumulating dir per PR). Each re-review adds a per-commit subdir under it.</summary>
-    private static string BuildNotesRelPath(string provider, RepoIdentity repo, string prId) =>
-        $"PRs/{provider}/{ReviewBotRepoManagerSlug(repo)}/{prId}";
+    /// <summary>The PR's persistent notes directory under the store (<c>PRs/{repo}-{pr}</c>,
+    /// design §4.3 D3 — one accumulating dir per PR, keyed by PR number for the PR's lifetime).</summary>
+    private static string BuildNotesRelPath(RepoIdentity repo, string prId) =>
+        $"PRs/{ReviewBotRepoManagerSlug(repo)}-{prId}";
 
     private static ReviewBotPublishRequest BuildNotesRequest(
         RepoIdentity repo, ReviewRun run, IReadOnlyList<ReviewArtifactFile> files) =>
@@ -1136,11 +1136,11 @@ internal sealed class DaemonReviewStageExecutor : IReviewStageExecutor
     {
         var hostGit = new GitRunner(_slotWorkspace!.HostRunner);
         var manager = new ReviewBranchManager(
-            hostGit, _slotWorkspace.HostFileSystem, provider, _loggerFactory.CreateLogger<ReviewBranchManager>());
+            hostGit, _slotWorkspace.HostFileSystem, _loggerFactory.CreateLogger<ReviewBranchManager>());
 
-        // The per-commit review file lives inside the accumulating per-PR notes dir (design §4.3 D3); only
+        // The review file lives directly inside the accumulating per-PR notes dir (design §4.3 D3); only
         // that dir is staged, so nothing the agent wrote elsewhere (code, scratch) can reach the commit.
-        var reviewFile = $"{lease.NotesRelPath}/{ShortSha(run.HeadSha)}/review.md";
+        var reviewFile = $"{lease.NotesRelPath}/review.md";
         var reqFiles = new[] { new ReviewArtifactFile(reviewFile, reviewBody) };
         var request = BuildNotesRequest(repo, run, reqFiles);
 
@@ -1207,13 +1207,12 @@ internal sealed class DaemonReviewStageExecutor : IReviewStageExecutor
         var manager = new ReviewBranchManager(
             git,
             fileSystem,
-            provider,
             _loggerFactory.CreateLogger<ReviewBranchManager>());
 
         // Only the PRs/... artifact is supplied explicitly; the manager's `git add -A` still captures any
         // other tracked changes in the checkout.
         var prArtifactPath =
-            $"PRs/{provider}/{ReviewBotRepoManagerSlug(repo)}/{run.PrId}-{ShortSha(run.HeadSha)}/review.md";
+            $"PRs/{ReviewBotRepoManagerSlug(repo)}-{run.PrId}/review.md";
         var request = new ReviewBotPublishRequest(
             repo,
             PrNumber: int.Parse(run.PrId, System.Globalization.CultureInfo.InvariantCulture),
@@ -1296,14 +1295,8 @@ internal sealed class DaemonReviewStageExecutor : IReviewStageExecutor
             HeadSha: run.HeadSha,
             VariantId: run.VariantId));
 
-    /// <summary>Slugs the target identity into a single ReviewBot path segment (mirrors the branch slug).</summary>
-    private static string ReviewBotRepoManagerSlug(RepoIdentity repo)
-    {
-        var parts = new[] { repo.OrgOrOwner, repo.Project, repo.RepoName }
-            .Where(static p => !string.IsNullOrEmpty(p))
-            .Select(static p => SlugSegment(p!));
-        return string.Join('-', parts);
-    }
+    /// <summary>Slugs the target repo name into a single ReviewBot path segment (mirrors the branch slug).</summary>
+    private static string ReviewBotRepoManagerSlug(RepoIdentity repo) => SlugSegment(repo.RepoName);
 
     private static string SlugSegment(string value)
     {
@@ -1312,8 +1305,6 @@ internal sealed class DaemonReviewStageExecutor : IReviewStageExecutor
             .Select(static c => char.IsLetterOrDigit(c) || c is '.' or '_' ? c : '-');
         return new string([.. chars]).Trim('-');
     }
-
-    private static string ShortSha(string sha) => sha.Length <= 8 ? sha : sha[..8];
 
     /// <summary>
     /// Resolves the run's repo and the publisher/artifact provider string. <c>RepoIdentity.Provider</c>

--- a/samples/CodeReviewDaemon.Sample/Orchestration/OrphanBranchReconciler.cs
+++ b/samples/CodeReviewDaemon.Sample/Orchestration/OrphanBranchReconciler.cs
@@ -1,0 +1,68 @@
+using System.Globalization;
+using CodeReviewDaemon.Sample.Workspace.Git;
+
+namespace CodeReviewDaemon.Sample.Orchestration;
+
+/// <summary>
+/// Reconciles the PR-lifecycle sweep's watch-set against the review store's actual <c>review/*</c> branches so
+/// a PR whose review row is missing from this daemon's SQLite DB — a fresh DB after a restart, or DB churn —
+/// still gets its notes branch merged-or-deleted when the PR closes. Without this, such a branch is orphaned:
+/// the merged PR's notes never reach the store default branch and the abandoned PR's branch is never deleted.
+/// <para>
+/// The DB-derived set is authoritative and always kept. This only <b>adds</b> orphaned branches whose
+/// <c>review/{repo}-{pr}</c> slug (see <see cref="ReviewBranchManager.TryParseReviewBranch"/>) matches a
+/// configured poll target — the daemon needs that target's <see cref="PrPollTarget.Repo"/> identity and
+/// <see cref="PrPollTarget.Provider"/> to look the PR's lifecycle up. A branch that matches no configured repo
+/// (or is in the legacy nested form) is logged and skipped: its identity cannot be recovered from the name.
+/// </para>
+/// </summary>
+internal static class OrphanBranchReconciler
+{
+    public static IReadOnlyList<ReviewedPr> Reconcile(
+        IReadOnlyList<ReviewedPr> fromDb,
+        IReadOnlyList<string> remoteReviewBranches,
+        IReadOnlyList<PrPollTarget> configuredTargets,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(fromDb);
+        ArgumentNullException.ThrowIfNull(remoteReviewBranches);
+        ArgumentNullException.ThrowIfNull(configuredTargets);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        var result = new List<ReviewedPr>(fromDb);
+        // Branches already covered by the DB set (or seen earlier in this loop) are not re-added.
+        var covered = new HashSet<string>(fromDb.Select(static p => p.Branch), StringComparer.Ordinal);
+
+        var targetsBySlug = new Dictionary<string, PrPollTarget>(StringComparer.OrdinalIgnoreCase);
+        foreach (var target in configuredTargets)
+        {
+            targetsBySlug[ReviewBranchManager.RepoSlug(target.Repo)] = target;
+        }
+
+        foreach (var branch in remoteReviewBranches)
+        {
+            if (!covered.Add(branch))
+            {
+                continue;
+            }
+
+            if (!ReviewBranchManager.TryParseReviewBranch(branch, out var slug, out var prNumber))
+            {
+                continue;
+            }
+
+            if (!targetsBySlug.TryGetValue(slug, out var target))
+            {
+                logger.LogWarning(
+                    "PR-lifecycle sweep: orphaned notes branch '{Branch}' matches no configured repo; skipping.",
+                    branch);
+                continue;
+            }
+
+            result.Add(new ReviewedPr(
+                target.Repo, target.Provider, prNumber.ToString(CultureInfo.InvariantCulture), branch));
+        }
+
+        return result;
+    }
+}

--- a/samples/CodeReviewDaemon.Sample/Orchestration/PrLifecycleSweeper.cs
+++ b/samples/CodeReviewDaemon.Sample/Orchestration/PrLifecycleSweeper.cs
@@ -16,7 +16,7 @@ internal static class PrLifecycleSweepSeam
     /// Maps a <see cref="ReviewedPrRow"/> from <see cref="ReviewStore.ListReviewedPrsAsync"/> to a
     /// <see cref="ReviewedPr"/> sweep unit: the storage provider is mapped to the branch/poll namespace
     /// (<c>azure-devops</c> → <c>ado</c>) and the persistent notes branch name is derived the same way the
-    /// executor's commit-notes does (<see cref="ReviewBranchManager.BuildReviewBranchName(string, RepoIdentity, int)"/>),
+    /// executor's commit-notes does (<see cref="ReviewBranchManager.BuildReviewBranchName(RepoIdentity, int)"/>),
     /// so the sweep targets the exact branch the reviews pushed to. Returns <c>null</c> for a non-numeric PR
     /// id (which cannot name a branch) so the caller can skip it without aborting the sweep.
     /// </summary>
@@ -31,7 +31,7 @@ internal static class PrLifecycleSweepSeam
 
         var provider = string.Equals(row.Provider, "azure-devops", StringComparison.Ordinal) ? "ado" : row.Provider;
         return new ReviewedPr(
-            row.Repo, provider, row.PrId, ReviewBranchManager.BuildReviewBranchName(provider, row.Repo, prNumber));
+            row.Repo, provider, row.PrId, ReviewBranchManager.BuildReviewBranchName(row.Repo, prNumber));
     }
 
     /// <summary>
@@ -54,14 +54,14 @@ internal static class PrLifecycleSweepSeam
 /// <summary>
 /// One reviewed PR whose persistent notes branch may need resolving once the PR reaches a terminal
 /// lifecycle. <see cref="Branch"/> is the review branch
-/// <see cref="ReviewBranchManager.BuildReviewBranchName(string, RepoIdentity, int)"/> produced for it
+/// <see cref="ReviewBranchManager.BuildReviewBranchName(RepoIdentity, int)"/> produced for it
 /// (precomputed by the caller — the <c>ReviewStore</c> query supplies the rows and the caller derives the
 /// branch name via the <c>listReviewedPrsAsync</c> seam so this type stays test-constructible).
 /// </summary>
 internal sealed record ReviewedPr(RepoIdentity Repo, string Provider, string PrId, string Branch);
 
 /// <summary>
-/// Resolves each reviewed PR's persistent notes branch (<c>review/{provider}/{owner-repo}/{pr}</c>,
+/// Resolves each reviewed PR's persistent notes branch (<c>review/{repo}-{pr}</c>,
 /// created once per PR by <see cref="ReviewBranchManager.CommitNotesAsync"/> and kept across re-reviews)
 /// once the PR closes: merges the branch into the store default branch when the PR merged (if enabled),
 /// deletes it when the PR was abandoned (closed unmerged), and leaves an open PR's branch untouched.

--- a/samples/CodeReviewDaemon.Sample/Program.cs
+++ b/samples/CodeReviewDaemon.Sample/Program.cs
@@ -302,7 +302,7 @@ if (daemonOptions.EnableToolAssistedReview
         var hostGit = new GitRunner(slots.HostRunner);
         var sweeperRepoRoot = Path.Combine(poolRoot, "sweeper-store");
         var branchManager = new ReviewBranchManager(
-            hostGit, slots.HostFileSystem, "github", loggerFactory.CreateLogger<ReviewBranchManager>());
+            hostGit, slots.HostFileSystem, loggerFactory.CreateLogger<ReviewBranchManager>());
         var sweepLogger = loggerFactory.CreateLogger("pr-lifecycle-sweep");
 
         // At-close knowledge extraction (Layer-2, design §1). Wired only when EnableKnowledgeAgent is set:

--- a/samples/CodeReviewDaemon.Sample/Program.cs
+++ b/samples/CodeReviewDaemon.Sample/Program.cs
@@ -304,6 +304,9 @@ if (daemonOptions.EnableToolAssistedReview
         var branchManager = new ReviewBranchManager(
             hostGit, slots.HostFileSystem, loggerFactory.CreateLogger<ReviewBranchManager>());
         var sweepLogger = loggerFactory.CreateLogger("pr-lifecycle-sweep");
+        // The configured repos (full identity + provider) let the sweep resolve an orphaned review/* branch —
+        // whose new-scheme name carries only the repo slug + PR number — back to a pollable PR.
+        var sweepPollTargets = PrPollTargetBuilder.Build(daemonOptions, sweepLogger);
 
         // At-close knowledge extraction (Layer-2, design §1). Wired only when EnableKnowledgeAgent is set:
         // on a merged PR, read the PR's accumulated notes off its notes branch, run the gated extraction
@@ -340,6 +343,38 @@ if (daemonOptions.EnableToolAssistedReview
             };
         }
 
+        // Lists the store's persistent review/* branches straight from origin (fresh each sweep) so orphaned
+        // notes branches are reconciled regardless of this daemon's DB state. A failure degrades to the DB set.
+        static async Task<IReadOnlyList<string>> ListRemoteReviewBranchesAsync(
+            GitRunner git, string repoRoot, ILogger logger, CancellationToken cancellationToken)
+        {
+            var result = await git
+                .RunAsync(["-C", repoRoot, "ls-remote", "--heads", "origin", "review/*"], repoRoot, cancellationToken)
+                .ConfigureAwait(false);
+            if (!result.Succeeded)
+            {
+                logger.LogWarning(
+                    "PR-lifecycle sweep: listing review/* branches failed (exit {Exit}): {Err}; sweeping the DB set only.",
+                    result.ExitCode, result.Stderr);
+                return [];
+            }
+
+            const string headsPrefix = "refs/heads/";
+            var branches = new List<string>();
+            foreach (var line in result.Stdout.Split(
+                '\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var tab = line.IndexOf('\t');
+                var refName = tab >= 0 ? line[(tab + 1)..] : line;
+                if (refName.StartsWith(headsPrefix, StringComparison.Ordinal))
+                {
+                    branches.Add(refName[headsPrefix.Length..]);
+                }
+            }
+
+            return branches;
+        }
+
         return new PrLifecycleSweeper(
             async ct =>
             {
@@ -359,7 +394,12 @@ if (daemonOptions.EnableToolAssistedReview
                 var rows = await store.ListReviewedPrsAsync(ct).ConfigureAwait(false);
                 IReadOnlyList<ReviewedPr> reviewed =
                     [.. rows.Select(PrLifecycleSweepSeam.MapReviewedPr).Where(pr => pr is not null).Select(pr => pr!)];
-                return reviewed;
+
+                // Reconcile against the store's actual review/* branches so a PR whose review row is absent
+                // from this daemon's DB (fresh DB / churn) still has its notes branch resolved when it closes.
+                var reviewBranches = await ListRemoteReviewBranchesAsync(hostGit, sweeperRepoRoot, sweepLogger, ct)
+                    .ConfigureAwait(false);
+                return OrphanBranchReconciler.Reconcile(reviewed, reviewBranches, sweepPollTargets, sweepLogger);
             },
             (pr, ct) => PrLifecycleSweepSeam.ResolveLifecycleAsync(providers, pr, ct),
             branchManager,

--- a/samples/CodeReviewDaemon.Sample/Workspace/Git/ReviewBranchManager.cs
+++ b/samples/CodeReviewDaemon.Sample/Workspace/Git/ReviewBranchManager.cs
@@ -362,13 +362,55 @@ internal sealed class ReviewBranchManager
     /// a reviewed row without a full request).
     /// </summary>
     public static string BuildReviewBranchName(RepoIdentity repo, int prNumber) =>
-        $"review/{SlugifyRepo(repo)}-{prNumber}";
+        $"review/{RepoSlug(repo)}-{prNumber}";
 
     private static string BuildCommitMessage(ReviewBotPublishRequest request) =>
         $"Review {request.TargetRepo.RepoName}#{request.PrNumber}";
 
-    /// <summary>Slugs the target repo name into a single ref-safe path segment (lowercased, separators to '-').</summary>
-    private static string SlugifyRepo(RepoIdentity repo) => Slug(repo.RepoName);
+    /// <summary>Slugs the target repo name into a single ref-safe path segment (lowercased, separators to '-').
+    /// Public so the orphan-branch reconciler can match a <c>review/{repo}-{pr}</c> branch back to a configured
+    /// repo identity.</summary>
+    public static string RepoSlug(RepoIdentity repo) => Slug(repo.RepoName);
+
+    /// <summary>
+    /// Reverse of <see cref="BuildReviewBranchName(RepoIdentity, int)"/>: parses a <c>review/{repo}-{pr}</c>
+    /// branch into its repo slug and PR number. Returns <c>false</c> for anything that is not a well-formed
+    /// new-scheme review branch — including the legacy <c>review/{provider}/{owner-repo}/{pr}</c> form, which
+    /// carries embedded '/'.
+    /// </summary>
+    public static bool TryParseReviewBranch(string branch, out string repoSlug, out int prNumber)
+    {
+        repoSlug = string.Empty;
+        prNumber = 0;
+        if (string.IsNullOrEmpty(branch) || !branch.StartsWith("review/", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // The new scheme is a single segment "{slug}-{pr}"; an embedded '/' means the legacy nested form.
+        var remainder = branch["review/".Length..];
+        if (remainder.Length == 0 || remainder.Contains('/'))
+        {
+            return false;
+        }
+
+        // The PR number is the trailing run of digits after the last '-'; the slug is everything before it
+        // (repo slugs may themselves contain '-').
+        var lastDash = remainder.LastIndexOf('-');
+        if (lastDash <= 0 || lastDash == remainder.Length - 1)
+        {
+            return false;
+        }
+
+        var prPart = remainder[(lastDash + 1)..];
+        if (!prPart.All(char.IsAsciiDigit) || !int.TryParse(prPart, out prNumber))
+        {
+            return false;
+        }
+
+        repoSlug = remainder[..lastDash];
+        return true;
+    }
 
     private static string Slug(string value)
     {

--- a/samples/CodeReviewDaemon.Sample/Workspace/Git/ReviewBranchManager.cs
+++ b/samples/CodeReviewDaemon.Sample/Workspace/Git/ReviewBranchManager.cs
@@ -4,7 +4,7 @@ using CodeReviewDaemon.Sample.Workspace.Sandbox;
 namespace CodeReviewDaemon.Sample.Workspace.Git;
 
 /// <summary>A single review artifact file to retain in the ReviewBot repo, relative to its root.</summary>
-/// <param name="RelativePath">Path under the ReviewBot checkout (e.g. <c>PRs/github/acme-widgets/42-abcd1234/review.md</c>).</param>
+/// <param name="RelativePath">Path under the ReviewBot checkout (e.g. <c>PRs/widgets-42/review.md</c>).</param>
 /// <param name="Content">UTF-8 file body.</param>
 internal sealed record ReviewArtifactFile(string RelativePath, string Content);
 
@@ -47,7 +47,7 @@ internal sealed record ReviewBotPublishRequest(
 
 /// <summary>
 /// Deterministic git/fs orchestration for the ReviewBot repo's per-PR review branch
-/// (<c>review/{provider}/{owner-repo}/{pr}</c>), split into three independently-callable ops so the
+/// (<c>review/{repo}-{pr}</c>), split into three independently-callable ops so the
 /// branch can persist across re-reviews and be merged-or-deleted only when the PR closes:
 /// <list type="bullet">
 /// <item><see cref="CommitNotesAsync"/> — create-or-reuse the branch, commit the review's artifacts,
@@ -67,20 +67,16 @@ internal sealed class ReviewBranchManager
 
     private readonly GitRunner _git;
     private readonly ISandboxFileSystem _fileSystem;
-    private readonly string _provider;
     private readonly ILogger<ReviewBranchManager> _logger;
 
     public ReviewBranchManager(
         GitRunner git,
         ISandboxFileSystem fileSystem,
-        string provider,
         ILogger<ReviewBranchManager> logger
     )
     {
         _git = git ?? throw new ArgumentNullException(nameof(git));
         _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
-        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
-        _provider = provider;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -353,32 +349,26 @@ internal sealed class ReviewBranchManager
     }
 
     /// <summary>
-    /// Builds the review branch name <c>review/{provider}/{owner-repo}/{pr}</c>. The <c>{owner-repo}</c>
-    /// segment uses the normalized, slug-escaped target identity so it is stable across casing drift and
-    /// safe as a git ref. Exposed so callers (and tests) can resolve the branch name for a request.
+    /// Builds the review branch name <c>review/{repo}-{pr}</c>. The <c>{repo}</c> segment uses the
+    /// normalized, slug-escaped target repo name so it is stable across casing drift and safe as a git ref.
+    /// Exposed so callers (and tests) can resolve the branch name for a request.
     /// </summary>
     public string BuildReviewBranchName(ReviewBotPublishRequest request) =>
-        BuildReviewBranchName(_provider, request.TargetRepo, request.PrNumber);
+        BuildReviewBranchName(request.TargetRepo, request.PrNumber);
 
     /// <summary>
-    /// The provider-parameterized branch-name builder the executor's commit-notes, the slot preparer, and
-    /// the PR-lifecycle sweeper all share so they name a PR's persistent notes branch identically (the
-    /// sweeper resolves the branch for a reviewed row without a full request).
+    /// The branch-name builder the executor's commit-notes, the slot preparer, and the PR-lifecycle sweeper
+    /// all share so they name a PR's persistent notes branch identically (the sweeper resolves the branch for
+    /// a reviewed row without a full request).
     /// </summary>
-    public static string BuildReviewBranchName(string provider, RepoIdentity repo, int prNumber) =>
-        $"review/{provider}/{SlugifyRepo(repo)}/{prNumber}";
+    public static string BuildReviewBranchName(RepoIdentity repo, int prNumber) =>
+        $"review/{SlugifyRepo(repo)}-{prNumber}";
 
-    private string BuildCommitMessage(ReviewBotPublishRequest request) =>
-        $"Review {_provider} {request.TargetRepo.DisplayName}#{request.PrNumber} @ {ShortSha(request.HeadSha)}";
+    private static string BuildCommitMessage(ReviewBotPublishRequest request) =>
+        $"Review {request.TargetRepo.RepoName}#{request.PrNumber}";
 
-    /// <summary>Slugs the target identity into a single ref-safe path segment (lowercased, separators to '-').</summary>
-    private static string SlugifyRepo(RepoIdentity repo)
-    {
-        var parts = new[] { repo.OrgOrOwner, repo.Project, repo.RepoName }
-            .Where(static p => !string.IsNullOrEmpty(p))
-            .Select(static p => Slug(p!));
-        return string.Join('-', parts);
-    }
+    /// <summary>Slugs the target repo name into a single ref-safe path segment (lowercased, separators to '-').</summary>
+    private static string SlugifyRepo(RepoIdentity repo) => Slug(repo.RepoName);
 
     private static string Slug(string value)
     {
@@ -388,8 +378,6 @@ internal sealed class ReviewBranchManager
             .ToArray();
         return new string(chars).Trim('-');
     }
-
-    private static string ShortSha(string sha) => sha.Length <= 8 ? sha : sha[..8];
 
     private static string JoinPath(string root, string relative) =>
         $"{root.TrimEnd('/')}/{relative.TrimStart('/')}";

--- a/samples/CodeReviewDaemon.Sample/Workspace/ReviewBot/ReviewBotInitializer.cs
+++ b/samples/CodeReviewDaemon.Sample/Workspace/ReviewBot/ReviewBotInitializer.cs
@@ -139,7 +139,7 @@ internal sealed class ReviewBotInitializer
         "# ReviewBot\n\n"
         + "Durable store for the Code-Review Daemon.\n\n"
         + "- `KnowledgeBase/` — accumulated review knowledge; `_toc.md` is the generated table of contents.\n"
-        + "- `PRs/` — retained per-PR review artifacts (`{provider}/{owner-repo}/{pr}-{head_sha8}/`).\n\n"
+        + "- `PRs/` — retained per-PR review artifacts (`{repo}-{pr}/`).\n\n"
         + "## Setup\n\n"
         + "This repository must be **created out-of-band** (the daemon does not create provider repos). "
         + "Create the empty remote, grant the bot identity access, then run `CodeReviewDaemon reviewbot "

--- a/samples/CodeReviewDaemon.Sample/Workspace/ReviewSlotPreparer.cs
+++ b/samples/CodeReviewDaemon.Sample/Workspace/ReviewSlotPreparer.cs
@@ -69,11 +69,11 @@ internal sealed class ReviewSlotPreparer : IReviewSlotPreparer
     /// <param name="submoduleRelPath">The reviewed submodule's path under the store, e.g.
     /// <c>repos/LmDotnetTools</c>.</param>
     /// <param name="branch">The PR's persistent review branch, e.g.
-    /// <c>review/github/achieveai-lmdotnettools/151</c>.</param>
+    /// <c>review/lmdotnettools-151</c>.</param>
     /// <param name="defaultBranch">The store's default branch, e.g. <c>main</c> — only used when
     /// <paramref name="branch"/> does not already exist on <c>origin</c>.</param>
     /// <param name="notesRelPath">The persistent notes path under the store, e.g.
-    /// <c>PRs/github/achieveai-lmdotnettools/151</c>.</param>
+    /// <c>PRs/lmdotnettools-151</c>.</param>
     /// <param name="policy">The per-run <see cref="OperationPolicy"/> scoping which submodules may be
     /// fetched.</param>
     /// <param name="cancellationToken">Propagated to every git step and the submodule initializer.</param>

--- a/tests/CodeReviewDaemon.Sample.Tests/Agents/ScopedToolFilterTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Agents/ScopedToolFilterTests.cs
@@ -7,7 +7,7 @@ namespace CodeReviewDaemon.Sample.Tests.Agents;
 
 public class ScopedToolFilterTests
 {
-    private const string NotesDir = "/store/PRs/github/acme-repo/123";
+    private const string NotesDir = "/store/PRs/acme-repo-123";
     private const string ScratchDir = "/store/scratch";
     private static readonly string[] ReadOnlyAllow = ["Read", "Grep", "Glob", "Skill"];
     private static readonly string[] WritableAllow = ["Write", "Edit", "Bash"];

--- a/tests/CodeReviewDaemon.Sample.Tests/Orchestration/DaemonReviewStageExecutorPooledTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Orchestration/DaemonReviewStageExecutorPooledTests.cs
@@ -21,8 +21,8 @@ namespace CodeReviewDaemon.Sample.Tests.Orchestration;
 public sealed class DaemonReviewStageExecutorPooledTests
 {
     private const string StoreUrl = "https://github.com/achieveai/AchieveAiReviews.git";
-    private const string Branch = "review/github/achieveai-lmdotnettools/118";
-    private const string NotesRelPath = "PRs/github/achieveai-lmdotnettools/118";
+    private const string Branch = "review/lmdotnettools-118";
+    private const string NotesRelPath = "PRs/lmdotnettools-118";
     private const string SubmoduleRelPath = "repos/LmDotnetTools";
 
     [Fact]
@@ -89,7 +89,7 @@ public sealed class DaemonReviewStageExecutorPooledTests
         toolContext.EnableReviewerWrites.Should().BeTrue();
         toolContext.WritableToolAllowList.Should().BeEquivalentTo(["Write", "Edit", "Bash"]);
         toolContext.ReadOnlyToolAllowList.Should().BeEquivalentTo(["Read", "Grep", "Glob", "Skill"]);
-        toolContext.NotesDir.Should().Be("/workspace/store/PRs/github/achieveai-lmdotnettools/118");
+        toolContext.NotesDir.Should().Be("/workspace/store/PRs/lmdotnettools-118");
         toolContext.ScratchDir.Should().Be("/workspace/scratch");
     }
 
@@ -108,7 +108,7 @@ public sealed class DaemonReviewStageExecutorPooledTests
         var profile = fixture.Factory.CreatedProfiles.Should().ContainSingle().Subject;
         profile.SystemPrompt.Should().Contain("/workspace/store/repos/LmDotnetTools");
         profile.SystemPrompt.Should().Contain("cross-repo store at /workspace/store");
-        profile.SystemPrompt.Should().Contain("/workspace/store/PRs/github/achieveai-lmdotnettools/118");
+        profile.SystemPrompt.Should().Contain("/workspace/store/PRs/lmdotnettools-118");
         profile.SystemPrompt.Should().MatchRegex("(?i)only writable location");
     }
 
@@ -143,7 +143,7 @@ public sealed class DaemonReviewStageExecutorPooledTests
 
         // The prior round's own notes are already on the notes dir the reviewer's tools address.
         fixture.BootFileSystem.Seed(
-            "/workspace/store/PRs/github/achieveai-lmdotnettools/118/PR_Findings_01.md", "prior findings");
+            "/workspace/store/PRs/lmdotnettools-118/PR_Findings_01.md", "prior findings");
 
         await fixture.Executor.ExecuteStageAsync(ReviewStage.ContextReady, run, CancellationToken.None);
         await fixture.Executor.ExecuteStageAsync(ReviewStage.Reviewed, run, CancellationToken.None);

--- a/tests/CodeReviewDaemon.Sample.Tests/Orchestration/HostRetentionTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Orchestration/HostRetentionTests.cs
@@ -33,7 +33,7 @@ public sealed class HostRetentionTests
 
         var host = new FakeSandboxCommandRunner()
             .OnArgvContains(
-                "rev-parse review/github/achieveai-lmdotnettools/118",
+                "rev-parse review/lmdotnettools-118",
                 new SandboxCommandResult(0, "f00dcafef00dcafe\n", string.Empty));
         var hostFileSystem = new FakeSandboxFileSystem()
             .Seed("/host/reviewbot/README.md", "# ReviewBot")
@@ -64,7 +64,7 @@ public sealed class HostRetentionTests
         var sandboxCommands = sandbox.Commands.Select(c => string.Join(' ', c.Argv)).ToList();
 
         hostCommands.Should().Contain(
-            c => c.Contains("push origin review/github/achieveai-lmdotnettools/118"),
+            c => c.Contains("push origin review/lmdotnettools-118"),
             "the retention push must run on the host runner");
         hostCommands.Should().NotContain(
             c => c.Contains("branch -D review/") || c.Contains("push origin --delete review/"),

--- a/tests/CodeReviewDaemon.Sample.Tests/Orchestration/OrphanBranchReconcilerTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Orchestration/OrphanBranchReconcilerTests.cs
@@ -1,0 +1,81 @@
+using CodeReviewDaemon.Sample.Orchestration;
+using CodeReviewDaemon.Sample.Persistence.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CodeReviewDaemon.Sample.Tests.Orchestration;
+
+/// <summary>
+/// The sweep watch-set reconciler: it must surface orphaned <c>review/*</c> branches (whose review row is
+/// missing from the DB) as pollable PRs resolved back to a configured repo identity, while never dropping or
+/// duplicating the DB-derived set, and skipping any branch it cannot resolve.
+/// </summary>
+public sealed class OrphanBranchReconcilerTests
+{
+    private static readonly RepoIdentity Widgets = new()
+    {
+        Provider = "github",
+        OrgOrOwner = "acme",
+        RepoName = "widgets",
+    };
+
+    private static readonly PrPollTarget WidgetsTarget = new()
+    {
+        Provider = "github",
+        Repo = Widgets,
+        Scope = "acme/widgets:open-prs",
+    };
+
+    [Fact]
+    public void Adds_an_orphaned_branch_that_matches_a_configured_repo()
+    {
+        var result = OrphanBranchReconciler.Reconcile(
+            fromDb: [],
+            remoteReviewBranches: ["review/widgets-42"],
+            configuredTargets: [WidgetsTarget],
+            NullLogger.Instance);
+
+        var pr = result.Should().ContainSingle().Subject;
+        pr.Provider.Should().Be("github");
+        pr.PrId.Should().Be("42");
+        pr.Branch.Should().Be("review/widgets-42");
+        pr.Repo.RepoName.Should().Be("widgets", "the identity is recovered from the configured target, not the branch name");
+    }
+
+    [Fact]
+    public void Keeps_the_db_set_and_does_not_duplicate_a_branch_already_covered()
+    {
+        ReviewedPr[] fromDb = [new(Widgets, "github", "42", "review/widgets-42")];
+
+        var result = OrphanBranchReconciler.Reconcile(
+            fromDb,
+            remoteReviewBranches: ["review/widgets-42"],
+            configuredTargets: [WidgetsTarget],
+            NullLogger.Instance);
+
+        result.Should().ContainSingle().Which.Branch.Should().Be("review/widgets-42");
+    }
+
+    [Fact]
+    public void Skips_a_branch_whose_slug_matches_no_configured_repo()
+    {
+        var result = OrphanBranchReconciler.Reconcile(
+            fromDb: [],
+            remoteReviewBranches: ["review/unknown-7"],
+            configuredTargets: [WidgetsTarget],
+            NullLogger.Instance);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Skips_a_legacy_nested_branch_name_it_cannot_resolve()
+    {
+        var result = OrphanBranchReconciler.Reconcile(
+            fromDb: [],
+            remoteReviewBranches: ["review/github/acme-widgets/42"],
+            configuredTargets: [WidgetsTarget],
+            NullLogger.Instance);
+
+        result.Should().BeEmpty();
+    }
+}

--- a/tests/CodeReviewDaemon.Sample.Tests/Orchestration/PrLifecycleSweepSeamTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Orchestration/PrLifecycleSweepSeamTests.cs
@@ -23,7 +23,7 @@ public sealed class PrLifecycleSweepSeamTests
         pr.Should().NotBeNull();
         pr!.Provider.Should().Be("github");
         pr.PrId.Should().Be("42");
-        pr.Branch.Should().Be("review/github/acme-widgets/42");
+        pr.Branch.Should().Be("review/widgets-42");
     }
 
     [Fact]
@@ -38,7 +38,7 @@ public sealed class PrLifecycleSweepSeamTests
 
         pr.Should().NotBeNull();
         pr!.Provider.Should().Be("ado", "the sweeper polls/branches under 'ado', not the 'azure-devops' storage namespace");
-        pr.Branch.Should().Be("review/ado/acme-platform-widgets/7");
+        pr.Branch.Should().Be("review/widgets-7");
     }
 
     [Fact]
@@ -59,9 +59,9 @@ public sealed class PrLifecycleSweepSeamTests
         var repo = new RepoIdentity { Provider = "github", OrgOrOwner = "acme", RepoName = "widgets" };
 
         var githubState = await PrLifecycleSweepSeam.ResolveLifecycleAsync(
-            providers, new ReviewedPr(repo, "github", "42", "review/github/acme-widgets/42"), CancellationToken.None);
+            providers, new ReviewedPr(repo, "github", "42", "review/widgets-42"), CancellationToken.None);
         var adoState = await PrLifecycleSweepSeam.ResolveLifecycleAsync(
-            providers, new ReviewedPr(repo, "ado", "7", "review/ado/acme-widgets/7"), CancellationToken.None);
+            providers, new ReviewedPr(repo, "ado", "7", "review/widgets-7"), CancellationToken.None);
 
         githubState.Should().Be(PrLifecycle.Merged, "the github PR routes to the github provider's state");
         adoState.Should().Be(PrLifecycle.Abandoned, "the ado PR routes to the ado provider's state");
@@ -74,7 +74,7 @@ public sealed class PrLifecycleSweepSeamTests
         var repo = new RepoIdentity { Provider = "github", OrgOrOwner = "acme", RepoName = "widgets" };
 
         var act = () => PrLifecycleSweepSeam.ResolveLifecycleAsync(
-            providers, new ReviewedPr(repo, "ado", "7", "review/ado/acme-widgets/7"), CancellationToken.None);
+            providers, new ReviewedPr(repo, "ado", "7", "review/widgets-7"), CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*ado*");
     }

--- a/tests/CodeReviewDaemon.Sample.Tests/Orchestration/PrLifecycleSweeperTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Orchestration/PrLifecycleSweeperTests.cs
@@ -37,7 +37,6 @@ public sealed class PrLifecycleSweeperTests : LoggingTestBase
         new(
             new GitRunner(runner),
             new FakeSandboxFileSystem(),
-            "github",
             LoggerFactory.CreateLogger<ReviewBranchManager>());
 
     private PrLifecycleSweeper CreateSweeper(
@@ -63,7 +62,7 @@ public sealed class PrLifecycleSweeperTests : LoggingTestBase
     public async Task Sweep_merges_the_notes_branch_of_a_merged_PR_when_merge_on_close_is_enabled()
     {
         var runner = new FakeSandboxCommandRunner();
-        var pr = Pr("42", "review/github/acme-widgets/42");
+        var pr = Pr("42", "review/widgets-42");
         var sweeper = CreateSweeper(
             [pr],
             (_, _) => Task.FromResult(PrLifecycle.Merged),
@@ -84,7 +83,7 @@ public sealed class PrLifecycleSweeperTests : LoggingTestBase
     public async Task Sweep_deletes_the_notes_branch_of_an_abandoned_PR_and_never_merges()
     {
         var runner = new FakeSandboxCommandRunner();
-        var pr = Pr("43", "review/github/acme-widgets/43");
+        var pr = Pr("43", "review/widgets-43");
         var sweeper = CreateSweeper(
             [pr],
             (_, _) => Task.FromResult(PrLifecycle.Abandoned),
@@ -103,7 +102,7 @@ public sealed class PrLifecycleSweeperTests : LoggingTestBase
     public async Task Sweep_takes_no_action_for_an_open_PR()
     {
         var runner = new FakeSandboxCommandRunner();
-        var pr = Pr("44", "review/github/acme-widgets/44");
+        var pr = Pr("44", "review/widgets-44");
         var sweeper = CreateSweeper(
             [pr],
             (_, _) => Task.FromResult(PrLifecycle.Open),
@@ -119,7 +118,7 @@ public sealed class PrLifecycleSweeperTests : LoggingTestBase
     public async Task Sweep_leaves_the_notes_branch_of_a_merged_PR_when_merge_on_close_is_disabled()
     {
         var runner = new FakeSandboxCommandRunner();
-        var pr = Pr("45", "review/github/acme-widgets/45");
+        var pr = Pr("45", "review/widgets-45");
         var sweeper = CreateSweeper(
             [pr],
             (_, _) => Task.FromResult(PrLifecycle.Merged),
@@ -135,8 +134,8 @@ public sealed class PrLifecycleSweeperTests : LoggingTestBase
     public async Task Sweep_isolates_a_per_PR_lifecycle_lookup_failure_so_the_remaining_PRs_still_resolve()
     {
         var runner = new FakeSandboxCommandRunner();
-        var failingPr = Pr("46", "review/github/acme-widgets/46");
-        var okPr = Pr("47", "review/github/acme-widgets/47");
+        var failingPr = Pr("46", "review/widgets-46");
+        var okPr = Pr("47", "review/widgets-47");
         var sweeper = CreateSweeper(
             [failingPr, okPr],
             (pr, _) => pr.PrId == failingPr.PrId
@@ -157,7 +156,7 @@ public sealed class PrLifecycleSweeperTests : LoggingTestBase
     public async Task Sweep_runs_knowledge_extraction_before_merging_a_merged_PR()
     {
         var runner = new FakeSandboxCommandRunner();
-        var pr = Pr("42", "review/github/acme-widgets/42");
+        var pr = Pr("42", "review/widgets-42");
         var invokedPrs = new List<string>();
         var runnerCommandCountAtInvocation = -1;
         var sweeper = CreateSweeper(
@@ -187,8 +186,8 @@ public sealed class PrLifecycleSweeperTests : LoggingTestBase
     public async Task Sweep_does_not_run_knowledge_extraction_for_abandoned_or_open_PRs()
     {
         var runner = new FakeSandboxCommandRunner();
-        var abandoned = Pr("43", "review/github/acme-widgets/43");
-        var open = Pr("44", "review/github/acme-widgets/44");
+        var abandoned = Pr("43", "review/widgets-43");
+        var open = Pr("44", "review/widgets-44");
         var invoked = new List<string>();
         var sweeper = CreateSweeper(
             [abandoned, open],
@@ -210,7 +209,7 @@ public sealed class PrLifecycleSweeperTests : LoggingTestBase
     public async Task Sweep_still_merges_when_knowledge_extraction_throws()
     {
         var runner = new FakeSandboxCommandRunner();
-        var pr = Pr("45", "review/github/acme-widgets/45");
+        var pr = Pr("45", "review/widgets-45");
         var sweeper = CreateSweeper(
             [pr],
             (_, _) => Task.FromResult(PrLifecycle.Merged),

--- a/tests/CodeReviewDaemon.Sample.Tests/Scenarios/DaemonAgentFactoryTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Scenarios/DaemonAgentFactoryTests.cs
@@ -87,7 +87,7 @@ public sealed class DaemonAgentFactoryTests
             ["has_store"] = false,
             ["store_root"] = string.Empty,
             ["has_notes"] = true,
-            ["notes_dir"] = "/workspace/store/PRs/github/acme/1",
+            ["notes_dir"] = "/workspace/store/PRs/acme-1",
             ["is_rereview"] = true,
             ["prev_commit"] = "abc123",
             ["new_commit"] = "def456",
@@ -116,7 +116,7 @@ public sealed class DaemonAgentFactoryTests
             ["has_store"] = false,
             ["store_root"] = string.Empty,
             ["has_notes"] = true,
-            ["notes_dir"] = "/workspace/store/PRs/github/acme/1",
+            ["notes_dir"] = "/workspace/store/PRs/acme-1",
             ["is_rereview"] = false,
             ["prev_commit"] = string.Empty,
             ["new_commit"] = "def456",
@@ -216,14 +216,14 @@ public sealed class DaemonAgentFactoryTests
             ["has_store"] = true,
             ["store_root"] = "/workspace/store",
             ["has_notes"] = true,
-            ["notes_dir"] = "/workspace/store/PRs/github/acme/1",
+            ["notes_dir"] = "/workspace/store/PRs/acme-1",
         };
 
         var prompt = DaemonAgentFactory.CreateReviewProfile(vars).SystemPrompt;
 
         prompt.Should().Contain("/workspace/store/repos/Foo");
         prompt.Should().Contain("cross-repo store at /workspace/store");
-        prompt.Should().Contain("/workspace/store/PRs/github/acme/1");
+        prompt.Should().Contain("/workspace/store/PRs/acme-1");
         prompt.Should().MatchRegex("(?i)only writable location");
     }
 

--- a/tests/CodeReviewDaemon.Sample.Tests/Scenarios/DaemonReviewStageExecutorTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Scenarios/DaemonReviewStageExecutorTests.cs
@@ -475,11 +475,11 @@ public sealed class DaemonReviewStageExecutorTests : LoggingTestBase
             new CodeReviewDaemonOptions { ReviewBotRepoUrl = "https://github.com/achieveai/CodeReviewBot-Workspace.git" });
         // This is the first review of the PR: the review branch does not exist yet.
         fixture.Runner.OnArgvContains(
-            "rev-parse --verify review/github/achieveai-lmdotnettools/118",
+            "rev-parse --verify review/lmdotnettools-118",
             new SandboxCommandResult(1, string.Empty, "unknown revision"));
         // The push must succeed so the retention sequence reaches the reviewbot_push record.
         fixture.Runner.OnArgvContains(
-            "rev-parse review/github/achieveai-lmdotnettools/118",
+            "rev-parse review/lmdotnettools-118",
             new SandboxCommandResult(0, "f00dcafef00dcafe\n", string.Empty));
         var run = fixture.SeedRun(watermark: "2026-06-29T12:34:56Z");
 
@@ -488,21 +488,21 @@ public sealed class DaemonReviewStageExecutorTests : LoggingTestBase
         var commands = fixture.Runner.Commands.Select(c => string.Join(' ', c.Argv)).ToList();
         // CommitNotesAsync commits onto the review branch and pushes the BRANCH (not the default branch) —
         // the branch persists so later re-reviews can keep appending notes to it.
-        commands.Should().Contain(a => a.Contains("checkout -B review/github/achieveai-lmdotnettools/118"));
+        commands.Should().Contain(a => a.Contains("checkout -B review/lmdotnettools-118"));
         commands.Should().Contain(a => a.Contains("commit -m"));
-        commands.Should().Contain(a => a.Contains("push origin review/github/achieveai-lmdotnettools/118"));
+        commands.Should().Contain(a => a.Contains("push origin review/lmdotnettools-118"));
 
         // The branch is kept: nothing merges or deletes it as part of a single review pass.
-        commands.Should().NotContain(a => a.Contains("branch -D review/github/achieveai-lmdotnettools/118"));
-        commands.Should().NotContain(a => a.Contains("push origin --delete review/github/achieveai-lmdotnettools/118"));
+        commands.Should().NotContain(a => a.Contains("branch -D review/lmdotnettools-118"));
+        commands.Should().NotContain(a => a.Contains("push origin --delete review/lmdotnettools-118"));
         commands.Should().NotContain(a => a.Contains("push origin main"), "a per-review commit must never fast-forward the default branch");
 
         // The PRs/... review artifact was written into the checkout before the commit.
-        fixture.FileSystem.Writes.Should().Contain(p => p.Contains("/PRs/github/") && p.EndsWith("review.md"));
+        fixture.FileSystem.Writes.Should().Contain(p => p.Contains("/PRs/") && p.EndsWith("review.md"));
         // The retained artifact carries the raw review text — the "[BotName]" prefix is only added to the
         // POSTED comment (see Posted_prefixes_the_posted_comment_with_the_configured_bot_name), never to
         // what's committed to the ReviewBot repo.
-        var reviewFilePath = fixture.FileSystem.Writes.Single(p => p.Contains("/PRs/github/") && p.EndsWith("review.md"));
+        var reviewFilePath = fixture.FileSystem.Writes.Single(p => p.Contains("/PRs/") && p.EndsWith("review.md"));
         fixture.FileSystem.Files[reviewFilePath].Should().NotStartWith("[");
 
         // The reviewbot_push outcome is persisted in SQLite (outbox row, terminal Posted with the pushed SHA).
@@ -579,7 +579,7 @@ public sealed class DaemonReviewStageExecutorTests : LoggingTestBase
             new CodeReviewDaemonOptions { ReviewBotRepoUrl = "https://github.com/achieveai/CodeReviewBot-Workspace.git" });
         // The push never succeeds → GitSyncFailed: nothing is deleted, the outbox row is left for reconcile.
         fixture.Runner.OnArgvContains(
-            "push origin review/github/achieveai-lmdotnettools/118",
+            "push origin review/lmdotnettools-118",
             new SandboxCommandResult(1, string.Empty, "rejected"));
         var run = fixture.SeedRun(watermark: "2026-06-29T12:34:56Z");
 

--- a/tests/CodeReviewDaemon.Sample.Tests/Scenarios/KnowledgeExtractionCommitterTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Scenarios/KnowledgeExtractionCommitterTests.cs
@@ -19,7 +19,7 @@ namespace CodeReviewDaemon.Sample.Tests.Scenarios;
 public sealed class KnowledgeExtractionCommitterTests : LoggingTestBase
 {
     private const string RepoRoot = "/host/sweeper-store";
-    private const string Branch = "review/github/acme-widgets/42";
+    private const string Branch = "review/widgets-42";
     private const string SourcePrRef = "github/acme/widgets/42";
 
     public KnowledgeExtractionCommitterTests(ITestOutputHelper output)

--- a/tests/CodeReviewDaemon.Sample.Tests/Scenarios/ReviewBranchManagerTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Scenarios/ReviewBranchManagerTests.cs
@@ -19,7 +19,7 @@ public sealed class ReviewBranchManagerTests : LoggingTestBase
 {
     private const string RepoRoot = "/work/reviewbot";
     private const string DefaultBranch = "main";
-    private const string ReviewBranch = "review/github/acme-widgets/42";
+    private const string ReviewBranch = "review/widgets-42";
 
     private static readonly RepoIdentity TargetRepo = new()
     {
@@ -35,7 +35,7 @@ public sealed class ReviewBranchManagerTests : LoggingTestBase
         DefaultBranch: DefaultBranch,
         Files:
         [
-            new ReviewArtifactFile("PRs/github/acme-widgets/42-abcd1234/review.md", "# Review"),
+            new ReviewArtifactFile("PRs/widgets-42/review.md", "# Review"),
             new ReviewArtifactFile("KnowledgeBase/_toc.md", "# ToC"),
         ]);
 
@@ -51,7 +51,6 @@ public sealed class ReviewBranchManagerTests : LoggingTestBase
         new(
             new GitRunner(runner),
             fileSystem,
-            "github",
             LoggerFactory.CreateLogger<ReviewBranchManager>());
 
     [Fact]
@@ -82,7 +81,7 @@ public sealed class ReviewBranchManagerTests : LoggingTestBase
         commands.Should().NotContain(a => a.Contains($"push origin --delete {ReviewBranch}"));
 
         // Both artifact sets were written into the checkout before the commit.
-        fs.Files.Should().ContainKey($"{RepoRoot}/PRs/github/acme-widgets/42-abcd1234/review.md");
+        fs.Files.Should().ContainKey($"{RepoRoot}/PRs/widgets-42/review.md");
         fs.Files.Should().ContainKey($"{RepoRoot}/KnowledgeBase/_toc.md");
 
         // Every git invocation carries the hardening flags.

--- a/tests/CodeReviewDaemon.Sample.Tests/Scenarios/ReviewBranchNameTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Scenarios/ReviewBranchNameTests.cs
@@ -1,0 +1,40 @@
+using CodeReviewDaemon.Sample.Persistence.Models;
+using CodeReviewDaemon.Sample.Workspace.Git;
+
+namespace CodeReviewDaemon.Sample.Tests.Scenarios;
+
+/// <summary>
+/// The pure branch-name helpers on <see cref="ReviewBranchManager"/>: the <c>{repo}-{pr}</c> slug/branch
+/// builders and their reverse parser, which the orphan-branch reconciler relies on.
+/// </summary>
+public sealed class ReviewBranchNameTests
+{
+    [Theory]
+    [InlineData("review/widgets-42", "widgets", 42)]
+    [InlineData("review/my-repo-7", "my-repo", 7)] // repo slugs may themselves contain '-'
+    public void TryParseReviewBranch_round_trips_a_new_scheme_branch(string branch, string expectedSlug, int expectedPr)
+    {
+        ReviewBranchManager.TryParseReviewBranch(branch, out var slug, out var pr).Should().BeTrue();
+        slug.Should().Be(expectedSlug);
+        pr.Should().Be(expectedPr);
+    }
+
+    [Theory]
+    [InlineData("review/github/acme-widgets/42")] // legacy nested form
+    [InlineData("review/widgets-")] // no PR number
+    [InlineData("review/widgets")] // no dash/number
+    [InlineData("feature/widgets-42")] // not a review branch
+    [InlineData("review/-42")] // empty slug
+    public void TryParseReviewBranch_rejects_non_new_scheme_names(string branch)
+    {
+        ReviewBranchManager.TryParseReviewBranch(branch, out _, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void RepoSlug_and_BuildReviewBranchName_agree()
+    {
+        var repo = new RepoIdentity { Provider = "github", OrgOrOwner = "achieveai", RepoName = "LmDotnetTools" };
+        ReviewBranchManager.RepoSlug(repo).Should().Be("lmdotnettools");
+        ReviewBranchManager.BuildReviewBranchName(repo, 156).Should().Be("review/lmdotnettools-156");
+    }
+}


### PR DESCRIPTION
## What

Two related changes to the Code-Review Daemon's cross-repo review store (`AchieveAiReviews`):

### 1. Simplify per-PR naming to `{repo}-{pr}` (commit 11f3d163)

The store named a PR's branch/folder/commit with a verbose, redundant scheme. The repo is already identified by its `repos/<Repo>` submodule in the store, so the `provider`/`owner` prefix and the head-sha suffix added noise:

| | before | after |
|---|---|---|
| branch | `review/github/achieveai-lmdotnettools/156` | `review/lmdotnettools-156` |
| folder | `PRs/github/achieveai-…/156/…-<sha>/review.md` | `PRs/lmdotnettools-156/review.md` |
| commit | `Review github achieveai/LmDotnetTools#156 @ 3c57b499` | `Review LmDotnetTools#156` |

Dropping the head-sha makes the folder a **stable, accumulating per-PR working directory keyed by PR number** for the PR's lifetime — room for progress-tracking artifacts, not just a per-commit `review.md`. `provider` is removed from `ReviewBranchManager`'s ctor and the naming helpers; the now-unused `ShortSha` helper is dropped.

### 2. Reconcile orphaned `review/*` branches in the PR-lifecycle sweep (commit d8e7fd66)

The sweep's watch-set came **only** from the daemon's SQLite DB (`ListReviewedPrsAsync`). A reviewed PR whose row was absent from the running daemon's DB (a fresh DB after a restart, or DB churn) never had its notes branch resolved — a merged PR's notes never reached the store default branch, and an abandoned PR's branch was never deleted. This is why `AchieveAiReviews` `main` stopped advancing even as PRs merged.

The sweep now **also** lists the store's actual `review/*` branches (`git ls-remote`, fresh each cycle) and reconciles them: any `review/{repo}-{pr}` branch not already covered by the DB set, whose slug matches a configured poll target, is added as a pollable PR — resolved back to that target's repo identity + provider. Unmatched or legacy-format branches are logged and skipped; a `ls-remote` failure degrades to the DB-only set.

## Why

- Naming: user-requested — the verbose path was redundant with the submodule layout.
- Reconciler: makes `main` advance robustly regardless of DB state; closes the durability gap where DB churn orphaned merged PRs (#156, #158) so their notes never reached `main`.

## Notes / follow-ups

- **Legacy branches are not auto-reconciled.** The parser handles only the new `review/{repo}-{pr}` form; the existing bring-up branches (`review/github/achieveai-…/88/156/157/158/169`) keep their old names and are skipped. If their notes are wanted on `main`, they need a one-time manual carry — happy to do that separately.
- The "folder holds more than `review.md`" capability is *enabled* by the stable per-PR dir but not itself built here.

## Tests

455 daemon tests green (12 new): `OrphanBranchReconcilerTests`, `ReviewBranchNameTests`, plus updated naming expectations across the existing suite. Solution builds 0-warning under `TreatWarningsAsErrors`.