### PR TITLE
StartWorkflow: agent-facing launch/check/wait for LmWorkflow runs (#179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **LmWorkflow (breaking, internal API narrowing)**: `WorkflowRuntime` and `WorkflowToolProvider` constructors are now `internal` (were `public`) so the workflow-authoring/mutation tools stay confined to a controller loop. No in-repo callers construct them directly; external consumers of the `AchieveAi.LmDotnetTools.LmWorkflow` package that instantiated these types must go through `WorkflowSession`/`WorkflowManager`. (#179)
+- **LmWorkflow (breaking — coordinated API changes for the controller-isolation invariant; warrants a minor/major version bump at release)** (#179):
+  - `WorkflowRuntime` and `WorkflowToolProvider` constructors are now `internal` (were `public`) so the workflow-authoring/mutation tools stay confined to a controller loop. External consumers that instantiated these types must go through `WorkflowSession`/`WorkflowManager`. A public compatibility shim is intentionally *not* provided — it would reopen the isolation boundary this change exists to enforce.
+  - `WorkflowSession.StartAsync` gained optional `includeAuthoringTool` / `controllerMaxTurnsPerRun` / `controllerDefaultOptions` parameters (before the trailing `CancellationToken`), a binary-signature change. Source callers using named/defaulted args are unaffected; compiled callers should recompile against this release.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the LmDotnetTools project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **LmWorkflow**: `StartWorkflow`/`CheckWorkflow`/`WaitWorkflow` agent-facing tools (`StartWorkflowToolProvider`) that launch a pre-authored `WorkflowDefinition` on an isolated controller loop via the new `WorkflowManager`, with bounded concurrency and proactive completion notifications (`NotifyKinds.WorkflowCompletion`). (#179)
+- **LmMultiTurn**: `SubAgentOptions.NonInheritedToolNames` to exclude specific tools from sub-agent inheritance, and a public `MultiTurnAgentLoop.RegisteredToolNames` accessor.
+
+### Changed
+
+- **LmWorkflow (breaking, internal API narrowing)**: `WorkflowRuntime` and `WorkflowToolProvider` constructors are now `internal` (were `public`) so the workflow-authoring/mutation tools stay confined to a controller loop. No in-repo callers construct them directly; external consumers of the `AchieveAi.LmDotnetTools.LmWorkflow` package that instantiated these types must go through `WorkflowSession`/`WorkflowManager`. (#179)
+
+---
+
 ## [1.0.33] - 2026-05-23
 
 ### Added

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -1069,6 +1069,11 @@ try
                             controllerSubAgentOptions: controllerSubAgentOptions,
                             completionNotifier: async (notify, notifyCt) =>
                             {
+                                // Late-bound to `agent` (assigned just below). Re-injects the async workflow's
+                                // completion as a NotifyMessage into the conversation. WorkflowManager wraps
+                                // this call in its own try/catch, so a SendAsync on an already-disposed loop
+                                // (conversation torn down before the workflow finished) is tolerated — logged,
+                                // never fatal.
                                 var conversation = agent;
                                 if (conversation is not null)
                                 {

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -1089,12 +1089,17 @@ try
                         ownedResources = [.. ownedResources ?? [], workflowManager];
 
                         // Keep the launch tools out of sub-agent inheritance so a spawned sub-agent can't
-                        // launch a nested workflow (out of scope for v1).
+                        // launch a nested workflow (out of scope for v1). Union with any exclusions the host
+                        // already set rather than replacing them.
                         if (subAgentOptions is not null)
                         {
                             subAgentOptions = subAgentOptions with
                             {
-                                NonInheritedToolNames = StartWorkflowToolProvider.ToolNames,
+                                NonInheritedToolNames =
+                                [
+                                    .. subAgentOptions.NonInheritedToolNames ?? [],
+                                    .. StartWorkflowToolProvider.ToolNames,
+                                ],
                             };
                         }
                     }

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -23,8 +23,7 @@ using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using AchieveAi.LmDotnetTools.LmStreaming.AspNetCore.Extensions;
 using AchieveAi.LmDotnetTools.LmStreaming.Sample.Triggers;
-using AchieveAi.LmDotnetTools.LmWorkflow.Prompts;
-using AchieveAi.LmDotnetTools.LmWorkflow.Runtime;
+using AchieveAi.LmDotnetTools.LmWorkflow;
 using AchieveAi.LmDotnetTools.LmWorkflow.Tools;
 using AchieveAi.LmDotnetTools.LmTestUtils;
 using AchieveAi.LmDotnetTools.McpMiddleware.Extensions;
@@ -817,7 +816,7 @@ try
                 // Add LlmQuery book search MCP tools — only for medical knowledge mode
                 // Track MCP clients for proper disposal alongside the agent
                 List<IAsyncDisposable>? ownedResources = null;
-                WorkflowRuntime? workflowRuntime = null;
+                var workspaceWorkflowEnabled = false;
                 if (!string.IsNullOrEmpty(mcpBaseUrl))
                 {
                     var (_, mcpClients) = ConnectLlmQueryMcpClients(
@@ -846,22 +845,20 @@ try
                     // observes the loop's own message stream (see ownedResources wiring below) to
                     // correlate Agent tool-call spawns back into workflow state.
                     //
+                    // Let the Workspace Agent launch LmWorkflow workflows via the StartWorkflow tool
+                    // family. Each StartWorkflow spins up an ISOLATED controller loop (its own model +
+                    // restricted tool surface); the chat agent never gets direct
+                    // SetWorkflow/GetWorkflow access (that #130 wiring is retired here). The tools
+                    // themselves are wired below, once the conversation loop exists so an async
+                    // workflow's completion notification can reach it.
+                    //
                     // On by default, but disable-able per deployment WITHOUT a redeploy via
-                    // WORKSPACE_AGENT_LMWORKFLOW_ENABLED=false. This one flag gates all three behaviors as a
-                    // unit — the workflow tool surface (here), the appended controller prompt (below), and the
-                    // correlation observer (further below, which is already gated on `workflowRuntime`).
-                    var workflowEnabled = !string.Equals(
+                    // WORKSPACE_AGENT_LMWORKFLOW_ENABLED=false.
+                    workspaceWorkflowEnabled = !string.Equals(
                         Environment.GetEnvironmentVariable("WORKSPACE_AGENT_LMWORKFLOW_ENABLED"),
                         "false",
                         StringComparison.OrdinalIgnoreCase
                     );
-                    if (workflowEnabled)
-                    {
-                        workflowRuntime = new WorkflowRuntime(
-                            logger: loggerFactory.CreateLogger<WorkflowRuntime>()
-                        );
-                        _ = filteredRegistry.AddProvider(new WorkflowToolProvider(workflowRuntime));
-                    }
 
                     // Workspace Agent mode: expose the sandbox file/shell tools via the gateway's
                     // MCP endpoint, bound to this agent's sandbox session by the X-Session-ID header
@@ -913,19 +910,6 @@ try
                                     + "the system prompt now reports degraded mode instead of claiming tools",
                                 threadId
                             );
-                    }
-
-                    // Append last, off whatever effectiveMode currently is (default or the
-                    // degraded-sandbox notice above) so the controller prompt survives either path. Gated on
-                    // the workflow runtime (i.e. WORKSPACE_AGENT_LMWORKFLOW_ENABLED) so disabling the feature
-                    // also drops the extra controller instructions from the prompt.
-                    if (workflowRuntime is not null)
-                    {
-                        effectiveMode = effectiveMode with
-                        {
-                            SystemPrompt =
-                                effectiveMode.SystemPrompt + "\n\n" + ControllerSystemPrompt.Default,
-                        };
                     }
                 }
 
@@ -1051,6 +1035,65 @@ try
                         sandboxEnabled: sandboxSession is not null,
                         subAgentManagerAccessor: () => agent?.SubAgentManager);
 
+                    // Wire the StartWorkflow tool family onto the conversation registry (Workspace Agent
+                    // mode). Declared before the loop ctor so the launch tools are registered before the
+                    // sub-agent snapshot is taken; the completion notifier is late-bound to `agent` (assigned
+                    // just below). This replaces #130's direct SetWorkflow/GetWorkflow wiring.
+                    if (workspaceWorkflowEnabled)
+                    {
+                        // Q2: the controller runs on a single, FIXED, pre-configured model — a configured
+                        // value if present, else the conversation's own default model. Never the caller's.
+                        var configuredControllerModel =
+                            Environment.GetEnvironmentVariable("WORKFLOW_CONTROLLER_MODEL");
+                        var controllerModelId = string.IsNullOrWhiteSpace(configuredControllerModel)
+                            ? modelId
+                            : configuredControllerModel;
+
+                        // Q5: concurrent-workflow cap defaults to 8, overridable via config.
+                        var maxConcurrentWorkflows =
+                            int.TryParse(
+                                Environment.GetEnvironmentVariable("WORKFLOW_MAX_CONCURRENT"),
+                                out var configuredCap
+                            ) && configuredCap >= 1
+                                ? configuredCap
+                                : 8;
+
+                        var controllerSubAgentOptions = new SubAgentOptions
+                        {
+                            Templates = BuiltInSubAgentTemplates.CreateWorkflowControllerTemplates(subAgentFactory),
+                            MaxConcurrentSubAgents = BuiltInSubAgentTemplates.DefaultMaxConcurrentSubAgents,
+                        };
+
+                        var workflowManager = new WorkflowManager(
+                            controllerAgentFactory: subAgentFactory,
+                            controllerSubAgentOptions: controllerSubAgentOptions,
+                            completionNotifier: async (notify, notifyCt) =>
+                            {
+                                var conversation = agent;
+                                if (conversation is not null)
+                                {
+                                    _ = await conversation.SendAsync([notify], ct: notifyCt);
+                                }
+                            },
+                            maxConcurrentWorkflows: maxConcurrentWorkflows,
+                            controllerDefaultOptions: new GenerateReplyOptions { ModelId = controllerModelId },
+                            logger: loggerFactory.CreateLogger<WorkflowManager>()
+                        );
+
+                        _ = filteredRegistry.AddProvider(new StartWorkflowToolProvider(workflowManager));
+                        ownedResources = [.. ownedResources ?? [], workflowManager];
+
+                        // Keep the launch tools out of sub-agent inheritance so a spawned sub-agent can't
+                        // launch a nested workflow (out of scope for v1).
+                        if (subAgentOptions is not null)
+                        {
+                            subAgentOptions = subAgentOptions with
+                            {
+                                NonInheritedToolNames = StartWorkflowToolProvider.ToolNames,
+                            };
+                        }
+                    }
+
                     agent = new MultiTurnAgentLoop(
                         providerAgent,
                         filteredRegistry,
@@ -1089,62 +1132,6 @@ try
                         // flag) is tracked in #161.
                         triggerOptions: isTestMode ? triggerOptions : null
                     );
-
-                    if (workflowRuntime is not null)
-                    {
-                        // Correlate sub-agent spawn results back into the workflow runtime via a
-                        // second, independent subscriber to this loop's own message stream (tool
-                        // handlers above cover the synchronous SetWorkflow/SetCurrentNode/etc. path;
-                        // this covers the async Agent-tool-call/result correlation). The first
-                        // MoveNextAsync() is primed synchronously here — before this factory returns
-                        // "agent" to the caller — so the per-subscriber channel is registered before
-                        // any SendAsync can occur on this conversation.
-                        var observerCts = new CancellationTokenSource();
-                        var enumerator = agent.SubscribeAsync(observerCts.Token)
-                            .GetAsyncEnumerator(observerCts.Token);
-                        var pendingFirstMoveNext = enumerator.MoveNextAsync();
-                        var observerTask = Task.Run(async () =>
-                        {
-                            try
-                            {
-                                if (await pendingFirstMoveNext)
-                                {
-                                    workflowRuntime.ObserveMessage(enumerator.Current);
-                                    while (await enumerator.MoveNextAsync())
-                                    {
-                                        workflowRuntime.ObserveMessage(enumerator.Current);
-                                    }
-                                }
-                            }
-                            catch (OperationCanceledException) when (observerCts.IsCancellationRequested)
-                            { /* expected on shutdown */
-                            }
-                            catch (Exception ex)
-                            {
-                                // This background task is the critical path that correlates Agent
-                                // tool-call spawns/results back into the workflow runtime. If it faults, the
-                                // agent keeps serving workflow tools but joins never settle — so surface the
-                                // first failure loudly (disposal below would otherwise swallow it).
-                                loggerFactory
-                                    .CreateLogger<WorkflowRuntime>()
-                                    .LogError(
-                                        ex,
-                                        "Workflow observer for thread {ThreadId} failed; Agent-result "
-                                            + "correlation is now disabled for this conversation",
-                                        threadId
-                                    );
-                            }
-                            finally
-                            {
-                                await enumerator.DisposeAsync();
-                            }
-                        });
-                        ownedResources =
-                        [
-                            .. ownedResources ?? [],
-                            new WorkflowObserverDisposable(observerCts, observerTask),
-                        ];
-                    }
 
                     return new MultiTurnAgentPool.AgentCreationResult(agent, ownedResources);
                 }
@@ -1428,28 +1415,6 @@ public partial class Program
         }
 
         return extraProperties;
-    }
-
-    /// <summary>
-    ///     Cancels and awaits the background workflow-observer task on disposal, mirroring the same
-    ///     cancel→await/swallow→dispose idiom <c>MultiTurnAgentPool.AgentEntry.DisposeAsync</c>
-    ///     already uses for the agent's own run loop.
-    /// </summary>
-    private sealed class WorkflowObserverDisposable(CancellationTokenSource cts, Task observerTask)
-        : IAsyncDisposable
-    {
-        public async ValueTask DisposeAsync()
-        {
-            await cts.CancelAsync();
-            try
-            {
-                await observerTask;
-            }
-            catch
-            { /* best-effort shutdown */
-            }
-            cts.Dispose();
-        }
     }
 
     /// <summary>

--- a/samples/LmStreaming.Sample/Services/BuiltInSubAgentTemplates.cs
+++ b/samples/LmStreaming.Sample/Services/BuiltInSubAgentTemplates.cs
@@ -66,4 +66,25 @@ internal static class BuiltInSubAgentTemplates
             },
         };
     }
+
+    /// <summary>
+    /// Builds the node-delegate templates for a StartWorkflow controller loop. These mirror the built-in
+    /// catalog but declare an EXPLICIT, empty <see cref="SubAgentTemplate.EnabledTools"/> allow-list: a
+    /// controller delegate must never inherit the controller's own workflow-state tools
+    /// (<c>WorkflowManager</c> asserts this at construction, rejecting an inherit-all template). V1
+    /// controller delegates are reasoning-only; passing domain (sandbox/web) tools through to a controller
+    /// delegate is a documented follow-up, not part of this migration.
+    /// </summary>
+    public static Dictionary<string, SubAgentTemplate> CreateWorkflowControllerTemplates(
+        Func<IStreamingAgent> providerAgentFactory
+    )
+    {
+        var templates = Create(providerAgentFactory);
+        foreach (var key in templates.Keys.ToList())
+        {
+            templates[key] = templates[key] with { EnabledTools = [] };
+        }
+
+        return templates;
+    }
 }

--- a/src/LmCore/Messages/NotifyMessage.cs
+++ b/src/LmCore/Messages/NotifyMessage.cs
@@ -16,6 +16,9 @@ public static class NotifyKinds
 
     /// <summary>A context file discovered by the sandbox was injected into the conversation.</summary>
     public const string ContextDiscovery = "context-discovery";
+
+    /// <summary>An async workflow launched via <c>StartWorkflow</c> reached a terminal state.</summary>
+    public const string WorkflowCompletion = "workflow-completion";
 }
 
 /// <summary>

--- a/src/LmMultiTurn/AchieveAi.LmDotnetTools.LmMultiTurn.csproj
+++ b/src/LmMultiTurn/AchieveAi.LmDotnetTools.LmMultiTurn.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="LmMultiTurn.Tests" />
+    <!-- LmWorkflow.Tests + the sample's tests assert a StartWorkflow controller/conversation loop's
+         restricted RegisteredToolNames set. -->
+    <InternalsVisibleTo Include="LmWorkflow.Tests" />
+    <InternalsVisibleTo Include="LmStreaming.Sample.Tests" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LmCore\AchieveAi.LmDotnetTools.LmCore.csproj" />

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -45,10 +45,10 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
     /// <summary>
     /// The names of every tool registered on this loop after the middleware stack was built —
     /// the parent's own tools plus any Agent/Wait tools the loop self-registered. Read-only; the
-    /// order is unspecified. Used to assert a loop's effective tool surface (e.g. the workflow
-    /// controller's restricted set).
+    /// order is unspecified. Internal diagnostic/test accessor used to assert a loop's effective
+    /// tool surface (e.g. the workflow controller's restricted set).
     /// </summary>
-    public IReadOnlyCollection<string> RegisteredToolNames => [.. _toolHandlers.Keys];
+    internal IReadOnlyCollection<string> RegisteredToolNames => [.. _toolHandlers.Keys];
 
     // Owns the Wait/trigger lifecycle when trigger options are supplied. Null otherwise.
     private readonly TriggerRuntime? _triggerRuntime;

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -42,6 +42,14 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
     /// sub-agent completions; the manager itself is still owned and disposed by the loop.</summary>
     public SubAgentManager? SubAgentManager { get; }
 
+    /// <summary>
+    /// The names of every tool registered on this loop after the middleware stack was built —
+    /// the parent's own tools plus any Agent/Wait tools the loop self-registered. Read-only; the
+    /// order is unspecified. Used to assert a loop's effective tool surface (e.g. the workflow
+    /// controller's restricted set).
+    /// </summary>
+    public IReadOnlyCollection<string> RegisteredToolNames => [.. _toolHandlers.Keys];
+
     // Owns the Wait/trigger lifecycle when trigger options are supplied. Null otherwise.
     private readonly TriggerRuntime? _triggerRuntime;
 
@@ -121,6 +129,16 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
             // Agent/CheckAgent tools, preventing unbounded recursive delegation.
             var (contracts, handlers) = functionRegistry.Build();
 
+            // Additionally drop any host-declared non-inherited tools (e.g. StartWorkflow/
+            // CheckWorkflow/WaitWorkflow) from the snapshot handed to sub-agents. Unlike the
+            // Agent-family tools — excluded structurally because they're registered AFTER this
+            // snapshot — these are registered on the parent's own registry BEFORE the loop is
+            // built, so they're already in the snapshot and would otherwise be inherited by a
+            // sub-agent whose template sets EnabledTools = null. Filtering the snapshot copy does
+            // not touch the parent's own tool set (built from the full registry below).
+            var inheritableContracts =
+                FilterInheritableContracts(contracts, subAgentOptions.NonInheritedToolNames);
+
             // Use the caller-supplied source when present (so an outer owner — typically
             // a sandbox session registry — can activate discovered subagents mid-session
             // by calling TryRegister on it). Otherwise wrap the static template dictionary
@@ -130,7 +148,7 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
 
             SubAgentManager = new SubAgentManager(
                 parentAgent: this,
-                parentContracts: [.. contracts],
+                parentContracts: [.. inheritableContracts],
                 parentHandlers: handlers,
                 options: subAgentOptions,
                 source: source,
@@ -200,6 +218,25 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
         {
             await _triggerRuntime.DisposeAsync();
         }
+    }
+
+    /// <summary>
+    /// Filters the parent-tool snapshot handed to sub-agents, dropping any contract whose name is
+    /// in <paramref name="nonInheritedToolNames"/>. Returns the input unchanged when there is
+    /// nothing to exclude. The parent's own tool set is unaffected — only the inherited copy is
+    /// filtered. See <see cref="SubAgents.SubAgentOptions.NonInheritedToolNames"/>.
+    /// </summary>
+    internal static IReadOnlyList<FunctionContract> FilterInheritableContracts(
+        IEnumerable<FunctionContract> contracts,
+        IReadOnlyCollection<string>? nonInheritedToolNames)
+    {
+        if (nonInheritedToolNames is not { Count: > 0 })
+        {
+            return contracts as IReadOnlyList<FunctionContract> ?? [.. contracts];
+        }
+
+        var excluded = new HashSet<string>(nonInheritedToolNames, StringComparer.Ordinal);
+        return [.. contracts.Where(c => !excluded.Contains(c.Name))];
     }
 
     /// <inheritdoc />

--- a/src/LmMultiTurn/SubAgents/SubAgentOptions.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentOptions.cs
@@ -22,4 +22,17 @@ public record SubAgentOptions
     /// Null = no persistence for sub-agents.
     /// </summary>
     public Func<string, IConversationStore>? DefaultConversationStoreFactory { get; init; }
