### PR TITLE
feat(daemon): reconcile legacy-named review branches so they auto-clean on close

### DIFF
--- a/samples/CodeReviewDaemon.Sample/Orchestration/OrphanBranchReconciler.cs
+++ b/samples/CodeReviewDaemon.Sample/Orchestration/OrphanBranchReconciler.cs
@@ -9,11 +9,13 @@ namespace CodeReviewDaemon.Sample.Orchestration;
 /// still gets its notes branch merged-or-deleted when the PR closes. Without this, such a branch is orphaned:
 /// the merged PR's notes never reach the store default branch and the abandoned PR's branch is never deleted.
 /// <para>
-/// The DB-derived set is authoritative and always kept. This only <b>adds</b> orphaned branches whose
-/// <c>review/{repo}-{pr}</c> slug (see <see cref="ReviewBranchManager.TryParseReviewBranch"/>) matches a
-/// configured poll target — the daemon needs that target's <see cref="PrPollTarget.Repo"/> identity and
-/// <see cref="PrPollTarget.Provider"/> to look the PR's lifecycle up. A branch that matches no configured repo
-/// (or is in the legacy nested form) is logged and skipped: its identity cannot be recovered from the name.
+/// The DB-derived set is authoritative and always kept. This only <b>adds</b> orphaned branches whose slug
+/// matches a configured poll target — either the new <c>review/{repo}-{pr}</c> form (see
+/// <see cref="ReviewBranchManager.TryParseReviewBranch"/>) or the legacy <c>review/{provider}/{owner-repo}/{pr}</c>
+/// form (see <see cref="ReviewBranchManager.TryParseLegacyReviewBranch"/>), so orphans from either naming
+/// generation get cleaned up. The daemon needs that target's <see cref="PrPollTarget.Repo"/> identity and
+/// <see cref="PrPollTarget.Provider"/> to look the PR's lifecycle up. A branch that matches no configured repo,
+/// or is unparseable, is logged and skipped: its identity cannot be recovered from the name.
 /// </para>
 /// </summary>
 internal static class OrphanBranchReconciler
@@ -36,7 +38,10 @@ internal static class OrphanBranchReconciler
         var targetsBySlug = new Dictionary<string, PrPollTarget>(StringComparer.OrdinalIgnoreCase);
         foreach (var target in configuredTargets)
         {
+            // Index by both the new {repo} slug and the legacy {owner-repo} slug so orphans from either naming
+            // generation resolve back to the same configured repo.
             targetsBySlug[ReviewBranchManager.RepoSlug(target.Repo)] = target;
+            targetsBySlug[ReviewBranchManager.LegacyRepoSlug(target.Repo)] = target;
         }
 
         foreach (var branch in remoteReviewBranches)
@@ -46,7 +51,9 @@ internal static class OrphanBranchReconciler
                 continue;
             }
 
-            if (!ReviewBranchManager.TryParseReviewBranch(branch, out var slug, out var prNumber))
+            // New scheme first, then the legacy nested form, so both orphan generations get cleaned up.
+            if (!ReviewBranchManager.TryParseReviewBranch(branch, out var slug, out var prNumber)
+                && !ReviewBranchManager.TryParseLegacyReviewBranch(branch, out slug, out prNumber))
             {
                 continue;
             }

--- a/samples/CodeReviewDaemon.Sample/Workspace/Git/ReviewBranchManager.cs
+++ b/samples/CodeReviewDaemon.Sample/Workspace/Git/ReviewBranchManager.cs
@@ -412,6 +412,49 @@ internal sealed class ReviewBranchManager
         return true;
     }
 
