### PR TITLE
feat(daemon): persist review conversations + optional JSONL logging

### DIFF
--- a/samples/CodeReviewDaemon.Sample/Agents/LiveReviewAgentLoopFactory.cs
+++ b/samples/CodeReviewDaemon.Sample/Agents/LiveReviewAgentLoopFactory.cs
@@ -8,6 +8,7 @@ using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
 using AchieveAi.LmDotnetTools.McpMiddleware.Extensions;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
@@ -50,16 +51,21 @@ internal sealed class LiveReviewAgentLoopFactory : IReviewAgentLoopFactory, IDis
 {
     private readonly ILoggerFactory _loggerFactory;
     private readonly CodeReviewDaemonOptions _options;
+    private readonly IConversationStore? _conversationStore;
     private readonly ICopilotTokenProvider _tokenProvider = new CliCredentialCopilotTokenProvider();
     private readonly CopilotSessionContext _session = new();
     private readonly object _agentGate = new();
     private IStreamingAgent? _anthropicAgent;
     private IStreamingAgent? _openAiAgent;
 
-    public LiveReviewAgentLoopFactory(ILoggerFactory loggerFactory, CodeReviewDaemonOptions options)
+    public LiveReviewAgentLoopFactory(
+        ILoggerFactory loggerFactory,
+        CodeReviewDaemonOptions options,
+        IConversationStore? conversationStore = null)
     {
         _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         _options = options ?? throw new ArgumentNullException(nameof(options));
+        _conversationStore = conversationStore;
     }
 
     /// <summary>
@@ -150,6 +156,15 @@ internal sealed class LiveReviewAgentLoopFactory : IReviewAgentLoopFactory, IDis
                 string.Join(",", keptContracts.Select(c => c.Name)));
         }
 
+        // Persist the conversation (primary + sub-agents) when a store is configured, so every review's tool
+        // calls — Skill loads and sub-agent Task dispatches — are auditable after the run. Sub-agents share the
+        // same store (keyed per thread) via DefaultConversationStoreFactory unless one is already supplied.
+        var subAgentOptions = toolContext?.SubAgentOptions;
+        if (_conversationStore is not null && subAgentOptions is { DefaultConversationStoreFactory: null })
+        {
+            subAgentOptions = subAgentOptions with { DefaultConversationStoreFactory = _ => _conversationStore };
+        }
+
         var loop = new MultiTurnAgentLoop(
             providerAgent,
             registry,
@@ -161,9 +176,11 @@ internal sealed class LiveReviewAgentLoopFactory : IReviewAgentLoopFactory, IDis
                 MaxToken = _options.ReviewMaxTokens,
                 ExtraProperties = extraProperties,
             },
+            store: _conversationStore,
             logger: _loggerFactory.CreateLogger<MultiTurnAgentLoop>(),
-            subAgentOptions: toolContext?.SubAgentOptions,
-            loggerFactory: _loggerFactory);
+            subAgentOptions: subAgentOptions,
+            loggerFactory: _loggerFactory,
+            persistRunLedger: _conversationStore is not null);
 
         // Start the loop's background processing task before returning: ExecuteRunAsync only enqueues input
         // and reads the output channel — it does NOT start RunLoopAsync — so without this the caller's

--- a/samples/CodeReviewDaemon.Sample/CodeReviewDaemon.Sample.csproj
+++ b/samples/CodeReviewDaemon.Sample/CodeReviewDaemon.Sample.csproj
@@ -18,6 +18,12 @@
          McpClient over HttpClientTransport (X-Session-ID header) and calls the gateway's Bash tool
          to run all deterministic git/fs work. Pinned to the version used across the MCP projects. -->
     <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <!-- Optional structured JSONL logging for the daemon's own logs (CodeReviewDaemon:LogFilePath) —