+
+    /// <summary>
+    /// Tool names that a spawned sub-agent must NOT inherit from the parent, even when its
+    /// template sets <c>EnabledTools = null</c> ("inherit everything"). The parent keeps these
+    /// tools; only the snapshot handed to sub-agents excludes them. This is the general seam that
+    /// keeps a launch/orchestration tool (e.g. <c>StartWorkflow</c>/<c>CheckWorkflow</c>/
+    /// <c>WaitWorkflow</c>) — registered on the parent's own registry before the loop is built, so
+    /// it lands in the inherit-all snapshot — from leaking into every sub-agent. The
+    /// <c>Agent</c>/<c>SendMessage</c>/<c>CheckAgent</c> tools are already excluded structurally
+    /// (registered AFTER the snapshot), so they need not be listed here. Null/empty = no extra
+    /// exclusions.
+    /// </summary>
+    public IReadOnlyCollection<string>? NonInheritedToolNames { get; init; }
 }

--- a/src/LmWorkflow/Runtime/WorkflowRuntime.cs
+++ b/src/LmWorkflow/Runtime/WorkflowRuntime.cs
@@ -88,8 +88,11 @@ public sealed class WorkflowRuntime
     /// <summary>
     ///     Creates a runtime. A custom <paramref name="schemaValidator"/> may be injected for tests, and an
     ///     optional <paramref name="logger"/> surfaces otherwise-swallowed best-effort persistence faults.
+    ///     Internal: a runtime is only constructed inside the library (via <see cref="WorkflowSession"/> /
+    ///     <see cref="WorkflowManager"/> / <see cref="FromSnapshot"/>) so the controller-isolation invariant
+    ///     cannot be bypassed by newing one up directly.
     /// </summary>
-    public WorkflowRuntime(IJsonSchemaValidator? schemaValidator = null, ILogger? logger = null)
+    internal WorkflowRuntime(IJsonSchemaValidator? schemaValidator = null, ILogger? logger = null)
     {
         _schemaValidator = schemaValidator ?? new JsonSchemaValidator();
         _logger = logger;

--- a/src/LmWorkflow/Tools/StartWorkflowToolProvider.cs
+++ b/src/LmWorkflow/Tools/StartWorkflowToolProvider.cs
@@ -1,0 +1,336 @@
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmCore.Models;
+using AchieveAi.LmDotnetTools.LmWorkflow.Ingest;
+using AchieveAi.LmDotnetTools.LmWorkflow.Model;
+
+namespace AchieveAi.LmDotnetTools.LmWorkflow.Tools;
+
+/// <summary>
+///     Exposes the agent-facing workflow launch tools over a <see cref="WorkflowManager"/>:
+///     <c>StartWorkflow</c> (launch a pre-authored definition, sync or async), <c>CheckWorkflow</c>
+///     (non-blocking status), and <c>WaitWorkflow</c> (block until terminal or timeout). These are the ONLY
+///     workflow tools a normal agent should ever see — the authoring/mutation tools
+///     (<c>GetWorkflow</c>/<c>SetCurrentNode</c>/<c>SetState</c>/<c>SetNotes</c>, and never
+///     <c>SetWorkflow</c>) live exclusively inside the controller loop the manager spins up.
+/// </summary>
+public sealed class StartWorkflowToolProvider : IFunctionProvider
+{
+    /// <summary>The launch tool name.</summary>
+    public const string StartWorkflowToolName = "StartWorkflow";
+
+    /// <summary>The non-blocking status tool name.</summary>
+    public const string CheckWorkflowToolName = "CheckWorkflow";
+
+    /// <summary>The blocking wait tool name.</summary>
+    public const string WaitWorkflowToolName = "WaitWorkflow";
+
+    /// <summary>Every tool name this provider exposes; a host keeps these out of sub-agent inheritance.</summary>
+    public static readonly IReadOnlyList<string> ToolNames =
+        [StartWorkflowToolName, CheckWorkflowToolName, WaitWorkflowToolName];
+
+    private static readonly JsonSerializerOptions ResultJson = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly WorkflowManager _manager;
+
+    /// <summary>Creates the provider over <paramref name="manager"/>.</summary>
+    public StartWorkflowToolProvider(WorkflowManager manager)
+    {
+        ArgumentNullException.ThrowIfNull(manager);
+        _manager = manager;
+    }
+
+    /// <inheritdoc />
+    public string ProviderName => "StartWorkflowTools";
+
+    /// <summary>Low priority (high number) so parent tools take precedence on a name clash.</summary>
+    public int Priority => 100;
+
+    /// <inheritdoc />
+    public IEnumerable<FunctionDescriptor> GetFunctions()
+    {
+        yield return CreateStartWorkflowDescriptor();
+        yield return CreateCheckWorkflowDescriptor();
+        yield return CreateWaitWorkflowDescriptor();
+    }
+
+    private FunctionDescriptor CreateStartWorkflowDescriptor()
+    {
+        var contract = new FunctionContract
+        {
+            Name = StartWorkflowToolName,
+            Description =
+                "Launch a fully pre-authored workflow definition as a bounded, delegated unit of work, run "
+                + "by an isolated controller agent. By default (mode: sync) this BLOCKS until the workflow "
+                + "reaches a terminal state and returns the terminal result. Set mode: async to return "
+                + "immediately with {workflowId, status:\"started\"}; you'll receive a proactive notification "
+                + "when it finishes, and can poll with CheckWorkflow or block with WaitWorkflow. You supply "
+                + "the complete workflow graph — you cannot author or mutate it once running.",
+            Parameters =
+            [
+                new FunctionParameterContract
+                {
+                    Name = "workflowId",
+                    Description =
+                        "An opaque, non-user-identifying handle for this workflow. Must be unique; a value "
+                        + "already used is rejected.",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
+                    IsRequired = true,
+                },
+                new FunctionParameterContract
+                {
+                    Name = "workflow",
+                    Description =
+                        "The full, pre-authored workflow definition object (objective + a graph of nodes: "
+                        + "one start, >=1 terminal, and the rest).",
+                    ParameterType = new JsonSchemaObject { Type = new("object") },
+                    IsRequired = true,
+                },
+                new FunctionParameterContract
+                {
+                    Name = "mode",
+                    Description = "Either \"sync\" (default, blocks for the terminal result) or \"async\".",
+                    ParameterType = new JsonSchemaObject { Type = new("string"), Enum = ["sync", "async"] },
+                    IsRequired = false,
+                },
+            ],
+        };
+
+        return new FunctionDescriptor
+        {
+            Contract = contract,
+            Handler = HandleStartWorkflowAsync,
+            ProviderName = ProviderName,
+        };
+    }
+
+    private FunctionDescriptor CreateCheckWorkflowDescriptor()
+    {
+        var contract = new FunctionContract
+        {
+            Name = CheckWorkflowToolName,
+            Description =
+                "Check the current status and state snapshot (current node, outputs, notes, and — once "
+                + "terminal — the final result) of a workflow started with StartWorkflow, WITHOUT blocking. "
+                + "Works in either mode and remains available after completion.",
+            Parameters =
+            [
+                new FunctionParameterContract
+                {
+                    Name = "workflowId",
+                    Description = "The workflowId returned/used when the workflow was started.",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
+                    IsRequired = true,
+                },
+            ],
+        };
+
+        return new FunctionDescriptor
+        {
+            Contract = contract,
+            Handler = HandleCheckWorkflowAsync,
+            ProviderName = ProviderName,
+        };
+    }
+
+    private FunctionDescriptor CreateWaitWorkflowDescriptor()
+    {
+        var contract = new FunctionContract
+        {
+            Name = WaitWorkflowToolName,
+            Description =
+                "Block until a workflow started with StartWorkflow reaches a terminal state, or until the "
+                + "optional timeout elapses, then return the final result (or a timeout signal). A timeout is "
+                + "non-destructive — the workflow keeps running and can be waited on again. NOTE: unlike the "
+                + "Agent tool's turn-bounded wait, this timeout is open-ended, so a long wait suspends this "
+                + "turn's tool dispatch for its full duration; prefer a bounded timeout, or async + "
+                + "CheckWorkflow, for long-running workflows.",
+            Parameters =
+            [
+                new FunctionParameterContract
+                {
+                    Name = "workflowId",
+                    Description = "The workflowId returned/used when the workflow was started.",
+                    ParameterType = new JsonSchemaObject { Type = new("string") },
+                    IsRequired = true,
+                },
+                new FunctionParameterContract
+                {
+                    Name = "timeout",
+                    Description =
+                        "Optional maximum seconds to block before returning a timeout signal. Omit to wait "
+                        + "for completion (bounded only by this turn's cancellation).",
+                    ParameterType = new JsonSchemaObject { Type = new("number") },
+                    IsRequired = false,
+                },
+            ],
+        };
+
+        return new FunctionDescriptor
+        {
+            Contract = contract,
+            Handler = HandleWaitWorkflowAsync,
+            ProviderName = ProviderName,
+        };
+    }
+
+    private async Task<ToolHandlerResult> HandleStartWorkflowAsync(
+        string argsJson,
+        ToolCallContext context,
+        CancellationToken cancellationToken
+    )
+    {
+        using var doc = JsonDocument.Parse(argsJson);
+        var root = doc.RootElement;
+
+        var workflowId = GetOptionalString(root, "workflowId");
+        if (string.IsNullOrWhiteSpace(workflowId))
+        {
+            return ToolHandlerResult.FromError("The 'workflowId' parameter is required.", "invalid_args");
+        }
+
+        if (
+            !root.TryGetProperty("workflow", out var workflowElement)
+            || workflowElement.ValueKind != JsonValueKind.Object
+        )
+        {
+            return ToolHandlerResult.FromError(
+                "The 'workflow' object parameter is required.",
+                "invalid_args"
+            );
+        }
+
+        WorkflowDefinition definition;
+        try
+        {
+            // Strict deserialize so a misspelled/invented field is rejected by name rather than silently
+            // dropped — matching SetWorkflow's authoring path.
+            definition = WorkflowJson.DeserializeStrict(workflowElement.GetRawText());
+        }
+        catch (JsonException ex)
+        {
+            return ToolHandlerResult.FromError(
+                $"The workflow definition is not valid JSON: {ex.Message}",
+                "invalid_workflow"
+            );
+        }
+
+        var mode = ParseMode(GetOptionalString(root, "mode"));
+
+        try
+        {
+            var result = await _manager
+                .StartAsync(workflowId, definition, mode, cancellationToken)
+                .ConfigureAwait(false);
+            return ToolHandlerResult.FromText(Serialize(result));
+        }
+        catch (WorkflowValidationException ex)
+        {
+            return ToolHandlerResult.FromError(
+                "The workflow definition is invalid: " + string.Join("; ", ex.Errors),
+                "invalid_workflow"
+            );
+        }
+        catch (DuplicateWorkflowException ex)
+        {
+            return ToolHandlerResult.FromError(ex.Message, "duplicate_workflow");
+        }
+        catch (WorkflowCapacityException ex)
+        {
+            return ToolHandlerResult.FromError(ex.Message, "workflow_capacity");
+        }
+    }
+
+    private Task<ToolHandlerResult> HandleCheckWorkflowAsync(
+        string argsJson,
+        ToolCallContext context,
+        CancellationToken cancellationToken
+    )
+    {
+        using var doc = JsonDocument.Parse(argsJson);
+        var workflowId = GetOptionalString(doc.RootElement, "workflowId");
+        if (string.IsNullOrWhiteSpace(workflowId))
+        {
+            return Task.FromResult<ToolHandlerResult>(
+                ToolHandlerResult.FromError("The 'workflowId' parameter is required.", "invalid_args")
+            );
+        }
+
+        try
+        {
+            return Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText(Serialize(_manager.Check(workflowId))));
+        }
+        catch (UnknownWorkflowException ex)
+        {
+            return Task.FromResult<ToolHandlerResult>(
+                ToolHandlerResult.FromError(ex.Message, "unknown_workflow")
+            );
+        }
+    }
+
+    private async Task<ToolHandlerResult> HandleWaitWorkflowAsync(
+        string argsJson,
+        ToolCallContext context,
+        CancellationToken cancellationToken
+    )
+    {
+        using var doc = JsonDocument.Parse(argsJson);
+        var root = doc.RootElement;
+
+        var workflowId = GetOptionalString(root, "workflowId");
+        if (string.IsNullOrWhiteSpace(workflowId))
+        {
+            return ToolHandlerResult.FromError("The 'workflowId' parameter is required.", "invalid_args");
+        }
+
+        var timeout = GetOptionalTimeout(root, "timeout");
+
+        try
+        {
+            var result = await _manager
+                .WaitAsync(workflowId, timeout, cancellationToken)
+                .ConfigureAwait(false);
+            return ToolHandlerResult.FromText(Serialize(result));
+        }
+        catch (UnknownWorkflowException ex)
+        {
+            return ToolHandlerResult.FromError(ex.Message, "unknown_workflow");
+        }
+    }
+
+    private static string Serialize(WorkflowRunResult result) => JsonSerializer.Serialize(result, ResultJson);
+
+    private static WorkflowStartMode ParseMode(string? mode) =>
+        string.Equals(mode, "async", StringComparison.OrdinalIgnoreCase)
+            ? WorkflowStartMode.Async
+            : WorkflowStartMode.Sync;
+
+    private static string? GetOptionalString(JsonElement root, string propertyName) =>
+        root.TryGetProperty(propertyName, out var prop) && prop.ValueKind == JsonValueKind.String
+            ? prop.GetString()
+            : null;
+
+    private static TimeSpan? GetOptionalTimeout(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var prop))
+        {
+            return null;
+        }
+
+        return prop.ValueKind switch
+        {
+            JsonValueKind.Number when prop.TryGetDouble(out var seconds) && seconds >= 0 =>
+                TimeSpan.FromSeconds(seconds),
+            // Some models emit numbers as strings.
+            JsonValueKind.String when double.TryParse(prop.GetString(), out var seconds) && seconds >= 0 =>
+                TimeSpan.FromSeconds(seconds),
+            _ => null,
+        };
+    }
+}

--- a/src/LmWorkflow/Tools/StartWorkflowToolProvider.cs
+++ b/src/LmWorkflow/Tools/StartWorkflowToolProvider.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
@@ -150,7 +151,9 @@ public sealed class StartWorkflowToolProvider : IFunctionProvider
                 + "non-destructive — the workflow keeps running and can be waited on again. NOTE: unlike the "
                 + "Agent tool's turn-bounded wait, this timeout is open-ended, so a long wait suspends this "
                 + "turn's tool dispatch for its full duration; prefer a bounded timeout, or async + "
