### PR TITLE
perf(daemon): stop re-resolving already-closed PRs on every sweep

### DIFF
--- a/samples/CodeReviewDaemon.Sample/Orchestration/PrLifecycleSweeper.cs
+++ b/samples/CodeReviewDaemon.Sample/Orchestration/PrLifecycleSweeper.cs
@@ -95,6 +95,15 @@ internal sealed class PrLifecycleSweeper
     /// </summary>
     private readonly Func<ReviewedPr, CancellationToken, Task>? _extractKnowledgeAsync;
 
+    /// <summary>
+    /// Notes branches this daemon lifetime has already resolved to a terminal lifecycle (merged-and-swept, or
+    /// abandoned-and-deleted). The reviewed-PR list only grows, so without this the sweep would re-run a GitHub
+    /// lifecycle lookup plus a git no-op for every PR it has ever closed, on every poll. Not persisted — a
+    /// restart re-confirms each branch once and then caches it, so this can never wrongly skip a PR whose
+    /// resolution did not actually complete.
+    /// </summary>
+    private readonly HashSet<string> _terminallyResolved = new(StringComparer.Ordinal);
+
     public PrLifecycleSweeper(
         Func<CancellationToken, Task<IReadOnlyList<ReviewedPr>>> listReviewedPrsAsync,
         Func<ReviewedPr, CancellationToken, Task<PrLifecycle>> getPrLifecycleAsync,
@@ -145,6 +154,13 @@ internal sealed class PrLifecycleSweeper
 
     private async Task ResolveAsync(ReviewedPr pr, CancellationToken cancellationToken)
     {
+        // A branch already resolved to a terminal state this lifetime never needs re-resolving; skipping it
+        // avoids a per-poll GitHub lifecycle lookup + git no-op for every PR the daemon has ever closed.
+        if (_terminallyResolved.Contains(pr.Branch))
+        {
+            return;
+        }
+
         var lifecycle = await _getPrLifecycleAsync(pr, cancellationToken).ConfigureAwait(false);
         switch (lifecycle)
         {
@@ -153,7 +169,10 @@ internal sealed class PrLifecycleSweeper
                 break;
 
             case PrLifecycle.Merged:
-                await ResolveMergedAsync(pr, cancellationToken).ConfigureAwait(false);
+                if (await ResolveMergedAsync(pr, cancellationToken).ConfigureAwait(false))
+                {
+                    _terminallyResolved.Add(pr.Branch);
+                }
                 break;
 
             case PrLifecycle.Abandoned:
@@ -164,6 +183,7 @@ internal sealed class PrLifecycleSweeper
                     pr.Branch,
                     pr.Provider,
                     pr.PrId);
+                _terminallyResolved.Add(pr.Branch);
                 break;
 
             default:
@@ -171,7 +191,12 @@ internal sealed class PrLifecycleSweeper
         }
     }
 
-    private async Task ResolveMergedAsync(ReviewedPr pr, CancellationToken cancellationToken)
+    /// <summary>
+    /// Resolves a merged PR's notes branch (KB extraction, then merge-to-default). Returns <c>true</c> when the
+    /// branch reached a terminal state — merged, already gone, or intentionally left because merge-on-close is
+    /// disabled — and <c>false</c> only when the merge push failed and should be retried on the next sweep.
+    /// </summary>
+    private async Task<bool> ResolveMergedAsync(ReviewedPr pr, CancellationToken cancellationToken)
     {
         if (!_mergeNotesBranchOnClose)
         {
@@ -180,7 +205,7 @@ internal sealed class PrLifecycleSweeper
                 pr.Branch,
                 pr.Provider,
                 pr.PrId);
-            return;
+            return true;
         }
 
         // Layer-2 (design §1): distill durable knowledge from the PR's accumulated notes BEFORE the notes
@@ -213,5 +238,6 @@ internal sealed class PrLifecycleSweeper
             pr.PrId,
             _defaultBranch,
             merged);
+        return merged;
     }
 }