+         Serilog CompactJsonFormatter, DuckDB-queryable. Same versions LmTestUtils pins for test logging. -->
+    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- All reusable agent/sandbox/OAuth/webhook machinery lives in LmAgentInfra (shared with

--- a/samples/CodeReviewDaemon.Sample/Configuration/CodeReviewDaemonOptions.cs
+++ b/samples/CodeReviewDaemon.Sample/Configuration/CodeReviewDaemonOptions.cs
@@ -53,6 +53,24 @@ internal sealed class CodeReviewDaemonOptions
     public string? DatabasePath { get; init; }
 
     /// <summary>
+    /// Directory the review agents persist their full <c>MultiTurnAgentLoop</c> conversation to (one
+    /// <c>&lt;threadId&gt;/messages.json</c> per primary and sub-agent thread, via
+    /// <see cref="AchieveAi.LmDotnetTools.LmMultiTurn.Persistence.FileConversationStore"/>) so every review's
+    /// tool calls — Skill loads and sub-agent Task dispatches — are auditable after the fact (the JSON is
+    /// DuckDB-queryable). When unset (default) conversations are NOT persisted: the loop streams and discards
+    /// them, exactly as before.
+    /// </summary>
+    public string? ConversationStorePath { get; init; }
+
+    /// <summary>
+    /// When set, the daemon ALSO writes its own logs as structured JSONL (Serilog
+    /// <see cref="Serilog.Formatting.Compact.CompactJsonFormatter"/>, daily-rolled) to this path — canonical
+    /// <c>@t</c>/<c>@l</c>/<c>@m</c>/<c>SourceContext</c> fields, DuckDB-queryable — in addition to the console
+    /// output. Unset (default) leaves only the console logger, exactly as before.
+    /// </summary>
+    public string? LogFilePath { get; init; }
+
+    /// <summary>
     /// Model id the primary review agent runs with (the id sent to the Copilot-backed Anthropic Messages
     /// backend, e.g. <c>claude-sonnet-5</c>). The poller stamps it onto each review run so the primary
     /// review has a concrete model — an empty id would be rejected by the provider. The A/B comparison

--- a/samples/CodeReviewDaemon.Sample/Hosting/DaemonLogging.cs
+++ b/samples/CodeReviewDaemon.Sample/Hosting/DaemonLogging.cs
@@ -1,0 +1,34 @@
+using Serilog;
+using Serilog.Formatting.Compact;
+
+namespace CodeReviewDaemon.Sample.Hosting;
+
+/// <summary>
+/// Opt-in structured logging for the daemon. When <c>CodeReviewDaemon:LogFilePath</c> is set, the daemon's
+/// own logs are ALSO written as JSONL (Serilog <see cref="CompactJsonFormatter"/>, daily-rolled) alongside
+/// the console logger, so they are queryable with DuckDB for later review — the console output (redirected
+/// to the process log) is unchanged.
+/// </summary>
+internal static class DaemonLogging
+{
+    /// <summary>
+    /// Adds a Serilog CompactJsonFormatter (JSONL) file sink to <paramref name="logging"/> at
+    /// <paramref name="path"/> (daily-rolled), enriched with the ambient <c>LogContext</c>. Canonical fields:
+    /// <c>@t</c> (ISO-8601 UTC), <c>@l</c> (level), <c>@m</c> (message), <c>@mt</c> (template),
+    /// <c>SourceContext</c> (component), plus any structured properties as top-level fields.
+    /// </summary>
+    public static void AddJsonlFileSink(ILoggingBuilder logging, string path)
+    {
+        ArgumentNullException.ThrowIfNull(logging);
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        var logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .Enrich.FromLogContext()
+            .WriteTo.File(new CompactJsonFormatter(), path, rollingInterval: RollingInterval.Day)
+            .CreateLogger();
+
+        // Added alongside (not replacing) the default console provider, so the existing process log stays.
+        _ = logging.AddSerilog(logger, dispose: true);
+    }
+}

--- a/samples/CodeReviewDaemon.Sample/Program.cs
+++ b/samples/CodeReviewDaemon.Sample/Program.cs
@@ -2,6 +2,7 @@ using AchieveAi.LmDotnetTools.LmAgentInfra.Auth;
 using AchieveAi.LmDotnetTools.LmAgentInfra.Controllers;
 using AchieveAi.LmDotnetTools.LmAgentInfra.Sandbox;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
 using CodeReviewDaemon.Sample.Agents;
 using CodeReviewDaemon.Sample.Auth;
 using CodeReviewDaemon.Sample.Configuration;
@@ -33,6 +34,13 @@ var daemonOptions =
     builder.Configuration.GetSection(CodeReviewDaemonOptions.SectionName).Get<CodeReviewDaemonOptions>()
     ?? new CodeReviewDaemonOptions();
 builder.Services.AddSingleton(daemonOptions);
+
+// Opt-in structured JSONL logging: when CodeReviewDaemon:LogFilePath is set, add a Serilog file sink
+// alongside the console logger so the daemon's own logs are DuckDB-queryable. Unset ⇒ console-only.
+if (!string.IsNullOrWhiteSpace(daemonOptions.LogFilePath))
+{
+    DaemonLogging.AddJsonlFileSink(builder.Logging, daemonOptions.LogFilePath);
+}
 
 // ── Sandbox gateway per-app identity (ADR 0029) ─────────────────────────────────────────────────
 // The daemon authenticates to the sandbox gateway under its OWN app identity — distinct from
@@ -199,11 +207,22 @@ builder.Services.AddSingleton<IDiscoveredItemsSource>(sp =>
     new RegistryDiscoverySource(sp.GetRequiredService<SandboxSessionRegistry>()));
 builder.Services.AddSingleton<DiscoveredSubAgentTemplateBuilder>();
 
+// Optional conversation persistence: when ConversationStorePath is set, every review agent's
+// MultiTurnAgentLoop (primary + sub-agents) persists its full message history — Skill loads, sub-agent Task
+// dispatches, tool results — to <path>/<threadId>/messages.json for after-the-fact audit (DuckDB-queryable).
+// Unset ⇒ conversations are streamed and discarded, exactly as before.
+IConversationStore? conversationStore = string.IsNullOrWhiteSpace(daemonOptions.ConversationStorePath)
+    ? null
+    : new FileConversationStore(daemonOptions.ConversationStorePath);
+
 // The live agent loop (OpenAI-compatible MultiTurnAgentLoop). Dead-by-default + lazy per run. Registered
 // by its concrete type too (rather than only the IReviewAgentLoopFactory interface) so the executor can
 // also resolve its SharedAgentFactory (Task 12) — the same Copilot-backed agent every review loop and any
 // discovered sub-agent are driven by — without standing up a second provider agent.
-builder.Services.AddSingleton<LiveReviewAgentLoopFactory>();
+builder.Services.AddSingleton<LiveReviewAgentLoopFactory>(sp => new LiveReviewAgentLoopFactory(
+    sp.GetRequiredService<ILoggerFactory>(),
+    daemonOptions,
+    conversationStore));
 builder.Services.AddSingleton<IReviewAgentLoopFactory>(sp => sp.GetRequiredService<LiveReviewAgentLoopFactory>());
 builder.Services.AddSingleton<Func<IStreamingAgent>>(sp =>
     sp.GetRequiredService<LiveReviewAgentLoopFactory>().SharedAgentFactory);


### PR DESCRIPTION
## Why

The review agents' `MultiTurnAgentLoop` was created with **no conversation store**, so every run's messages — `Skill` loads, sub-agent `Task` dispatches, tool results — were streamed and discarded. Nothing was persisted, so "which skills/agents did that review use?" was unanswerable from any store or log.

## What (both opt-in; unset ⇒ unchanged)

- **`CodeReviewDaemon:ConversationStorePath`** — wires a `FileConversationStore` into the primary loop **and** its sub-agents (`SubAgentOptions.DefaultConversationStoreFactory`), so each thread's full history persists to `<path>/<threadId>/messages.json` (JSON, DuckDB-queryable). `persistRunLedger` on when a store is present.
- **`CodeReviewDaemon:LogFilePath`** — adds a Serilog `CompactJsonFormatter` JSONL file sink (daily-rolled) **alongside** the console logger, so the daemon's own logs are DuckDB-queryable. Isolated in `Hosting/DaemonLogging` to avoid a `using Serilog;` / `ILogger` clash in `Program.cs`.

## Verify

467 daemon tests green; 0-warning. Live: with `ConversationStorePath` set, each review writes `messages.json` (tool calls incl. Skill/Task) queryable via `duckdb -c "SELECT ... FROM read_json('.../messages.json')"`.