-                + "CheckWorkflow, for long-running workflows.",
+                + "CheckWorkflow, for long-running workflows. A returned status of \"timeout\" or \"running\" "
+                + "means the workflow has NOT finished yet — call WaitWorkflow or CheckWorkflow again to "
+                + "observe completion.",
             Parameters =
             [
                 new FunctionParameterContract
@@ -188,7 +191,7 @@ public sealed class StartWorkflowToolProvider : IFunctionProvider
     {
         if (!TryParseArgs(argsJson, out var doc, out var argsError))
         {
-            return argsError!;
+            return argsError;
         }
 
         using (doc)
@@ -262,7 +265,7 @@ public sealed class StartWorkflowToolProvider : IFunctionProvider
     {
         if (!TryParseArgs(argsJson, out var doc, out var argsError))
         {
-            return Task.FromResult<ToolHandlerResult>(argsError!);
+            return Task.FromResult<ToolHandlerResult>(argsError);
         }
 
         using (doc)
@@ -298,7 +301,7 @@ public sealed class StartWorkflowToolProvider : IFunctionProvider
     {
         if (!TryParseArgs(argsJson, out var doc, out var argsError))
         {
-            return argsError!;
+            return argsError;
         }
 
         using (doc)
@@ -349,7 +352,11 @@ public sealed class StartWorkflowToolProvider : IFunctionProvider
     ///     Parses the handler args, returning a structured <c>invalid_args</c> error instead of letting a
     ///     malformed-JSON <see cref="JsonException"/> escape to the executor as a generic tool failure.
     /// </summary>
-    private static bool TryParseArgs(string argsJson, out JsonDocument doc, out ToolHandlerResult? error)
+    private static bool TryParseArgs(
+        string argsJson,
+        [NotNullWhen(true)] out JsonDocument? doc,
+        [NotNullWhen(false)] out ToolHandlerResult? error
+    )
     {
         try
         {
@@ -359,7 +366,7 @@ public sealed class StartWorkflowToolProvider : IFunctionProvider
         }
         catch (JsonException ex)
         {
-            doc = null!;
+            doc = null;
             error = ToolHandlerResult.FromError(
                 $"Tool arguments are not valid JSON: {ex.Message}",
                 "invalid_args"

--- a/src/LmWorkflow/Tools/StartWorkflowToolProvider.cs
+++ b/src/LmWorkflow/Tools/StartWorkflowToolProvider.cs
@@ -323,14 +323,22 @@ public sealed class StartWorkflowToolProvider : IFunctionProvider
             return null;
         }
 
-        return prop.ValueKind switch
+        var seconds = prop.ValueKind switch
         {
-            JsonValueKind.Number when prop.TryGetDouble(out var seconds) && seconds >= 0 =>
-                TimeSpan.FromSeconds(seconds),
+            JsonValueKind.Number when prop.TryGetDouble(out var value) && value >= 0 => value,
             // Some models emit numbers as strings.
-            JsonValueKind.String when double.TryParse(prop.GetString(), out var seconds) && seconds >= 0 =>
-                TimeSpan.FromSeconds(seconds),
-            _ => null,
+            JsonValueKind.String when double.TryParse(prop.GetString(), out var value) && value >= 0 => value,
+            _ => (double?)null,
         };
+
+        if (seconds is not { } s)
+        {
+            return null;
+        }
+
+        // Clamp to a range Task.WaitAsync accepts (it throws for a timeout beyond ~49.7 days). ~24.8 days is
+        // effectively "wait indefinitely" for a tool call while staying safely in range.
+        var ms = Math.Min(s * 1000d, int.MaxValue);
+        return TimeSpan.FromMilliseconds(ms);
     }
 }

--- a/src/LmWorkflow/Tools/StartWorkflowToolProvider.cs
+++ b/src/LmWorkflow/Tools/StartWorkflowToolProvider.cs
@@ -186,64 +186,71 @@ public sealed class StartWorkflowToolProvider : IFunctionProvider
         CancellationToken cancellationToken
     )
     {
-        using var doc = JsonDocument.Parse(argsJson);
-        var root = doc.RootElement;
-
-        var workflowId = GetOptionalString(root, "workflowId");
-        if (string.IsNullOrWhiteSpace(workflowId))
+        if (!TryParseArgs(argsJson, out var doc, out var argsError))
         {
-            return ToolHandlerResult.FromError("The 'workflowId' parameter is required.", "invalid_args");
+            return argsError!;
         }
 
-        if (
-            !root.TryGetProperty("workflow", out var workflowElement)
-            || workflowElement.ValueKind != JsonValueKind.Object
-        )
+        using (doc)
         {
-            return ToolHandlerResult.FromError(
-                "The 'workflow' object parameter is required.",
-                "invalid_args"
-            );
-        }
+            var root = doc.RootElement;
 
-        WorkflowDefinition definition;
-        try
-        {
-            // Strict deserialize so a misspelled/invented field is rejected by name rather than silently
-            // dropped — matching SetWorkflow's authoring path.
-            definition = WorkflowJson.DeserializeStrict(workflowElement.GetRawText());
-        }
-        catch (JsonException ex)
-        {
-            return ToolHandlerResult.FromError(
-                $"The workflow definition is not valid JSON: {ex.Message}",
-                "invalid_workflow"
-            );
-        }
+            var workflowId = GetOptionalString(root, "workflowId");
+            if (string.IsNullOrWhiteSpace(workflowId))
+            {
+                return ToolHandlerResult.FromError("The 'workflowId' parameter is required.", "invalid_args");
+            }
 
-        var mode = ParseMode(GetOptionalString(root, "mode"));
+            if (
+                !root.TryGetProperty("workflow", out var workflowElement)
+                || workflowElement.ValueKind != JsonValueKind.Object
+            )
+            {
+                return ToolHandlerResult.FromError(
+                    "The 'workflow' object parameter is required.",
+                    "invalid_args"
+                );
+            }
 
-        try
-        {
-            var result = await _manager
-                .StartAsync(workflowId, definition, mode, cancellationToken)
-                .ConfigureAwait(false);
-            return ToolHandlerResult.FromText(Serialize(result));
-        }
-        catch (WorkflowValidationException ex)
-        {
-            return ToolHandlerResult.FromError(
-                "The workflow definition is invalid: " + string.Join("; ", ex.Errors),
-                "invalid_workflow"
-            );
-        }
-        catch (DuplicateWorkflowException ex)
-        {
-            return ToolHandlerResult.FromError(ex.Message, "duplicate_workflow");
-        }
-        catch (WorkflowCapacityException ex)
-        {
-            return ToolHandlerResult.FromError(ex.Message, "workflow_capacity");
+            WorkflowDefinition definition;
+            try
+            {
+                // Strict deserialize so a misspelled/invented field is rejected by name rather than silently
+                // dropped — matching SetWorkflow's authoring path.
+                definition = WorkflowJson.DeserializeStrict(workflowElement.GetRawText());
+            }
+            catch (JsonException ex)
+            {
+                return ToolHandlerResult.FromError(
+                    $"The workflow definition is not valid JSON: {ex.Message}",
+                    "invalid_workflow"
+                );
+            }
+
+            var mode = ParseMode(GetOptionalString(root, "mode"));
+
+            try
+            {
+                var result = await _manager
+                    .StartAsync(workflowId, definition, mode, cancellationToken, context.ToolCallId)
+                    .ConfigureAwait(false);
+                return ToolHandlerResult.FromText(Serialize(result));
+            }
+            catch (WorkflowValidationException ex)
+            {
+                return ToolHandlerResult.FromError(
+                    "The workflow definition is invalid: " + string.Join("; ", ex.Errors),
+                    "invalid_workflow"
+                );
+            }
+            catch (DuplicateWorkflowException ex)
+            {
+                return ToolHandlerResult.FromError(ex.Message, "duplicate_workflow");
+            }
+            catch (WorkflowCapacityException ex)
+            {
+                return ToolHandlerResult.FromError(ex.Message, "workflow_capacity");
+            }
         }
     }
 
@@ -253,24 +260,33 @@ public sealed class StartWorkflowToolProvider : IFunctionProvider
         CancellationToken cancellationToken
     )
     {
-        using var doc = JsonDocument.Parse(argsJson);
-        var workflowId = GetOptionalString(doc.RootElement, "workflowId");
-        if (string.IsNullOrWhiteSpace(workflowId))
+        if (!TryParseArgs(argsJson, out var doc, out var argsError))
         {
-            return Task.FromResult<ToolHandlerResult>(
-                ToolHandlerResult.FromError("The 'workflowId' parameter is required.", "invalid_args")
-            );
+            return Task.FromResult<ToolHandlerResult>(argsError!);
         }
 
-        try
+        using (doc)
         {
-            return Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText(Serialize(_manager.Check(workflowId))));
-        }
-        catch (UnknownWorkflowException ex)
-        {
-            return Task.FromResult<ToolHandlerResult>(
-                ToolHandlerResult.FromError(ex.Message, "unknown_workflow")
-            );
+            var workflowId = GetOptionalString(doc.RootElement, "workflowId");
+            if (string.IsNullOrWhiteSpace(workflowId))
+            {
+                return Task.FromResult<ToolHandlerResult>(
+                    ToolHandlerResult.FromError("The 'workflowId' parameter is required.", "invalid_args")
+                );
+            }
+
+            try
+            {
+                return Task.FromResult<ToolHandlerResult>(
+                    ToolHandlerResult.FromText(Serialize(_manager.Check(workflowId)))
+                );
+            }
+            catch (UnknownWorkflowException ex)
+            {
+                return Task.FromResult<ToolHandlerResult>(
+                    ToolHandlerResult.FromError(ex.Message, "unknown_workflow")
+                );
+            }
         }
     }
 
@@ -280,27 +296,40 @@ public sealed class StartWorkflowToolProvider : IFunctionProvider
         CancellationToken cancellationToken
     )
     {
-        using var doc = JsonDocument.Parse(argsJson);
-        var root = doc.RootElement;
-
-        var workflowId = GetOptionalString(root, "workflowId");
-        if (string.IsNullOrWhiteSpace(workflowId))
+        if (!TryParseArgs(argsJson, out var doc, out var argsError))
         {
-            return ToolHandlerResult.FromError("The 'workflowId' parameter is required.", "invalid_args");
+            return argsError!;
         }
 
-        var timeout = GetOptionalTimeout(root, "timeout");
+        using (doc)
+        {
+            var root = doc.RootElement;
 
-        try
-        {
-            var result = await _manager
-                .WaitAsync(workflowId, timeout, cancellationToken)
-                .ConfigureAwait(false);
-            return ToolHandlerResult.FromText(Serialize(result));
-        }
-        catch (UnknownWorkflowException ex)
-        {
-            return ToolHandlerResult.FromError(ex.Message, "unknown_workflow");
+            var workflowId = GetOptionalString(root, "workflowId");
+            if (string.IsNullOrWhiteSpace(workflowId))
+            {
+                return ToolHandlerResult.FromError("The 'workflowId' parameter is required.", "invalid_args");
+            }
+
+            // Distinguish an omitted timeout (→ wait until completion) from a present-but-invalid one
+            // (negative / non-numeric / NaN / infinity), which must be rejected rather than silently
+            // collapsing to an unbounded wait.
+            if (!TryReadTimeout(root, "timeout", out var timeout, out var timeoutError))
+            {
+                return ToolHandlerResult.FromError(timeoutError!, "invalid_args");
+            }
+
+            try
+            {
+                var result = await _manager
+                    .WaitAsync(workflowId, timeout, cancellationToken)
+                    .ConfigureAwait(false);
+                return ToolHandlerResult.FromText(Serialize(result));
+            }
+            catch (UnknownWorkflowException ex)
+            {
+                return ToolHandlerResult.FromError(ex.Message, "unknown_workflow");
+            }
         }
     }
 
@@ -316,29 +345,73 @@ public sealed class StartWorkflowToolProvider : IFunctionProvider
             ? prop.GetString()
             : null;
 
-    private static TimeSpan? GetOptionalTimeout(JsonElement root, string propertyName)
+    /// <summary>
+    ///     Parses the handler args, returning a structured <c>invalid_args</c> error instead of letting a
+    ///     malformed-JSON <see cref="JsonException"/> escape to the executor as a generic tool failure.
+    /// </summary>
+    private static bool TryParseArgs(string argsJson, out JsonDocument doc, out ToolHandlerResult? error)
     {
+        try
+        {
+            doc = JsonDocument.Parse(argsJson);
+            error = null;
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            doc = null!;
+            error = ToolHandlerResult.FromError(
+                $"Tool arguments are not valid JSON: {ex.Message}",
+                "invalid_args"
+            );
+            return false;
+        }
+    }
+
+    /// <summary>
+    ///     Reads an optional <c>timeout</c> (seconds). An OMITTED property yields <c>null</c> (wait until
+    ///     completion) and returns <c>true</c>. A PRESENT-but-invalid value (negative, NaN/infinity, or a
+    ///     non-numeric string) returns <c>false</c> with an error, so an invalid input is rejected rather than
+    ///     silently collapsing to an unbounded wait. Valid values are clamped to <c>Task.WaitAsync</c>'s range.
+    /// </summary>
+    private static bool TryReadTimeout(
+        JsonElement root,
+        string propertyName,
+        out TimeSpan? timeout,
+        out string? error
+    )
+    {
+        timeout = null;
+        error = null;
+
         if (!root.TryGetProperty(propertyName, out var prop))
         {
-            return null;
+            return true; // omitted → no timeout
         }
 
-        var seconds = prop.ValueKind switch
+        double? seconds = prop.ValueKind switch
         {
-            JsonValueKind.Number when prop.TryGetDouble(out var value) && value >= 0 => value,
+            JsonValueKind.Null => null,
+            JsonValueKind.Number when prop.TryGetDouble(out var value) => value,
             // Some models emit numbers as strings.
-            JsonValueKind.String when double.TryParse(prop.GetString(), out var value) && value >= 0 => value,
-            _ => (double?)null,
+            JsonValueKind.String when double.TryParse(prop.GetString(), out var value) => value,
+            _ => double.NaN, // present but not a usable number
         };
 
-        if (seconds is not { } s)
+        if (seconds is null)
         {
-            return null;
+            return true; // explicit null → no timeout
         }
 
-        // Clamp to a range Task.WaitAsync accepts (it throws for a timeout beyond ~49.7 days). ~24.8 days is
-        // effectively "wait indefinitely" for a tool call while staying safely in range.
-        var ms = Math.Min(s * 1000d, int.MaxValue);
-        return TimeSpan.FromMilliseconds(ms);
+        if (double.IsNaN(seconds.Value) || double.IsInfinity(seconds.Value) || seconds.Value < 0)
+        {
+            error = "The 'timeout' parameter must be a non-negative number of seconds.";
+            return false;
+        }
+
+        // Clamp to the range Task.WaitAsync accepts (~24.8 days), which is effectively "wait until completion".
+        var ms = Math.Min(seconds.Value * 1000d, int.MaxValue);
+        timeout = TimeSpan.FromMilliseconds(ms);
+        return true;
     }
 }

--- a/src/LmWorkflow/Tools/WorkflowToolProvider.cs
+++ b/src/LmWorkflow/Tools/WorkflowToolProvider.cs
@@ -27,13 +27,26 @@ public sealed class WorkflowToolProvider : IFunctionProvider
     /// <summary>The tool name the controller authors/replaces the definition with.</summary>
     public const string SetWorkflowToolName = "SetWorkflow";
 
+    /// <summary>The tool name that reads the runtime + ready-to-spawn next action.</summary>
+    public const string GetWorkflowToolName = "GetWorkflow";
+
+    /// <summary>The tool name that routes between nodes / finalizes a terminal.</summary>
+    public const string SetCurrentNodeToolName = "SetCurrentNode";
+
+    /// <summary>The tool name that writes the mutable state channel.</summary>
+    public const string SetStateToolName = "SetState";
+
+    /// <summary>The tool name that records a scoped note.</summary>
+    public const string SetNotesToolName = "SetNotes";
+
     /// <summary>
     ///     Every workflow-state tool name this provider can expose. These are the authoring/mutation tools
     ///     that must stay confined to a workflow controller loop and never reach a normal agent — a host
     ///     asserting that invariant (or restricting a controller's sub-agent templates) keys on this list.
+    ///     Derived from the same name constants <see cref="GetFunctions"/> uses so the two cannot drift.
     /// </summary>
     public static readonly IReadOnlyList<string> AllToolNames =
-        [SetWorkflowToolName, "GetWorkflow", "SetCurrentNode", "SetState", "SetNotes"];
+        [SetWorkflowToolName, GetWorkflowToolName, SetCurrentNodeToolName, SetStateToolName, SetNotesToolName];
 
     private readonly WorkflowRuntime _runtime;
     private readonly bool _includeSetWorkflow;