--- a/tests/CodeReviewDaemon.Sample.Tests/Orchestration/PrLifecycleSweeperTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Orchestration/PrLifecycleSweeperTests.cs
@@ -3,6 +3,7 @@ using CodeReviewDaemon.Sample.Orchestration;
 using CodeReviewDaemon.Sample.Persistence.Models;
 using CodeReviewDaemon.Sample.Tests.Infrastructure;
 using CodeReviewDaemon.Sample.Workspace.Git;
+using CodeReviewDaemon.Sample.Workspace.Sandbox;
 using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
 
@@ -224,5 +225,56 @@ public sealed class PrLifecycleSweeperTests : LoggingTestBase
         var commands = runner.Commands.Select(c => string.Join(' ', c.Argv)).ToList();
         commands.Should().Contain(a => a.Contains($"merge --ff-only origin/{pr.Branch}"));
         commands.Should().Contain(a => a.Contains($"push origin {DefaultBranch}"));
+    }
+
+    [Fact]
+    public async Task Sweep_does_not_re_resolve_a_merged_PR_on_a_later_sweep()
+    {
+        var runner = new FakeSandboxCommandRunner();
+        var pr = Pr("42", "review/widgets-42");
+        var lifecycleLookups = 0;
+        var sweeper = CreateSweeper(
+            [pr],
+            (_, _) =>
+            {
+                lifecycleLookups++;
+                return Task.FromResult(PrLifecycle.Merged);
+            },
+            CreateBranchManager(runner),
+            mergeNotesBranchOnClose: true);
+
+        await sweeper.SweepAsync(CancellationToken.None);
+        await sweeper.SweepAsync(CancellationToken.None);
+
+        lifecycleLookups.Should().Be(1, "a merged-and-swept branch is cached, so later sweeps skip it entirely");
+        runner.Commands.Select(c => string.Join(' ', c.Argv))
+            .Count(a => a.Contains($"push origin {DefaultBranch}"))
+            .Should().Be(1, "the notes branch is merged exactly once, not re-merged every poll");
+    }
+
+    [Fact]
+    public async Task Sweep_retries_a_merged_PR_whose_merge_push_failed()
+    {
+        var runner = new FakeSandboxCommandRunner();
+        // The push never succeeds, so MergeToDefaultAsync returns false and the branch is NOT cached as done.
+        runner.OnArgvContains(
+            $"push origin {DefaultBranch}",
+            new SandboxCommandResult(1, string.Empty, "rejected: non-fast-forward"));
+        var pr = Pr("48", "review/widgets-48");
+        var lifecycleLookups = 0;
+        var sweeper = CreateSweeper(
+            [pr],
+            (_, _) =>
+            {
+                lifecycleLookups++;
+                return Task.FromResult(PrLifecycle.Merged);
+            },
+            CreateBranchManager(runner),
+            mergeNotesBranchOnClose: true);
+
+        await sweeper.SweepAsync(CancellationToken.None);
+        await sweeper.SweepAsync(CancellationToken.None);
+
+        lifecycleLookups.Should().Be(2, "a failed merge is not cached, so the next sweep retries it");
     }
 }


### PR DESCRIPTION
## Why

The PR-lifecycle sweep resolves every reviewed PR from the review DB each poll. The DB only grows, so a PR that's already been merged-and-swept (or abandoned-and-deleted) still costs a GitHub lifecycle lookup + a git no-op **every cycle** — visible live as the recurring `merge of notes branch …lmdotnettools-170/-172… into main: True` log lines (idempotent no-ops on branches already merged+deleted), and O(all-PRs-ever-closed) work per sweep.

## What

- `PrLifecycleSweeper` caches branches it has resolved to a terminal state this daemon lifetime and skips them **before** the lifecycle lookup.
- Cached only on *confirmed* terminal resolution: `ResolveMergedAsync` now returns whether the merge actually succeeded, so a failed merge push is **retried** next sweep rather than cached.
- Not persisted — a restart re-confirms each branch once then caches, so it can never wrongly skip a PR whose resolution didn't complete.

## Tests

465 daemon tests green (2 new): resolve-once-then-skip, and retry-when-merge-push-fails. 0 warnings.