### PR TITLE
NotifyMessage: typed out-of-band notifications tied to originating tool calls (#171)

### DIFF
--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/NotificationPill.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/NotificationPill.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import NotificationPill from '@/components/NotificationPill.vue';
+import { type NotifyMessage, type NotificationDisplayData, MessageType } from '@/types';
+
+describe('NotificationPill.vue', () => {
+  it('renders a sub-agent completion notification with kind, source tool and label', () => {
+    const notification: NotificationDisplayData = {
+      notifyKind: 'subagent-completion',
+      sourceToolName: 'Spawn',
+      sourceToolCallId: 'call_7',
+      label: 'build-fixer',
+      detail: 'all green',
+    };
+    const wrapper = mount(NotificationPill, { props: { notification } });
+
+    const pill = wrapper.find('[data-testid="notification-pill"]');
+    expect(pill.exists()).toBe(true);
+    expect(pill.attributes('data-notify-kind')).toBe('subagent-completion');
+    expect(wrapper.find('[data-testid="notification-source"]').text()).toContain('Spawn');
+    expect(wrapper.find('[data-testid="notification-label"]').text()).toContain('build-fixer');
+    // It is NOT rendered as a user/assistant chat bubble.
+    expect(wrapper.find('.markdown-content').exists()).toBe(false);
+  });
+
+  it('renders a legacy context-discovery notification with the file path and truncated badge', () => {
+    const notification: NotificationDisplayData = {
+      notifyKind: 'context-discovery',
+      contextPath: 'AGENTS.md',
+      contextTruncated: true,
+      text: '<context-discovery path="AGENTS.md">…</context-discovery>',
+    };
+    const wrapper = mount(NotificationPill, { props: { notification } });
+
+    const pill = wrapper.find('[data-testid="notification-pill"]');
+    expect(pill.attributes('data-notify-kind')).toBe('context-discovery');
+    expect(wrapper.find('[data-testid="notification-label"]').text()).toContain('AGENTS.md');
+    expect(wrapper.find('[data-testid="notification-truncated"]').exists()).toBe(true);
+  });
+
+  it('accepts a raw NotifyMessage and normalizes its snake_case fields', () => {
+    const message: NotifyMessage = {
+      $type: MessageType.Notify,
+      role: 'user',
+      text: '<notification kind="subagent-completion" label="agent-x">body</notification>',
+      notify_kind: 'subagent-completion',
+      source_tool_name: 'Spawn',
+      label: 'agent-x',
+      detail: 'body',
+    };
+    const wrapper = mount(NotificationPill, { props: { notification: message } });
+
+    const pill = wrapper.find('[data-testid="notification-pill"]');
+    expect(pill.attributes('data-notify-kind')).toBe('subagent-completion');
+    expect(wrapper.find('[data-testid="notification-label"]').text()).toContain('agent-x');
+    expect(wrapper.find('[data-testid="notification-source"]').text()).toContain('Spawn');
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/NotificationPill.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/NotificationPill.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 import NotificationPill from '@/components/NotificationPill.vue';
-import { type NotifyMessage, type NotificationDisplayData, MessageType } from '@/types';
+import { type NotificationDisplayData } from '@/types';
 
 describe('NotificationPill.vue', () => {
   it('renders a sub-agent completion notification with kind, source tool and label', () => {
@@ -36,23 +36,5 @@ describe('NotificationPill.vue', () => {
     expect(pill.attributes('data-notify-kind')).toBe('context-discovery');
     expect(wrapper.find('[data-testid="notification-label"]').text()).toContain('AGENTS.md');
     expect(wrapper.find('[data-testid="notification-truncated"]').exists()).toBe(true);
-  });
-
-  it('accepts a raw NotifyMessage and normalizes its snake_case fields', () => {
-    const message: NotifyMessage = {
-      $type: MessageType.Notify,
-      role: 'user',
-      text: '<notification kind="subagent-completion" label="agent-x">body</notification>',
-      notify_kind: 'subagent-completion',
-      source_tool_name: 'Spawn',
-      label: 'agent-x',
-      detail: 'body',
-    };
-    const wrapper = mount(NotificationPill, { props: { notification: message } });
-
-    const pill = wrapper.find('[data-testid="notification-pill"]');
-    expect(pill.attributes('data-notify-kind')).toBe('subagent-completion');
-    expect(wrapper.find('[data-testid="notification-label"]').text()).toContain('agent-x');
-    expect(wrapper.find('[data-testid="notification-source"]').text()).toContain('Spawn');
   });
 });

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChatNotify.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChatNotify.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useChat } from '@/composables/useChat';
+import { MessageType } from '@/types';
+
+const wsMocks = vi.hoisted(() => ({
+  createWebSocketConnection: vi.fn(),
+  sendWebSocketMessage: vi.fn(),
+  closeWebSocketConnection: vi.fn(),
+}));
+
+vi.mock('@/api/wsClient', () => ({
+  createWebSocketConnection: wsMocks.createWebSocketConnection,
+  sendWebSocketMessage: wsMocks.sendWebSocketMessage,
+  closeWebSocketConnection: wsMocks.closeWebSocketConnection,
+}));
+
+const conversationsMocks = vi.hoisted(() => ({
+  loadConversationMessages: vi.fn(),
+}));
+
+vi.mock('@/api/conversationsApi', () => ({
+  loadConversationMessages: conversationsMocks.loadConversationMessages,
+}));
+
+// A live NotifyMessage as it arrives on the WebSocket (normalized through IMessageJsonConverter →
+// $type present, snake_case structured fields, camelCase identity fields, Role.User).
+function notify(overrides: Record<string, unknown> = {}) {
+  return {
+    $type: MessageType.Notify,
+    role: 'user',
+    text: '<notification kind="subagent-completion" in-response-to="Spawn:call_7" label="build-fixer">\ndone\n</notification>',
+    notify_kind: 'subagent-completion',
+    source_tool_name: 'Spawn',
+    source_tool_call_id: 'call_7',
+    label: 'build-fixer',
+    detail: 'done',
+    runId: 'run-1',
+    generationId: 'notify:0',
+    threadId: 'thread-1',
+    messageOrderIdx: 0,
+    ...overrides,
+  };
+}
+
+// A persisted NotifyMessage row as the conversation store serves it (messageJson carries $type via
+// the controller's IMessageJsonConverter normalization; identity fields also live on the row).
+function persistedNotify(id: string, timestamp: number, generationId: string, label: string) {
+  return {
+    id,
+    threadId: 'thread-x',
+    runId: 'run-1',
+    generationId,
+    messageOrderIdx: 0,
+    timestamp,
+    messageType: 'notify',
+    role: 'user',
+    messageJson: JSON.stringify({
+      $type: MessageType.Notify,
+      role: 'user',
+      text: `<notification kind="subagent-completion" label="${label}">\ndone\n</notification>`,
+      notify_kind: 'subagent-completion',
+      source_tool_name: 'Spawn',
+      label,
+      detail: 'done',
+      generationId,
+    }),
+  };
+}
+
+describe('useChat NotifyMessage (out-of-band notification pill)', () => {
+  beforeEach(() => {
+    wsMocks.createWebSocketConnection.mockReset();
+    wsMocks.sendWebSocketMessage.mockReset();
+    wsMocks.closeWebSocketConnection.mockReset();
+    conversationsMocks.loadConversationMessages.mockReset();
+
+    wsMocks.createWebSocketConnection.mockImplementation(async (options: any) => ({
+      socket: { readyState: 1 },
+      connectionId: `ws-${Date.now()}`,
+      threadId: options.threadId,
+      isConnected: true,
+    }));
+  });
+
+  // handleMessage must NOT drop a NotifyMessage as "unknown message type", and displayItems must
+  // route it through the notification branch that PRECEDES the `role === 'user'` catch-all — so it
+  // renders as a pill, never a user bubble, even though it maps to Role.User.
+  it('routes a NotifyMessage to a notification item, not a user bubble', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    await chat.sendMessage('hello there');
+    const options = wsMocks.createWebSocketConnection.mock.calls[0]?.[0];
+    expect(options).toBeDefined();
+
+    // Activate the pending user message so a genuine user bubble coexists with the notification.
+    options.onMessage({
+      $type: MessageType.RunAssignment,
+      role: 'assistant',
+      Assignment: { runId: 'run-1', inputIds: ['input-1'], generationId: 'gen-1' },
+    });
+
+    options.onMessage(notify({ generationId: 'notify:1' }));
+
+    const items = chat.displayItems.value;
+    const notifications = items.filter((i) => i.type === 'notification');
+    const users = items.filter((i) => i.type === 'user-message');
+
+    expect(notifications, 'the notification is added, not dropped').toHaveLength(1);
+    expect(users, 'the real user message is unaffected').toHaveLength(1);
+    // The notification content never leaked into a user bubble.
+    expect((users[0] as { content: { text?: string } }).content.text).toBe('hello there');
+    expect(
+      (notifications[0] as { notification: { notifyKind: string } }).notification.notifyKind
+    ).toBe('subagent-completion');
+  });
+
+  // Two notifications in one run share runId + messageOrderIdx (both 0) and differ only by the
+  // distinct 'notify:<guid>' generationId. They must render as TWO distinct pills in arrival order —
+  // no collision onto a single merge key.
+  it('renders two notifications in one run as two distinct items, in order (live)', async () => {
+    const chat = useChat({ getModeId: () => 'default' });
+    await chat.sendMessage('go');
+    const options = wsMocks.createWebSocketConnection.mock.calls[0]?.[0];
+    expect(options).toBeDefined();
+
+    options.onMessage(notify({ generationId: 'notify:1', label: 'first' }));
+    options.onMessage(notify({ generationId: 'notify:2', label: 'second' }));
+
+    const notifications = chat.displayItems.value.filter((i) => i.type === 'notification');
+    expect(notifications).toHaveLength(2);
+    expect(
+      notifications.map((i) => (i as { notification: { label?: string | null } }).notification.label)
+    ).toEqual(['first', 'second']);
+  });
+
+  it('renders two notifications in one run as two distinct items, in order (after reload)', async () => {
+    conversationsMocks.loadConversationMessages.mockResolvedValue([
+      persistedNotify('n1', 1000, 'notify:1', 'first'),
+      persistedNotify('n2', 1001, 'notify:2', 'second'),
+    ]);
+
+    const chat = useChat({ getModeId: () => 'default' });
+    await chat.loadMessagesFromBackend('thread-x');
+
+    const items = chat.displayItems.value;
+    const notifications = items.filter((i) => i.type === 'notification');
+    const users = items.filter((i) => i.type === 'user-message');
+
+    expect(notifications, 'both reloaded notifications survive').toHaveLength(2);
+    expect(users, 'a reloaded notify (Role.User) must not render as a user bubble').toHaveLength(0);
+    expect(
+      notifications.map((i) => (i as { notification: { label?: string | null } }).notification.label)
+    ).toEqual(['first', 'second']);
+  });
+
+  // Back-compat: a conversation persisted BEFORE the migration carried the context file as a
+  // Role.User TextMessage with a flattened `context_discovery` marker. Reloading it must render one
+  // unified context pill through the SAME notification branch — no duplicate, no user bubble.
+  it('renders a legacy context_discovery TextMessage as a single context pill (no user bubble)', async () => {
+    conversationsMocks.loadConversationMessages.mockResolvedValue([
+      {
+        id: 'c1',
+        threadId: 'thread-x',
+        runId: 'run-1',
+        generationId: 'gen-1',
+        messageOrderIdx: 0,
+        timestamp: 1000,
+        messageType: 'text',
+        role: 'user',
+        messageJson: JSON.stringify({
+          $type: MessageType.Text,
+          role: 'user',
+          text: '<context-discovery path="CLAUDE.md">…body…</context-discovery>',
+          context_discovery: { path: 'CLAUDE.md', truncated: true },
+        }),
+      },
+    ]);
+
+    const chat = useChat({ getModeId: () => 'default' });
+    await chat.loadMessagesFromBackend('thread-x');
+
+    const items = chat.displayItems.value;
+    const notifications = items.filter((i) => i.type === 'notification');
+    const users = items.filter((i) => i.type === 'user-message');
+
+    expect(notifications, 'exactly one unified context pill').toHaveLength(1);
+    expect(users, 'the legacy context message must not render as a user bubble').toHaveLength(0);
+    const data = (notifications[0] as {
+      notification: { notifyKind: string; contextPath?: string | null; contextTruncated?: boolean };
+    }).notification;
+    expect(data.notifyKind).toBe('context-discovery');
+    expect(data.contextPath).toBe('CLAUDE.md');
+    expect(data.contextTruncated).toBe(true);
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/components/MessageList.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/MessageList.vue
@@ -274,6 +274,12 @@ watch(
                 <!-- Assistant message with pill -->
                 <MetadataPill v-else-if="item.type === 'pill'" :items="item.items" />
 
+                <!-- Out-of-band notification (sub-agent completion, context discovery, ...) -->
+                <NotificationPill
+                  v-else-if="item.type === 'notification'"
+                  :notification="item.notification"
+                />
+
                 <!-- Assistant text message -->
                 <div v-else-if="item.type === 'assistant-message'" class="text-bubble" data-testid="assistant-text">
                   <TextMessage :message="item.content" :is-streaming="false" />

--- a/samples/LmStreaming.Sample/ClientApp/src/components/MessageList.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/MessageList.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch, nextTick, onMounted, onUnmounted } from 'vue';
 import type { DisplayItem } from '@/types';
 import TextMessage from './TextMessage.vue';
 import MetadataPill from './MetadataPill.vue';
+import NotificationPill from './NotificationPill.vue';
 import PendingMessage from './PendingMessage.vue';
 import AssistantTypingIndicator from './AssistantTypingIndicator.vue';
 import { logger } from '@/utils/logger';
@@ -221,6 +222,12 @@ watch(
               
               <!-- Assistant message with pill -->
               <MetadataPill v-else-if="item.type === 'pill'" :items="item.items" />
+
+              <!-- Out-of-band notification (sub-agent completion, context discovery, ...) -->
+              <NotificationPill
+                v-else-if="item.type === 'notification'"
+                :notification="item.notification"
+              />
 
               <!-- Assistant text message -->
               <div v-else-if="item.type === 'assistant-message'" class="text-bubble" data-testid="assistant-text">

--- a/samples/LmStreaming.Sample/ClientApp/src/components/NotificationPill.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/NotificationPill.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { NotificationDisplayData, NotifyMessage } from '@/types';
+
+/**
+ * Presentational pill for an out-of-band notification (async sub-agent completion, sandbox
+ * context-discovery, monitors, timers). Distinct from a user bubble. Accepts either the normalized
+ * {@link NotificationDisplayData} that `displayItems` produces, or a raw {@link NotifyMessage}
+ * (normalized here) so callers/tests can pass whichever they hold.
+ */
+const props = defineProps<{
+  notification: NotificationDisplayData | NotifyMessage;
+}>();
+
+/** Normalize the prop to a single shape regardless of whether a raw NotifyMessage was passed. */
+const data = computed<NotificationDisplayData>(() => {
+  const n = props.notification;
+  // Only a raw NotifyMessage carries `$type`; NotificationDisplayData never does.
+  if ('$type' in n) {
+    return {
+      notifyKind: n.notify_kind,
+      label: n.label,
+      sourceToolName: n.source_tool_name,
+      sourceToolCallId: n.source_tool_call_id,
+      detail: n.detail,
+      text: n.text,
+    };
+  }
+  return n;
+});
+
+/** Icon per well-known kind; a bell is the generic fallback for future kinds. */
+const icon = computed<string>(() => {
+  switch (data.value.notifyKind) {
+    case 'context-discovery':
+      return '\u{1F4C4}'; // 📄
+    case 'subagent-completion':
+      return '\u{1F916}'; // 🤖
+    default:
+      return '\u{1F514}'; // 🔔
+  }
+});
+
+/** Human-friendly heading per well-known kind; unknown kinds show the raw kind string. */
+const kindLabel = computed<string>(() => {
+  switch (data.value.notifyKind) {
+    case 'context-discovery':
+      return 'Context loaded';
+    case 'subagent-completion':
+      return 'Sub-agent completed';
+    default:
+      return data.value.notifyKind;
+  }
+});
+
+/** The primary label shown on the header: the file path for context, else the notification label. */
+const primaryLabel = computed<string | null>(() => {
+  if (data.value.notifyKind === 'context-discovery') {
+    return data.value.contextPath ?? null;
+  }
+  return data.value.label ?? null;
+});
+
+/** Expandable body: the pre-rendered detail if present, otherwise the full envelope text. */
+const bodyText = computed<string | null>(() => data.value.detail ?? data.value.text ?? null);
+const hasBody = computed<boolean>(() => !!bodyText.value && bodyText.value.trim().length > 0);
+
+const expanded = ref(false);
+function toggle(): void {
+  if (hasBody.value) {
+    expanded.value = !expanded.value;
+  }
+}
+</script>
+
+<template>
+  <div
+    class="notification-pill"
+    data-testid="notification-pill"
+    :data-notify-kind="data.notifyKind"
+  >
+    <div
+      class="notification-header"
+      :class="{ clickable: hasBody }"
+      @click="toggle"
+    >
+      <span class="notification-icon" aria-hidden="true">{{ icon }}</span>
+      <span class="notification-kind">{{ kindLabel }}</span>
+      <span
+        v-if="data.sourceToolName"
+        class="notification-source"
+        data-testid="notification-source"
+      >&larr; {{ data.sourceToolName }}</span>
+      <span
+        v-if="primaryLabel"
+        class="notification-label"
+        data-testid="notification-label"
+      >{{ primaryLabel }}</span>
+      <span
+        v-if="data.contextTruncated"
+        class="notification-truncated"
+        data-testid="notification-truncated"
+      >(truncated)</span>
+      <span v-if="hasBody" class="notification-expand" aria-hidden="true">{{ expanded ? '▼' : '▶' }}</span>
+    </div>
+    <pre v-if="expanded && hasBody" class="notification-body" data-testid="notification-body">{{ bodyText }}</pre>
+  </div>
+</template>
+
+<style scoped>
+.notification-pill {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 6px;
+  max-width: 100%;
+  padding: 6px 10px;
+  background: #eef2ff;
+  border: 1px solid #c7d2fe;
+  border-radius: 12px;
+  color: #3730a3;
+  font-size: 13px;
+}
+
+.notification-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  user-select: none;
+}
+
+.notification-header.clickable {
+  cursor: pointer;
+}
+
+.notification-icon {
+  font-size: 15px;
+  flex-shrink: 0;
+}
+
+.notification-kind {
+  font-weight: 600;
+}
+
+.notification-source {
+  color: #4f46e5;
+  font-family: monospace;
+  font-size: 12px;
+}
+
+.notification-label {
+  font-family: monospace;
+  color: #4338ca;
+}
+
+.notification-truncated {
+  color: #9a3412;
+  font-size: 12px;
+}
+
+.notification-expand {
+  color: #6366f1;
+  font-size: 10px;
+  margin-left: auto;
+}
+
+.notification-body {
+  margin: 0;
+  padding: 8px;
+  background: #ffffff;
+  border: 1px solid #e0e7ff;
+  border-radius: 6px;
+  font-size: 12px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-x: auto;
+  color: #1e1b4b;
+}
+</style>

--- a/samples/LmStreaming.Sample/ClientApp/src/components/NotificationPill.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/NotificationPill.vue
@@ -1,33 +1,18 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
-import type { NotificationDisplayData, NotifyMessage } from '@/types';
+import { computed, ref, toRef } from 'vue';
+import type { NotificationDisplayData } from '@/types';
 
 /**
  * Presentational pill for an out-of-band notification (async sub-agent completion, sandbox
- * context-discovery, monitors, timers). Distinct from a user bubble. Accepts either the normalized
- * {@link NotificationDisplayData} that `displayItems` produces, or a raw {@link NotifyMessage}
- * (normalized here) so callers/tests can pass whichever they hold.
+ * context-discovery, monitors, timers). Distinct from a user bubble. Takes the normalized
+ * {@link NotificationDisplayData} that `useChat`'s `displayItems` produces — the single normalization
+ * site for both new NotifyMessages and legacy context_discovery rows.
  */
 const props = defineProps<{
-  notification: NotificationDisplayData | NotifyMessage;
+  notification: NotificationDisplayData;
 }>();
 
-/** Normalize the prop to a single shape regardless of whether a raw NotifyMessage was passed. */
-const data = computed<NotificationDisplayData>(() => {
-  const n = props.notification;
-  // Only a raw NotifyMessage carries `$type`; NotificationDisplayData never does.
-  if ('$type' in n) {
-    return {
-      notifyKind: n.notify_kind,
-      label: n.label,
-      sourceToolName: n.source_tool_name,
-      sourceToolCallId: n.source_tool_call_id,
-      detail: n.detail,
-      text: n.text,
-    };
-  }
-  return n;
-});
+const data = toRef(props, 'notification');
 
 /** Icon per well-known kind; a bell is the generic fallback for future kinds. */
 const icon = computed<string>(() => {

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -5,10 +5,12 @@ import type {
   UsageMessage,
   ToolCallResultMessage,
   DisplayItem,
+  NotificationDisplayData,
   MessageStatus,
   ReasoningMessage,
   ToolsCallMessage,
   ToolCallMessage,
+  NotifyMessage,
   AuthEvent,
   AuthRequiredEvent,
 } from '@/types';
@@ -29,6 +31,7 @@ import {
   isServerToolUseMessage,
   isServerToolResultMessage,
   isTextWithCitationsMessage,
+  isNotifyMessage,
   normalizeReasoningVisibility,
 } from '@/types';
 import { sendChatMessage } from '@/api/chatClient';
@@ -97,6 +100,15 @@ function getMergeKey(msg: Message, turnSeq = 0): string {
   const messageOrderIdx = msg.messageOrderIdx ?? 0;
   const mergeKind = getMergeKind(msg);
 
+  // A notification carries a distinct generationId ('notify:<guid>' stamped by the backend on the
+  // ONE message object), so two notifications in one run never collide on the shared
+  // runId/messageOrderIdx (both 0), and the live-published copy merges with its reload-parsed twin
+  // (same generationId). Keyed explicitly so a null/missing messageOrderIdx can't fold two distinct
+  // notifications onto one pill.
+  if (isNotifyMessage(msg)) {
+    return `${mergeKind}-${runId}-${generationId}-${messageOrderIdx}`;
+  }
+
   // Individual tool calls — streaming OR finalized — are keyed by tool_call_id. Several concurrent
   // tool calls in one turn share runId/generationId/messageOrderIdx and differ only by tool_call_id
   // (e.g. GPT-5.5 via the OpenAI Responses API); without it they collapse into a single pill.
@@ -131,12 +143,29 @@ function getMergeKey(msg: Message, turnSeq = 0): string {
   return `${mergeKind}-${runId}-${generationId}-${messageOrderIdx}`;
 }
 
-function getMergeKind(msg: Message): 'text' | 'reasoning' | 'tools' | 'tool' | 'other' {
+function getMergeKind(msg: Message): 'text' | 'reasoning' | 'tools' | 'tool' | 'notify' | 'other' {
+  if (isNotifyMessage(msg)) return 'notify';
   if (isTextMessage(msg) || isTextUpdateMessage(msg)) return 'text';
   if (isReasoningMessage(msg) || isReasoningUpdateMessage(msg)) return 'reasoning';
   if (isToolsCallMessage(msg) || isToolsCallUpdateMessage(msg)) return 'tools';
   if (isToolCallMessage(msg) || isToolCallUpdateMessage(msg)) return 'tool';
   return 'other';
+}
+
+/**
+ * Normalize a NotifyMessage into the shape the notification pill renders. Producing the pill data
+ * here (rather than passing the raw message) lets the legacy `context_discovery` TextMessage path
+ * feed the SAME pill via a hand-built {@link NotificationDisplayData}.
+ */
+function notifyToDisplayData(msg: NotifyMessage): NotificationDisplayData {
+  return {
+    notifyKind: msg.notify_kind,
+    label: msg.label,
+    sourceToolName: msg.source_tool_name,
+    sourceToolCallId: msg.source_tool_call_id,
+    detail: msg.detail,
+    text: msg.text,
+  };
 }
 
 /**
@@ -329,7 +358,34 @@ export function useChat(options: UseChatOptions = {}) {
     }
 
     for (const msg of sortedMessages) {
-      if (msg.role === 'user') {
+      const content = msg.content;
+      // Out-of-band notifications render as a distinct pill, NEVER a user bubble — so this branch
+      // must precede the `role === 'user'` catch-all (a NotifyMessage maps to Role.User, and a
+      // reload-parsed one is tagged role 'user'). The legacy pre-migration path — a context_discovery
+      // marker flattened onto a Role.User TextMessage — is folded into the SAME branch so already
+      // persisted rows render one unified context pill (no duplicate, no user bubble) too.
+      if (isNotifyMessage(content)) {
+        flushPill();
+        items.push({
+          type: 'notification',
+          id: msg.id,
+          notification: notifyToDisplayData(content),
+          runId: msg.runId,
+        });
+      } else if (isTextMessage(content) && content.context_discovery != null) {
+        flushPill();
+        items.push({
+          type: 'notification',
+          id: msg.id,
+          notification: {
+            notifyKind: 'context-discovery',
+            contextPath: content.context_discovery.path,
+            contextTruncated: content.context_discovery.truncated,
+            text: content.text,
+          },
+          runId: msg.runId,
+        });
+      } else if (msg.role === 'user') {
         flushPill();
         items.push({
           type: 'user-message',
@@ -772,8 +828,10 @@ export function useChat(options: UseChatOptions = {}) {
     const isUpdate = isTextUpdateMessage(msg) || isReasoningUpdateMessage(msg) ||
                      isToolsCallUpdateMessage(msg) || isToolCallUpdateMessage(msg);
 
-    // Determine if this is a complete (non-update) content message
-    const isCompleteMessage = isTextMessage(msg) || isReasoningMessage(msg) || isToolsCallMessage(msg) || isToolCallMessage(msg);
+    // Determine if this is a complete (non-update) content message. A NotifyMessage is a terminal,
+    // non-streamed message (out-of-band notification) — routed here so it is NOT dropped as an
+    // "unknown message type"; the displayItems notification branch renders it as a pill.
+    const isCompleteMessage = isTextMessage(msg) || isReasoningMessage(msg) || isToolsCallMessage(msg) || isToolCallMessage(msg) || isNotifyMessage(msg);
 
     if (!isUpdate && !isCompleteMessage) {
       // Unknown message type - skip

--- a/samples/LmStreaming.Sample/ClientApp/src/types/messages.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/types/messages.ts
@@ -22,6 +22,8 @@ export const MessageType = {
   ServerToolUse: 'server_tool_use',
   ServerToolResult: 'server_tool_result',
   TextWithCitations: 'text_with_citations',
+  // Out-of-band notification (async sub-agent completion, context discovery, monitors, timers)
+  Notify: 'notify',
 } as const;
 
 export type MessageTypeValue = (typeof MessageType)[keyof typeof MessageType];
@@ -338,6 +340,50 @@ export interface TextWithCitationsMessage extends IMessage {
 }
 
 /**
+ * NotifyMessage matching C# NotifyMessage.cs.
+ *
+ * An out-of-band notification pushed into a running conversation from an asynchronous source
+ * (async sub-agent completion, context discovery, monitors, timers/cron). It maps to a user-role
+ * message for the LLM whose {@link text} is a self-describing envelope naming the originating tool
+ * call, but renders as a distinct notification pill in the UI (never a user bubble). The structured
+ * fields carry snake_case wire names (matching the C# `[JsonPropertyName]` attributes) so the client
+ * can render the pill without parsing the envelope text.
+ */
+export interface NotifyMessage extends IMessage {
+  $type: typeof MessageType.Notify;
+  /** The rendered envelope the LLM reads (computed on the backend from the structured fields). */
+  text: string;
+  /** Discriminating kind of notification, e.g. 'subagent-completion' | 'context-discovery'. */
+  notify_kind: string;
+  /** Id of the tool call this notification responds to, if any (omitted for timer/cron/context). */
+  source_tool_call_id?: string | null;
+  /** Name of the tool call this notification responds to, if any. */
+  source_tool_name?: string | null;
+  /** Short human/UI label (e.g. sub-agent template name, discovered file path). */
+  label?: string | null;
+  /** Pre-rendered payload body dropped verbatim into the envelope. Opaque — do not parse. */
+  detail?: string | null;
+}
+
+/**
+ * Normalized data driving the notification pill. `displayItems` produces this from either a
+ * {@link NotifyMessage} or a legacy `context_discovery` {@link TextMessage} so both render through the
+ * one unified pill.
+ */
+export interface NotificationDisplayData {
+  notifyKind: string;
+  label?: string | null;
+  sourceToolName?: string | null;
+  sourceToolCallId?: string | null;
+  detail?: string | null;
+  text?: string | null;
+  /** Legacy sandbox context-discovery file path (mirrors TextMessage.context_discovery.path). */
+  contextPath?: string | null;
+  /** Legacy sandbox context-discovery truncation flag. */
+  contextTruncated?: boolean;
+}
+
+/**
  * Union type for all message types
  */
 export type Message =
@@ -357,7 +403,8 @@ export type Message =
   | RunCompletedMessage
   | ServerToolUseMessage
   | ServerToolResultMessage
-  | TextWithCitationsMessage;
+  | TextWithCitationsMessage
+  | NotifyMessage;
 
 // Type guard functions
 
@@ -433,6 +480,10 @@ export function isTextWithCitationsMessage(msg: IMessage): msg is TextWithCitati
   return msg.$type === MessageType.TextWithCitations;
 }
 
+export function isNotifyMessage(msg: IMessage): msg is NotifyMessage {
+  return msg.$type === MessageType.Notify;
+}
+
 /**
  * Check if a message is a streaming update (not final)
  */
@@ -458,7 +509,8 @@ export function isLifecycleMessage(msg: IMessage): boolean {
 export type DisplayItem =
   | { type: 'user-message'; id: string; content: TextMessage; status: 'pending' | 'active' | 'completed'; timestamp: number }
   | { type: 'assistant-message'; id: string; content: TextMessage; runId?: string | null; parentRunId?: string | null; messageOrderIdx?: number | null }
-  | { type: 'pill'; id: string; items: Array<ReasoningMessage | ToolsCallMessage>; runId?: string | null; parentRunId?: string | null; messageOrderIdx?: number | null };
+  | { type: 'pill'; id: string; items: Array<ReasoningMessage | ToolsCallMessage>; runId?: string | null; parentRunId?: string | null; messageOrderIdx?: number | null }
+  | { type: 'notification'; id: string; notification: NotificationDisplayData; runId?: string | null };
 
 /**
  * Status for tracking message lifecycle

--- a/src/AnthropicProvider/Models/AnthropicRequest.cs
+++ b/src/AnthropicProvider/Models/AnthropicRequest.cs
@@ -372,6 +372,12 @@ public record AnthropicRequest
         {
             anthropicMessage.Content.Add(new AnthropicContent { Type = "text", Text = txtMsg.Text });
         }
+        else if (message is NotifyMessage notifyMsg)
+        {
+            // Out-of-band notification: its self-describing envelope is delivered to the model as user
+            // text (NotifyMessage is Role.User, so the caller maps this message to a user turn).
+            anthropicMessage.Content.Add(new AnthropicContent { Type = "text", Text = notifyMsg.Text });
+        }
         else if (message is ImageMessage imageMsg)
         {
             anthropicMessage.Content.Add(new AnthropicContent

--- a/src/LmAgentInfra/Context/ContextDiscoveryInjector.cs
+++ b/src/LmAgentInfra/Context/ContextDiscoveryInjector.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmAgentInfra.Agents;
 using AchieveAi.LmDotnetTools.LmAgentInfra.Sandbox;
@@ -102,7 +101,6 @@ public sealed class ContextDiscoveryInjector
 
         var truncated = body.Truncated ?? false;
         var text = _formatter.BuildInjectedMessage(body.Path!, body.Content!, truncated);
-        var metadata = BuildMetadata(body.Path!, truncated);
 
         var injected = 0;
         foreach (var threadId in threads)
@@ -116,12 +114,12 @@ public sealed class ContextDiscoveryInjector
 
             try
             {
-                var message = new TextMessage
-                {
-                    Role = Role.User,
-                    Text = text,
-                    Metadata = metadata,
-                };
+                // Emit a typed notification (kind=context-discovery). The formatted file body stays in
+                // Detail so it still reaches the LLM (via ICanGetText), and the UI renders it as a pill.
+                var message = NotifyMessage.Create(
+                    NotifyKinds.ContextDiscovery,
+                    detail: text,
+                    label: body.Path);
 
                 _ = await agent.SendAsync([message], inputId: null, parentRunId: null, ct).ConfigureAwait(false);
                 injected++;
@@ -147,17 +145,5 @@ public sealed class ContextDiscoveryInjector
             body.SessionId);
 
         return injected;
-    }
-
-    private static ImmutableDictionary<string, object> BuildMetadata(string path, bool truncated)
-    {
-        // The UI reads this key off TextMessage.Metadata; ShadowPropertiesJsonConverter flattens
-        // it to a top-level field on the serialised message so the Vue client sees it as
-        // `message.context_discovery` without any extra middleware.
-        var contextDiscovery = ImmutableDictionary<string, object>.Empty
-            .Add("path", path)
-            .Add("truncated", truncated);
-
-        return ImmutableDictionary<string, object>.Empty.Add(MetadataKey, contextDiscovery);
     }
 }

--- a/src/LmAgentInfra/Context/ContextDiscoveryInjector.cs
+++ b/src/LmAgentInfra/Context/ContextDiscoveryInjector.cs
@@ -7,8 +7,9 @@ namespace AchieveAi.LmDotnetTools.LmAgentInfra.Context;
 /// <summary>
 /// Routes a <c>context_file</c> discovery from the gateway webhook into every live agent thread
 /// bound to the same sandbox session: looks up the thread set, dedups gateway retries, and
-/// enqueues a user-role <see cref="TextMessage"/> carrying the formatted file body plus a
-/// <c>context_discovery</c> metadata key the chat UI uses to render a pill.
+/// enqueues a <see cref="NotifyMessage"/> (kind <c>context-discovery</c>) carrying the formatted
+/// file body — delivered to the model via <c>ICanGetText</c> and rendered as a distinct pill by the
+/// chat UI.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -26,9 +27,10 @@ namespace AchieveAi.LmDotnetTools.LmAgentInfra.Context;
 public sealed class ContextDiscoveryInjector
 {
     /// <summary>
-    /// Metadata key set on the injected <see cref="TextMessage"/>. The chat UI looks this key up
-    /// under <see cref="TextMessage.Metadata"/> to render a "Context loaded" pill — the value is
-    /// the metadata object the renderer reads (path, host_path, truncated).
+    /// Legacy metadata key. New discoveries are emitted as a <see cref="NotifyMessage"/> and no longer
+    /// set this key; it is retained because pre-migration conversations persisted it on a
+    /// <see cref="TextMessage"/>, and the chat UI still reads it to render those historical rows as a
+    /// context pill.
     /// </summary>
     public const string MetadataKey = "context_discovery";
 

--- a/src/LmCore/Messages/NotifyMessage.cs
+++ b/src/LmCore/Messages/NotifyMessage.cs
@@ -74,12 +74,16 @@ public record NotifyMessage : IMessage, ICanGetText
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Detail { get; init; }
 
+    private string? _cachedText;
+
     /// <summary>
-    ///     The self-describing envelope the LLM reads. Computed from the structured fields — never set
-    ///     directly, so it cannot drift from them.
+    ///     The self-describing envelope the LLM reads. Computed once from the structured fields (all
+    ///     <c>init</c>-only, so the value is immutable) and cached — a <see cref="NotifyMessage" /> lives in
+    ///     history and is re-mapped by the active provider on every subsequent turn, so this avoids
+    ///     rebuilding the envelope each access. Never set directly, so it cannot drift from the fields.
     /// </summary>
     [JsonPropertyName("text")]
-    public string Text => BuildEnvelope(NotifyKind, SourceToolName, SourceToolCallId, Label, Detail);
+    public string Text => _cachedText ??= BuildEnvelope(NotifyKind, SourceToolName, SourceToolCallId, Label, Detail);
 
     /// <inheritdoc />
     public string? GetText()
@@ -214,6 +218,12 @@ public class NotifyMessageJsonConverter : ShadowPropertiesJsonConverter<NotifyMe
 {
     protected override NotifyMessage CreateInstance()
     {
+        // NotifyKind is required (see Create), but the converter fills it from the wire's notify_kind.
+        // A hand-crafted/corrupt $type:"notify" payload with the field missing would deserialize to an
+        // empty kind rather than throwing. We deliberately do NOT throw here: this converter also runs on
+        // the unguarded history-rehydration path, so a hard failure would brick recovery of an entire
+        // conversation over one bad row. The gap is unreachable via our own serializer (Create always sets
+        // the field, and structural inference requires notify_kind to route here at all).
         return new NotifyMessage { NotifyKind = string.Empty };
     }
 }

--- a/src/LmCore/Messages/NotifyMessage.cs
+++ b/src/LmCore/Messages/NotifyMessage.cs
@@ -1,0 +1,219 @@
+using System.Collections.Immutable;
+using System.Text;
+using System.Text.Json.Serialization;
+using AchieveAi.LmDotnetTools.LmCore.Utils;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Messages;
+
+/// <summary>
+///     Well-known <see cref="NotifyMessage.NotifyKind" /> values. This is an <b>open</b> set — additional
+///     kinds (monitor/bash/timer/cron) are introduced by their producing features without changing LmCore.
+/// </summary>
+public static class NotifyKinds
+{
+    /// <summary>A background sub-agent finished and reported its result to the parent.</summary>
+    public const string SubAgentCompletion = "subagent-completion";
+
+    /// <summary>A context file discovered by the sandbox was injected into the conversation.</summary>
+    public const string ContextDiscovery = "context-discovery";
+}
+
+/// <summary>
+///     An out-of-band notification pushed into a running conversation from an asynchronous source
+///     (async sub-agent completion, monitors, async bash, timers/cron). It is delivered like any other
+///     input — injected into the next turn when a run is in progress, or starting a turn when the agent
+///     is idle — maps to a <see cref="Role.User" /> message for the LLM whose content is a self-describing
+///     envelope naming the originating tool call, and renders as a distinct notification pill (not a user
+///     bubble) in the UI.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <see cref="Text" /> is a computed projection of the structured fields via the envelope builder,
+///         so the envelope shown to the LLM and the structured fields read by the UI can never desync. The
+///         <see cref="ShadowPropertiesJsonConverter{T}" /> writes the computed value and skips it on read
+///         (get-only), recomputing from the fields — a lossless round-trip.
+///     </para>
+///     <para>
+///         <see cref="Detail" /> is dropped verbatim into the envelope body and is treated as opaque —
+///         consumers must not parse it. The only structured fields the UI/observers should key on are
+///         <see cref="NotifyKind" />, <see cref="SourceToolName" />, <see cref="SourceToolCallId" /> and
+///         <see cref="Label" />.
+///     </para>
+/// </remarks>
+[JsonConverter(typeof(NotifyMessageJsonConverter))]
+public record NotifyMessage : IMessage, ICanGetText
+{
+    /// <summary>
+    ///     Discriminating kind of notification (see <see cref="NotifyKinds" />). Required — a notification
+    ///     without a kind is not a valid <see cref="NotifyMessage" />; the serializer keys structural
+    ///     inference on this field.
+    /// </summary>
+    [JsonPropertyName("notify_kind")]
+    public required string NotifyKind { get; init; }
+
+    /// <summary>
+    ///     Id of the tool call this notification responds to, if any. Null for sources with no originating
+    ///     tool call (timer/cron/context-discovery); the envelope then omits <c>in-response-to</c>.
+    /// </summary>
+    [JsonPropertyName("source_tool_call_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SourceToolCallId { get; init; }
+
+    /// <summary>Name of the tool call this notification responds to, if any.</summary>
+    [JsonPropertyName("source_tool_name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SourceToolName { get; init; }
+
+    /// <summary>Short human/UI label (e.g. sub-agent template name, discovered file path).</summary>
+    [JsonPropertyName("label")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Label { get; init; }
+
+    /// <summary>Pre-rendered payload body dropped verbatim into the envelope. Opaque — do not parse.</summary>
+    [JsonPropertyName("detail")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Detail { get; init; }
+
+    /// <summary>
+    ///     The self-describing envelope the LLM reads. Computed from the structured fields — never set
+    ///     directly, so it cannot drift from them.
+    /// </summary>
+    [JsonPropertyName("text")]
+    public string Text => BuildEnvelope(NotifyKind, SourceToolName, SourceToolCallId, Label, Detail);
+
+    /// <inheritdoc />
+    public string? GetText()
+    {
+        return Text;
+    }
+
+    [JsonPropertyName("role")]
+    public Role Role { get; init; } = Role.User;
+
+    [JsonPropertyName("fromAgent")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? FromAgent { get; init; }
+
+    [JsonIgnore]
+    public ImmutableDictionary<string, object>? Metadata { get; init; }
+
+    [JsonPropertyName("generationId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? GenerationId { get; init; }
+
+    [JsonPropertyName("threadId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ThreadId { get; init; }
+
+    [JsonPropertyName("runId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? RunId { get; init; }
+
+    [JsonPropertyName("parentRunId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ParentRunId { get; init; }
+
+    [JsonPropertyName("messageOrderIdx")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MessageOrderIdx { get; init; }
+
+    /// <summary>
+    ///     Creates a notification and stamps a unique <see cref="GenerationId" /> so that multiple
+    ///     notifications within a single run keep distinct client merge keys. Tests may pass an explicit
+    ///     <paramref name="generationId" /> for determinism.
+    /// </summary>
+    public static NotifyMessage Create(
+        string notifyKind,
+        string? detail = null,
+        string? sourceToolName = null,
+        string? sourceToolCallId = null,
+        string? label = null,
+        string? generationId = null,
+        Role role = Role.User
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(notifyKind);
+
+        return new NotifyMessage
+        {
+            NotifyKind = notifyKind,
+            Detail = detail,
+            SourceToolName = sourceToolName,
+            SourceToolCallId = sourceToolCallId,
+            Label = label,
+            Role = role,
+            GenerationId = generationId ?? $"notify:{Guid.NewGuid():N}",
+        };
+    }
+
+    /// <summary>
+    ///     Builds the self-describing envelope. The <c>in-response-to</c> attribute is omitted when there is
+    ///     no originating tool call. Attribute values are XML-escaped and the payload body is sanitized so a
+    ///     hostile payload cannot break out of / close the envelope early.
+    /// </summary>
+    private static string BuildEnvelope(
+        string kind,
+        string? sourceToolName,
+        string? sourceToolCallId,
+        string? label,
+        string? detail
+    )
+    {
+        var sb = new StringBuilder();
+        _ = sb.Append("<notification kind=\"").Append(EscapeAttribute(kind)).Append('"');
+
+        if (!string.IsNullOrEmpty(sourceToolCallId))
+        {
+            var target = string.IsNullOrEmpty(sourceToolName)
+                ? sourceToolCallId
+                : $"{sourceToolName}:{sourceToolCallId}";
+            _ = sb.Append(" in-response-to=\"").Append(EscapeAttribute(target)).Append('"');
+        }
+
+        if (!string.IsNullOrEmpty(label))
+        {
+            _ = sb.Append(" label=\"").Append(EscapeAttribute(label)).Append('"');
+        }
+
+        _ = sb.Append('>');
+
+        if (!string.IsNullOrEmpty(detail))
+        {
+            _ = sb.Append('\n').Append(SanitizeBody(detail)).Append('\n');
+        }
+
+        _ = sb.Append("</notification>");
+        return sb.ToString();
+    }
+
+    private static string EscapeAttribute(string value)
+    {
+        return value
+            .Replace("&", "&amp;")
+            .Replace("<", "&lt;")
+            .Replace(">", "&gt;")
+            .Replace("\"", "&quot;");
+    }
+
+    /// <summary>
+    ///     Neutralizes any attempt to close the envelope early from within the (otherwise raw) payload body.
+    ///     The body is left intact for readability apart from the exact closing marker.
+    /// </summary>
+    private static string SanitizeBody(string detail)
+    {
+        return detail.Replace("</notification>", "&lt;/notification&gt;", StringComparison.OrdinalIgnoreCase);
+    }
+}
+
+/// <summary>
+///     JSON converter for <see cref="NotifyMessage" /> using the shadow-properties pattern. Mirrors
+///     <c>TextMessageJsonConverter</c>; the computed get-only <see cref="NotifyMessage.Text" /> is written
+///     on serialize and skipped on read (recomputed from the structured fields).
+/// </summary>
+public class NotifyMessageJsonConverter : ShadowPropertiesJsonConverter<NotifyMessage>
+{
+    protected override NotifyMessage CreateInstance()
+    {
+        return new NotifyMessage { NotifyKind = string.Empty };
+    }
+}

--- a/src/LmCore/Utils/IMessageJsonConverter.cs
+++ b/src/LmCore/Utils/IMessageJsonConverter.cs
@@ -263,6 +263,11 @@ public class IMessageJsonConverter : JsonConverter<IMessage>
             return "composite";
         }
 
+        if (type == typeof(NotifyMessage))
+        {
+            return "notify";
+        }
+
         // If not a known type, fallback to name conversion
         var typeName = type.Name;
 
@@ -294,6 +299,14 @@ public class IMessageJsonConverter : JsonConverter<IMessage>
 
         if (element.TryGetProperty("text", out _))
         {
+            // A notification also carries "text" (its rendered envelope), so this guard must run
+            // before the generic text check — otherwise a $type-less notify (e.g. rehydrated from the
+            // conversation store, which persists without $type) would deserialize as a plain TextMessage.
+            if (element.TryGetProperty("notify_kind", out _))
+            {
+                return typeof(NotifyMessage);
+            }
+
             // Check if this is a TextUpdateMessage or a regular TextMessage
             return
                 element.TryGetProperty("isUpdate", out var isUpdateProp) && isUpdateProp.ValueKind == JsonValueKind.True
@@ -401,6 +414,7 @@ public class IMessageJsonConverter : JsonConverter<IMessage>
             "server_tool_result" => typeof(ToolCallResultMessage),
             "text_with_citations" => typeof(TextWithCitationsMessage),
             "composite" => typeof(CompositeMessage),
+            "notify" => typeof(NotifyMessage),
             _ => null,
         };
     }

--- a/src/LmMultiTurn/CodexEventTranslator.cs
+++ b/src/LmMultiTurn/CodexEventTranslator.cs
@@ -1126,6 +1126,12 @@ internal sealed class CodexEventTranslator
                 {
                     _ = sb.AppendLine(textMessage.Text);
                 }
+                else if (message is NotifyMessage notifyMessage)
+                {
+                    // Out-of-band notification: append its self-describing envelope to the CLI prompt so
+                    // the model sees the async event (it arrives via the input batch, not history).
+                    _ = sb.AppendLine(notifyMessage.Text);
+                }
                 else
                 {
                     logger?.LogWarning(

--- a/src/LmMultiTurn/CopilotEventTranslator.cs
+++ b/src/LmMultiTurn/CopilotEventTranslator.cs
@@ -129,6 +129,12 @@ internal sealed class CopilotEventTranslator
                 {
                     _ = sb.AppendLine(textMessage.Text);
                 }
+                else if (message is NotifyMessage notifyMessage)
+                {
+                    // Out-of-band notification: append its self-describing envelope to the CLI prompt so
+                    // the model sees the async event (it arrives via the input batch, not history).
+                    _ = sb.AppendLine(notifyMessage.Text);
+                }
                 else
                 {
                     logger?.LogWarning(

--- a/src/LmMultiTurn/MultiTurnAgentBase.cs
+++ b/src/LmMultiTurn/MultiTurnAgentBase.cs
@@ -41,6 +41,7 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     private bool _replayRunActive;
     private bool _replayBufferTruncated;
     private long _replayBufferBytes;
+    private string? _replayRunId;
     // Replay is bounded by BOTH a message count and an estimated byte budget: a long tool/reasoning
     // turn can stay under the count cap while still retaining large per-message payloads (text, tool
     // args/results), and multiple live conversations multiply that. Whichever cap trips first stops
@@ -269,6 +270,17 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     /// <param name="message">The message to add</param>
     protected void AddToHistory(IMessage message)
     {
+        AddToHistory(message, runIdOverride: null);
+    }
+
+    /// <summary>
+    /// Adds a message to the conversation history, persisting it under an explicit run id when the
+    /// current run id is unavailable (e.g. an out-of-band notification folded into history while the
+    /// conversation is parked on an unresolved deferral, between runs). Falls back to
+    /// <c>_currentRunId</c> when <paramref name="runIdOverride"/> is null.
+    /// </summary>
+    protected void AddToHistory(IMessage message, string? runIdOverride)
+    {
         lock (_historyLock)
         {
             ConversationHistory.Add(message);
@@ -277,10 +289,13 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
         // Fire-and-forget persistence
         if (Store != null)
         {
-            string? runId;
-            lock (_stateLock)
+            var runId = runIdOverride;
+            if (runId == null)
             {
-                runId = _currentRunId;
+                lock (_stateLock)
+                {
+                    runId = _currentRunId;
+                }
             }
 
             if (runId != null)
@@ -344,7 +359,7 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     /// the message. If persistence fails, the exception propagates and no in-memory state is
     /// mutated — callers (e.g., <c>MultiTurnAgentLoop.ExecuteAndPublishToolCallAsync</c>) are
     /// responsible for unwinding any pre-registered deferred entries on failure. The
-    /// non-deferred <see cref="AddToHistory"/> path remains fire-and-forget; synchronous
+    /// non-deferred <see cref="AddToHistory(IMessage)"/> path remains fire-and-forget; synchronous
     /// persistence is only required where in-place replacement is on the table.
     /// </remarks>
     protected async Task AddDeferredToHistoryAsync(IMessage message, CancellationToken ct)
@@ -988,18 +1003,25 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
         List<KeyValuePair<string, Channel<IMessage>>> targets;
         lock (_replayLock)
         {
-            // Maintain the in-flight run's replay buffer. RunAssignmentMessage opens a fresh run;
-            // RunCompletedMessage closes it (after which a joining subscriber must NOT replay it —
-            // the client already has completed messages via persisted REST history, so replaying
-            // would duplicate). Snapshotting subscribers under the SAME lock SubscribeAsync uses to
-            // register + snapshot the buffer guarantees this message reaches each subscriber exactly
-            // once (replay XOR live).
-            if (message is RunAssignmentMessage)
+            // Maintain the in-flight run's replay buffer. A RunAssignmentMessage for a NEW run opens a
+            // fresh buffer; RunCompletedMessage closes it (after which a joining subscriber must NOT
+            // replay it — the client already has completed messages via persisted REST history, so
+            // replaying would duplicate). A same-run injection assignment (WasInjected, same RunId — e.g.
+            // an out-of-band NotifyMessage folded into the active run) must NOT clear the buffer, or a
+            // client reconnecting after the injection would lose the run's earlier deltas. Snapshotting
+            // subscribers under the SAME lock SubscribeAsync uses to register + snapshot the buffer
+            // guarantees this message reaches each subscriber exactly once (replay XOR live).
+            if (message is RunAssignmentMessage ram)
             {
-                _replayBuffer.Clear();
-                _replayBufferBytes = 0;
-                _replayRunActive = true;
-                _replayBufferTruncated = false;
+                var incomingRunId = ram.Assignment?.RunId;
+                if (!_replayRunActive || !string.Equals(incomingRunId, _replayRunId, StringComparison.Ordinal))
+                {
+                    _replayBuffer.Clear();
+                    _replayBufferBytes = 0;
+                    _replayRunActive = true;
+                    _replayBufferTruncated = false;
+                    _replayRunId = incomingRunId;
+                }
             }
 
             if (_replayRunActive)

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -250,9 +250,7 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                 // correct at-resume delivery. A regular user input while deferred deliberately keeps the
                 // existing fail-fast guard (the caller must resolve the deferral first), so this is
                 // restricted to batches that are entirely notifications.
-                var allNotifications = realInputs.Count > 0
-                    && realInputs.All(i => i.Input.Messages.Count > 0 && i.Input.Messages.All(m => m is NotifyMessage));
-                if (allNotifications && resumeSentinels.Count == 0 && !_deferred.IsEmpty)
+                if (resumeSentinels.Count == 0 && !_deferred.IsEmpty && AllMessagesAreNotifications(realInputs))
                 {
                     await AppendParkedInputsAsync(realInputs, ct);
                     continue;
@@ -455,6 +453,37 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         {
             Logger.LogWarning("Max turns ({MaxTurns}) reached for run {RunId}", MaxTurnsPerRun, runId);
         }
+    }
+
+    /// <summary>
+    /// True when the batch is non-empty and every message in it is a <see cref="NotifyMessage"/>. A
+    /// zero-allocation foreach (vs. LINQ) since this runs on every input drain.
+    /// </summary>
+    private static bool AllMessagesAreNotifications(List<QueuedInput> inputs)
+    {
+        if (inputs.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var input in inputs)
+        {
+            var messages = input.Input.Messages;
+            if (messages.Count == 0)
+            {
+                return false;
+            }
+
+            foreach (var message in messages)
+            {
+                if (message is not NotifyMessage)
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -240,6 +240,24 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                     }
                 }
 
+                // Parked-on-deferral safety, scoped to notifications. When the conversation is parked on
+                // an unresolved deferral and there is no resume in flight, a fresh model turn cannot run
+                // (the provider would reject the pending tool_result — see the ExecuteTurnAsync
+                // precondition). For an out-of-band NotifyMessage (e.g. a background sub-agent completing
+                // while the parent is parked on a Wait) we fold it into history now — persisted under the
+                // deferring run and published live as a pill — and let the resume-sentinel path deliver it
+                // to the model once the deferral resolves, turning what was an unconditional RunFailed into
+                // correct at-resume delivery. A regular user input while deferred deliberately keeps the
+                // existing fail-fast guard (the caller must resolve the deferral first), so this is
+                // restricted to batches that are entirely notifications.
+                var allNotifications = realInputs.Count > 0
+                    && realInputs.All(i => i.Input.Messages.Count > 0 && i.Input.Messages.All(m => m is NotifyMessage));
+                if (allNotifications && resumeSentinels.Count == 0 && !_deferred.IsEmpty)
+                {
+                    await AppendParkedInputsAsync(realInputs, ct);
+                    continue;
+                }
+
                 // Start run with the available inputs (use real if any, otherwise sentinels
                 // — StartRun records receipt IDs for telemetry but doesn't otherwise care).
                 // Fork signal sourced from caller input only — resume sentinels never carry
@@ -262,6 +280,7 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                     foreach (var msg in input.Input.Messages)
                     {
                         AddToHistory(msg);
+                        await PublishIfNotifyAsync(msg, ct);
                     }
                 }
 
@@ -372,6 +391,7 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
                         foreach (var msg in input.Input.Messages)
                         {
                             AddToHistory(msg);
+                            await PublishIfNotifyAsync(msg, ct);
                         }
                     }
 
@@ -435,6 +455,50 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         {
             Logger.LogWarning("Max turns ({MaxTurns}) reached for run {RunId}", MaxTurnsPerRun, runId);
         }
+    }
+
+    /// <summary>
+    /// Publishes an out-of-band <see cref="NotifyMessage"/> to subscribers so its pill renders live and
+    /// lands in the in-flight replay buffer. Injected inputs are otherwise only appended to history
+    /// (persisted), never published, so without this a notification would appear only on a REST reload.
+    /// No-op for any other message type (regular user turns render from the client's optimistic echo).
+    /// </summary>
+    private async Task PublishIfNotifyAsync(IMessage message, CancellationToken ct)
+    {
+        if (message is NotifyMessage)
+        {
+            await PublishToAllAsync(message, ct);
+        }
+    }
+
+    /// <summary>
+    /// Folds inputs that arrived while the conversation is parked on an unresolved deferral into history
+    /// (persisted under the deferring run so they survive a restart) and publishes any notification pills
+    /// live — without starting a model turn. The resume-sentinel path delivers them to the model once the
+    /// deferral resolves. See the call site in <see cref="RunLoopAsync"/> for why a turn cannot run here.
+    /// </summary>
+    private async Task AppendParkedInputsAsync(List<QueuedInput> realInputs, CancellationToken ct)
+    {
+        string? parkRunId;
+        lock (_resumeLock)
+        {
+            parkRunId = _lastDeferringRunId;
+        }
+
+        var count = 0;
+        foreach (var input in realInputs)
+        {
+            foreach (var msg in input.Input.Messages)
+            {
+                AddToHistory(msg, parkRunId);
+                await PublishIfNotifyAsync(msg, ct);
+                count++;
+            }
+        }
+
+        Logger.LogInformation(
+            "Parked on unresolved deferral(s); folded {Count} input message(s) into history for delivery on resume.",
+            count);
     }
 
     private async Task<bool> ExecuteTurnAsync(

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -990,8 +990,16 @@ public sealed class SubAgentManager : IAsyncDisposable
     {
         try
         {
+            // Deliver the completion as a typed notification, not a plain user turn: the parent LLM
+            // reads it as an async response to the sub-agent spawn, and the UI renders a pill. The raw
+            // <sub-agent …> block stays in Detail so downstream parsers (e.g. LmWorkflow) still find it.
             _ = await _parentAgent.SendAsync(
-                [new TextMessage { Role = Role.User, Text = text }]);
+                [NotifyMessage.Create(
+                    NotifyKinds.SubAgentCompletion,
+                    detail: text,
+                    sourceToolName: "Agent",
+                    sourceToolCallId: state.AgentId,
+                    label: state.TemplateName)]);
         }
         catch (Exception ex)
         {

--- a/src/LmWorkflow/Runtime/WorkflowRuntime.cs
+++ b/src/LmWorkflow/Runtime/WorkflowRuntime.cs
@@ -464,12 +464,13 @@ public sealed class WorkflowRuntime
 
                 break;
 
-            // Injected sub-agent completion (DORMANT / forward-built in V1): MultiTurnAgentLoop does not
-            // publish injected sub-agent completions to its subscribers, so this case does not fire in V1.
-            // Even if it did, the background receipt path now fails fast (ObserveSpawnResult) and never records
-            // an agent_id correlation, so ObserveInjectedResult would find no mapping and surface the result as
-            // harmless "unmatched". Re-enabled in the follow-up that makes injected completions observable.
-            // The completion now arrives as a NotifyMessage whose Detail carries the raw <sub-agent …> block
+            // Injected sub-agent completion. As of #171, MultiTurnAgentLoop DOES publish injected
+            // NotifyMessages (including sub-agent completions) to its subscribers, so — unlike before —
+            // this case is reachable if a host wires the loop's message stream into ObserveMessage. It
+            // stays safe in V1 because the background receipt path fails fast (ObserveSpawnResult) and
+            // never records an agent_id correlation, so ObserveInjectedResult finds no mapping and surfaces
+            // the result as a harmless "unmatched"; full correlation is re-enabled in the follow-up.
+            // The completion arrives as a NotifyMessage whose Detail carries the raw <sub-agent …> block
             // (its envelope Text wraps that block), so parse Detail rather than GetText().
             case NotifyMessage { NotifyKind: NotifyKinds.SubAgentCompletion, Detail: { } detail }:
                 if (SubAgentResultParser.TryParse(detail, out var agentId, out var payload, out var isError))

--- a/src/LmWorkflow/Runtime/WorkflowRuntime.cs
+++ b/src/LmWorkflow/Runtime/WorkflowRuntime.cs
@@ -464,14 +464,15 @@ public sealed class WorkflowRuntime
 
                 break;
 
-            // Injected <sub-agent> completion (DORMANT / forward-built in V1): MultiTurnAgentLoop does not
+            // Injected sub-agent completion (DORMANT / forward-built in V1): MultiTurnAgentLoop does not
             // publish injected sub-agent completions to its subscribers, so this case does not fire in V1.
             // Even if it did, the background receipt path now fails fast (ObserveSpawnResult) and never records
             // an agent_id correlation, so ObserveInjectedResult would find no mapping and surface the result as
             // harmless "unmatched". Re-enabled in the follow-up that makes injected completions observable.
-            case TextMessage { Role: Role.User, Text: { } text }
-                when text.TrimStart().StartsWith("<sub-agent", StringComparison.Ordinal):
-                if (SubAgentResultParser.TryParse(text, out var agentId, out var payload, out var isError))
+            // The completion now arrives as a NotifyMessage whose Detail carries the raw <sub-agent …> block
+            // (its envelope Text wraps that block), so parse Detail rather than GetText().
+            case NotifyMessage { NotifyKind: NotifyKinds.SubAgentCompletion, Detail: { } detail }:
+                if (SubAgentResultParser.TryParse(detail, out var agentId, out var payload, out var isError))
                 {
                     ObserveInjectedResult(agentId, payload, isError);
                 }

--- a/src/OpenAiResponsesProvider/Agents/MessageMapper.cs
+++ b/src/OpenAiResponsesProvider/Agents/MessageMapper.cs
@@ -231,6 +231,24 @@ internal static class MessageMapper
                 );
                 break;
 
+            case NotifyMessage notify:
+                inputItems.Add(
+                    new ResponseInputItem
+                    {
+                        Type = "message",
+                        Role = MapRole(notify.Role),
+                        Content =
+                        [
+                            new ResponseInputContent
+                            {
+                                Type = notify.Role == Role.Assistant ? "output_text" : "input_text",
+                                Text = notify.Text,
+                            },
+                        ],
+                    }
+                );
+                break;
+
             default:
                 // Unsupported message types (e.g. UsageMessage on the input side) have no Responses
                 // input-side analog and are intentionally dropped.

--- a/tests/AnthropicProvider.Tests/Models/NotifyMessageMappingTests.cs
+++ b/tests/AnthropicProvider.Tests/Models/NotifyMessageMappingTests.cs
@@ -1,0 +1,49 @@
+using AchieveAi.LmDotnetTools.LmCore.Core;
+
+namespace AchieveAi.LmDotnetTools.AnthropicProvider.Tests.Models;
+
+/// <summary>
+///     A <see cref="NotifyMessage"/> must reach the Anthropic request as a user-role text block carrying
+///     its envelope — the mapper pattern-matches concrete <c>TextMessage</c>, so without an explicit arm
+///     a notification would add no content and be dropped (an empty Anthropic message → 400 / silent loss).
+/// </summary>
+public class NotifyMessageMappingTests
+{
+    private static readonly GenerateReplyOptions Options = new() { ModelId = "claude-3-7-sonnet-20250219" };
+
+    [Fact]
+    public void NotifyMessage_MapsToUserTextBlock_WithEnvelope()
+    {
+        var notify = NotifyMessage.Create(
+            NotifyKinds.SubAgentCompletion, detail: "sub done", sourceToolName: "Agent", sourceToolCallId: "call-1");
+
+        var request = AnthropicRequest.FromMessages([notify], Options);
+
+        var userMsg = Assert.Single(request.Messages);
+        Assert.Equal("user", userMsg.Role);
+        Assert.Contains(
+            userMsg.Content,
+            c => c.Type == "text" && (c.Text ?? string.Empty).Contains("<notification")
+                && (c.Text ?? string.Empty).Contains("subagent-completion"));
+    }
+
+    [Fact]
+    public void NotifyMessage_AfterToolResultUserTurn_KeepsToolResult_AndEnvelopeLegible()
+    {
+        // Realistic ordering: a notify is appended to history AFTER a tool_result placeholder. Under
+        // Anthropic's consecutive-same-role merge the two user-role messages combine into a single user
+        // turn [tool_result, text(envelope)] — tool_result stays first (valid) and the envelope survives.
+        IMessage[] messages =
+        [
+            new ToolCallMessage { FunctionName = "f", FunctionArgs = "{}", ToolCallId = "tc1", Role = Role.Assistant },
+            new ToolCallResultMessage { ToolCallId = "tc1", ToolName = "f", Result = "ok", Role = Role.User },
+            NotifyMessage.Create(NotifyKinds.SubAgentCompletion, detail: "bg done"),
+        ];
+
+        var request = AnthropicRequest.FromMessages(messages, Options);
+
+        var allContent = request.Messages.SelectMany(m => m.Content).ToList();
+        Assert.Contains(allContent, c => c.Type == "tool_result");
+        Assert.Contains(allContent, c => c.Type == "text" && (c.Text ?? string.Empty).Contains("<notification"));
+    }
+}

--- a/tests/LmCore.Tests/Messages/NotifyMessageSerializationTests.cs
+++ b/tests/LmCore.Tests/Messages/NotifyMessageSerializationTests.cs
@@ -1,0 +1,204 @@
+using System.Text.Json;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.Messages;
+
+/// <summary>
+///     Serialization / structural-inference coverage for <see cref="NotifyMessage" /> — the wire ($type)
+///     path, the persistence path (no $type → structural inference on <c>notify_kind</c>), the computed
+///     get-only envelope, and the envelope-format invariants.
+/// </summary>
+public class NotifyMessageSerializationTests
+{
+    private static JsonSerializerOptions GetOptionsWithConverter()
+    {
+        var options = new JsonSerializerOptions { WriteIndented = false };
+
+        options.Converters.Add(new IMessageJsonConverter());
+        options.Converters.Add(new TextMessageJsonConverter());
+        options.Converters.Add(new NotifyMessageJsonConverter());
+        return options;
+    }
+
+    [Fact]
+    public void Serialize_NotifyMessage_AsIMessage_AddsNotifyDiscriminator()
+    {
+        IMessage message = NotifyMessage.Create(
+            NotifyKinds.SubAgentCompletion,
+            detail: "<sub-agent id=\"agent-7\">done</sub-agent>",
+            sourceToolName: "Agent",
+            sourceToolCallId: "call-1",
+            label: "build-fixer",
+            generationId: "notify:test"
+        );
+
+        var options = GetOptionsWithConverter();
+
+        var json = JsonSerializer.Serialize(message, options);
+        TestContextLogger.LogDebug("Serialized notify JSON: {Json}", json);
+
+        var root = JsonDocument.Parse(json).RootElement;
+        Assert.True(root.TryGetProperty("$type", out var typeProperty));
+        Assert.Equal("notify", typeProperty.GetString());
+        Assert.Equal("subagent-completion", root.GetProperty("notify_kind").GetString());
+        Assert.Equal("call-1", root.GetProperty("source_tool_call_id").GetString());
+        Assert.Equal("user", root.GetProperty("role").GetString());
+        // The envelope is emitted as "text" so LLM backends that read ICanGetText/text see it.
+        Assert.Contains("<notification", root.GetProperty("text").GetString());
+    }
+
+    [Fact]
+    public void Deserialize_NotifyMessage_WithTypeDiscriminator_ReturnsNotifyMessage()
+    {
+        var json =
+            @"{
+                ""$type"": ""notify"",
+                ""notify_kind"": ""subagent-completion"",
+                ""source_tool_call_id"": ""call-1"",
+                ""source_tool_name"": ""Agent"",
+                ""label"": ""build-fixer"",
+                ""detail"": ""done"",
+                ""role"": ""user""
+            }";
+
+        var message = JsonSerializer.Deserialize<IMessage>(json, GetOptionsWithConverter());
+
+        var notify = Assert.IsType<NotifyMessage>(message);
+        Assert.Equal("subagent-completion", notify.NotifyKind);
+        Assert.Equal("call-1", notify.SourceToolCallId);
+        Assert.Equal("Agent", notify.SourceToolName);
+        Assert.Equal("build-fixer", notify.Label);
+        Assert.Equal("done", notify.Detail);
+        Assert.Equal(Role.User, notify.Role);
+    }
+
+    [Fact]
+    public void Deserialize_NotifyMessage_WithoutTypeDiscriminator_InfersNotifyMessage_NotTextMessage()
+    {
+        // The conversation store persists messages WITHOUT a $type (serialized by concrete type),
+        // so rehydration relies on structural inference. A notify carries "text", so the notify_kind
+        // guard must win over the generic text → TextMessage fallback, or history recovery loses the type.
+        var json =
+            @"{
+                ""notify_kind"": ""context-discovery"",
+                ""label"": ""CLAUDE.md"",
+                ""detail"": ""file body"",
+                ""text"": ""<notification kind=\""context-discovery\"">"",
+                ""role"": ""user""
+            }";
+
+        var message = JsonSerializer.Deserialize<IMessage>(json, GetOptionsWithConverter());
+
+        var notify = Assert.IsType<NotifyMessage>(message);
+        Assert.Equal("context-discovery", notify.NotifyKind);
+        Assert.Equal("CLAUDE.md", notify.Label);
+    }
+
+    [Fact]
+    public void Deserialize_TextMessage_WithoutNotifyKind_StillInfersTextMessage()
+    {
+        // Regression: a plain text message (no notify_kind) must NOT be captured by the notify guard.
+        var json = @"{ ""text"": ""hello"", ""role"": ""assistant"" }";
+
+        var message = JsonSerializer.Deserialize<IMessage>(json, GetOptionsWithConverter());
+
+        _ = Assert.IsType<TextMessage>(message);
+    }
+
+    [Fact]
+    public void RoundTrip_NotifyMessage_PreservesStructuredFields_AndRecomputesEnvelope()
+    {
+        IMessage original = NotifyMessage.Create(
+            NotifyKinds.SubAgentCompletion,
+            detail: "result body",
+            sourceToolName: "Agent",
+            sourceToolCallId: "call-9",
+            label: "fixer",
+            generationId: "notify:rt"
+        );
+
+        var options = GetOptionsWithConverter();
+        var json = JsonSerializer.Serialize(original, options);
+        var round = Assert.IsType<NotifyMessage>(JsonSerializer.Deserialize<IMessage>(json, options));
+
+        Assert.Equal("subagent-completion", round.NotifyKind);
+        Assert.Equal("call-9", round.SourceToolCallId);
+        Assert.Equal("Agent", round.SourceToolName);
+        Assert.Equal("fixer", round.Label);
+        Assert.Equal("result body", round.Detail);
+        Assert.Equal("notify:rt", round.GenerationId);
+        // Envelope is recomputed from the fields, identical to the original's projection.
+        Assert.Equal(((NotifyMessage)original).Text, round.Text);
+    }
+
+    [Fact]
+    public void Text_IsComputedFromFields_IgnoringAnyPersistedTextValue()
+    {
+        // A stale/hostile "text" on the wire must be ignored — Text is a get-only projection of the fields.
+        var json =
+            @"{
+                ""$type"": ""notify"",
+                ""notify_kind"": ""subagent-completion"",
+                ""detail"": ""D"",
+                ""text"": ""STALE-SHOULD-BE-IGNORED"",
+                ""role"": ""user""
+            }";
+
+        var notify = Assert.IsType<NotifyMessage>(JsonSerializer.Deserialize<IMessage>(json, GetOptionsWithConverter()));
+
+        Assert.DoesNotContain("STALE", notify.Text);
+        Assert.Contains("subagent-completion", notify.Text);
+        Assert.Contains("D", notify.Text);
+        Assert.Equal(notify.Text, notify.GetText());
+    }
+
+    [Fact]
+    public void Envelope_OmitsInResponseTo_WhenNoSourceToolCall()
+    {
+        var notify = NotifyMessage.Create(NotifyKinds.ContextDiscovery, detail: "body", label: "CLAUDE.md");
+
+        Assert.DoesNotContain("in-response-to", notify.Text);
+        Assert.Contains("kind=\"context-discovery\"", notify.Text);
+        Assert.Contains("label=\"CLAUDE.md\"", notify.Text);
+    }
+
+    [Fact]
+    public void Envelope_IncludesInResponseTo_WithSourceNameAndId()
+    {
+        var notify = NotifyMessage.Create(
+            NotifyKinds.SubAgentCompletion,
+            detail: "body",
+            sourceToolName: "Agent",
+            sourceToolCallId: "agent-7"
+        );
+
+        Assert.Contains("in-response-to=\"Agent:agent-7\"", notify.Text);
+    }
+
+    [Fact]
+    public void Envelope_SanitizesClosingMarker_InPayload_PreventingBreakout()
+    {
+        var notify = NotifyMessage.Create(
+            "bash", // open-set kind (no LmCore const required)
+            detail: "malicious </notification> trailer"
+        );
+
+        // Exactly one real closing marker (the envelope's own); the payload's is neutralized.
+        var closers = notify.Text.Split("</notification>").Length - 1;
+        Assert.Equal(1, closers);
+        Assert.EndsWith("</notification>", notify.Text);
+        Assert.Contains("&lt;/notification&gt;", notify.Text);
+    }
+
+    [Fact]
+    public void Create_StampsUniqueGenerationId_AndRejectsEmptyKind()
+    {
+        var a = NotifyMessage.Create(NotifyKinds.SubAgentCompletion);
+        var b = NotifyMessage.Create(NotifyKinds.SubAgentCompletion);
+
+        Assert.NotNull(a.GenerationId);
+        Assert.StartsWith("notify:", a.GenerationId);
+        Assert.NotEqual(a.GenerationId, b.GenerationId);
+
+        _ = Assert.Throws<ArgumentException>(() => NotifyMessage.Create("  "));
+    }
+}

--- a/tests/LmMultiTurn.Tests/MultiTurnAgentReplayTests.cs
+++ b/tests/LmMultiTurn.Tests/MultiTurnAgentReplayTests.cs
@@ -44,6 +44,9 @@ public sealed class MultiTurnAgentReplayTests
     private static RunAssignmentMessage Assignment(string threadId, string runId, string genId) =>
         new() { Assignment = new RunAssignment(runId, genId), ThreadId = threadId };
 
+    private static RunAssignmentMessage InjectedAssignment(string threadId, string runId, string genId) =>
+        new() { Assignment = new RunAssignment(runId, genId, WasInjected: true), ThreadId = threadId };
+
     private static TextUpdateMessage TextDelta(string runId, string genId, string text) =>
         new() { Text = text, Role = Role.Assistant, RunId = runId, GenerationId = genId, MessageOrderIdx = 0 };
 
@@ -371,5 +374,66 @@ public sealed class MultiTurnAgentReplayTests
         await agent.PublishForTest(TextDelta(runId, genId, "SENTINEL"));
         (await e.MoveNextAsync()).Should().BeTrue();
         e.Current.Should().BeOfType<TextUpdateMessage>().Which.Text.Should().Be("SENTINEL");
+    }
+
+    [Fact]
+    public async Task Same_run_injection_assignment_does_not_clear_the_replay_buffer()
+    {
+        // #171: an out-of-band notification folded into the ACTIVE run publishes a WasInjected
+        // RunAssignmentMessage with the SAME runId. That must NOT reset the replay buffer, or a client
+        // reconnecting after the notification loses the run's earlier streamed deltas. The reset keys on
+        // a NEW runId, not on every RunAssignmentMessage (see MultiTurnAgentBase.PublishToAllAsync).
+        await using var agent = new ReplayTestAgent("thread-1");
+        const string runId = "run-1";
+        const string genId = "gen-1";
+
+        await agent.PublishForTest(Assignment("thread-1", runId, genId));
+        await agent.PublishForTest(TextDelta(runId, genId, "Hel"));
+        await agent.PublishForTest(TextDelta(runId, genId, "lo"));
+        // The notification's injection assignment — same run.
+        await agent.PublishForTest(InjectedAssignment("thread-1", runId, genId));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await using var e = agent.SubscribeAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+
+        // A reconnecting subscriber still replays the run's earlier assignment + deltas (not cleared).
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<RunAssignmentMessage>()
+            .Which.Assignment.WasInjected.Should().BeFalse("the original run assignment is replayed first");
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<TextUpdateMessage>().Which.Text.Should().Be("Hel");
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<TextUpdateMessage>().Which.Text.Should().Be("lo");
+        // Followed by the injection assignment itself (also buffered within the same run).
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<RunAssignmentMessage>()
+            .Which.Assignment.WasInjected.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task New_run_assignment_clears_the_previous_runs_replay_buffer()
+    {
+        // The other side of the runId-keyed reset: a genuinely new run (different runId) MUST clear the
+        // prior run's buffer, so a subscriber joining during run-2 never replays run-1's stale deltas.
+        await using var agent = new ReplayTestAgent("thread-1");
+
+        await agent.PublishForTest(Assignment("thread-1", "run-1", "gen-1"));
+        await agent.PublishForTest(TextDelta("run-1", "gen-1", "old"));
+        await agent.PublishForTest(Assignment("thread-1", "run-2", "gen-2"));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await using var e = agent.SubscribeAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+
+        // Only run-2's assignment is replayed — run-1's assignment + "old" delta were cleared.
+        (await e.MoveNextAsync()).Should().BeTrue();
+        e.Current.Should().BeOfType<RunAssignmentMessage>()
+            .Which.Assignment.RunId.Should().Be("run-2");
+
+        // Nothing else is buffered: the next read blocks until a genuinely live message arrives.
+        var next = e.MoveNextAsync();
+        next.IsCompleted.Should().BeFalse("run-1's buffered messages were cleared by the new-run assignment");
+        await agent.PublishForTest(TextDelta("run-2", "gen-2", "new"));
+        (await next).Should().BeTrue();
+        e.Current.Should().BeOfType<TextUpdateMessage>().Which.Text.Should().Be("new");
     }
 }

--- a/tests/LmMultiTurn.Tests/NotifyMessageBuildPromptTests.cs
+++ b/tests/LmMultiTurn.Tests/NotifyMessageBuildPromptTests.cs
@@ -1,0 +1,39 @@
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using FluentAssertions;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+/// <summary>
+///     The Copilot and Codex CLI loops build the model prompt from the input batch (not history) and
+///     previously skipped any non-<c>TextMessage</c> with a "unsupported_message_type" warning. A
+///     <see cref="NotifyMessage"/> must instead have its envelope appended so the async event reaches
+///     a CLI model turn.
+/// </summary>
+public class NotifyMessageBuildPromptTests
+{
+    private static IReadOnlyList<QueuedInput> OneNotify()
+    {
+        var notify = NotifyMessage.Create(
+            NotifyKinds.SubAgentCompletion, detail: "sub-agent done", sourceToolName: "Agent", sourceToolCallId: "call-1");
+        return [new QueuedInput(new UserInput([notify]), "r1", DateTimeOffset.UtcNow)];
+    }
+
+    [Fact]
+    public void CopilotBuildPrompt_IncludesNotifyEnvelope_NotSkipped()
+    {
+        var prompt = CopilotEventTranslator.BuildPrompt(OneNotify());
+
+        prompt.Should().Contain("<notification").And.Contain("subagent-completion");
+    }
+
+    [Fact]
+    public void CodexBuildPrompt_IncludesNotifyEnvelope_NotSkipped()
+    {
+        var prompt = CodexEventTranslator.BuildPrompt(OneNotify());
+
+        prompt.Should().Contain("<notification").And.Contain("subagent-completion");
+    }
+}

--- a/tests/LmMultiTurn.Tests/NotifyMessageLoopTests.cs
+++ b/tests/LmMultiTurn.Tests/NotifyMessageLoopTests.cs
@@ -1,0 +1,269 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+/// <summary>
+/// Loop-level behavior for out-of-band <see cref="NotifyMessage"/> delivery: a notification behaves
+/// like any input (wakes an idle agent / injects into a running one), its pill is published live, and
+/// — the one edge — a notification arriving while the agent is parked on an unresolved deferral is
+/// folded into history and delivered on resume instead of tripping the deferred-guard (RunFailed).
+/// </summary>
+public class NotifyMessageLoopTests
+{
+    private readonly Mock<IStreamingAgent> _mockAgent = new();
+    private readonly Mock<ILogger<MultiTurnAgentLoop>> _loggerMock = new();
+
+    private static string WaitArgs(object body) => JsonSerializer.Serialize(body);
+
+    [Fact]
+    public async Task Notify_WhenIdle_StartsATurn_EnvelopeReachesModel_AndPillPublishedWithPreservedIdentity()
+    {
+        IEnumerable<IMessage>? sentToModel = null;
+        var callCount = 0;
+        _mockAgent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>((msgs, _, _) =>
+            {
+                callCount++;
+                sentToModel = [.. msgs];
+                return Task.FromResult(ToAsyncEnumerable([new TextMessage { Text = "ack", Role = Role.Assistant }]));
+            });
+
+        await using var loop = BuildLoop(new TriggerOptions());
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+
+        var collector = new MessageCollector(loop, cts.Token);
+
+        var notify = NotifyMessage.Create(
+            NotifyKinds.SubAgentCompletion,
+            detail: "sub-agent done",
+            sourceToolName: "Agent",
+            sourceToolCallId: "call-1",
+            generationId: "notify:fixed");
+        await loop.SendAsync([notify]);
+        await collector.WaitForCompletionsAsync(1);
+
+        // Idle notify woke the agent: exactly one LLM turn ran, and the envelope reached the model.
+        callCount.Should().Be(1);
+        sentToModel.Should().NotBeNull();
+        sentToModel!.OfType<NotifyMessage>().Should().ContainSingle()
+            .Which.NotifyKind.Should().Be(NotifyKinds.SubAgentCompletion);
+
+        // The pill was published live (not merely persisted) with identity preserved from the producer.
+        collector.Snapshot().OfType<NotifyMessage>().Should()
+            .ContainSingle(n => n.GenerationId == "notify:fixed" && n.NotifyKind == NotifyKinds.SubAgentCompletion);
+
+        await cts.CancelAsync();
+    }
+
+    [Fact]
+    public async Task Notify_WhileParkedOnWait_DoesNotRunFailed_AndIsDeliveredOnResume()
+    {
+        var manual = new ManualLoopTriggerSource();
+        var options = new TriggerOptions
+        {
+            AdditionalRegistrations =
+            [
+                new TriggerSourceRegistration
+                {
+                    Kind = "host_event",
+                    Description = "wait for a host-fired event",
+                    ArgsSchema = "{}",
+                    Capabilities = new TriggerCapabilities(true, false, false),
+                    Source = manual,
+                },
+            ],
+        };
+
+        var waitCall = new ToolCallMessage
+        {
+            FunctionName = WaitToolProvider.WaitToolName,
+            FunctionArgs = WaitArgs(new { kind = "host_event", args = new { }, timeout = "10m" }),
+            ToolCallId = "tc_host",
+            Role = Role.Assistant,
+        };
+        var finalText = new TextMessage { Text = "resumed", Role = Role.Assistant };
+
+        var callCount = 0;
+        IEnumerable<IMessage>? resumeMessages = null;
+        _mockAgent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>((msgs, _, _) =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    return Task.FromResult(ToAsyncEnumerable([waitCall]));
+                }
+                resumeMessages = [.. msgs];
+                return Task.FromResult(ToAsyncEnumerable([finalText]));
+            });
+
+        await using var loop = BuildLoop(options);
+        using var cts = new CancellationTokenSource();
+        _ = loop.RunAsync(cts.Token);
+        var collector = new MessageCollector(loop, cts.Token);
+
+        // Turn 1: the LLM parks on a host_event Wait.
+        await loop.SendAsync([new TextMessage { Text = "wait for host", Role = Role.User }]);
+        await collector.WaitForCompletionsAsync(1);
+        (await loop.GetDeferredToolCallsAsync()).Should().ContainSingle(p => p.ToolCallId == "tc_host");
+
+        // A background sub-agent completes while the parent is parked → notify arrives.
+        var notify = NotifyMessage.Create(
+            NotifyKinds.SubAgentCompletion, detail: "bg done", sourceToolName: "Agent", sourceToolCallId: "call-x");
+        await loop.SendAsync([notify]);
+
+        // Give the loop time to drain-and-park the notify. It must NOT start a turn (no extra LLM call),
+        // must NOT fail the run (no error completion), and the Wait stays deferred.
+        await Task.Delay(300);
+        callCount.Should().Be(1);
+        collector.Snapshot().OfType<RunCompletedMessage>().Should().NotContain(m => m.IsError);
+        (await loop.GetDeferredToolCallsAsync()).Should().ContainSingle(p => p.ToolCallId == "tc_host");
+
+        // The host fires → the parked run resumes and turn 2 sees BOTH the resolved Wait and the notify.
+        await manual.FireAsync("host-payload");
+        await collector.WaitForCompletionsAsync(2);
+        callCount.Should().Be(2);
+
+        resumeMessages.Should().NotBeNull();
+        resumeMessages!.OfType<NotifyMessage>().Should().ContainSingle(n => n.Detail == "bg done");
+        ExtractResults(resumeMessages!).Should().ContainSingle(r => r.ToolCallId == "tc_host");
+        collector.Snapshot().OfType<RunCompletedMessage>().Should().NotContain(m => m.IsError);
+
+        await cts.CancelAsync();
+    }
+
+    private MultiTurnAgentLoop BuildLoop(TriggerOptions options) => new(
+        _mockAgent.Object,
+        new FunctionRegistry(),
+        "notify-thread",
+        logger: _loggerMock.Object,
+        triggerOptions: options);
+
+    /// <summary>Collects the loop's published output on a background task for assertions.</summary>
+    private sealed class MessageCollector
+    {
+        private readonly List<IMessage> _messages = [];
+        private readonly object _gate = new();
+        private volatile int _completions;
+
+        public MessageCollector(MultiTurnAgentLoop loop, CancellationToken ct)
+        {
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await foreach (var msg in loop.SubscribeAsync(ct))
+                    {
+                        lock (_gate)
+                        {
+                            _messages.Add(msg);
+                        }
+
+                        if (msg is RunCompletedMessage)
+                        {
+                            _completions++;
+                        }
+                    }
+                }
+                catch (OperationCanceledException) { }
+            }, ct);
+        }
+
+        public List<IMessage> Snapshot()
+        {
+            lock (_gate)
+            {
+                return [.. _messages];
+            }
+        }
+
+        public async Task WaitForCompletionsAsync(int count)
+        {
+            var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+            while (DateTimeOffset.UtcNow < deadline)
+            {
+                if (_completions >= count)
+                {
+                    return;
+                }
+
+                await Task.Delay(25);
+            }
+
+            throw new TimeoutException($"Expected {count} run completion(s); saw {_completions}.");
+        }
+    }
+
+    private static List<ToolCallResultMessage> ExtractResults(IEnumerable<IMessage> messages) =>
+    [
+        .. messages.OfType<ToolCallResultMessage>()
+            .Concat(messages.OfType<ToolsCallResultMessage>()
+                .SelectMany(m => m.ToolCallResults.Select(r => new ToolCallResultMessage
+                {
+                    ToolCallId = r.ToolCallId,
+                    Result = r.Result,
+                    IsError = r.IsError,
+                }))),
+    ];
+
+    private static async IAsyncEnumerable<IMessage> ToAsyncEnumerable(
+        IEnumerable<IMessage> messages,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        foreach (var msg in messages)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return msg;
+            await Task.Yield();
+        }
+    }
+
+    private sealed class ManualLoopTriggerSource : ITriggerSource
+    {
+        private volatile ITriggerEventSink? _sink;
+
+        public ValueTask<IArmedTrigger> ArmAsync(
+            TriggerArmRequest request, ITriggerEventSink eventSink, CancellationToken cancellationToken)
+        {
+            _sink = eventSink;
+            return ValueTask.FromResult<IArmedTrigger>(new Handle(request.WaitId));
+        }
+
+        public async Task FireAsync(string payload)
+        {
+            var sink = _sink;
+            if (sink != null)
+            {
+                await sink.FireAsync(new TriggerFireEvent(payload), CancellationToken.None);
+            }
+        }
+
+        private sealed class Handle(string waitId) : IArmedTrigger
+        {
+            public string WaitId { get; } = waitId;
+
+            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/LmMultiTurn.Tests/SubAgentManagerTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentManagerTests.cs
@@ -600,7 +600,7 @@ public class SubAgentManagerTests : IAsyncLifetime
     }
 
     /// <summary>
-    /// Checks if a message is a TextMessage containing sub-agent completion markers.
+    /// Checks if a message is a sub-agent-completion NotifyMessage containing the completion markers.
     /// Extracted as a static method to avoid pattern matching in Moq expression trees.
     /// </summary>
     private static bool ContainsSubAgentResult(
@@ -608,32 +608,34 @@ public class SubAgentManagerTests : IAsyncLifetime
         string templateName,
         string expectedResultText)
     {
-        if (message is not TextMessage tm)
+        if (message is not NotifyMessage { NotifyKind: NotifyKinds.SubAgentCompletion } nm)
         {
             return false;
         }
 
-        return tm.Text.Contains($"<sub-agent name=\"{templateName}\"")
-            && tm.Text.Contains("</sub-agent>")
-            && tm.Text.Contains(expectedResultText);
+        var text = nm.GetText() ?? string.Empty;
+        return text.Contains($"<sub-agent name=\"{templateName}\"")
+            && text.Contains("</sub-agent>")
+            && text.Contains(expectedResultText);
     }
 
     /// <summary>
-    /// Checks if a message is a TextMessage containing sub-agent error markers.
+    /// Checks if a message is a sub-agent-completion NotifyMessage containing the error markers.
     /// Verifies the [Error] tag specifically to distinguish from [Completed].
     /// </summary>
     private static bool ContainsSubAgentError(
         IMessage message,
         string templateName)
     {
-        if (message is not TextMessage tm)
+        if (message is not NotifyMessage { NotifyKind: NotifyKinds.SubAgentCompletion } nm)
         {
             return false;
         }
 
-        return tm.Text.Contains($"<sub-agent name=\"{templateName}\"")
-            && tm.Text.Contains("</sub-agent>")
-            && tm.Text.Contains("[Error]");
+        var text = nm.GetText() ?? string.Empty;
+        return text.Contains($"<sub-agent name=\"{templateName}\"")
+            && text.Contains("</sub-agent>")
+            && text.Contains("[Error]");
     }
 
     /// <summary>

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs
@@ -115,6 +115,15 @@ public static class UiHelpers
         return page.GetByTestId("tool-call-pill");
     }
 
+    /// <summary>
+    /// Out-of-band notification pills (async sub-agent completion, context discovery, ...). Distinct
+    /// from a user bubble; use <c>data-notify-kind</c> to identify the specific kind.
+    /// </summary>
+    public static ILocator NotificationPills(this IPage page)
+    {
+        return page.GetByTestId("notification-pill");
+    }
+
     /// <summary>Returns rendered tool-call names from metadata pills.</summary>
     public static Task<string[]> ToolCallNamesAsync(this IPage page)
     {

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/NotificationPillTests.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/NotificationPillTests.cs
@@ -1,0 +1,110 @@
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using FluentAssertions;
+using LmStreaming.Sample.Browser.E2E.Tests.Infrastructure;
+
+namespace LmStreaming.Sample.Browser.E2E.Tests.Scenarios;
+
+/// <summary>
+/// #171 — A <see cref="AchieveAi.LmDotnetTools.LmCore.Messages.NotifyMessage"/> renders as a distinct
+/// notification pill, NOT a user bubble. The parent (scripted) issues an <c>Agent</c> tool call with
+/// <c>run_in_background: true</c>: the spawn returns immediately, the parent finishes its turn and goes
+/// idle, and the background researcher runs asynchronously. When the researcher completes,
+/// <c>SubAgentManager.SendToParentAsync</c> relays its result as a <c>NotifyMessage</c> that wakes the
+/// idle parent and is published live over the persistent WebSocket — surfacing a
+/// <c>notification-pill</c> with <c>data-notify-kind="subagent-completion"</c>.
+/// </summary>
+/// <remarks>
+/// Unlike <see cref="SubAgentLifecycleTests"/> (a SYNCHRONOUS Agent call whose sub-agent result becomes
+/// the tool result), this exercises the BACKGROUND path — the only producer that emits a
+/// <c>NotifyMessage</c> for a sub-agent completion. The decisive assertions: a
+/// <c>notification-pill[data-notify-kind="subagent-completion"]</c> appears, and the number of user
+/// bubbles stays at one (the message the user typed) — proving the notify (which maps to
+/// <c>Role.User</c>) never rendered as a second user bubble.
+/// </remarks>
+[Collection(PlaywrightCollection.Name)]
+public sealed class NotificationPillTests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public NotificationPillTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Theory]
+    [InlineData("test")]
+    [InlineData("test-anthropic")]
+    public async Task Background_sub_agent_completion_renders_notification_pill(string providerMode)
+    {
+        const string ResearcherMarker = "You are the research sub-agent";
+
+        var responder = ScriptedSseResponder
+            .New()
+            // Declared first (most specific marker) so the sub-agent's request matches here, not the
+            // parent role. The researcher runs one text turn, then completes.
+            .ForRole("researcher", ctx => ctx.SystemPromptContains(ResearcherMarker))
+            .Turn(t => t.Text("Found three fresh AI papers today."))
+            .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
+            // Turn 1: spawn the researcher in the BACKGROUND (returns an id immediately, does not block).
+            .Turn(t => t.ToolCall(
+                "Agent",
+                new { subagent_type = "researcher", prompt = "Find AI papers", run_in_background = true }))
+            // Turn 2: acknowledge the spawn and end the run, so the parent goes idle while the
+            // background researcher is still running.
+            .Turn(t => t.Text("Spawned the researcher in the background; I'll report back when it finishes."))
+            // Turn 3: the wake-run the injected NotifyMessage triggers once the researcher completes.
+            // Consumed only when the notify arrives AFTER the parent went idle (a fast researcher can
+            // instead land mid-run-2); either ordering publishes the pill, so this turn is best-effort
+            // and RemainingTurns is intentionally not asserted.
+            .Turn(t => t.Text("The researcher finished and reported its findings."))
+            .Build();
+
+        await using var session = await _fixture.OpenAsync(
+            providerMode,
+            responder.HandlerFor(providerMode),
+            subAgentFactory: (_, providerAgentFactory) =>
+                new SubAgentOptions
+                {
+                    Templates = new Dictionary<string, SubAgentTemplate>
+                    {
+                        ["researcher"] = new SubAgentTemplate
+                        {
+                            Name = "Researcher",
+                            SystemPrompt = ResearcherMarker,
+                            AgentFactory = providerAgentFactory,
+                            MaxTurnsPerRun = 5,
+                        },
+                    },
+                    MaxConcurrentSubAgents = 5,
+                }
+        );
+        var page = session.Page;
+
+        await page.SendMessageAsync("research AI papers in the background");
+
+        // The pill is published out-of-band after the background researcher completes — it can arrive
+        // during run 2 or after the parent goes idle (the persistent WebSocket stays open across runs),
+        // so poll on the DOM state with a generous timeout rather than on stream-idle.
+        await page.NotificationPills().WaitForCountAtLeastAsync(1, timeoutMs: 30_000);
+
+        // It renders as a subagent-completion notification pill.
+        var kinds = await page.NotificationPills()
+            .EvaluateAllAsync<string[]>("nodes => nodes.map(n => n.getAttribute('data-notify-kind') ?? '')");
+        kinds.Should().Contain("subagent-completion");
+
+        // The background spawn's Agent tool-call pill is present too.
+        await page.ToolCallPills().WaitForCountAtLeastAsync(1, timeoutMs: 20_000);
+        var toolNames = await page.ToolCallPills()
+            .EvaluateAllAsync<string[]>("nodes => nodes.map(n => n.getAttribute('data-tool-name') ?? '')");
+        toolNames.Should().Contain("Agent");
+
+        // The notify maps to Role.User but must NOT render as a user bubble: exactly one user-message
+        // group exists — the message the user typed — proving the notify rendered only as a pill.
+        var userGroups = await page.UserMessageGroups().CountAsync();
+        userGroups.Should().Be(1, "the out-of-band NotifyMessage must render as a pill, not a second user bubble");
+
+        await session.SaveSuccessScreenshotAsync(
+            $"NotificationPill.Background_sub_agent_completion_{providerMode}");
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorTests.cs
@@ -28,12 +28,13 @@ public class ContextDiscoveryInjectorTests
 
         sent.Should().Be(1);
         agent.SentMessages.Should().ContainSingle();
-        var message = agent.SentMessages[0].Should().BeOfType<TextMessage>().Subject;
+        var message = agent.SentMessages[0].Should().BeOfType<NotifyMessage>().Subject;
         message.Role.Should().Be(Role.User);
+        message.NotifyKind.Should().Be(NotifyKinds.ContextDiscovery);
+        message.Label.Should().Be(Path);
+        // The formatted file body stays reachable to the LLM inside the notification envelope.
         message.Text.Should().Contain("<context-discovery path=\"CLAUDE.md\">");
         message.Text.Should().Contain(Content);
-        message.Metadata.Should().NotBeNull();
-        message.Metadata!.Should().ContainKey(ContextDiscoveryInjector.MetadataKey);
     }
 
     [Fact]
@@ -132,7 +133,7 @@ public class ContextDiscoveryInjectorTests
     }
 
     [Fact]
-    public async Task InjectAsync_TruncatedFlag_PropagatesToMetadata()
+    public async Task InjectAsync_TruncatedFlag_PropagatesToEnvelope()
     {
         using var harness = new Harness();
         var agent = harness.RegisterThread(SessionId, "thread-1");
@@ -141,13 +142,9 @@ public class ContextDiscoveryInjectorTests
             BuildPayload(sessionId: SessionId, content: Content, truncated: true),
             CancellationToken.None);
 
-        var message = agent.SentMessages.Should().ContainSingle().Which.Should().BeOfType<TextMessage>().Subject;
+        var message = agent.SentMessages.Should().ContainSingle().Which.Should().BeOfType<NotifyMessage>().Subject;
+        message.NotifyKind.Should().Be(NotifyKinds.ContextDiscovery);
         message.Text.Should().Contain("truncated=\"true\"");
-
-        var metadata = message.Metadata.Should().NotBeNull().And.Subject;
-        metadata!.Should().ContainKey(ContextDiscoveryInjector.MetadataKey);
-        var contextDiscovery = metadata[ContextDiscoveryInjector.MetadataKey];
-        contextDiscovery.Should().BeAssignableTo<System.Collections.Immutable.ImmutableDictionary<string, object>>();
     }
 
     [Fact]

--- a/tests/OpenAIProvider.Tests/Models/NotifyMessageMappingTests.cs
+++ b/tests/OpenAIProvider.Tests/Models/NotifyMessageMappingTests.cs
@@ -1,0 +1,27 @@
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.OpenAIProvider.Models;
+
+namespace AchieveAi.LmDotnetTools.OpenAIProvider.Tests.Models;
+
+/// <summary>
+///     OpenAI chat maps a <see cref="NotifyMessage"/> for free via its <c>ICanGetText</c> path — no
+///     bespoke case is added. This regression pins that the envelope still reaches the request as a
+///     user message (so the "no silent drops on any backend" guarantee holds here too).
+/// </summary>
+public class NotifyMessageMappingTests
+{
+    [Fact]
+    public void NotifyMessage_MapsToUserMessage_ViaICanGetText()
+    {
+        var notify = NotifyMessage.Create(
+            NotifyKinds.SubAgentCompletion, detail: "done", sourceToolName: "Agent", sourceToolCallId: "c1");
+
+        var chatMessages = ChatCompletionRequest.FromMessage(notify).ToList();
+
+        var msg = Assert.Single(chatMessages);
+        Assert.Equal(RoleEnum.User, msg.Role);
+        var content = msg.Content!.Get<string>();
+        Assert.Contains("<notification", content);
+        Assert.Contains("subagent-completion", content);
+    }
+}

--- a/tests/OpenAiResponsesProvider.Tests/NotifyMessageMappingTests.cs
+++ b/tests/OpenAiResponsesProvider.Tests/NotifyMessageMappingTests.cs
@@ -1,0 +1,30 @@
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Tests;
+
+/// <summary>
+///     A <see cref="NotifyMessage"/> must map to a Responses <c>input_text</c> message item carrying its
+///     envelope. The mapper's <c>default:</c> arm silently drops unknown types, so an explicit case is
+///     required or the notification never reaches the model on this backend.
+/// </summary>
+public sealed class NotifyMessageMappingTests
+{
+    [Fact]
+    public void NotifyMessage_MapsTo_UserInputTextMessage_WithEnvelope()
+    {
+        var notify = NotifyMessage.Create(
+            NotifyKinds.SubAgentCompletion, detail: "done", sourceToolName: "Agent", sourceToolCallId: "c1");
+
+        var request = MessageMapper.BuildRequest([notify], options: null);
+
+        request.Input.Should().HaveCount(1);
+        var item = request.Input[0];
+        item.Type.Should().Be("message");
+        item.Role.Should().Be("user");
+        item.Content.Should().NotBeNull();
+        item.Content![0].Type.Should().Be("input_text");
+        item.Content[0].Text.Should().Contain("<notification").And.Contain("subagent-completion");
+    }
+}


### PR DESCRIPTION
## Summary

Introduces a first-class **`NotifyMessage`** type so out-of-band notifications pushed into a running `MultiTurnAgent` (async sub-agent completion, monitors, async bash, timers/cron) stop injecting as plain `Role.User` `TextMessage`s. A notification is delivered like any input — **injected into the next turn if a run is in progress, or it starts a turn when the agent is idle** — maps to a **user-role message** for the LLM whose content is a self-describing envelope naming the originating tool call, and renders as a **distinct notification pill** (not a user bubble) in the UI.

Fixes #171.

## Key decisions

- **Text-envelope correlation only** (no provider `tool_result` pairing). `NotifyMessage.Text` is a **computed get-only projection** of the structured fields (`notify_kind`, `source_tool_call_id`, `source_tool_name`, `label`, `detail`) via a single envelope builder, so the LLM envelope and the UI fields can never desync. Envelope: `<notification kind="…" [in-response-to="Name:id"] [label="…"]>detail</notification>`; the payload's closing marker is sanitized to prevent envelope breakout.
- **Delivery reuses the existing gate** (`SendAsync`) — no new emit API. The loop gains notify-awareness: it publishes the notification body live (so the pill renders immediately and lands in the replay buffer), and — the one edge — a notification arriving while the agent is **parked on an unresolved block-`Wait`** is folded into history and delivered by the resume path instead of tripping the deferred-guard (`RunFailed`). A regular user input while deferred keeps its existing fail-fast behavior.
- **Serialization registered before any producer emits**: `notify` in `GetDiscriminatorFromType`, `GetTypeFromDiscriminator`, and an `InferTypeFromProperties` guard **before** the `text` check (keyed on `notify_kind`) — load-bearing because the conversation store persists without `$type`, so a rehydrated notify must infer as `NotifyMessage`, not `TextMessage` (otherwise history recovery would silently downgrade it).
- **No silent drops on any backend**: every provider/CLI request builder pattern-matches concrete `TextMessage`, so an explicit `NotifyMessage` arm was added to Anthropic, OpenAI-Responses, and the Copilot/Codex CLI prompt builders; OpenAI chat needs no change (it maps via `ICanGetText`).
- **Replay-buffer reset keyed on a new runId** (was: every `RunAssignmentMessage`), so a same-run injection no longer truncates a reconnecting client's replay.
- **Rejected**: metadata-on-`TextMessage` (contradicts the explicit distinct-type requirement) and `NotifyMessage : TextMessage` inheritance (`ShadowPropertiesJsonConverter<TextMessage>` is closed-generic and would erase the subtype).

## What changed

- **LmCore**: `NotifyMessage` + `NotifyKinds` + envelope builder; `notify` registered in `IMessageJsonConverter` (3 sites).
- **LmMultiTurn**: gate delivery + live pill publish + parked-Wait safety + replay-reset-on-runId; `SubAgentManager.SendToParentAsync` → `NotifyMessage`; Copilot/Codex `BuildPrompt` arms.
- **Providers**: Anthropic `AddBasicMessageContents`, OpenAI-Responses `MessageMapper` arms.
- **LmAgentInfra**: `ContextDiscoveryInjector` → `NotifyMessage` (retires the legacy `context_discovery` metadata emit; keeps the const for back-compat rendering of old rows).
- **LmWorkflow**: the dormant injected-completion case matches `NotifyMessage` and parses `Detail`, so the #106 fan-out re-enable isn't silently broken.
- **Client (LmStreaming.Sample)**: `notify` token/interface/guard; `NotificationPill.vue`; `displayItems` notification branch **before** the `role==='user'` catch-all (also unifies legacy `context_discovery` rows into one pill); merge-key disambiguation via the per-message `generationId`.

## Testing

- **C#**: full solution builds clean (0 warnings / 0 errors). Green per project: `LmCore.Tests` 784, `LmMultiTurn.Tests` 431 (incl. new notify loop/build-prompt tests: idle-wake, mid-run inject, parked-Wait no-RunFailed + delivered-on-resume, serialization round-trip incl. `$type`-stripped inference), `LmWorkflow.Tests` 195, provider mapping tests on all 5 backends + Anthropic tool_result-adjacency, updated `SubAgentManagerTests` + `ContextDiscoveryInjectorTests`.
- **Client**: 311 Vitest passing (incl. 7 new) — notify routes to a pill not a user bubble, two-in-one-run distinct/ordered live and after reload, legacy `context_discovery` unified pill; `vue-tsc` type-check + production build clean.
- **Bug-focused review**: an adversarial pass over the loop concurrency, serialization, envelope, provider mapping, client, and producers found no correctness issues (the Anthropic `[tool_use][tool_result][notify]` ordering holds because the deferred placeholder is updated in place, not appended).

## Deferred

- **Browser (Playwright) E2E** for the pill (live / reload / two-in-one-run) is not yet run in this PR; the equivalent scenarios are covered at the Vitest unit level and the `data-testid="notification-pill"` / `data-notify-kind` hooks are in place for it.
- Payload size-cap, PII/secret redaction, rollout/kill-switch flags → #161. Trigger notify-mode delivery → #140; cron/interval → #143; durable restore → #145; background fan-out re-enable → #106.