@@ -77,7 +90,7 @@ public sealed class WorkflowToolProvider : IFunctionProvider
         }
 
         yield return Descriptor(
-            "GetWorkflow",
+            GetWorkflowToolName,
             "Read the current workflow state. The result always includes the ready-to-spawn "
                 + "nextExpectedAction unit(s) for the active node.",
             [
@@ -93,7 +106,7 @@ public sealed class WorkflowToolProvider : IFunctionProvider
         );
 
         yield return Descriptor(
-            "SetCurrentNode",
+            SetCurrentNodeToolName,
             "Advance the controller from the completed node to the next node along a declared edge. "
                 + "Supply a result object when advancing into a terminal to finalize the workflow.",
             [
@@ -110,7 +123,7 @@ public sealed class WorkflowToolProvider : IFunctionProvider
         );
 
         yield return Descriptor(
-            "SetState",
+            SetStateToolName,
             "Write a value into the mutable state channel at a 'state.' path.",
             [
                 Param("path", "The destination path, e.g. state.analysis.", JsonSchemaObject.String(), required: true),
@@ -121,7 +134,7 @@ public sealed class WorkflowToolProvider : IFunctionProvider
         );
 
         yield return Descriptor(
-            "SetNotes",
+            SetNotesToolName,
             "Record a scoped note for later reference.",
             [
                 Param("scope", "The note scope.", JsonSchemaObject.String(), required: true),

--- a/src/LmWorkflow/Tools/WorkflowToolProvider.cs
+++ b/src/LmWorkflow/Tools/WorkflowToolProvider.cs
@@ -24,13 +24,33 @@ namespace AchieveAi.LmDotnetTools.LmWorkflow.Tools;
 /// </remarks>
 public sealed class WorkflowToolProvider : IFunctionProvider
 {
+    /// <summary>The tool name the controller authors/replaces the definition with.</summary>
+    public const string SetWorkflowToolName = "SetWorkflow";
+
+    /// <summary>
+    ///     Every workflow-state tool name this provider can expose. These are the authoring/mutation tools
+    ///     that must stay confined to a workflow controller loop and never reach a normal agent — a host
+    ///     asserting that invariant (or restricting a controller's sub-agent templates) keys on this list.
+    /// </summary>
+    public static readonly IReadOnlyList<string> AllToolNames =
+        [SetWorkflowToolName, "GetWorkflow", "SetCurrentNode", "SetState", "SetNotes"];
+
     private readonly WorkflowRuntime _runtime;
+    private readonly bool _includeSetWorkflow;
 
     /// <summary>Creates the provider over <paramref name="runtime"/>.</summary>
-    public WorkflowToolProvider(WorkflowRuntime runtime)
+    /// <param name="runtime">The runtime the tools drive.</param>
+    /// <param name="includeSetWorkflow">
+    ///     When <c>true</c> (default) the provider exposes all five tools including <c>SetWorkflow</c>. When
+    ///     <c>false</c> the <c>SetWorkflow</c> authoring tool is omitted — used for a controller that always
+    ///     receives a pre-authored definition (e.g. via <c>StartWorkflow</c>) and so never needs to author or
+    ///     replace one.
+    /// </param>
+    public WorkflowToolProvider(WorkflowRuntime runtime, bool includeSetWorkflow = true)
     {
         ArgumentNullException.ThrowIfNull(runtime);
         _runtime = runtime;
+        _includeSetWorkflow = includeSetWorkflow;
     }
 
     /// <inheritdoc />
@@ -42,12 +62,15 @@ public sealed class WorkflowToolProvider : IFunctionProvider
     /// <inheritdoc />
     public IEnumerable<FunctionDescriptor> GetFunctions()
     {
-        yield return Descriptor(
-            "SetWorkflow",
-            "Author (or replace) the workflow definition and position the controller at the start node.",
-            [Param("definition", "The full workflow definition object.", DefinitionSchema(), required: true)],
-            HandleSetWorkflowAsync
-        );
+        if (_includeSetWorkflow)
+        {
+            yield return Descriptor(
+                SetWorkflowToolName,
+                "Author (or replace) the workflow definition and position the controller at the start node.",
+                [Param("definition", "The full workflow definition object.", DefinitionSchema(), required: true)],
+                HandleSetWorkflowAsync
+            );
+        }
 
         yield return Descriptor(
             "GetWorkflow",

--- a/src/LmWorkflow/Tools/WorkflowToolProvider.cs
+++ b/src/LmWorkflow/Tools/WorkflowToolProvider.cs
@@ -46,7 +46,11 @@ public sealed class WorkflowToolProvider : IFunctionProvider
     ///     receives a pre-authored definition (e.g. via <c>StartWorkflow</c>) and so never needs to author or
     ///     replace one.
     /// </param>
-    public WorkflowToolProvider(WorkflowRuntime runtime, bool includeSetWorkflow = true)
+    /// <remarks>
+    ///     Internal: this provider is only wired inside the library (via <see cref="WorkflowSession"/>) so the
+    ///     workflow-state tools stay confined to a controller loop and never reach a normal agent's registry.
+    /// </remarks>
+    internal WorkflowToolProvider(WorkflowRuntime runtime, bool includeSetWorkflow = true)
     {
         ArgumentNullException.ThrowIfNull(runtime);
         _runtime = runtime;

--- a/src/LmWorkflow/WorkflowManager.cs
+++ b/src/LmWorkflow/WorkflowManager.cs
@@ -25,6 +25,29 @@ public enum WorkflowStartMode
 }
 
 /// <summary>
+///     The well-known <see cref="WorkflowRunResult.Status"/> values a workflow run reports. Kept as named
+///     constants (like <c>NotifyKinds</c>) so producers and the <c>BuildNotifyDetail</c> dispatch never drift
+///     on a raw string literal.
+/// </summary>
+public static class WorkflowStatuses
+{
+    /// <summary>An async run was accepted and is now running on a background task.</summary>
+    public const string Started = "started";
+
+    /// <summary>The run has not yet reached a terminal state.</summary>
+    public const string Running = "running";
+
+    /// <summary>The run reached a terminal node; <see cref="WorkflowRunResult.Result"/> carries the outcome.</summary>
+    public const string Completed = "completed";
+
+    /// <summary>The run ended without a terminal node (fault, cancellation, or turn-budget exhaustion).</summary>
+    public const string Failed = "failed";
+
+    /// <summary>A <c>WaitWorkflow</c> call returned before the run finished; the run is still going.</summary>
+    public const string Timeout = "timeout";
+}
+
+/// <summary>
 ///     The status/result of a workflow run, returned by <see cref="WorkflowManager.StartAsync"/> (sync mode
 ///     terminal, or an async <c>started</c> receipt), <see cref="WorkflowManager.Check"/>, and
 ///     <see cref="WorkflowManager.WaitAsync"/>. Not every field is populated in every status — e.g. a
@@ -35,7 +58,7 @@ public sealed record WorkflowRunResult
     /// <summary>The caller-supplied opaque workflow handle.</summary>
     public required string WorkflowId { get; init; }
 
-    /// <summary>One of <c>started</c>, <c>running</c>, <c>completed</c>, <c>failed</c>, <c>timeout</c>.</summary>
+    /// <summary>One of the <see cref="WorkflowStatuses"/> values (started/running/completed/failed/timeout).</summary>
     public required string Status { get; init; }
 
     /// <summary>The validated final result when <see cref="Status"/> is <c>completed</c>; otherwise <c>null</c>.</summary>
@@ -102,6 +125,9 @@ public sealed class WorkflowManager : IAsyncDisposable
 {
     /// <summary>The default bounded wait for a concurrency slot before signalling backpressure.</summary>
     private static readonly TimeSpan DefaultGateWaitTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>The largest wait <see cref="Task.WaitAsync(TimeSpan, CancellationToken)"/> accepts (~24.8 days).</summary>
+    private static readonly TimeSpan MaxWaitTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
 
     /// <summary>The initial message handed to a controller whose definition is already loaded.</summary>
     internal const string StartObjective =
@@ -262,7 +288,7 @@ public sealed class WorkflowManager : IAsyncDisposable
 
         if (mode == WorkflowStartMode.Async)
         {
-            return new WorkflowRunResult { WorkflowId = workflowId, Status = "started" };
+            return new WorkflowRunResult { WorkflowId = workflowId, Status = WorkflowStatuses.Started };
         }
 
         // Sync: block until terminal, then return the outcome inline. Gate release + disposal are handled by
@@ -288,20 +314,28 @@ public sealed class WorkflowManager : IAsyncDisposable
 
     /// <summary>
     ///     Returns the current status and a state snapshot for <paramref name="workflowId"/> WITHOUT blocking.
-    ///     Works for a running, completed, or failed workflow — including after its handle was disposed on
-    ///     completion (the runtime state stays readable).
+    ///     Works for a running, completed, or failed workflow — after completion it answers from a retained
+    ///     lightweight snapshot (the heavy run graph is released).
     /// </summary>
     /// <exception cref="UnknownWorkflowException">No such workflow.</exception>
     public WorkflowRunResult Check(string workflowId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(workflowId);
 
-        if (!_workflows.TryGetValue(workflowId, out var entry) || entry.Handle is null)
+        if (!_workflows.TryGetValue(workflowId, out var entry))
         {
             throw new UnknownWorkflowException(workflowId);
         }
 
-        var handle = entry.Handle;
+        // A captured terminal snapshot is authoritative once present (the handle may already be released).
+        if (Volatile.Read(ref entry.TerminalSnapshot) is { } terminal)
+        {
+            return terminal;
+        }
+
+        // Reserved but not yet started (a sub-millisecond, synchronous window inside StartAsync) → unknown.
+        var handle = Volatile.Read(ref entry.Handle) ?? throw new UnknownWorkflowException(workflowId);
+
         return handle.Completion.IsCompleted
             ? BuildResult(workflowId, handle)
             : Running(workflowId, handle);
@@ -323,32 +357,36 @@ public sealed class WorkflowManager : IAsyncDisposable
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(workflowId);
 
-        if (!_workflows.TryGetValue(workflowId, out var entry) || entry.Handle is null)
+        if (!_workflows.TryGetValue(workflowId, out var entry))
         {
             throw new UnknownWorkflowException(workflowId);
         }
 
-        var handle = entry.Handle;
+        // Already terminal → return the retained snapshot without blocking.
+        if (Volatile.Read(ref entry.TerminalSnapshot) is { } cached)
+        {
+            return cached;
+        }
+
+        var handle = Volatile.Read(ref entry.Handle) ?? throw new UnknownWorkflowException(workflowId);
 
         if (!handle.Completion.IsCompleted)
         {
             if (timeout is { } wait)
             {
+                // Clamp to a range Task.WaitAsync accepts (it throws for a timeout beyond ~49.7 days); ~24.8
+                // days is effectively "wait until completion" while staying in range. A direct library caller
+                // passing an out-of-range TimeSpan is handled here, not just the tool's own clamp.
+                var bounded = wait > MaxWaitTimeout ? MaxWaitTimeout : wait;
                 try
                 {
                     // WaitAsync(timeout, ct) is non-destructive: it stops waiting without cancelling the
                     // underlying run, and observes the source task internally.
-                    await handle.Completion.WaitAsync(wait, ct).ConfigureAwait(false);
+                    await handle.Completion.WaitAsync(bounded, ct).ConfigureAwait(false);
                 }
                 catch (TimeoutException)
                 {
-                    return new WorkflowRunResult
-                    {
-                        WorkflowId = workflowId,
-                        Status = "timeout",
-                        CurrentNodeId = handle.CurrentNodeId,
-                        IsComplete = false,
-                    };
+                    return Timeout(workflowId, handle);
                 }
                 catch (OperationCanceledException) when (ct.IsCancellationRequested)
                 {
@@ -356,7 +394,7 @@ public sealed class WorkflowManager : IAsyncDisposable
                 }
                 catch
                 {
-                    // Faulted run → surfaced as Failed by BuildResult below.
+                    // Faulted run → surfaced as Failed by the terminal read below.
                 }
             }
             else
@@ -371,23 +409,20 @@ public sealed class WorkflowManager : IAsyncDisposable
                 }
                 catch
                 {
-                    // Faulted run → surfaced as Failed by BuildResult below.
+                    // Faulted run → surfaced as Failed by the terminal read below.
                 }
             }
         }
 
-        // Only report a terminal outcome once Completion has actually resolved. If the wait returned while
-        // the run is still going (a timeout, or any swallowed non-fatal wait error), report it as still
-        // waiting rather than letting BuildResult misread a running workflow as "failed".
-        return handle.Completion.IsCompleted
-            ? BuildResult(workflowId, handle)
-            : new WorkflowRunResult
-            {
-                WorkflowId = workflowId,
-                Status = "timeout",
-                CurrentNodeId = handle.CurrentNodeId,
-                IsComplete = false,
-            };
+        // Prefer a snapshot the observer may have captured while we waited; otherwise only report a terminal
+        // outcome once Completion has actually resolved — a still-running workflow is reported as waiting, not
+        // misread as "failed".
+        if (Volatile.Read(ref entry.TerminalSnapshot) is { } terminal)
+        {
+            return terminal;
+        }
+
+        return handle.Completion.IsCompleted ? BuildResult(workflowId, handle) : Timeout(workflowId, handle);
     }
 
     /// <inheritdoc />
@@ -462,9 +497,10 @@ public sealed class WorkflowManager : IAsyncDisposable
     }
 
     /// <summary>
-    ///     Awaits the run's completion, then (once, in order): releases the concurrency slot, sends the
-    ///     proactive completion notification for an async run (exception-isolated, so a delivery failure never
-    ///     masks the result), and disposes the handle. Fully guarded so it never faults as background work.
+    ///     Awaits the run's completion, then (once, in order): captures the lightweight terminal snapshot,
+    ///     releases the concurrency slot, sends the proactive completion notification for an async run
+    ///     (exception-isolated, so a delivery failure never masks the result), disposes the handle, and
+    ///     releases the heavy run graph. Fully guarded so it never faults as background work.
     /// </summary>
     private async Task ObserveCompletionAsync(string workflowId, WorkflowEntry entry, WorkflowStartMode mode)
     {
@@ -475,10 +511,17 @@ public sealed class WorkflowManager : IAsyncDisposable
             {
                 await handle.Completion.ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex)
             {
-                // The terminal fault is read back from the handle by BuildResult; nothing to do here.
+                // The terminal fault is also read back from the handle by BuildResult (→ a Failed result);
+                // surface it here at Warning so a controller run fault is never entirely silent.
+                _logger.LogWarning(ex, "Workflow {WorkflowId} controller run faulted", workflowId);
             }
+
+            // Capture the lightweight terminal snapshot BEFORE releasing/notifying/disposing so Check/Wait can
+            // answer from it and the heavy WorkflowRunHandle → WorkflowRuntime graph can be released below.
+            var result = BuildResult(workflowId, handle);
+            Volatile.Write(ref entry.TerminalSnapshot, result);
 
             // Release the slot as soon as the run ends — BEFORE the possibly-slow notify — so a blocked
             // notification never holds up a fresh StartWorkflow waiting on the gate. Guarded against a
@@ -497,9 +540,8 @@ public sealed class WorkflowManager : IAsyncDisposable
                 && _completionNotifier is not null
                 && Interlocked.Exchange(ref entry.NotifySent, 1) == 0)
             {
-                // Revision #4: the terminal outcome is fully determined from the handle BEFORE the notify,
-                // and the notify is isolated so a failure never loses the result (still queryable via Check).
-                var result = BuildResult(workflowId, handle);
+                // Revision #4: the terminal outcome is fully determined BEFORE the notify, and the notify is
+                // isolated so a failure never loses the result (still queryable via Check).
                 var notify = NotifyMessage.Create(
                     NotifyKinds.WorkflowCompletion,
                     detail: BuildNotifyDetail(result),
@@ -526,6 +568,11 @@ public sealed class WorkflowManager : IAsyncDisposable
         finally
         {
             await DisposeHandleOnceAsync(workflowId, entry).ConfigureAwait(false);
+
+            // Release the heavy run graph now that a lightweight terminal snapshot answers Check/Wait. The
+            // entry itself is retained (see the class remarks on the accepted v1 no-eviction limitation), but
+            // it now holds only the small result, not the disposed loop + runtime + definition.
+            Volatile.Write(ref entry.Handle, null);
         }
     }
 
@@ -568,7 +615,7 @@ public sealed class WorkflowManager : IAsyncDisposable
             ? new WorkflowRunResult
             {
                 WorkflowId = workflowId,
-                Status = "completed",
+                Status = WorkflowStatuses.Completed,
                 Result = handle.Result,
                 CurrentNodeId = handle.CurrentNodeId,
                 IsComplete = true,
@@ -587,7 +634,7 @@ public sealed class WorkflowManager : IAsyncDisposable
         new()
         {
             WorkflowId = workflowId,
-            Status = "failed",
+            Status = WorkflowStatuses.Failed,
             Error = error,
             CurrentNodeId = handle.CurrentNodeId,
             IsComplete = handle.IsComplete,
@@ -599,24 +646,36 @@ public sealed class WorkflowManager : IAsyncDisposable
         new()
         {
             WorkflowId = workflowId,
-            Status = "running",
+            Status = WorkflowStatuses.Running,
             CurrentNodeId = handle.CurrentNodeId,
             IsComplete = false,
             Outputs = handle.Outputs,
             Notes = handle.Notes,
         };
 
+    private static WorkflowRunResult Timeout(string workflowId, WorkflowRunHandle handle) =>
+        new()
+        {
+            WorkflowId = workflowId,
+            Status = WorkflowStatuses.Timeout,
+            CurrentNodeId = handle.CurrentNodeId,
+            IsComplete = false,
+        };
+
     /// <summary>Renders the notification payload body dropped into the completion envelope.</summary>
     private static string BuildNotifyDetail(WorkflowRunResult result)
     {
+        // XML-escape the model-supplied id/status into the inner markup. The OUTER envelope
+        // (NotifyMessage.BuildEnvelope) already escapes + sanitizes, so this is robustness against malformed
+        // inner markup (a workflowId containing " or <) the model would otherwise read, not a security fix.
         var sb = new StringBuilder();
         _ = sb.Append("<workflow id=\"")
-            .Append(result.WorkflowId)
+            .Append(EscapeXml(result.WorkflowId))
             .Append("\" status=\"")
-            .Append(result.Status)
+            .Append(EscapeXml(result.Status))
             .Append("\">\n");
 
-        if (result.Status == "completed")
+        if (result.Status == WorkflowStatuses.Completed)
         {
             _ = sb.Append("Result: ").Append(result.Result?.ToJsonString() ?? "(no result)").Append('\n');
         }
@@ -629,10 +688,23 @@ public sealed class WorkflowManager : IAsyncDisposable
         return sb.ToString();
     }
 
-    /// <summary>A tracked workflow: its run handle plus one-shot notify/dispose guards. Deliberately thin.</summary>
+    private static string EscapeXml(string value) =>
+        value
+            .Replace("&", "&amp;")
+            .Replace("<", "&lt;")
+            .Replace(">", "&gt;")
+            .Replace("\"", "&quot;");
+
+    /// <summary>A tracked workflow: a lightweight terminal snapshot plus the live run handle (released once
+    /// terminal) and one-shot notify/dispose guards. Fields are published/read via <see cref="Volatile"/>.</summary>
     private sealed class WorkflowEntry
     {
+        /// <summary>The live run handle while running; nulled once terminal so its heavy graph can be collected.</summary>
         public WorkflowRunHandle? Handle;
+
+        /// <summary>The lightweight terminal result, captured at completion. Authoritative once non-null.</summary>
+        public WorkflowRunResult? TerminalSnapshot;
+
         public Task? Observer;
         public int NotifySent;
         public int Disposed;

--- a/src/LmWorkflow/WorkflowManager.cs
+++ b/src/LmWorkflow/WorkflowManager.cs
@@ -1,0 +1,591 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json.Nodes;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Utils;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.LmWorkflow.Ingest;
+using AchieveAi.LmDotnetTools.LmWorkflow.Model;
+using AchieveAi.LmDotnetTools.LmWorkflow.Tools;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AchieveAi.LmDotnetTools.LmWorkflow;
+
+/// <summary>How <see cref="WorkflowManager.StartAsync"/> should return to the caller.</summary>
+public enum WorkflowStartMode
+{
+    /// <summary>Block until the workflow reaches a terminal state, then return the terminal result inline.</summary>
+    Sync,
+
+    /// <summary>Return immediately once validation passes; the run continues on a background task.</summary>
+    Async,
+}
+
+/// <summary>
+///     The status/result of a workflow run, returned by <see cref="WorkflowManager.StartAsync"/> (sync mode
+///     terminal, or an async <c>started</c> receipt), <see cref="WorkflowManager.Check"/>, and
+///     <see cref="WorkflowManager.WaitAsync"/>. Not every field is populated in every status — e.g. a
+///     <c>started</c>/<c>running</c>/<c>timeout</c> result carries no terminal <see cref="Result"/>.
+/// </summary>
+public sealed record WorkflowRunResult
+{
+    /// <summary>The caller-supplied opaque workflow handle.</summary>
+    public required string WorkflowId { get; init; }
+
+    /// <summary>One of <c>started</c>, <c>running</c>, <c>completed</c>, <c>failed</c>, <c>timeout</c>.</summary>
+    public required string Status { get; init; }
+
+    /// <summary>The validated final result when <see cref="Status"/> is <c>completed</c>; otherwise <c>null</c>.</summary>
+    public JsonNode? Result { get; init; }
+
+    /// <summary>A human-readable failure reason when <see cref="Status"/> is <c>failed</c>; otherwise <c>null</c>.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>The node the controller is currently positioned on, when known.</summary>
+    public string? CurrentNodeId { get; init; }
+
+    /// <summary>Whether the workflow reached a terminal node.</summary>
+    public bool IsComplete { get; init; }
+
+    /// <summary>The per-node task outputs channel snapshot (a deep copy), when populated.</summary>
+    public JsonObject? Outputs { get; init; }
+
+    /// <summary>The scoped notes channel snapshot (a deep copy), when populated.</summary>
+    public JsonObject? Notes { get; init; }
+}
+
+/// <summary>Thrown when a <c>workflowId</c> is already reserved (in flight or completed but still queryable).</summary>
+public sealed class DuplicateWorkflowException(string workflowId)
+    : Exception($"A workflow with id '{workflowId}' already exists. Choose a distinct workflowId.")
+{
+    /// <summary>The conflicting workflow id.</summary>
+    public string WorkflowId { get; } = workflowId;
+}
+
+/// <summary>Thrown by <c>CheckWorkflow</c>/<c>WaitWorkflow</c> for an unrecognized or expired <c>workflowId</c>.</summary>
+public sealed class UnknownWorkflowException(string workflowId)
+    : Exception($"No workflow with id '{workflowId}' is known (it was never started, or was lost to a restart).")
+{
+    /// <summary>The unrecognized workflow id.</summary>
+    public string WorkflowId { get; } = workflowId;
+}
+
+/// <summary>Thrown when the concurrent-workflow cap is reached and no slot frees up within the wait window.</summary>
+public sealed class WorkflowCapacityException(int maxConcurrentWorkflows)
+    : Exception(
+        $"The concurrent-workflow limit ({maxConcurrentWorkflows}) is reached. "
+            + "Wait for a running workflow to finish, or increase maxConcurrentWorkflows."
+    )
+{
+    /// <summary>The configured concurrency cap.</summary>
+    public int MaxConcurrentWorkflows { get; } = maxConcurrentWorkflows;
+}
+
+/// <summary>
+///     Owns the lifecycle of workflows launched via <c>StartWorkflow</c>: validates the definition, bounds
+///     concurrency, spins up an isolated controller loop (via <see cref="WorkflowSession"/>) with a
+///     restricted tool surface (no <c>SetWorkflow</c>; a controller always gets a pre-authored definition),
+///     and exposes non-blocking status (<see cref="Check"/>) and blocking wait (<see cref="WaitAsync"/>). An
+///     async run proactively notifies the originating caller on completion, while its result stays queryable
+///     via <see cref="Check"/> even if that notification fails.
+/// </summary>
+/// <remarks>
+///     Mirrors the shape of <c>SubAgentManager</c>/<c>SubAgentToolProvider</c>. V1 is in-memory only: a
+///     workflow is lost on process restart (surfaced as <see cref="UnknownWorkflowException"/>), and a
+///     completed entry is retained (so its result stays queryable) rather than evicted — so a given
+///     <c>workflowId</c> cannot be reused once started.
+/// </remarks>
+public sealed class WorkflowManager : IAsyncDisposable
+{
+    /// <summary>The default bounded wait for a concurrency slot before signalling backpressure.</summary>
+    private static readonly TimeSpan DefaultGateWaitTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>The initial message handed to a controller whose definition is already loaded.</summary>
+    internal const string StartObjective =
+        "A workflow definition has been loaded for you. Call GetWorkflow to read the current node and its "
+        + "ready-to-spawn nextExpectedAction unit(s), then drive it to a terminal node.";
+
+    private readonly Func<IStreamingAgent> _controllerAgentFactory;
+    private readonly SubAgentOptions _controllerSubAgentOptions;
+    private readonly Func<NotifyMessage, CancellationToken, Task>? _completionNotifier;
+    private readonly int _maxConcurrentWorkflows;
+    private readonly int _controllerMaxTurnsPerRun;
+    private readonly TimeSpan _gateWaitTimeout;
+    private readonly ILogger _logger;
+    private readonly IJsonSchemaValidator? _schemaValidator;
+
+    private readonly WorkflowValidator _validator = new();
+    private readonly ConcurrentDictionary<string, WorkflowEntry> _workflows = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim _concurrencyGate;
+
+    /// <summary>Creates the manager.</summary>
+    /// <param name="controllerAgentFactory">
+    ///     Builds a FRESH controller <see cref="IStreamingAgent"/> per workflow run. The caller resolves the
+    ///     fixed, pre-configured controller model once (a configured model id, else the conversation's own
+    ///     default) and closes over it here — the controller model is never taken from the calling agent.
+    /// </param>
+    /// <param name="controllerSubAgentOptions">
+    ///     The sub-agent templates a controller may delegate node work to. Every template MUST declare an
+    ///     explicit <c>EnabledTools</c> allow-list that omits the workflow-state/launch tools, so a
+    ///     node-delegate can never inherit the controller's own workflow tools; this is asserted here.
+    /// </param>
+    /// <param name="completionNotifier">
+    ///     Optional sink that delivers the proactive completion <see cref="NotifyMessage"/> to the originating
+    ///     caller for async runs. When null, async runs still complete and stay queryable via
+    ///     <see cref="Check"/> — only the proactive push is skipped.
+    /// </param>
+    /// <param name="maxConcurrentWorkflows">The concurrent-workflow cap (default 8). Must be >= 1.</param>
+    /// <param name="controllerMaxTurnsPerRun">The controller loop's per-run turn budget (default 150). Must be >= 1.</param>
+    /// <param name="gateWaitTimeout">How long <see cref="StartAsync"/> waits for a slot before backpressure. Null = 5s.</param>
+    /// <param name="logger">Optional logger.</param>
+    /// <param name="schemaValidator">Optional JSON-Schema validator forwarded to the runtime.</param>
+    public WorkflowManager(
+        Func<IStreamingAgent> controllerAgentFactory,
+        SubAgentOptions controllerSubAgentOptions,
+        Func<NotifyMessage, CancellationToken, Task>? completionNotifier = null,
+        int maxConcurrentWorkflows = 8,
+        int controllerMaxTurnsPerRun = 150,
+        TimeSpan? gateWaitTimeout = null,
+        ILogger? logger = null,
+        IJsonSchemaValidator? schemaValidator = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(controllerAgentFactory);
+        ArgumentNullException.ThrowIfNull(controllerSubAgentOptions);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxConcurrentWorkflows, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(controllerMaxTurnsPerRun, 1);
+
+        AssertRestrictedControllerTemplates(controllerSubAgentOptions);
+
+        _controllerAgentFactory = controllerAgentFactory;
+        _controllerSubAgentOptions = controllerSubAgentOptions;
+        _completionNotifier = completionNotifier;
+        _maxConcurrentWorkflows = maxConcurrentWorkflows;
+        _controllerMaxTurnsPerRun = controllerMaxTurnsPerRun;
+        _gateWaitTimeout = gateWaitTimeout ?? DefaultGateWaitTimeout;
+        _logger = logger ?? NullLogger.Instance;
+        _schemaValidator = schemaValidator;
+        _concurrencyGate = new SemaphoreSlim(maxConcurrentWorkflows, maxConcurrentWorkflows);
+    }
+
+    /// <summary>
+    ///     Validates <paramref name="definition"/> synchronously (before any background task starts, in both
+    ///     modes), reserves the <paramref name="workflowId"/> slot, and launches an isolated controller loop.
+    ///     Sync mode blocks until the workflow reaches a terminal state and returns the terminal result;
+    ///     async mode returns a <c>started</c> receipt immediately.
+    /// </summary>
+    /// <exception cref="WorkflowValidationException">The definition is invalid.</exception>
+    /// <exception cref="DuplicateWorkflowException"><paramref name="workflowId"/> is already reserved.</exception>
+    /// <exception cref="WorkflowCapacityException">No concurrency slot freed up within the wait window.</exception>
+    public async Task<WorkflowRunResult> StartAsync(
+        string workflowId,
+        WorkflowDefinition definition,
+        WorkflowStartMode mode,
+        CancellationToken ct = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workflowId);
+        ArgumentNullException.ThrowIfNull(definition);
+
+        // Validate BEFORE reserving a slot or starting anything, so an invalid definition never consumes a
+        // workflowId or a concurrency slot and surfaces synchronously in both modes.
+        _validator.ValidateAndThrow(definition);
+
+        // Reserve the id slot atomically BEFORE the (effectively synchronous) start, closing the duplicate
+        // TOCTOU: two concurrent starts for the same id cannot both pass the check.
+        var entry = new WorkflowEntry();
+        if (!_workflows.TryAdd(workflowId, entry))
+        {
+            throw new DuplicateWorkflowException(workflowId);
+        }
+
+        var gateAcquired = false;
+        WorkflowRunHandle handle;
+        try
+        {
+            if (!await _concurrencyGate.WaitAsync(_gateWaitTimeout, ct).ConfigureAwait(false))
+            {
+                throw new WorkflowCapacityException(_maxConcurrentWorkflows);
+            }
+
+            gateAcquired = true;
+
+            handle = await WorkflowSession
+                .StartAsync(
+                    objective: StartObjective,
+                    inputs: null,
+                    definition: definition,
+                    subAgentOptions: _controllerSubAgentOptions,
+                    controllerAgent: _controllerAgentFactory(),
+                    threadId: $"workflow-{workflowId}",
+                    store: null,
+                    instanceId: workflowId,
+                    conversationStore: null,
+                    logger: _logger is NullLogger ? null : _logger,
+                    schemaValidator: _schemaValidator,
+                    includeAuthoringTool: false,
+                    controllerMaxTurnsPerRun: _controllerMaxTurnsPerRun,
+                    ct: CancellationToken.None
+                )
+                .ConfigureAwait(false);
+
+            entry.Handle = handle;
+
+            // Past this point the completion handler owns the concurrency slot and the handle's disposal.
+            _ = ObserveCompletionAsync(workflowId, entry, mode);
+        }
+        catch
+        {
+            // Start failed before the completion handler took ownership: roll back the reservation and
+            // release the slot if it was acquired.
+            _ = _workflows.TryRemove(workflowId, out _);
+            if (gateAcquired)
+            {
+                _ = _concurrencyGate.Release();
+            }
+
+            throw;
+        }
+
+        if (mode == WorkflowStartMode.Async)
+        {
+            return new WorkflowRunResult { WorkflowId = workflowId, Status = "started" };
+        }
+
+        // Sync: block until terminal, then return the outcome inline. Gate release + disposal are handled by
+        // the completion handler; this path only reads the terminal state.
+        try
+        {
+            await handle.Completion.WaitAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            // A faulted run is surfaced as a Failed result below; the fault itself is observed by the
+            // completion handler.
+        }
+
+        return BuildResult(workflowId, handle);
+    }
+
+    /// <summary>
+    ///     Returns the current status and a state snapshot for <paramref name="workflowId"/> WITHOUT blocking.
+    ///     Works for a running, completed, or failed workflow — including after its handle was disposed on
+    ///     completion (the runtime state stays readable).
+    /// </summary>
+    /// <exception cref="UnknownWorkflowException">No such workflow.</exception>
+    public WorkflowRunResult Check(string workflowId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workflowId);
+
+        if (!_workflows.TryGetValue(workflowId, out var entry) || entry.Handle is null)
+        {
+            throw new UnknownWorkflowException(workflowId);
+        }
+
+        var handle = entry.Handle;
+        return handle.Completion.IsCompleted
+            ? BuildResult(workflowId, handle)
+            : Running(workflowId, handle);
+    }
+
+    /// <summary>
+    ///     Blocks until <paramref name="workflowId"/> reaches a terminal state or <paramref name="timeout"/>
+    ///     elapses, then returns the terminal result (or a <c>timeout</c> result). NON-DESTRUCTIVE: a timeout
+    ///     leaves the workflow running so a later <see cref="Check"/>/<see cref="WaitAsync"/> can still observe
+    ///     it. Unlike <c>Agent</c>'s bounded-turn wait, the timeout here is open-ended, so a long wait suspends
+    ///     the calling loop's dispatch cycle for its duration.
+    /// </summary>
+    /// <exception cref="UnknownWorkflowException">No such workflow.</exception>
+    public async Task<WorkflowRunResult> WaitAsync(
+        string workflowId,
+        TimeSpan? timeout,
+        CancellationToken ct = default
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workflowId);
+
+        if (!_workflows.TryGetValue(workflowId, out var entry) || entry.Handle is null)
+        {
+            throw new UnknownWorkflowException(workflowId);
+        }
+
+        var handle = entry.Handle;
+
+        if (!handle.Completion.IsCompleted)
+        {
+            if (timeout is { } wait)
+            {
+                try
+                {
+                    // WaitAsync(timeout, ct) is non-destructive: it stops waiting without cancelling the
+                    // underlying run, and observes the source task internally.
+                    await handle.Completion.WaitAsync(wait, ct).ConfigureAwait(false);
+                }
+                catch (TimeoutException)
+                {
+                    return new WorkflowRunResult
+                    {
+                        WorkflowId = workflowId,
+                        Status = "timeout",
+                        CurrentNodeId = handle.CurrentNodeId,
+                        IsComplete = false,
+                    };
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch
+                {
+                    // Faulted run → surfaced as Failed by BuildResult below.
+                }
+            }
+            else
+            {
+                try
+                {
+                    await handle.Completion.WaitAsync(ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch
+                {
+                    // Faulted run → surfaced as Failed by BuildResult below.
+                }
+            }
+        }
+
+        return BuildResult(workflowId, handle);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var (id, entry) in _workflows)
+        {
+            await DisposeHandleOnceAsync(id, entry).ConfigureAwait(false);
+        }
+
+        _workflows.Clear();
+        _concurrencyGate.Dispose();
+    }
+
+    /// <summary>
+    ///     Rejects a controller sub-agent template set that would let a node-delegate inherit the controller's
+    ///     workflow tools: an <c>EnabledTools = null</c> (inherit-all) template, or one that explicitly enables
+    ///     any workflow-state/launch tool. Called at construction so misconfiguration fails fast, before any
+    ///     controller loop is built.
+    /// </summary>
+    internal static void AssertRestrictedControllerTemplates(SubAgentOptions options)
+    {
+        var forbidden = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var name in WorkflowToolProvider.AllToolNames)
+        {
+            _ = forbidden.Add(name);
+        }
+
+        foreach (var name in StartWorkflowToolProvider.ToolNames)
+        {
+            _ = forbidden.Add(name);
+        }
+
+        foreach (var (templateName, template) in options.Templates)
+        {
+            if (template.EnabledTools is null)
+            {
+                throw new ArgumentException(
+                    $"Controller sub-agent template '{templateName}' must declare an explicit EnabledTools "
+                        + "allow-list; a null (inherit-all) list would let the node-delegate inherit the "
+                        + "controller's workflow-state tools.",
+                    nameof(options)
+                );
+            }
+
+            var leaked = template.EnabledTools.Where(forbidden.Contains).ToList();
+            if (leaked.Count > 0)
+            {
+                throw new ArgumentException(
+                    $"Controller sub-agent template '{templateName}' must not enable workflow tools: "
+                        + string.Join(", ", leaked)
+                        + ".",
+                    nameof(options)
+                );
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Awaits the run's completion, then (once, in order): releases the concurrency slot, sends the
+    ///     proactive completion notification for an async run (exception-isolated, so a delivery failure never
+    ///     masks the result), and disposes the handle. Fully guarded so it never faults as background work.
+    /// </summary>
+    private async Task ObserveCompletionAsync(string workflowId, WorkflowEntry entry, WorkflowStartMode mode)
+    {
+        var handle = entry.Handle!;
+        try
+        {
+            try
+            {
+                await handle.Completion.ConfigureAwait(false);
+            }
+            catch
+            {
+                // The terminal fault is read back from the handle by BuildResult; nothing to do here.
+            }
+
+            // Release the slot as soon as the run ends — BEFORE the possibly-slow notify — so a blocked
+            // notification never holds up a fresh StartWorkflow waiting on the gate.
+            _ = _concurrencyGate.Release();
+
+            if (mode == WorkflowStartMode.Async
+                && _completionNotifier is not null
+                && Interlocked.Exchange(ref entry.NotifySent, 1) == 0)
+            {
+                // Revision #4: the terminal outcome is fully determined from the handle BEFORE the notify,
+                // and the notify is isolated so a failure never loses the result (still queryable via Check).
+                var result = BuildResult(workflowId, handle);
+                var notify = NotifyMessage.Create(
+                    NotifyKinds.WorkflowCompletion,
+                    detail: BuildNotifyDetail(result),
+                    sourceToolName: StartWorkflowToolProvider.StartWorkflowToolName,
+                    sourceToolCallId: workflowId,
+                    label: workflowId
+                );
+
+                try
+                {
+                    await _completionNotifier(notify, CancellationToken.None).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(
+                        ex,
+                        "Proactive completion notification for workflow {WorkflowId} failed; the result "
+                            + "remains queryable via CheckWorkflow",
+                        workflowId
+                    );
+                }
+            }
+        }
+        finally
+        {
+            await DisposeHandleOnceAsync(workflowId, entry).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Disposes the entry's handle at most once (guards against the completion handler racing DisposeAsync).</summary>
+    private async Task DisposeHandleOnceAsync(string workflowId, WorkflowEntry entry)
+    {
+        if (entry.Handle is not { } handle || Interlocked.Exchange(ref entry.Disposed, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            await handle.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Disposing the handle for workflow {WorkflowId} failed", workflowId);
+        }
+    }
+
+    /// <summary>Builds the terminal outcome from a handle whose <c>Completion</c> has already resolved.</summary>
+    private static WorkflowRunResult BuildResult(string workflowId, WorkflowRunHandle handle)
+    {
+        if (handle.Completion.IsFaulted)
+        {
+            var ex = handle.Completion.Exception?.GetBaseException();
+            return Failed(workflowId, handle, ex?.Message ?? "The workflow controller run failed.");
+        }
+
+        if (handle.Completion.IsCanceled)
+        {
+            return Failed(workflowId, handle, "The workflow run was cancelled.");
+        }
+
+        // Ran to completion. The controller loop can end WITHOUT the workflow reaching a terminal node (turn
+        // budget exhausted, or a task failed with no matching edge and no onBudgetExhausted escape) — treat
+        // that as an explicit terminal failure rather than reporting a phantom success.
+        return handle.IsComplete
+            ? new WorkflowRunResult
+            {
+                WorkflowId = workflowId,
+                Status = "completed",
+                Result = handle.Result,
+                CurrentNodeId = handle.CurrentNodeId,
+                IsComplete = true,
+                Outputs = handle.Outputs,
+                Notes = handle.Notes,
+            }
+            : Failed(
+                workflowId,
+                handle,
+                "The workflow controller ended without reaching a terminal node "
+                    + "(turn budget exhausted, or no available transition)."
+            );
+    }
+
+    private static WorkflowRunResult Failed(string workflowId, WorkflowRunHandle handle, string error) =>
+        new()
+        {
+            WorkflowId = workflowId,
+            Status = "failed",
+            Error = error,
+            CurrentNodeId = handle.CurrentNodeId,
+            IsComplete = handle.IsComplete,
+            Outputs = handle.Outputs,
+            Notes = handle.Notes,
+        };
+
+    private static WorkflowRunResult Running(string workflowId, WorkflowRunHandle handle) =>
+        new()
+        {
+            WorkflowId = workflowId,
+            Status = "running",
+            CurrentNodeId = handle.CurrentNodeId,
+            IsComplete = false,
+            Outputs = handle.Outputs,
+            Notes = handle.Notes,
+        };
+
+    /// <summary>Renders the notification payload body dropped into the completion envelope.</summary>
+    private static string BuildNotifyDetail(WorkflowRunResult result)
+    {
+        var sb = new StringBuilder();
+        _ = sb.Append("<workflow id=\"")
+            .Append(result.WorkflowId)
+            .Append("\" status=\"")
+            .Append(result.Status)
+            .Append("\">\n");
+
+        if (result.Status == "completed")
+        {
+            _ = sb.Append("Result: ").Append(result.Result?.ToJsonString() ?? "(no result)").Append('\n');
+        }
+        else if (result.Error is { } error)
+        {
+            _ = sb.Append("Error: ").Append(error).Append('\n');
+        }
+
+        _ = sb.Append("</workflow>");
+        return sb.ToString();
+    }
+
+    /// <summary>A tracked workflow: its run handle plus one-shot notify/dispose guards. Deliberately thin.</summary>
+    private sealed class WorkflowEntry
+    {
+        public WorkflowRunHandle? Handle;
+        public int NotifySent;
+        public int Disposed;
+    }
+}

--- a/src/LmWorkflow/WorkflowManager.cs
+++ b/src/LmWorkflow/WorkflowManager.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Text;
 using System.Text.Json.Nodes;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Utils;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
@@ -113,6 +114,7 @@ public sealed class WorkflowManager : IAsyncDisposable
     private readonly int _maxConcurrentWorkflows;
     private readonly int _controllerMaxTurnsPerRun;
     private readonly TimeSpan _gateWaitTimeout;
+    private readonly GenerateReplyOptions? _controllerDefaultOptions;
     private readonly ILogger _logger;
     private readonly IJsonSchemaValidator? _schemaValidator;
 
@@ -139,6 +141,10 @@ public sealed class WorkflowManager : IAsyncDisposable
     /// <param name="maxConcurrentWorkflows">The concurrent-workflow cap (default 8). Must be >= 1.</param>
     /// <param name="controllerMaxTurnsPerRun">The controller loop's per-run turn budget (default 150). Must be >= 1.</param>
     /// <param name="gateWaitTimeout">How long <see cref="StartAsync"/> waits for a slot before backpressure. Null = 5s.</param>
+    /// <param name="controllerDefaultOptions">
+    ///     Optional request defaults (notably <c>ModelId</c>) for the controller loop, so it runs on the fixed,
+    ///     pre-configured controller model rather than the provider agent's hardcoded default.
+    /// </param>
     /// <param name="logger">Optional logger.</param>
     /// <param name="schemaValidator">Optional JSON-Schema validator forwarded to the runtime.</param>
     public WorkflowManager(
@@ -148,6 +154,7 @@ public sealed class WorkflowManager : IAsyncDisposable
         int maxConcurrentWorkflows = 8,
         int controllerMaxTurnsPerRun = 150,
         TimeSpan? gateWaitTimeout = null,
+        GenerateReplyOptions? controllerDefaultOptions = null,
         ILogger? logger = null,
         IJsonSchemaValidator? schemaValidator = null
     )
@@ -165,6 +172,7 @@ public sealed class WorkflowManager : IAsyncDisposable
         _maxConcurrentWorkflows = maxConcurrentWorkflows;
         _controllerMaxTurnsPerRun = controllerMaxTurnsPerRun;
         _gateWaitTimeout = gateWaitTimeout ?? DefaultGateWaitTimeout;
+        _controllerDefaultOptions = controllerDefaultOptions;
         _logger = logger ?? NullLogger.Instance;
         _schemaValidator = schemaValidator;
         _concurrencyGate = new SemaphoreSlim(maxConcurrentWorkflows, maxConcurrentWorkflows);
@@ -227,6 +235,7 @@ public sealed class WorkflowManager : IAsyncDisposable
                     schemaValidator: _schemaValidator,
                     includeAuthoringTool: false,
                     controllerMaxTurnsPerRun: _controllerMaxTurnsPerRun,
+                    controllerDefaultOptions: _controllerDefaultOptions,
                     ct: CancellationToken.None
                 )
                 .ConfigureAwait(false);

--- a/src/LmWorkflow/WorkflowManager.cs
+++ b/src/LmWorkflow/WorkflowManager.cs
@@ -147,6 +147,7 @@ public sealed class WorkflowManager : IAsyncDisposable
     private readonly WorkflowValidator _validator = new();
     private readonly ConcurrentDictionary<string, WorkflowEntry> _workflows = new(StringComparer.Ordinal);
     private readonly SemaphoreSlim _concurrencyGate;
+    private bool _disposed;
 
     /// <summary>Creates the manager.</summary>
     /// <param name="controllerAgentFactory">
@@ -210,18 +211,29 @@ public sealed class WorkflowManager : IAsyncDisposable
     ///     Sync mode blocks until the workflow reaches a terminal state and returns the terminal result;
     ///     async mode returns a <c>started</c> receipt immediately.
     /// </summary>
+    /// <param name="workflowId">The opaque, caller-supplied workflow handle.</param>
+    /// <param name="definition">The pre-authored workflow definition to run.</param>
+    /// <param name="mode">Whether to block for the terminal result (sync) or return a started receipt (async).</param>
+    /// <param name="ct">Cancels the caller's wait (sync mode); the run itself is not cancelled by this token.</param>
+    /// <param name="originatingToolCallId">
+    ///     The <c>StartWorkflow</c> tool-call id, so an async run's completion notification can be correlated
+    ///     back to the initiating call. Null falls back to <paramref name="workflowId"/>.
+    /// </param>
     /// <exception cref="WorkflowValidationException">The definition is invalid.</exception>
     /// <exception cref="DuplicateWorkflowException"><paramref name="workflowId"/> is already reserved.</exception>
     /// <exception cref="WorkflowCapacityException">No concurrency slot freed up within the wait window.</exception>
+    /// <exception cref="ObjectDisposedException">The manager is disposing/disposed.</exception>
     public async Task<WorkflowRunResult> StartAsync(
         string workflowId,
         WorkflowDefinition definition,
         WorkflowStartMode mode,
-        CancellationToken ct = default
+        CancellationToken ct = default,
+        string? originatingToolCallId = null
     )
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(workflowId);
         ArgumentNullException.ThrowIfNull(definition);
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed), this);
 
         // Validate BEFORE reserving a slot or starting anything, so an invalid definition never consumes a
         // workflowId or a concurrency slot and surfaces synchronously in both modes.
@@ -229,10 +241,18 @@ public sealed class WorkflowManager : IAsyncDisposable
 
         // Reserve the id slot atomically BEFORE the (effectively synchronous) start, closing the duplicate
         // TOCTOU: two concurrent starts for the same id cannot both pass the check.
-        var entry = new WorkflowEntry();
+        var entry = new WorkflowEntry { OriginatingToolCallId = originatingToolCallId };
         if (!_workflows.TryAdd(workflowId, entry))
         {
             throw new DuplicateWorkflowException(workflowId);
+        }
+
+        // Reject a start that races DisposeAsync: if disposal began after our TryAdd, roll the reservation
+        // back so we never return "started" backed by a run the disposing manager won't observe.
+        if (Volatile.Read(ref _disposed))
+        {
+            _ = _workflows.TryRemove(workflowId, out _);
+            throw new ObjectDisposedException(nameof(WorkflowManager));
         }
 
         var gateAcquired = false;
@@ -333,8 +353,14 @@ public sealed class WorkflowManager : IAsyncDisposable
             return terminal;
         }
 
-        // Reserved but not yet started (a sub-millisecond, synchronous window inside StartAsync) → unknown.
-        var handle = Volatile.Read(ref entry.Handle) ?? throw new UnknownWorkflowException(workflowId);
+        var handle = Volatile.Read(ref entry.Handle);
+        if (handle is null)
+        {
+            // The completion observer captures the snapshot BEFORE nulling the handle, so a null handle here
+            // means either that handoff is mid-flight (re-read the snapshot) or the entry is still in its
+            // admitted-but-starting window (a coherent "running", never "unknown" for a known id).
+            return Volatile.Read(ref entry.TerminalSnapshot) ?? Pending(workflowId);
+        }
 
         return handle.Completion.IsCompleted
             ? BuildResult(workflowId, handle)
@@ -357,6 +383,22 @@ public sealed class WorkflowManager : IAsyncDisposable
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(workflowId);
 
+        // Reject an invalid negative timeout at the public API (the tool handler already rejects it earlier);
+        // Timeout.InfiniteTimeSpan (-1ms) is the one allowed negative — it means "no timeout".
+        if (timeout is { } requested && requested < TimeSpan.Zero && requested != System.Threading.Timeout.InfiniteTimeSpan)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(timeout),
+                "Timeout must be non-negative (or Timeout.InfiniteTimeSpan)."
+            );
+        }
+
+        // Treat the infinite sentinel as "no timeout" so the wait blocks on ct only.
+        if (timeout == System.Threading.Timeout.InfiniteTimeSpan)
+        {
+            timeout = null;
+        }
+
         if (!_workflows.TryGetValue(workflowId, out var entry))
         {
             throw new UnknownWorkflowException(workflowId);
@@ -368,7 +410,12 @@ public sealed class WorkflowManager : IAsyncDisposable
             return cached;
         }
 
-        var handle = Volatile.Read(ref entry.Handle) ?? throw new UnknownWorkflowException(workflowId);
+        var handle = Volatile.Read(ref entry.Handle);
+        if (handle is null)
+        {
+            // Mid-completion-handoff (re-read snapshot) or admitted-but-starting (coherent "running").
+            return Volatile.Read(ref entry.TerminalSnapshot) ?? Pending(workflowId);
+        }
 
         if (!handle.Completion.IsCompleted)
         {
@@ -428,6 +475,9 @@ public sealed class WorkflowManager : IAsyncDisposable
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
+        // Reject any new starts that race this disposal (StartAsync re-checks the flag after reserving).
+        Volatile.Write(ref _disposed, true);
+
         foreach (var (id, entry) in _workflows)
         {
             await DisposeHandleOnceAsync(id, entry).ConfigureAwait(false);
@@ -546,7 +596,9 @@ public sealed class WorkflowManager : IAsyncDisposable
                     NotifyKinds.WorkflowCompletion,
                     detail: BuildNotifyDetail(result),
                     sourceToolName: StartWorkflowToolProvider.StartWorkflowToolName,
-                    sourceToolCallId: workflowId,
+                    // Correlate to the originating StartWorkflow tool call when known; the workflowId is still
+                    // carried in the label + detail body.
+                    sourceToolCallId: entry.OriginatingToolCallId ?? workflowId,
                     label: workflowId
                 );
 
@@ -653,6 +705,12 @@ public sealed class WorkflowManager : IAsyncDisposable
             Notes = handle.Notes,
         };
 
+    /// <summary>A known workflow that has been admitted but whose controller handle is not yet published
+    /// (queued at the concurrency gate, or the completion handoff is mid-flight) — reported as running, not
+    /// unknown, since the id is genuinely known.</summary>
+    private static WorkflowRunResult Pending(string workflowId) =>
+        new() { WorkflowId = workflowId, Status = WorkflowStatuses.Running, IsComplete = false };
+
     private static WorkflowRunResult Timeout(string workflowId, WorkflowRunHandle handle) =>
         new()
         {
@@ -704,6 +762,9 @@ public sealed class WorkflowManager : IAsyncDisposable
 
         /// <summary>The lightweight terminal result, captured at completion. Authoritative once non-null.</summary>
         public WorkflowRunResult? TerminalSnapshot;
+
+        /// <summary>The originating StartWorkflow tool-call id for completion-notify correlation, or null.</summary>
+        public string? OriginatingToolCallId;
 
         public Task? Observer;
         public int NotifySent;

--- a/src/LmWorkflow/WorkflowManager.cs
+++ b/src/LmWorkflow/WorkflowManager.cs
@@ -243,7 +243,9 @@ public sealed class WorkflowManager : IAsyncDisposable
             entry.Handle = handle;
 
             // Past this point the completion handler owns the concurrency slot and the handle's disposal.
-            _ = ObserveCompletionAsync(workflowId, entry, mode);
+            // Track the observer task so DisposeAsync can await it before disposing the gate (otherwise its
+            // fire-and-forget Release could land on an already-disposed semaphore).
+            entry.Observer = ObserveCompletionAsync(workflowId, entry, mode);
         }
         catch
         {
@@ -264,7 +266,9 @@ public sealed class WorkflowManager : IAsyncDisposable
         }
 
         // Sync: block until terminal, then return the outcome inline. Gate release + disposal are handled by
-        // the completion handler; this path only reads the terminal state.
+        // the completion handler; this path only reads the terminal state. Note: cancelling the caller here
+        // rethrows OperationCanceledException but deliberately does NOT cancel the run (it stays queryable via
+        // Check/Wait and finishes on its own); the run is bounded instead by controllerMaxTurnsPerRun.
         try
         {
             await handle.Completion.WaitAsync(ct).ConfigureAwait(false);
@@ -372,7 +376,18 @@ public sealed class WorkflowManager : IAsyncDisposable
             }
         }
 
-        return BuildResult(workflowId, handle);
+        // Only report a terminal outcome once Completion has actually resolved. If the wait returned while
+        // the run is still going (a timeout, or any swallowed non-fatal wait error), report it as still
+        // waiting rather than letting BuildResult misread a running workflow as "failed".
+        return handle.Completion.IsCompleted
+            ? BuildResult(workflowId, handle)
+            : new WorkflowRunResult
+            {
+                WorkflowId = workflowId,
+                Status = "timeout",
+                CurrentNodeId = handle.CurrentNodeId,
+                IsComplete = false,
+            };
     }
 
     /// <inheritdoc />
@@ -381,6 +396,21 @@ public sealed class WorkflowManager : IAsyncDisposable
         foreach (var (id, entry) in _workflows)
         {
             await DisposeHandleOnceAsync(id, entry).ConfigureAwait(false);
+
+            // Await the completion observer (its Completion is now resolved by the disposal above) so its
+            // one-shot gate Release runs BEFORE the gate is disposed below — otherwise a still-in-flight
+            // observer could Release an already-disposed semaphore and fault as unobserved background work.
+            if (entry.Observer is { } observer)
+            {
+                try
+                {
+                    await observer.ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Workflow {WorkflowId} completion observer faulted during dispose", id);
+                }
+            }
         }
 
         _workflows.Clear();
@@ -451,8 +481,17 @@ public sealed class WorkflowManager : IAsyncDisposable
             }
 
             // Release the slot as soon as the run ends — BEFORE the possibly-slow notify — so a blocked
-            // notification never holds up a fresh StartWorkflow waiting on the gate.
-            _ = _concurrencyGate.Release();
+            // notification never holds up a fresh StartWorkflow waiting on the gate. Guarded against a
+            // concurrent DisposeAsync having already disposed the gate (belt-and-suspenders: DisposeAsync
+            // now awaits this observer before disposing, so this is normally unreachable).
+            try
+            {
+                _ = _concurrencyGate.Release();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The manager was disposed; the slot no longer matters.
+            }
 
             if (mode == WorkflowStartMode.Async
                 && _completionNotifier is not null
@@ -594,6 +633,7 @@ public sealed class WorkflowManager : IAsyncDisposable
     private sealed class WorkflowEntry
     {
         public WorkflowRunHandle? Handle;
+        public Task? Observer;
         public int NotifySent;
         public int Disposed;
     }

--- a/src/LmWorkflow/WorkflowSession.cs
+++ b/src/LmWorkflow/WorkflowSession.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmCore.Utils;
@@ -60,6 +61,10 @@ public static class WorkflowSession
     /// <param name="controllerMaxTurnsPerRun">
     ///     An optional bound on the controller loop's turns per run; <c>null</c> keeps the loop's default (50).
     /// </param>
+    /// <param name="controllerDefaultOptions">
+    ///     Optional request defaults (notably <c>ModelId</c>) for the controller loop, so the controller runs
+    ///     on a fixed, pre-configured model rather than the provider agent's hardcoded default.
+    /// </param>
     /// <param name="ct">A cancellation token bound to the run.</param>
     public static Task<WorkflowRunHandle> StartAsync(
         string objective,
@@ -75,6 +80,7 @@ public static class WorkflowSession
         IJsonSchemaValidator? schemaValidator = null,
         bool includeAuthoringTool = true,
         int? controllerMaxTurnsPerRun = null,
+        GenerateReplyOptions? controllerDefaultOptions = null,
         CancellationToken ct = default
     )
     {
@@ -108,7 +114,8 @@ public static class WorkflowSession
             subAgentOptions,
             conversationStore,
             includeAuthoringTool,
-            controllerMaxTurnsPerRun
+            controllerMaxTurnsPerRun,
+            controllerDefaultOptions
         );
         return Task.FromResult(BeginRun(loop, runtime, objective, ct));
     }
@@ -180,7 +187,8 @@ public static class WorkflowSession
         SubAgentOptions subAgentOptions,
         IConversationStore? conversationStore,
         bool includeAuthoringTool = true,
-        int? maxTurnsPerRun = null
+        int? maxTurnsPerRun = null,
+        GenerateReplyOptions? controllerDefaultOptions = null
     )
     {
         var registry = new FunctionRegistry();
@@ -191,6 +199,9 @@ public static class WorkflowSession
             registry,
             threadId,
             systemPrompt: ControllerSystemPrompt.Default,
+            // Pin the controller's model (and any other request defaults) so it never falls back to the
+            // provider agent's hardcoded default model.
+            defaultOptions: controllerDefaultOptions,
             // Fall back to MultiTurnAgentLoop's own default (50) when the caller does not bound it.
             maxTurnsPerRun: maxTurnsPerRun ?? 50,
             store: conversationStore,

--- a/src/LmWorkflow/WorkflowSession.cs
+++ b/src/LmWorkflow/WorkflowSession.cs
@@ -52,6 +52,14 @@ public static class WorkflowSession
     /// <param name="conversationStore">An optional conversation store; when supplied the controller's history is persisted under <paramref name="threadId"/> (and recoverable on resume).</param>
     /// <param name="logger">An optional logger; forwarded to the runtime so swallowed best-effort persistence faults are surfaced at Warning.</param>
     /// <param name="schemaValidator">An optional JSON-Schema validator the runtime validates task/terminal outputs with.</param>
+    /// <param name="includeAuthoringTool">
+    ///     When <c>true</c> (default) the controller loop exposes the <c>SetWorkflow</c> authoring tool.
+    ///     Pass <c>false</c> when the controller always receives a pre-authored <paramref name="definition"/>
+    ///     and must not be able to author/replace it (e.g. a <c>StartWorkflow</c>-launched controller).
+    /// </param>
+    /// <param name="controllerMaxTurnsPerRun">
+    ///     An optional bound on the controller loop's turns per run; <c>null</c> keeps the loop's default (50).
+    /// </param>
     /// <param name="ct">A cancellation token bound to the run.</param>
     public static Task<WorkflowRunHandle> StartAsync(
         string objective,
@@ -65,6 +73,8 @@ public static class WorkflowSession
         IConversationStore? conversationStore = null,
         ILogger? logger = null,
         IJsonSchemaValidator? schemaValidator = null,
+        bool includeAuthoringTool = true,
+        int? controllerMaxTurnsPerRun = null,
         CancellationToken ct = default
     )
     {
@@ -91,7 +101,15 @@ public static class WorkflowSession
             runtime.AttachStore(store, instanceId);
         }
 
-        var loop = BuildLoop(controllerAgent, runtime, threadId, subAgentOptions, conversationStore);
+        var loop = BuildLoop(
+            controllerAgent,
+            runtime,
+            threadId,
+            subAgentOptions,
+            conversationStore,
+            includeAuthoringTool,
+            controllerMaxTurnsPerRun
+        );
         return Task.FromResult(BeginRun(loop, runtime, objective, ct));
     }
 
@@ -160,17 +178,21 @@ public static class WorkflowSession
         WorkflowRuntime runtime,
         string threadId,
         SubAgentOptions subAgentOptions,
-        IConversationStore? conversationStore
+        IConversationStore? conversationStore,
+        bool includeAuthoringTool = true,
+        int? maxTurnsPerRun = null
     )
     {
         var registry = new FunctionRegistry();
-        _ = registry.AddProvider(new WorkflowToolProvider(runtime));
+        _ = registry.AddProvider(new WorkflowToolProvider(runtime, includeSetWorkflow: includeAuthoringTool));
 
         return new MultiTurnAgentLoop(
             controllerAgent,
             registry,
             threadId,
             systemPrompt: ControllerSystemPrompt.Default,
+            // Fall back to MultiTurnAgentLoop's own default (50) when the caller does not bound it.
+            maxTurnsPerRun: maxTurnsPerRun ?? 50,
             store: conversationStore,
             subAgentOptions: subAgentOptions
         );

--- a/tests/LmMultiTurn.Tests/SubAgentToolInheritanceExclusionTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentToolInheritanceExclusionTests.cs
@@ -1,0 +1,85 @@
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace LmMultiTurn.Tests;
+
+/// <summary>
+/// Covers <see cref="SubAgentOptions.NonInheritedToolNames"/>: a host-declared launch/orchestration
+/// tool (e.g. StartWorkflow) that lives on the parent's own registry must NOT leak into a sub-agent
+/// spawned with an inherit-all template, while the parent keeps it. Also covers the
+/// <see cref="MultiTurnAgentLoop.RegisteredToolNames"/> accessor used to assert a loop's tool surface.
+/// </summary>
+public class SubAgentToolInheritanceExclusionTests
+{
+    private static FunctionContract Contract(string name) =>
+        new() { Name = name, Description = name, Parameters = [] };
+
+    [Fact]
+    public void FilterInheritableContracts_ExcludesNamedTools()
+    {
+        var contracts = new List<FunctionContract> { Contract("SafeTool"), Contract("StartWorkflow") };
+
+        var filtered = MultiTurnAgentLoop.FilterInheritableContracts(contracts, ["StartWorkflow"]);
+
+        filtered.Select(c => c.Name).Should().BeEquivalentTo(["SafeTool"]);
+    }
+
+    [Fact]
+    public void FilterInheritableContracts_NullOrEmpty_ReturnsAllUnchanged()
+    {
+        var contracts = new List<FunctionContract> { Contract("SafeTool"), Contract("StartWorkflow") };
+
+        MultiTurnAgentLoop.FilterInheritableContracts(contracts, null)
+            .Select(c => c.Name).Should().BeEquivalentTo(["SafeTool", "StartWorkflow"]);
+        MultiTurnAgentLoop.FilterInheritableContracts(contracts, [])
+            .Select(c => c.Name).Should().BeEquivalentTo(["SafeTool", "StartWorkflow"]);
+    }
+
+    [Fact]
+    public async Task RegisteredToolNames_KeepsExcludedToolOnParent_AndSelfRegistersAgentTools()
+    {
+        var providerAgent = new Mock<IStreamingAgent>().Object;
+
+        var registry = new FunctionRegistry();
+        _ = registry.AddFunction(
+            Contract("SafeTool"),
+            (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText("ok")),
+            "ParentTools");
+        _ = registry.AddFunction(
+            Contract("StartWorkflow"),
+            (_, _, _) => Task.FromResult<ToolHandlerResult>(ToolHandlerResult.FromText("ok")),
+            "ParentTools");
+
+        var subAgentOptions = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate>
+            {
+                ["worker"] = new SubAgentTemplate
+                {
+                    SystemPrompt = "worker",
+                    AgentFactory = () => new Mock<IStreamingAgent>().Object,
+                    // inherit-all: without the exclusion this template WOULD inherit StartWorkflow.
+                    EnabledTools = null,
+                },
+            },
+            // The general Q3 exclusion: sub-agents must never inherit the launch tool.
+            NonInheritedToolNames = ["StartWorkflow"],
+        };
+
+        await using var loop = new MultiTurnAgentLoop(
+            providerAgent,
+            registry,
+            threadId: "exclusion-test",
+            subAgentOptions: subAgentOptions);
+
+        // The PARENT keeps both its own tools plus the self-registered Agent-family tools.
+        loop.RegisteredToolNames.Should().Contain(["SafeTool", "StartWorkflow", "Agent", "SendMessage", "CheckAgent"]);
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/WorkspaceWorkflowWiringTests.cs
+++ b/tests/LmStreaming.Sample.Tests/WorkspaceWorkflowWiringTests.cs
@@ -1,0 +1,92 @@
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.LmWorkflow;
+using AchieveAi.LmDotnetTools.LmWorkflow.Tools;
+using LmStreaming.Sample.Services;
+
+namespace LmStreaming.Sample.Tests;
+
+/// <summary>
+///     Covers the Workspace Agent migration off #130's direct <c>SetWorkflow</c>/<c>GetWorkflow</c> wiring
+///     onto the <c>StartWorkflow</c> tool family: the controller node-delegate templates are restricted (so
+///     <c>WorkflowManager</c> accepts them), the default conversation templates are inherit-all (which is
+///     why the launch tools must be excluded from inheritance), and a migrated conversation surface exposes
+///     the launch tools but NEVER the workflow-state tools.
+/// </summary>
+public sealed class WorkspaceWorkflowWiringTests
+{
+    private static IStreamingAgent FakeAgent() => Mock.Of<IStreamingAgent>();
+
+    private static readonly HashSet<string> WorkflowAndLaunchToolNames =
+        [.. WorkflowToolProvider.AllToolNames, .. StartWorkflowToolProvider.ToolNames];
+
+    [Fact]
+    public void ControllerTemplates_AreRestricted_AndAcceptedByWorkflowManager()
+    {
+        var templates = BuiltInSubAgentTemplates.CreateWorkflowControllerTemplates(FakeAgent);
+
+        templates.Should().NotBeEmpty();
+        foreach (var (name, template) in templates)
+        {
+            template.EnabledTools.Should().NotBeNull($"controller template '{name}' must not be inherit-all");
+            template.EnabledTools!.Should()
+                .NotIntersectWith(WorkflowAndLaunchToolNames, $"controller template '{name}' must not leak workflow tools");
+        }
+
+        // WorkflowManager asserts the restricted-template invariant at construction; these must pass.
+        var act = () =>
+            new WorkflowManager(
+                FakeAgent,
+                new SubAgentOptions { Templates = templates }
+            );
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void DefaultConversationTemplates_AreInheritAll_SoLaunchToolsMustBeExcluded()
+    {
+        var defaults = BuiltInSubAgentTemplates.Create(FakeAgent);
+
+        // The default sub-agent templates inherit ALL parent tools — so once StartWorkflow is on the
+        // conversation registry, the launch tools would leak into every sub-agent unless excluded. This is
+        // exactly what the migration's NonInheritedToolNames = StartWorkflowToolProvider.ToolNames guards.
+        defaults.Values.Should().OnlyContain(t => t.EnabledTools == null);
+        StartWorkflowToolProvider.ToolNames.Should()
+            .BeEquivalentTo(["StartWorkflow", "CheckWorkflow", "WaitWorkflow"]);
+    }
+
+    [Fact]
+    public async Task MigratedConversation_ExposesLaunchTools_NotWorkflowStateTools()
+    {
+        // Reproduce the migrated Workspace Agent wiring: StartWorkflow family on the conversation registry,
+        // default (inherit-all) sub-agent templates, and the launch tools excluded from inheritance.
+        var manager = new WorkflowManager(
+            FakeAgent,
+            new SubAgentOptions { Templates = BuiltInSubAgentTemplates.CreateWorkflowControllerTemplates(FakeAgent) }
+        );
+
+        var registry = new FunctionRegistry();
+        _ = registry.AddProvider(new StartWorkflowToolProvider(manager));
+
+        var subAgentOptions = new SubAgentOptions
+        {
+            Templates = BuiltInSubAgentTemplates.Create(FakeAgent),
+            NonInheritedToolNames = StartWorkflowToolProvider.ToolNames,
+        };
+
+        await using var manager2 = manager;
+        await using var loop = new MultiTurnAgentLoop(
+            FakeAgent(),
+            registry,
+            threadId: "workspace-workflow-surface",
+            subAgentOptions: subAgentOptions
+        );
+
+        // A normal agent sees the launch tools...
+        loop.RegisteredToolNames.Should().Contain(["StartWorkflow", "CheckWorkflow", "WaitWorkflow"]);
+        // ...and NEVER the workflow-state/authoring tools (those live only inside a controller loop).
+        loop.RegisteredToolNames.Should()
+            .NotContain(["SetWorkflow", "GetWorkflow", "SetCurrentNode", "SetState", "SetNotes"]);
+    }
+}

--- a/tests/LmWorkflow.Tests/StartWorkflowTestHarness.cs
+++ b/tests/LmWorkflow.Tests/StartWorkflowTestHarness.cs
@@ -1,0 +1,118 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json.Nodes;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.LmWorkflow.Model;
+using Moq;
+
+namespace AchieveAi.LmDotnetTools.LmWorkflow.Tests;
+
+/// <summary>
+///     Shared scaffolding for the StartWorkflow tool-family tests: scripted controllers, minimal/invalid
+///     definitions, and empty controller options.
+/// </summary>
+internal static class StartWorkflowTestHarness
+{
+    /// <summary>A structurally-parseable but INVALID definition: a start with no terminal node.</summary>
+    public const string InvalidNoTerminal = """
+        {
+          "schemaVersion": 1,
+          "objective": "invalid",
+          "nodes": [
+            { "id": "s", "type": "start", "title": "Start", "next": ["t"] }
+          ]
+        }
+        """;
+
+    public static WorkflowDefinition MinimalDefinition() =>
+        WorkflowJson.Deserialize(WorkflowFixtures.MinimalValid);
+
+    public static WorkflowDefinition InvalidDefinition() => WorkflowJson.Deserialize(InvalidNoTerminal);
+
+    public static SubAgentOptions EmptyControllerOptions() =>
+        new() { Templates = new Dictionary<string, SubAgentTemplate>() };
+
+    /// <summary>Routes <c>start → terminal</c> for <see cref="WorkflowFixtures.MinimalValid"/>, then ends the run.</summary>
+    public static IMessage DriveMinimalToTerminal(int turn) =>
+        turn switch
+        {
+            1 => ToolCall("SetCurrentNode", new JsonObject { ["nextNodeId"] = "t" }, "tc_route"),
+            _ => new TextMessage { Text = "Workflow finished.", Role = Role.Assistant },
+        };
+
+    /// <summary>Never advances the workflow — keeps calling GetWorkflow so the loop runs until its turn cap.</summary>
+    public static IMessage NeverComplete(int turn) =>
+        ToolCall("GetWorkflow", [], $"tc_get_{turn}");
+
+    /// <summary>A controller that returns one scripted message per turn.</summary>
+    public static Mock<IStreamingAgent> ScriptedController(Func<int, IMessage> script)
+    {
+        var controller = new Mock<IStreamingAgent>();
+        var turn = 0;
+        controller
+            .Setup(a =>
+                a.GenerateReplyStreamingAsync(
+                    It.IsAny<IEnumerable<IMessage>>(),
+                    It.IsAny<GenerateReplyOptions>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(() => Task.FromResult(ToAsyncEnumerable([script(++turn)])));
+        return controller;
+    }
+
+    /// <summary>
+    ///     A controller whose FIRST turn blocks until <paramref name="gate"/> is released, then drives the
+    ///     minimal workflow to its terminal. Used to hold a workflow "running" for Check/Wait/capacity tests.
+    /// </summary>
+    public static Mock<IStreamingAgent> GatedController(TaskCompletionSource gate)
+    {
+        var controller = new Mock<IStreamingAgent>();
+        var turn = 0;
+        controller
+            .Setup(a =>
+                a.GenerateReplyStreamingAsync(
+                    It.IsAny<IEnumerable<IMessage>>(),
+                    It.IsAny<GenerateReplyOptions>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(
+                async (IEnumerable<IMessage> _, GenerateReplyOptions _, CancellationToken ct) =>
+                {
+                    var thisTurn = Interlocked.Increment(ref turn);
+                    if (thisTurn == 1)
+                    {
+                        await gate.Task.WaitAsync(ct).ConfigureAwait(false);
+                    }
+
+                    return ToAsyncEnumerable([DriveMinimalToTerminal(thisTurn)]);
+                }
+            );
+        return controller;
+    }
+
+    public static ToolCallMessage ToolCall(string functionName, JsonObject args, string toolCallId) =>
+        new()
+        {
+            FunctionName = functionName,
+            FunctionArgs = args.ToJsonString(),
+            ToolCallId = toolCallId,
+            Role = Role.Assistant,
+        };
+
+    public static async IAsyncEnumerable<IMessage> ToAsyncEnumerable(
+        List<IMessage> messages,
+        [EnumeratorCancellation] CancellationToken ct = default
+    )
+    {
+        foreach (var message in messages)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return message;
+            await Task.Yield();
+        }
+    }
+}

--- a/tests/LmWorkflow.Tests/StartWorkflowTestHarness.cs
+++ b/tests/LmWorkflow.Tests/StartWorkflowTestHarness.cs
@@ -94,6 +94,26 @@ internal static class StartWorkflowTestHarness
         return controller;
     }
 
+    /// <summary>
+    ///     A controller whose pump faults: it throws an <see cref="OperationCanceledException"/> while nothing
+    ///     is cancelled, which faults the run's Completion (see WorkflowSession's pump-fault handling) — the
+    ///     "controller run threw" path, distinct from turn-budget exhaustion.
+    /// </summary>
+    public static Mock<IStreamingAgent> FaultingController()
+    {
+        var controller = new Mock<IStreamingAgent>();
+        controller
+            .Setup(a =>
+                a.GenerateReplyStreamingAsync(
+                    It.IsAny<IEnumerable<IMessage>>(),
+                    It.IsAny<GenerateReplyOptions>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Throws(new OperationCanceledException("controller pump fault"));
+        return controller;
+    }
+
     public static ToolCallMessage ToolCall(string functionName, JsonObject args, string toolCallId) =>
         new()
         {

--- a/tests/LmWorkflow.Tests/StartWorkflowToolProviderTests.cs
+++ b/tests/LmWorkflow.Tests/StartWorkflowToolProviderTests.cs
@@ -182,12 +182,11 @@ public class StartWorkflowToolProviderTests
 
     [Theory]
     [InlineData("5")] // number-as-string (some models emit this)
-    [InlineData(-1)] // negative → treated as no timeout
     [InlineData(5000000)] // ~57 days → clamped, must not throw
     public async Task WaitWorkflow_ParsesAndClampsTimeout_OnCompletedWorkflow(object timeout)
     {
         // The workflow is already terminal, so WaitWorkflow returns immediately regardless of the timeout —
-        // this exercises GetOptionalTimeout's string/negative/clamp paths through the actual handler.
+        // this exercises TryReadTimeout's string/clamp paths through the actual handler.
         var provider = new StartWorkflowToolProvider(NewManager(() => ScriptedController(DriveMinimalToTerminal).Object));
         var start = Tool(provider, "StartWorkflow");
         var wait = Tool(provider, "WaitWorkflow");
@@ -204,5 +203,43 @@ public class StartWorkflowToolProviderTests
         result.Payload.IsError.Should().BeFalse();
         using var doc = JsonDocument.Parse(result.Payload.Text);
         doc.RootElement.GetProperty("status").GetString().Should().Be("completed");
+    }
+
+    [Theory]
+    [InlineData("-5")] // negative number-as-string
+    [InlineData(-5)] // negative number
+    [InlineData("abc")] // non-numeric string
+    public async Task WaitWorkflow_PresentButInvalidTimeout_ReturnsInvalidArgs(object timeout)
+    {
+        // A present-but-invalid timeout must be rejected, not silently collapsed to an unbounded wait.
+        var provider = new StartWorkflowToolProvider(NewManager(() => ScriptedController(DriveMinimalToTerminal).Object));
+        var start = Tool(provider, "StartWorkflow");
+        var wait = Tool(provider, "WaitWorkflow");
+
+        _ = await Invoke(start, StartArgs("inv", WorkflowFixtures.MinimalValid, "sync"));
+
+        var args = new JsonObject
+        {
+            ["workflowId"] = "inv",
+            ["timeout"] = timeout is string s ? JsonValue.Create(s) : JsonValue.Create((int)timeout),
+        };
+        var result = await Invoke(wait, args.ToJsonString());
+
+        result.Payload.IsError.Should().BeTrue();
+        result.Payload.ErrorCode.Should().Be("invalid_args");
+    }
+
+    [Theory]
+    [InlineData("StartWorkflow")]
+    [InlineData("CheckWorkflow")]
+    [InlineData("WaitWorkflow")]
+    public async Task Handlers_MalformedJson_ReturnInvalidArgs(string toolName)
+    {
+        var provider = new StartWorkflowToolProvider(NewManager(() => ScriptedController(DriveMinimalToTerminal).Object));
+
+        var result = await Invoke(Tool(provider, toolName), "{not valid json");
+
+        result.Payload.IsError.Should().BeTrue();
+        result.Payload.ErrorCode.Should().Be("invalid_args");
     }
 }

--- a/tests/LmWorkflow.Tests/StartWorkflowToolProviderTests.cs
+++ b/tests/LmWorkflow.Tests/StartWorkflowToolProviderTests.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmWorkflow.Tools;
+using FluentAssertions;
+using Xunit;
+using static AchieveAi.LmDotnetTools.LmWorkflow.Tests.StartWorkflowTestHarness;
+
+namespace AchieveAi.LmDotnetTools.LmWorkflow.Tests;
+
+/// <summary>
+///     Surface + error-mapping coverage for <see cref="StartWorkflowToolProvider"/>: the exact tool-name set
+///     exposed to normal agents, the WaitWorkflow open-ended-timeout caveat in its description, and the
+///     tool-error codes each manager failure maps to.
+/// </summary>
+public class StartWorkflowToolProviderTests
+{
+    private static WorkflowManager NewManager(
+        Func<IStreamingAgent> controllerFactory,
+        int maxConcurrentWorkflows = 8,
+        TimeSpan? gateWaitTimeout = null
+    ) =>
+        new(
+            controllerFactory,
+            EmptyControllerOptions(),
+            maxConcurrentWorkflows: maxConcurrentWorkflows,
+            gateWaitTimeout: gateWaitTimeout
+        );
+
+    private static FunctionDescriptor Tool(StartWorkflowToolProvider provider, string name) =>
+        provider.GetFunctions().Single(f => f.Contract.Name == name);
+
+    private static async Task<ToolHandlerResult.Resolved> Invoke(FunctionDescriptor tool, string argsJson) =>
+        (ToolHandlerResult.Resolved)await tool.Handler(argsJson, new ToolCallContext(), CancellationToken.None);
+
+    private static string StartArgs(string workflowId, string definitionJson, string mode) =>
+        new JsonObject
+        {
+            ["workflowId"] = workflowId,
+            ["workflow"] = JsonNode.Parse(definitionJson),
+            ["mode"] = mode,
+        }.ToJsonString();
+
+    [Fact]
+    public void ExposesExactlyStartCheckWait()
+    {
+        var provider = new StartWorkflowToolProvider(NewManager(() => ScriptedController(DriveMinimalToTerminal).Object));
+
+        provider
+            .GetFunctions()
+            .Select(f => f.Contract.Name)
+            .Should()
+            .BeEquivalentTo(["StartWorkflow", "CheckWorkflow", "WaitWorkflow"]);
+    }
+
+    [Fact]
+    public void WaitWorkflowDescription_DocumentsOpenEndedTimeoutTradeoff()
+    {
+        var provider = new StartWorkflowToolProvider(NewManager(() => ScriptedController(DriveMinimalToTerminal).Object));
+
+        Tool(provider, "WaitWorkflow").Contract.Description.Should().Contain("open-ended");
+    }
+
+    [Fact]
+    public async Task StartWorkflow_InvalidDefinition_MapsToInvalidWorkflow()
+    {
+        var provider = new StartWorkflowToolProvider(NewManager(() => ScriptedController(DriveMinimalToTerminal).Object));
+
+        var result = await Invoke(Tool(provider, "StartWorkflow"), StartArgs("x", InvalidNoTerminal, "sync"));
+
+        result.Payload.IsError.Should().BeTrue();
+        result.Payload.ErrorCode.Should().Be("invalid_workflow");
+    }
+
+    [Fact]
+    public async Task StartWorkflow_DuplicateId_MapsToDuplicateWorkflow()
+    {
+        var provider = new StartWorkflowToolProvider(NewManager(() => ScriptedController(DriveMinimalToTerminal).Object));
+        var start = Tool(provider, "StartWorkflow");
+
+        var first = await Invoke(start, StartArgs("dup", WorkflowFixtures.MinimalValid, "sync"));
+        first.Payload.IsError.Should().BeFalse();
+
+        var second = await Invoke(start, StartArgs("dup", WorkflowFixtures.MinimalValid, "async"));
+        second.Payload.IsError.Should().BeTrue();
+        second.Payload.ErrorCode.Should().Be("duplicate_workflow");
+    }
+
+    [Fact]
+    public async Task CheckWorkflow_UnknownId_MapsToUnknownWorkflow()
+    {
+        var provider = new StartWorkflowToolProvider(NewManager(() => ScriptedController(DriveMinimalToTerminal).Object));
+
+        var result = await Invoke(
+            Tool(provider, "CheckWorkflow"),
+            new JsonObject { ["workflowId"] = "nope" }.ToJsonString()
+        );
+
+        result.Payload.IsError.Should().BeTrue();
+        result.Payload.ErrorCode.Should().Be("unknown_workflow");
+    }
+
+    [Fact]
+    public async Task StartWorkflow_AtCapacity_MapsToWorkflowCapacity()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var provider = new StartWorkflowToolProvider(
+            NewManager(() => GatedController(gate).Object, maxConcurrentWorkflows: 1, gateWaitTimeout: TimeSpan.FromMilliseconds(200))
+        );
+        var start = Tool(provider, "StartWorkflow");
+
+        // Hold the only slot with a gated async workflow.
+        var first = await Invoke(start, StartArgs("cap-1", WorkflowFixtures.MinimalValid, "async"));
+        first.Payload.IsError.Should().BeFalse();
+
+        var second = await Invoke(start, StartArgs("cap-2", WorkflowFixtures.MinimalValid, "async"));
+        second.Payload.IsError.Should().BeTrue();
+        second.Payload.ErrorCode.Should().Be("workflow_capacity");
+
+        gate.SetResult();
+    }
+
+    [Fact]
+    public async Task StartWorkflow_Sync_ReturnsCompletedJson()
+    {
+        var provider = new StartWorkflowToolProvider(NewManager(() => ScriptedController(DriveMinimalToTerminal).Object));
+
+        var result = await Invoke(Tool(provider, "StartWorkflow"), StartArgs("ok", WorkflowFixtures.MinimalValid, "sync"));
+
+        result.Payload.IsError.Should().BeFalse();
+        using var doc = JsonDocument.Parse(result.Payload.Text);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("completed");
+        doc.RootElement.GetProperty("workflowId").GetString().Should().Be("ok");
+    }
+}

--- a/tests/LmWorkflow.Tests/StartWorkflowToolProviderTests.cs
+++ b/tests/LmWorkflow.Tests/StartWorkflowToolProviderTests.cs
@@ -134,4 +134,75 @@ public class StartWorkflowToolProviderTests
         doc.RootElement.GetProperty("status").GetString().Should().Be("completed");
         doc.RootElement.GetProperty("workflowId").GetString().Should().Be("ok");
     }
+
+    [Fact]
+    public async Task CheckWorkflow_RunningWorkflow_ReturnsRunningJson()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var provider = new StartWorkflowToolProvider(NewManager(() => GatedController(gate).Object));
+        var start = Tool(provider, "StartWorkflow");
+        var check = Tool(provider, "CheckWorkflow");
+
+        _ = await Invoke(start, StartArgs("chk", WorkflowFixtures.MinimalValid, "async"));
+
+        var result = await Invoke(check, new JsonObject { ["workflowId"] = "chk" }.ToJsonString());
+        result.Payload.IsError.Should().BeFalse();
+        using (var doc = JsonDocument.Parse(result.Payload.Text))
+        {
+            doc.RootElement.GetProperty("status").GetString().Should().Be("running");
+        }
+
+        gate.SetResult();
+    }
+
+    [Fact]
+    public async Task WaitWorkflow_UnknownId_MapsToUnknownWorkflow()
+    {
+        var provider = new StartWorkflowToolProvider(NewManager(() => ScriptedController(DriveMinimalToTerminal).Object));
+
+        var result = await Invoke(
+            Tool(provider, "WaitWorkflow"),
+            new JsonObject { ["workflowId"] = "nope", ["timeout"] = 1 }.ToJsonString()
+        );
+
+        result.Payload.IsError.Should().BeTrue();
+        result.Payload.ErrorCode.Should().Be("unknown_workflow");
+    }
+
+    [Fact]
+    public async Task WaitWorkflow_MissingWorkflowId_ReturnsInvalidArgs()
+    {
+        var provider = new StartWorkflowToolProvider(NewManager(() => ScriptedController(DriveMinimalToTerminal).Object));
+
+        var result = await Invoke(Tool(provider, "WaitWorkflow"), "{}");
+
+        result.Payload.IsError.Should().BeTrue();
+        result.Payload.ErrorCode.Should().Be("invalid_args");
+    }
+
+    [Theory]
+    [InlineData("5")] // number-as-string (some models emit this)
+    [InlineData(-1)] // negative → treated as no timeout
+    [InlineData(5000000)] // ~57 days → clamped, must not throw
+    public async Task WaitWorkflow_ParsesAndClampsTimeout_OnCompletedWorkflow(object timeout)
+    {
+        // The workflow is already terminal, so WaitWorkflow returns immediately regardless of the timeout —
+        // this exercises GetOptionalTimeout's string/negative/clamp paths through the actual handler.
+        var provider = new StartWorkflowToolProvider(NewManager(() => ScriptedController(DriveMinimalToTerminal).Object));
+        var start = Tool(provider, "StartWorkflow");
+        var wait = Tool(provider, "WaitWorkflow");
+
+        _ = await Invoke(start, StartArgs("done", WorkflowFixtures.MinimalValid, "sync"));
+
+        var args = new JsonObject
+        {
+            ["workflowId"] = "done",
+            ["timeout"] = timeout is string s ? JsonValue.Create(s) : JsonValue.Create((int)timeout),
+        };
+        var result = await Invoke(wait, args.ToJsonString());
+
+        result.Payload.IsError.Should().BeFalse();
+        using var doc = JsonDocument.Parse(result.Payload.Text);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("completed");
+    }
 }

--- a/tests/LmWorkflow.Tests/WorkflowControllerToolRestrictionTests.cs
+++ b/tests/LmWorkflow.Tests/WorkflowControllerToolRestrictionTests.cs
@@ -1,0 +1,108 @@
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.LmWorkflow.Runtime;
+using AchieveAi.LmDotnetTools.LmWorkflow.Tools;
+using FluentAssertions;
+using Xunit;
+using static AchieveAi.LmDotnetTools.LmWorkflow.Tests.StartWorkflowTestHarness;
+
+namespace AchieveAi.LmDotnetTools.LmWorkflow.Tests;
+
+/// <summary>
+///     The tool-restriction invariant: a StartWorkflow-launched controller loop exposes exactly the
+///     restricted workflow-state + Agent-family tools (never <c>SetWorkflow</c>, never a library <c>Read</c>),
+///     and a controller sub-agent template set that could leak the workflow tools is rejected at construction.
+///     (The complementary "controller Agent must not spawn background sub-agents" rail is enforced by
+///     <c>WorkflowRuntime.ObserveSpawnResult</c> and covered by <see cref="BackgroundCorrelationTests"/>, which
+///     this controller inherits unchanged via <see cref="WorkflowSession"/>.)
+/// </summary>
+public class WorkflowControllerToolRestrictionTests
+{
+    [Fact]
+    public async Task ControllerLoop_ExposesExactlyRestrictedToolSet_NoSetWorkflow()
+    {
+        var controller = ScriptedController(DriveMinimalToTerminal);
+
+        await using var handle = await WorkflowSession.StartAsync(
+            objective: "drive",
+            inputs: null,
+            definition: MinimalDefinition(),
+            subAgentOptions: EmptyControllerOptions(),
+            controllerAgent: controller.Object,
+            threadId: "wf-restrict-thread",
+            includeAuthoringTool: false
+        );
+
+        handle
+            .Loop.RegisteredToolNames.Should()
+            .BeEquivalentTo(
+                [
+                    "GetWorkflow",
+                    "SetCurrentNode",
+                    "SetState",
+                    "SetNotes",
+                    "Agent",
+                    "SendMessage",
+                    "CheckAgent",
+                ]
+            );
+    }
+
+    [Fact]
+    public void Manager_RejectsControllerTemplate_WithNullEnabledTools()
+    {
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate>
+            {
+                ["leaky"] = new SubAgentTemplate
+                {
+                    SystemPrompt = "leaky",
+                    AgentFactory = () => ScriptedController(DriveMinimalToTerminal).Object,
+                    EnabledTools = null, // inherit-all → would inherit the controller's workflow tools.
+                },
+            },
+        };
+
+        var act = () => WorkflowManager.AssertRestrictedControllerTemplates(options);
+        act.Should().Throw<ArgumentException>().WithMessage("*EnabledTools*");
+    }
+
+    [Fact]
+    public void Manager_RejectsControllerTemplate_ThatEnablesAWorkflowTool()
+    {
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate>
+            {
+                ["leaky"] = new SubAgentTemplate
+                {
+                    SystemPrompt = "leaky",
+                    AgentFactory = () => ScriptedController(DriveMinimalToTerminal).Object,
+                    EnabledTools = ["Read", "SetState"], // SetState is a controller-only workflow tool.
+                },
+            },
+        };
+
+        var act = () => WorkflowManager.AssertRestrictedControllerTemplates(options);
+        act.Should().Throw<ArgumentException>().WithMessage("*SetState*");
+    }
+
+    [Fact]
+    public void WorkflowToolProvider_OmitsSetWorkflow_WhenAuthoringDisabled()
+    {
+        var runtime = new WorkflowRuntime();
+
+        new WorkflowToolProvider(runtime, includeSetWorkflow: false)
+            .GetFunctions()
+            .Select(f => f.Contract.Name)
+            .Should()
+            .BeEquivalentTo(["GetWorkflow", "SetCurrentNode", "SetState", "SetNotes"]);
+
+        // The default surface is unchanged for other callers (e.g. the authoring/test path).
+        new WorkflowToolProvider(runtime)
+            .GetFunctions()
+            .Select(f => f.Contract.Name)
+            .Should()
+            .Contain("SetWorkflow");
+    }
+}

--- a/tests/LmWorkflow.Tests/WorkflowManagerTests.cs
+++ b/tests/LmWorkflow.Tests/WorkflowManagerTests.cs
@@ -1,0 +1,243 @@
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmWorkflow.Ingest;
+using FluentAssertions;
+using Xunit;
+using static AchieveAi.LmDotnetTools.LmWorkflow.Tests.StartWorkflowTestHarness;
+
+namespace AchieveAi.LmDotnetTools.LmWorkflow.Tests;
+
+/// <summary>
+///     Behavioral coverage for <see cref="WorkflowManager"/>: sync/async launch, proactive notify, non-blocking
+///     Check, blocking + non-destructive-timeout Wait, duplicate/invalid/capacity/unknown errors, the
+///     turn-budget-exhausted → Failed rail, notify-failure-doesn't-lose-result, and the long-lived / disposed-
+///     but-queryable handle lifecycle that has no prior precedent in the codebase.
+/// </summary>
+public class WorkflowManagerTests
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    private static WorkflowManager NewManager(
+        Func<IStreamingAgent> controllerFactory,
+        Func<NotifyMessage, CancellationToken, Task>? notifier = null,
+        int maxConcurrentWorkflows = 8,
+        int controllerMaxTurnsPerRun = 150,
+        TimeSpan? gateWaitTimeout = null
+    ) =>
+        new(
+            controllerFactory,
+            EmptyControllerOptions(),
+            completionNotifier: notifier,
+            maxConcurrentWorkflows: maxConcurrentWorkflows,
+            controllerMaxTurnsPerRun: controllerMaxTurnsPerRun,
+            gateWaitTimeout: gateWaitTimeout
+        );
+
+    [Fact]
+    public async Task StartAsync_Sync_DrivesToTerminal_ReturnsCompletedInline()
+    {
+        var controller = ScriptedController(DriveMinimalToTerminal);
+        await using var manager = NewManager(() => controller.Object);
+
+        var result = await manager.StartAsync("wf-sync", MinimalDefinition(), WorkflowStartMode.Sync);
+
+        result.Status.Should().Be("completed");
+        result.IsComplete.Should().BeTrue();
+        result.CurrentNodeId.Should().Be("t");
+    }
+
+    [Fact]
+    public async Task StartAsync_Async_ReturnsStarted_AndProactivelyNotifiesOnCompletion()
+    {
+        var notified = new TaskCompletionSource<NotifyMessage>(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        var controller = ScriptedController(DriveMinimalToTerminal);
+        await using var manager = NewManager(
+            () => controller.Object,
+            notifier: (n, _) =>
+            {
+                notified.TrySetResult(n);
+                return Task.CompletedTask;
+            }
+        );
+
+        var started = await manager.StartAsync("wf-async", MinimalDefinition(), WorkflowStartMode.Async);
+        started.Status.Should().Be("started");
+
+        var notify = await notified.Task.WaitAsync(Timeout);
+        notify.NotifyKind.Should().Be(NotifyKinds.WorkflowCompletion);
+        notify.SourceToolCallId.Should().Be("wf-async");
+        notify.SourceToolName.Should().Be("StartWorkflow");
+    }
+
+    [Fact]
+    public async Task Check_ReturnsRunning_ThenCompleted_WithoutBlocking()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var controller = GatedController(gate);
+        await using var manager = NewManager(() => controller.Object);
+
+        _ = await manager.StartAsync("wf-check", MinimalDefinition(), WorkflowStartMode.Async);
+
+        // Running while the controller is gated.
+        manager.Check("wf-check").Status.Should().Be("running");
+
+        // Release and let it finish, then Check reports completed.
+        gate.SetResult();
+        _ = await manager.WaitAsync("wf-check", Timeout);
+        manager.Check("wf-check").Status.Should().Be("completed");
+    }
+
+    [Fact]
+    public async Task WaitAsync_Timeout_IsNonDestructive_ThenCompletes()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var controller = GatedController(gate);
+        await using var manager = NewManager(() => controller.Object);
+
+        _ = await manager.StartAsync("wf-wait", MinimalDefinition(), WorkflowStartMode.Async);
+
+        // A short wait times out WITHOUT cancelling the run.
+        var timedOut = await manager.WaitAsync("wf-wait", TimeSpan.FromMilliseconds(150));
+        timedOut.Status.Should().Be("timeout");
+
+        // The workflow is still alive: release it and a fresh Wait observes completion.
+        gate.SetResult();
+        var completed = await manager.WaitAsync("wf-wait", Timeout);
+        completed.Status.Should().Be("completed");
+    }
+
+    [Fact]
+    public async Task StartAsync_DuplicateWorkflowId_Throws()
+    {
+        var controller = ScriptedController(DriveMinimalToTerminal);
+        await using var manager = NewManager(() => controller.Object);
+
+        _ = await manager.StartAsync("dup", MinimalDefinition(), WorkflowStartMode.Sync);
+
+        var act = () => manager.StartAsync("dup", MinimalDefinition(), WorkflowStartMode.Async);
+        await act.Should().ThrowAsync<DuplicateWorkflowException>();
+    }
+
+    [Theory]
+    [InlineData(WorkflowStartMode.Sync)]
+    [InlineData(WorkflowStartMode.Async)]
+    public async Task StartAsync_InvalidDefinition_ThrowsSynchronously_NoSlotConsumed(WorkflowStartMode mode)
+    {
+        var controller = ScriptedController(DriveMinimalToTerminal);
+        await using var manager = NewManager(() => controller.Object);
+
+        var act = () => manager.StartAsync("bad", InvalidDefinition(), mode);
+        await act.Should().ThrowAsync<WorkflowValidationException>();
+
+        // The id was never reserved, so it is still unknown (no slot consumed by a rejected definition).
+        var check = () => manager.Check("bad");
+        check.Should().Throw<UnknownWorkflowException>();
+    }
+
+    [Fact]
+    public async Task StartAsync_AtCapacity_ThrowsBackpressure()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var controller = GatedController(gate);
+        await using var manager = NewManager(
+            () => controller.Object,
+            maxConcurrentWorkflows: 1,
+            gateWaitTimeout: TimeSpan.FromMilliseconds(200)
+        );
+
+        // First workflow holds the only slot (gated, still running).
+        _ = await manager.StartAsync("cap-1", MinimalDefinition(), WorkflowStartMode.Async);
+
+        var act = () => manager.StartAsync("cap-2", MinimalDefinition(), WorkflowStartMode.Async);
+        await act.Should().ThrowAsync<WorkflowCapacityException>();
+
+        // The rejected id was rolled back — it is unknown, and the cap is truly reached (not leaked).
+        var check = () => manager.Check("cap-2");
+        check.Should().Throw<UnknownWorkflowException>();
+
+        gate.SetResult();
+    }
+
+    [Fact]
+    public async Task Check_And_Wait_UnknownId_Throw()
+    {
+        var controller = ScriptedController(DriveMinimalToTerminal);
+        await using var manager = NewManager(() => controller.Object);
+
+        var check = () => manager.Check("nope");
+        check.Should().Throw<UnknownWorkflowException>();
+
+        var wait = () => manager.WaitAsync("nope", TimeSpan.FromSeconds(1));
+        await wait.Should().ThrowAsync<UnknownWorkflowException>();
+    }
+
+    [Fact]
+    public async Task Controller_ExhaustsTurnBudget_ResultIsFailed_NotHang()
+    {
+        var controller = ScriptedController(NeverComplete);
+        // A tiny turn budget so the controller loop ends WITHOUT reaching a terminal node, quickly.
+        await using var manager = NewManager(() => controller.Object, controllerMaxTurnsPerRun: 2);
+
+        var result = await manager.StartAsync("wf-budget", MinimalDefinition(), WorkflowStartMode.Sync);
+
+        result.Status.Should().Be("failed");
+        result.IsComplete.Should().BeFalse();
+        result.Error.Should().Contain("terminal");
+    }
+
+    [Fact]
+    public async Task NotifyDeliveryFailure_DoesNotLoseResult_StillQueryable()
+    {
+        var controller = ScriptedController(DriveMinimalToTerminal);
+        await using var manager = NewManager(
+            () => controller.Object,
+            notifier: (_, _) => throw new InvalidOperationException("caller is gone")
+        );
+
+        _ = await manager.StartAsync("wf-notify-fail", MinimalDefinition(), WorkflowStartMode.Async);
+
+        // Even though the proactive notify throws, the terminal result stays queryable.
+        var completed = await manager.WaitAsync("wf-notify-fail", Timeout);
+        completed.Status.Should().Be("completed");
+        manager.Check("wf-notify-fail").Status.Should().Be("completed");
+    }
+
+    [Fact]
+    public async Task LongLivedHandle_SurvivesMultipleInterleavedCheckAndWaitCalls()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var controller = GatedController(gate);
+        await using var manager = NewManager(() => controller.Object);
+
+        _ = await manager.StartAsync("wf-long", MinimalDefinition(), WorkflowStartMode.Async);
+
+        // Interleave several external observations while the controller is held open.
+        manager.Check("wf-long").Status.Should().Be("running");
+        (await manager.WaitAsync("wf-long", TimeSpan.FromMilliseconds(100))).Status.Should().Be("timeout");
+        manager.Check("wf-long").Status.Should().Be("running");
+        (await manager.WaitAsync("wf-long", TimeSpan.FromMilliseconds(100))).Status.Should().Be("timeout");
+
+        gate.SetResult();
+        (await manager.WaitAsync("wf-long", Timeout)).Status.Should().Be("completed");
+        manager.Check("wf-long").Status.Should().Be("completed");
+    }
+
+    [Fact]
+    public async Task Check_AfterTerminalAndDisposal_StillReturnsCompleted()
+    {
+        var controller = ScriptedController(DriveMinimalToTerminal);
+        await using var manager = NewManager(() => controller.Object);
+
+        // Sync completion; the completion handler disposes the handle once terminal.
+        var sync = await manager.StartAsync("wf-disposed", MinimalDefinition(), WorkflowStartMode.Sync);
+        sync.Status.Should().Be("completed");
+
+        // Give the completion continuation a moment to run its dispose, then prove Check still works.
+        await manager.WaitAsync("wf-disposed", Timeout);
+        var check = manager.Check("wf-disposed");
+        check.Status.Should().Be("completed");
+        check.IsComplete.Should().BeTrue();
+    }
+}