+    /// <summary>Slugs the target identity the LEGACY way — <c>owner[-project]-repo</c> — so the reconciler can
+    /// also match pre-<c>{repo}-{pr}</c> branches (<c>review/{provider}/{owner-repo}/{pr}</c>) left over from the
+    /// naming change and clean them up when their PR closes.</summary>
+    public static string LegacyRepoSlug(RepoIdentity repo)
+    {
+        var parts = new[] { repo.OrgOrOwner, repo.Project, repo.RepoName }
+            .Where(static p => !string.IsNullOrEmpty(p))
+            .Select(static p => Slug(p!));
+        return string.Join('-', parts);
+    }
+
+    /// <summary>
+    /// Parses a LEGACY <c>review/{provider}/{owner-repo}/{pr}</c> branch (the pre-<c>{repo}-{pr}</c> form) into
+    /// its <c>owner-repo</c> slug and PR number. Returns <c>false</c> for the new single-segment form or anything
+    /// malformed. Pairs with <see cref="LegacyRepoSlug"/> so the reconciler can still resolve these orphans.
+    /// </summary>
+    public static bool TryParseLegacyReviewBranch(string branch, out string repoSlug, out int prNumber)
+    {
+        repoSlug = string.Empty;
+        prNumber = 0;
+        if (string.IsNullOrEmpty(branch))
+        {
+            return false;
+        }
+
+        // review / {provider} / {owner-repo} / {pr} — exactly four '/'-separated segments.
+        var parts = branch.Split('/');
+        if (parts.Length != 4 || !string.Equals(parts[0], "review", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var prPart = parts[3];
+        if (parts[1].Length == 0 || parts[2].Length == 0 || prPart.Length == 0
+            || !prPart.All(char.IsAsciiDigit) || !int.TryParse(prPart, out prNumber))
+        {
+            return false;
+        }
+
+        repoSlug = parts[2];
+        return true;
+    }
+
     private static string Slug(string value)
     {
         var chars = value

--- a/tests/CodeReviewDaemon.Sample.Tests/Orchestration/OrphanBranchReconcilerTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Orchestration/OrphanBranchReconcilerTests.cs
@@ -68,11 +68,28 @@ public sealed class OrphanBranchReconcilerTests
     }
 
     [Fact]
-    public void Skips_a_legacy_nested_branch_name_it_cannot_resolve()
+    public void Resolves_a_legacy_nested_branch_via_the_owner_repo_slug()
     {
+        // Left over from before the {repo}-{pr} rename: review/{provider}/{owner-repo}/{pr}.
         var result = OrphanBranchReconciler.Reconcile(
             fromDb: [],
             remoteReviewBranches: ["review/github/acme-widgets/42"],
+            configuredTargets: [WidgetsTarget],
+            NullLogger.Instance);
+
+        var pr = result.Should().ContainSingle().Subject;
+        pr.Provider.Should().Be("github");
+        pr.PrId.Should().Be("42");
+        pr.Branch.Should().Be("review/github/acme-widgets/42", "the sweep must act on the actual legacy branch name");
+        pr.Repo.RepoName.Should().Be("widgets");
+    }
+
+    [Fact]
+    public void Skips_a_legacy_branch_whose_slug_matches_no_configured_repo()
+    {
+        var result = OrphanBranchReconciler.Reconcile(
+            fromDb: [],
+            remoteReviewBranches: ["review/github/other-owner-other-repo/9"],
             configuredTargets: [WidgetsTarget],
             NullLogger.Instance);
 

--- a/tests/CodeReviewDaemon.Sample.Tests/Scenarios/ReviewBranchNameTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Scenarios/ReviewBranchNameTests.cs
@@ -37,4 +37,31 @@ public sealed class ReviewBranchNameTests
         ReviewBranchManager.RepoSlug(repo).Should().Be("lmdotnettools");
         ReviewBranchManager.BuildReviewBranchName(repo, 156).Should().Be("review/lmdotnettools-156");
     }
+
+    [Theory]
+    [InlineData("review/github/acme-widgets/42", "acme-widgets", 42)]
+    [InlineData("review/ado/acme-platform-widgets/7", "acme-platform-widgets", 7)]
+    public void TryParseLegacyReviewBranch_round_trips_a_legacy_branch(string branch, string expectedSlug, int expectedPr)
+    {
+        ReviewBranchManager.TryParseLegacyReviewBranch(branch, out var slug, out var pr).Should().BeTrue();
+        slug.Should().Be(expectedSlug);
+        pr.Should().Be(expectedPr);
+    }
+
+    [Theory]
+    [InlineData("review/lmdotnettools-156")] // new single-segment form
+    [InlineData("review/github/acme-widgets")] // no PR segment
+    [InlineData("review/github/acme-widgets/x")] // non-numeric PR
+    [InlineData("feature/github/acme-widgets/42")] // not a review branch
+    public void TryParseLegacyReviewBranch_rejects_non_legacy_names(string branch)
+    {
+        ReviewBranchManager.TryParseLegacyReviewBranch(branch, out _, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void LegacyRepoSlug_matches_the_legacy_branch_slug()
+    {
+        var repo = new RepoIdentity { Provider = "github", OrgOrOwner = "achieveai", RepoName = "LmDotnetTools" };
+        ReviewBranchManager.LegacyRepoSlug(repo).Should().Be("achieveai-lmdotnettools");
+    }
 }


### PR DESCRIPTION
## Why

The `{repo}-{pr}` rename (#170) taught the orphan-branch reconciler only the **new** branch-name form. Review branches created *before* the rename — `review/{provider}/{owner-repo}/{pr}` — are silently skipped, so when their PR closes the daemon leaves the branch behind instead of merging-to-main + deleting it. That's the exact orphaning the reconciler exists to prevent (and it just bit #156/#158, which had to be carried + deleted by hand).

The three in-flight legacy branches (#88/157/169) would hit the same fate when they close.

## What

- `ReviewBranchManager.TryParseLegacyReviewBranch` + `LegacyRepoSlug` — reverse of the pre-rename `owner[-project]-repo` naming.
- `OrphanBranchReconciler` now indexes configured poll targets by **both** the new `{repo}` slug and the legacy `{owner-repo}` slug, and tries both parsers per branch — so the sweep self-heals orphans from either naming generation and acts on the branch's *actual* name.

Result: any completed PR's review branch — old-named or new — is merged-to-main and deleted automatically, no hand-cleanup.

## Tests

463 daemon tests green (8 new): legacy parse round-trip/reject, `LegacyRepoSlug`, and reconciler resolves-legacy / skips-unmatched-legacy. Builds 0-warning under `TreatWarningsAsErrors`.