### PR TITLE
feat(#145): durable notify-watcher restore across restart in LmStreaming.Sample

### DIFF
--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -395,9 +395,16 @@ try
     // IAsyncDisposable-only singleton makes ServiceProvider.Dispose() (synchronous) throw
     // "only implements IAsyncDisposable". The sample host is torn down synchronously in tests
     // (BrowserWebAppFactory calls IHost.Dispose()), so tracking the factory would regress every E2E
-    // test that creates an agent. The inline factory is instead reclaimed by GC at process end — a
-    // benign leak (it only holds SemaphoreSlims, which allocate no OS handle here), which is the right
-    // trade for a sample host that must stay sync-dispose-safe.
+    // test that creates an agent. The factory OBJECT itself only holds SemaphoreSlims (no OS handle)
+    // and is reclaimed by GC at process end; the real cost of never disposing it is that the
+    // PROCESS-WIDE Microsoft.Data.Sqlite connection pool — not owned by this object — stays populated
+    // with live WAL connections (this factory sets Pooling=true + Cache=Shared and runs
+    // PRAGMA journal_mode=WAL), each an open OS file handle plus its -wal/-shm sidecars, until the
+    // process exits or SqliteConnection.ClearAllPools() is called. Acceptable here ONLY because this
+    // path is test-mode-gated and the tests clear the pool in their finally. FOLLOW-UP (#161): before
+    // flipping the real-provider gate, register real async disposal (e.g.
+    // IHostApplicationLifetime.ApplicationStopped -> SqliteConnection.ClearAllPools()) so the pooled
+    // WAL handles are released deterministically instead of lingering to process exit.
     // Configurable path (default a sibling of the conversations/ folder) mirrors
     // CodeReviewDaemon.Sample's CodeReviewDaemon:DatabasePath so a WebApplicationFactory test can
     // UseSetting an isolated file.

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -20,6 +20,7 @@ using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmCore.Utils;
 using AchieveAi.LmDotnetTools.LmMultiTurn;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence.Sqlite;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using AchieveAi.LmDotnetTools.LmStreaming.AspNetCore.Extensions;
 using AchieveAi.LmDotnetTools.LmStreaming.Sample.Triggers;
@@ -388,6 +389,33 @@ try
     _ = builder.Services.AddSingleton<IConversationStore>(conversationStore);
     _ = builder.Services.AddSingleton<IRunLedgerStore>(conversationStore);
 
+    // #145: durable notify-wait persistence. Register ONLY the (non-disposable) INotifyWaitStore and
+    // construct its SqliteConnectionFactory INLINE — deliberately NOT as a separately-tracked
+    // singleton. ISqliteConnectionFactory is IAsyncDisposable-only; a container-tracked
+    // IAsyncDisposable-only singleton makes ServiceProvider.Dispose() (synchronous) throw
+    // "only implements IAsyncDisposable". The sample host is torn down synchronously in tests
+    // (BrowserWebAppFactory calls IHost.Dispose()), so tracking the factory would regress every E2E
+    // test that creates an agent. The inline factory is instead reclaimed by GC at process end — a
+    // benign leak (it only holds SemaphoreSlims, which allocate no OS handle here), which is the right
+    // trade for a sample host that must stay sync-dispose-safe.
+    // Configurable path (default a sibling of the conversations/ folder) mirrors
+    // CodeReviewDaemon.Sample's CodeReviewDaemon:DatabasePath so a WebApplicationFactory test can
+    // UseSetting an isolated file.
+    // NOTE (intentional): SqliteNotifyWaitStore self-initializes via the shared SqliteSchemaInitializer,
+    // which also creates currently-unused sibling tables (messages/thread_metadata/run_ledger/
+    // accepted_inputs) in this db file — accepted to reuse shared infra rather than fork a
+    // notify-only initializer.
+    // KNOWN LIMITATION (#145, accepted): notify_waits rows for threads that are never reopened after a
+    // restart are never pruned (restore/cleanup only runs when that thread's loop is reconstructed).
+    // Acceptable for a sample app; no pruning logic added.
+    var notifyWaitDbPath = builder.Configuration["LmStreaming:NotifyWaitDbPath"];
+    if (string.IsNullOrWhiteSpace(notifyWaitDbPath))
+    {
+        notifyWaitDbPath = Path.Combine(AppContext.BaseDirectory, "notify-waits.db");
+    }
+    _ = builder.Services.AddSingleton<INotifyWaitStore>(_ =>
+        new SqliteNotifyWaitStore(new SqliteConnectionFactory(notifyWaitDbPath)));
+
     // The REST status resolver (ConversationsController dependency) reads the conversation store plus
     // its run ledger. Resolve the ledger from the registered IConversationStore so a test host that
     // swaps the store (see BrowserWebAppFactory) keeps both halves pointing at the same instance —
@@ -472,6 +500,10 @@ try
         var functionRegistry = sp.GetRequiredService<FunctionRegistry>();
         var agentFactory = sp.GetRequiredService<Func<string, IStreamingAgent>>();
         var conversationStore = sp.GetRequiredService<IConversationStore>();
+        // #145: the durable notify-wait store is a process singleton (like conversationStore); captured
+        // here so the inner per-thread agent factory can attach it to TriggerOptions (see the Build(...)
+        // call site below). ThreadId is per-thread via context.ThreadId inside that factory.
+        var notifyWaitStore = sp.GetRequiredService<INotifyWaitStore>();
         var providerRegistry = sp.GetRequiredService<ProviderRegistry>();
         var codexLifetime = sp.GetRequiredService<CodexMcpServerLifetime>();
         var mockHostLifetime = sp.GetRequiredService<MockProviderHostLifetime>();
@@ -1047,9 +1079,20 @@ try
                     // inside its own ctor, so a subagent-kind source can't be handed the manager
                     // directly — it resolves it lazily once the loop (and thus the manager) exists.
                     MultiTurnAgentLoop agent = null!;
+                    // #145: attach the durable notify-wait store + this thread's id so notify-mode waits
+                    // survive a process restart (TriggerRuntime restores/reconciles them on thread
+                    // recovery). Set via a record `with` on Build's result so SampleTriggerRegistrations.Build
+                    // keeps its trigger-source-only responsibility. Test-mode/mock-provider ONLY today — same
+                    // gate as the triggerOptions pass-through at the loop ctor below; real-provider rollout is
+                    // tracked in #161. (When !isTestMode the whole triggerOptions object is discarded there,
+                    // so leaving the store null keeps it from being attached to a thrown-away options value.)
                     var triggerOptions = SampleTriggerRegistrations.Build(
                         sandboxEnabled: sandboxSession is not null,
-                        subAgentManagerAccessor: () => agent?.SubAgentManager);
+                        subAgentManagerAccessor: () => agent?.SubAgentManager) with
+                    {
+                        NotifyWaitStore = isTestMode ? notifyWaitStore : null,
+                        ThreadId = isTestMode ? threadId : null,
+                    };
 
                     agent = new MultiTurnAgentLoop(
                         providerAgent,

--- a/tests/LmStreaming.Sample.Tests/Triggers/NotifyWaitDurableRestoreTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Triggers/NotifyWaitDurableRestoreTests.cs
@@ -1,0 +1,292 @@
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence.Sqlite;
+using AchieveAi.LmDotnetTools.LmStreaming.Sample.Triggers;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace LmStreaming.Sample.Tests.Triggers;
+
+/// <summary>
+/// Issue #145 integration test: proves the sample host's durable notify-wait wiring
+/// (<c>Program.cs</c> DI registration of <see cref="INotifyWaitStore"/> + the <c>TriggerOptions</c>
+/// <c>with</c>-attach in the pool's agent factory) actually persists notify-watcher arming records
+/// and reconciles them across a simulated restart against REAL on-disk SQLite — the one gap no
+/// existing in-memory test covers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A "restart" is simulated as: (1) seed the durable notify-wait store + thread metadata on disk
+/// directly (write side), then (2) boot the real <c>Program</c> host over that same on-disk
+/// state and open the thread. Booting the host resolves the DI-registered store and drives the pool
+/// agent factory, whose <c>RunAsync</c> auto-recovery calls
+/// <c>TriggerRuntime.RestoreNotifyWaitsAsync</c> — the wiring under test. Seeding directly (rather
+/// than driving the mock model to arm a wait) keeps the test focused on the new host wiring; the
+/// model-driven arm path is already covered at the loop level.
+/// </para>
+/// <para>
+/// Thread metadata MUST be seeded: <c>MultiTurnAgentBase.RecoverAsync</c> only invokes
+/// <c>OnThreadRecoveredAsync</c> (→ notify restore) when the thread has metadata; a metadata-less
+/// thread short-circuits and restore never runs.
+/// </para>
+/// <para>
+/// Tests are serialized (see <c>AssemblyInfo.cs</c> <c>DisableTestParallelization</c>) because the
+/// host reads the process-global <c>LM_PROVIDER_MODE</c>.
+/// </para>
+/// </remarks>
+public sealed class NotifyWaitDurableRestoreTests
+{
+    private const string ScheduleWaitId = "call_schedule_1";
+    private const string ProcessWaitId = "call_process_1";
+    private const string ProcessBarrierWaitId = "call_process_barrier";
+
+    /// <summary>
+    /// Boots the real <c>Program</c> over an isolated notify-wait db + conversation store.
+    /// Uses the default in-memory <c>TestServer</c> (we only need <see cref="WebApplicationFactory{TEntryPoint}.Services"/>,
+    /// not HTTP), so — unlike <c>BrowserWebAppFactory</c> — no Kestrel swap / cast workaround is needed.
+    /// </summary>
+    private sealed class NotifyRestoreWebAppFactory : WebApplicationFactory<Program>
+    {
+        private readonly string _notifyDbPath;
+        private readonly string _conversationsPath;
+
+        public NotifyRestoreWebAppFactory(string notifyDbPath, string conversationsPath)
+        {
+            _notifyDbPath = notifyDbPath;
+            _conversationsPath = conversationsPath;
+
+            // Program.cs reads LM_PROVIDER_MODE at the top level, before any host-builder callback.
+            // 'test' selects the scripted agent factory — the agent never needs a script here because
+            // RunAsync runs recovery (and thus notify restore) before it processes any input.
+            Environment.SetEnvironmentVariable("LM_PROVIDER_MODE", "test");
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            // Production avoids the Vite dev-server auto-spawn (matches BrowserWebAppFactory / DaemonWebAppFactory).
+            builder.UseEnvironment("Production");
+
+            // Point the #145 notify-wait store at this test's isolated db (mirrors
+            // CodeReviewDaemon.Sample's CodeReviewDaemon:DatabasePath test-override via UseSetting).
+            builder.UseSetting("LmStreaming:NotifyWaitDbPath", _notifyDbPath);
+
+            builder.ConfigureTestServices(services =>
+            {
+                // Isolate the conversation store to this test's temp dir so the seeded metadata (which
+                // gates recovery) is what the host recovers. Same override seam BrowserWebAppFactory uses.
+                services.RemoveAll<IConversationStore>();
+                services.AddSingleton<IConversationStore>(new FileConversationStore(_conversationsPath));
+            });
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+            {
+                Environment.SetEnvironmentVariable("LM_PROVIDER_MODE", null);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ProcessNotifyWait_UnregisteredKindAfterRestart_DeliversTriggerLostAndClearsRow()
+    {
+        var (root, conversationsPath, notifyDbPath) = NewTempPaths();
+        var threadId = "notify-restore-process-" + Guid.NewGuid().ToString("N");
+        try
+        {
+            var now = NowMs();
+            // A gateway-less host builds SampleTriggerRegistrations with sandboxEnabled:false, so the
+            // 'process' kind is never registered. Restore therefore hits the unregistered-kind branch,
+            // delivers trigger_lost_on_restart, and clears the row once the terminal envelope is accepted.
+            await SeedAsync(conversationsPath, notifyDbPath, threadId,
+            [
+                new NotifyWaitRecord(
+                    WaitId: ProcessWaitId,
+                    ThreadId: threadId,
+                    Kind: ProcessTriggerSource.KindName,
+                    Args: "{\"handle\":\"proc-abc\"}",
+                    Label: null,
+                    MaxFires: null,
+                    FiresSoFar: 0,
+                    TimeoutAtUnixMs: now + 3_600_000,
+                    ArmedAtUnixMs: now,
+                    Status: "active"),
+            ]);
+
+            await using var host = new NotifyRestoreWebAppFactory(notifyDbPath, conversationsPath);
+            var notifyStore = host.Services.GetRequiredService<INotifyWaitStore>();
+            var pool = host.Services.GetRequiredService<MultiTurnAgentPool>();
+            var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+
+            // Opening the thread runs the real agent-factory closure (the #145 wiring) and its
+            // RunAsync auto-recovery → RestoreNotifyWaitsAsync.
+            _ = pool.GetOrCreateAgent(threadId, mode, requestedProviderId: "test", requestResponseDumpFileName: null);
+
+            var active = await PollActiveUntilAsync(notifyStore, threadId, rows => rows.Count == 0);
+
+            active.Should().BeEmpty(
+                "the process kind is not registered in a gateway-less host, so restore delivers " +
+                "trigger_lost_on_restart and clears the durable row");
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            TryDeleteDir(root);
+        }
+    }
+
+    [Fact]
+    public async Task ScheduleNotifyWait_RestorableKind_SurvivesRestartAndReArms()
+    {
+        var (root, conversationsPath, notifyDbPath) = NewTempPaths();
+        var threadId = "notify-restore-schedule-" + Guid.NewGuid().ToString("N");
+        try
+        {
+            var now = NowMs();
+            await SeedAsync(conversationsPath, notifyDbPath, threadId,
+            [
+                // Restorable: the schedule kind is always registered and re-arms deterministically from
+                // (interval, armedAt). A long interval guarantees it never fires during the test, so the
+                // row stays active after a successful re-arm.
+                new NotifyWaitRecord(
+                    WaitId: ScheduleWaitId,
+                    ThreadId: threadId,
+                    Kind: ScheduleTriggerSource.KindName,
+                    Args: "{\"intervalSeconds\":86400}",
+                    Label: null,
+                    MaxFires: null,
+                    FiresSoFar: 0,
+                    TimeoutAtUnixMs: now + 3_600_000,
+                    ArmedAtUnixMs: now,
+                    Status: "active"),
+
+                // Non-restorable barrier: its deletion is the positive signal that restore ran this pass.
+                // Both rows are processed in one synchronous RestoreNotifyWaitsAsync loop, so once the
+                // barrier is gone the schedule row has also been processed — making the schedule-survival
+                // assertion race-free (rather than indistinguishable from "restore hasn't run yet").
+                new NotifyWaitRecord(
+                    WaitId: ProcessBarrierWaitId,
+                    ThreadId: threadId,
+                    Kind: ProcessTriggerSource.KindName,
+                    Args: "{\"handle\":\"proc-xyz\"}",
+                    Label: null,
+                    MaxFires: null,
+                    FiresSoFar: 0,
+                    TimeoutAtUnixMs: now + 3_600_000,
+                    ArmedAtUnixMs: now,
+                    Status: "active"),
+            ]);
+
+            await using var host = new NotifyRestoreWebAppFactory(notifyDbPath, conversationsPath);
+            var notifyStore = host.Services.GetRequiredService<INotifyWaitStore>();
+            var pool = host.Services.GetRequiredService<MultiTurnAgentPool>();
+            var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+
+            _ = pool.GetOrCreateAgent(threadId, mode, requestedProviderId: "test", requestResponseDumpFileName: null);
+
+            // Converge to exactly {schedule}: the process barrier is gone (restore ran) AND the schedule
+            // row is still active (it re-armed rather than being lost).
+            var active = await PollActiveUntilAsync(
+                notifyStore,
+                threadId,
+                rows => rows.Count == 1 && rows[0].WaitId == ScheduleWaitId);
+
+            active.Select(r => r.WaitId).Should().BeEquivalentTo(
+                [ScheduleWaitId],
+                "the restorable schedule kind re-arms and survives the restart while the non-restorable " +
+                "process barrier is cleared");
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            TryDeleteDir(root);
+        }
+    }
+
+    // --- helpers -----------------------------------------------------------------------------
+
+    private static long NowMs() => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+    private static (string Root, string ConversationsPath, string NotifyDbPath) NewTempPaths()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "lm-notify-restore-test", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return (root, Path.Combine(root, "conversations"), Path.Combine(root, "notify-waits.db"));
+    }
+
+    /// <summary>
+    /// Seeds the on-disk conversation metadata (required for recovery to fire) and the durable notify
+    /// rows directly, then releases the SQLite connection pool's file handle so the host opens the db
+    /// cleanly (needed on Windows, where the shared-cache pool otherwise pins the file).
+    /// </summary>
+    private static async Task SeedAsync(
+        string conversationsPath,
+        string notifyDbPath,
+        string threadId,
+        IReadOnlyList<NotifyWaitRecord> rows)
+    {
+        var conversationStore = new FileConversationStore(conversationsPath);
+        await conversationStore.SaveMetadataAsync(
+            threadId,
+            new ThreadMetadata { ThreadId = threadId, LastUpdated = NowMs(), LatestRunId = "run_seed" });
+
+        var factory = new SqliteConnectionFactory(notifyDbPath);
+        try
+        {
+            var store = new SqliteNotifyWaitStore(factory);
+            foreach (var row in rows)
+            {
+                await store.SaveAsync(row);
+            }
+        }
+        finally
+        {
+            await factory.DisposeAsync();
+        }
+
+        SqliteConnection.ClearAllPools();
+    }
+
+    /// <summary>
+    /// Polls <see cref="INotifyWaitStore.LoadActiveAsync"/> until <paramref name="predicate"/> holds
+    /// or the bounded budget (~10s) elapses; returns the last-observed active set for assertion.
+    /// </summary>
+    private static async Task<IReadOnlyList<NotifyWaitRecord>> PollActiveUntilAsync(
+        INotifyWaitStore store,
+        string threadId,
+        Func<IReadOnlyList<NotifyWaitRecord>, bool> predicate)
+    {
+        IReadOnlyList<NotifyWaitRecord> active = [];
+        for (var i = 0; i < 200; i++)
+        {
+            active = await store.LoadActiveAsync(threadId);
+            if (predicate(active))
+            {
+                break;
+            }
+
+            await Task.Delay(50);
+        }
+
+        return active;
+    }
+
+    private static void TryDeleteDir(string root)
+    {
+        try
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup; a leftover temp dir must not fail the test.
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Triggers/NotifyWaitDurableRestoreTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Triggers/NotifyWaitDurableRestoreTests.cs
@@ -340,24 +340,28 @@ public sealed class NotifyWaitDurableRestoreTests
             var now = NowMs();
             await SeedAsync(conversationsPath, notifyDbPath, threadId,
             [
-                // Short interval + small cap: restore re-arms this schedule wait, its wall-clock timer
+                // Short interval + HIGH cap: restore re-arms this schedule wait, its wall-clock timer
                 // fires ~1s later, and because a CAPPED wait persists fires_so_far on EVERY fire (only
                 // uncapped waits debounce the count — see OnSourceFiredAsync), the durable row advances to
                 // fires_so_far >= 1 while still active. That advanced-count-while-active state is the
                 // strongest durable proof: it shows the restored wait actually re-armed AND fired AND
                 // persisted the new count, not merely that its row survived.
                 //
-                // Signal chosen: fires_so_far >= 1 while the row is still active. It is observable during
-                // the ~1s window between the first fire (fires_so_far -> 1, row stays active) and the
-                // second/final fire (which tears the row down), comfortably inside the ~10s poll budget.
-                // The alternative "row terminates at maxFires" would also work but proves strictly less.
+                // The cap is deliberately large (100 fires ~= 100s of lifetime) so the row does NOT tear
+                // down anywhere near the ~10s poll budget. This makes "fires_so_far >= 1 while active" a
+                // LATCHED, monotonic state rather than a transient ~1s window: once the first fire lands,
+                // every later poll still observes it, so a slow/loaded CI agent (host-boot + recovery + GC
+                // latency) can never overshoot it into a torn-down row. (A small cap like MaxFires:2 made
+                // this test flaky — the active-with-count state only existed briefly before the final fire
+                // deleted the row.) The sibling exhausted/timed-out tests already cover row teardown; this
+                // fact's distinct job is proving a live post-restore re-arm + fire, so it keeps that proof.
                 new NotifyWaitRecord(
                     WaitId: ScheduleWaitId,
                     ThreadId: threadId,
                     Kind: ScheduleTriggerSource.KindName,
                     Args: "{\"intervalSeconds\":1}",
                     Label: null,
-                    MaxFires: 2,
+                    MaxFires: 100,
                     FiresSoFar: 0,
                     TimeoutAtUnixMs: now + 3_600_000,
                     ArmedAtUnixMs: now,

--- a/tests/LmStreaming.Sample.Tests/Triggers/NotifyWaitDurableRestoreTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Triggers/NotifyWaitDurableRestoreTests.cs
@@ -207,6 +207,189 @@ public sealed class NotifyWaitDurableRestoreTests
         }
     }
 
+    [Fact]
+    public async Task ScheduleNotifyWait_ExhaustedFireBudgetAfterRestart_ClearsRowWithoutReArming()
+    {
+        var (root, conversationsPath, notifyDbPath) = NewTempPaths();
+        var threadId = "notify-restore-exhausted-" + Guid.NewGuid().ToString("N");
+        try
+        {
+            var now = NowMs();
+            await SeedAsync(conversationsPath, notifyDbPath, threadId,
+            [
+                // Restorable schedule kind whose fire budget is already spent (FiresSoFar == MaxFires):
+                // stale terminal state left behind when the process crashed between the final fire's
+                // envelope and its row-delete. Restore must DELETE this row without re-arming — never
+                // double-firing — even though its TTL is far in the future. This is the exact inverse of
+                // the survive-test's non-exhausted schedule row, which re-arms and stays active.
+                new NotifyWaitRecord(
+                    WaitId: ScheduleWaitId,
+                    ThreadId: threadId,
+                    Kind: ScheduleTriggerSource.KindName,
+                    Args: "{\"intervalSeconds\":86400}",
+                    Label: null,
+                    MaxFires: 1,
+                    FiresSoFar: 1,
+                    TimeoutAtUnixMs: now + 3_600_000,
+                    ArmedAtUnixMs: now,
+                    Status: "active"),
+
+                // Non-restorable barrier: its deletion proves restore ran this pass, so the exhausted
+                // row's absence is a real cleanup rather than "restore hasn't run yet".
+                new NotifyWaitRecord(
+                    WaitId: ProcessBarrierWaitId,
+                    ThreadId: threadId,
+                    Kind: ProcessTriggerSource.KindName,
+                    Args: "{\"handle\":\"proc-xyz\"}",
+                    Label: null,
+                    MaxFires: null,
+                    FiresSoFar: 0,
+                    TimeoutAtUnixMs: now + 3_600_000,
+                    ArmedAtUnixMs: now,
+                    Status: "active"),
+            ]);
+
+            await using var host = new NotifyRestoreWebAppFactory(notifyDbPath, conversationsPath);
+            var notifyStore = host.Services.GetRequiredService<INotifyWaitStore>();
+            var pool = host.Services.GetRequiredService<MultiTurnAgentPool>();
+            var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+
+            _ = pool.GetOrCreateAgent(threadId, mode, requestedProviderId: "test", requestResponseDumpFileName: null);
+
+            var active = await PollActiveUntilAsync(notifyStore, threadId, rows => rows.Count == 0);
+
+            active.Should().BeEmpty(
+                "an exhausted schedule row (fires_so_far >= maxFires) is deleted without re-arming, so no " +
+                "fire is double-delivered on restart");
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            TryDeleteDir(root);
+        }
+    }
+
+    [Fact]
+    public async Task ScheduleNotifyWait_TtlElapsedWhileOffline_TimesOutAndClearsRow()
+    {
+        var (root, conversationsPath, notifyDbPath) = NewTempPaths();
+        var threadId = "notify-restore-timeout-" + Guid.NewGuid().ToString("N");
+        try
+        {
+            var now = NowMs();
+            await SeedAsync(conversationsPath, notifyDbPath, threadId,
+            [
+                // Restorable schedule kind, but its ceiling already elapsed while the process was offline
+                // (deadline in the past). Restore must resolve it as timed_out and CLEAR the row rather
+                // than re-arm — the mirror image of the survive-test, where a live-TTL schedule row stays
+                // active. A long interval rules out any fire racing the ceiling for the latch.
+                new NotifyWaitRecord(
+                    WaitId: ScheduleWaitId,
+                    ThreadId: threadId,
+                    Kind: ScheduleTriggerSource.KindName,
+                    Args: "{\"intervalSeconds\":86400}",
+                    Label: null,
+                    MaxFires: null,
+                    FiresSoFar: 0,
+                    TimeoutAtUnixMs: now - 1000,
+                    ArmedAtUnixMs: now - 2000,
+                    Status: "active"),
+
+                // Non-restorable barrier: its deletion proves restore ran this pass, so the timed-out
+                // row's absence is a real cleanup rather than "restore hasn't run yet".
+                new NotifyWaitRecord(
+                    WaitId: ProcessBarrierWaitId,
+                    ThreadId: threadId,
+                    Kind: ProcessTriggerSource.KindName,
+                    Args: "{\"handle\":\"proc-xyz\"}",
+                    Label: null,
+                    MaxFires: null,
+                    FiresSoFar: 0,
+                    TimeoutAtUnixMs: now + 3_600_000,
+                    ArmedAtUnixMs: now,
+                    Status: "active"),
+            ]);
+
+            await using var host = new NotifyRestoreWebAppFactory(notifyDbPath, conversationsPath);
+            var notifyStore = host.Services.GetRequiredService<INotifyWaitStore>();
+            var pool = host.Services.GetRequiredService<MultiTurnAgentPool>();
+            var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+
+            _ = pool.GetOrCreateAgent(threadId, mode, requestedProviderId: "test", requestResponseDumpFileName: null);
+
+            var active = await PollActiveUntilAsync(notifyStore, threadId, rows => rows.Count == 0);
+
+            active.Should().BeEmpty(
+                "the schedule row's ceiling elapsed while offline, so restore resolves it as timed_out and " +
+                "clears the durable row (unlike a live-TTL schedule row, which re-arms and survives)");
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            TryDeleteDir(root);
+        }
+    }
+
+    [Fact]
+    public async Task ScheduleNotifyWait_ReArmsAndFiresAfterRestart_PersistsAdvancedFireCount()
+    {
+        var (root, conversationsPath, notifyDbPath) = NewTempPaths();
+        var threadId = "notify-restore-refire-" + Guid.NewGuid().ToString("N");
+        try
+        {
+            var now = NowMs();
+            await SeedAsync(conversationsPath, notifyDbPath, threadId,
+            [
+                // Short interval + small cap: restore re-arms this schedule wait, its wall-clock timer
+                // fires ~1s later, and because a CAPPED wait persists fires_so_far on EVERY fire (only
+                // uncapped waits debounce the count — see OnSourceFiredAsync), the durable row advances to
+                // fires_so_far >= 1 while still active. That advanced-count-while-active state is the
+                // strongest durable proof: it shows the restored wait actually re-armed AND fired AND
+                // persisted the new count, not merely that its row survived.
+                //
+                // Signal chosen: fires_so_far >= 1 while the row is still active. It is observable during
+                // the ~1s window between the first fire (fires_so_far -> 1, row stays active) and the
+                // second/final fire (which tears the row down), comfortably inside the ~10s poll budget.
+                // The alternative "row terminates at maxFires" would also work but proves strictly less.
+                new NotifyWaitRecord(
+                    WaitId: ScheduleWaitId,
+                    ThreadId: threadId,
+                    Kind: ScheduleTriggerSource.KindName,
+                    Args: "{\"intervalSeconds\":1}",
+                    Label: null,
+                    MaxFires: 2,
+                    FiresSoFar: 0,
+                    TimeoutAtUnixMs: now + 3_600_000,
+                    ArmedAtUnixMs: now,
+                    Status: "active"),
+            ]);
+
+            await using var host = new NotifyRestoreWebAppFactory(notifyDbPath, conversationsPath);
+            var notifyStore = host.Services.GetRequiredService<INotifyWaitStore>();
+            var pool = host.Services.GetRequiredService<MultiTurnAgentPool>();
+            var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+
+            _ = pool.GetOrCreateAgent(threadId, mode, requestedProviderId: "test", requestResponseDumpFileName: null);
+
+            // Converge on the durable proof: the restored schedule wait is active with an advanced fire
+            // count. Polling a predicate (never a fixed sleep) keeps this race-free.
+            var active = await PollActiveUntilAsync(
+                notifyStore,
+                threadId,
+                rows => rows.Any(r => r.WaitId == ScheduleWaitId && r.FiresSoFar >= 1));
+
+            active.Should().Contain(
+                r => r.WaitId == ScheduleWaitId && r.FiresSoFar >= 1,
+                "the restored schedule wait re-arms, fires on its wall-clock timer, and persists an " +
+                "advanced fires_so_far while still active");
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            TryDeleteDir(root);
+        }
+    }
+
     // --- helpers -----------------------------------------------------------------------------
 
     private static long NowMs() => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();


### PR DESCRIPTION
## Summary

Fixes #145. Notify-mode waits in the `LmStreaming.Sample` host were process-lifetime only — nothing persisted their arming records, so a restart silently dropped them. The core durability primitive already exists on `main` (from PR #158): `INotifyWaitStore`/`SqliteNotifyWaitStore`, the `notify_waits` table, `TriggerRuntime.RestoreNotifyWaitsAsync`, `TriggerOptions.NotifyWaitStore`/`ThreadId`, and `MultiTurnAgentLoop.OnThreadRecoveredAsync` already calls restore on every thread recovery. **This was purely a sample-host wiring gap** — the sample never constructed a store nor set `NotifyWaitStore`/`ThreadId`.

## Changes

- **Register a standalone SQLite-backed `INotifyWaitStore`** in the sample host — its own db file, configurable via the `LmStreaming:NotifyWaitDbPath` key (default beside the existing `conversations/` folder). The conversation store stays `FileConversationStore`; only notify-wait persistence uses SQLite.
- **Attach the store + per-thread `ThreadId`** onto the `TriggerOptions` the pool's agent factory already builds, via a record `with` expression at the call site. `SampleTriggerRegistrations.Build`'s signature is **unchanged**. Gated to test-mode only, matching the existing `triggerOptions: isTestMode ? … : null` pass-through; broader real-provider rollout is tracked in #161.
- **New `NotifyWaitDurableRestoreTests`** — a `WebApplicationFactory<Program>` integration test that seeds notify rows + thread metadata on disk, boots the real host over that state, and asserts against **real on-disk SQLite** that:
  - a `schedule` wait (restorable) re-arms and survives the restart, and
  - an unregistered/non-restorable `process` wait delivers `trigger_lost_on_restart` and is cleared.

  This is the one scenario no existing in-memory test covered.

## Design note — deviation from the approved plan (DI registration)

The approved plan proposed registering `ISqliteConnectionFactory` as its own DI singleton so the container disposes it. During implementation this was found to be **wrong for this host**: `ISqliteConnectionFactory` is `IAsyncDisposable`-only, and a container-tracked `IAsyncDisposable`-only singleton makes **synchronous** `ServiceProvider.Dispose()` throw `InvalidOperationException`. The sample host is torn down synchronously in tests (`BrowserWebAppFactory.Dispose()` → `IHost.Dispose()`), so tracking the factory would have regressed every E2E test that opens a conversation. 

Final approach: register only the non-disposable `INotifyWaitStore`, constructing `SqliteConnectionFactory` **inline**. The factory is reclaimed by GC at process end — a benign leak (it holds only `SemaphoreSlim`s, no OS handle). Rationale is documented inline in `Program.cs`.

## Known limitations (accepted, documented in code)

- Test-mode only today (real-provider rollout tracked in #161).
- No pruning of `notify_waits` rows for threads never reopened after a restart (acceptable for a sample app).
- The reused `SqliteSchemaInitializer` creates a few unused sibling tables in the notify db (intentional — reuses shared infra).

## Verification

- Build (sample + test project): clean, 0 warnings / 0 errors; husky `format-verify` passes.
- New tests: **2/2 pass** against real on-disk SQLite through the full `Program` host.
- `LmMultiTurn.Tests` trigger/notify/persistence: **43/43 pass**.
- `LmStreaming.Sample.Tests`: 556 passed, 1 skipped, 5 failed — **all 5 failures are pre-existing on clean `origin/main`** (unrelated ContextDiscovery/GatewayAuth tests tied to the #174 NotifyMessage merge), verified by stashing this change and re-running: the same 5 fail. This change is innocent.

## Files

| File | Action |
|------|--------|
| `samples/LmStreaming.Sample/Program.cs` | Modify — Sqlite using; `INotifyWaitStore` DI registration; resolve in pool closure; `with`-attach on `TriggerOptions` |
| `tests/LmStreaming.Sample.Tests/Triggers/NotifyWaitDurableRestoreTests.cs` | Add — `WebApplicationFactory<Program>` restart test (2 facts) |