--- a/tests/LmWorkflow.Tests/WorkflowManagerTests.cs
+++ b/tests/LmWorkflow.Tests/WorkflowManagerTests.cs
@@ -294,6 +294,51 @@ public class WorkflowManagerTests
     }
 
     [Fact]
+    public async Task StartAsync_Async_Notify_UsesOriginatingToolCallId_WhenSupplied()
+    {
+        var notified = new TaskCompletionSource<NotifyMessage>(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        var controller = ScriptedController(DriveMinimalToTerminal);
+        await using var manager = NewManager(
+            () => controller.Object,
+            notifier: (n, _) =>
+            {
+                notified.TrySetResult(n);
+                return Task.CompletedTask;
+            }
+        );
+
+        _ = await manager.StartAsync("wf-corr", MinimalDefinition(), WorkflowStartMode.Async, default, "toolcall-123");
+
+        var notify = await notified.Task.WaitAsync(Timeout);
+        // Correlated to the originating StartWorkflow tool call, not the workflowId.
+        notify.SourceToolCallId.Should().Be("toolcall-123");
+        notify.Label.Should().Be("wf-corr");
+    }
+
+    [Fact]
+    public async Task StartAsync_AfterDispose_ThrowsObjectDisposed()
+    {
+        var manager = NewManager(() => ScriptedController(DriveMinimalToTerminal).Object);
+        await manager.DisposeAsync();
+
+        var act = () => manager.StartAsync("after-dispose", MinimalDefinition(), WorkflowStartMode.Sync);
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public async Task WaitAsync_NegativeTimeout_ThrowsArgumentOutOfRange()
+    {
+        var controller = ScriptedController(DriveMinimalToTerminal);
+        await using var manager = NewManager(() => controller.Object);
+        _ = await manager.StartAsync("neg", MinimalDefinition(), WorkflowStartMode.Sync);
+
+        var act = () => manager.WaitAsync("neg", TimeSpan.FromSeconds(-5));
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
     public async Task Check_AfterTerminalAndDisposal_StillReturnsCompleted()
     {
         var controller = ScriptedController(DriveMinimalToTerminal);

--- a/tests/LmWorkflow.Tests/WorkflowManagerTests.cs
+++ b/tests/LmWorkflow.Tests/WorkflowManagerTests.cs
@@ -225,22 +225,19 @@ public class WorkflowManagerTests
     }
 
     [Fact]
-    public async Task WaitAsync_HugeTimeout_OnRunningWorkflow_ReportsTimeout_NotFailed()
+    public async Task WaitAsync_HugeTimeout_ClampsWithoutThrowing_AndResolvesOnCompletion()
     {
-        // Regression: a very large timeout must not throw out of Task.WaitAsync and get swallowed into a
-        // phantom "failed" for a still-running workflow.
-        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var controller = GatedController(gate);
+        // Regression: a very large timeout must be CLAMPED (not throw out of Task.WaitAsync and get swallowed)
+        // and resolve on the run's completion rather than on the raw out-of-range value.
+        var controller = ScriptedController(DriveMinimalToTerminal);
         await using var manager = NewManager(() => controller.Object);
 
         _ = await manager.StartAsync("wf-hugewait", MinimalDefinition(), WorkflowStartMode.Async);
 
-        // ~57 days in seconds — beyond Task.WaitAsync's accepted range if unclamped.
+        // ~57 days in seconds — beyond Task.WaitAsync's accepted range if unclamped. The run completes
+        // quickly, so the wait returns completed well before any timeout.
         var result = await manager.WaitAsync("wf-hugewait", TimeSpan.FromSeconds(5_000_000));
-        result.Status.Should().Be("timeout");
-
-        gate.SetResult();
-        (await manager.WaitAsync("wf-hugewait", Timeout)).Status.Should().Be("completed");
+        result.Status.Should().Be("completed");
     }
 
     [Fact]
@@ -260,6 +257,40 @@ public class WorkflowManagerTests
         await dispose.Should().NotThrowAsync();
 
         gate.TrySetResult();
+    }
+
+    [Fact]
+    public async Task WaitAsync_CallerCancelled_Throws_ButRunStaysAliveAndQueryable()
+    {
+        // Pins the non-destructive-cancellation invariant: cancelling a WaitAsync must NOT cancel the run.
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var controller = GatedController(gate);
+        await using var manager = NewManager(() => controller.Object);
+
+        _ = await manager.StartAsync("wf-cancel", MinimalDefinition(), WorkflowStartMode.Async);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var wait = () => manager.WaitAsync("wf-cancel", TimeSpan.FromSeconds(30), cts.Token);
+        await wait.Should().ThrowAsync<OperationCanceledException>();
+
+        // The run is untouched: still running, and it can still complete.
+        manager.Check("wf-cancel").Status.Should().Be("running");
+        gate.SetResult();
+        (await manager.WaitAsync("wf-cancel", Timeout)).Status.Should().Be("completed");
+    }
+
+    [Fact]
+    public async Task Controller_ThatFaults_ResultIsFailed()
+    {
+        var controller = FaultingController();
+        await using var manager = NewManager(() => controller.Object);
+
+        var result = await manager.StartAsync("wf-fault", MinimalDefinition(), WorkflowStartMode.Sync);
+
+        result.Status.Should().Be("failed");
+        result.IsComplete.Should().BeFalse();
+        result.Error.Should().NotBeNullOrEmpty();
     }
 
     [Fact]

--- a/tests/LmWorkflow.Tests/WorkflowManagerTests.cs
+++ b/tests/LmWorkflow.Tests/WorkflowManagerTests.cs
@@ -225,6 +225,44 @@ public class WorkflowManagerTests
     }
 
     [Fact]
+    public async Task WaitAsync_HugeTimeout_OnRunningWorkflow_ReportsTimeout_NotFailed()
+    {
+        // Regression: a very large timeout must not throw out of Task.WaitAsync and get swallowed into a
+        // phantom "failed" for a still-running workflow.
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var controller = GatedController(gate);
+        await using var manager = NewManager(() => controller.Object);
+
+        _ = await manager.StartAsync("wf-hugewait", MinimalDefinition(), WorkflowStartMode.Async);
+
+        // ~57 days in seconds — beyond Task.WaitAsync's accepted range if unclamped.
+        var result = await manager.WaitAsync("wf-hugewait", TimeSpan.FromSeconds(5_000_000));
+        result.Status.Should().Be("timeout");
+
+        gate.SetResult();
+        (await manager.WaitAsync("wf-hugewait", Timeout)).Status.Should().Be("completed");
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WithInFlightWorkflow_DoesNotFault_NorLeakUnobservedException()
+    {
+        // Regression: disposing the manager while an async workflow is still running must not leave the
+        // completion observer releasing an already-disposed gate (unobserved ObjectDisposedException).
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var controller = GatedController(gate);
+        var manager = NewManager(() => controller.Object);
+
+        _ = await manager.StartAsync("wf-dispose", MinimalDefinition(), WorkflowStartMode.Async);
+        manager.Check("wf-dispose").Status.Should().Be("running");
+
+        // Dispose mid-run — this drives the handle to completion and must await the observer cleanly.
+        var dispose = async () => await manager.DisposeAsync();
+        await dispose.Should().NotThrowAsync();
+
+        gate.TrySetResult();
+    }
+
+    [Fact]
     public async Task Check_AfterTerminalAndDisposal_StillReturnsCompleted()
     {
         var controller = ScriptedController(DriveMinimalToTerminal);


### PR DESCRIPTION
## Summary
Adds `StartWorkflow` (with sister tools `CheckWorkflow` and `WaitWorkflow`) so any agent can launch a pre-authored `WorkflowDefinition` as a bounded, delegated unit of work — sync (blocks for the terminal result) or async (returns immediately, with a proactive completion notification plus on-demand poll/block). Internally each launch spins up an **isolated controller loop** with a deliberately restricted tool surface, so the workflow-authoring/mutation tools (`SetWorkflow`/`GetWorkflow`/`SetCurrentNode`/`SetState`/`SetNotes`) are never reachable by a normal agent or by anything it spawns. The `LmStreaming.Sample` Workspace Agent is migrated off #130's direct `SetWorkflow`/`GetWorkflow` wiring onto this primitive.

## Key Decisions
1. **New `WorkflowManager` + `StartWorkflowToolProvider`**, mirroring the existing `SubAgentManager`/`SubAgentToolProvider` split. Chosen over a mode-flag on `WorkflowToolProvider` (which would turn the security boundary into a runtime toggle instead of a structural type split) and over routing `WaitWorkflow` through `TriggerRuntime`/`ITriggerSource` (v1 is in-memory-only, so that persistence/parking machinery isn't needed — `WaitWorkflow` is a direct await over the run's completion).
2. **The controller drops `SetWorkflow` entirely** (it always receives a pre-authored definition) and exposes exactly `{GetWorkflow, SetCurrentNode, SetState, SetNotes}` + `{Agent, SendMessage, CheckAgent}`. `WorkflowRuntime` and `WorkflowToolProvider` constructors are now **`internal`**, so the isolation invariant is enforced structurally, not by convention.
3. **The nested-workflow leak is fixed generally**, not just in the sample: `SubAgentOptions.NonInheritedToolNames` keeps `StartWorkflow`/`CheckWorkflow`/`WaitWorkflow` out of the inherit-all (`EnabledTools=null`) sub-agent snapshot — protecting every host, mirroring how the `Agent`-family tools are already excluded structurally.
4. **Controller runs on a single, fixed, pre-configured model** (`WORKFLOW_CONTROLLER_MODEL`, else the conversation's default) — never the calling agent's model. Concurrent workflows are **capped at 8** (`WORKFLOW_MAX_CONCURRENT`, configurable). Async completion reuses `NotifyMessage`/`NotifyKinds.WorkflowCompletion`; the result stays queryable via `CheckWorkflow` even if the proactive notify fails.
5. **Workspace Agent migration**: the env-flag-gated direct workflow wiring from #130 is retired; the controller-prompt append and in-loop correlation observer are removed. Known, documented v1 limitations: in-memory only (no restart survival — surfaced as "unknown workflowId"), controller node-delegates are reasoning-only (domain-tool passthrough is a follow-up), and completed entries are retained (queryable, not evicted).

## Changes
- **LmCore**: `NotifyKinds.WorkflowCompletion` (additive; generic delivery pipeline, zero new plumbing).
- **LmMultiTurn**: `SubAgentOptions.NonInheritedToolNames` + `MultiTurnAgentLoop` filters those out of the sub-agent snapshot (`FilterInheritableContracts`); public `RegisteredToolNames` accessor.
- **LmWorkflow**: new `WorkflowManager` (validate-before-reserve, atomic id reservation closing the duplicate TOCTOU, bounded concurrency gate, sync/async launch, non-blocking `Check`, non-destructive `Wait`, notify-then-dispose completion handler, turn-budget→`Failed` rail, restricted-controller-template assertion) and `StartWorkflowToolProvider` (error-code mapping `invalid_workflow`/`duplicate_workflow`/`workflow_capacity`/`unknown_workflow`). `WorkflowSession` gains `includeAuthoringTool`/`controllerMaxTurnsPerRun`/`controllerDefaultOptions` seams; `WorkflowRuntime`/`WorkflowToolProvider` ctors → `internal`.
- **LmStreaming.Sample**: `Program.cs` migrated to wire `WorkflowManager` + `StartWorkflowToolProvider` behind `WORKSPACE_AGENT_LMWORKFLOW_ENABLED`; `BuiltInSubAgentTemplates.CreateWorkflowControllerTemplates` (restricted node-delegate templates).

## Testing
- **New**: `WorkflowManagerTests` (sync/async happy path + proactive notify, non-blocking Check, non-destructive Wait timeout, duplicate/invalid/capacity/unknown errors, turn-budget→Failed, notify-failure-still-queryable, long-lived + disposed-but-queryable handle, huge-timeout-not-failed, dispose-with-in-flight), `StartWorkflowToolProviderTests` (exact tool-name set, WaitWorkflow open-ended-timeout note, error-code mapping), `WorkflowControllerToolRestrictionTests` (7-name controller set, the two template-rejection regressions), `SubAgentToolInheritanceExclusionTests`, and sample `WorkspaceWorkflowWiringTests`.
- **Suites**: full solution builds **0-warn/0-err**; LmWorkflow.Tests **221/221**, LmCore.Tests **784/784**. The handful of failures in LmMultiTurn.Tests / LmStreaming.Sample.Tests are **pre-existing on `main`** — verified against a base-commit (46a61a18) worktree: `ContextDiscoveryEndToEndTests` and `GatewayAppAuthWiringTests` fail identically on the base (NotifyMessage-post-#174 / env-key-dependent), and the `RunLedgerRoundTrip` batch test passes in isolation (flaky-under-load). None touch any file this PR changes.
- A pre-publish adversarial self-review flagged two MEDIUM defects (a disposal-time gate `Release`-after-`Dispose` race, and an over-range `WaitWorkflow` timeout misreporting a running workflow as `failed`); both are fixed with regression tests.

## Related Issues
Fixes #179
