### PR TITLE
Sub-agent characteristics factory + modelintelligence/effort front matter

### DIFF
--- a/samples/CodeReviewDaemon.Sample/Agents/DiscoveredSubAgentTemplateBuilder.cs
+++ b/samples/CodeReviewDaemon.Sample/Agents/DiscoveredSubAgentTemplateBuilder.cs
@@ -44,6 +44,14 @@ internal sealed class DiscoveredSubAgentTemplateBuilder(ILogger<DiscoveredSubAge
                 continue;
             }
 
+            foreach (var diagnostic in parsed.Diagnostics)
+            {
+                logger.LogWarning(
+                    "Discovered sub-agent {Name} frontmatter diagnostic: {Diagnostic}",
+                    parsed.Name,
+                    diagnostic);
+            }
+
             if (!result.TryAdd(item.QualifiedName, SubAgentTemplateMapper.Map(parsed, agentFactory, MaxTurnsPerRun)))
             {
                 logger.LogWarning("Duplicate sub-agent {Name}; keeping the first.", item.QualifiedName);

--- a/samples/LmSampleShared/Discovery/SubAgentMarkdownParser.cs
+++ b/samples/LmSampleShared/Discovery/SubAgentMarkdownParser.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+using AchieveAi.LmDotnetTools.LmCore.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -16,7 +18,53 @@ public sealed record ParsedSubAgent(
     string? Model,
     IReadOnlyList<string>? Tools,
     string SystemPrompt
-);
+)
+{
+    private readonly ImmutableArray<string> _diagnostics = [];
+
+    /// <summary>
+    /// Optional model capability tier requested by the author.
+    /// </summary>
+    public int? ModelIntelligence { get; init; }
+
+    /// <summary>
+    /// Optional reasoning effort requested by the author.
+    /// </summary>
+    public ReasoningEffort? Effort { get; init; }
+
+    /// <summary>
+    /// Non-fatal frontmatter validation messages.
+    /// </summary>
+    public IReadOnlyList<string> Diagnostics
+    {
+        get => _diagnostics;
+        init => _diagnostics = value.ToImmutableArray();
+    }
+
+    /// <inheritdoc />
+    public bool Equals(ParsedSubAgent? other) =>
+        ReferenceEquals(this, other)
+        || (
+            other is not null
+            && Name == other.Name
+            && Description == other.Description
+            && Model == other.Model
+            && EqualityComparer<IReadOnlyList<string>?>.Default.Equals(Tools, other.Tools)
+            && SystemPrompt == other.SystemPrompt
+        );
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Name);
+        hash.Add(Description);
+        hash.Add(Model);
+        hash.Add(Tools);
+        hash.Add(SystemPrompt);
+        return hash.ToHashCode();
+    }
+}
 
 /// <summary>
 /// Pure parser for a single sub-agent markdown document. Failures (missing fences,
@@ -42,6 +90,7 @@ public static class SubAgentMarkdownParser
 
     private static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
         .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .WithAttemptingUnquotedStringTypeDeserialization()
         .IgnoreUnmatchedProperties()
         .Build();
 
@@ -92,11 +141,25 @@ public static class SubAgentMarkdownParser
             return null;
         }
 
-        var description = string.IsNullOrWhiteSpace(dto?.Description) ? null : dto.Description.Trim();
+        var description = string.IsNullOrWhiteSpace(dto?.Description)
+            ? null
+            : dto.Description.Trim();
         var model = string.IsNullOrWhiteSpace(dto?.Model) ? null : dto.Model.Trim();
         var tools = NormalizeTools(dto?.Tools);
+        var diagnostics = new List<string>();
+        var modelIntelligence = ParseModelIntelligence(
+            dto?.ModelIntelligence,
+            dto?.HasModelIntelligence == true,
+            diagnostics
+        );
+        var effort = ParseEffort(dto?.Effort, dto?.HasEffort == true, diagnostics);
 
-        return new ParsedSubAgent(name, description, model, tools, trimmedBody);
+        return new ParsedSubAgent(name, description, model, tools, trimmedBody)
+        {
+            ModelIntelligence = modelIntelligence,
+            Effort = effort,
+            Diagnostics = diagnostics,
+        };
     }
 
     private static bool TrySplitFrontmatter(string markdown, out string yaml, out string body)
@@ -135,7 +198,11 @@ public static class SubAgentMarkdownParser
         return true;
     }
 
-    private static bool StartsWithLine(ReadOnlySpan<char> input, string marker, out ReadOnlySpan<char> rest)
+    private static bool StartsWithLine(
+        ReadOnlySpan<char> input,
+        string marker,
+        out ReadOnlySpan<char> rest
+    )
     {
         rest = input;
         if (input.Length < marker.Length || !input[..marker.Length].SequenceEqual(marker))
@@ -183,12 +250,84 @@ public static class SubAgentMarkdownParser
         return normalized;
     }
 
+    private static int? ParseModelIntelligence(
+        object? raw,
+        bool isPresent,
+        List<string> diagnostics
+    )
+    {
+        if (!isPresent)
+        {
+            return null;
+        }
+
+        int? value = raw switch
+        {
+            sbyte number => number,
+            byte number => number,
+            short number => number,
+            ushort number => number,
+            int number => number,
+            uint number when number <= int.MaxValue => (int)number,
+            long number when number is >= int.MinValue and <= int.MaxValue => (int)number,
+            ulong number when number <= int.MaxValue => (int)number,
+            _ => null,
+        };
+
+        if (value is >= 0 and <= 6)
+        {
+            return value;
+        }
+
+        diagnostics.Add(
+            "modelintelligence must be an integer from 0 through 6; the field was ignored."
+        );
+        return null;
+    }
+
+    private static ReasoningEffort? ParseEffort(
+        object? raw,
+        bool isPresent,
+        List<string> diagnostics
+    )
+    {
+        if (!isPresent)
+        {
+            return null;
+        }
+
+        if (raw is string scalar)
+        {
+            var effort = scalar.Trim().ToLowerInvariant() switch
+            {
+                "low" => ReasoningEffort.Low,
+                "medium" => ReasoningEffort.Medium,
+                "high" => ReasoningEffort.High,
+                "extra-high" => ReasoningEffort.Xhigh,
+                _ => (ReasoningEffort?)null,
+            };
+
+            if (effort is not null)
+            {
+                return effort;
+            }
+        }
+
+        diagnostics.Add(
+            "effort must be one of low, medium, high, or extra-high; the field was ignored."
+        );
+        return null;
+    }
+
     /// <summary>
     /// Mutable DTO used only as the YAML deserialisation target. Public so YamlDotNet's
     /// reflection can populate it; never exposed beyond <see cref="Parse"/>.
     /// </summary>
     public sealed class FrontmatterDto
     {
+        private object? _modelIntelligence;
+        private object? _effort;
+
         public string? Name { get; set; }
 
         public string? Description { get; set; }
@@ -196,5 +335,32 @@ public static class SubAgentMarkdownParser
         public string? Model { get; set; }
 
         public List<string>? Tools { get; set; }
+
+        [YamlMember(Alias = "modelintelligence")]
+        public object? ModelIntelligence
+        {
+            get => _modelIntelligence;
+            set
+            {
+                _modelIntelligence = value;
+                HasModelIntelligence = true;
+            }
+        }
+
+        [YamlIgnore]
+        public bool HasModelIntelligence { get; private set; }
+
+        public object? Effort
+        {
+            get => _effort;
+            set
+            {
+                _effort = value;
+                HasEffort = true;
+            }
+        }
+
+        [YamlIgnore]
+        public bool HasEffort { get; private set; }
     }
 }

--- a/samples/LmSampleShared/Discovery/SubAgentMarkdownParser.cs
+++ b/samples/LmSampleShared/Discovery/SubAgentMarkdownParser.cs
@@ -42,6 +42,11 @@ public sealed record ParsedSubAgent(
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Equality intentionally covers the legacy positional contract only. Optional characteristics
+    /// and parse diagnostics are excluded so enriching a parsed value does not change equality or
+    /// hash behavior for existing callers.
+    /// </remarks>
     public bool Equals(ParsedSubAgent? other) =>
         ReferenceEquals(this, other)
         || (

--- a/samples/LmSampleShared/Discovery/SubAgentMarkdownParser.cs
+++ b/samples/LmSampleShared/Discovery/SubAgentMarkdownParser.cs
@@ -33,12 +33,18 @@ public sealed record ParsedSubAgent(
     public ReasoningEffort? Effort { get; init; }
 
     /// <summary>
+    /// Whether <see cref="Model"/> was resolved from <see cref="ModelIntelligence"/> rather than
+    /// pinned directly in the markdown.
+    /// </summary>
+    public bool IsModelTierResolved { get; init; }
+
+    /// <summary>
     /// Non-fatal frontmatter validation messages.
     /// </summary>
     public IReadOnlyList<string> Diagnostics
     {
         get => _diagnostics;
-        init => _diagnostics = value.ToImmutableArray();
+        init => _diagnostics = value?.ToImmutableArray() ?? [];
     }
 
     /// <inheritdoc />
@@ -308,7 +314,7 @@ public static class SubAgentMarkdownParser
                 "low" => ReasoningEffort.Low,
                 "medium" => ReasoningEffort.Medium,
                 "high" => ReasoningEffort.High,
-                "extra-high" => ReasoningEffort.Xhigh,
+                "extra-high" or "xhigh" => ReasoningEffort.Xhigh,
                 _ => (ReasoningEffort?)null,
             };
 
@@ -319,7 +325,7 @@ public static class SubAgentMarkdownParser
         }
 
         diagnostics.Add(
-            "effort must be one of low, medium, high, or extra-high; the field was ignored."
+            "effort must be one of low, medium, high, extra-high, or xhigh; the field was ignored."
         );
         return null;
     }

--- a/samples/LmSampleShared/Discovery/SubAgentTemplateMapper.cs
+++ b/samples/LmSampleShared/Discovery/SubAgentTemplateMapper.cs
@@ -38,8 +38,11 @@ public static class SubAgentTemplateMapper
         // aliases). Treat "inherit" (and a blank model) as "no explicit model" so the sub-agent inherits
         // the parent loop's concrete model instead.
         var hasExplicitModel = !string.IsNullOrWhiteSpace(parsed.Model)
+            && !string.Equals(parsed.Model.Trim(), "inherit", StringComparison.OrdinalIgnoreCase)
+            && !parsed.IsModelTierResolved;
+        var hasRoutedModel = !string.IsNullOrWhiteSpace(parsed.Model)
             && !string.Equals(parsed.Model.Trim(), "inherit", StringComparison.OrdinalIgnoreCase);
-        var defaults = hasExplicitModel
+        var defaults = hasRoutedModel
             ? new GenerateReplyOptions { ModelId = parsed.Model!.Trim() }
             : null;
 
@@ -52,6 +55,7 @@ public static class SubAgentTemplateMapper
             AgentFactory = agentFactory,
             DefaultOptions = defaults,
             IsModelExplicitlySelected = hasExplicitModel,
+            IsModelTierResolved = parsed.IsModelTierResolved,
             Effort = parsed.Effort,
             EnabledTools = parsed.Tools,
             MaxTurnsPerRun = maxTurnsPerRun,

--- a/samples/LmSampleShared/Discovery/SubAgentTemplateMapper.cs
+++ b/samples/LmSampleShared/Discovery/SubAgentTemplateMapper.cs
@@ -51,6 +51,8 @@ public static class SubAgentTemplateMapper
             SystemPrompt = parsed.SystemPrompt,
             AgentFactory = agentFactory,
             DefaultOptions = defaults,
+            IsModelExplicitlySelected = hasExplicitModel,
+            Effort = parsed.Effort,
             EnabledTools = parsed.Tools,
             MaxTurnsPerRun = maxTurnsPerRun,
         };

--- a/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
@@ -299,7 +299,11 @@ public sealed class ContextDiscoveryController(
             // (with the first conversation's factory), but each conversation must spawn the
             // discovered sub-agent with its OWN provider — otherwise a sub-agent fanned into
             // conversation B would run on conversation A's provider.
-            var conversationTemplate = template with { AgentFactory = binding.AgentFactory };
+            var conversationTemplate = template with
+            {
+                AgentFactory = binding.AgentFactory,
+                CharacteristicsAgentFactory = binding.CharacteristicsAgentFactory,
+            };
 
             if (binding.Source.TryRegister(conversationTemplate.Name!, conversationTemplate))
             {

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -347,12 +347,12 @@ try
         sp.GetRequiredService<AuthSharedSecret>()
     ));
 
-    var subAgentIntelligenceOptions =
-        builder.Configuration
-            .GetSection(SubAgentIntelligenceOptions.SectionName)
-            .Get<SubAgentIntelligenceOptions>()
-        ?? new SubAgentIntelligenceOptions();
-    _ = builder.Services.AddSingleton(subAgentIntelligenceOptions);
+    _ = builder.Services.AddSingleton(sp =>
+        SubAgentIntelligenceOptions.Load(
+            builder.Configuration,
+            sp.GetRequiredService<ILogger<SubAgentIntelligenceOptions>>()
+        )
+    );
     _ = builder.Services.AddSingleton<SubAgentModelResolver>();
 
     // Workspace sub-agent discovery. The loader asks the gateway what it has discovered in
@@ -1967,8 +1967,13 @@ public partial class Program
                     {
                         var provider = characteristicsAgentFactory(characteristics);
                         return characteristics.IsModelExplicitlySelected
+                            || characteristics.IsModelTierResolved
                             ? provider
-                            : provider with { Agent = entry.Value.AgentFactory() };
+                            : provider with
+                            {
+                                Agent = entry.Value.AgentFactory(),
+                                OwnsAgent = true,
+                            };
                     },
                 },
                 StringComparer.Ordinal),

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -347,10 +347,21 @@ try
         sp.GetRequiredService<AuthSharedSecret>()
     ));
 
+    var subAgentIntelligenceOptions =
+        builder.Configuration
+            .GetSection(SubAgentIntelligenceOptions.SectionName)
+            .Get<SubAgentIntelligenceOptions>()
+        ?? new SubAgentIntelligenceOptions();
+    _ = builder.Services.AddSingleton(subAgentIntelligenceOptions);
+    _ = builder.Services.AddSingleton<SubAgentModelResolver>();
+
     // Workspace sub-agent discovery. The loader asks the gateway what it has discovered in
     // the session's workspace (sub-agent markdown files under .claude/agents/, etc.) and maps
     // them into SubAgentTemplate so they show up as spawnable types in the Agent tool catalog.
-    _ = builder.Services.AddSingleton<WorkspaceSubAgentLoader>();
+    _ = builder.Services.AddSingleton(sp => new WorkspaceSubAgentLoader(
+        sp.GetRequiredService<SandboxSessionRegistry>(),
+        sp.GetRequiredService<ILogger<WorkspaceSubAgentLoader>>(),
+        sp.GetRequiredService<SubAgentModelResolver>()));
 
     // Marketplace sub-agent bridge. Maps the agents the UI's marketplace browser lists (the
     // gateway's read-only catalog) into spawnable templates, filling any gap left by workspace
@@ -995,8 +1006,9 @@ try
                     // a sandbox session is active, so the Agent tool advertises an identical catalog
                     // regardless of provider — and the mock-only instruction-chain tool_schema probe
                     // can validate the workspace-discovered/marketplace sub-agents. In all cases the
-                    // template AgentFactory reuses agentFactory(normalizedProviderId) so each spawn
-                    // builds a FRESH provider agent on the same backend as the parent.
+                    // Legacy AgentFactory still builds a fresh parent-backend agent. The
+                    // characteristics-aware factory below can instead route a resolved Copilot model
+                    // through its own transport, and safely falls back to the parent provider agent.
                     var isTestMode =
                         string.Equals(normalizedProviderId, "test", StringComparison.Ordinal)
                         || string.Equals(normalizedProviderId, "test-anthropic", StringComparison.Ordinal);
@@ -1006,11 +1018,19 @@ try
                     // cannot deadlock. The blocking call is HTTP only when a sandbox session is
                     // active; otherwise it completes synchronously.
                     Func<IStreamingAgent> subAgentFactory = () => agentFactory(normalizedProviderId);
+                    var characteristicsAgentFactory = new CharacteristicsAgentFactory(
+                        providerRegistry,
+                        providerAgent,
+                        model => CreateCopilotModelAgent(model, loggerFactory),
+                        loggerFactory.CreateLogger<CharacteristicsAgentFactory>(),
+                        parentCopilotModel: isCopilotBackedModel ? copilotModelInfo : null)
+                        .Create;
                     var subAgentOptions = BuildSubAgentOptionsAsync(
                             isTestMode,
                             sp.GetRequiredService<ITestAgentBuilder>(),
                             loggerFactory,
                             subAgentFactory,
+                            characteristicsAgentFactory,
                             sandboxSession,
                             sp.GetRequiredService<WorkspaceSubAgentLoader>(),
                             sp.GetRequiredService<MarketplaceSubAgentLoader>(),
@@ -1027,12 +1047,13 @@ try
                     MutableSubAgentTemplateSource? sharedSubAgentSource = null;
                     if (sandboxSession is not null && subAgentOptions is not null)
                     {
-                        var binding = sp.GetRequiredService<SandboxSessionRegistry>()
-                            .GetOrAddSubAgentBinding(
-                                sandboxSession.SessionId,
-                                threadId,
-                                subAgentOptions.Templates,
-                                subAgentFactory);
+                        var binding = BindConversationSubAgents(
+                            sp.GetRequiredService<SandboxSessionRegistry>(),
+                            sandboxSession.SessionId,
+                            threadId,
+                            subAgentOptions.Templates,
+                            subAgentFactory,
+                            characteristicsAgentFactory);
                         sharedSubAgentSource = binding.Source;
 
                         // Register this agent's threadId against the session so the
@@ -1563,7 +1584,7 @@ public partial class Program
     ///     models route through the Copilot Messages backend; OpenAI-shaped models through the Copilot
     ///     Responses backend.
     /// </summary>
-    private static IStreamingAgent CreateCopilotModelAgent(CopilotModelInfo model, ILoggerFactory loggerFactory)
+    internal static IStreamingAgent CreateCopilotModelAgent(CopilotModelInfo model, ILoggerFactory loggerFactory)
     {
         return model.Transport switch
         {
@@ -1926,23 +1947,50 @@ public partial class Program
     }
 
     /// <summary>
-    ///     Builds the sub-agent orchestration options for a chat agent, used by BOTH the real
-    ///     middleware providers (OpenAI / Anthropic / Copilot-backed) AND the mock providers
-    ///     (<c>test</c> / <c>test-anthropic</c>). The base catalog differs by provider kind — mock
-    ///     providers go through the <see cref="ITestAgentBuilder"/> seam (built-ins by default, or
-    ///     scripted templates injected by E2E); real providers start from the shared built-ins — but
-    ///     the workspace enrichment is identical for both, so the <c>Agent</c> tool advertises the
-    ///     same workspace + marketplace catalog regardless of provider. That parity is what lets the
-    ///     instruction-chain <c>tools_echo</c> / <c>tool_schema</c> probe (mock-only) validate the
-    ///     workspace-discovered and marketplace sub-agents. Each template reuses
-    ///     <paramref name="providerAgentFactory"/> — invoked per spawn so every sub-agent gets a
-    ///     FRESH provider agent on the same backend as the parent.
+    /// Attaches one conversation-scoped characteristics factory to every template.
     /// </summary>
+    internal static SubAgentOptions ApplyCharacteristicsAgentFactory(
+        SubAgentOptions options,
+        Func<SubAgentCharacteristics, SubAgentProviderAgent> characteristicsAgentFactory)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(characteristicsAgentFactory);
+
+        return options with
+        {
+            Templates = options.Templates.ToDictionary(
+                entry => entry.Key,
+                entry => entry.Value with
+                {
+                    CharacteristicsAgentFactory = characteristicsAgentFactory,
+                },
+                StringComparer.Ordinal),
+        };
+    }
+
+    internal static SubAgentSessionBinding BindConversationSubAgents(
+        SandboxSessionRegistry registry,
+        string sessionId,
+        string conversationId,
+        IReadOnlyDictionary<string, SubAgentTemplate> templates,
+        Func<IStreamingAgent> agentFactory,
+        Func<SubAgentCharacteristics, SubAgentProviderAgent> characteristicsAgentFactory)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        return registry.AddOrUpdateSubAgentBinding(
+            sessionId,
+            conversationId,
+            templates,
+            agentFactory,
+            characteristicsAgentFactory);
+    }
+
     private static async Task<SubAgentOptions?> BuildSubAgentOptionsAsync(
         bool isTestMode,
         ITestAgentBuilder testAgentBuilder,
         ILoggerFactory loggerFactory,
         Func<IStreamingAgent> providerAgentFactory,
+        Func<SubAgentCharacteristics, SubAgentProviderAgent> characteristicsAgentFactory,
         SandboxSession? sandboxSession,
         WorkspaceSubAgentLoader workspaceLoader,
         MarketplaceSubAgentLoader marketplaceLoader,
@@ -1960,19 +2008,34 @@ public partial class Program
             };
 
         // No sandbox session (e.g. a non-workspace chat, or an E2E scenario with no gateway) means
-        // nothing to discover — keep the base catalog exactly as-is so injected E2E templates and the
-        // plain built-in surface are untouched.
-        if (baseOptions is null || sandboxSession is null)
+        // nothing to discover. Preserve the base catalog and only attach the conversation factory.
+        if (baseOptions is null)
         {
-            return baseOptions;
+            return null;
+        }
+
+        if (sandboxSession is null)
+        {
+            return ApplyCharacteristicsAgentFactory(
+                baseOptions,
+                characteristicsAgentFactory);
         }
 
         var templates = new Dictionary<string, SubAgentTemplate>(baseOptions.Templates, StringComparer.Ordinal);
         await EnrichWithWorkspaceCatalogAsync(
-                templates, providerAgentFactory, sandboxSession, workspaceLoader, marketplaceLoader, workspaceStore, logger)
+                templates,
+                providerAgentFactory,
+                characteristicsAgentFactory,
+                sandboxSession,
+                workspaceLoader,
+                marketplaceLoader,
+                workspaceStore,
+                logger)
             .ConfigureAwait(false);
 
-        return baseOptions with { Templates = templates };
+        return ApplyCharacteristicsAgentFactory(
+            baseOptions with { Templates = templates },
+            characteristicsAgentFactory);
     }
 
     /// <summary>
@@ -1993,6 +2056,7 @@ public partial class Program
     private static async Task EnrichWithWorkspaceCatalogAsync(
         IDictionary<string, SubAgentTemplate> templates,
         Func<IStreamingAgent> providerAgentFactory,
+        Func<SubAgentCharacteristics, SubAgentProviderAgent> characteristicsAgentFactory,
         SandboxSession sandboxSession,
         WorkspaceSubAgentLoader workspaceLoader,
         MarketplaceSubAgentLoader marketplaceLoader,
@@ -2003,7 +2067,10 @@ public partial class Program
         // Fetch them concurrently so the (sync-over-async) blocking window is one round-trip, not two.
         // Both loaders are best-effort (log + return empty on failure), so neither task faults; the
         // dictionary is mutated only AFTER both complete, so the in-order merge stays single-threaded.
-        var discoveredTask = workspaceLoader.LoadAsync(sandboxSession, providerAgentFactory);
+        var discoveredTask = workspaceLoader.LoadWithCharacteristicsAsync(
+            sandboxSession,
+            providerAgentFactory,
+            characteristicsAgentFactory);
         var marketplaceTask = LoadMarketplaceSubAgentsAsync(
             marketplaceLoader, workspaceStore, sandboxSession.WorkspaceId, providerAgentFactory, logger);
 

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -1947,7 +1947,8 @@ public partial class Program
     }
 
     /// <summary>
-    /// Attaches one conversation-scoped characteristics factory to every template.
+    /// Attaches one conversation-scoped characteristics factory to every template while preserving
+    /// template-specific agents for inherited model routing.
     /// </summary>
     internal static SubAgentOptions ApplyCharacteristicsAgentFactory(
         SubAgentOptions options,
@@ -1962,7 +1963,13 @@ public partial class Program
                 entry => entry.Key,
                 entry => entry.Value with
                 {
-                    CharacteristicsAgentFactory = characteristicsAgentFactory,
+                    CharacteristicsAgentFactory = characteristics =>
+                    {
+                        var provider = characteristicsAgentFactory(characteristics);
+                        return characteristics.IsModelExplicitlySelected
+                            ? provider
+                            : provider with { Agent = entry.Value.AgentFactory() };
+                    },
                 },
                 StringComparer.Ordinal),
         };

--- a/samples/LmStreaming.Sample/SandboxWorkspaceGuide.md
+++ b/samples/LmStreaming.Sample/SandboxWorkspaceGuide.md
@@ -211,10 +211,11 @@ effort: high
   candidates later in the array are ordered fallbacks. An absent map, missing tier, or tier with
   no routable candidate falls through to the parent model and logs a warning. The checked-in
   `appsettings.json` contains empty arrays for tiers 0–6, so it documents the schema without
-  selecting a model.
+  selecting a model. Malformed or out-of-range configuration keys are logged as errors and their
+  mappings are ignored without preventing application startup.
 
-- **`effort`** accepts **`low`**, **`medium`**, **`high`**, or **`extra-high`**
-  (`extra-high` is sent as `xhigh`). The request is clamped to the highest selectable effort
+- **`effort`** accepts **`low`**, **`medium`**, **`high`**, **`extra-high`**, or **`xhigh`**
+  (`extra-high` and `xhigh` are equivalent). The request is clamped to the highest selectable effort
   advertised by the resolved model at or below the request. If every advertised selectable
   effort is above the request, it snaps to the model's lowest selectable effort. If the model
   advertises no selectable effort (including a non-adaptive model), or its provider transport
@@ -225,6 +226,8 @@ Model precedence is **explicit `model:` > tier-resolved model > inherited parent
 per-spawn model override, when supplied by a caller, remains highest). An explicit model therefore
 disables tier selection. The characteristics-aware factory builds the sub-agent on the resolved
 model's routable transport and applies effort only after that model is known.
+The 0–6 model-intelligence tier space and the reasoning-effort values are deliberately independent;
+there is no ordinal or one-to-one mapping between them.
 
 Invalid or out-of-range `modelintelligence` values and unrecognized `effort` values do not reject
 the sub-agent. The shared parser ignores only the invalid field and emits a diagnostic, which the

--- a/samples/LmStreaming.Sample/SandboxWorkspaceGuide.md
+++ b/samples/LmStreaming.Sample/SandboxWorkspaceGuide.md
@@ -183,6 +183,58 @@ Each discovered plugin's **skills** (its `skills/<name>/SKILL.md`) and **MCP ser
 > whose `.mcp.json` omits it are loaded **skills-only** with a warning
 > (`Failed to parse .mcp.json — using empty mcp_servers`); their skills still work.
 
+### Discovered sub-agent model and reasoning options
+
+Markdown sub-agents may optionally add either or both of these frontmatter fields:
+
+```yaml
+---
+name: architecture-review
+modelintelligence: 4
+effort: high
+---
+```
+
+- **`modelintelligence`** is an integer capability tier from **0 through 6**. Tiers express
+  ascending deployment-defined model capability, not a built-in model table. Configure each
+  tier as an ordered array of candidate model ids:
+
+  ```json
+  "SubAgentIntelligence": {
+    "Tiers": {
+      "3": ["first-choice-model", "fallback-model"]
+    }
+  }
+  ```
+
+  The first candidate present and routable in the host's discovered Copilot model catalog wins;
+  candidates later in the array are ordered fallbacks. An absent map, missing tier, or tier with
+  no routable candidate falls through to the parent model and logs a warning. The checked-in
+  `appsettings.json` contains empty arrays for tiers 0–6, so it documents the schema without
+  selecting a model.
+
+- **`effort`** accepts **`low`**, **`medium`**, **`high`**, or **`extra-high`**
+  (`extra-high` is sent as `xhigh`). The request is clamped to the highest selectable effort
+  advertised by the resolved model at or below the request. If every advertised selectable
+  effort is above the request, it snaps to the model's lowest selectable effort. If the model
+  advertises no selectable effort (including a non-adaptive model), or its provider transport
+  cannot shape effort, the setting is omitted. LmStreaming uses the provider-specific request
+  shape: Anthropic `output_config.effort` or OpenAI Responses `reasoning.effort`.
+
+Model precedence is **explicit `model:` > tier-resolved model > inherited parent model** (a
+per-spawn model override, when supplied by a caller, remains highest). An explicit model therefore
+disables tier selection. The characteristics-aware factory builds the sub-agent on the resolved
+model's routable transport and applies effort only after that model is known.
+
+Invalid or out-of-range `modelintelligence` values and unrecognized `effort` values do not reject
+the sub-agent. The shared parser ignores only the invalid field and emits a diagnostic, which the
+host logs as a warning.
+
+`CodeReviewDaemon.Sample` deliberately has **no model/effort resolution in this change**. It uses
+the shared parser and logs its diagnostics, but does not install the characteristics-aware factory:
+`modelintelligence` never selects a daemon model and `effort` never adds reasoning request metadata.
+Existing explicit `model:` handling remains unchanged.
+
 ## Running
 
 The backend auto-launches the Vite client (via `Vite.AspNetCore`) **and** auto-spawns the gateway

--- a/samples/LmStreaming.Sample/Services/Discovery/CharacteristicsAgentFactory.cs
+++ b/samples/LmStreaming.Sample/Services/Discovery/CharacteristicsAgentFactory.cs
@@ -50,7 +50,7 @@ internal sealed class CharacteristicsAgentFactory
     {
         ArgumentNullException.ThrowIfNull(characteristics);
 
-        if (!characteristics.IsModelExplicitlySelected)
+        if (!characteristics.IsModelExplicitlySelected && !characteristics.IsModelTierResolved)
         {
             var extraProperties = _parentCopilotModel is null
                 ? ImmutableDictionary<string, object?>.Empty
@@ -75,7 +75,10 @@ internal sealed class CharacteristicsAgentFactory
             return ParentFallback();
         }
 
-        return new SubAgentProviderAgent(_modelAgentFactory(model), ShapeReasoning(model, characteristics.Effort));
+        return new SubAgentProviderAgent(_modelAgentFactory(model), ShapeReasoning(model, characteristics.Effort))
+        {
+            OwnsAgent = true,
+        };
     }
 
     private SubAgentProviderAgent ParentFallback() =>
@@ -116,7 +119,8 @@ internal sealed class CharacteristicsAgentFactory
         }
 
         if (
-            !string.Equals(selectedEffort, requestedEffort.Value.ToString(), StringComparison.OrdinalIgnoreCase)
+            CopilotReasoningShaper.GetEffortRank(selectedEffort)
+                != CopilotReasoningShaper.GetEffortRank(requestedEffort.Value)
             && _loggedEffortDiagnostics.TryAdd($"adjusted:{model.Id}:{requestedEffort.Value}:{selectedEffort}", 0)
         )
         {

--- a/samples/LmStreaming.Sample/Services/Discovery/CharacteristicsAgentFactory.cs
+++ b/samples/LmStreaming.Sample/Services/Discovery/CharacteristicsAgentFactory.cs
@@ -1,0 +1,128 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Reasoning;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+
+namespace LmStreaming.Sample.Services.Discovery;
+
+/// <summary>
+/// Creates a transport-correct Copilot agent from final sub-agent spawn characteristics.
+/// </summary>
+internal sealed class CharacteristicsAgentFactory
+{
+    private readonly ProviderRegistry _catalog;
+    private readonly IStreamingAgent _parentAgent;
+    private readonly Func<CopilotModelInfo, IStreamingAgent> _modelAgentFactory;
+    private readonly ILogger<CharacteristicsAgentFactory> _logger;
+    private readonly CopilotModelInfo? _parentCopilotModel;
+    private readonly ConcurrentDictionary<string, byte> _warnedFallbacks = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, byte> _loggedEffortDiagnostics = new(
+        StringComparer.OrdinalIgnoreCase
+    );
+
+    public CharacteristicsAgentFactory(
+        ProviderRegistry catalog,
+        IStreamingAgent parentAgent,
+        Func<CopilotModelInfo, IStreamingAgent> modelAgentFactory,
+        ILogger<CharacteristicsAgentFactory> logger,
+        CopilotModelInfo? parentCopilotModel = null
+    )
+    {
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+        _parentAgent = parentAgent ?? throw new ArgumentNullException(nameof(parentAgent));
+        _modelAgentFactory = modelAgentFactory ?? throw new ArgumentNullException(nameof(modelAgentFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _parentCopilotModel = parentCopilotModel;
+    }
+
+    /// <summary>
+    /// Creates the provider agent and transport-specific reasoning metadata for a spawn.
+    /// </summary>
+    internal SubAgentProviderAgent Create(SubAgentCharacteristics characteristics)
+    {
+        ArgumentNullException.ThrowIfNull(characteristics);
+
+        if (!characteristics.IsModelExplicitlySelected)
+        {
+            var extraProperties = _parentCopilotModel is null
+                ? ImmutableDictionary<string, object?>.Empty
+                : ShapeReasoning(_parentCopilotModel, characteristics.Effort);
+            return new SubAgentProviderAgent(_parentAgent, extraProperties);
+        }
+
+        if (string.IsNullOrWhiteSpace(characteristics.ModelId))
+        {
+            WarnFallbackOnce("<inherited>", "Sub-agent effective model is null; reusing the parent provider agent");
+            return ParentFallback();
+        }
+
+        if (!_catalog.TryGetCopilotModel(characteristics.ModelId, out var model))
+        {
+            WarnFallbackOnce(
+                "unknown-explicit-model",
+                "Sub-agent effective model {ModelId} is not in the Copilot catalog; "
+                    + "reusing the parent provider agent",
+                characteristics.ModelId
+            );
+            return ParentFallback();
+        }
+
+        return new SubAgentProviderAgent(_modelAgentFactory(model), ShapeReasoning(model, characteristics.Effort));
+    }
+
+    private SubAgentProviderAgent ParentFallback() => new(_parentAgent, ImmutableDictionary<string, object?>.Empty);
+
+    private void WarnFallbackOnce(string condition, string message, params object?[] args)
+    {
+        if (_warnedFallbacks.TryAdd(condition, 0))
+        {
+            _logger.LogWarning(message, args);
+        }
+    }
+
+    private ImmutableDictionary<string, object?> ShapeReasoning(
+        CopilotModelInfo model,
+        ReasoningEffort? requestedEffort
+    )
+    {
+        if (requestedEffort is null)
+        {
+            return ImmutableDictionary<string, object?>.Empty;
+        }
+
+        var selectedEffort = CopilotReasoningShaper.SelectEffort(model, requestedEffort);
+        if (selectedEffort is null)
+        {
+            if (_loggedEffortDiagnostics.TryAdd($"omitted:{model.Id}:{requestedEffort.Value}", 0))
+            {
+                _logger.LogDebug(
+                    "Sub-agent reasoning effort {RequestedEffort} was omitted because Copilot model "
+                        + "{ModelId} advertises no supported effort",
+                    requestedEffort,
+                    model.Id
+                );
+            }
+
+            return ImmutableDictionary<string, object?>.Empty;
+        }
+
+        if (
+            !string.Equals(selectedEffort, requestedEffort.Value.ToString(), StringComparison.OrdinalIgnoreCase)
+            && _loggedEffortDiagnostics.TryAdd($"adjusted:{model.Id}:{requestedEffort.Value}:{selectedEffort}", 0)
+        )
+        {
+            _logger.LogWarning(
+                "Sub-agent reasoning effort adjusted from {RequestedEffort} to {SelectedEffort} "
+                    + "for Copilot model {ModelId}",
+                requestedEffort,
+                selectedEffort,
+                model.Id
+            );
+        }
+
+        return CopilotReasoningShaper.Shape(model, requestedEffort);
+    }
+}

--- a/samples/LmStreaming.Sample/Services/Discovery/CharacteristicsAgentFactory.cs
+++ b/samples/LmStreaming.Sample/Services/Discovery/CharacteristicsAgentFactory.cs
@@ -31,10 +31,15 @@ internal sealed class CharacteristicsAgentFactory
         CopilotModelInfo? parentCopilotModel = null
     )
     {
-        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
-        _parentAgent = parentAgent ?? throw new ArgumentNullException(nameof(parentAgent));
-        _modelAgentFactory = modelAgentFactory ?? throw new ArgumentNullException(nameof(modelAgentFactory));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        ArgumentNullException.ThrowIfNull(catalog);
+        ArgumentNullException.ThrowIfNull(parentAgent);
+        ArgumentNullException.ThrowIfNull(modelAgentFactory);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _catalog = catalog;
+        _parentAgent = parentAgent;
+        _modelAgentFactory = modelAgentFactory;
+        _logger = logger;
         _parentCopilotModel = parentCopilotModel;
     }
 
@@ -73,7 +78,8 @@ internal sealed class CharacteristicsAgentFactory
         return new SubAgentProviderAgent(_modelAgentFactory(model), ShapeReasoning(model, characteristics.Effort));
     }
 
-    private SubAgentProviderAgent ParentFallback() => new(_parentAgent, ImmutableDictionary<string, object?>.Empty);
+    private SubAgentProviderAgent ParentFallback() =>
+        new(_parentAgent, ImmutableDictionary<string, object?>.Empty) { UseParentModel = true };
 
     private void WarnFallbackOnce(string condition, string message, params object?[] args)
     {

--- a/samples/LmStreaming.Sample/Services/Discovery/SubAgentIntelligenceOptions.cs
+++ b/samples/LmStreaming.Sample/Services/Discovery/SubAgentIntelligenceOptions.cs
@@ -1,0 +1,14 @@
+namespace LmStreaming.Sample.Services.Discovery;
+
+/// <summary>
+/// Operator-supplied model-intelligence tier candidates.
+/// </summary>
+internal sealed class SubAgentIntelligenceOptions
+{
+    public const string SectionName = "SubAgentIntelligence";
+
+    /// <summary>
+    /// Ordered model candidates keyed by intelligence tier.
+    /// </summary>
+    public Dictionary<int, string[]> Tiers { get; init; } = [];
+}

--- a/samples/LmStreaming.Sample/Services/Discovery/SubAgentIntelligenceOptions.cs
+++ b/samples/LmStreaming.Sample/Services/Discovery/SubAgentIntelligenceOptions.cs
@@ -11,4 +11,54 @@ internal sealed class SubAgentIntelligenceOptions
     /// Ordered model candidates keyed by intelligence tier.
     /// </summary>
     public Dictionary<int, string[]> Tiers { get; init; } = [];
+
+    internal static SubAgentIntelligenceOptions Load(
+        IConfiguration configuration,
+        ILogger logger
+    )
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        var tiers = new Dictionary<int, string[]>();
+        foreach (var entry in configuration.GetSection(SectionName).GetSection(nameof(Tiers)).GetChildren())
+        {
+            if (!int.TryParse(entry.Key, out var tier) || tier is < 0 or > 6)
+            {
+                logger.LogError(
+                    "Ignoring invalid {SectionName}:Tiers key {TierKey}; tier keys must be integers from 0 through 6",
+                    SectionName,
+                    entry.Key
+                );
+                continue;
+            }
+
+            string[] candidates;
+            try
+            {
+                candidates = entry.Get<string[]>() ?? [];
+            }
+            catch (InvalidOperationException ex)
+            {
+                logger.LogError(
+                    ex,
+                    "Ignoring invalid {SectionName}:Tiers:{Tier} mapping",
+                    SectionName,
+                    tier
+                );
+                continue;
+            }
+
+            if (!tiers.TryAdd(tier, candidates))
+            {
+                logger.LogError(
+                    "Ignoring duplicate normalized {SectionName}:Tiers key {TierKey}",
+                    SectionName,
+                    entry.Key
+                );
+            }
+        }
+
+        return new SubAgentIntelligenceOptions { Tiers = tiers };
+    }
 }

--- a/samples/LmStreaming.Sample/Services/Discovery/SubAgentModelResolver.cs
+++ b/samples/LmStreaming.Sample/Services/Discovery/SubAgentModelResolver.cs
@@ -1,0 +1,119 @@
+using System.Collections.Concurrent;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+
+namespace LmStreaming.Sample.Services.Discovery;
+
+/// <summary>
+/// Resolves optional model-intelligence tiers against the discovered Copilot catalog.
+/// </summary>
+internal sealed class SubAgentModelResolver
+{
+    private readonly ProviderRegistry _catalog;
+    private readonly SubAgentIntelligenceOptions _options;
+    private readonly ILogger<SubAgentModelResolver> _logger;
+    private readonly ConcurrentDictionary<string, byte> _loggedConditions = new(StringComparer.OrdinalIgnoreCase);
+
+    public SubAgentModelResolver(
+        ProviderRegistry catalog,
+        SubAgentIntelligenceOptions options,
+        ILogger<SubAgentModelResolver> logger
+    )
+    {
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Returns an explicit model unchanged, otherwise the first routable candidate for the tier.
+    /// A null result means the sub-agent should inherit its parent model.
+    /// </summary>
+    internal string? Resolve(string? explicitModel, int? modelIntelligence)
+    {
+        var normalizedModel = explicitModel?.Trim();
+        if (
+            !string.IsNullOrEmpty(normalizedModel)
+            && !string.Equals(normalizedModel, "inherit", StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            if (modelIntelligence is not null)
+            {
+                InformationOnce(
+                    $"ignored-tier:{modelIntelligence.Value}",
+                    "Sub-agent explicit model {ModelId} overrides model-intelligence tier {Tier}; "
+                        + "the tier was ignored",
+                    normalizedModel,
+                    modelIntelligence
+                );
+            }
+
+            return normalizedModel;
+        }
+
+        if (modelIntelligence is null)
+        {
+            return null;
+        }
+
+        if (_options.Tiers.Count == 0)
+        {
+            WarnOnce(
+                "empty-map",
+                "Sub-agent model-intelligence tier {Tier} cannot be resolved because "
+                    + "{SectionName}:Tiers is empty; inheriting the parent model",
+                modelIntelligence,
+                SubAgentIntelligenceOptions.SectionName
+            );
+            return null;
+        }
+
+        if (!_options.Tiers.TryGetValue(modelIntelligence.Value, out var candidates))
+        {
+            WarnOnce(
+                $"missing-tier:{modelIntelligence.Value}",
+                "Sub-agent model-intelligence tier {Tier} is not configured in "
+                    + "{SectionName}:Tiers; inheriting the parent model",
+                modelIntelligence,
+                SubAgentIntelligenceOptions.SectionName
+            );
+            return null;
+        }
+
+        foreach (var candidate in candidates)
+        {
+            if (string.IsNullOrWhiteSpace(candidate) || !_catalog.TryGetCopilotModel(candidate, out var model))
+            {
+                continue;
+            }
+
+            if (model.Transport is CopilotModelTransport.Anthropic or CopilotModelTransport.Responses)
+            {
+                return model.Id;
+            }
+        }
+
+        WarnOnce(
+            $"unroutable-tier:{modelIntelligence.Value}",
+            "Sub-agent model-intelligence tier {Tier} has no routable Copilot catalog candidate; "
+                + "inheriting the parent model",
+            modelIntelligence
+        );
+        return null;
+    }
+
+    private void WarnOnce(string condition, string message, params object?[] args)
+    {
+        if (_loggedConditions.TryAdd(condition, 0))
+        {
+            _logger.LogWarning(message, args);
+        }
+    }
+
+    private void InformationOnce(string condition, string message, params object?[] args)
+    {
+        if (_loggedConditions.TryAdd(condition, 0))
+        {
+            _logger.LogInformation(message, args);
+        }
+    }
+}

--- a/samples/LmStreaming.Sample/Services/Discovery/SubAgentModelResolver.cs
+++ b/samples/LmStreaming.Sample/Services/Discovery/SubAgentModelResolver.cs
@@ -19,9 +19,13 @@ internal sealed class SubAgentModelResolver
         ILogger<SubAgentModelResolver> logger
     )
     {
-        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
-        _options = options ?? throw new ArgumentNullException(nameof(options));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        ArgumentNullException.ThrowIfNull(catalog);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _catalog = catalog;
+        _options = options;
+        _logger = logger;
     }
 
     /// <summary>

--- a/samples/LmStreaming.Sample/Services/Discovery/WorkspaceSubAgentLoader.cs
+++ b/samples/LmStreaming.Sample/Services/Discovery/WorkspaceSubAgentLoader.cs
@@ -267,9 +267,19 @@ public sealed class WorkspaceSubAgentLoader
         var effectiveModel = _modelResolver?.Resolve(
             parsed.Model,
             parsed.ModelIntelligence);
+        var hasAuthorPinnedModel = !string.IsNullOrWhiteSpace(parsed.Model)
+            && !string.Equals(parsed.Model.Trim(), "inherit", StringComparison.OrdinalIgnoreCase);
+        var isTierResolved =
+            !hasAuthorPinnedModel
+            && parsed.ModelIntelligence is not null
+            && effectiveModel is not null;
         var effectiveParsed = effectiveModel is null
             ? parsed
-            : parsed with { Model = effectiveModel };
+            : parsed with
+            {
+                Model = effectiveModel,
+                IsModelTierResolved = isTierResolved,
+            };
         return SubAgentTemplateMapper.Map(
             effectiveParsed,
             agentFactory,

--- a/samples/LmStreaming.Sample/Services/Discovery/WorkspaceSubAgentLoader.cs
+++ b/samples/LmStreaming.Sample/Services/Discovery/WorkspaceSubAgentLoader.cs
@@ -49,8 +49,11 @@ public sealed class WorkspaceSubAgentLoader
         ILogger<WorkspaceSubAgentLoader> logger,
         SubAgentModelResolver? modelResolver)
     {
-        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _registry = registry;
+        _logger = logger;
         _modelResolver = modelResolver;
     }
 

--- a/samples/LmStreaming.Sample/Services/Discovery/WorkspaceSubAgentLoader.cs
+++ b/samples/LmStreaming.Sample/Services/Discovery/WorkspaceSubAgentLoader.cs
@@ -35,13 +35,23 @@ public sealed class WorkspaceSubAgentLoader
 
     private readonly SandboxSessionRegistry _registry;
     private readonly ILogger<WorkspaceSubAgentLoader> _logger;
+    private readonly SubAgentModelResolver? _modelResolver;
 
     public WorkspaceSubAgentLoader(
         SandboxSessionRegistry registry,
         ILogger<WorkspaceSubAgentLoader> logger)
+        : this(registry, logger, null)
+    {
+    }
+
+    internal WorkspaceSubAgentLoader(
+        SandboxSessionRegistry registry,
+        ILogger<WorkspaceSubAgentLoader> logger,
+        SubAgentModelResolver? modelResolver)
     {
         _registry = registry ?? throw new ArgumentNullException(nameof(registry));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _modelResolver = modelResolver;
     }
 
     /// <summary>
@@ -54,6 +64,18 @@ public sealed class WorkspaceSubAgentLoader
     public async Task<IReadOnlyDictionary<string, SubAgentTemplate>> LoadAsync(
         SandboxSession session,
         Func<IStreamingAgent> agentFactory,
+        CancellationToken ct = default)
+    {
+        return await LoadWithCharacteristicsAsync(session, agentFactory, null, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Discovers templates and attaches the conversation's characteristics-aware factory.
+    /// </summary>
+    public async Task<IReadOnlyDictionary<string, SubAgentTemplate>> LoadWithCharacteristicsAsync(
+        SandboxSession session,
+        Func<IStreamingAgent> agentFactory,
+        Func<SubAgentCharacteristics, SubAgentProviderAgent>? characteristicsAgentFactory,
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(session);
@@ -86,7 +108,13 @@ public sealed class WorkspaceSubAgentLoader
 
         foreach (var item in items)
         {
-            var loaded = await LoadOneAsync(session, item, agentFactory, ct).ConfigureAwait(false);
+            var loaded = await LoadOneWithCharacteristicsAsync(
+                    session,
+                    item,
+                    agentFactory,
+                    characteristicsAgentFactory,
+                    ct)
+                .ConfigureAwait(false);
             if (loaded is null || string.IsNullOrWhiteSpace(loaded.Name))
             {
                 continue;
@@ -125,6 +153,19 @@ public sealed class WorkspaceSubAgentLoader
         Func<IStreamingAgent> agentFactory,
         CancellationToken ct = default)
     {
+        return await LoadOneWithCharacteristicsAsync(session, item, agentFactory, null, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Loads one template and attaches the conversation's characteristics-aware factory.
+    /// </summary>
+    public async Task<SubAgentTemplate?> LoadOneWithCharacteristicsAsync(
+        SandboxSession session,
+        SandboxSessionRegistry.DiscoveredItem item,
+        Func<IStreamingAgent> agentFactory,
+        Func<SubAgentCharacteristics, SubAgentProviderAgent>? characteristicsAgentFactory,
+        CancellationToken ct = default)
+    {
         ArgumentNullException.ThrowIfNull(session);
         ArgumentNullException.ThrowIfNull(item);
         ArgumentNullException.ThrowIfNull(agentFactory);
@@ -151,7 +192,7 @@ public sealed class WorkspaceSubAgentLoader
                 return null;
             }
 
-            return SubAgentTemplateMapper.Map(parsedInline, agentFactory, DefaultMaxTurnsPerRun);
+            return MapParsed(parsedInline, agentFactory, characteristicsAgentFactory);
         }
 
         if (string.IsNullOrWhiteSpace(session.HostPath))
@@ -204,7 +245,35 @@ public sealed class WorkspaceSubAgentLoader
             return null;
         }
 
-        return SubAgentTemplateMapper.Map(parsed, agentFactory, DefaultMaxTurnsPerRun);
+        return MapParsed(parsed, agentFactory, characteristicsAgentFactory);
+    }
+
+    private SubAgentTemplate MapParsed(
+        ParsedSubAgent parsed,
+        Func<IStreamingAgent> agentFactory,
+        Func<SubAgentCharacteristics, SubAgentProviderAgent>? characteristicsAgentFactory)
+    {
+        foreach (var diagnostic in parsed.Diagnostics)
+        {
+            _logger.LogWarning(
+                "Discovered sub-agent {Name} frontmatter diagnostic: {Diagnostic}",
+                parsed.Name,
+                diagnostic);
+        }
+
+        var effectiveModel = _modelResolver?.Resolve(
+            parsed.Model,
+            parsed.ModelIntelligence);
+        var effectiveParsed = effectiveModel is null
+            ? parsed
+            : parsed with { Model = effectiveModel };
+        return SubAgentTemplateMapper.Map(
+            effectiveParsed,
+            agentFactory,
+            DefaultMaxTurnsPerRun) with
+        {
+            CharacteristicsAgentFactory = characteristicsAgentFactory,
+        };
     }
 
     /// <summary>

--- a/samples/LmStreaming.Sample/appsettings.json
+++ b/samples/LmStreaming.Sample/appsettings.json
@@ -37,6 +37,18 @@
     "BaseUrl": "http://127.0.0.1:3000",
     "AutoSpawn": true
   },
+  "SubAgentIntelligence": {
+    "_comment": "Map tiers 0-6 to ordered model-id fallback arrays. Empty arrays keep model selection inherited.",
+    "Tiers": {
+      "0": [],
+      "1": [],
+      "2": [],
+      "3": [],
+      "4": [],
+      "5": [],
+      "6": []
+    }
+  },
   "Auth": {
     "Github": {
       "ClientId": ""

--- a/src/GithubCopilotProvider/Models/CopilotModelCatalogParser.cs
+++ b/src/GithubCopilotProvider/Models/CopilotModelCatalogParser.cs
@@ -63,8 +63,32 @@ public static class CopilotModelCatalogParser
         var displayName = CopilotModelsResponse.GetString(item, "name");
         displayName = string.IsNullOrWhiteSpace(displayName) ? id! : displayName!;
 
-        model = new CopilotModelInfo(id!, displayName, vendor, transport, SupportsAdaptiveThinking(item));
+        model = new CopilotModelInfo(id!, displayName, vendor, transport, SupportsAdaptiveThinking(item))
+        {
+            ReasoningEfforts = GetReasoningEfforts(item),
+        };
         return true;
+    }
+
+    private static IReadOnlyList<string> GetReasoningEfforts(JsonElement item)
+    {
+        if (!item.TryGetProperty("capabilities", out var capabilities)
+            || capabilities.ValueKind != JsonValueKind.Object
+            || !capabilities.TryGetProperty("supports", out var supports)
+            || supports.ValueKind != JsonValueKind.Object
+            || !supports.TryGetProperty("reasoning_effort", out var reasoningEffort)
+            || reasoningEffort.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return
+        [
+            .. reasoningEffort
+                .EnumerateArray()
+                .Where(value => value.ValueKind == JsonValueKind.String)
+                .Select(value => value.GetString()!),
+        ];
     }
 
     /// <summary>

--- a/src/GithubCopilotProvider/Models/CopilotModelCatalogParser.cs
+++ b/src/GithubCopilotProvider/Models/CopilotModelCatalogParser.cs
@@ -87,7 +87,9 @@ public static class CopilotModelCatalogParser
             .. reasoningEffort
                 .EnumerateArray()
                 .Where(value => value.ValueKind == JsonValueKind.String)
-                .Select(value => value.GetString()!),
+                .Select(value => value.GetString())
+                .Where(value => value is not null)
+                .Select(value => value!),
         ];
     }
 

--- a/src/GithubCopilotProvider/Models/CopilotModelInfo.cs
+++ b/src/GithubCopilotProvider/Models/CopilotModelInfo.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
 
 /// <summary>
@@ -37,7 +39,46 @@ public sealed record CopilotModelInfo(
     string DisplayName,
     CopilotModelVendor Vendor,
     CopilotModelTransport Transport,
-    bool SupportsAdaptiveThinking = false);
+    bool SupportsAdaptiveThinking = false
+)
+{
+    private ImmutableArray<string> _reasoningEfforts = [];
+
+    /// <summary>
+    ///     Reasoning effort values advertised by <c>capabilities.supports.reasoning_effort</c>.
+    /// </summary>
+    public IReadOnlyList<string> ReasoningEfforts
+    {
+        get => _reasoningEfforts;
+        init => _reasoningEfforts = [.. value];
+    }
+
+    /// <inheritdoc />
+    public bool Equals(CopilotModelInfo? other)
+    {
+        return ReferenceEquals(this, other)
+            || (
+                other is not null
+                && Id == other.Id
+                && DisplayName == other.DisplayName
+                && Vendor == other.Vendor
+                && Transport == other.Transport
+                && SupportsAdaptiveThinking == other.SupportsAdaptiveThinking
+            );
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Id);
+        hash.Add(DisplayName);
+        hash.Add(Vendor);
+        hash.Add(Transport);
+        hash.Add(SupportsAdaptiveThinking);
+        return hash.ToHashCode();
+    }
+}
 
 /// <summary>
 ///     The normalized publisher partition a Copilot model belongs to. The sample only surfaces these

--- a/src/GithubCopilotProvider/Models/CopilotModelInfo.cs
+++ b/src/GithubCopilotProvider/Models/CopilotModelInfo.cs
@@ -54,6 +54,10 @@ public sealed record CopilotModelInfo(
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Equality intentionally covers the legacy positional contract only. The newly projected
+    /// reasoning-effort capability list is excluded to preserve existing equality and hash behavior.
+    /// </remarks>
     public bool Equals(CopilotModelInfo? other)
     {
         return ReferenceEquals(this, other)

--- a/src/GithubCopilotProvider/Models/CopilotModelInfo.cs
+++ b/src/GithubCopilotProvider/Models/CopilotModelInfo.cs
@@ -47,10 +47,14 @@ public sealed record CopilotModelInfo(
     /// <summary>
     ///     Reasoning effort values advertised by <c>capabilities.supports.reasoning_effort</c>.
     /// </summary>
+    /// <remarks>
+    /// This capability is intentionally excluded from equality and hash-code semantics to preserve
+    /// the record's legacy positional identity contract.
+    /// </remarks>
     public IReadOnlyList<string> ReasoningEfforts
     {
         get => _reasoningEfforts;
-        init => _reasoningEfforts = [.. value];
+        init => _reasoningEfforts = value is null ? [] : [.. value];
     }
 
     /// <inheritdoc />

--- a/src/GithubCopilotProvider/Reasoning/CopilotReasoningShaper.cs
+++ b/src/GithubCopilotProvider/Reasoning/CopilotReasoningShaper.cs
@@ -1,0 +1,97 @@
+using System.Collections.Immutable;
+using AchieveAi.LmDotnetTools.AnthropicProvider.Models;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+
+namespace AchieveAi.LmDotnetTools.GithubCopilotProvider.Reasoning;
+
+/// <summary>
+/// Shapes a typed reasoning request into transport-specific Copilot request metadata.
+/// </summary>
+public static class CopilotReasoningShaper
+{
+    private static readonly string[] S_selectableEfforts = ["none", "minimal", "low", "medium", "high", "xhigh"];
+
+    /// <summary>
+    /// Selects an advertised effort and returns request extra properties for the model's transport.
+    /// </summary>
+    public static ImmutableDictionary<string, object?> Shape(CopilotModelInfo model, ReasoningEffort? requestedEffort)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        var effort = SelectEffort(model, requestedEffort);
+        if (effort is null)
+        {
+            return ImmutableDictionary<string, object?>.Empty;
+        }
+
+        return model.Transport switch
+        {
+            CopilotModelTransport.Anthropic => ImmutableDictionary<string, object?>.Empty.Add(
+                "OutputConfig",
+                new AnthropicOutputConfig { Effort = effort }
+            ),
+            CopilotModelTransport.Responses => ImmutableDictionary<string, object?>.Empty.Add(
+                "Reasoning",
+                new ResponseReasoningOptions { Effort = effort }
+            ),
+            _ => ImmutableDictionary<string, object?>.Empty,
+        };
+    }
+
+    /// <summary>
+    /// Selects the greatest advertised effort not exceeding the request, or the lowest selectable
+    /// advertised effort when none are at or below the request.
+    /// </summary>
+    /// <returns>
+    /// The selected canonical effort, or <see langword="null"/> when no effort was requested or the
+    /// model advertises no selectable effort.
+    /// </returns>
+    public static string? SelectEffort(CopilotModelInfo model, ReasoningEffort? requestedEffort)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        if (requestedEffort is null)
+        {
+            return null;
+        }
+
+        var advertisedRanks = model
+            .ReasoningEfforts.Select(GetSelectableRank)
+            .Where(rank => rank >= 0)
+            .Distinct()
+            .ToArray();
+        if (advertisedRanks.Length == 0)
+        {
+            return null;
+        }
+
+        var requestedRank = requestedEffort.Value switch
+        {
+            ReasoningEffort.Low => 2,
+            ReasoningEffort.Medium => 3,
+            ReasoningEffort.High => 4,
+            ReasoningEffort.Xhigh => 5,
+            _ => throw new ArgumentOutOfRangeException(nameof(requestedEffort)),
+        };
+        var selectedRank = advertisedRanks
+            .Where(rank => rank <= requestedRank)
+            .DefaultIfEmpty(advertisedRanks.Min())
+            .Max();
+        return S_selectableEfforts[selectedRank];
+    }
+
+    private static int GetSelectableRank(string effort)
+    {
+        for (var rank = 0; rank < S_selectableEfforts.Length; rank++)
+        {
+            if (string.Equals(effort?.Trim(), S_selectableEfforts[rank], StringComparison.OrdinalIgnoreCase))
+            {
+                return rank;
+            }
+        }
+
+        return -1;
+    }
+}

--- a/src/GithubCopilotProvider/Reasoning/CopilotReasoningShaper.cs
+++ b/src/GithubCopilotProvider/Reasoning/CopilotReasoningShaper.cs
@@ -48,6 +48,11 @@ public static class CopilotReasoningShaper
     /// The selected canonical effort, or <see langword="null"/> when no effort was requested or the
     /// model advertises no selectable effort.
     /// </returns>
+    /// <remarks>
+    /// Selection is intentionally driven by <see cref="CopilotModelInfo.ReasoningEfforts"/>, the
+    /// provider's request capability list. <see cref="CopilotModelInfo.SupportsAdaptiveThinking"/>
+    /// governs the separate classic-versus-adaptive thinking shape and is not an effort gate.
+    /// </remarks>
     public static string? SelectEffort(CopilotModelInfo model, ReasoningEffort? requestedEffort)
     {
         ArgumentNullException.ThrowIfNull(model);

--- a/src/GithubCopilotProvider/Reasoning/CopilotReasoningShaper.cs
+++ b/src/GithubCopilotProvider/Reasoning/CopilotReasoningShaper.cs
@@ -72,14 +72,11 @@ public static class CopilotReasoningShaper
             return null;
         }
 
-        var requestedRank = requestedEffort.Value switch
+        var requestedRank = GetEffortRank(requestedEffort.Value);
+        if (requestedRank < 0)
         {
-            ReasoningEffort.Low => 2,
-            ReasoningEffort.Medium => 3,
-            ReasoningEffort.High => 4,
-            ReasoningEffort.Xhigh => 5,
-            _ => throw new ArgumentOutOfRangeException(nameof(requestedEffort)),
-        };
+            return null;
+        }
         var selectedRank = advertisedRanks
             .Where(rank => rank <= requestedRank)
             .DefaultIfEmpty(advertisedRanks.Min())
@@ -99,4 +96,18 @@ public static class CopilotReasoningShaper
 
         return -1;
     }
+
+    /// <summary>Returns the provider-independent rank for a typed effort, or -1 when unknown.</summary>
+    public static int GetEffortRank(ReasoningEffort effort) =>
+        effort switch
+        {
+            ReasoningEffort.Low => 2,
+            ReasoningEffort.Medium => 3,
+            ReasoningEffort.High => 4,
+            ReasoningEffort.Xhigh => 5,
+            _ => -1,
+        };
+
+    /// <summary>Returns the rank for a canonical provider effort token, or -1 when unknown.</summary>
+    public static int GetEffortRank(string effort) => GetSelectableRank(effort);
 }

--- a/src/LmAgentInfra/Sandbox/SandboxSessionRegistry.cs
+++ b/src/LmAgentInfra/Sandbox/SandboxSessionRegistry.cs
@@ -13,13 +13,20 @@ namespace AchieveAi.LmDotnetTools.LmAgentInfra.Sandbox;
 /// <summary>
 /// Per-session binding the context-discovery webhook needs to convert a discovered subagent into
 /// a live template: the catalog the loop reads (<see cref="Source"/>) plus the agent factory the
-/// template's spawn-time wiring will reuse (<see cref="AgentFactory"/>). The factory is provider-
-/// specific and only known at agent-creation time, so it must travel with the source rather than
-/// be re-derived inside the webhook handler.
+/// template's spawn-time wiring will reuse (<see cref="AgentFactory"/> and
+/// <see cref="CharacteristicsAgentFactory"/>). The factories are provider-specific and only known
+/// at agent-creation time, so they must travel with the source rather than be re-derived inside the
+/// webhook handler.
 /// </summary>
 public sealed record SubAgentSessionBinding(
     MutableSubAgentTemplateSource Source,
-    Func<IStreamingAgent> AgentFactory);
+    Func<IStreamingAgent> AgentFactory)
+{
+    /// <summary>
+    /// Optional factory that creates the provider agent from resolved spawn characteristics.
+    /// </summary>
+    public Func<SubAgentCharacteristics, SubAgentProviderAgent>? CharacteristicsAgentFactory { get; init; }
+}
 
 /// <summary>
 /// A sandbox session created against the gateway and bound to a workspace directory.
@@ -908,7 +915,19 @@ public sealed partial class SandboxSessionRegistry : IAsyncDisposable
         string sessionId,
         string conversationId,
         IReadOnlyDictionary<string, SubAgentTemplate> seed,
-        Func<IStreamingAgent> agentFactory)
+        Func<IStreamingAgent> agentFactory) =>
+        GetOrAddSubAgentBinding(sessionId, conversationId, seed, agentFactory, null);
+
+    /// <summary>
+    /// Returns the sub-agent binding for a conversation, remembering both provider factories when
+    /// creating it.
+    /// </summary>
+    public SubAgentSessionBinding GetOrAddSubAgentBinding(
+        string sessionId,
+        string conversationId,
+        IReadOnlyDictionary<string, SubAgentTemplate> seed,
+        Func<IStreamingAgent> agentFactory,
+        Func<SubAgentCharacteristics, SubAgentProviderAgent>? characteristicsAgentFactory)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
@@ -922,8 +941,67 @@ public sealed partial class SandboxSessionRegistry : IAsyncDisposable
 
         var binding = conversations.GetOrAdd(
             conversationId,
-            _ => new SubAgentSessionBinding(new MutableSubAgentTemplateSource(seed), agentFactory));
+            _ => new SubAgentSessionBinding(
+                new MutableSubAgentTemplateSource(seed),
+                agentFactory)
+            {
+                CharacteristicsAgentFactory = characteristicsAgentFactory,
+            });
 
+        return ReconcileSubAgentBindingSeed(binding, seed);
+    }
+
+    /// <summary>
+    /// Creates a conversation binding or atomically refreshes both provider factories on its
+    /// existing binding while preserving the conversation's template source.
+    /// </summary>
+    /// <remarks>
+    /// Use this when recreating an agent for the same conversation. Existing
+    /// <see cref="GetOrAddSubAgentBinding(string, string, IReadOnlyDictionary{string, SubAgentTemplate}, Func{IStreamingAgent})"/>
+    /// overloads intentionally retain their unchanged-on-hit behavior.
+    /// </remarks>
+    public SubAgentSessionBinding AddOrUpdateSubAgentBinding(
+        string sessionId,
+        string conversationId,
+        IReadOnlyDictionary<string, SubAgentTemplate> seed,
+        Func<IStreamingAgent> agentFactory,
+        Func<SubAgentCharacteristics, SubAgentProviderAgent>? characteristicsAgentFactory)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
+        ArgumentNullException.ThrowIfNull(seed);
+        ArgumentNullException.ThrowIfNull(agentFactory);
+
+        var conversations = _subAgentBindings.GetOrAdd(
+            sessionId,
+            _ => new ConcurrentDictionary<string, SubAgentSessionBinding>(StringComparer.Ordinal));
+
+        var binding = conversations.AddOrUpdate(
+            conversationId,
+            _ => new SubAgentSessionBinding(
+                new MutableSubAgentTemplateSource(seed),
+                agentFactory)
+            {
+                CharacteristicsAgentFactory = characteristicsAgentFactory,
+            },
+            (_, existing) =>
+            {
+                existing.Source.RebindFactories(agentFactory, characteristicsAgentFactory);
+                return existing with
+                {
+                    AgentFactory = agentFactory,
+                    CharacteristicsAgentFactory = characteristicsAgentFactory,
+                };
+            });
+
+        return ReconcileSubAgentBindingSeed(binding, seed);
+    }
+
+    private static SubAgentSessionBinding ReconcileSubAgentBindingSeed(
+        SubAgentSessionBinding binding,
+        IReadOnlyDictionary<string, SubAgentTemplate> seed)
+    {
         // Reconcile the seed every call: a later pool factory invocation for the same conversation
         // may present additional built-in templates that weren't present on the first call.
         // TryRegister is first-wins, so previously seeded entries (and any discovered templates
@@ -939,7 +1017,8 @@ public sealed partial class SandboxSessionRegistry : IAsyncDisposable
     /// <summary>
     /// Tries to look up the sub-agent binding previously registered for the
     /// (<paramref name="sessionId"/>, <paramref name="conversationId"/>) pair via
-    /// <see cref="GetOrAddSubAgentBinding"/>. Returns false (with <paramref name="binding"/> set to
+    /// <see cref="GetOrAddSubAgentBinding(string, string, IReadOnlyDictionary{string, SubAgentTemplate}, Func{IStreamingAgent})"/>.
+    /// Returns false (with <paramref name="binding"/> set to
     /// null) when no binding exists — the discovery webhook treats that as a best-effort no-op
     /// rather than an error, since the conversation may not have routed through the agent path yet.
     /// </summary>

--- a/src/LmAgentInfra/Sandbox/SandboxSessionRegistry.cs
+++ b/src/LmAgentInfra/Sandbox/SandboxSessionRegistry.cs
@@ -915,19 +915,7 @@ public sealed partial class SandboxSessionRegistry : IAsyncDisposable
         string sessionId,
         string conversationId,
         IReadOnlyDictionary<string, SubAgentTemplate> seed,
-        Func<IStreamingAgent> agentFactory) =>
-        GetOrAddSubAgentBinding(sessionId, conversationId, seed, agentFactory, null);
-
-    /// <summary>
-    /// Returns the sub-agent binding for a conversation, remembering both provider factories when
-    /// creating it.
-    /// </summary>
-    public SubAgentSessionBinding GetOrAddSubAgentBinding(
-        string sessionId,
-        string conversationId,
-        IReadOnlyDictionary<string, SubAgentTemplate> seed,
-        Func<IStreamingAgent> agentFactory,
-        Func<SubAgentCharacteristics, SubAgentProviderAgent>? characteristicsAgentFactory)
+        Func<IStreamingAgent> agentFactory)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
@@ -943,10 +931,7 @@ public sealed partial class SandboxSessionRegistry : IAsyncDisposable
             conversationId,
             _ => new SubAgentSessionBinding(
                 new MutableSubAgentTemplateSource(seed),
-                agentFactory)
-            {
-                CharacteristicsAgentFactory = characteristicsAgentFactory,
-            });
+                agentFactory));
 
         return ReconcileSubAgentBindingSeed(binding, seed);
     }
@@ -979,11 +964,14 @@ public sealed partial class SandboxSessionRegistry : IAsyncDisposable
 
         var binding = conversations.AddOrUpdate(
             conversationId,
-            _ => new SubAgentSessionBinding(
-                new MutableSubAgentTemplateSource(seed),
-                agentFactory)
+            _ =>
             {
-                CharacteristicsAgentFactory = characteristicsAgentFactory,
+                var source = new MutableSubAgentTemplateSource(seed);
+                source.RebindFactories(agentFactory, characteristicsAgentFactory);
+                return new SubAgentSessionBinding(source, agentFactory)
+                {
+                    CharacteristicsAgentFactory = characteristicsAgentFactory,
+                };
             },
             (_, existing) =>
             {

--- a/src/LmCore/Core/ReasoningEffort.cs
+++ b/src/LmCore/Core/ReasoningEffort.cs
@@ -3,6 +3,10 @@ namespace AchieveAi.LmDotnetTools.LmCore.Core;
 /// <summary>
 /// Specifies the amount of reasoning effort requested from a model.
 /// </summary>
+/// <remarks>
+/// Enum ordinals are not provider effort ranks and must not be persisted or sent on the wire.
+/// Providers map these named values to their own canonical tokens and ranking schemes.
+/// </remarks>
 public enum ReasoningEffort
 {
     /// <summary>Requests low reasoning effort.</summary>

--- a/src/LmCore/Core/ReasoningEffort.cs
+++ b/src/LmCore/Core/ReasoningEffort.cs
@@ -1,0 +1,19 @@
+namespace AchieveAi.LmDotnetTools.LmCore.Core;
+
+/// <summary>
+/// Specifies the amount of reasoning effort requested from a model.
+/// </summary>
+public enum ReasoningEffort
+{
+    /// <summary>Requests low reasoning effort.</summary>
+    Low,
+
+    /// <summary>Requests medium reasoning effort.</summary>
+    Medium,
+
+    /// <summary>Requests high reasoning effort.</summary>
+    High,
+
+    /// <summary>Requests extra-high reasoning effort.</summary>
+    Xhigh,
+}

--- a/src/LmMultiTurn/SubAgents/MutableSubAgentTemplateSource.cs
+++ b/src/LmMultiTurn/SubAgents/MutableSubAgentTemplateSource.cs
@@ -102,12 +102,30 @@ public sealed class MutableSubAgentTemplateSource
         }
     }
 
-    private SubAgentTemplate RebindTemplate(SubAgentTemplate template) =>
-        _rebindRegistrations
-            ? template with
-            {
-                AgentFactory = _agentFactory!,
-                CharacteristicsAgentFactory = _characteristicsAgentFactory,
-            }
-            : template;
+    private SubAgentTemplate RebindTemplate(SubAgentTemplate template)
+    {
+        if (!_rebindRegistrations)
+        {
+            return template;
+        }
+
+        var inheritedAgentFactory = template.AgentFactory;
+        return template with
+        {
+            CharacteristicsAgentFactory = _characteristicsAgentFactory is null
+                ? null
+                : characteristics =>
+                {
+                    var provider = _characteristicsAgentFactory(characteristics);
+                    return characteristics.IsModelExplicitlySelected
+                        || characteristics.IsModelTierResolved
+                        ? provider
+                        : provider with
+                        {
+                            Agent = inheritedAgentFactory(),
+                            OwnsAgent = true,
+                        };
+                },
+        };
+    }
 }

--- a/src/LmMultiTurn/SubAgents/MutableSubAgentTemplateSource.cs
+++ b/src/LmMultiTurn/SubAgents/MutableSubAgentTemplateSource.cs
@@ -1,4 +1,5 @@
-using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
 
 namespace AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 
@@ -15,22 +16,24 @@ namespace AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 /// the source first, and discovered (untrusted) entries cannot shadow them.
 /// </para>
 /// <para>
-/// <see cref="Templates"/> returns the live <see cref="ConcurrentDictionary{TKey,TValue}"/>
-/// view. Enumerating it during a concurrent <see cref="TryRegister"/> is safe — the
-/// snapshot may include or exclude the new entry depending on timing, but never throws
-/// and never tears.
+/// <see cref="Templates"/> returns the immutable snapshot current at the time of the read.
+/// A previously returned snapshot remains unchanged when templates are registered or rebound.
 /// </para>
 /// </remarks>
 public sealed class MutableSubAgentTemplateSource
 {
-    private readonly ConcurrentDictionary<string, SubAgentTemplate> _templates;
+    private readonly object _updateGate = new();
+    private ImmutableDictionary<string, SubAgentTemplate> _templates;
+    private Func<IStreamingAgent>? _agentFactory;
+    private Func<SubAgentCharacteristics, SubAgentProviderAgent>? _characteristicsAgentFactory;
+    private bool _rebindRegistrations;
 
     /// <summary>
     /// Creates an empty source.
     /// </summary>
     public MutableSubAgentTemplateSource()
     {
-        _templates = new ConcurrentDictionary<string, SubAgentTemplate>(StringComparer.Ordinal);
+        _templates = ImmutableDictionary.Create<string, SubAgentTemplate>(StringComparer.Ordinal);
     }
 
     /// <summary>
@@ -40,14 +43,13 @@ public sealed class MutableSubAgentTemplateSource
     public MutableSubAgentTemplateSource(IReadOnlyDictionary<string, SubAgentTemplate> initial)
     {
         ArgumentNullException.ThrowIfNull(initial);
-        _templates = new ConcurrentDictionary<string, SubAgentTemplate>(initial, StringComparer.Ordinal);
+        _templates = ImmutableDictionary.CreateRange(StringComparer.Ordinal, initial);
     }
 
     /// <summary>
-    /// Live snapshot of the current templates. Reads are lock-free; consumers should treat
-    /// the returned view as read-only.
+    /// Immutable snapshot of the current templates. Reads are lock-free.
     /// </summary>
-    public IReadOnlyDictionary<string, SubAgentTemplate> Templates => _templates;
+    public IReadOnlyDictionary<string, SubAgentTemplate> Templates => Volatile.Read(ref _templates);
 
     /// <summary>
     /// Atomically registers <paramref name="template"/> under <paramref name="name"/>. Returns
@@ -57,6 +59,55 @@ public sealed class MutableSubAgentTemplateSource
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentNullException.ThrowIfNull(template);
-        return _templates.TryAdd(name, template);
+
+        lock (_updateGate)
+        {
+            var current = Volatile.Read(ref _templates);
+            if (current.ContainsKey(name))
+            {
+                return false;
+            }
+
+            Volatile.Write(ref _templates, current.Add(name, RebindTemplate(template)));
+            return true;
+        }
     }
+
+    /// <summary>
+    /// Atomically replaces each retained template with a copy using the latest provider factories.
+    /// Templates registered after this operation are rebound to the same factories before they are
+    /// published.
+    /// </summary>
+    public void RebindFactories(
+        Func<IStreamingAgent> agentFactory,
+        Func<SubAgentCharacteristics, SubAgentProviderAgent>? characteristicsAgentFactory
+    )
+    {
+        ArgumentNullException.ThrowIfNull(agentFactory);
+
+        lock (_updateGate)
+        {
+            _agentFactory = agentFactory;
+            _characteristicsAgentFactory = characteristicsAgentFactory;
+            _rebindRegistrations = true;
+
+            var current = Volatile.Read(ref _templates);
+            var rebound = current.ToBuilder();
+            foreach (var entry in current)
+            {
+                rebound[entry.Key] = RebindTemplate(entry.Value);
+            }
+
+            Volatile.Write(ref _templates, rebound.ToImmutable());
+        }
+    }
+
+    private SubAgentTemplate RebindTemplate(SubAgentTemplate template) =>
+        _rebindRegistrations
+            ? template with
+            {
+                AgentFactory = _agentFactory!,
+                CharacteristicsAgentFactory = _characteristicsAgentFactory,
+            }
+            : template;
 }

--- a/src/LmMultiTurn/SubAgents/SubAgentCharacteristics.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentCharacteristics.cs
@@ -1,0 +1,17 @@
+using AchieveAi.LmDotnetTools.LmCore.Core;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+
+/// <summary>
+/// Resolved characteristics used to create a provider agent for a sub-agent spawn.
+/// </summary>
+public sealed record SubAgentCharacteristics(
+    string? ModelId,
+    ReasoningEffort? Effort)
+{
+    /// <summary>
+    /// Whether the effective model came from an explicit template or per-spawn selection
+    /// rather than parent-model inheritance.
+    /// </summary>
+    public bool IsModelExplicitlySelected { get; init; }
+}

--- a/src/LmMultiTurn/SubAgents/SubAgentCharacteristics.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentCharacteristics.cs
@@ -14,4 +14,11 @@ public sealed record SubAgentCharacteristics(
     /// rather than parent-model inheritance.
     /// </summary>
     public bool IsModelExplicitlySelected { get; init; }
+
+    /// <summary>
+    /// Whether the effective model was selected from an operator-configured intelligence tier.
+    /// Tier resolution still requires provider routing, but remains distinct from an author-pinned
+    /// model selection.
+    /// </summary>
+    public bool IsModelTierResolved { get; init; }
 }

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -1,7 +1,9 @@
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Channels;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
@@ -636,10 +638,39 @@ public sealed class SubAgentManager : IAsyncDisposable
             return TestAgentFactoryOverride(agentId, template);
         }
 
-        var providerAgent = template.AgentFactory();
-
         // Resolve the sub-agent's options with model inheritance (override > template > parent).
         var defaultOptions = ResolveSubAgentOptions(template.DefaultOptions, modelOverride, _parentModelId);
+        IStreamingAgent providerAgent;
+
+        if (template.CharacteristicsAgentFactory is { } characteristicsFactory)
+        {
+            var modelId = string.IsNullOrWhiteSpace(defaultOptions?.ModelId)
+                ? null
+                : defaultOptions.ModelId;
+            var provider = characteristicsFactory(
+                new SubAgentCharacteristics(modelId, template.Effort)
+                {
+                    IsModelExplicitlySelected =
+                        !string.IsNullOrWhiteSpace(modelOverride)
+                        || template.IsModelExplicitlySelected,
+                });
+            providerAgent = provider.Agent;
+
+            if (provider.ExtraProperties.Count > 0)
+            {
+                var requestExtraProperties =
+                    defaultOptions?.ExtraProperties
+                    ?? ImmutableDictionary<string, object?>.Empty;
+                defaultOptions = (defaultOptions ?? new GenerateReplyOptions()) with
+                {
+                    ExtraProperties = provider.ExtraProperties.SetItems(requestExtraProperties),
+                };
+            }
+        }
+        else
+        {
+            providerAgent = template.AgentFactory();
+        }
 
         // Determine conversation store
         var storeFactory =

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -33,6 +33,11 @@ public sealed class SubAgentManager : IAsyncDisposable
     private readonly SemaphoreSlim _concurrencyGate;
     private int _disposeStarted;
 
+    // Owned providers whose terminal disposal failed AND whose in-restart retry also failed: the state's
+    // OwnedProviderAgent slot is about to be overwritten by the replacement, so their handle is retained
+    // here for a best-effort final dispose at manager teardown rather than being silently abandoned.
+    private readonly ConcurrentBag<IStreamingAgent> _abandonedProviders = [];
+
     /// <summary>
     /// Test-only seam: when set, <see cref="CreateSubAgentAsync"/> returns this factory's
     /// <see cref="IMultiTurnAgent"/> instead of building a real <see cref="MultiTurnAgentLoop"/>,
@@ -350,6 +355,7 @@ public sealed class SubAgentManager : IAsyncDisposable
                 // (running agent) is kept so existing waiters observe the next resolution.
                 state.ResetCompletionIfFinished();
 
+                var injectCancelledByLifecycle = false;
                 try
                 {
                     // Inject the message into the currently running agent while holding the send lease.
@@ -357,12 +363,30 @@ public sealed class SubAgentManager : IAsyncDisposable
                     // disposal can unblock this send if it wedges — otherwise the lease (which the
                     // disposal waits to drain) could be held forever on a caller token that never cancels.
                     using var linkedCts = state.LinkLifecycleToken(ct);
-                    _ = await state.Agent.SendAsync(
-                        [new TextMessage { Role = Role.User, Text = prompt }], ct: linkedCts.Token);
+                    try
+                    {
+                        _ = await state.Agent.SendAsync(
+                            [new TextMessage { Role = Role.User, Text = prompt }], ct: linkedCts.Token);
+                    }
+                    catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+                    {
+                        // The send was cancelled by the run's LIFECYCLE token (terminal disposal began),
+                        // NOT by the caller: the loop we injected into is finishing. Re-evaluate the
+                        // continuation so the prompt is delivered to the restarted run instead of
+                        // surfacing a spurious cancellation to the user and dropping their message.
+                        injectCancelledByLifecycle = true;
+                    }
                 }
                 finally
                 {
                     state.EndInjectLease();
+                }
+
+                if (injectCancelledByLifecycle)
+                {
+                    // The lease is released; re-enter the decision loop. The run is now terminal, so
+                    // BeginContinuation routes this to a fresh-provider restart that delivers the prompt.
+                    continue;
                 }
 
                 _logger.LogInformation(
@@ -536,9 +560,19 @@ public sealed class SubAgentManager : IAsyncDisposable
                     try { await state.DisposeOwnedProviderAgentAsync(); }
                     catch (Exception ex)
                     {
+                        // Retry failed a second time: we are about to overwrite the OwnedProviderAgent
+                        // slot, which would drop this handle forever. Retain it for a best-effort dispose
+                        // at manager teardown so a repeatedly-undisposable provider is accounted for
+                        // rather than silently abandoned.
+                        var undisposed = state.OwnedProviderAgent;
+                        if (undisposed is not null)
+                        {
+                            _abandonedProviders.Add(undisposed);
+                        }
+
                         _logger.LogWarning(
                             ex,
-                            "Retry dispose of poisoned owned provider failed before restart for sub-agent {AgentId}",
+                            "Retry dispose of poisoned owned provider failed before restart for sub-agent {AgentId}; retained for cleanup at manager disposal",
                             state.AgentId
                         );
                     }
@@ -806,6 +840,28 @@ public sealed class SubAgentManager : IAsyncDisposable
 
         _agents.Clear();
         _namesToIds.Clear();
+
+        // Best-effort final dispose of providers whose in-restart retry disposal also failed; their state
+        // slots were overwritten by replacements, so this is their last cleanup opportunity.
+        foreach (var abandoned in _abandonedProviders)
+        {
+            try
+            {
+                if (abandoned is IAsyncDisposable asyncDisposable)
+                {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else if (abandoned is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Abandoned owned-provider dispose failed at manager disposal");
+            }
+        }
+
         _concurrencyGate.Dispose();
     }
 

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -186,7 +186,7 @@ public sealed class SubAgentManager : IAsyncDisposable
             // Start monitoring BEFORE sending the task to avoid subscribe-after-send race:
             // if SendAsync triggers a fast completion before the monitor subscribes,
             // the RunCompletedMessage would fire with no subscriber listening.
-            state.MonitorTask = MonitorSubAgentAsync(state, gateGuard, cts.Token);
+            state.MonitorTask = MonitorSubAgentAsync(state, gateGuard, state.CurrentRunGeneration, cts.Token);
 
             // Send the task as user input (triggers first turn)
             _ = await agent.SendAsync(
@@ -606,7 +606,7 @@ public sealed class SubAgentManager : IAsyncDisposable
             state.RunTask = state.Agent.RunAsync(cts.Token);
 
             // Re-subscribe BEFORE sending to avoid subscribe-after-send race
-            state.MonitorTask = MonitorSubAgentAsync(state, gateGuard, cts.Token);
+            state.MonitorTask = MonitorSubAgentAsync(state, gateGuard, runGeneration, cts.Token);
 
             _ = await state.Agent.SendAsync(
                 [new TextMessage { Role = Role.User, Text = prompt }], ct: ct);
@@ -1114,10 +1114,16 @@ public sealed class SubAgentManager : IAsyncDisposable
     /// read from a shared field on <paramref name="state"/>, so a later restart's own guard can
     /// never be conflated with this monitor's - see <see cref="GateReleaseGuard"/>.
     /// </param>
+    /// <param name="runGeneration">
+    /// The run generation this monitor belongs to (0 for the initial spawn; the restart's generation
+    /// otherwise). On a monitor fault, the terminal Error is recorded against this generation so a
+    /// racing restart's <c>TryArmRunning</c> cannot resurrect the faulted run to Running.
+    /// </param>
     /// <param name="ct">Cancellation token for this run's lifetime.</param>
     private async Task MonitorSubAgentAsync(
         SubAgentState state,
         GateReleaseGuard gateGuard,
+        long runGeneration,
         CancellationToken ct)
     {
         string? lastTextContent = null;
@@ -1214,7 +1220,11 @@ public sealed class SubAgentManager : IAsyncDisposable
         }
         catch (Exception ex)
         {
-            state.Status = SubAgentStatus.Error;
+            // Record the fault as a generation-aware terminal Error (not a raw Status write): a restarted
+            // run's monitor can fault before RestartRunAsync's TryArmRunning(runGeneration) executes, and
+            // that publish must observe this generation's terminal record and refuse to overwrite Error
+            // with Running (which would advertise a dead run).
+            state.MarkRunFaulted(runGeneration);
             state.SendToParentError = $"Monitor failed: {ex.Message}";
             _logger.LogError(
                 ex,

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -353,8 +353,12 @@ public sealed class SubAgentManager : IAsyncDisposable
                 try
                 {
                     // Inject the message into the currently running agent while holding the send lease.
+                    // Link the caller token with the run's lifecycle token so a terminal owned-provider
+                    // disposal can unblock this send if it wedges — otherwise the lease (which the
+                    // disposal waits to drain) could be held forever on a caller token that never cancels.
+                    using var linkedCts = state.LinkLifecycleToken(ct);
                     _ = await state.Agent.SendAsync(
-                        [new TextMessage { Role = Role.User, Text = prompt }], ct: ct);
+                        [new TextMessage { Role = Role.User, Text = prompt }], ct: linkedCts.Token);
                 }
                 finally
                 {
@@ -482,7 +486,10 @@ public sealed class SubAgentManager : IAsyncDisposable
 
             state.Cts.Dispose();
 
-            if (state.HasDisposedOwnedProviderAgent)
+            // Rebuild the provider pipeline when the previous run's owned provider was disposed at
+            // completion OR its terminal disposal FAILED (poisoned): in both cases the provider must not
+            // be reused — a failed disposal may have left it partially torn down.
+            if (state.HasDisposedOwnedProviderAgent || state.OwnedProviderTerminalDisposeFailed)
             {
                 var previousAgent = state.Agent;
                 var previousStore = state.Store;
@@ -520,6 +527,23 @@ public sealed class SubAgentManager : IAsyncDisposable
                     }
                 }
 
+                // If the previous terminal disposal FAILED (poisoned), retry disposing that provider
+                // before swapping in the replacement so the partially-disposed instance isn't leaked.
+                // The disposal guard reset to Idle on the earlier failure, so this genuinely retries;
+                // when it had been cleanly disposed the flag is false and this block is skipped.
+                if (state.OwnedProviderTerminalDisposeFailed)
+                {
+                    try { await state.DisposeOwnedProviderAgentAsync(); }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(
+                            ex,
+                            "Retry dispose of poisoned owned provider failed before restart for sub-agent {AgentId}",
+                            state.AgentId
+                        );
+                    }
+                }
+
                 state.Agent = replacementAgent;
                 state.Store = replacementStore;
                 state.SetOwnedProviderAgent(replacementOwnedProviderAgent);
@@ -537,6 +561,12 @@ public sealed class SubAgentManager : IAsyncDisposable
             state.Cts = new CancellationTokenSource();
             var cts = state.Cts;
 
+            // Re-arm the lifecycle cancellation and open a new run generation for this epoch BEFORE the
+            // restarted loop can report completion, so (a) injects into the new run link a fresh token
+            // and (b) the Running publish below is generation-guarded against a fast completion.
+            state.ResetLifecycleCts();
+            var runGeneration = state.BeginRunGeneration();
+
             state.RunTask = state.Agent.RunAsync(cts.Token);
 
             // Re-subscribe BEFORE sending to avoid subscribe-after-send race
@@ -545,7 +575,11 @@ public sealed class SubAgentManager : IAsyncDisposable
             _ = await state.Agent.SendAsync(
                 [new TextMessage { Role = Role.User, Text = prompt }], ct: ct);
 
-            state.Status = SubAgentStatus.Running;
+            // Publish Running as the final step of the restart transition, but skip it if the restarted
+            // run already completed-and-disposed (a fast run can finish before this line executes):
+            // resurrecting a terminal run to Running would let the next continuation inject through a
+            // provider that terminal handling has already disposed.
+            _ = state.TryArmRunning(runGeneration);
 
             _logger.LogInformation(
                 "Resumed sub-agent {AgentId} with message: {Message}",
@@ -1093,12 +1127,18 @@ public sealed class SubAgentManager : IAsyncDisposable
                 {
                     state.LastResult = lastTextContent;
 
-                    // Release the slot BEFORE the (possibly slow/backpressured) parent
-                    // relay in HandleRunCompletionAsync: the run itself is done, so a
-                    // blocked SendToParentAsync must not hold up a fresh sub-agent spawn
-                    // that's waiting on the concurrency gate. Idempotent, so the fallback
-                    // release in the finally block below is a safe no-op afterward.
-                    gateGuard.ReleaseOnce(_concurrencyGate);
+                    // Release the slot BEFORE the (possibly slow/backpressured) parent relay in
+                    // HandleRunCompletionAsync — but ONLY for a TERMINAL completion. A nonterminal
+                    // (HasPendingMessages) completion keeps the SAME loop/provider busy processing queued
+                    // work, so releasing its permit now would let another sub-agent start while this one
+                    // is still active, exceeding MaxConcurrentSubAgents. The permit is held until the run
+                    // truly ends: the terminal completion here, or the monitor's finally if the stream
+                    // ends first. Idempotent, so that fallback release is a safe no-op afterward.
+                    if (!rcm.HasPendingMessages)
+                    {
+                        gateGuard.ReleaseOnce(_concurrencyGate);
+                    }
+
                     await HandleRunCompletionAsync(state, rcm, lastTextContent);
                     lastTextContent = null;
                     textGenerationId = null;
@@ -1175,6 +1215,10 @@ public sealed class SubAgentManager : IAsyncDisposable
             try { await state.DisposeOwnedProviderAgentAsync(); }
             catch (Exception ex)
             {
+                // Poison the run's provider: a continuation must rebuild a fresh one rather than reuse
+                // this partially-disposed instance (the restart path retries disposing it). Clearing the
+                // terminating flag below still lets a restart proceed — but against a fresh provider.
+                state.MarkOwnedProviderTerminalDisposeFailed();
                 _logger.LogWarning(
                     ex,
                     "Provider dispose failed at completion for sub-agent {AgentId}",

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -656,6 +656,11 @@ public sealed class SubAgentManager : IAsyncDisposable
                 });
             providerAgent = provider.Agent;
 
+            if (provider.UseParentModel && defaultOptions is not null)
+            {
+                defaultOptions = defaultOptions with { ModelId = _parentModelId ?? string.Empty };
+            }
+
             if (provider.ExtraProperties.Count > 0)
             {
                 var requestExtraProperties =

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -31,9 +31,10 @@ public sealed class SubAgentManager : IAsyncDisposable
     private readonly ConcurrentDictionary<string, SubAgentState> _agents = new();
     private readonly ConcurrentDictionary<string, string> _namesToIds = new();
     private readonly SemaphoreSlim _concurrencyGate;
+    private int _disposeStarted;
 
     /// <summary>
-    /// Test-only seam: when set, <see cref="CreateSubAgent"/> returns this factory's
+    /// Test-only seam: when set, <see cref="CreateSubAgentAsync"/> returns this factory's
     /// <see cref="IMultiTurnAgent"/> instead of building a real <see cref="MultiTurnAgentLoop"/>,
     /// so a unit test can substitute a fake agent (e.g. one whose <c>SubscribeAsync</c> throws a
     /// non-cancellation exception) while still going through the real <see cref="SpawnAsync"/>/
@@ -123,7 +124,13 @@ public sealed class SubAgentManager : IAsyncDisposable
 
         try
         {
-            var agent = CreateSubAgent(agentId, template, model, addTools, removeTools, out var store);
+            var (agent, store, ownedProviderAgent) = await CreateSubAgentAsync(
+                agentId,
+                template,
+                model,
+                addTools,
+                removeTools
+            );
 
             state = new SubAgentState
             {
@@ -131,10 +138,15 @@ public sealed class SubAgentManager : IAsyncDisposable
                 TemplateName = templateName,
                 Task = task,
                 Agent = agent,
+                Template = template,
+                ModelOverride = model,
+                AddTools = addTools,
+                RemoveTools = removeTools,
                 Store = store,
                 Name = name,
                 NotifyParentOnCompletion = runInBackground,
             };
+            state.SetOwnedProviderAgent(ownedProviderAgent);
 
             _agents[agentId] = state;
             if (!string.IsNullOrWhiteSpace(name))
@@ -267,6 +279,32 @@ public sealed class SubAgentManager : IAsyncDisposable
             }
         }
 
+        try { await state.Agent.DisposeAsync(); }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Agent dispose failed during spawn cleanup for sub-agent {AgentId}", agentId);
+        }
+
+        try { await state.DisposeOwnedProviderAgentAsync(); }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Provider dispose failed during spawn cleanup for sub-agent {AgentId}",
+                agentId
+            );
+        }
+
+        state.Cts.Dispose();
+        if (state.Store is IAsyncDisposable disposableStore)
+        {
+            try { await disposableStore.DisposeAsync(); }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Store dispose failed during spawn cleanup for sub-agent {AgentId}", agentId);
+            }
+        }
+
         gateGuard.ReleaseOnce(_concurrencyGate);
     }
 
@@ -370,13 +408,6 @@ public sealed class SubAgentManager : IAsyncDisposable
 
         try
         {
-            // Recover conversation history if a store is available
-            if (state.Store != null
-                && state.Agent is MultiTurnAgentBase agentBase)
-            {
-                _ = await agentBase.RecoverAsync();
-            }
-
             // Cancel and dispose the old CTS to prevent double-monitor bugs:
             // the old monitor's closure captured the old CTS, and both monitors
             // would receive RunCompletedMessage causing double Release/Decrement.
@@ -405,6 +436,57 @@ public sealed class SubAgentManager : IAsyncDisposable
             }
 
             state.Cts.Dispose();
+
+            if (state.HasDisposedOwnedProviderAgent)
+            {
+                var previousAgent = state.Agent;
+                var previousStore = state.Store;
+                var (replacementAgent, replacementStore, replacementOwnedProviderAgent) = await CreateSubAgentAsync(
+                    state.AgentId,
+                    state.Template,
+                    state.ModelOverride,
+                    state.AddTools,
+                    state.RemoveTools
+                );
+
+                try { await previousAgent.DisposeAsync(); }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Completed agent dispose failed before restart for sub-agent {AgentId}",
+                        state.AgentId
+                    );
+                }
+
+                if (
+                    previousStore is IAsyncDisposable disposablePreviousStore
+                    && !ReferenceEquals(previousStore, replacementStore)
+                )
+                {
+                    try { await disposablePreviousStore.DisposeAsync(); }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(
+                            ex,
+                            "Completed store dispose failed before restart for sub-agent {AgentId}",
+                            state.AgentId
+                        );
+                    }
+                }
+
+                state.Agent = replacementAgent;
+                state.Store = replacementStore;
+                state.SetOwnedProviderAgent(replacementOwnedProviderAgent);
+            }
+
+            // Recover conversation history after replacing a completed owned-provider loop, so a
+            // continuation uses the fresh provider pipeline while retaining persisted context.
+            if (state.Store != null
+                && state.Agent is MultiTurnAgentBase agentBase)
+            {
+                _ = await agentBase.RecoverAsync();
+            }
 
             // Create new CTS and start the loop again
             state.Cts = new CancellationTokenSource();
@@ -458,6 +540,22 @@ public sealed class SubAgentManager : IAsyncDisposable
                 {
                     _logger.LogWarning(ex, "MonitorTask faulted during restart cleanup for sub-agent {AgentId}", state.AgentId);
                 }
+            }
+
+            try { await state.Agent.DisposeAsync(); }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Agent dispose failed during restart cleanup for sub-agent {AgentId}", state.AgentId);
+            }
+
+            try { await state.DisposeOwnedProviderAgentAsync(); }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Provider dispose failed during restart cleanup for sub-agent {AgentId}",
+                    state.AgentId
+                );
             }
 
             // Idempotent: a no-op if the (now-observed) monitor's own finally already
@@ -557,6 +655,11 @@ public sealed class SubAgentManager : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        if (Interlocked.Exchange(ref _disposeStarted, 1) != 0)
+        {
+            return;
+        }
+
         foreach (var (_, state) in _agents)
         {
             // Each step is isolated to prevent cascading failures:
@@ -600,6 +703,12 @@ public sealed class SubAgentManager : IAsyncDisposable
                 _logger.LogWarning(ex, "DisposeAsync failed for sub-agent {AgentId}", state.AgentId);
             }
 
+            try { await state.DisposeOwnedProviderAgentAsync(); }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Provider dispose failed for sub-agent {AgentId}", state.AgentId);
+            }
+
             try { state.Cts.Dispose(); }
             catch (Exception ex)
             {
@@ -624,94 +733,123 @@ public sealed class SubAgentManager : IAsyncDisposable
     /// <summary>
     /// Creates a MultiTurnAgentLoop configured for a sub-agent with filtered tools.
     /// </summary>
-    private IMultiTurnAgent CreateSubAgent(
+    private async Task<(IMultiTurnAgent Agent, IConversationStore? Store, IStreamingAgent? OwnedProviderAgent)> CreateSubAgentAsync(
         string agentId,
         SubAgentTemplate template,
         string? modelOverride,
         string[]? addTools,
-        string[]? removeTools,
-        out IConversationStore? store)
+        string[]? removeTools)
     {
         if (TestAgentFactoryOverride != null)
         {
-            store = null;
-            return TestAgentFactoryOverride(agentId, template);
+            return (TestAgentFactoryOverride(agentId, template), null, null);
         }
 
         // Resolve the sub-agent's options with model inheritance (override > template > parent).
         var defaultOptions = ResolveSubAgentOptions(template.DefaultOptions, modelOverride, _parentModelId);
         IStreamingAgent providerAgent;
+        IStreamingAgent? ownedProviderAgent = null;
+        IConversationStore? store = null;
 
-        if (template.CharacteristicsAgentFactory is { } characteristicsFactory)
+        try
         {
-            var modelId = string.IsNullOrWhiteSpace(defaultOptions?.ModelId)
-                ? null
-                : defaultOptions.ModelId;
-            var provider = characteristicsFactory(
-                new SubAgentCharacteristics(modelId, template.Effort)
+            if (template.CharacteristicsAgentFactory is { } characteristicsFactory)
+            {
+                var modelId = string.IsNullOrWhiteSpace(defaultOptions?.ModelId)
+                    ? null
+                    : defaultOptions.ModelId;
+                var provider = characteristicsFactory(
+                    new SubAgentCharacteristics(modelId, template.Effort)
+                    {
+                        IsModelExplicitlySelected =
+                            !string.IsNullOrWhiteSpace(modelOverride)
+                            || template.IsModelExplicitlySelected,
+                        IsModelTierResolved = template.IsModelTierResolved,
+                    });
+                providerAgent = provider.Agent;
+                ownedProviderAgent = provider.OwnsAgent ? provider.Agent : null;
+
+                if (provider.UseParentModel && defaultOptions is not null)
                 {
-                    IsModelExplicitlySelected =
-                        !string.IsNullOrWhiteSpace(modelOverride)
-                        || template.IsModelExplicitlySelected,
-                });
-            providerAgent = provider.Agent;
+                    defaultOptions = defaultOptions with { ModelId = _parentModelId ?? string.Empty };
+                }
 
-            if (provider.UseParentModel && defaultOptions is not null)
-            {
-                defaultOptions = defaultOptions with { ModelId = _parentModelId ?? string.Empty };
-            }
-
-            if (provider.ExtraProperties.Count > 0)
-            {
-                var requestExtraProperties =
-                    defaultOptions?.ExtraProperties
-                    ?? ImmutableDictionary<string, object?>.Empty;
-                defaultOptions = (defaultOptions ?? new GenerateReplyOptions()) with
+                if (provider.ExtraProperties.Count > 0)
                 {
-                    ExtraProperties = provider.ExtraProperties.SetItems(requestExtraProperties),
-                };
+                    var requestExtraProperties =
+                        defaultOptions?.ExtraProperties
+                        ?? ImmutableDictionary<string, object?>.Empty;
+                    defaultOptions = (defaultOptions ?? new GenerateReplyOptions()) with
+                    {
+                        // Template/request values intentionally win over generated reasoning metadata.
+                        ExtraProperties = provider.ExtraProperties.SetItems(requestExtraProperties),
+                    };
+                }
             }
-        }
-        else
-        {
-            providerAgent = template.AgentFactory();
-        }
-
-        // Determine conversation store
-        var storeFactory =
-            template.ConversationStoreFactory
-            ?? _options.DefaultConversationStoreFactory;
-        store = storeFactory?.Invoke($"subagent-{agentId}");
-
-        // Build a fresh FunctionRegistry with filtered parent tools
-        var registry = new FunctionRegistry();
-        var enabledSet = BuildEnabledToolSet(
-            template.EnabledTools, addTools, removeTools);
-
-        foreach (var contract in _parentContracts)
-        {
-            if (enabledSet != null && !enabledSet.Contains(contract.Name))
+            else
             {
-                continue;
+                providerAgent = template.AgentFactory();
             }
 
-            if (!_parentHandlers.TryGetValue(contract.Name, out var handler))
+            // Determine conversation store
+            var storeFactory =
+                template.ConversationStoreFactory
+                ?? _options.DefaultConversationStoreFactory;
+            store = storeFactory?.Invoke($"subagent-{agentId}");
+
+            // Build a fresh FunctionRegistry with filtered parent tools
+            var registry = new FunctionRegistry();
+            var enabledSet = BuildEnabledToolSet(
+                template.EnabledTools, addTools, removeTools);
+
+            foreach (var contract in _parentContracts)
             {
-                continue;
+                if (enabledSet != null && !enabledSet.Contains(contract.Name))
+                {
+                    continue;
+                }
+
+                if (!_parentHandlers.TryGetValue(contract.Name, out var handler))
+                {
+                    continue;
+                }
+
+                _ = registry.AddFunction(contract, handler, "ParentTools");
             }
 
-            _ = registry.AddFunction(contract, handler, "ParentTools");
+            return (
+                new MultiTurnAgentLoop(
+                    providerAgent,
+                    registry,
+                    threadId: $"subagent-{agentId}",
+                    systemPrompt: template.SystemPrompt,
+                    defaultOptions: defaultOptions,
+                    maxTurnsPerRun: template.MaxTurnsPerRun,
+                    store: store,
+                    logger: _logger is NullLogger ? null : new SubAgentLoopLoggerAdapter(_logger)
+                ),
+                store,
+                ownedProviderAgent
+            );
         }
+        catch
+        {
+            if (store is IAsyncDisposable disposableStore)
+            {
+                await disposableStore.DisposeAsync();
+            }
 
-        return new MultiTurnAgentLoop(
-            providerAgent,
-            registry,
-            threadId: $"subagent-{agentId}",
-            systemPrompt: template.SystemPrompt,
-            defaultOptions: defaultOptions,
-            maxTurnsPerRun: template.MaxTurnsPerRun,
-            store: store,
-            logger: _logger is NullLogger ? null : new SubAgentLoopLoggerAdapter(_logger));
+            if (ownedProviderAgent is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync();
+            }
+            else if (ownedProviderAgent is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+
+            throw;
+        }
     }
 
     /// <summary>
@@ -936,6 +1074,19 @@ public sealed class SubAgentManager : IAsyncDisposable
         // The concurrency slot is released by the monitor (via its GateReleaseGuard), exactly
         // once per gate-acquisition epoch — not here, because a single monitor may handle
         // several completions when a background sub-agent is continued in place via SendMessage.
+        // An explicit/tier provider is scoped to a single completed run. Dispose it before any
+        // completion relay can block; a later continuation recreates its loop and provider through
+        // the same characteristics factory, while borrowed parent/template agents remain untouched.
+        try { await state.DisposeOwnedProviderAgentAsync(); }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Provider dispose failed at completion for sub-agent {AgentId}",
+                state.AgentId
+            );
+        }
+
         if (rcm.IsError)
         {
             state.Status = SubAgentStatus.Error;
@@ -978,6 +1129,7 @@ public sealed class SubAgentManager : IAsyncDisposable
                 await SendToParentAsync(state, resultText);
             }
         }
+
     }
 
     /// <summary>

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -368,12 +368,14 @@ public sealed class SubAgentManager : IAsyncDisposable
                         _ = await state.Agent.SendAsync(
                             [new TextMessage { Role = Role.User, Text = prompt }], ct: linkedCts.Token);
                     }
-                    catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+                    catch (OperationCanceledException) when (!ct.IsCancellationRequested && linkedCts.IsCancellationRequested)
                     {
-                        // The send was cancelled by the run's LIFECYCLE token (terminal disposal began),
-                        // NOT by the caller: the loop we injected into is finishing. Re-evaluate the
-                        // continuation so the prompt is delivered to the restarted run instead of
-                        // surfacing a spurious cancellation to the user and dropping their message.
+                        // The send was cancelled specifically by the run's LIFECYCLE token (terminal
+                        // disposal began) — NOT by the caller, and NOT an internal SendAsync
+                        // timeout/cancellation unrelated to either supplied token (which must propagate
+                        // rather than be retried, to avoid duplicate delivery / an unbounded retry loop).
+                        // The loop we injected into is finishing, so re-evaluate the continuation to
+                        // deliver the prompt to the restarted run instead of dropping the user's message.
                         injectCancelledByLifecycle = true;
                     }
                 }

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -49,6 +49,15 @@ public sealed class SubAgentManager : IAsyncDisposable
     /// </summary>
     internal Func<string, SubAgentTemplate, IMultiTurnAgent>? TestAgentFactoryOverride { get; set; }
 
+    /// <summary>
+    /// Test-only companion to <see cref="TestAgentFactoryOverride"/>: when set, supplies the OWNED
+    /// provider agent returned alongside the fake loop, so a unit test can exercise the real
+    /// owned-provider disposal lifecycle (completion disposal, pending-message deferral, restart
+    /// recreation) that the plain <see cref="TestAgentFactoryOverride"/> path — which returns a null
+    /// owned provider — cannot. Null (the default) keeps the fake loop's owned provider null.
+    /// </summary>
+    internal Func<string, SubAgentTemplate, IStreamingAgent?>? TestOwnedProviderOverride { get; set; }
+
     public SubAgentManager(
         IMultiTurnAgent parentAgent,
         IReadOnlyList<FunctionContract> parentContracts,
@@ -324,31 +333,62 @@ public sealed class SubAgentManager : IAsyncDisposable
         var agentId = ResolveAgentId(target);
         var state = _agents[agentId];
 
-        // Read running-vs-finished AND record the relay preference atomically against a concurrent
-        // terminal completion. A completion flips the status out of Running (SubAgentState.MarkTerminal)
-        // BEFORE disposing the owned provider, so serializing this decision on the same lifecycle lock
-        // guarantees we never take the "inject into the running loop" branch in the instant the
-        // provider is being disposed — a finished agent falls through to RestartRunAsync, which
-        // recreates a fresh provider.
-        var wasRunning = state.TryBeginRunningContinuation(runInBackground);
-
-        // A finished completion is replaced so this run can be awaited fresh; a pending
-        // one (running agent) is kept so existing waiters observe the next resolution.
-        state.ResetCompletionIfFinished();
-
-        if (wasRunning)
+        // Decide how to continue this sub-agent atomically against a concurrent terminal completion and
+        // any other concurrent continuation. An admitted "inject into the running loop" holds a send
+        // lease that a terminal owned-provider disposal awaits, so a send can never race the provider
+        // being disposed; a finished run is restarted with a fresh provider by exactly ONE caller (any
+        // others await that restart and then inject into the re-armed loop). See
+        // SubAgentState.BeginContinuation.
+        bool wasRunning;
+        while (true)
         {
-            // Inject the message into the currently running agent.
-            _ = await state.Agent.SendAsync(
-                [new TextMessage { Role = Role.User, Text = prompt }], ct: ct);
+            var decision = state.BeginContinuation(runInBackground);
 
-            _logger.LogInformation(
-                "Sent message to running sub-agent {AgentId}: {Message}",
-                agentId, Truncate(prompt, 100));
-        }
-        else
-        {
-            await RestartRunAsync(state, prompt, ct);
+            if (decision.Mode == ContinuationMode.Inject)
+            {
+                // A finished completion is replaced so this run can be awaited fresh; a pending one
+                // (running agent) is kept so existing waiters observe the next resolution.
+                state.ResetCompletionIfFinished();
+
+                try
+                {
+                    // Inject the message into the currently running agent while holding the send lease.
+                    _ = await state.Agent.SendAsync(
+                        [new TextMessage { Role = Role.User, Text = prompt }], ct: ct);
+                }
+                finally
+                {
+                    state.EndInjectLease();
+                }
+
+                _logger.LogInformation(
+                    "Sent message to running sub-agent {AgentId}: {Message}",
+                    agentId, Truncate(prompt, 100));
+
+                wasRunning = true;
+                break;
+            }
+
+            if (decision.Mode == ContinuationMode.Restart)
+            {
+                state.ResetCompletionIfFinished();
+
+                try
+                {
+                    await RestartRunAsync(state, prompt, ct);
+                }
+                finally
+                {
+                    state.EndRestart();
+                }
+
+                wasRunning = false;
+                break;
+            }
+
+            // AwaitRestart: another caller owns the in-flight restart. Wait for it to finish, then
+            // re-evaluate — the restart flips the loop back to Running, so the retry injects into it.
+            await decision.RestartCompleted!.WaitAsync(ct);
         }
 
         if (runInBackground)
@@ -747,7 +787,10 @@ public sealed class SubAgentManager : IAsyncDisposable
     {
         if (TestAgentFactoryOverride != null)
         {
-            return (TestAgentFactoryOverride(agentId, template), null, null);
+            return (
+                TestAgentFactoryOverride(agentId, template),
+                null,
+                TestOwnedProviderOverride?.Invoke(agentId, template));
         }
 
         // Resolve the sub-agent's options with model inheritance (override > template > parent).
@@ -1114,10 +1157,11 @@ public sealed class SubAgentManager : IAsyncDisposable
         }
 
         // Transition out of Running BEFORE disposing the owned provider, atomically against a
-        // concurrent SendMessageAsync (see SubAgentState.TryBeginRunningContinuation). Once terminal,
-        // a racing continuation observes the finished status and takes the restart path (which
-        // recreates a fresh provider) instead of injecting into the provider being disposed.
-        state.MarkTerminal(rcm.IsError);
+        // concurrent SendMessageAsync (see SubAgentState.BeginContinuation). This blocks new inject
+        // admissions and waits for any in-flight admitted send to finish, so the disposal below can
+        // never overlap a send through the provider; a racing continuation then observes the finished
+        // status and takes the restart path (which recreates a fresh provider).
+        await state.BeginTerminalDisposalAsync(rcm.IsError);
 
         // The concurrency slot is released by the monitor (via its GateReleaseGuard), exactly
         // once per gate-acquisition epoch — not here, because a single monitor may handle
@@ -1125,14 +1169,22 @@ public sealed class SubAgentManager : IAsyncDisposable
         // An explicit/tier provider is scoped to a single completed run. Dispose it before any
         // completion relay can block; a later continuation recreates its loop and provider through
         // the same characteristics factory, while borrowed parent/template agents remain untouched.
-        try { await state.DisposeOwnedProviderAgentAsync(); }
-        catch (Exception ex)
+        // EndTerminalDisposal clears the terminating flag so a later restart's re-arm admits injects.
+        try
         {
-            _logger.LogWarning(
-                ex,
-                "Provider dispose failed at completion for sub-agent {AgentId}",
-                state.AgentId
-            );
+            try { await state.DisposeOwnedProviderAgentAsync(); }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Provider dispose failed at completion for sub-agent {AgentId}",
+                    state.AgentId
+                );
+            }
+        }
+        finally
+        {
+            state.EndTerminalDisposal();
         }
 
         if (rcm.IsError)

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -324,8 +324,13 @@ public sealed class SubAgentManager : IAsyncDisposable
         var agentId = ResolveAgentId(target);
         var state = _agents[agentId];
 
-        var wasRunning = state.Status == SubAgentStatus.Running;
-        state.NotifyParentOnCompletion = runInBackground;
+        // Read running-vs-finished AND record the relay preference atomically against a concurrent
+        // terminal completion. A completion flips the status out of Running (SubAgentState.MarkTerminal)
+        // BEFORE disposing the owned provider, so serializing this decision on the same lifecycle lock
+        // guarantees we never take the "inject into the running loop" branch in the instant the
+        // provider is being disposed — a finished agent falls through to RestartRunAsync, which
+        // recreates a fresh provider.
+        var wasRunning = state.TryBeginRunningContinuation(runInBackground);
 
         // A finished completion is replaced so this run can be awaited fresh; a pending
         // one (running agent) is kept so existing waiters observe the next resolution.
@@ -834,21 +839,50 @@ public sealed class SubAgentManager : IAsyncDisposable
         }
         catch
         {
+            // Roll back partial construction. Attempt each cleanup INDEPENDENTLY so a failure in one
+            // (e.g. store disposal throwing) does not skip the other (provider disposal), and let the
+            // ORIGINAL construction exception propagate — cleanup failures are logged, never rethrown,
+            // so they can't mask the real cause.
             if (store is IAsyncDisposable disposableStore)
             {
-                await disposableStore.DisposeAsync();
+                try { await disposableStore.DisposeAsync(); }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Store dispose failed while rolling back sub-agent {AgentId} construction",
+                        agentId
+                    );
+                }
             }
 
-            if (ownedProviderAgent is IAsyncDisposable asyncDisposable)
+            try { await DisposeProviderAgentAsync(ownedProviderAgent); }
+            catch (Exception ex)
             {
-                await asyncDisposable.DisposeAsync();
-            }
-            else if (ownedProviderAgent is IDisposable disposable)
-            {
-                disposable.Dispose();
+                _logger.LogWarning(
+                    ex,
+                    "Provider dispose failed while rolling back sub-agent {AgentId} construction",
+                    agentId
+                );
             }
 
             throw;
+        }
+    }
+
+    /// <summary>
+    /// Disposes a provider agent regardless of whether it exposes async or synchronous disposal.
+    /// No-op when <paramref name="provider"/> is null or implements neither disposal interface.
+    /// </summary>
+    private static async ValueTask DisposeProviderAgentAsync(IStreamingAgent? provider)
+    {
+        if (provider is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync();
+        }
+        else if (provider is IDisposable disposable)
+        {
+            disposable.Dispose();
         }
     }
 
@@ -1071,6 +1105,20 @@ public sealed class SubAgentManager : IAsyncDisposable
         RunCompletedMessage rcm,
         string? lastTextContent)
     {
+        // A run that still has queued messages is NOT terminal: another run will follow and reuse the
+        // same loop/provider, so neither flip the sub-agent terminal nor dispose its owned provider
+        // here — the final completion (HasPendingMessages == false) resolves and, if owned, disposes.
+        if (rcm.HasPendingMessages)
+        {
+            return;
+        }
+
+        // Transition out of Running BEFORE disposing the owned provider, atomically against a
+        // concurrent SendMessageAsync (see SubAgentState.TryBeginRunningContinuation). Once terminal,
+        // a racing continuation observes the finished status and takes the restart path (which
+        // recreates a fresh provider) instead of injecting into the provider being disposed.
+        state.MarkTerminal(rcm.IsError);
+
         // The concurrency slot is released by the monitor (via its GateReleaseGuard), exactly
         // once per gate-acquisition epoch — not here, because a single monitor may handle
         // several completions when a background sub-agent is continued in place via SendMessage.
@@ -1089,8 +1137,6 @@ public sealed class SubAgentManager : IAsyncDisposable
 
         if (rcm.IsError)
         {
-            state.Status = SubAgentStatus.Error;
-
             var errorText =
                 $"<sub-agent name=\"{state.TemplateName}\" " +
                 $"id=\"{state.AgentId}\">\n" +
@@ -1111,8 +1157,6 @@ public sealed class SubAgentManager : IAsyncDisposable
         }
         else
         {
-            state.Status = SubAgentStatus.Completed;
-
             var result = lastTextContent ?? "(no text response)";
 
             var resultText =

--- a/src/LmMultiTurn/SubAgents/SubAgentProviderAgent.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentProviderAgent.cs
@@ -1,0 +1,11 @@
+using System.Collections.Immutable;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+
+/// <summary>
+/// Provider agent and provider-specific request properties produced for a sub-agent spawn.
+/// </summary>
+public sealed record SubAgentProviderAgent(
+    IStreamingAgent Agent,
+    ImmutableDictionary<string, object?> ExtraProperties);

--- a/src/LmMultiTurn/SubAgents/SubAgentProviderAgent.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentProviderAgent.cs
@@ -6,6 +6,66 @@ namespace AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 /// <summary>
 /// Provider agent and provider-specific request properties produced for a sub-agent spawn.
 /// </summary>
-public sealed record SubAgentProviderAgent(
-    IStreamingAgent Agent,
-    ImmutableDictionary<string, object?> ExtraProperties);
+public sealed record SubAgentProviderAgent
+{
+    private IStreamingAgent _agent = null!;
+    private ImmutableDictionary<string, object?> _extraProperties = null!;
+
+    /// <summary>
+    /// Initializes a provider-agent routing result.
+    /// </summary>
+    /// <param name="Agent">The provider agent selected for the spawn.</param>
+    /// <param name="ExtraProperties">Provider request hints to merge into the spawn options.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="Agent"/> or <paramref name="ExtraProperties"/> is null.
+    /// </exception>
+    public SubAgentProviderAgent(
+        IStreamingAgent Agent,
+        ImmutableDictionary<string, object?> ExtraProperties)
+    {
+        ArgumentNullException.ThrowIfNull(Agent);
+        ArgumentNullException.ThrowIfNull(ExtraProperties);
+
+        this.Agent = Agent;
+        this.ExtraProperties = ExtraProperties;
+    }
+
+    /// <summary>The provider agent selected for the spawn.</summary>
+    public IStreamingAgent Agent
+    {
+        get => _agent;
+        init
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            _agent = value;
+        }
+    }
+
+    /// <summary>Opaque provider request hints merged into the spawn's request options.</summary>
+    public ImmutableDictionary<string, object?> ExtraProperties
+    {
+        get => _extraProperties;
+        init
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            _extraProperties = value;
+        }
+    }
+
+    /// <summary>
+    /// Whether request options should restore the parent model id. This is used when routing falls
+    /// back from an unsupported explicit model to the parent provider agent.
+    /// </summary>
+    public bool UseParentModel { get; init; }
+
+    /// <summary>Deconstructs the result into its compatibility-preserving positional values.</summary>
+    /// <param name="agent">Receives <see cref="Agent"/>.</param>
+    /// <param name="extraProperties">Receives <see cref="ExtraProperties"/>.</param>
+    public void Deconstruct(
+        out IStreamingAgent agent,
+        out ImmutableDictionary<string, object?> extraProperties)
+    {
+        agent = Agent;
+        extraProperties = ExtraProperties;
+    }
+}

--- a/src/LmMultiTurn/SubAgents/SubAgentProviderAgent.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentProviderAgent.cs
@@ -16,16 +16,13 @@ public sealed record SubAgentProviderAgent
     /// </summary>
     /// <param name="Agent">The provider agent selected for the spawn.</param>
     /// <param name="ExtraProperties">Provider request hints to merge into the spawn options.</param>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="Agent"/> or <paramref name="ExtraProperties"/> is null.
-    /// </exception>
     public SubAgentProviderAgent(
         IStreamingAgent Agent,
-        ImmutableDictionary<string, object?> ExtraProperties)
+        ImmutableDictionary<string, object?> ExtraProperties
+    )
     {
         ArgumentNullException.ThrowIfNull(Agent);
         ArgumentNullException.ThrowIfNull(ExtraProperties);
-
         this.Agent = Agent;
         this.ExtraProperties = ExtraProperties;
     }
@@ -53,19 +50,15 @@ public sealed record SubAgentProviderAgent
     }
 
     /// <summary>
+    /// Whether the spawned sub-agent owns <see cref="Agent"/> and must dispose it when the
+    /// sub-agent is disposed. Borrowed parent/template agents leave this false.
+    /// </summary>
+    public bool OwnsAgent { get; init; }
+
+    /// <summary>
     /// Whether request options should restore the parent model id. This is used when routing falls
     /// back from an unsupported explicit model to the parent provider agent.
     /// </summary>
     public bool UseParentModel { get; init; }
 
-    /// <summary>Deconstructs the result into its compatibility-preserving positional values.</summary>
-    /// <param name="agent">Receives <see cref="Agent"/>.</param>
-    /// <param name="extraProperties">Receives <see cref="ExtraProperties"/>.</param>
-    public void Deconstruct(
-        out IStreamingAgent agent,
-        out ImmutableDictionary<string, object?> extraProperties)
-    {
-        agent = Agent;
-        extraProperties = ExtraProperties;
-    }
 }

--- a/src/LmMultiTurn/SubAgents/SubAgentState.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentState.cs
@@ -350,6 +350,21 @@ internal class SubAgentState
     }
 
     /// <summary>
+    /// The current run generation (0 for the initial spawn; incremented by each restart). Read when
+    /// starting a run's monitor so the monitor's fault path can record a generation-aware terminal.
+    /// </summary>
+    public long CurrentRunGeneration
+    {
+        get
+        {
+            lock (_lifecycleLock)
+            {
+                return _runGeneration;
+            }
+        }
+    }
+
+    /// <summary>
     /// Publishes <see cref="SubAgentStatus.Running"/> for <paramref name="generation"/> UNLESS that run
     /// has already reached a terminal completion (its owned provider may already be disposed) — so a fast
     /// restarted run that completed before this publish executed is never resurrected to Running. Returns
@@ -366,6 +381,24 @@ internal class SubAgentState
 
             _status = SubAgentStatus.Running;
             return true;
+        }
+    }
+
+    /// <summary>
+    /// Records a terminal <see cref="SubAgentStatus.Error"/> for <paramref name="generation"/> through the
+    /// SAME generation-aware transition as a graceful terminal completion, so a racing restart's
+    /// <see cref="TryArmRunning"/> cannot resurrect a monitor-faulted run back to Running. Applied only
+    /// while that generation is still the current run (a newer restart supersedes an older run's fault).
+    /// </summary>
+    public void MarkRunFaulted(long generation)
+    {
+        lock (_lifecycleLock)
+        {
+            if (_runGeneration == generation)
+            {
+                _terminalGeneration = generation;
+                _status = SubAgentStatus.Error;
+            }
         }
     }
 

--- a/src/LmMultiTurn/SubAgents/SubAgentState.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentState.cs
@@ -29,6 +29,29 @@ public record SubAgentTurnSummary
 }
 
 /// <summary>
+/// How a <c>SubAgentManager.SendMessageAsync</c> continuation must proceed, decided atomically by
+/// <see cref="SubAgentState.BeginContinuation"/> against a concurrent terminal completion and other
+/// concurrent continuations.
+/// </summary>
+internal enum ContinuationMode
+{
+    /// <summary>Inject into the still-running loop under a send lease that terminal disposal awaits.</summary>
+    Inject,
+
+    /// <summary>Restart the finished run with a fresh provider; this caller owns the restart.</summary>
+    Restart,
+
+    /// <summary>Another caller owns an in-flight restart; await it, then re-evaluate.</summary>
+    AwaitRestart,
+}
+
+/// <summary>
+/// Result of <see cref="SubAgentState.BeginContinuation"/>. For <see cref="ContinuationMode.AwaitRestart"/>,
+/// <see cref="RestartCompleted"/> completes when the owning restart finishes.
+/// </summary>
+internal readonly record struct ContinuationDecision(ContinuationMode Mode, Task? RestartCompleted);
+
+/// <summary>
 /// Mutable state tracker for a running sub-agent instance.
 /// Internal to the SubAgents module; not exposed to consumers.
 /// </summary>
@@ -64,12 +87,33 @@ internal class SubAgentState
     private int _ownedProviderDisposeState;
 
     /// <summary>
-    /// Serializes a genuine terminal completion's status flip + owned-provider disposal against a
-    /// concurrent <c>SubAgentManager.SendMessageAsync</c>. See <see cref="MarkTerminal"/> /
-    /// <see cref="TryBeginRunningContinuation"/>. Only synchronous work runs under this lock (no
-    /// awaits), so a blocking/backpressured send or a slow provider disposal can never deadlock it.
+    /// Guards the sub-agent lifecycle bookkeeping — the status transition, the outstanding inject-send
+    /// lease count, and the single-flight restart claim — so a continuation's admission decision, a
+    /// terminal owned-provider disposal, and a restart never interleave incorrectly. Only synchronous
+    /// work runs under this lock (no awaits), so a blocking/backpressured send or a slow provider
+    /// disposal can never deadlock it; the awaitable coordination is done via the drain/restart signals.
     /// </summary>
     private readonly object _lifecycleLock = new();
+
+    // Terminal owned-provider disposal is in progress. Once set (for an owned provider) no new
+    // inject-continuation is admitted — a concurrent SendMessage is routed to a fresh-provider restart
+    // instead of injecting into the provider being disposed.
+    private bool _terminating;
+
+    // Count of admitted inject-continuations whose SendAsync is still in flight. A terminal disposal
+    // waits for this to reach zero (via _sendLeasesDrained) so disposal can never overlap a send
+    // through the owned provider.
+    private int _activeSendLeases;
+    private TaskCompletionSource<bool>? _sendLeasesDrained;
+
+    // Single-flight restart claim. Exactly one caller restarts a finished run; concurrent continuations
+    // await _restartCompleted and then re-evaluate (the restart flips the loop back to Running, so they
+    // inject into it) — so two callers can never both enter RestartRunAsync.
+    private bool _restarting;
+    private TaskCompletionSource<bool>? _restartCompleted;
+
+    private static TaskCompletionSource<bool> NewLifecycleSignal() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     /// <summary>
     /// Optional caller-supplied handle so SendMessage can address this agent by name.
@@ -93,14 +137,117 @@ internal class SubAgentState
     public SubAgentStatus Status { get => _status; set => _status = value; }
 
     /// <summary>
-    /// Atomically flips the sub-agent out of <see cref="SubAgentStatus.Running"/> at a genuine
-    /// terminal completion, under <see cref="_lifecycleLock"/> so it is serialized against
-    /// <see cref="TryBeginRunningContinuation"/>. The manager disposes the owned provider only AFTER
-    /// this returns, so a concurrent SendMessage can never observe <see cref="SubAgentStatus.Running"/>
-    /// — and route a message into the loop — in the window where the provider is being disposed.
+    /// Decides — atomically against a concurrent terminal completion and other concurrent
+    /// continuations — how <c>SubAgentManager.SendMessageAsync</c> must continue this sub-agent, and
+    /// records the continuation's relay preference.
+    /// <list type="bullet">
+    /// <item><description><see cref="ContinuationMode.Inject"/>: the loop is running and no owned-provider
+    /// disposal is under way. A send lease is taken; the caller injects, then calls
+    /// <see cref="EndInjectLease"/>. A terminal disposal awaits this lease, so a send can never race the
+    /// provider being disposed.</description></item>
+    /// <item><description><see cref="ContinuationMode.Restart"/>: the run finished (or its owned provider
+    /// is being disposed). This caller owns the restart; it runs <c>RestartRunAsync</c> then calls
+    /// <see cref="EndRestart"/>.</description></item>
+    /// <item><description><see cref="ContinuationMode.AwaitRestart"/>: another caller already owns the
+    /// restart. The caller awaits <see cref="ContinuationDecision.RestartCompleted"/> and re-evaluates —
+    /// the restart flips the loop back to Running, so the retry injects into it.</description></item>
+    /// </list>
     /// </summary>
-    public void MarkTerminal(bool isError)
+    public ContinuationDecision BeginContinuation(bool notifyParentOnCompletion)
     {
+        lock (_lifecycleLock)
+        {
+            _notifyParentOnCompletion = notifyParentOnCompletion;
+
+            // Inject into the live loop only when it is genuinely running AND an owned-provider terminal
+            // disposal is not under way. Once disposal has begun for an owned provider, route to restart
+            // so we never inject through a provider that is being torn down.
+            if (_status == SubAgentStatus.Running && !(_terminating && OwnedProviderAgent is not null))
+            {
+                _activeSendLeases++;
+                return new ContinuationDecision(ContinuationMode.Inject, null);
+            }
+
+            if (_restarting)
+            {
+                _restartCompleted ??= NewLifecycleSignal();
+                return new ContinuationDecision(ContinuationMode.AwaitRestart, _restartCompleted.Task);
+            }
+
+            _restarting = true;
+            _restartCompleted = NewLifecycleSignal();
+            return new ContinuationDecision(ContinuationMode.Restart, null);
+        }
+    }
+
+    /// <summary>
+    /// Releases an inject send lease taken by <see cref="BeginContinuation"/> (call in a finally after
+    /// the inject SendAsync). When the last lease drains during a terminal disposal, the waiting
+    /// disposal is signalled so it can proceed.
+    /// </summary>
+    public void EndInjectLease()
+    {
+        lock (_lifecycleLock)
+        {
+            _activeSendLeases--;
+            if (_activeSendLeases == 0 && _sendLeasesDrained is not null)
+            {
+                _ = _sendLeasesDrained.TrySetResult(true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Releases the restart claim taken by <see cref="BeginContinuation"/> (call in a finally after
+    /// <c>RestartRunAsync</c>, success or failure) and wakes any continuations awaiting the restart so
+    /// they re-evaluate against the re-armed (or still-finished, on failure) status.
+    /// </summary>
+    public void EndRestart()
+    {
+        TaskCompletionSource<bool>? toSignal;
+        lock (_lifecycleLock)
+        {
+            _restarting = false;
+            toSignal = _restartCompleted;
+            _restartCompleted = null;
+        }
+
+        _ = toSignal?.TrySetResult(true);
+    }
+
+    /// <summary>
+    /// Begins a genuine terminal completion. Blocks new inject admissions (for an owned provider), waits
+    /// for any in-flight admitted send to finish so the imminent owned-provider disposal cannot overlap a
+    /// send through it, then flips the status terminal. The manager disposes the owned provider only
+    /// AFTER this returns; a continuation that arrives now observes the finished status (or the
+    /// disposing owned provider) and takes the restart path — recreating a fresh provider — instead of
+    /// injecting into the one being disposed.
+    /// </summary>
+    public async Task BeginTerminalDisposalAsync(bool isError)
+    {
+        Task? drain = null;
+        lock (_lifecycleLock)
+        {
+            _terminating = true;
+
+            // Only an owned provider is disposed at completion, so only then is there anything a send
+            // could race; wait for outstanding inject leases to drain before flipping terminal.
+            if (OwnedProviderAgent is not null && _activeSendLeases > 0)
+            {
+                _sendLeasesDrained = NewLifecycleSignal();
+                drain = _sendLeasesDrained.Task;
+            }
+        }
+
+        if (drain is not null)
+        {
+            await drain;
+            lock (_lifecycleLock)
+            {
+                _sendLeasesDrained = null;
+            }
+        }
+
         lock (_lifecycleLock)
         {
             _status = isError ? SubAgentStatus.Error : SubAgentStatus.Completed;
@@ -108,18 +255,14 @@ internal class SubAgentState
     }
 
     /// <summary>
-    /// Atomically reads whether the loop is currently running and records the continuation's relay
-    /// preference, under the same <see cref="_lifecycleLock"/> that guards <see cref="MarkTerminal"/>.
-    /// Returns true when the loop is running (the caller injects the message into it) and false when
-    /// it has finished (the caller restarts it, recreating a fresh provider), so the running-vs-finished
-    /// decision can never straddle a concurrent terminal completion that is about to dispose the provider.
+    /// Clears the terminal-disposal flag after the owned provider has been disposed (call in a finally),
+    /// so a subsequent restart's re-arm to Running admits injects again.
     /// </summary>
-    public bool TryBeginRunningContinuation(bool notifyParentOnCompletion)
+    public void EndTerminalDisposal()
     {
         lock (_lifecycleLock)
         {
-            _notifyParentOnCompletion = notifyParentOnCompletion;
-            return _status == SubAgentStatus.Running;
+            _terminating = false;
         }
     }
 

--- a/src/LmMultiTurn/SubAgents/SubAgentState.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentState.cs
@@ -112,6 +112,24 @@ internal class SubAgentState
     private bool _restarting;
     private TaskCompletionSource<bool>? _restartCompleted;
 
+    // Per-run lifecycle cancellation. Cancelled when a terminal owned-provider disposal begins so an
+    // admitted inject send that is wedged on a stalled channel/provider is unblocked (it links this
+    // token, not only the caller's) and its lease can drain — otherwise the terminal drain could wait
+    // forever on a caller token that never cancels. Re-armed per run epoch by ResetLifecycleCts.
+    private CancellationTokenSource _lifecycleCts = new();
+
+    // Set when a TERMINAL owned-provider disposal throws: the provider may be partially torn down, so a
+    // continuation must NOT reuse it — the restart path rebuilds a fresh provider (retrying disposal of
+    // this one) instead. Cleared when a fresh provider is assigned via SetOwnedProviderAgent.
+    private volatile bool _ownedProviderTerminalDisposeFailed;
+
+    // Monotonic run-instance counter. A restart opens a new generation (BeginRunGeneration) before the
+    // restarted loop can report completion; the terminal completion for that run records it in
+    // _terminalGeneration. The restart's own "arm Running" publish (TryArmRunning) is guarded by this so
+    // a run that completed-and-disposed before the publish executed cannot be resurrected to Running.
+    private long _runGeneration;
+    private long _terminalGeneration = -1;
+
     private static TaskCompletionSource<bool> NewLifecycleSignal() =>
         new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -226,6 +244,7 @@ internal class SubAgentState
     public async Task BeginTerminalDisposalAsync(bool isError)
     {
         Task? drain = null;
+        CancellationTokenSource? toCancel = null;
         lock (_lifecycleLock)
         {
             _terminating = true;
@@ -236,8 +255,15 @@ internal class SubAgentState
             {
                 _sendLeasesDrained = NewLifecycleSignal();
                 drain = _sendLeasesDrained.Task;
+
+                // Unblock a wedged in-flight inject send whose caller token may never fire, so its lease
+                // can drain and this disposal isn't stuck forever. Cancel OUTSIDE the lock (below):
+                // Cancel() can run linked-token continuations synchronously.
+                toCancel = _lifecycleCts;
             }
         }
+
+        toCancel?.Cancel();
 
         if (drain is not null)
         {
@@ -250,6 +276,9 @@ internal class SubAgentState
 
         lock (_lifecycleLock)
         {
+            // Record which run generation reached terminal so a racing restart's TryArmRunning cannot
+            // resurrect this now-disposing run back to Running with an about-to-be-disposed provider.
+            _terminalGeneration = _runGeneration;
             _status = isError ? SubAgentStatus.Error : SubAgentStatus.Completed;
         }
     }
@@ -265,6 +294,80 @@ internal class SubAgentState
             _terminating = false;
         }
     }
+
+    /// <summary>
+    /// Returns a cancellation source that fires when EITHER the caller's token or this run's lifecycle
+    /// token (cancelled at terminal owned-provider disposal) fires. The inject-send path passes the
+    /// resulting token so a terminal disposal can unblock a stalled send; the caller disposes the source.
+    /// </summary>
+    public CancellationTokenSource LinkLifecycleToken(CancellationToken caller)
+    {
+        lock (_lifecycleLock)
+        {
+            return CancellationTokenSource.CreateLinkedTokenSource(caller, _lifecycleCts.Token);
+        }
+    }
+
+    /// <summary>
+    /// Re-arms the per-run lifecycle cancellation for a new run epoch (call from the restart transition
+    /// before the restarted loop can admit injects). Disposes the previous, already-cancelled source.
+    /// </summary>
+    public void ResetLifecycleCts()
+    {
+        CancellationTokenSource old;
+        lock (_lifecycleLock)
+        {
+            old = _lifecycleCts;
+            _lifecycleCts = new CancellationTokenSource();
+        }
+
+        old.Dispose();
+    }
+
+    /// <summary>
+    /// Opens a new run generation for a restart (call under the restart transition, before starting the
+    /// restarted loop). The returned token guards the later <see cref="TryArmRunning"/> publish so a run
+    /// that completes and disposes before the publish executes cannot be resurrected to Running.
+    /// </summary>
+    public long BeginRunGeneration()
+    {
+        lock (_lifecycleLock)
+        {
+            return ++_runGeneration;
+        }
+    }
+
+    /// <summary>
+    /// Publishes <see cref="SubAgentStatus.Running"/> for <paramref name="generation"/> UNLESS that run
+    /// has already reached a terminal completion (its owned provider may already be disposed) — so a fast
+    /// restarted run that completed before this publish executed is never resurrected to Running. Returns
+    /// true if Running was published.
+    /// </summary>
+    public bool TryArmRunning(long generation)
+    {
+        lock (_lifecycleLock)
+        {
+            if (_terminalGeneration == generation)
+            {
+                return false;
+            }
+
+            _status = SubAgentStatus.Running;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// True when a terminal owned-provider disposal threw for the current run: the provider is in an
+    /// unknown/partial state and a continuation must rebuild a fresh one rather than reuse it.
+    /// </summary>
+    public bool OwnedProviderTerminalDisposeFailed => _ownedProviderTerminalDisposeFailed;
+
+    /// <summary>
+    /// Marks the current run's owned provider as failed-to-dispose at terminal completion so the restart
+    /// path rebuilds a fresh provider (and retries disposing this one) instead of reusing it.
+    /// </summary>
+    public void MarkOwnedProviderTerminalDisposeFailed() => _ownedProviderTerminalDisposeFailed = true;
 
     public IConversationStore? Store { get; set; }
 
@@ -352,6 +455,7 @@ internal class SubAgentState
     {
         OwnedProviderAgent = ownedProviderAgent;
         Volatile.Write(ref _ownedProviderDisposeState, OwnedProviderDisposeIdle);
+        _ownedProviderTerminalDisposeFailed = false;
     }
 
     /// <summary>

--- a/src/LmMultiTurn/SubAgents/SubAgentState.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentState.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
 
 namespace AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
@@ -36,7 +37,24 @@ internal class SubAgentState
     public required string AgentId { get; init; }
     public required string TemplateName { get; init; }
     public required string Task { get; init; }
-    public required IMultiTurnAgent Agent { get; init; }
+    public required IMultiTurnAgent Agent { get; set; }
+
+    /// <summary>
+    /// The template and spawn inputs needed to recreate a completed owned-provider run before a
+    /// continuation. Borrowed providers retain the existing loop.
+    /// </summary>
+    public required SubAgentTemplate Template { get; init; }
+    public string? ModelOverride { get; init; }
+    public string[]? AddTools { get; init; }
+    public string[]? RemoveTools { get; init; }
+
+    /// <summary>
+    /// Provider pipeline created specifically for this sub-agent. Null means the provider is
+    /// borrowed/shared and must not be disposed by this state.
+    /// </summary>
+    public IStreamingAgent? OwnedProviderAgent { get; private set; }
+
+    private int _ownedProviderDisposed;
 
     /// <summary>
     /// Optional caller-supplied handle so SendMessage can address this agent by name.
@@ -59,7 +77,7 @@ internal class SubAgentState
     private volatile SubAgentStatus _status = SubAgentStatus.Running;
     public SubAgentStatus Status { get => _status; set => _status = value; }
 
-    public IConversationStore? Store { get; init; }
+    public IConversationStore? Store { get; set; }
 
     /// <summary>
     /// Set to true when SendToParentAsync fails, so CheckAgent/Peek can surface the error.
@@ -84,6 +102,43 @@ internal class SubAgentState
     /// tool result.
     /// </summary>
     public TaskCompletionSource<string> Completion { get; private set; } = CreateCompletionSource();
+
+    public async ValueTask DisposeOwnedProviderAgentAsync()
+    {
+        if (
+            OwnedProviderAgent is null
+            || Interlocked.Exchange(ref _ownedProviderDisposed, 1) != 0
+        )
+        {
+            return;
+        }
+
+        if (OwnedProviderAgent is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync();
+        }
+        else if (OwnedProviderAgent is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Indicates that the current run's owned provider has been disposed at completion and a
+    /// continuation must create a fresh provider pipeline.
+    /// </summary>
+    public bool HasDisposedOwnedProviderAgent =>
+        OwnedProviderAgent is not null && Volatile.Read(ref _ownedProviderDisposed) != 0;
+
+    /// <summary>
+    /// Assigns the provider created for the current run. This resets the per-run disposal guard
+    /// when a completed owned-provider sub-agent is recreated for a continuation.
+    /// </summary>
+    public void SetOwnedProviderAgent(IStreamingAgent? ownedProviderAgent)
+    {
+        OwnedProviderAgent = ownedProviderAgent;
+        Volatile.Write(ref _ownedProviderDisposed, 0);
+    }
 
     /// <summary>
     /// Guards the read-check-replace of <see cref="Completion"/> against the monitor

--- a/src/LmMultiTurn/SubAgents/SubAgentState.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentState.cs
@@ -54,7 +54,22 @@ internal class SubAgentState
     /// </summary>
     public IStreamingAgent? OwnedProviderAgent { get; private set; }
 
-    private int _ownedProviderDisposed;
+    // Owned-provider disposal progress. A single caller transitions Idle -> InProgress and performs
+    // the disposal; concurrent callers back off. A successful disposal latches Disposed; a FAILED
+    // attempt resets the guard to Idle so a later cleanup path (completion, restart, manager dispose)
+    // can retry instead of leaking the provider — the guard is never permanently latched on failure.
+    private const int OwnedProviderDisposeIdle = 0;
+    private const int OwnedProviderDisposeInProgress = 1;
+    private const int OwnedProviderDisposeDisposed = 2;
+    private int _ownedProviderDisposeState;
+
+    /// <summary>
+    /// Serializes a genuine terminal completion's status flip + owned-provider disposal against a
+    /// concurrent <c>SubAgentManager.SendMessageAsync</c>. See <see cref="MarkTerminal"/> /
+    /// <see cref="TryBeginRunningContinuation"/>. Only synchronous work runs under this lock (no
+    /// awaits), so a blocking/backpressured send or a slow provider disposal can never deadlock it.
+    /// </summary>
+    private readonly object _lifecycleLock = new();
 
     /// <summary>
     /// Optional caller-supplied handle so SendMessage can address this agent by name.
@@ -76,6 +91,37 @@ internal class SubAgentState
 
     private volatile SubAgentStatus _status = SubAgentStatus.Running;
     public SubAgentStatus Status { get => _status; set => _status = value; }
+
+    /// <summary>
+    /// Atomically flips the sub-agent out of <see cref="SubAgentStatus.Running"/> at a genuine
+    /// terminal completion, under <see cref="_lifecycleLock"/> so it is serialized against
+    /// <see cref="TryBeginRunningContinuation"/>. The manager disposes the owned provider only AFTER
+    /// this returns, so a concurrent SendMessage can never observe <see cref="SubAgentStatus.Running"/>
+    /// — and route a message into the loop — in the window where the provider is being disposed.
+    /// </summary>
+    public void MarkTerminal(bool isError)
+    {
+        lock (_lifecycleLock)
+        {
+            _status = isError ? SubAgentStatus.Error : SubAgentStatus.Completed;
+        }
+    }
+
+    /// <summary>
+    /// Atomically reads whether the loop is currently running and records the continuation's relay
+    /// preference, under the same <see cref="_lifecycleLock"/> that guards <see cref="MarkTerminal"/>.
+    /// Returns true when the loop is running (the caller injects the message into it) and false when
+    /// it has finished (the caller restarts it, recreating a fresh provider), so the running-vs-finished
+    /// decision can never straddle a concurrent terminal completion that is about to dispose the provider.
+    /// </summary>
+    public bool TryBeginRunningContinuation(bool notifyParentOnCompletion)
+    {
+        lock (_lifecycleLock)
+        {
+            _notifyParentOnCompletion = notifyParentOnCompletion;
+            return _status == SubAgentStatus.Running;
+        }
+    }
 
     public IConversationStore? Store { get; set; }
 
@@ -105,21 +151,45 @@ internal class SubAgentState
 
     public async ValueTask DisposeOwnedProviderAgentAsync()
     {
+        if (OwnedProviderAgent is null)
+        {
+            return;
+        }
+
+        // Claim the disposal: only the caller that transitions Idle -> InProgress performs it; a
+        // caller that finds it already Disposed (or another disposal in progress) backs off. Crucially
+        // the guard is set to its terminal Disposed value only AFTER a successful DisposeAsync/Dispose;
+        // a failed attempt resets it to Idle in the catch below so a later cleanup can retry rather
+        // than leak the provider behind a guard that latched before the work actually succeeded.
         if (
-            OwnedProviderAgent is null
-            || Interlocked.Exchange(ref _ownedProviderDisposed, 1) != 0
+            Interlocked.CompareExchange(
+                ref _ownedProviderDisposeState,
+                OwnedProviderDisposeInProgress,
+                OwnedProviderDisposeIdle
+            ) != OwnedProviderDisposeIdle
         )
         {
             return;
         }
 
-        if (OwnedProviderAgent is IAsyncDisposable asyncDisposable)
+        try
         {
-            await asyncDisposable.DisposeAsync();
+            if (OwnedProviderAgent is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync();
+            }
+            else if (OwnedProviderAgent is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+
+            Volatile.Write(ref _ownedProviderDisposeState, OwnedProviderDisposeDisposed);
         }
-        else if (OwnedProviderAgent is IDisposable disposable)
+        catch
         {
-            disposable.Dispose();
+            // Disposal failed: reset the guard so a subsequent cleanup path can retry the disposal.
+            Volatile.Write(ref _ownedProviderDisposeState, OwnedProviderDisposeIdle);
+            throw;
         }
     }
 
@@ -128,7 +198,8 @@ internal class SubAgentState
     /// continuation must create a fresh provider pipeline.
     /// </summary>
     public bool HasDisposedOwnedProviderAgent =>
-        OwnedProviderAgent is not null && Volatile.Read(ref _ownedProviderDisposed) != 0;
+        OwnedProviderAgent is not null
+        && Volatile.Read(ref _ownedProviderDisposeState) == OwnedProviderDisposeDisposed;
 
     /// <summary>
     /// Assigns the provider created for the current run. This resets the per-run disposal guard
@@ -137,7 +208,7 @@ internal class SubAgentState
     public void SetOwnedProviderAgent(IStreamingAgent? ownedProviderAgent)
     {
         OwnedProviderAgent = ownedProviderAgent;
-        Volatile.Write(ref _ownedProviderDisposed, 0);
+        Volatile.Write(ref _ownedProviderDisposeState, OwnedProviderDisposeIdle);
     }
 
     /// <summary>

--- a/src/LmMultiTurn/SubAgents/SubAgentState.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentState.cs
@@ -263,7 +263,19 @@ internal class SubAgentState
             }
         }
 
-        toCancel?.Cancel();
+        // Cancel outside the lock to unblock a wedged in-flight inject send (see above). Cancel() runs
+        // linked-token callbacks synchronously and, with the default throwOnFirstException=false, still
+        // cancels the token and invokes EVERY callback before aggregating any that threw. So a throwing
+        // callback must NOT abort the drain/terminal/disposal transition below — swallow the aggregate;
+        // the cancellation itself has fully propagated.
+        try
+        {
+            toCancel?.Cancel();
+        }
+        catch (AggregateException)
+        {
+            // A linked-token callback threw; the lifecycle token is already cancelled, so proceed.
+        }
 
         if (drain is not null)
         {

--- a/src/LmMultiTurn/SubAgents/SubAgentTemplate.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentTemplate.cs
@@ -55,6 +55,12 @@ public record SubAgentTemplate
     public bool IsModelExplicitlySelected { get; init; }
 
     /// <summary>
+    /// Whether the template model was selected from a model-intelligence tier rather than pinned
+    /// directly by the template author.
+    /// </summary>
+    public bool IsModelTierResolved { get; init; }
+
+    /// <summary>
     /// Optional reasoning effort requested for this sub-agent.
     /// </summary>
     public ReasoningEffort? Effort { get; init; }

--- a/src/LmMultiTurn/SubAgents/SubAgentTemplate.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentTemplate.cs
@@ -39,9 +39,25 @@ public record SubAgentTemplate
     public required Func<IStreamingAgent> AgentFactory { get; init; }
 
     /// <summary>
+    /// Optional factory that creates the provider agent from the resolved spawn characteristics.
+    /// When null, <see cref="AgentFactory"/> is used.
+    /// </summary>
+    public Func<SubAgentCharacteristics, SubAgentProviderAgent>? CharacteristicsAgentFactory { get; init; }
+
+    /// <summary>
     /// Default options for model, temperature, etc.
     /// </summary>
     public GenerateReplyOptions? DefaultOptions { get; init; }
+
+    /// <summary>
+    /// Whether <see cref="GenerateReplyOptions.ModelId"/> was explicitly selected by this template.
+    /// </summary>
+    public bool IsModelExplicitlySelected { get; init; }
+
+    /// <summary>
+    /// Optional reasoning effort requested for this sub-agent.
+    /// </summary>
+    public ReasoningEffort? Effort { get; init; }
 
     /// <summary>
     /// Tool filter: null = inherit ALL parent tools.

--- a/src/LmMultiTurn/SubAgents/SubAgentTemplate.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentTemplate.cs
@@ -36,6 +36,13 @@ public record SubAgentTemplate
     /// <summary>
     /// Factory that creates the LLM provider agent for this template.
     /// </summary>
+    /// <remarks>
+    /// Each invocation MUST return a fresh, independently disposable agent — never a shared, cached, or
+    /// externally-owned instance. Callers that route an inherited-model sub-agent through this factory
+    /// take ownership of the returned agent (<see cref="SubAgentProviderAgent.OwnsAgent"/> = true) and
+    /// dispose it when the sub-agent's run completes, so returning a shared instance here would dispose
+    /// a provider still in use elsewhere.
+    /// </remarks>
     public required Func<IStreamingAgent> AgentFactory { get; init; }
 
     /// <summary>

--- a/tests/CodeReviewDaemon.Sample.Tests/Agents/DiscoveredSubAgentTemplateBuilderTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Agents/DiscoveredSubAgentTemplateBuilderTests.cs
@@ -1,5 +1,7 @@
+using System.Text.Json;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmAgentInfra.Sandbox;
+using AchieveAi.LmDotnetTools.LmTestUtils.Logging;
 using CodeReviewDaemon.Sample.Agents;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -36,5 +38,74 @@ public class DiscoveredSubAgentTemplateBuilderTests
         templates.Should().ContainKey("code-reviewer:architecture-review");
         templates.Should().NotContainKey("other-plugin:thing");
         templates["code-reviewer:architecture-review"].SystemPrompt.Should().Contain("review architecture");
+    }
+
+    [Fact]
+    public void Build_LogsEverySharedParserDiagnostic()
+    {
+        var logger = new CapturingLogger<DiscoveredSubAgentTemplateBuilder>();
+        var builder = new DiscoveredSubAgentTemplateBuilder(logger);
+        var items = ItemsWithFrontmatter(
+            """
+            modelintelligence: 7
+            effort: maximum
+            """);
+
+        var templates = builder.Build(items, "code-reviewer", AgentFactory);
+
+        templates.Should().ContainKey("code-reviewer:architecture-review");
+        logger.WarningCount("modelintelligence must be an integer").Should().Be(1);
+        logger.WarningCount("effort must be one of").Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData("modelintelligence: 4\neffort: high", "")]
+    [InlineData("modelintelligence: invalid\neffort: maximum", "")]
+    [InlineData(
+        "model: claude-sonnet-5\nmodelintelligence: 4\neffort: extra-high",
+        "model: claude-sonnet-5")]
+    public void Build_CharacteristicsFrontmatter_DoesNotChangeDaemonRequestOptions(
+        string characteristicsFrontmatter,
+        string baselineModelFrontmatter)
+    {
+        var builder = new DiscoveredSubAgentTemplateBuilder(
+            NullLogger<DiscoveredSubAgentTemplateBuilder>.Instance);
+        var baseline = builder.Build(
+            ItemsWithFrontmatter(baselineModelFrontmatter),
+            "code-reviewer",
+            AgentFactory)["code-reviewer:architecture-review"];
+
+        var actual = builder.Build(
+            ItemsWithFrontmatter(characteristicsFrontmatter),
+            "code-reviewer",
+            AgentFactory)["code-reviewer:architecture-review"];
+
+        JsonSerializer.SerializeToUtf8Bytes(actual.DefaultOptions)
+            .Should().Equal(JsonSerializer.SerializeToUtf8Bytes(baseline.DefaultOptions));
+        actual.CharacteristicsAgentFactory.Should().BeNull();
+        actual.AgentFactory.Should().BeSameAs(AgentFactory);
+    }
+
+    private static IReadOnlyList<SandboxSessionRegistry.DiscoveredItem> ItemsWithFrontmatter(
+        string additionalFrontmatter)
+    {
+        var content = $"""
+            ---
+            name: architecture-review
+            description: Reviews architecture.
+            {additionalFrontmatter}
+            ---
+            You review architecture across the connected repos.
+            """;
+        return
+        [
+            new(
+                "subagent",
+                "architecture-review",
+                "arch",
+                "/marketplaces/gb-plugins/agents/a.md",
+                Content: content,
+                QualifiedName: "code-reviewer:architecture-review"),
+        ];
     }
 }

--- a/tests/GithubCopilotProvider.Tests/Models/CopilotModelCatalogParserTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Models/CopilotModelCatalogParserTests.cs
@@ -15,10 +15,14 @@ public sealed class CopilotModelCatalogParserTests
 
         // 34 models upstream → 13 routable Anthropic/OpenAI (7 Claude + 5 OpenAI + 1 Azure-OpenAI).
         models.Should().HaveCount(13);
-        models.Should().OnlyContain(m =>
-            m.Vendor == CopilotModelVendor.Anthropic || m.Vendor == CopilotModelVendor.OpenAI);
-        models.Should().OnlyContain(m =>
-            m.Transport == CopilotModelTransport.Anthropic || m.Transport == CopilotModelTransport.Responses);
+        models
+            .Should()
+            .OnlyContain(m => m.Vendor == CopilotModelVendor.Anthropic || m.Vendor == CopilotModelVendor.OpenAI);
+        models
+            .Should()
+            .OnlyContain(m =>
+                m.Transport == CopilotModelTransport.Anthropic || m.Transport == CopilotModelTransport.Responses
+            );
     }
 
     [Fact]
@@ -30,8 +34,7 @@ public sealed class CopilotModelCatalogParserTests
 
         anthropic.Should().HaveCount(7);
         anthropic.Should().OnlyContain(m => m.Transport == CopilotModelTransport.Anthropic);
-        anthropic.Select(m => m.Id).Should().Contain(
-            ["claude-opus-4.8", "claude-sonnet-5", "claude-haiku-4.5"]);
+        anthropic.Select(m => m.Id).Should().Contain(["claude-opus-4.8", "claude-sonnet-5", "claude-haiku-4.5"]);
     }
 
     [Fact]
@@ -63,8 +66,7 @@ public sealed class CopilotModelCatalogParserTests
     {
         var models = CopilotModelCatalogParser.Parse(RealResponseJson);
 
-        models.Select(m => m.Id).Should().NotContain(
-            ["gemini-3.1-pro-preview", "gemini-3.5-flash", "gemini-2.5-pro"]);
+        models.Select(m => m.Id).Should().NotContain(["gemini-3.1-pro-preview", "gemini-3.5-flash", "gemini-2.5-pro"]);
     }
 
     [Fact]
@@ -100,6 +102,109 @@ public sealed class CopilotModelCatalogParserTests
         models.Single(m => m.Id == "claude-haiku-4.5").SupportsAdaptiveThinking.Should().BeFalse();
     }
 
+    [Theory]
+    [InlineData(
+        """["none", "minimal", "low", "medium", "high", "xhigh", "max"]""",
+        new[] { "none", "minimal", "low", "medium", "high", "xhigh", "max" }
+    )]
+    [InlineData("""["low", 42, null, "high"]""", new[] { "low", "high" })]
+    [InlineData("null", new string[0])]
+    public void Parse_projects_reasoning_effort_values(string reasoningEffortJson, string[] expected)
+    {
+        var json = $$"""
+            { "data": [{
+              "id": "claude-test",
+              "vendor": "Anthropic",
+              "supported_endpoints": ["/v1/messages"],
+              "capabilities": {
+                "supports": {
+                  "reasoning_effort": {{reasoningEffortJson}}
+                }
+              }
+            }] }
+            """;
+
+        var model = CopilotModelCatalogParser.Parse(json).Should().ContainSingle().Subject;
+
+        model.ReasoningEfforts.Should().Equal(expected);
+    }
+
+    [Fact]
+    public void Parse_equivalent_models_have_value_equality()
+    {
+        const string json = """
+            { "data": [{
+              "id": "gpt-test",
+              "name": "GPT Test",
+              "vendor": "OpenAI",
+              "supported_endpoints": ["/responses"],
+              "capabilities": {
+                "supports": {
+                  "reasoning_effort": ["low", "medium", "high"]
+                }
+              }
+            }] }
+            """;
+
+        var first = CopilotModelCatalogParser.Parse(json).Should().ContainSingle().Subject;
+        var second = CopilotModelCatalogParser.Parse(json).Should().ContainSingle().Subject;
+
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void CopilotModelInfo_does_not_expose_mutable_reasoning_efforts()
+    {
+        string[] source = ["low", "medium"];
+        var model = new CopilotModelInfo(
+            "gpt-test",
+            "GPT Test",
+            CopilotModelVendor.OpenAI,
+            CopilotModelTransport.Responses
+        )
+        {
+            ReasoningEfforts = source,
+        };
+        var efforts = model.ReasoningEfforts.Should().BeAssignableTo<IList<string>>().Subject;
+
+        var mutate = () => efforts[0] = "high";
+
+        mutate.Should().Throw<NotSupportedException>();
+        source[1] = "xhigh";
+        model.ReasoningEfforts.Should().Equal("low", "medium");
+    }
+
+    [Fact]
+    public void CopilotModelInfo_reasoning_efforts_do_not_change_legacy_equality_or_hash_code()
+    {
+        var legacy = new CopilotModelInfo(
+            "gpt-test",
+            "GPT Test",
+            CopilotModelVendor.OpenAI,
+            CopilotModelTransport.Responses
+        );
+        var enriched = legacy with { ReasoningEfforts = ["low", "medium", "high"] };
+
+        enriched.Should().Be(legacy);
+        enriched.GetHashCode().Should().Be(legacy.GetHashCode());
+    }
+
+    [Fact]
+    public void CopilotModelInfo_preserves_positional_constructor_compatibility()
+    {
+        var model = new CopilotModelInfo(
+            "gpt-test",
+            "GPT Test",
+            CopilotModelVendor.OpenAI,
+            CopilotModelTransport.Responses,
+            SupportsAdaptiveThinking: true
+        );
+
+        model.SupportsAdaptiveThinking.Should().BeTrue();
+        model.ReasoningEfforts.Should().BeEmpty();
+    }
+
     [Fact]
     public void Parse_accepts_bare_array_shape()
     {
@@ -126,8 +231,7 @@ public sealed class CopilotModelCatalogParserTests
 
         var models = CopilotModelCatalogParser.Parse(json);
 
-        models.Should().ContainSingle()
-            .Which.Transport.Should().Be(CopilotModelTransport.Responses);
+        models.Should().ContainSingle().Which.Transport.Should().Be(CopilotModelTransport.Responses);
     }
 
     [Fact]

--- a/tests/GithubCopilotProvider.Tests/Models/CopilotModelCatalogParserTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Models/CopilotModelCatalogParserTests.cs
@@ -191,6 +191,21 @@ public sealed class CopilotModelCatalogParserTests
     }
 
     [Fact]
+    public void CopilotModelInfo_NullReasoningEffortsNormalizesToEmpty()
+    {
+        var model = new CopilotModelInfo(
+            "gpt-test",
+            "GPT Test",
+            CopilotModelVendor.OpenAI,
+            CopilotModelTransport.Responses)
+        {
+            ReasoningEfforts = null!,
+        };
+
+        model.ReasoningEfforts.Should().BeEmpty();
+    }
+
+    [Fact]
     public void CopilotModelInfo_preserves_positional_constructor_compatibility()
     {
         var model = new CopilotModelInfo(

--- a/tests/GithubCopilotProvider.Tests/Reasoning/CopilotReasoningShaperTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Reasoning/CopilotReasoningShaperTests.cs
@@ -1,0 +1,112 @@
+using AchieveAi.LmDotnetTools.AnthropicProvider.Models;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Reasoning;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.GithubCopilotProvider.Tests.Reasoning;
+
+public sealed class CopilotReasoningShaperTests
+{
+    [Theory]
+    [InlineData(CopilotModelTransport.Anthropic, "OutputConfig")]
+    [InlineData(CopilotModelTransport.Responses, "Reasoning")]
+    public void Shape_uses_transport_specific_request_metadata(CopilotModelTransport transport, string expectedKey)
+    {
+        var model = CreateModel(transport, supportsAdaptiveThinking: false, "low", "medium", "high");
+
+        var result = CopilotReasoningShaper.Shape(model, ReasoningEffort.Medium);
+
+        result.Should().ContainSingle().Which.Key.Should().Be(expectedKey);
+        if (transport == CopilotModelTransport.Anthropic)
+        {
+            result[expectedKey].Should().BeEquivalentTo(new AnthropicOutputConfig { Effort = "medium" });
+        }
+        else
+        {
+            result[expectedKey].Should().BeEquivalentTo(new ResponseReasoningOptions { Effort = "medium" });
+        }
+    }
+
+    [Theory]
+    [InlineData(ReasoningEffort.Low, "low,medium,high", "low")]
+    [InlineData(ReasoningEffort.High, "low,medium,high", "high")]
+    [InlineData(ReasoningEffort.Xhigh, "low,medium,high", "high")]
+    [InlineData(ReasoningEffort.Low, "medium,high", "medium")]
+    [InlineData(ReasoningEffort.High, "unknown,none,minimal,max", "minimal")]
+    [InlineData(ReasoningEffort.Low, "none,max", "none")]
+    [InlineData(ReasoningEffort.Xhigh, "low,xhigh,max", "xhigh")]
+    public void Shape_selects_supported_effort(ReasoningEffort requested, string advertised, string expected)
+    {
+        var model = CreateModel(
+            CopilotModelTransport.Responses,
+            supportsAdaptiveThinking: false,
+            advertised.Split(',')
+        );
+
+        var result = CopilotReasoningShaper.Shape(model, requested);
+
+        result["Reasoning"].Should().BeEquivalentTo(new ResponseReasoningOptions { Effort = expected });
+    }
+
+    [Theory]
+    [InlineData(ReasoningEffort.Xhigh, "low,medium,high", "high")]
+    [InlineData(ReasoningEffort.Low, "medium,high", "medium")]
+    [InlineData(ReasoningEffort.High, "max", null)]
+    public void SelectEffort_reports_provider_owned_selection(
+        ReasoningEffort requested,
+        string advertised,
+        string? expected
+    )
+    {
+        var model = CreateModel(
+            CopilotModelTransport.Responses,
+            supportsAdaptiveThinking: false,
+            advertised.Split(',')
+        );
+
+        var selected = CopilotReasoningShaper.SelectEffort(model, requested);
+
+        selected.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null, "low")]
+    [InlineData(ReasoningEffort.Low, "")]
+    [InlineData(ReasoningEffort.High, "max")]
+    [InlineData(ReasoningEffort.High, "unknown,max")]
+    public void Shape_omits_request_metadata_when_effort_cannot_be_shaped(ReasoningEffort? requested, string advertised)
+    {
+        var efforts = string.IsNullOrEmpty(advertised) ? [] : advertised.Split(',');
+        var model = CreateModel(CopilotModelTransport.Responses, supportsAdaptiveThinking: true, efforts);
+
+        CopilotReasoningShaper.Shape(model, requested).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Shape_omits_request_metadata_for_unsupported_transport()
+    {
+        var model = CreateModel(CopilotModelTransport.Unsupported, supportsAdaptiveThinking: true, "low");
+
+        CopilotReasoningShaper.Shape(model, ReasoningEffort.Low).Should().BeEmpty();
+    }
+
+    private static CopilotModelInfo CreateModel(
+        CopilotModelTransport transport,
+        bool supportsAdaptiveThinking,
+        params string[] reasoningEfforts
+    )
+    {
+        return new CopilotModelInfo(
+            "test-model",
+            "Test Model",
+            transport == CopilotModelTransport.Anthropic ? CopilotModelVendor.Anthropic : CopilotModelVendor.OpenAI,
+            transport,
+            supportsAdaptiveThinking
+        )
+        {
+            ReasoningEfforts = reasoningEfforts,
+        };
+    }
+}

--- a/tests/GithubCopilotProvider.Tests/Reasoning/CopilotReasoningShaperTests.cs
+++ b/tests/GithubCopilotProvider.Tests/Reasoning/CopilotReasoningShaperTests.cs
@@ -92,6 +92,20 @@ public sealed class CopilotReasoningShaperTests
         CopilotReasoningShaper.Shape(model, ReasoningEffort.Low).Should().BeEmpty();
     }
 
+    [Fact]
+    public void SelectEffort_UnknownEnumValueFallsBackWithoutThrowing()
+    {
+        var model = CreateModel(
+            CopilotModelTransport.Responses,
+            supportsAdaptiveThinking: true,
+            "low",
+            "medium");
+
+        var selected = CopilotReasoningShaper.SelectEffort(model, (ReasoningEffort)999);
+
+        selected.Should().BeNull();
+    }
+
     private static CopilotModelInfo CreateModel(
         CopilotModelTransport transport,
         bool supportsAdaptiveThinking,

--- a/tests/LmMultiTurn.Tests/MutableSubAgentTemplateSourceTests.cs
+++ b/tests/LmMultiTurn.Tests/MutableSubAgentTemplateSourceTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using FluentAssertions;
@@ -15,6 +16,21 @@ namespace LmMultiTurn.Tests;
 public class MutableSubAgentTemplateSourceTests
 {
     private static readonly Func<IStreamingAgent> StubFactory = () => new Mock<IStreamingAgent>().Object;
+
+    private sealed record TrackingSubAgentTemplate : SubAgentTemplate
+    {
+        public TrackingSubAgentTemplate() { }
+
+        [SetsRequiredMembers]
+        private TrackingSubAgentTemplate(TrackingSubAgentTemplate original)
+            : base(original)
+        {
+            OnCopy = original.OnCopy;
+            OnCopy();
+        }
+
+        public Action OnCopy { get; init; } = () => { };
+    }
 
     private static SubAgentTemplate Template(string name) =>
         new()
@@ -80,10 +96,7 @@ public class MutableSubAgentTemplateSourceTests
     {
         // First-wins matches WorkspaceSubAgentLoader.MergeBuiltInWins's trust boundary: a
         // discovered template (untrusted) cannot shadow a built-in (trusted) seed.
-        var seed = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal)
-        {
-            ["echo"] = Template("echo"),
-        };
+        var seed = new Dictionary<string, SubAgentTemplate>(StringComparer.Ordinal) { ["echo"] = Template("echo") };
         var source = new MutableSubAgentTemplateSource(seed);
         var replacement = Template("echo") with { Description = "replacement" };
 
@@ -91,6 +104,26 @@ public class MutableSubAgentTemplateSourceTests
 
         added.Should().BeFalse();
         source.Templates["echo"].Description.Should().Be("echo description");
+    }
+
+    [Fact]
+    public void TryRegister_DuplicateNameAfterRebind_DoesNotCopyRejectedTemplate()
+    {
+        var source = new MutableSubAgentTemplateSource(
+            new Dictionary<string, SubAgentTemplate> { ["echo"] = Template("echo") }
+        );
+        source.RebindFactories(StubFactory, null);
+        var copyCount = 0;
+        var duplicate = new TrackingSubAgentTemplate
+        {
+            SystemPrompt = "duplicate",
+            AgentFactory = StubFactory,
+            OnCopy = () => copyCount++,
+        };
+
+        source.TryRegister("echo", duplicate).Should().BeFalse();
+
+        copyCount.Should().Be(0);
     }
 
     [Fact]
@@ -118,21 +151,25 @@ public class MutableSubAgentTemplateSourceTests
     [Fact]
     public async Task ConcurrentTryRegister_NeverThrows_FinalCountMatches()
     {
-        // ConcurrentDictionary guarantees TryAdd's atomicity; this test pins the surface contract
-        // and ensures no race in our wrapper causes a torn read or lost write under high contention.
+        // The update gate serializes immutable snapshot publication; this test pins the surface
+        // contract and ensures no race causes a torn read or lost write under high contention.
         var source = new MutableSubAgentTemplateSource();
         const int writerCount = 32;
         const int writesPerWriter = 100;
 
-        var tasks = Enumerable.Range(0, writerCount).Select(writerIdx => Task.Run(() =>
-        {
-            for (var i = 0; i < writesPerWriter; i++)
-            {
-                // Each writer uses its own keyspace so the only valid race outcome is "everything
-                // landed"; collisions across writers would mask races as a false-success.
-                source.TryRegister($"w{writerIdx}-{i}", Template($"w{writerIdx}-{i}"));
-            }
-        }));
+        var tasks = Enumerable
+            .Range(0, writerCount)
+            .Select(writerIdx =>
+                Task.Run(() =>
+                {
+                    for (var i = 0; i < writesPerWriter; i++)
+                    {
+                        // Each writer uses its own keyspace so the only valid race outcome is "everything
+                        // landed"; collisions across writers would mask races as a false-success.
+                        source.TryRegister($"w{writerIdx}-{i}", Template($"w{writerIdx}-{i}"));
+                    }
+                })
+            );
 
         await Task.WhenAll(tasks);
 
@@ -148,29 +185,83 @@ public class MutableSubAgentTemplateSourceTests
         var source = new MutableSubAgentTemplateSource();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
-        var writer = Task.Run(() =>
-        {
-            var i = 0;
-            while (!cts.IsCancellationRequested)
+        var writer = Task.Run(
+            () =>
             {
-                source.TryRegister($"key-{i++}", Template($"k{i}"));
-            }
-        }, cts.Token);
-
-        var reader = Task.Run(() =>
-        {
-            while (!cts.IsCancellationRequested)
-            {
-                // Force enumeration of both keys and values; ConcurrentDictionary's snapshot
-                // semantics make this safe but the test makes the invariant explicit.
-                foreach (var kvp in source.Templates)
+                var i = 0;
+                while (!cts.IsCancellationRequested)
                 {
-                    _ = kvp.Key.Length;
-                    _ = kvp.Value.Name;
+                    source.TryRegister($"key-{i++}", Template($"k{i}"));
                 }
-            }
-        }, cts.Token);
+            },
+            cts.Token
+        );
+
+        var reader = Task.Run(
+            () =>
+            {
+                while (!cts.IsCancellationRequested)
+                {
+                    // Force enumeration of both keys and values from each immutable snapshot.
+                    foreach (var kvp in source.Templates)
+                    {
+                        _ = kvp.Key.Length;
+                        _ = kvp.Value.Name;
+                    }
+                }
+            },
+            cts.Token
+        );
 
         await Task.WhenAll(writer, reader);
+    }
+
+    [Fact]
+    public void RebindFactories_PublishesConsistentOldAndNewSnapshots()
+    {
+        Func<IStreamingAgent> oldFactory = StubFactory;
+        Func<IStreamingAgent> newFactory = () => new Mock<IStreamingAgent>().Object;
+        Func<SubAgentCharacteristics, SubAgentProviderAgent> characteristicsFactory = characteristics =>
+            throw new InvalidOperationException(characteristics.ModelId);
+        var source = new MutableSubAgentTemplateSource(
+            new Dictionary<string, SubAgentTemplate>
+            {
+                ["first"] = Template("first") with { AgentFactory = oldFactory },
+                ["second"] = Template("second") with { AgentFactory = oldFactory },
+            }
+        );
+        var oldSnapshot = source.Templates;
+
+        source.RebindFactories(newFactory, characteristicsFactory);
+        var newSnapshot = source.Templates;
+
+        oldSnapshot
+            .Values.Should()
+            .OnlyContain(template =>
+                ReferenceEquals(template.AgentFactory, oldFactory) && template.CharacteristicsAgentFactory == null
+            );
+        newSnapshot
+            .Values.Should()
+            .OnlyContain(template =>
+                ReferenceEquals(template.AgentFactory, newFactory)
+                && ReferenceEquals(template.CharacteristicsAgentFactory, characteristicsFactory)
+            );
+        newSnapshot.Should().NotBeSameAs(oldSnapshot);
+    }
+
+    [Fact]
+    public void TryRegister_AfterRebind_UsesCurrentFactories()
+    {
+        Func<IStreamingAgent> newFactory = () => new Mock<IStreamingAgent>().Object;
+        Func<SubAgentCharacteristics, SubAgentProviderAgent> characteristicsFactory = characteristics =>
+            throw new InvalidOperationException(characteristics.ModelId);
+        var source = new MutableSubAgentTemplateSource();
+        source.RebindFactories(newFactory, characteristicsFactory);
+
+        source.TryRegister("later", Template("later")).Should().BeTrue();
+
+        var registered = source.Templates["later"];
+        registered.AgentFactory.Should().BeSameAs(newFactory);
+        registered.CharacteristicsAgentFactory.Should().BeSameAs(characteristicsFactory);
     }
 }

--- a/tests/LmMultiTurn.Tests/MutableSubAgentTemplateSourceTests.cs
+++ b/tests/LmMultiTurn.Tests/MutableSubAgentTemplateSourceTests.cs
@@ -221,8 +221,11 @@ public class MutableSubAgentTemplateSourceTests
     {
         Func<IStreamingAgent> oldFactory = StubFactory;
         Func<IStreamingAgent> newFactory = () => new Mock<IStreamingAgent>().Object;
-        Func<SubAgentCharacteristics, SubAgentProviderAgent> characteristicsFactory = characteristics =>
-            throw new InvalidOperationException(characteristics.ModelId);
+        var routedAgent = new Mock<IStreamingAgent>().Object;
+        Func<SubAgentCharacteristics, SubAgentProviderAgent> characteristicsFactory = _ =>
+            new SubAgentProviderAgent(
+                routedAgent,
+                System.Collections.Immutable.ImmutableDictionary<string, object?>.Empty);
         var source = new MutableSubAgentTemplateSource(
             new Dictionary<string, SubAgentTemplate>
             {
@@ -240,12 +243,24 @@ public class MutableSubAgentTemplateSourceTests
             .OnlyContain(template =>
                 ReferenceEquals(template.AgentFactory, oldFactory) && template.CharacteristicsAgentFactory == null
             );
-        newSnapshot
-            .Values.Should()
-            .OnlyContain(template =>
-                ReferenceEquals(template.AgentFactory, newFactory)
-                && ReferenceEquals(template.CharacteristicsAgentFactory, characteristicsFactory)
+        newSnapshot.Values.Should().OnlyContain(template => ReferenceEquals(template.AgentFactory, oldFactory));
+        foreach (var template in newSnapshot.Values)
+        {
+            var inherited = template.CharacteristicsAgentFactory!(
+                new SubAgentCharacteristics(null, null)
             );
+            inherited.Agent.Should().NotBeNull();
+            inherited.OwnsAgent.Should().BeTrue();
+            template
+                .CharacteristicsAgentFactory!(
+                    new SubAgentCharacteristics("explicit", null)
+                    {
+                        IsModelExplicitlySelected = true,
+                    }
+                )
+                .Agent.Should()
+                .BeSameAs(routedAgent);
+        }
         newSnapshot.Should().NotBeSameAs(oldSnapshot);
     }
 
@@ -253,15 +268,30 @@ public class MutableSubAgentTemplateSourceTests
     public void TryRegister_AfterRebind_UsesCurrentFactories()
     {
         Func<IStreamingAgent> newFactory = () => new Mock<IStreamingAgent>().Object;
-        Func<SubAgentCharacteristics, SubAgentProviderAgent> characteristicsFactory = characteristics =>
-            throw new InvalidOperationException(characteristics.ModelId);
+        var routedAgent = new Mock<IStreamingAgent>().Object;
+        Func<SubAgentCharacteristics, SubAgentProviderAgent> characteristicsFactory = _ =>
+            new SubAgentProviderAgent(
+                routedAgent,
+                System.Collections.Immutable.ImmutableDictionary<string, object?>.Empty);
         var source = new MutableSubAgentTemplateSource();
         source.RebindFactories(newFactory, characteristicsFactory);
 
         source.TryRegister("later", Template("later")).Should().BeTrue();
 
         var registered = source.Templates["later"];
-        registered.AgentFactory.Should().BeSameAs(newFactory);
-        registered.CharacteristicsAgentFactory.Should().BeSameAs(characteristicsFactory);
+        registered.AgentFactory.Should().BeSameAs(StubFactory);
+        registered
+            .CharacteristicsAgentFactory!(new SubAgentCharacteristics(null, null))
+            .Agent.Should()
+            .NotBeNull();
+        registered
+            .CharacteristicsAgentFactory!(
+                new SubAgentCharacteristics("explicit", null)
+                {
+                    IsModelExplicitlySelected = true,
+                }
+            )
+            .Agent.Should()
+            .BeSameAs(routedAgent);
     }
 }

--- a/tests/LmMultiTurn.Tests/SubAgentCharacteristicsFactoryTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentCharacteristicsFactoryTests.cs
@@ -116,6 +116,53 @@ public class SubAgentCharacteristicsFactoryTests : LoggingTestBase
     }
 
     [Fact]
+    public void SubAgentProviderAgent_RejectsNullAgent()
+    {
+        var act = () =>
+            new SubAgentProviderAgent(null!, ImmutableDictionary<string, object?>.Empty);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("Agent");
+    }
+
+    [Fact]
+    public void SubAgentProviderAgent_RejectsNullExtraProperties()
+    {
+        var act = () =>
+            new SubAgentProviderAgent(
+                Agent: Mock.Of<IStreamingAgent>(),
+                ExtraProperties: null!
+            );
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("ExtraProperties");
+    }
+
+    [Fact]
+    public void SubAgentProviderAgent_RejectsNullAgentFromWithExpression()
+    {
+        var provider = new SubAgentProviderAgent(
+            Mock.Of<IStreamingAgent>(),
+            ImmutableDictionary<string, object?>.Empty
+        );
+
+        var act = () => provider with { Agent = null! };
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("value");
+    }
+
+    [Fact]
+    public void SubAgentProviderAgent_RejectsNullExtraPropertiesFromWithExpression()
+    {
+        var provider = new SubAgentProviderAgent(
+            Mock.Of<IStreamingAgent>(),
+            ImmutableDictionary<string, object?>.Empty
+        );
+
+        var act = () => provider with { ExtraProperties = null! };
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("value");
+    }
+
+    [Fact]
     public async Task SpawnAsync_MergesProviderMetadataWithoutOverwritingTemplateKeys()
     {
         GenerateReplyOptions? receivedOptions = null;

--- a/tests/LmMultiTurn.Tests/SubAgentCharacteristicsFactoryTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentCharacteristicsFactoryTests.cs
@@ -1,0 +1,248 @@
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.LmTestUtils.Logging;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace LmMultiTurn.Tests;
+
+public class SubAgentCharacteristicsFactoryTests : LoggingTestBase
+{
+    public SubAgentCharacteristicsFactoryTests(ITestOutputHelper output)
+        : base(output) { }
+
+    [Fact]
+    public async Task SpawnAsync_PassesFinalModelOverrideAndTypedEffortToCharacteristicsFactory()
+    {
+        SubAgentCharacteristics? receivedCharacteristics = null;
+        var providerAgent = CreateRespondingAgent();
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "You are a test agent.",
+            AgentFactory = () => throw new InvalidOperationException("Legacy factory should not run."),
+            DefaultOptions = new GenerateReplyOptions { ModelId = "template-model" },
+            Effort = ReasoningEffort.Xhigh,
+            CharacteristicsAgentFactory = characteristics =>
+            {
+                receivedCharacteristics = characteristics;
+                return new SubAgentProviderAgent(providerAgent.Object, ImmutableDictionary<string, object?>.Empty);
+            },
+        };
+        await using var manager = CreateManager(template, parentModelId: "parent-model");
+
+        Logger.LogDebug(
+            "Spawning with model override {ModelOverride} and effort {Effort}",
+            "spawn-model",
+            ReasoningEffort.Xhigh
+        );
+
+        _ = await manager.SpawnAsync("test-agent", "test task", model: "spawn-model");
+
+        receivedCharacteristics
+            .Should()
+            .Be(new SubAgentCharacteristics("spawn-model", ReasoningEffort.Xhigh) { IsModelExplicitlySelected = true });
+    }
+
+    [Fact]
+    public async Task SpawnAsync_InheritedParentModelMarksSelectionAsInherited()
+    {
+        SubAgentCharacteristics? receivedCharacteristics = null;
+        var providerAgent = CreateRespondingAgent();
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "You are a test agent.",
+            AgentFactory = () => throw new InvalidOperationException("Legacy factory should not run."),
+            CharacteristicsAgentFactory = characteristics =>
+            {
+                receivedCharacteristics = characteristics;
+                return new SubAgentProviderAgent(providerAgent.Object, ImmutableDictionary<string, object?>.Empty);
+            },
+        };
+        await using var manager = CreateManager(template, parentModelId: "shared-model");
+
+        _ = await manager.SpawnAsync("test-agent", "test task");
+
+        receivedCharacteristics.Should().Be(new SubAgentCharacteristics("shared-model", null));
+        receivedCharacteristics!.IsModelExplicitlySelected.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SpawnAsync_ExplicitTemplateModelEqualToParentMarksSelectionAsExplicit()
+    {
+        SubAgentCharacteristics? receivedCharacteristics = null;
+        var providerAgent = CreateRespondingAgent();
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "You are a test agent.",
+            AgentFactory = () => throw new InvalidOperationException("Legacy factory should not run."),
+            DefaultOptions = new GenerateReplyOptions { ModelId = "shared-model" },
+            IsModelExplicitlySelected = true,
+            CharacteristicsAgentFactory = characteristics =>
+            {
+                receivedCharacteristics = characteristics;
+                return new SubAgentProviderAgent(providerAgent.Object, ImmutableDictionary<string, object?>.Empty);
+            },
+        };
+        await using var manager = CreateManager(template, parentModelId: "shared-model");
+
+        _ = await manager.SpawnAsync("test-agent", "test task");
+
+        receivedCharacteristics
+            .Should()
+            .Be(new SubAgentCharacteristics("shared-model", null) { IsModelExplicitlySelected = true });
+    }
+
+    [Fact]
+    public void SubAgentCharacteristics_PreservesTwoValuePositionalApi()
+    {
+        var characteristics = new SubAgentCharacteristics("model", ReasoningEffort.High)
+        {
+            IsModelExplicitlySelected = true,
+        };
+
+        var (modelId, effort) = characteristics;
+
+        modelId.Should().Be("model");
+        effort.Should().Be(ReasoningEffort.High);
+    }
+
+    [Fact]
+    public async Task SpawnAsync_MergesProviderMetadataWithoutOverwritingTemplateKeys()
+    {
+        GenerateReplyOptions? receivedOptions = null;
+        var providerAgent = CreateRespondingAgent(options => receivedOptions = options);
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "You are a test agent.",
+            AgentFactory = () => throw new InvalidOperationException("Legacy factory should not run."),
+            DefaultOptions = new GenerateReplyOptions
+            {
+                ExtraProperties = ImmutableDictionary<string, object?>
+                    .Empty.Add("template-only", "template-value")
+                    .Add("shared", "template-wins"),
+            },
+            CharacteristicsAgentFactory = _ => new SubAgentProviderAgent(
+                providerAgent.Object,
+                ImmutableDictionary<string, object?>
+                    .Empty.Add("factory-only", "factory-value")
+                    .Add("shared", "factory-loses")
+            ),
+        };
+        await using var manager = CreateManager(template);
+
+        _ = await manager.SpawnAsync("test-agent", "test task");
+
+        Logger.LogDebug(
+            "Asserting merged provider options with {ExtraPropertyCount} extra properties",
+            receivedOptions?.ExtraProperties.Count
+        );
+        receivedOptions.Should().NotBeNull();
+        receivedOptions!.ExtraProperties.Should().Contain("factory-only", "factory-value");
+        receivedOptions.ExtraProperties.Should().Contain("template-only", "template-value");
+        receivedOptions.ExtraProperties.Should().Contain("shared", "template-wins");
+    }
+
+    [Fact]
+    public async Task SpawnAsync_NullDefaultOptionsCreatesOptionsForProviderMetadata()
+    {
+        GenerateReplyOptions? receivedOptions = null;
+        var providerAgent = CreateRespondingAgent(options => receivedOptions = options);
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "You are a test agent.",
+            AgentFactory = () => throw new InvalidOperationException("Legacy factory should not run."),
+            DefaultOptions = null,
+            CharacteristicsAgentFactory = _ => new SubAgentProviderAgent(
+                providerAgent.Object,
+                ImmutableDictionary<string, object?>.Empty.Add("factory-only", "factory-value")
+            ),
+        };
+        await using var manager = CreateManager(template);
+
+        _ = await manager.SpawnAsync("test-agent", "test task");
+
+        receivedOptions.Should().NotBeNull();
+        receivedOptions!.ExtraProperties.Should().Contain("factory-only", "factory-value");
+    }
+
+    [Fact]
+    public async Task SpawnAsync_UsesLegacyAgentFactoryWhenCharacteristicsFactoryIsAbsent()
+    {
+        var legacyFactoryCalls = 0;
+        var providerAgent = CreateRespondingAgent();
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "You are a test agent.",
+            AgentFactory = () =>
+            {
+                legacyFactoryCalls++;
+                return providerAgent.Object;
+            },
+        };
+        await using var manager = CreateManager(template);
+
+        _ = await manager.SpawnAsync("test-agent", "test task");
+
+        Logger.LogDebug("Asserting legacy factory invocation count {LegacyFactoryCalls}", legacyFactoryCalls);
+        legacyFactoryCalls.Should().Be(1);
+    }
+
+    private SubAgentManager CreateManager(SubAgentTemplate template, string? parentModelId = null)
+    {
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate> { ["test-agent"] = template },
+        };
+
+        return new SubAgentManager(
+            Mock.Of<IMultiTurnAgent>(),
+            parentContracts: [],
+            parentHandlers: new Dictionary<string, ToolHandler>(),
+            options,
+            new MutableSubAgentTemplateSource(options.Templates),
+            LoggerFactory.CreateLogger<SubAgentManager>(),
+            parentModelId
+        );
+    }
+
+    private static Mock<IStreamingAgent> CreateRespondingAgent(Action<GenerateReplyOptions?>? captureOptions = null)
+    {
+        var agent = new Mock<IStreamingAgent>();
+        agent
+            .Setup(a =>
+                a.GenerateReplyStreamingAsync(
+                    It.IsAny<IEnumerable<IMessage>>(),
+                    It.IsAny<GenerateReplyOptions?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback<IEnumerable<IMessage>, GenerateReplyOptions?, CancellationToken>(
+                (_, options, _) => captureOptions?.Invoke(options)
+            )
+            .ReturnsAsync(ToAsyncEnumerable([new TextMessage { Text = "done", Role = Role.Assistant }]));
+
+        return agent;
+    }
+
+    private static async IAsyncEnumerable<IMessage> ToAsyncEnumerable(
+        IReadOnlyList<IMessage> messages,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
+    {
+        foreach (var message in messages)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return message;
+            await Task.Yield();
+        }
+    }
+}

--- a/tests/LmMultiTurn.Tests/SubAgents/SubAgentManagerGateReleaseRegressionTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgents/SubAgentManagerGateReleaseRegressionTests.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmMultiTurn;
@@ -268,6 +269,59 @@ public class SubAgentManagerGateReleaseRegressionTests : IAsyncLifetime
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("subscribe blew up");
     }
 
+    [Fact]
+    public async Task HandleRunCompletion_PendingMessageCompletion_DefersOwnedProviderDisposalUntilTerminalCompletion()
+    {
+        // The HasPendingMessages branch (SubAgentManager.HandleRunCompletionAsync) must NOT treat a
+        // pending (non-terminal) completion as terminal: it must leave the completion latch unresolved
+        // and the owned provider undisposed, and only the following terminal completion disposes the
+        // provider — exactly once. Without direct coverage this branch could regress while the rest of
+        // the suite stays green.
+        var templates = new Dictionary<string, SubAgentTemplate>
+        {
+            ["owned"] = DummyTemplate("owned"),
+        };
+
+        _manager = CreateManagerWithTemplates(maxConcurrent: 2, templates);
+
+        var disposeCount = 0;
+        var provider = new Mock<IStreamingAgent>();
+        provider.As<IAsyncDisposable>()
+            .Setup(d => d.DisposeAsync())
+            .Returns(() =>
+            {
+                _ = Interlocked.Increment(ref disposeCount);
+                return ValueTask.CompletedTask;
+            });
+
+        var pendingEmitted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseTerminal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        _manager.TestAgentFactoryOverride = (_, _) => new FakeMultiTurnAgent
+        {
+            SubscribeImpl = (_, ct) => FakeMultiTurnAgent.PendingThenTerminalStream(
+                "run-1", pendingEmitted, releaseTerminal.Task, ct),
+        };
+        _manager.TestOwnedProviderOverride = (_, _) => provider.Object;
+
+        var spawnJson = await _manager.SpawnAsync("owned", "task", runInBackground: true);
+        using var spawnDoc = JsonDocument.Parse(spawnJson);
+        var agentId = spawnDoc.RootElement.GetProperty("agent_id").GetString()!;
+
+        // After the pending (non-terminal) completion: the owned provider must remain undisposed and
+        // the sub-agent must still read as running.
+        (await pendingEmitted.Task.WaitAsync(TimeSpan.FromSeconds(10))).Should().BeTrue();
+        await Task.Delay(150); // give HandleRunCompletionAsync time to (wrongly) dispose if it regressed
+        Volatile.Read(ref disposeCount).Should()
+            .Be(0, "a HasPendingMessages completion must not dispose the owned provider");
+        _manager.Peek(agentId).Should().Contain("\"running\"");
+
+        // The terminal completion disposes the owned provider exactly once.
+        releaseTerminal.SetResult(true);
+        await WaitForConditionAsync(() => Volatile.Read(ref disposeCount) == 1, TimeSpan.FromSeconds(10));
+        Volatile.Read(ref disposeCount).Should().Be(1, "the terminal completion disposes the owned provider once");
+    }
+
     #region Helpers
 
     private static async Task WaitForConditionAsync(Func<bool> condition, TimeSpan timeout)
@@ -433,6 +487,26 @@ internal sealed class FakeMultiTurnAgent : IMultiTurnAgent
         string completedRunId,
         [EnumeratorCancellation] CancellationToken ct)
     {
+        yield return new RunCompletedMessage { CompletedRunId = completedRunId };
+        await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+    }
+
+    /// <summary>
+    /// Stream that yields a NON-terminal <see cref="RunCompletedMessage"/> (HasPendingMessages =
+    /// true), signals <paramref name="pendingEmitted"/>, waits for <paramref name="releaseTerminal"/>,
+    /// then yields the terminal completion and keeps the subscription open — lets a test verify that a
+    /// pending completion neither resolves the latch nor disposes the owned provider, and that the
+    /// following terminal completion disposes exactly once.
+    /// </summary>
+    internal static async IAsyncEnumerable<IMessage> PendingThenTerminalStream(
+        string completedRunId,
+        TaskCompletionSource<bool> pendingEmitted,
+        Task releaseTerminal,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        yield return new RunCompletedMessage { CompletedRunId = completedRunId, HasPendingMessages = true };
+        _ = pendingEmitted.TrySetResult(true);
+        await releaseTerminal.WaitAsync(ct);
         yield return new RunCompletedMessage { CompletedRunId = completedRunId };
         await Task.Delay(Timeout.InfiniteTimeSpan, ct);
     }

--- a/tests/LmMultiTurn.Tests/SubAgents/SubAgentManagerGateReleaseRegressionTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgents/SubAgentManagerGateReleaseRegressionTests.cs
@@ -350,7 +350,9 @@ public class SubAgentManagerGateReleaseRegressionTests : IAsyncLifetime
             };
         };
 
-        // Provider #1's terminal disposal throws (poison); provider #2 is the fresh rebuild.
+        // Provider #1's terminal disposal throws the FIRST time (poison), then SUCCEEDS on the restart
+        // retry; provider #2 is the fresh rebuild. Failing-once-then-succeeding lets us assert the retry
+        // disposal path actually runs (a second attempt) rather than just that a replacement was created.
         var providerCallCount = 0;
         var poisonedDisposeAttempts = 0;
         _manager.TestOwnedProviderOverride = (_, _) =>
@@ -363,8 +365,10 @@ public class SubAgentManagerGateReleaseRegressionTests : IAsyncLifetime
                     .Setup(d => d.DisposeAsync())
                     .Returns(() =>
                     {
-                        _ = Interlocked.Increment(ref poisonedDisposeAttempts);
-                        return ValueTask.FromException(new InvalidOperationException("dispose failed"));
+                        var attempt = Interlocked.Increment(ref poisonedDisposeAttempts);
+                        return attempt == 1
+                            ? ValueTask.FromException(new InvalidOperationException("dispose failed"))
+                            : ValueTask.CompletedTask;
                     });
                 return poisoned.Object;
             }
@@ -384,8 +388,8 @@ public class SubAgentManagerGateReleaseRegressionTests : IAsyncLifetime
                 catch { return false; }
             },
             TimeSpan.FromSeconds(10));
-        Volatile.Read(ref poisonedDisposeAttempts).Should().BeGreaterThanOrEqualTo(1,
-            "the terminal disposal must have attempted (and failed) to dispose provider #1");
+        Volatile.Read(ref poisonedDisposeAttempts).Should().Be(1,
+            "the terminal disposal must have attempted (and failed) to dispose provider #1 exactly once");
         providerCallCount.Should().Be(1, "only the initial provider exists before the continuation");
 
         // Act: a continuation restarts the finished run. Because provider #1's terminal disposal FAILED,
@@ -393,7 +397,85 @@ public class SubAgentManagerGateReleaseRegressionTests : IAsyncLifetime
         _ = await _manager.SendMessageAsync(agentId, "continue", runInBackground: true);
 
         providerCallCount.Should().Be(2, "the poisoned provider must be replaced with a fresh one on restart");
+        Volatile.Read(ref poisonedDisposeAttempts).Should().Be(2,
+            "the restart must RETRY disposing the poisoned provider before swapping in the replacement");
         _manager.Peek(agentId).Should().Contain("\"running\"", "the resumed run is live on the fresh provider");
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_InjectCancelledByTerminalDisposal_RedeliversPromptToRestartedRun()
+    {
+        // Blocker (round 4): the inject send links the caller token with the run's lifecycle token, and
+        // terminal disposal cancels that token. This must NOT surface as a caller cancellation that drops
+        // the user's message — the continuation must re-enter the decision loop and deliver the prompt to
+        // the restarted run. Exercised through the REAL SubAgentManager.SendMessageAsync boundary (not the
+        // SubAgentState primitive directly), so it fails if the manager stops using the linked token.
+        var templates = new Dictionary<string, SubAgentTemplate>
+        {
+            ["owned"] = DummyTemplate("owned"),
+        };
+
+        _manager = CreateManagerWithTemplates(maxConcurrent: 2, templates);
+
+        var sentSink = new System.Collections.Concurrent.ConcurrentQueue<string>();
+        var injectStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var agentCallCount = 0;
+
+        _manager.TestAgentFactoryOverride = (_, _) =>
+        {
+            var which = Interlocked.Increment(ref agentCallCount);
+            if (which != 1)
+            {
+                // Agent #2 (the restart) stays running and uses the default succeeding send.
+                return new FakeMultiTurnAgent
+                {
+                    SentSink = sentSink,
+                    SubscribeImpl = (_, ct) => FakeMultiTurnAgent.WaitForeverStream(ct),
+                };
+            }
+
+            // Agent #1: spawn send (call 1) succeeds; the inject (call >= 2) signals it is in flight then
+            // BLOCKS on its token — the manager's linked lifecycle token — until terminal disposal cancels
+            // it. Its run completes terminally only AFTER the inject is in flight, so the lease is held when
+            // terminal disposal runs and the lifecycle-cancel path is exercised end to end.
+            return new FakeMultiTurnAgent
+            {
+                SentSink = sentSink,
+                SendWithTokenImpl = async (idx, sendCt) =>
+                {
+                    if (idx >= 2)
+                    {
+                        _ = injectStarted.TrySetResult(true);
+                        await Task.Delay(Timeout.InfiniteTimeSpan, sendCt);
+                    }
+
+                    return new SendReceipt(Guid.NewGuid().ToString("N"), null, DateTimeOffset.UtcNow);
+                },
+                SubscribeImpl = (_, ct) => FakeMultiTurnAgent.WaitThenCompleteStream(injectStarted.Task, "run-1", ct),
+            };
+        };
+
+        // Owned provider disposes cleanly at terminal completion, so HasDisposedOwnedProviderAgent drives
+        // the restart rebuild.
+        _manager.TestOwnedProviderOverride = (_, _) => new Mock<IStreamingAgent>().Object;
+
+        var spawnJson = await _manager.SpawnAsync("owned", "task", runInBackground: true);
+        using var spawnDoc = JsonDocument.Parse(spawnJson);
+        var agentId = spawnDoc.RootElement.GetProperty("agent_id").GetString()!;
+
+        // Act: a continuation whose caller token is non-cancelable. Its inject send blocks, terminal
+        // completion lands and lifecycle-cancels it, and the manager must restart and deliver the prompt
+        // — returning normally rather than throwing OperationCanceledException.
+        var resultJson = await _manager
+            .SendMessageAsync(agentId, "resumed-prompt", runInBackground: true)
+            .WaitAsync(TimeSpan.FromSeconds(15));
+
+        using var resultDoc = JsonDocument.Parse(resultJson);
+        resultDoc.RootElement.GetProperty("status").GetString().Should().Be("resumed",
+            "the lifecycle-cancelled inject must be re-driven through the restart path, not surfaced as cancellation");
+        agentCallCount.Should().Be(2, "the finished run must be restarted on a fresh agent");
+        sentSink.Should().Contain("resumed-prompt",
+            "the user's prompt must reach the restarted run rather than being dropped on lifecycle cancellation");
     }
 
     [Fact]
@@ -531,6 +613,20 @@ internal sealed class FakeMultiTurnAgent : IMultiTurnAgent
     public Func<int, ValueTask<SendReceipt>>? SendImpl { get; set; }
 
     /// <summary>
+    /// Token-aware variant of <see cref="SendImpl"/> (takes precedence when set): receives the
+    /// send's <see cref="CancellationToken"/> so a test can block on it and prove terminal
+    /// disposal cancels a wedged inject send through the manager's linked lifecycle token.
+    /// </summary>
+    public Func<int, CancellationToken, ValueTask<SendReceipt>>? SendWithTokenImpl { get; set; }
+
+    /// <summary>
+    /// Optional sink recording the first user text of every <see cref="SendAsync"/> call — shared
+    /// across agent instances (e.g. a restart's replacement agent) so a test can assert a prompt
+    /// reached the restarted run.
+    /// </summary>
+    public System.Collections.Concurrent.ConcurrentQueue<string>? SentSink { get; init; }
+
+    /// <summary>
     /// Invoked for each <see cref="SubscribeAsync"/> call with a 1-based call index, so a test
     /// can give a later restart's monitor different behavior than the original epoch's. Null
     /// (default) =&gt; <see cref="WaitForeverStream"/>.
@@ -543,7 +639,13 @@ internal sealed class FakeMultiTurnAgent : IMultiTurnAgent
         string? parentRunId = null,
         CancellationToken ct = default)
     {
+        SentSink?.Enqueue(messages.OfType<TextMessage>().Select(m => m.Text).FirstOrDefault() ?? string.Empty);
         var callIndex = Interlocked.Increment(ref _sendCallCount);
+        if (SendWithTokenImpl != null)
+        {
+            return SendWithTokenImpl(callIndex, ct);
+        }
+
         return SendImpl != null
             ? SendImpl(callIndex)
             : new ValueTask<SendReceipt>(
@@ -608,6 +710,22 @@ internal sealed class FakeMultiTurnAgent : IMultiTurnAgent
     {
         await Task.Delay(Timeout.InfiniteTimeSpan, ct);
         yield break;
+    }
+
+    /// <summary>
+    /// Stream that waits for <paramref name="gate"/> (e.g. "an inject send is now in flight"), then yields
+    /// a single TERMINAL <see cref="RunCompletedMessage"/> and keeps the subscription open. Lets a test
+    /// drive a terminal completion to land WHILE an admitted inject send is blocked, so the manager's
+    /// lifecycle-token cancellation + continuation-restart path is exercised end to end.
+    /// </summary>
+    internal static async IAsyncEnumerable<IMessage> WaitThenCompleteStream(
+        Task gate,
+        string completedRunId,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        await gate.WaitAsync(ct);
+        yield return new RunCompletedMessage { CompletedRunId = completedRunId };
+        await Task.Delay(Timeout.InfiniteTimeSpan, ct);
     }
 
     /// <summary>

--- a/tests/LmMultiTurn.Tests/SubAgents/SubAgentManagerGateReleaseRegressionTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgents/SubAgentManagerGateReleaseRegressionTests.cs
@@ -520,6 +520,78 @@ public class SubAgentManagerGateReleaseRegressionTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task RestartRunAsync_RestartedMonitorFaultsBeforeArmRunning_DoesNotResurrectRunning()
+    {
+        // Round-6 blocker: a restarted run's monitor can fault BEFORE RestartRunAsync's TryArmRunning
+        // executes. The monitor's fault path must record a GENERATION-AWARE terminal Error (not a raw
+        // Status write), so TryArmRunning observes this generation's terminal and refuses to overwrite
+        // Error with Running — which would advertise a dead run. Synchronized so it deterministically hits
+        // the fault-before-arm ordering.
+        var templates = new Dictionary<string, SubAgentTemplate>
+        {
+            ["owned"] = DummyTemplate("owned"),
+        };
+
+        _manager = CreateManagerWithTemplates(maxConcurrent: 2, templates);
+
+        var restartSendGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var agentCallCount = 0;
+        _manager.TestAgentFactoryOverride = (_, _) =>
+        {
+            var which = Interlocked.Increment(ref agentCallCount);
+            if (which == 1)
+            {
+                // Agent #1 completes once (becomes restartable), then keeps its subscription open.
+                return new FakeMultiTurnAgent
+                {
+                    SubscribeImpl = (_, ct) => FakeMultiTurnAgent.CompleteOnceThenWaitForeverStream("run-1", ct),
+                };
+            }
+
+            // Agent #2 (the restart): its monitor faults immediately; its restart SendAsync blocks on the
+            // gate so the test can confirm the fault was recorded (status Error) BEFORE TryArmRunning runs.
+            return new FakeMultiTurnAgent
+            {
+                SubscribeImpl = (_, _) =>
+                    FakeMultiTurnAgent.ThrowingStream(new InvalidOperationException("restarted monitor blew up")),
+                SendWithTokenImpl = async (_, sendCt) =>
+                {
+                    await restartSendGate.Task.WaitAsync(sendCt);
+                    return new SendReceipt("restart-send", null, DateTimeOffset.UtcNow);
+                },
+            };
+        };
+
+        // Owned provider disposes cleanly at agent #1's terminal, so the restart rebuilds (agent #2).
+        _manager.TestOwnedProviderOverride = (_, _) => new Mock<IStreamingAgent>().Object;
+
+        var spawnJson = await _manager.SpawnAsync("owned", "task", runInBackground: true);
+        using var spawnDoc = JsonDocument.Parse(spawnJson);
+        var agentId = spawnDoc.RootElement.GetProperty("agent_id").GetString()!;
+
+        await WaitForConditionAsync(
+            () => { try { return _manager!.Peek(agentId).Contains("\"completed\""); } catch { return false; } },
+            TimeSpan.FromSeconds(10));
+
+        // Begin the restart on a background task; its restart SendAsync blocks on the gate.
+        var restartTask = Task.Run(() => _manager!.SendMessageAsync(agentId, "resumed-prompt", runInBackground: true));
+
+        // The restarted monitor faults and records the generation-aware terminal Error.
+        await WaitForConditionAsync(
+            () => { try { return _manager!.Peek(agentId).Contains("\"error\""); } catch { return false; } },
+            TimeSpan.FromSeconds(10));
+
+        // Now let the restart SendAsync return so TryArmRunning(runGeneration) executes AFTER the fault.
+        restartSendGate.SetResult(true);
+        _ = await restartTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // TryArmRunning must NOT resurrect the faulted run: status stays Error, never Running.
+        _manager.Peek(agentId).Should().Contain("\"error\"",
+            "a monitor fault recorded against the run generation must block TryArmRunning from restoring Running");
+        _manager.Peek(agentId).Should().NotContain("\"running\"");
+    }
+
+    [Fact]
     public async Task MonitorSubAgentAsync_PendingMessageCompletion_HoldsConcurrencyPermitUntilTerminal()
     {
         // Blocker D: with limit 1, a nonterminal (HasPendingMessages) completion must NOT release the

--- a/tests/LmMultiTurn.Tests/SubAgents/SubAgentManagerGateReleaseRegressionTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgents/SubAgentManagerGateReleaseRegressionTests.cs
@@ -322,6 +322,139 @@ public class SubAgentManagerGateReleaseRegressionTests : IAsyncLifetime
         Volatile.Read(ref disposeCount).Should().Be(1, "the terminal completion disposes the owned provider once");
     }
 
+    [Fact]
+    public async Task RestartRunAsync_AfterFailedTerminalDisposal_RebuildsFreshProviderInsteadOfReusingPoisoned()
+    {
+        // Blocker A: if a terminal owned-provider disposal THROWS, the provider may be partially torn
+        // down. A later continuation must NOT reuse it — the restart path must rebuild a fresh provider.
+        // A failed disposal resets the dispose guard (HasDisposedOwnedProviderAgent == false), so without
+        // the poison flag the rebuild branch would be skipped and the partially-disposed provider reused.
+        var templates = new Dictionary<string, SubAgentTemplate>
+        {
+            ["owned"] = DummyTemplate("owned"),
+        };
+
+        _manager = CreateManagerWithTemplates(maxConcurrent: 2, templates);
+
+        // Agent #1 completes once (triggering terminal disposal), then keeps its subscription open; the
+        // restarted agent #2 just waits so the resumed run stays alive for assertions.
+        var agentCallCount = 0;
+        _manager.TestAgentFactoryOverride = (_, _) =>
+        {
+            var idx = Interlocked.Increment(ref agentCallCount);
+            return new FakeMultiTurnAgent
+            {
+                SubscribeImpl = (_, ct) => idx == 1
+                    ? FakeMultiTurnAgent.CompleteOnceThenWaitForeverStream("run-1", ct)
+                    : FakeMultiTurnAgent.WaitForeverStream(ct),
+            };
+        };
+
+        // Provider #1's terminal disposal throws (poison); provider #2 is the fresh rebuild.
+        var providerCallCount = 0;
+        var poisonedDisposeAttempts = 0;
+        _manager.TestOwnedProviderOverride = (_, _) =>
+        {
+            var idx = Interlocked.Increment(ref providerCallCount);
+            if (idx == 1)
+            {
+                var poisoned = new Mock<IStreamingAgent>();
+                poisoned.As<IAsyncDisposable>()
+                    .Setup(d => d.DisposeAsync())
+                    .Returns(() =>
+                    {
+                        _ = Interlocked.Increment(ref poisonedDisposeAttempts);
+                        return ValueTask.FromException(new InvalidOperationException("dispose failed"));
+                    });
+                return poisoned.Object;
+            }
+
+            return new Mock<IStreamingAgent>().Object;
+        };
+
+        var spawnJson = await _manager.SpawnAsync("owned", "task", runInBackground: true);
+        using var spawnDoc = JsonDocument.Parse(spawnJson);
+        var agentId = spawnDoc.RootElement.GetProperty("agent_id").GetString()!;
+
+        // Wait until the first run has completed (its terminal disposal ran and threw).
+        await WaitForConditionAsync(
+            () =>
+            {
+                try { return _manager!.Peek(agentId).Contains("\"completed\""); }
+                catch { return false; }
+            },
+            TimeSpan.FromSeconds(10));
+        Volatile.Read(ref poisonedDisposeAttempts).Should().BeGreaterThanOrEqualTo(1,
+            "the terminal disposal must have attempted (and failed) to dispose provider #1");
+        providerCallCount.Should().Be(1, "only the initial provider exists before the continuation");
+
+        // Act: a continuation restarts the finished run. Because provider #1's terminal disposal FAILED,
+        // the restart must rebuild a fresh provider (call #2), never reuse the poisoned instance.
+        _ = await _manager.SendMessageAsync(agentId, "continue", runInBackground: true);
+
+        providerCallCount.Should().Be(2, "the poisoned provider must be replaced with a fresh one on restart");
+        _manager.Peek(agentId).Should().Contain("\"running\"", "the resumed run is live on the fresh provider");
+    }
+
+    [Fact]
+    public async Task MonitorSubAgentAsync_PendingMessageCompletion_HoldsConcurrencyPermitUntilTerminal()
+    {
+        // Blocker D: with limit 1, a nonterminal (HasPendingMessages) completion must NOT release the
+        // concurrency permit — the same sub-agent keeps processing queued work. Releasing early would let
+        // a second sub-agent start, exceeding MaxConcurrentSubAgents. The permit is freed only on the
+        // TERMINAL completion.
+        const int maxConcurrent = 1;
+        var templates = new Dictionary<string, SubAgentTemplate>
+        {
+            ["pending"] = DummyTemplate("pending"),
+            ["normal"] = DummyTemplate("normal"),
+        };
+
+        _manager = CreateManagerWithTemplates(maxConcurrent, templates);
+
+        var pendingEmitted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseTerminal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        _manager.TestAgentFactoryOverride = (_, template) => template.Name == "pending"
+            ? new FakeMultiTurnAgent
+            {
+                SubscribeImpl = (_, ct) => FakeMultiTurnAgent.PendingThenTerminalStream(
+                    "run-1", pendingEmitted, releaseTerminal.Task, ct),
+            }
+            : new FakeMultiTurnAgent();
+
+        var spawnJson = await _manager.SpawnAsync("pending", "task", runInBackground: true);
+        using var spawnDoc = JsonDocument.Parse(spawnJson);
+        var pendingAgentId = spawnDoc.RootElement.GetProperty("agent_id").GetString()!;
+
+        // After the pending completion is processed, the permit must still be held.
+        (await pendingEmitted.Task.WaitAsync(TimeSpan.FromSeconds(10))).Should().BeTrue();
+        await Task.Delay(150); // give the monitor time to (wrongly) release the permit if it regressed
+
+        var whileBusy = () => _manager!.SpawnAsync("normal", "should-not-start", runInBackground: true);
+        await whileBusy.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Max concurrent sub-agents*",
+                "a pending (nonterminal) completion must not free the slot while the sub-agent is still active");
+
+        // The terminal completion frees the slot: wait for the busy agent to settle terminal, then a
+        // single fresh spawn must succeed on the now-released slot.
+        releaseTerminal.SetResult(true);
+        await WaitForConditionAsync(
+            () =>
+            {
+                try { return _manager!.Peek(pendingAgentId).Contains("\"completed\""); }
+                catch { return false; }
+            },
+            TimeSpan.FromSeconds(10));
+
+        var afterTerminalJson = await _manager
+            .SpawnAsync("normal", "after-terminal", runInBackground: true)
+            .WaitAsync(TimeSpan.FromSeconds(10));
+        using var afterDoc = JsonDocument.Parse(afterTerminalJson);
+        afterDoc.RootElement.GetProperty("status").GetString().Should().Be("spawned",
+            "the terminal completion released the slot, so a new sub-agent can start");
+    }
+
     #region Helpers
 
     private static async Task WaitForConditionAsync(Func<bool> condition, TimeSpan timeout)

--- a/tests/LmMultiTurn.Tests/SubAgents/SubAgentManagerGateReleaseRegressionTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgents/SubAgentManagerGateReleaseRegressionTests.cs
@@ -479,6 +479,47 @@ public class SubAgentManagerGateReleaseRegressionTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task SendMessageAsync_InjectSendThrowsInternalCancellation_PropagatesWithoutRetry()
+    {
+        // Round-5 blocker: the inject catch must treat ONLY lifecycle-token cancellation as "retry via
+        // restart". An internal OperationCanceledException from Agent.SendAsync (e.g. its own timeout) with
+        // NEITHER the caller token NOR the linked lifecycle token cancelled must PROPAGATE, not be retried —
+        // otherwise the manager risks duplicate delivery or an unbounded retry loop.
+        var templates = new Dictionary<string, SubAgentTemplate>
+        {
+            ["owned"] = DummyTemplate("owned"),
+        };
+
+        _manager = CreateManagerWithTemplates(maxConcurrent: 2, templates);
+
+        var sendCount = 0;
+        _manager.TestAgentFactoryOverride = (_, _) => new FakeMultiTurnAgent
+        {
+            // Spawn send (call 1) succeeds; the inject (call 2) throws an INTERNAL cancellation unrelated
+            // to either supplied token.
+            SendImpl = _ =>
+            {
+                var n = Interlocked.Increment(ref sendCount);
+                return n == 1
+                    ? new ValueTask<SendReceipt>(new SendReceipt("r1", null, DateTimeOffset.UtcNow))
+                    : ValueTask.FromException<SendReceipt>(new OperationCanceledException("internal send timeout"));
+            },
+            SubscribeImpl = (_, ct) => FakeMultiTurnAgent.WaitForeverStream(ct),
+        };
+
+        var spawnJson = await _manager.SpawnAsync("owned", "task", runInBackground: true);
+        using var spawnDoc = JsonDocument.Parse(spawnJson);
+        var agentId = spawnDoc.RootElement.GetProperty("agent_id").GetString()!;
+
+        // The internal OCE must surface to the caller, not be swallowed-and-retried.
+        var act = () => _manager!.SendMessageAsync(agentId, "resumed-prompt", runInBackground: true);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        // Exactly the spawn send + the single failed inject attempt — no restart / re-send.
+        Volatile.Read(ref sendCount).Should().Be(2, "an internal SendAsync cancellation must not be retried");
+    }
+
+    [Fact]
     public async Task MonitorSubAgentAsync_PendingMessageCompletion_HoldsConcurrencyPermitUntilTerminal()
     {
         // Blocker D: with limit 1, a nonterminal (HasPendingMessages) completion must NOT release the

--- a/tests/LmMultiTurn.Tests/SubAgents/SubAgentStateLifecycleTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgents/SubAgentStateLifecycleTests.cs
@@ -182,6 +182,44 @@ public class SubAgentStateLifecycleTests
         state.OwnedProviderTerminalDisposeFailed.Should().BeFalse("assigning a fresh provider clears the poison");
     }
 
+    [Fact]
+    public async Task BeginTerminalDisposal_ThrowingLifecycleCancellationCallback_StillCompletesTerminalTransition()
+    {
+        // Blocker (round 4): CancellationTokenSource.Cancel() runs callbacks synchronously and aggregates
+        // any that throw into an AggregateException. That must NOT abort BeginTerminalDisposalAsync's lease
+        // drain / terminal-status transition — otherwise the provider is left neither disposed nor poisoned
+        // and a later restart could reuse an interrupted provider.
+        var state = NewOwnedProviderState();
+
+        var decision = state.BeginContinuation(notifyParentOnCompletion: false);
+        decision.Mode.Should().Be(ContinuationMode.Inject);
+
+        // A linked token (as the inject send would hold) with a callback that throws when the lifecycle
+        // token is cancelled during terminal disposal.
+        using var linked = state.LinkLifecycleToken(CancellationToken.None);
+        var callbackFired = false;
+        _ = linked.Token.Register(() =>
+        {
+            callbackFired = true;
+            throw new InvalidOperationException("cancellation callback boom");
+        });
+
+        // The cancel (with its throwing callback) happens inside here; it must be swallowed and the
+        // disposal must park on the still-held lease rather than fault or skip the transition.
+        var disposal = state.BeginTerminalDisposalAsync(isError: false);
+
+        await Task.Delay(100);
+        callbackFired.Should().BeTrue("terminal disposal must have cancelled the lifecycle token");
+        disposal.IsCompleted.Should().BeFalse("the throwing callback must not skip the lease drain");
+        state.Status.Should().Be(SubAgentStatus.Running, "status stays Running until the lease drains");
+
+        // Releasing the lease lets the (un-aborted) transition finish and flip terminal.
+        state.EndInjectLease();
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+        state.Status.Should().Be(SubAgentStatus.Completed,
+            "a throwing cancellation callback must not abort the terminal transition");
+    }
+
     private static SubAgentState NewOwnedProviderState()
     {
         var state = new SubAgentState

--- a/tests/LmMultiTurn.Tests/SubAgents/SubAgentStateLifecycleTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgents/SubAgentStateLifecycleTests.cs
@@ -95,6 +95,93 @@ public class SubAgentStateLifecycleTests
         third.RestartCompleted!.IsCompleted.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task BeginTerminalDisposal_UnblocksWedgedInjectSend_ViaLifecycleTokenCancellation()
+    {
+        // Blocker B: an admitted inject send that wedges on a stalled provider/channel must be
+        // cancellable by terminal disposal, even when the CALLER'S token never fires. The send links
+        // LinkLifecycleToken(caller); terminal disposal cancels the lifecycle token so the send unblocks,
+        // its lease drains, and disposal proceeds instead of parking forever.
+        var state = NewOwnedProviderState();
+
+        var decision = state.BeginContinuation(notifyParentOnCompletion: false);
+        decision.Mode.Should().Be(ContinuationMode.Inject);
+
+        // The wedged inject send: a non-cancelable caller token (CancellationToken.None) linked with the
+        // run's lifecycle token, awaiting forever. Its lease is released in finally, mirroring the manager.
+        var sendObservedCancellation = false;
+        var wedgedSend = Task.Run(async () =>
+        {
+            using var linked = state.LinkLifecycleToken(CancellationToken.None);
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, linked.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                sendObservedCancellation = true;
+            }
+            finally
+            {
+                state.EndInjectLease();
+            }
+        });
+
+        // Terminal disposal parks on the lease drain AND cancels the lifecycle token, which unblocks the
+        // wedged send; without the lifecycle link this would hang forever on the non-cancelable caller.
+        var disposal = state.BeginTerminalDisposalAsync(isError: false);
+
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+        await wedgedSend.WaitAsync(TimeSpan.FromSeconds(5));
+
+        sendObservedCancellation.Should().BeTrue("terminal disposal must cancel the wedged inject send");
+        state.Status.Should().Be(SubAgentStatus.Completed);
+    }
+
+    [Fact]
+    public async Task TryArmRunning_AfterRunReachedTerminal_DoesNotResurrectToRunning()
+    {
+        // Blocker C: a fast restarted run can complete and dispose its owned provider before the restart's
+        // "arm Running" publish executes. That publish (TryArmRunning) must be generation-guarded so it
+        // cannot overwrite the terminal state — otherwise the next continuation injects into a dead run
+        // whose provider is already disposed.
+        var terminated = NewOwnedProviderState();
+        var generation = terminated.BeginRunGeneration();
+
+        // The restarted run completes terminally BEFORE TryArmRunning runs.
+        await terminated.BeginTerminalDisposalAsync(isError: false);
+        terminated.Status.Should().Be(SubAgentStatus.Completed);
+
+        terminated.TryArmRunning(generation).Should().BeFalse(
+            "a run that already reached terminal must not be resurrected to Running");
+        terminated.Status.Should().Be(SubAgentStatus.Completed, "the terminal state must survive the guarded publish");
+
+        // Control: a generation whose run has NOT gone terminal publishes Running normally.
+        var live = NewOwnedProviderState();
+        var liveGeneration = live.BeginRunGeneration();
+        live.TryArmRunning(liveGeneration).Should().BeTrue();
+        live.Status.Should().Be(SubAgentStatus.Running);
+    }
+
+    [Fact]
+    public void OwnedProviderPoison_IsSetOnFailedDisposal_AndClearedByFreshProvider()
+    {
+        // Blocker A: a FAILED terminal disposal must poison the run's provider so a continuation rebuilds a
+        // fresh one instead of reusing a partially-disposed instance. A failed disposal leaves the dispose
+        // guard reset (HasDisposedOwnedProviderAgent == false), so the poison flag is the signal the
+        // restart path keys on; assigning a fresh provider clears it.
+        var state = NewOwnedProviderState();
+        state.OwnedProviderTerminalDisposeFailed.Should().BeFalse();
+
+        state.MarkOwnedProviderTerminalDisposeFailed();
+        state.OwnedProviderTerminalDisposeFailed.Should().BeTrue("a failed terminal disposal poisons the provider");
+        state.HasDisposedOwnedProviderAgent.Should().BeFalse(
+            "a failed disposal did not latch Disposed, so poison — not HasDisposed — must drive the rebuild");
+
+        state.SetOwnedProviderAgent(new Mock<IStreamingAgent>().Object);
+        state.OwnedProviderTerminalDisposeFailed.Should().BeFalse("assigning a fresh provider clears the poison");
+    }
+
     private static SubAgentState NewOwnedProviderState()
     {
         var state = new SubAgentState

--- a/tests/LmMultiTurn.Tests/SubAgents/SubAgentStateLifecycleTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgents/SubAgentStateLifecycleTests.cs
@@ -1,0 +1,118 @@
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace LmMultiTurn.Tests.SubAgents;
+
+/// <summary>
+/// Synchronized race tests for <see cref="SubAgentState"/>'s continuation-admission /
+/// terminal-disposal / restart coordination — the deadlock-free lease + single-flight-restart
+/// primitives that <c>SubAgentManager.SendMessageAsync</c> and <c>HandleRunCompletionAsync</c>
+/// build on. They prove, deterministically:
+/// <list type="bullet">
+/// <item><description>A terminal owned-provider disposal cannot overlap an admitted inject send:
+/// <see cref="SubAgentState.BeginTerminalDisposalAsync"/> parks until the in-flight send lease is
+/// released.</description></item>
+/// <item><description>A continuation that arrives while the owned provider is being disposed is
+/// routed to a fresh-provider restart, never injected through the provider being torn
+/// down.</description></item>
+/// <item><description>Exactly one caller performs the restart of a finished run; concurrent
+/// continuations await it instead of both entering <c>RestartRunAsync</c>.</description></item>
+/// </list>
+/// </summary>
+public class SubAgentStateLifecycleTests
+{
+    [Fact]
+    public async Task BeginTerminalDisposal_ParksUntilInFlightInjectSendLeaseIsReleased()
+    {
+        var state = NewOwnedProviderState();
+
+        // Admit an inject continuation: a send lease is now in flight (the manager would be inside
+        // state.Agent.SendAsync at this point).
+        var decision = state.BeginContinuation(notifyParentOnCompletion: false);
+        decision.Mode.Should().Be(ContinuationMode.Inject);
+
+        // A terminal completion must NOT flip the sub-agent terminal — which is the point just
+        // before the manager disposes the owned provider — while the send lease is still held.
+        var disposal = state.BeginTerminalDisposalAsync(isError: false);
+        await Task.Delay(150);
+        disposal.IsCompleted.Should().BeFalse(
+            "terminal disposal must await the in-flight inject send lease so disposal cannot overlap a send");
+        state.Status.Should().Be(SubAgentStatus.Running, "status must stay Running until the send lease drains");
+
+        // Releasing the lease lets the disposal proceed and flip terminal.
+        state.EndInjectLease();
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+        state.Status.Should().Be(SubAgentStatus.Completed);
+    }
+
+    [Fact]
+    public async Task BeginContinuation_WhileOwnedProviderDisposalPending_RoutesToRestartNotInject()
+    {
+        var state = NewOwnedProviderState();
+
+        // Hold a send lease so the terminal disposal parks in the "terminating" state (status still
+        // Running, owned provider about to be disposed).
+        var held = state.BeginContinuation(notifyParentOnCompletion: false);
+        held.Mode.Should().Be(ContinuationMode.Inject);
+
+        var disposal = state.BeginTerminalDisposalAsync(isError: false);
+        await Task.Delay(50);
+
+        // A continuation arriving now must NOT inject through the disposing owned provider — it is
+        // routed to a fresh-provider restart instead.
+        var racing = state.BeginContinuation(notifyParentOnCompletion: false);
+        racing.Mode.Should().Be(ContinuationMode.Restart);
+
+        // Drain the lease so the parked disposal completes, then release the restart claim.
+        state.EndInjectLease();
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+        state.EndRestart();
+    }
+
+    [Fact]
+    public async Task BeginContinuation_FromFinishedRun_OnlyOneCallerClaimsRestart()
+    {
+        var state = NewOwnedProviderState();
+        state.Status = SubAgentStatus.Completed; // the run has finished
+
+        var first = state.BeginContinuation(notifyParentOnCompletion: false);
+        var second = state.BeginContinuation(notifyParentOnCompletion: false);
+        var third = state.BeginContinuation(notifyParentOnCompletion: false);
+
+        first.Mode.Should().Be(ContinuationMode.Restart, "exactly one caller performs the restart");
+        second.Mode.Should().Be(ContinuationMode.AwaitRestart);
+        third.Mode.Should().Be(ContinuationMode.AwaitRestart);
+        second.RestartCompleted.Should().NotBeNull();
+        second.RestartCompleted!.IsCompleted.Should().BeFalse("the restart is still in flight");
+
+        // The restart owner finishing wakes every waiter so they re-evaluate against the re-armed loop.
+        state.EndRestart();
+        await second.RestartCompleted!.WaitAsync(TimeSpan.FromSeconds(5));
+        third.RestartCompleted!.IsCompleted.Should().BeTrue();
+    }
+
+    private static SubAgentState NewOwnedProviderState()
+    {
+        var state = new SubAgentState
+        {
+            AgentId = "agent-1",
+            TemplateName = "tmpl",
+            Task = "do work",
+            Agent = new Mock<IMultiTurnAgent>().Object,
+            Template = new SubAgentTemplate
+            {
+                Name = "tmpl",
+                SystemPrompt = "You are a test agent.",
+                AgentFactory = () => new Mock<IStreamingAgent>().Object,
+            },
+        };
+
+        // Give it an owned provider so the terminal-disposal path engages the send-lease drain.
+        state.SetOwnedProviderAgent(new Mock<IStreamingAgent>().Object);
+        return state;
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
@@ -397,13 +397,13 @@ public class ContextDiscoveryControllerTests
                         ImmutableDictionary<string, object?>.Empty);
                 };
             var emptySeed = new Dictionary<string, SubAgentTemplate>();
-            var bindingA = registry.GetOrAddSubAgentBinding(
+            var bindingA = registry.AddOrUpdateSubAgentBinding(
                 gatewaySessionId,
                 "conv-A",
                 emptySeed,
                 () => agentA,
                 characteristicsFactoryA);
-            var bindingB = registry.GetOrAddSubAgentBinding(
+            var bindingB = registry.AddOrUpdateSubAgentBinding(
                 gatewaySessionId,
                 "conv-B",
                 emptySeed,
@@ -430,12 +430,8 @@ public class ContextDiscoveryControllerTests
             bindingB.Source.Templates["echo"].AgentFactory().Should().BeSameAs(
                 agentB,
                 "conversation B's discovered sub-agent must spawn with B's provider, not the first conversation's");
-            bindingA.Source.Templates["echo"]
-                .CharacteristicsAgentFactory.Should().BeSameAs(characteristicsFactoryA);
-            bindingB.Source.Templates["echo"]
-                .CharacteristicsAgentFactory.Should().BeSameAs(
-                    characteristicsFactoryB,
-                    "conversation B must retain its own cross-transport factory identity");
+            bindingA.Source.Templates["echo"].CharacteristicsAgentFactory.Should().NotBeNull();
+            bindingB.Source.Templates["echo"].CharacteristicsAgentFactory.Should().NotBeNull();
 
             var characteristics = new SubAgentCharacteristics("conversation-b-model", ReasoningEffort.High);
             var reboundProvider = bindingB.Source.Templates["echo"]
@@ -443,8 +439,14 @@ public class ContextDiscoveryControllerTests
 
             receivedCharacteristicsB.Should().BeSameAs(characteristics);
             reboundProvider.Agent.Should().BeSameAs(
+                agentB,
+                "inherited webhook spawns must use the conversation's fresh legacy route");
+            var explicitProvider = bindingB.Source.Templates["echo"]
+                .CharacteristicsAgentFactory!(
+                    characteristics with { IsModelExplicitlySelected = true });
+            explicitProvider.Agent.Should().BeSameAs(
                 characteristicsAgentB,
-                "the rebound template must route through conversation B's characteristics factory");
+                "explicit webhook spawns must use the conversation's characteristics route");
         }
         finally
         {

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
@@ -1,6 +1,8 @@
+using System.Collections.Immutable;
 using System.Net;
 using System.Text;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using LmStreaming.Sample.Services.Discovery;
 using LmStreaming.Sample.Tests.TestDoubles;
@@ -379,9 +381,34 @@ public class ContextDiscoveryControllerTests
 
             var agentA = new Mock<IStreamingAgent>().Object;
             var agentB = new Mock<IStreamingAgent>().Object;
+            var characteristicsAgentA = new Mock<IStreamingAgent>().Object;
+            var characteristicsAgentB = new Mock<IStreamingAgent>().Object;
+            SubAgentCharacteristics? receivedCharacteristicsB = null;
+            Func<SubAgentCharacteristics, SubAgentProviderAgent> characteristicsFactoryA =
+                _ => new SubAgentProviderAgent(
+                    characteristicsAgentA,
+                    ImmutableDictionary<string, object?>.Empty);
+            Func<SubAgentCharacteristics, SubAgentProviderAgent> characteristicsFactoryB =
+                characteristics =>
+                {
+                    receivedCharacteristicsB = characteristics;
+                    return new SubAgentProviderAgent(
+                        characteristicsAgentB,
+                        ImmutableDictionary<string, object?>.Empty);
+                };
             var emptySeed = new Dictionary<string, SubAgentTemplate>();
-            var bindingA = registry.GetOrAddSubAgentBinding(gatewaySessionId, "conv-A", emptySeed, () => agentA);
-            var bindingB = registry.GetOrAddSubAgentBinding(gatewaySessionId, "conv-B", emptySeed, () => agentB);
+            var bindingA = registry.GetOrAddSubAgentBinding(
+                gatewaySessionId,
+                "conv-A",
+                emptySeed,
+                () => agentA,
+                characteristicsFactoryA);
+            var bindingB = registry.GetOrAddSubAgentBinding(
+                gatewaySessionId,
+                "conv-B",
+                emptySeed,
+                () => agentB,
+                characteristicsFactoryB);
 
             var loader = new WorkspaceSubAgentLoader(registry, NullLogger<WorkspaceSubAgentLoader>.Instance);
             var controller = CreateController(authorizationHeader: Secret, registry: registry, loader: loader);
@@ -403,6 +430,21 @@ public class ContextDiscoveryControllerTests
             bindingB.Source.Templates["echo"].AgentFactory().Should().BeSameAs(
                 agentB,
                 "conversation B's discovered sub-agent must spawn with B's provider, not the first conversation's");
+            bindingA.Source.Templates["echo"]
+                .CharacteristicsAgentFactory.Should().BeSameAs(characteristicsFactoryA);
+            bindingB.Source.Templates["echo"]
+                .CharacteristicsAgentFactory.Should().BeSameAs(
+                    characteristicsFactoryB,
+                    "conversation B must retain its own cross-transport factory identity");
+
+            var characteristics = new SubAgentCharacteristics("conversation-b-model", ReasoningEffort.High);
+            var reboundProvider = bindingB.Source.Templates["echo"]
+                .CharacteristicsAgentFactory!(characteristics);
+
+            receivedCharacteristicsB.Should().BeSameAs(characteristics);
+            reboundProvider.Agent.Should().BeSameAs(
+                characteristicsAgentB,
+                "the rebound template must route through conversation B's characteristics factory");
         }
         finally
         {

--- a/tests/LmStreaming.Sample.Tests/ProgramSubAgentCompositionTests.cs
+++ b/tests/LmStreaming.Sample.Tests/ProgramSubAgentCompositionTests.cs
@@ -1,0 +1,217 @@
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+
+namespace LmStreaming.Sample.Tests;
+
+public sealed class ProgramSubAgentCompositionTests
+{
+    [Fact]
+    public void ApplyCharacteristicsAgentFactory_AttachesSameFactoryToEveryTemplate()
+    {
+        var legacyFactory = new Func<IStreamingAgent>(() => new Mock<IStreamingAgent>().Object);
+        var characteristicsFactory =
+            new Func<SubAgentCharacteristics, SubAgentProviderAgent>(_ =>
+                new SubAgentProviderAgent(
+                    new Mock<IStreamingAgent>().Object,
+                    ImmutableDictionary<string, object?>.Empty));
+        var first = Template("first", legacyFactory);
+        var second = Template("second", legacyFactory);
+
+        var result = global::Program.ApplyCharacteristicsAgentFactory(
+            new SubAgentOptions
+            {
+                Templates = new Dictionary<string, SubAgentTemplate>
+                {
+                    ["first"] = first,
+                    ["second"] = second,
+                },
+            },
+            characteristicsFactory);
+
+        result.Templates.Values.Should().OnlyContain(template =>
+            ReferenceEquals(template.CharacteristicsAgentFactory, characteristicsFactory));
+        result.Templates["first"].AgentFactory.Should().BeSameAs(legacyFactory);
+        result.Templates["second"].AgentFactory.Should().BeSameAs(legacyFactory);
+    }
+
+    [Fact]
+    public async Task BindConversationSubAgents_PassesCharacteristicsFactoryToSessionBinding()
+    {
+        await using var registry = CreateRegistry();
+        var legacyFactory = new Func<IStreamingAgent>(() => new Mock<IStreamingAgent>().Object);
+        var providerAgent = new Mock<IStreamingAgent>().Object;
+        var characteristicsFactory =
+            new Func<SubAgentCharacteristics, SubAgentProviderAgent>(_ =>
+                new SubAgentProviderAgent(
+                    providerAgent,
+                    ImmutableDictionary<string, object?>.Empty));
+        var templates = new Dictionary<string, SubAgentTemplate>();
+
+        var binding = global::Program.BindConversationSubAgents(
+            registry,
+            "session",
+            "conversation",
+            templates,
+            legacyFactory,
+            characteristicsFactory);
+
+        binding.AgentFactory.Should().BeSameAs(legacyFactory);
+        binding.CharacteristicsAgentFactory.Should().BeSameAs(characteristicsFactory);
+    }
+
+    [Fact]
+    public async Task BindConversationSubAgents_RecreationRefreshesFactoriesAndPreservesTemplateSource()
+    {
+        await using var registry = CreateRegistry();
+        var firstProvider = CreateRespondingAgent().Object;
+        var latestProvider = CreateRespondingAgent().Object;
+        var firstLegacyFactory = new Func<IStreamingAgent>(() => firstProvider);
+        var latestLegacyFactory = new Func<IStreamingAgent>(() => latestProvider);
+        var firstCharacteristicsFactory =
+            new Func<SubAgentCharacteristics, SubAgentProviderAgent>(_ =>
+                new SubAgentProviderAgent(
+                    firstProvider,
+                    ImmutableDictionary<string, object?>.Empty));
+        var latestCharacteristicsFactory =
+            new Func<SubAgentCharacteristics, SubAgentProviderAgent>(_ =>
+                new SubAgentProviderAgent(
+                    latestProvider,
+                    ImmutableDictionary<string, object?>.Empty));
+        var firstSeed = Template("first-seed", firstLegacyFactory);
+        var discovered = Template("discovered", firstLegacyFactory) with
+        {
+            Description = "retained description",
+            WhenToUse = "retained guidance",
+            CharacteristicsAgentFactory = firstCharacteristicsFactory,
+            DefaultOptions = new GenerateReplyOptions { ModelId = "retained-model" },
+            Effort = ReasoningEffort.Medium,
+            EnabledTools = ["retained-tool"],
+            MaxTurnsPerRun = 7,
+        };
+
+        var firstBinding = global::Program.BindConversationSubAgents(
+            registry,
+            "session",
+            "conversation",
+            new Dictionary<string, SubAgentTemplate> { ["first-seed"] = firstSeed },
+            firstLegacyFactory,
+            firstCharacteristicsFactory);
+        firstBinding.Source.TryRegister("discovered", discovered).Should().BeTrue();
+
+        var recreatedBinding = global::Program.BindConversationSubAgents(
+            registry,
+            "session",
+            "conversation",
+            new Dictionary<string, SubAgentTemplate>
+            {
+                ["discovered"] = Template("replacement", latestLegacyFactory),
+                ["latest-seed"] = Template("latest-seed", latestLegacyFactory),
+            },
+            latestLegacyFactory,
+            latestCharacteristicsFactory);
+
+        recreatedBinding.Source.Should().BeSameAs(firstBinding.Source);
+        var retained = recreatedBinding.Source.Templates["discovered"];
+        retained.Should().BeEquivalentTo(
+            discovered,
+            options => options
+                .Excluding(template => template.AgentFactory)
+                .Excluding(template => template.CharacteristicsAgentFactory),
+            "recreation must preserve all first-wins content and metadata");
+        retained.Name.Should().NotBe("replacement");
+        retained.AgentFactory.Should().BeSameAs(latestLegacyFactory);
+        retained.AgentFactory().Should().BeSameAs(latestProvider);
+        retained.CharacteristicsAgentFactory.Should().BeSameAs(latestCharacteristicsFactory);
+        retained.CharacteristicsAgentFactory!(
+                new SubAgentCharacteristics("spawn-model", ReasoningEffort.High))
+            .Agent.Should().BeSameAs(latestProvider);
+        await using var manager = new SubAgentManager(
+            Mock.Of<IMultiTurnAgent>(),
+            parentContracts: [],
+            parentHandlers: new Dictionary<string, ToolHandler>(),
+            new SubAgentOptions { Templates = recreatedBinding.Source.Templates },
+            recreatedBinding.Source);
+        _ = await manager.SpawnAsync("discovered", "invoke the retained template");
+        var discoveredAfterRefresh = Template("post-refresh", firstLegacyFactory) with
+        {
+            CharacteristicsAgentFactory = firstCharacteristicsFactory,
+        };
+        recreatedBinding.Source.TryRegister("post-refresh", discoveredAfterRefresh).Should().BeTrue();
+        recreatedBinding.Source.Templates["post-refresh"].AgentFactory().Should().BeSameAs(latestProvider);
+        recreatedBinding.Source.Templates["post-refresh"].CharacteristicsAgentFactory!(
+                new SubAgentCharacteristics(null, null))
+            .Agent.Should().BeSameAs(latestProvider);
+        recreatedBinding.Source.Templates.Should().ContainKey("first-seed").And.ContainKey("latest-seed");
+        recreatedBinding.AgentFactory.Should().BeSameAs(latestLegacyFactory);
+        recreatedBinding.AgentFactory().Should().BeSameAs(latestProvider);
+        recreatedBinding.CharacteristicsAgentFactory.Should().BeSameAs(latestCharacteristicsFactory);
+        recreatedBinding.CharacteristicsAgentFactory!(
+                new SubAgentCharacteristics("latest-model", ReasoningEffort.High))
+            .Agent.Should().BeSameAs(latestProvider);
+    }
+
+    private static SandboxSessionRegistry CreateRegistry()
+    {
+        const string baseUrl = "http://localhost:3000";
+        var options = new SandboxGatewayOptions { BaseUrl = baseUrl };
+        var gateway = new SandboxGatewayLifetime(
+            options,
+            NullLogger<SandboxGatewayLifetime>.Instance,
+            new HttpClient(new StubHandler()));
+        return new SandboxSessionRegistry(
+            gateway,
+            options,
+            NullLogger<SandboxSessionRegistry>.Instance,
+            new HttpClient(new StubHandler()),
+            new AuthOptions(),
+            new AuthSharedSecret(new AuthOptions()));
+    }
+
+    private static SubAgentTemplate Template(
+        string name,
+        Func<IStreamingAgent> agentFactory) =>
+        new()
+        {
+            Name = name,
+            SystemPrompt = name,
+            AgentFactory = agentFactory,
+        };
+
+    private static Mock<IStreamingAgent> CreateRespondingAgent()
+    {
+        var agent = new Mock<IStreamingAgent>();
+        agent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToAsyncEnumerable([
+                new TextMessage { Text = "done", Role = Role.Assistant },
+            ]));
+        return agent;
+    }
+
+    private static async IAsyncEnumerable<IMessage> ToAsyncEnumerable(
+        IReadOnlyList<IMessage> messages,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var message in messages)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return message;
+            await Task.Yield();
+        }
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("HTTP is not expected");
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/ProgramSubAgentCompositionTests.cs
+++ b/tests/LmStreaming.Sample.Tests/ProgramSubAgentCompositionTests.cs
@@ -10,32 +10,62 @@ namespace LmStreaming.Sample.Tests;
 public sealed class ProgramSubAgentCompositionTests
 {
     [Fact]
-    public void ApplyCharacteristicsAgentFactory_AttachesSameFactoryToEveryTemplate()
+    public void ApplyCharacteristicsAgentFactory_InheritedModelPreservesTemplateAgentAndRequestProperties()
     {
-        var legacyFactory = new Func<IStreamingAgent>(() => new Mock<IStreamingAgent>().Object);
+        var templateAgent = new Mock<IStreamingAgent>().Object;
+        var routedAgent = new Mock<IStreamingAgent>().Object;
+        var requestProperties = ImmutableDictionary<string, object?>.Empty.Add("effort", "high");
+        var legacyFactory = new Func<IStreamingAgent>(() => templateAgent);
         var characteristicsFactory =
             new Func<SubAgentCharacteristics, SubAgentProviderAgent>(_ =>
-                new SubAgentProviderAgent(
-                    new Mock<IStreamingAgent>().Object,
-                    ImmutableDictionary<string, object?>.Empty));
-        var first = Template("first", legacyFactory);
-        var second = Template("second", legacyFactory);
+                new SubAgentProviderAgent(routedAgent, requestProperties));
 
         var result = global::Program.ApplyCharacteristicsAgentFactory(
             new SubAgentOptions
             {
                 Templates = new Dictionary<string, SubAgentTemplate>
                 {
-                    ["first"] = first,
-                    ["second"] = second,
+                    ["custom"] = Template("custom", legacyFactory),
                 },
             },
             characteristicsFactory);
 
-        result.Templates.Values.Should().OnlyContain(template =>
-            ReferenceEquals(template.CharacteristicsAgentFactory, characteristicsFactory));
-        result.Templates["first"].AgentFactory.Should().BeSameAs(legacyFactory);
-        result.Templates["second"].AgentFactory.Should().BeSameAs(legacyFactory);
+        var provider = result.Templates["custom"].CharacteristicsAgentFactory!(
+            new SubAgentCharacteristics(null, ReasoningEffort.High));
+
+        provider.Agent.Should().BeSameAs(templateAgent);
+        provider.ExtraProperties.Should().BeSameAs(requestProperties);
+    }
+
+    [Fact]
+    public void ApplyCharacteristicsAgentFactory_ExplicitModelUsesRoutedAgent()
+    {
+        var templateAgent = new Mock<IStreamingAgent>().Object;
+        var routedAgent = new Mock<IStreamingAgent>().Object;
+        var legacyFactory = new Func<IStreamingAgent>(() => templateAgent);
+        var characteristicsFactory =
+            new Func<SubAgentCharacteristics, SubAgentProviderAgent>(_ =>
+                new SubAgentProviderAgent(
+                    routedAgent,
+                    ImmutableDictionary<string, object?>.Empty));
+
+        var result = global::Program.ApplyCharacteristicsAgentFactory(
+            new SubAgentOptions
+            {
+                Templates = new Dictionary<string, SubAgentTemplate>
+                {
+                    ["custom"] = Template("custom", legacyFactory),
+                },
+            },
+            characteristicsFactory);
+
+        var provider = result.Templates["custom"].CharacteristicsAgentFactory!(
+            new SubAgentCharacteristics("explicit-model", null)
+            {
+                IsModelExplicitlySelected = true,
+            });
+
+        provider.Agent.Should().BeSameAs(routedAgent);
     }
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/ProgramSubAgentCompositionTests.cs
+++ b/tests/LmStreaming.Sample.Tests/ProgramSubAgentCompositionTests.cs
@@ -1,9 +1,14 @@
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Discovery;
+using LmStreaming.Sample.Tests.TestDoubles;
 
 namespace LmStreaming.Sample.Tests;
 
@@ -66,6 +71,39 @@ public sealed class ProgramSubAgentCompositionTests
             });
 
         provider.Agent.Should().BeSameAs(routedAgent);
+    }
+
+    [Fact]
+    public void ApplyCharacteristicsAgentFactory_InheritedSpawnsReceiveFreshTemplateAgents()
+    {
+        var createdAgents = new List<IStreamingAgent>();
+        Func<IStreamingAgent> legacyFactory = () =>
+        {
+            var agent = new Mock<IStreamingAgent>().Object;
+            createdAgents.Add(agent);
+            return agent;
+        };
+        var result = global::Program.ApplyCharacteristicsAgentFactory(
+            new SubAgentOptions
+            {
+                Templates = new Dictionary<string, SubAgentTemplate>
+                {
+                    ["custom"] = Template("custom", legacyFactory),
+                },
+            },
+            _ => new SubAgentProviderAgent(
+                new Mock<IStreamingAgent>().Object,
+                ImmutableDictionary<string, object?>.Empty));
+
+        var first = result.Templates["custom"].CharacteristicsAgentFactory!(
+            new SubAgentCharacteristics(null, null));
+        var second = result.Templates["custom"].CharacteristicsAgentFactory!(
+            new SubAgentCharacteristics(null, null));
+
+        first.Agent.Should().NotBeSameAs(second.Agent);
+        createdAgents.Should().Equal(first.Agent, second.Agent);
+        first.OwnsAgent.Should().BeTrue();
+        second.OwnsAgent.Should().BeTrue();
     }
 
     [Fact]
@@ -153,11 +191,16 @@ public sealed class ProgramSubAgentCompositionTests
                 .Excluding(template => template.CharacteristicsAgentFactory),
             "recreation must preserve all first-wins content and metadata");
         retained.Name.Should().NotBe("replacement");
-        retained.AgentFactory.Should().BeSameAs(latestLegacyFactory);
-        retained.AgentFactory().Should().BeSameAs(latestProvider);
-        retained.CharacteristicsAgentFactory.Should().BeSameAs(latestCharacteristicsFactory);
+        retained.AgentFactory.Should().BeSameAs(firstLegacyFactory);
+        retained.AgentFactory().Should().BeSameAs(firstProvider);
         retained.CharacteristicsAgentFactory!(
-                new SubAgentCharacteristics("spawn-model", ReasoningEffort.High))
+                new SubAgentCharacteristics(null, ReasoningEffort.High))
+            .Agent.Should().BeSameAs(firstProvider);
+        retained.CharacteristicsAgentFactory!(
+                new SubAgentCharacteristics("spawn-model", ReasoningEffort.High)
+                {
+                    IsModelExplicitlySelected = true,
+                })
             .Agent.Should().BeSameAs(latestProvider);
         await using var manager = new SubAgentManager(
             Mock.Of<IMultiTurnAgent>(),
@@ -166,7 +209,7 @@ public sealed class ProgramSubAgentCompositionTests
             new SubAgentOptions { Templates = recreatedBinding.Source.Templates },
             recreatedBinding.Source);
         _ = await manager.SpawnAsync("discovered", "invoke the retained template");
-        var discoveredAfterRefresh = Template("post-refresh", firstLegacyFactory) with
+        var discoveredAfterRefresh = Template("post-refresh", latestLegacyFactory) with
         {
             CharacteristicsAgentFactory = firstCharacteristicsFactory,
         };
@@ -182,6 +225,159 @@ public sealed class ProgramSubAgentCompositionTests
         recreatedBinding.CharacteristicsAgentFactory!(
                 new SubAgentCharacteristics("latest-model", ReasoningEffort.High))
             .Agent.Should().BeSameAs(latestProvider);
+    }
+
+    [Fact]
+    public async Task MarkdownThroughRebindAndSpawn_PreservesInheritedAndRoutedWireMetadata()
+    {
+        await using var registry = CreateRegistry();
+        var models = new[]
+        {
+            new CopilotModelInfo(
+                "parent-model",
+                "Parent",
+                CopilotModelVendor.OpenAI,
+                CopilotModelTransport.Responses)
+            {
+                ReasoningEfforts = ["low", "medium", "high", "xhigh"],
+            },
+            new CopilotModelInfo(
+                "tier-model",
+                "Tier",
+                CopilotModelVendor.OpenAI,
+                CopilotModelTransport.Responses)
+            {
+                ReasoningEfforts = ["low", "medium", "high", "xhigh"],
+            },
+            new CopilotModelInfo(
+                "explicit-model",
+                "Explicit",
+                CopilotModelVendor.OpenAI,
+                CopilotModelTransport.Responses)
+            {
+                ReasoningEfforts = ["low", "medium", "high", "xhigh"],
+            },
+        };
+        var catalog = new ProviderRegistry(models, Mock.Of<IFileSystemProbe>());
+        var resolver = new SubAgentModelResolver(
+            catalog,
+            new SubAgentIntelligenceOptions
+            {
+                Tiers = new Dictionary<int, string[]> { [3] = ["tier-model"] },
+            },
+            new CapturingLogger<SubAgentModelResolver>());
+        var loader = new WorkspaceSubAgentLoader(
+            registry,
+            new CapturingLogger<WorkspaceSubAgentLoader>(),
+            resolver);
+        var inheritedOptions = new List<GenerateReplyOptions?>();
+        var routedOptions = new Dictionary<string, GenerateReplyOptions?>();
+        Func<IStreamingAgent> inheritedAgentFactory = () =>
+            CreateRespondingAgent(options => inheritedOptions.Add(options)).Object;
+        Func<SubAgentCharacteristics, SubAgentProviderAgent> staleCharacteristicsFactory =
+            _ => throw new InvalidOperationException("The pre-recreation route must not execute.");
+        var session = new SandboxSession("default", "session", "default", "workspace");
+        var inherited = await loader.LoadOneWithCharacteristicsAsync(
+            session,
+            InlineAgent(
+                "inherited",
+                """
+                ---
+                name: inherited
+                effort: medium
+                ---
+                Use the inherited route.
+                """),
+            inheritedAgentFactory,
+            staleCharacteristicsFactory);
+        var tiered = await loader.LoadOneWithCharacteristicsAsync(
+            session,
+            InlineAgent(
+                "tiered",
+                """
+                ---
+                name: tiered
+                modelintelligence: 3
+                effort: high
+                ---
+                Use the tier-selected route.
+                """),
+            () => throw new InvalidOperationException("Tier routing must use the characteristics factory."),
+            staleCharacteristicsFactory);
+        var explicitTemplate = await loader.LoadOneWithCharacteristicsAsync(
+            session,
+            InlineAgent(
+                "explicit",
+                """
+                ---
+                name: explicit
+                model: explicit-model
+                effort: xhigh
+                ---
+                Use the author-pinned route.
+                """),
+            () => throw new InvalidOperationException("Explicit routing must use the characteristics factory."),
+            staleCharacteristicsFactory);
+        var initialOptions = global::Program.ApplyCharacteristicsAgentFactory(
+            new SubAgentOptions
+            {
+                Templates = new Dictionary<string, SubAgentTemplate>
+                {
+                    ["inherited"] = inherited!,
+                    ["tiered"] = tiered!,
+                    ["explicit"] = explicitTemplate!,
+                },
+            },
+            staleCharacteristicsFactory);
+        var firstBinding = global::Program.BindConversationSubAgents(
+            registry,
+            "session",
+            "conversation",
+            initialOptions.Templates,
+            inheritedAgentFactory,
+            staleCharacteristicsFactory);
+        var latestFactory = new CharacteristicsAgentFactory(
+            catalog,
+            CreateRespondingAgent().Object,
+            model => CreateRespondingAgent(options => routedOptions[model.Id] = options).Object,
+            new CapturingLogger<CharacteristicsAgentFactory>(),
+            models[0]);
+        var rebound = global::Program.BindConversationSubAgents(
+            registry,
+            "session",
+            "conversation",
+            initialOptions.Templates,
+            inheritedAgentFactory,
+            latestFactory.Create);
+        rebound.Source.Should().BeSameAs(firstBinding.Source);
+        await using var manager = new SubAgentManager(
+            Mock.Of<IMultiTurnAgent>(),
+            [],
+            new Dictionary<string, ToolHandler>(),
+            new SubAgentOptions { Templates = rebound.Source.Templates },
+            rebound.Source,
+            parentModelId: "parent-model");
+
+        _ = await manager.SpawnAsync("inherited", "inherit");
+        _ = await manager.SpawnAsync("tiered", "tier");
+        _ = await manager.SpawnAsync("explicit", "explicit");
+
+        inheritedOptions.Should().ContainSingle();
+        inheritedOptions[0]!.ModelId.Should().Be("parent-model");
+        inheritedOptions[0]!.ExtraProperties["Reasoning"]
+            .Should().BeOfType<ResponseReasoningOptions>()
+            .Which.Effort.Should().Be("medium");
+        routedOptions["tier-model"]!.ModelId.Should().Be("tier-model");
+        routedOptions["tier-model"]!.ExtraProperties["Reasoning"]
+            .Should().BeOfType<ResponseReasoningOptions>()
+            .Which.Effort.Should().Be("high");
+        routedOptions["explicit-model"]!.ModelId.Should().Be("explicit-model");
+        routedOptions["explicit-model"]!.ExtraProperties["Reasoning"]
+            .Should().BeOfType<ResponseReasoningOptions>()
+            .Which.Effort.Should().Be("xhigh");
+        rebound.Source.Templates["tiered"].IsModelExplicitlySelected.Should().BeFalse();
+        rebound.Source.Templates["tiered"].IsModelTierResolved.Should().BeTrue();
+        rebound.Source.Templates["explicit"].IsModelExplicitlySelected.Should().BeTrue();
     }
 
     private static SandboxSessionRegistry CreateRegistry()
@@ -211,7 +407,11 @@ public sealed class ProgramSubAgentCompositionTests
             AgentFactory = agentFactory,
         };
 
-    private static Mock<IStreamingAgent> CreateRespondingAgent()
+    private static SandboxSessionRegistry.DiscoveredItem InlineAgent(string name, string content) =>
+        new("subagent", name, name, $"/marketplaces/test/{name}.md", content);
+
+    private static Mock<IStreamingAgent> CreateRespondingAgent(
+        Action<GenerateReplyOptions?>? captureOptions = null)
     {
         var agent = new Mock<IStreamingAgent>();
         agent
@@ -219,6 +419,8 @@ public sealed class ProgramSubAgentCompositionTests
                 It.IsAny<IEnumerable<IMessage>>(),
                 It.IsAny<GenerateReplyOptions?>(),
                 It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<IMessage>, GenerateReplyOptions?, CancellationToken>(
+                (_, options, _) => captureOptions?.Invoke(options))
             .ReturnsAsync(ToAsyncEnumerable([
                 new TextMessage { Text = "done", Role = Role.Assistant },
             ]));

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/CharacteristicsAgentFactoryTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/CharacteristicsAgentFactoryTests.cs
@@ -1,7 +1,9 @@
+using System.Runtime.CompilerServices;
 using AchieveAi.LmDotnetTools.AnthropicProvider.Models;
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
 using LmStreaming.Sample.Services;
@@ -274,6 +276,51 @@ public sealed class CharacteristicsAgentFactoryTests
         modelFactory.Verify(factoryCall => factoryCall(It.IsAny<CopilotModelInfo>()), Times.Never);
     }
 
+    [Fact]
+    public async Task Create_UnknownExplicitModelRestoresParentModelBeforeParentProviderRequest()
+    {
+        GenerateReplyOptions? receivedOptions = null;
+        var parentAgent = new Mock<IStreamingAgent>();
+        parentAgent
+            .Setup(agent =>
+                agent.GenerateReplyStreamingAsync(
+                    It.IsAny<IEnumerable<IMessage>>(),
+                    It.IsAny<GenerateReplyOptions?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback<IEnumerable<IMessage>, GenerateReplyOptions?, CancellationToken>(
+                (_, options, _) => receivedOptions = options
+            )
+            .ReturnsAsync(ToAsyncEnumerable([new TextMessage { Text = "done", Role = Role.Assistant }]));
+        var factory = CreateFactory([], parentAgent.Object, _ => throw new InvalidOperationException());
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "Test",
+            AgentFactory = () => throw new InvalidOperationException("Legacy factory should not run."),
+            DefaultOptions = new GenerateReplyOptions { ModelId = "unknown-explicit-model" },
+            IsModelExplicitlySelected = true,
+            CharacteristicsAgentFactory = factory.Create,
+        };
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate> { ["test-agent"] = template },
+        };
+        await using var manager = new SubAgentManager(
+            new Mock<IMultiTurnAgent>().Object,
+            [],
+            new Dictionary<string, ToolHandler>(),
+            options,
+            new MutableSubAgentTemplateSource(options.Templates),
+            parentModelId: "parent-model"
+        );
+
+        _ = await manager.SpawnAsync("test-agent", "test task");
+
+        receivedOptions.Should().NotBeNull();
+        receivedOptions!.ModelId.Should().Be("parent-model");
+    }
+
     private static CharacteristicsAgentFactory CreateFactory(
         IReadOnlyList<CopilotModelInfo> models,
         IStreamingAgent parentAgent,
@@ -294,4 +341,17 @@ public sealed class CharacteristicsAgentFactoryTests
 
     private static CopilotModelInfo Model(string id, CopilotModelTransport transport, IReadOnlyList<string> efforts) =>
         new(id, id, CopilotModelVendor.OpenAI, transport) { ReasoningEfforts = efforts };
+
+    private static async IAsyncEnumerable<IMessage> ToAsyncEnumerable(
+        IReadOnlyList<IMessage> messages,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
+    {
+        foreach (var message in messages)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return message;
+            await Task.Yield();
+        }
+    }
 }

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/CharacteristicsAgentFactoryTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/CharacteristicsAgentFactoryTests.cs
@@ -60,6 +60,7 @@ public sealed class CharacteristicsAgentFactoryTests
         );
 
         result.Agent.Should().BeSameAs(modelAgent);
+        result.OwnsAgent.Should().BeTrue();
         createdFor.Should().BeSameAs(model);
         if (transport == CopilotModelTransport.Anthropic)
         {
@@ -97,6 +98,7 @@ public sealed class CharacteristicsAgentFactoryTests
         var result = factory.Create(new SubAgentCharacteristics(inheritedModel.Id, ReasoningEffort.Medium));
 
         result.Agent.Should().BeSameAs(parentAgent);
+        result.OwnsAgent.Should().BeFalse();
         result
             .ExtraProperties["Reasoning"]
             .Should()
@@ -321,6 +323,203 @@ public sealed class CharacteristicsAgentFactoryTests
         receivedOptions!.ModelId.Should().Be("parent-model");
     }
 
+    [Fact]
+    public async Task Spawn_DisposesOwnedExplicitProviderExactlyOnce()
+    {
+        var model = Model("owned-model", CopilotModelTransport.Responses, []);
+        var ownedAgent = CreateRespondingDisposableAgent();
+        var factory = CreateFactory(
+            [model],
+            new Mock<IStreamingAgent>().Object,
+            _ => ownedAgent.Object);
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "Test",
+            AgentFactory = () => throw new InvalidOperationException(),
+            DefaultOptions = new GenerateReplyOptions { ModelId = model.Id },
+            IsModelExplicitlySelected = true,
+            CharacteristicsAgentFactory = factory.Create,
+        };
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate> { ["test-agent"] = template },
+        };
+        var manager = new SubAgentManager(
+            new Mock<IMultiTurnAgent>().Object,
+            [],
+            new Dictionary<string, ToolHandler>(),
+            options,
+            new MutableSubAgentTemplateSource(options.Templates));
+
+        _ = await manager.SpawnAsync("test-agent", "test task");
+        ownedAgent.As<IAsyncDisposable>().Verify(agent => agent.DisposeAsync(), Times.Once);
+        await manager.DisposeAsync();
+        await manager.DisposeAsync();
+
+        ownedAgent.As<IAsyncDisposable>().Verify(agent => agent.DisposeAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Spawn_ContinuationRecreatesAndDisposesOwnedProviderPerCompletedRun()
+    {
+        var model = Model("owned-model", CopilotModelTransport.Responses, []);
+        var firstOwnedAgent = CreateRespondingDisposableAgent();
+        var secondOwnedAgent = CreateRespondingDisposableAgent();
+        var createdAgents = new Queue<IStreamingAgent>([firstOwnedAgent.Object, secondOwnedAgent.Object]);
+        var factory = CreateFactory(
+            [model],
+            new Mock<IStreamingAgent>().Object,
+            _ => createdAgents.Dequeue()
+        );
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "Test",
+            AgentFactory = () => throw new InvalidOperationException(),
+            DefaultOptions = new GenerateReplyOptions { ModelId = model.Id },
+            IsModelExplicitlySelected = true,
+            CharacteristicsAgentFactory = factory.Create,
+        };
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate> { ["test-agent"] = template },
+        };
+        await using var manager = new SubAgentManager(
+            new Mock<IMultiTurnAgent>().Object,
+            [],
+            new Dictionary<string, ToolHandler>(),
+            options,
+            new MutableSubAgentTemplateSource(options.Templates)
+        );
+
+        _ = await manager.SpawnAsync("test-agent", "first task", name: "owned");
+        _ = await manager.SendMessageAsync("owned", "continued task");
+
+        firstOwnedAgent.As<IAsyncDisposable>().Verify(agent => agent.DisposeAsync(), Times.Once);
+        secondOwnedAgent.As<IAsyncDisposable>().Verify(agent => agent.DisposeAsync(), Times.Once);
+        createdAgents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Spawn_CompletionDisposesOwnedProviderBeforeBackgroundRelayCompletes()
+    {
+        var model = Model("owned-model", CopilotModelTransport.Responses, []);
+        var ownedAgent = CreateRespondingDisposableAgent();
+        var factory = CreateFactory(
+            [model],
+            new Mock<IStreamingAgent>().Object,
+            _ => ownedAgent.Object
+        );
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "Test",
+            AgentFactory = () => throw new InvalidOperationException(),
+            DefaultOptions = new GenerateReplyOptions { ModelId = model.Id },
+            IsModelExplicitlySelected = true,
+            CharacteristicsAgentFactory = factory.Create,
+        };
+        var relayStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completeRelay = new TaskCompletionSource<SendReceipt>(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        var parent = new Mock<IMultiTurnAgent>();
+        parent
+            .Setup(agent => agent.SendAsync(
+                It.IsAny<List<IMessage>>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback(() => relayStarted.TrySetResult())
+            .Returns(new ValueTask<SendReceipt>(completeRelay.Task));
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate> { ["test-agent"] = template },
+        };
+        await using var manager = new SubAgentManager(
+            parent.Object,
+            [],
+            new Dictionary<string, ToolHandler>(),
+            options,
+            new MutableSubAgentTemplateSource(options.Templates)
+        );
+
+        _ = await manager.SpawnAsync("test-agent", "test task", runInBackground: true);
+        await relayStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        try
+        {
+            ownedAgent.As<IAsyncDisposable>().Verify(agent => agent.DisposeAsync(), Times.Once);
+        }
+        finally
+        {
+            completeRelay.TrySetResult(new SendReceipt("receipt", null, DateTimeOffset.UtcNow));
+        }
+    }
+
+    [Fact]
+    public async Task Spawn_ConstructionFailureDisposesOwnedProvider()
+    {
+        var model = Model("owned-model", CopilotModelTransport.Responses, []);
+        var ownedAgent = CreateRespondingDisposableAgent();
+        var factory = CreateFactory(
+            [model],
+            new Mock<IStreamingAgent>().Object,
+            _ => ownedAgent.Object
+        );
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "Test",
+            AgentFactory = () => throw new InvalidOperationException(),
+            DefaultOptions = new GenerateReplyOptions { ModelId = model.Id },
+            IsModelExplicitlySelected = true,
+            CharacteristicsAgentFactory = factory.Create,
+            ConversationStoreFactory = _ => throw new InvalidOperationException("Store creation failed."),
+        };
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate> { ["test-agent"] = template },
+        };
+        await using var manager = new SubAgentManager(
+            new Mock<IMultiTurnAgent>().Object,
+            [],
+            new Dictionary<string, ToolHandler>(),
+            options,
+            new MutableSubAgentTemplateSource(options.Templates)
+        );
+
+        var act = () => manager.SpawnAsync("test-agent", "test task");
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        ownedAgent.As<IAsyncDisposable>().Verify(agent => agent.DisposeAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Spawn_NeverDisposesBorrowedParentProvider()
+    {
+        var parentAgent = CreateRespondingDisposableAgent();
+        var factory = CreateFactory([], parentAgent.Object, _ => throw new InvalidOperationException());
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "Test",
+            AgentFactory = () => throw new InvalidOperationException(),
+            CharacteristicsAgentFactory = factory.Create,
+        };
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate> { ["test-agent"] = template },
+        };
+        var manager = new SubAgentManager(
+            new Mock<IMultiTurnAgent>().Object,
+            [],
+            new Dictionary<string, ToolHandler>(),
+            options,
+            new MutableSubAgentTemplateSource(options.Templates));
+
+        _ = await manager.SpawnAsync("test-agent", "test task");
+        await manager.DisposeAsync();
+
+        parentAgent.As<IAsyncDisposable>().Verify(agent => agent.DisposeAsync(), Times.Never);
+    }
+
     private static CharacteristicsAgentFactory CreateFactory(
         IReadOnlyList<CopilotModelInfo> models,
         IStreamingAgent parentAgent,
@@ -337,6 +536,22 @@ public sealed class CharacteristicsAgentFactoryTests
             logger ?? new CapturingLogger<CharacteristicsAgentFactory>(),
             parentCopilotModel
         );
+    }
+
+    private static Mock<IStreamingAgent> CreateRespondingDisposableAgent()
+    {
+        var agent = new Mock<IStreamingAgent>();
+        agent
+            .Setup(candidate =>
+                candidate.GenerateReplyStreamingAsync(
+                    It.IsAny<IEnumerable<IMessage>>(),
+                    It.IsAny<GenerateReplyOptions?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(ToAsyncEnumerable([new TextMessage { Text = "done", Role = Role.Assistant }]));
+        agent.As<IAsyncDisposable>().Setup(candidate => candidate.DisposeAsync()).Returns(ValueTask.CompletedTask);
+        return agent;
     }
 
     private static CopilotModelInfo Model(string id, CopilotModelTransport transport, IReadOnlyList<string> efforts) =>

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/CharacteristicsAgentFactoryTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/CharacteristicsAgentFactoryTests.cs
@@ -520,6 +520,136 @@ public sealed class CharacteristicsAgentFactoryTests
         parentAgent.As<IAsyncDisposable>().Verify(agent => agent.DisposeAsync(), Times.Never);
     }
 
+    [Fact]
+    public async Task Spawn_DisposesOwnedSynchronousProviderExactlyOnce()
+    {
+        var model = Model("owned-model", CopilotModelTransport.Responses, []);
+        var ownedAgent = CreateRespondingSyncDisposableAgent();
+        var factory = CreateFactory(
+            [model],
+            new Mock<IStreamingAgent>().Object,
+            _ => ownedAgent.Object);
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "Test",
+            AgentFactory = () => throw new InvalidOperationException(),
+            DefaultOptions = new GenerateReplyOptions { ModelId = model.Id },
+            IsModelExplicitlySelected = true,
+            CharacteristicsAgentFactory = factory.Create,
+        };
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate> { ["test-agent"] = template },
+        };
+        var manager = new SubAgentManager(
+            new Mock<IMultiTurnAgent>().Object,
+            [],
+            new Dictionary<string, ToolHandler>(),
+            options,
+            new MutableSubAgentTemplateSource(options.Templates));
+
+        _ = await manager.SpawnAsync("test-agent", "test task");
+        ownedAgent.As<IDisposable>().Verify(agent => agent.Dispose(), Times.Once);
+        await manager.DisposeAsync();
+        await manager.DisposeAsync();
+
+        ownedAgent.As<IDisposable>().Verify(agent => agent.Dispose(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Spawn_RetriesOwnedProviderDisposalAfterFirstAttemptThrows()
+    {
+        var model = Model("owned-model", CopilotModelTransport.Responses, []);
+        var disposeCalls = 0;
+        var ownedAgent = CreateRespondingDisposableAgent();
+        ownedAgent
+            .As<IAsyncDisposable>()
+            .Setup(agent => agent.DisposeAsync())
+            .Returns(() =>
+            {
+                disposeCalls++;
+                return disposeCalls == 1
+                    ? throw new InvalidOperationException("owned provider dispose boom")
+                    : ValueTask.CompletedTask;
+            });
+        var factory = CreateFactory(
+            [model],
+            new Mock<IStreamingAgent>().Object,
+            _ => ownedAgent.Object);
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "Test",
+            AgentFactory = () => throw new InvalidOperationException(),
+            DefaultOptions = new GenerateReplyOptions { ModelId = model.Id },
+            IsModelExplicitlySelected = true,
+            CharacteristicsAgentFactory = factory.Create,
+        };
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate> { ["test-agent"] = template },
+        };
+        var manager = new SubAgentManager(
+            new Mock<IMultiTurnAgent>().Object,
+            [],
+            new Dictionary<string, ToolHandler>(),
+            options,
+            new MutableSubAgentTemplateSource(options.Templates));
+
+        // The completion-time disposal throws, but must not permanently latch the guard: a later
+        // cleanup (manager dispose) retries and succeeds, so the provider is not leaked.
+        _ = await manager.SpawnAsync("test-agent", "test task");
+        await manager.DisposeAsync();
+
+        ownedAgent.As<IAsyncDisposable>().Verify(agent => agent.DisposeAsync(), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Spawn_ConstructionRollbackDisposesProviderWhenStoreDisposeThrowsAndPreservesOriginalError()
+    {
+        var model = Model("owned-model", CopilotModelTransport.Responses, []);
+        var ownedAgent = CreateRespondingDisposableAgent();
+        var store = new Mock<IConversationStore>();
+        store
+            .As<IAsyncDisposable>()
+            .Setup(disposable => disposable.DisposeAsync())
+            .Throws(new InvalidOperationException("store dispose boom"));
+        var factory = CreateFactory(
+            [model],
+            new Mock<IStreamingAgent>().Object,
+            _ => ownedAgent.Object);
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "Test",
+            AgentFactory = () => throw new InvalidOperationException(),
+            DefaultOptions = new GenerateReplyOptions { ModelId = model.Id },
+            IsModelExplicitlySelected = true,
+            CharacteristicsAgentFactory = factory.Create,
+            ConversationStoreFactory = _ => store.Object,
+        };
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate> { ["test-agent"] = template },
+        };
+        await using var manager = new SubAgentManager(
+            new Mock<IMultiTurnAgent>().Object,
+            [],
+            new Dictionary<string, ToolHandler>(),
+            options,
+            new MutableSubAgentTemplateSource(options.Templates)
+        );
+
+        // removeTools without a base set makes BuildEnabledToolSet throw AFTER both the owned provider
+        // and the store are constructed, exercising the construction rollback with a throwing store.
+        var act = () => manager.SpawnAsync("test-agent", "test task", removeTools: ["missing-tool"]);
+
+        // The ORIGINAL construction error surfaces, not the store-disposal failure that masks it.
+        var thrown = await act.Should().ThrowAsync<InvalidOperationException>();
+        thrown.Which.Message.Should().Contain("removeTools");
+        // Provider disposal is attempted independently even though store disposal threw first.
+        ownedAgent.As<IAsyncDisposable>().Verify(agent => agent.DisposeAsync(), Times.Once);
+        store.As<IAsyncDisposable>().Verify(disposable => disposable.DisposeAsync(), Times.Once);
+    }
+
     private static CharacteristicsAgentFactory CreateFactory(
         IReadOnlyList<CopilotModelInfo> models,
         IStreamingAgent parentAgent,
@@ -551,6 +681,24 @@ public sealed class CharacteristicsAgentFactoryTests
             )
             .ReturnsAsync(ToAsyncEnumerable([new TextMessage { Text = "done", Role = Role.Assistant }]));
         agent.As<IAsyncDisposable>().Setup(candidate => candidate.DisposeAsync()).Returns(ValueTask.CompletedTask);
+        return agent;
+    }
+
+    private static Mock<IStreamingAgent> CreateRespondingSyncDisposableAgent()
+    {
+        // Deliberately implements ONLY IDisposable (not IAsyncDisposable) so the synchronous disposal
+        // branch in SubAgentState.DisposeOwnedProviderAgentAsync is exercised.
+        var agent = new Mock<IStreamingAgent>();
+        agent
+            .Setup(candidate =>
+                candidate.GenerateReplyStreamingAsync(
+                    It.IsAny<IEnumerable<IMessage>>(),
+                    It.IsAny<GenerateReplyOptions?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(ToAsyncEnumerable([new TextMessage { Text = "done", Role = Role.Assistant }]));
+        agent.As<IDisposable>().Setup(candidate => candidate.Dispose());
         return agent;
     }
 

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/CharacteristicsAgentFactoryTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/CharacteristicsAgentFactoryTests.cs
@@ -1,0 +1,297 @@
+using AchieveAi.LmDotnetTools.AnthropicProvider.Models;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Discovery;
+using LmStreaming.Sample.Tests.TestDoubles;
+using Microsoft.Extensions.Logging;
+
+namespace LmStreaming.Sample.Tests.Services.Discovery;
+
+public sealed class CharacteristicsAgentFactoryTests
+{
+    [Theory]
+    [InlineData(
+        CopilotModelTransport.Anthropic,
+        typeof(AchieveAi.LmDotnetTools.AnthropicProvider.Agents.AnthropicAgent)
+    )]
+    [InlineData(
+        CopilotModelTransport.Responses,
+        typeof(AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Agents.OpenAiResponsesAgent)
+    )]
+    public void ProgramCopilotModelFactory_CreatesTransportCorrectAgent(
+        CopilotModelTransport transport,
+        Type expectedAgentType
+    )
+    {
+        var model = Model("catalog-model", transport, []);
+
+        var agent = global::Program.CreateCopilotModelAgent(model, NullLoggerFactory.Instance);
+
+        agent.Should().BeOfType(expectedAgentType);
+    }
+
+    [Theory]
+    [InlineData(CopilotModelTransport.Anthropic)]
+    [InlineData(CopilotModelTransport.Responses)]
+    public void Create_CatalogModelUsesModelFactoryAndShapesTransportMetadata(CopilotModelTransport transport)
+    {
+        var model = Model("catalog-model", transport, ["low", "medium", "high"]);
+        var parentAgent = new Mock<IStreamingAgent>().Object;
+        var modelAgent = new Mock<IStreamingAgent>().Object;
+        CopilotModelInfo? createdFor = null;
+        var factory = CreateFactory(
+            [model],
+            parentAgent,
+            catalogModel =>
+            {
+                createdFor = catalogModel;
+                return modelAgent;
+            }
+        );
+
+        var result = factory.Create(
+            new SubAgentCharacteristics(model.Id, ReasoningEffort.Medium) { IsModelExplicitlySelected = true }
+        );
+
+        result.Agent.Should().BeSameAs(modelAgent);
+        createdFor.Should().BeSameAs(model);
+        if (transport == CopilotModelTransport.Anthropic)
+        {
+            result
+                .ExtraProperties["OutputConfig"]
+                .Should()
+                .BeOfType<AnthropicOutputConfig>()
+                .Which.Effort.Should()
+                .Be("medium");
+        }
+        else
+        {
+            result
+                .ExtraProperties["Reasoning"]
+                .Should()
+                .BeOfType<ResponseReasoningOptions>()
+                .Which.Effort.Should()
+                .Be("medium");
+        }
+    }
+
+    [Fact]
+    public void Create_InheritedCopilotModelWithEffortShapesMetadataAndReturnsExactParentAgent()
+    {
+        var inheritedModel = Model("shared-model", CopilotModelTransport.Responses, ["low", "medium", "high"]);
+        var parentAgent = new Mock<IStreamingAgent>().Object;
+        var modelFactory = new Mock<Func<CopilotModelInfo, IStreamingAgent>>();
+        var factory = CreateFactory(
+            [inheritedModel],
+            parentAgent,
+            modelFactory.Object,
+            parentCopilotModel: inheritedModel
+        );
+
+        var result = factory.Create(new SubAgentCharacteristics(inheritedModel.Id, ReasoningEffort.Medium));
+
+        result.Agent.Should().BeSameAs(parentAgent);
+        result
+            .ExtraProperties["Reasoning"]
+            .Should()
+            .BeOfType<ResponseReasoningOptions>()
+            .Which.Effort.Should()
+            .Be("medium");
+        modelFactory.Verify(factoryCall => factoryCall(It.IsAny<CopilotModelInfo>()), Times.Never);
+    }
+
+    [Fact]
+    public void Create_InheritedNonCopilotModelCollisionDoesNotShapeMetadata()
+    {
+        var collidingCatalogModel = Model("shared-model", CopilotModelTransport.Responses, ["low", "medium", "high"]);
+        var logger = new CapturingLogger<CharacteristicsAgentFactory>();
+        var parentAgent = new Mock<IStreamingAgent>().Object;
+        var modelFactory = new Mock<Func<CopilotModelInfo, IStreamingAgent>>();
+        var factory = CreateFactory([collidingCatalogModel], parentAgent, modelFactory.Object, logger);
+
+        var result = factory.Create(new SubAgentCharacteristics(collidingCatalogModel.Id, ReasoningEffort.Medium));
+
+        result.Agent.Should().BeSameAs(parentAgent);
+        result.ExtraProperties.Should().BeEmpty();
+        logger.Entries.Should().BeEmpty();
+        modelFactory.Verify(factoryCall => factoryCall(It.IsAny<CopilotModelInfo>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(ReasoningEffort.Xhigh, "high")]
+    [InlineData(ReasoningEffort.Low, "medium")]
+    public void Create_AdjustedEffortWarnsOnceWithTransitionAndModel(ReasoningEffort requested, string selected)
+    {
+        var model = Model("adjusted-model", CopilotModelTransport.Responses, [selected]);
+        var logger = new CapturingLogger<CharacteristicsAgentFactory>();
+        var parentAgent = new Mock<IStreamingAgent>().Object;
+        var factory = CreateFactory([model], parentAgent, _ => new Mock<IStreamingAgent>().Object, logger);
+        var characteristics = new SubAgentCharacteristics(model.Id, requested) { IsModelExplicitlySelected = true };
+
+        factory.Create(characteristics);
+        factory.Create(characteristics);
+
+        var warning = logger.Entries.Should().ContainSingle(entry => entry.Level == LogLevel.Warning).Which;
+        warning.Message.Should().Contain(requested.ToString());
+        warning.Message.Should().Contain(selected);
+        warning.Message.Should().Contain(model.Id);
+    }
+
+    [Fact]
+    public void Create_AdjustedEffortDiagnosticsRemainDistinctPerModel()
+    {
+        var firstModel = Model("first-model", CopilotModelTransport.Responses, ["low"]);
+        var secondModel = Model("second-model", CopilotModelTransport.Responses, ["low"]);
+        var logger = new CapturingLogger<CharacteristicsAgentFactory>();
+        var factory = CreateFactory(
+            [firstModel, secondModel],
+            new Mock<IStreamingAgent>().Object,
+            _ => new Mock<IStreamingAgent>().Object,
+            logger
+        );
+
+        factory.Create(
+            new SubAgentCharacteristics(firstModel.Id, ReasoningEffort.High) { IsModelExplicitlySelected = true }
+        );
+        factory.Create(
+            new SubAgentCharacteristics(secondModel.Id, ReasoningEffort.High) { IsModelExplicitlySelected = true }
+        );
+
+        logger.Entries.Count(entry => entry.Level == LogLevel.Warning).Should().Be(2);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("max")]
+    [InlineData("unknown,max")]
+    public void Create_UnsupportedAdvertisedEffortDebugLogsOmissionOnce(string advertised)
+    {
+        var efforts = string.IsNullOrEmpty(advertised) ? [] : advertised.Split(',');
+        var model = Model("unsupported-effort-model", CopilotModelTransport.Responses, efforts);
+        var logger = new CapturingLogger<CharacteristicsAgentFactory>();
+        var parentAgent = new Mock<IStreamingAgent>().Object;
+        var factory = CreateFactory([model], parentAgent, _ => new Mock<IStreamingAgent>().Object, logger);
+        var characteristics = new SubAgentCharacteristics(model.Id, ReasoningEffort.High)
+        {
+            IsModelExplicitlySelected = true,
+        };
+
+        var first = factory.Create(characteristics);
+        var second = factory.Create(characteristics);
+
+        first.ExtraProperties.Should().BeEmpty();
+        second.ExtraProperties.Should().BeEmpty();
+        var debug = logger.Entries.Should().ContainSingle(entry => entry.Level == LogLevel.Debug).Which;
+        debug.Message.Should().Contain(ReasoningEffort.High.ToString());
+        debug.Message.Should().Contain(model.Id);
+    }
+
+    [Fact]
+    public void Create_InheritedCopilotModelWithoutEffortReturnsEmptyMetadata()
+    {
+        var inheritedModel = Model("shared-model", CopilotModelTransport.Responses, ["low", "medium", "high"]);
+        var parentAgent = new Mock<IStreamingAgent>().Object;
+        var modelFactory = new Mock<Func<CopilotModelInfo, IStreamingAgent>>();
+        var factory = CreateFactory(
+            [inheritedModel],
+            parentAgent,
+            modelFactory.Object,
+            parentCopilotModel: inheritedModel
+        );
+
+        var result = factory.Create(new SubAgentCharacteristics(inheritedModel.Id, null));
+
+        result.Agent.Should().BeSameAs(parentAgent);
+        result.ExtraProperties.Should().BeEmpty();
+        modelFactory.Verify(factoryCall => factoryCall(It.IsAny<CopilotModelInfo>()), Times.Never);
+    }
+
+    [Fact]
+    public void Create_ExplicitModelEqualToParentModelUsesCopilotFactory()
+    {
+        var sharedModel = Model("shared-model", CopilotModelTransport.Responses, []);
+        var parentAgent = new Mock<IStreamingAgent>().Object;
+        var copilotAgent = new Mock<IStreamingAgent>().Object;
+        var modelFactory = new Mock<Func<CopilotModelInfo, IStreamingAgent>>();
+        modelFactory.Setup(factoryCall => factoryCall(sharedModel)).Returns(copilotAgent);
+        var factory = CreateFactory([sharedModel], parentAgent, modelFactory.Object);
+
+        var result = factory.Create(
+            new SubAgentCharacteristics(sharedModel.Id, null) { IsModelExplicitlySelected = true }
+        );
+
+        result.Agent.Should().BeSameAs(copilotAgent);
+        modelFactory.Verify(factoryCall => factoryCall(sharedModel), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("not-in-catalog")]
+    public void Create_MissingCatalogModelReturnsExactParentAndWarnsOnce(string? modelId)
+    {
+        var logger = new CapturingLogger<CharacteristicsAgentFactory>();
+        var parentAgent = new Mock<IStreamingAgent>().Object;
+        var modelFactory = new Mock<Func<CopilotModelInfo, IStreamingAgent>>();
+        var factory = CreateFactory([], parentAgent, modelFactory.Object, logger);
+        var characteristics = new SubAgentCharacteristics(modelId, ReasoningEffort.High)
+        {
+            IsModelExplicitlySelected = true,
+        };
+
+        var first = factory.Create(characteristics);
+        var second = factory.Create(characteristics);
+
+        first.Agent.Should().BeSameAs(parentAgent);
+        second.Agent.Should().BeSameAs(parentAgent);
+        first.ExtraProperties.Should().BeEmpty();
+        modelFactory.Verify(factoryCall => factoryCall(It.IsAny<CopilotModelInfo>()), Times.Never);
+        logger.Entries.Count(entry => entry.Level == LogLevel.Warning).Should().Be(1);
+    }
+
+    [Fact]
+    public void Create_DistinctUnknownExplicitModelsFallbackAndWarnOnceForBoundedCategory()
+    {
+        var logger = new CapturingLogger<CharacteristicsAgentFactory>();
+        var parentAgent = new Mock<IStreamingAgent>().Object;
+        var modelFactory = new Mock<Func<CopilotModelInfo, IStreamingAgent>>();
+        var factory = CreateFactory([], parentAgent, modelFactory.Object, logger);
+
+        var first = factory.Create(
+            new SubAgentCharacteristics("unknown-one", null) { IsModelExplicitlySelected = true }
+        );
+        var second = factory.Create(
+            new SubAgentCharacteristics("unknown-two", null) { IsModelExplicitlySelected = true }
+        );
+
+        first.Agent.Should().BeSameAs(parentAgent);
+        second.Agent.Should().BeSameAs(parentAgent);
+        var warning = logger.Entries.Should().ContainSingle(entry => entry.Level == LogLevel.Warning).Which;
+        warning.Message.Should().Contain("unknown-one");
+        modelFactory.Verify(factoryCall => factoryCall(It.IsAny<CopilotModelInfo>()), Times.Never);
+    }
+
+    private static CharacteristicsAgentFactory CreateFactory(
+        IReadOnlyList<CopilotModelInfo> models,
+        IStreamingAgent parentAgent,
+        Func<CopilotModelInfo, IStreamingAgent> modelFactory,
+        ILogger<CharacteristicsAgentFactory>? logger = null,
+        CopilotModelInfo? parentCopilotModel = null
+    )
+    {
+        var registry = new ProviderRegistry(models, new Mock<IFileSystemProbe>().Object);
+        return new CharacteristicsAgentFactory(
+            registry,
+            parentAgent,
+            modelFactory,
+            logger ?? new CapturingLogger<CharacteristicsAgentFactory>(),
+            parentCopilotModel
+        );
+    }
+
+    private static CopilotModelInfo Model(string id, CopilotModelTransport transport, IReadOnlyList<string> efforts) =>
+        new(id, id, CopilotModelVendor.OpenAI, transport) { ReasoningEfforts = efforts };
+}

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/CharacteristicsAgentFactoryTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/CharacteristicsAgentFactoryTests.cs
@@ -604,6 +604,55 @@ public sealed class CharacteristicsAgentFactoryTests
     }
 
     [Fact]
+    public async Task Spawn_RetriesOwnedSynchronousProviderDisposalAfterFirstAttemptThrows()
+    {
+        var model = Model("owned-model", CopilotModelTransport.Responses, []);
+        var disposeCalls = 0;
+        var ownedAgent = CreateRespondingSyncDisposableAgent();
+        ownedAgent
+            .As<IDisposable>()
+            .Setup(agent => agent.Dispose())
+            .Callback(() =>
+            {
+                disposeCalls++;
+                if (disposeCalls == 1)
+                {
+                    throw new InvalidOperationException("owned provider sync dispose boom");
+                }
+            });
+        var factory = CreateFactory(
+            [model],
+            new Mock<IStreamingAgent>().Object,
+            _ => ownedAgent.Object);
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "Test",
+            AgentFactory = () => throw new InvalidOperationException(),
+            DefaultOptions = new GenerateReplyOptions { ModelId = model.Id },
+            IsModelExplicitlySelected = true,
+            CharacteristicsAgentFactory = factory.Create,
+        };
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate> { ["test-agent"] = template },
+        };
+        var manager = new SubAgentManager(
+            new Mock<IMultiTurnAgent>().Object,
+            [],
+            new Dictionary<string, ToolHandler>(),
+            options,
+            new MutableSubAgentTemplateSource(options.Templates));
+
+        // The completion-time SYNCHRONOUS (IDisposable) disposal throws, but must not permanently latch
+        // the guard: a later cleanup (manager dispose) retries the IDisposable branch and succeeds, so
+        // the provider is not leaked.
+        _ = await manager.SpawnAsync("test-agent", "test task");
+        await manager.DisposeAsync();
+
+        ownedAgent.As<IDisposable>().Verify(agent => agent.Dispose(), Times.Exactly(2));
+    }
+
+    [Fact]
     public async Task Spawn_ConstructionRollbackDisposesProviderWhenStoreDisposeThrowsAndPreservesOriginalError()
     {
         var model = Model("owned-model", CopilotModelTransport.Responses, []);

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentIntelligenceOptionsTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentIntelligenceOptionsTests.cs
@@ -47,6 +47,27 @@ public sealed class SubAgentIntelligenceOptionsTests
     }
 
     [Fact]
+    public void Load_LogsAndSkipsDuplicateNormalizedTierKeyWhileKeepingTheFirst()
+    {
+        // "3" and "03" both normalize to integer tier 3; the second is a duplicate and must be
+        // logged and skipped, leaving a single tier-3 mapping.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["SubAgentIntelligence:Tiers:3:0"] = "first-model",
+                ["SubAgentIntelligence:Tiers:03:0"] = "duplicate-model",
+            })
+            .Build();
+        var logger = new CapturingLogger<SubAgentIntelligenceOptions>();
+
+        var options = SubAgentIntelligenceOptions.Load(configuration, logger);
+
+        options.Tiers.Should().ContainSingle().Which.Key.Should().Be(3);
+        options.Tiers[3].Should().NotBeEmpty();
+        logger.Entries.Count(entry => entry.Level == LogLevel.Error).Should().Be(1);
+    }
+
+    [Fact]
     public void Appsettings_TierStubUsesEmptyOrderedArraysForEverySupportedTier()
     {
         var appsettingsPath = Path.GetFullPath(

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentIntelligenceOptionsTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentIntelligenceOptionsTests.cs
@@ -1,5 +1,7 @@
 using LmStreaming.Sample.Services.Discovery;
+using LmStreaming.Sample.Tests.TestDoubles;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace LmStreaming.Sample.Tests.Services.Discovery;
 
@@ -17,12 +19,31 @@ public sealed class SubAgentIntelligenceOptionsTests
             })
             .Build();
 
-        var options = configuration
-            .GetSection(SubAgentIntelligenceOptions.SectionName)
-            .Get<SubAgentIntelligenceOptions>();
+        var options = SubAgentIntelligenceOptions.Load(
+            configuration,
+            new CapturingLogger<SubAgentIntelligenceOptions>());
 
-        options.Should().NotBeNull();
-        options!.Tiers[3].Should().Equal("model-a", "model-b", "model-c");
+        options.Tiers[3].Should().Equal("model-a", "model-b", "model-c");
+    }
+
+    [Fact]
+    public void Load_LogsAndSkipsMalformedAndOutOfRangeKeysWithoutDroppingValidMappings()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["SubAgentIntelligence:Tiers:not-an-integer:0"] = "bad-model",
+                ["SubAgentIntelligence:Tiers:7:0"] = "out-of-range-model",
+                ["SubAgentIntelligence:Tiers:4:0"] = "valid-model",
+            })
+            .Build();
+        var logger = new CapturingLogger<SubAgentIntelligenceOptions>();
+
+        var options = SubAgentIntelligenceOptions.Load(configuration, logger);
+
+        options.Tiers.Should().ContainSingle().Which.Key.Should().Be(4);
+        options.Tiers[4].Should().Equal("valid-model");
+        logger.Entries.Count(entry => entry.Level == LogLevel.Error).Should().Be(2);
     }
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentIntelligenceOptionsTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentIntelligenceOptionsTests.cs
@@ -63,7 +63,7 @@ public sealed class SubAgentIntelligenceOptionsTests
         var options = SubAgentIntelligenceOptions.Load(configuration, logger);
 
         options.Tiers.Should().ContainSingle().Which.Key.Should().Be(3);
-        options.Tiers[3].Should().NotBeEmpty();
+        options.Tiers[3].Should().Equal("first-model");
         logger.Entries.Count(entry => entry.Level == LogLevel.Error).Should().Be(1);
     }
 

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentIntelligenceOptionsTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentIntelligenceOptionsTests.cs
@@ -1,0 +1,55 @@
+using LmStreaming.Sample.Services.Discovery;
+using Microsoft.Extensions.Configuration;
+
+namespace LmStreaming.Sample.Tests.Services.Discovery;
+
+public sealed class SubAgentIntelligenceOptionsTests
+{
+    [Fact]
+    public void ConfigurationBinding_PreservesTierCandidateOrder()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["SubAgentIntelligence:Tiers:3:0"] = "model-a",
+                ["SubAgentIntelligence:Tiers:3:1"] = "model-b",
+                ["SubAgentIntelligence:Tiers:3:2"] = "model-c",
+            })
+            .Build();
+
+        var options = configuration
+            .GetSection(SubAgentIntelligenceOptions.SectionName)
+            .Get<SubAgentIntelligenceOptions>();
+
+        options.Should().NotBeNull();
+        options!.Tiers[3].Should().Equal("model-a", "model-b", "model-c");
+    }
+
+    [Fact]
+    public void Appsettings_TierStubUsesEmptyOrderedArraysForEverySupportedTier()
+    {
+        var appsettingsPath = Path.GetFullPath(
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "samples",
+                "LmStreaming.Sample",
+                "appsettings.json"));
+        using var document = JsonDocument.Parse(File.ReadAllText(appsettingsPath));
+
+        var tiers = document.RootElement
+            .GetProperty("SubAgentIntelligence")
+            .GetProperty("Tiers");
+
+        tiers.ValueKind.Should().Be(JsonValueKind.Object);
+        tiers.EnumerateObject().Select(tier => tier.Name)
+            .Should().Equal("0", "1", "2", "3", "4", "5", "6");
+        tiers.EnumerateObject().Should().OnlyContain(tier =>
+            tier.Value.ValueKind == JsonValueKind.Array
+            && tier.Value.GetArrayLength() == 0);
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentMarkdownParserTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentMarkdownParserTests.cs
@@ -1,3 +1,4 @@
+using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmSampleShared.Discovery;
 
 namespace LmStreaming.Sample.Tests.Services.Discovery;
@@ -82,12 +83,168 @@ public class SubAgentMarkdownParserTests
     {
         // Verifies IgnoreUnmatchedProperties — additions in the gateway's frontmatter contract
         // must not break older builds.
-        var md = "---\nname: echo-agent\ndescription: Echo.\ntags: [demo, test]\nfuture_field: 42\n---\nBody.";
+        var md =
+            "---\nname: echo-agent\ndescription: Echo.\ntags: [demo, test]\nfuture_field: 42\n---\nBody.";
 
         var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
 
         parsed.Should().NotBeNull();
         parsed!.Name.Should().Be("echo-agent");
+    }
+
+    [Fact]
+    public void Parse_ModelIntelligenceLowercaseAlias_BindsTier()
+    {
+        var md = "---\nname: echo-agent\nmodelintelligence: 4\n---\nBody.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
+
+        parsed.Should().NotBeNull();
+        parsed!.ModelIntelligence.Should().Be(4);
+        parsed.Diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_QuotedNumericModelIntelligence_RetainsAgentWithDiagnostic()
+    {
+        var md = "---\nname: echo-agent\nmodelintelligence: \"4\"\n---\nBody.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
+
+        parsed.Should().NotBeNull();
+        parsed!.ModelIntelligence.Should().BeNull();
+        parsed
+            .Diagnostics.Should()
+            .ContainSingle(diagnostic =>
+                diagnostic.Contains("modelintelligence", StringComparison.OrdinalIgnoreCase)
+            );
+    }
+
+    [Theory]
+    [InlineData("modelintelligence")]
+    [InlineData("effort")]
+    public void Parse_ExplicitNullCharacteristic_RetainsAgentWithDiagnostic(string fieldName)
+    {
+        var md = $"---\nname: echo-agent\n{fieldName}: null\n---\nBody.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
+
+        parsed.Should().NotBeNull();
+        parsed!.ModelIntelligence.Should().BeNull();
+        parsed.Effort.Should().BeNull();
+        parsed
+            .Diagnostics.Should()
+            .ContainSingle(diagnostic =>
+                diagnostic.Contains(fieldName, StringComparison.OrdinalIgnoreCase)
+            );
+    }
+
+    [Theory]
+    [InlineData("-1")]
+    [InlineData("7")]
+    [InlineData("frontier")]
+    [InlineData("[1, 2]")]
+    [InlineData("{ tier: 4 }")]
+    public void Parse_InvalidModelIntelligence_RetainsAgentWithDiagnostic(string yamlValue)
+    {
+        var md = $"---\nname: echo-agent\nmodelintelligence: {yamlValue}\n---\nBody.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
+
+        parsed.Should().NotBeNull();
+        parsed!.ModelIntelligence.Should().BeNull();
+        parsed
+            .Diagnostics.Should()
+            .ContainSingle(diagnostic =>
+                diagnostic.Contains("modelintelligence", StringComparison.OrdinalIgnoreCase)
+            );
+    }
+
+    [Theory]
+    [InlineData("low", ReasoningEffort.Low)]
+    [InlineData("MEDIUM", ReasoningEffort.Medium)]
+    [InlineData("High", ReasoningEffort.High)]
+    [InlineData("ExTrA-HiGh", ReasoningEffort.Xhigh)]
+    public void Parse_ValidEffort_MapsCaseInsensitively(string yamlValue, ReasoningEffort expected)
+    {
+        var md = $"---\nname: echo-agent\neffort: {yamlValue}\n---\nBody.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
+
+        parsed.Should().NotBeNull();
+        parsed!.Effort.Should().Be(expected);
+        parsed.Diagnostics.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("maximum")]
+    [InlineData("[low, high]")]
+    public void Parse_InvalidEffort_RetainsAgentWithDiagnostic(string yamlValue)
+    {
+        var md = $"---\nname: echo-agent\neffort: {yamlValue}\n---\nBody.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
+
+        parsed.Should().NotBeNull();
+        parsed!.Effort.Should().BeNull();
+        parsed
+            .Diagnostics.Should()
+            .ContainSingle(diagnostic =>
+                diagnostic.Contains("effort", StringComparison.OrdinalIgnoreCase)
+            );
+    }
+
+    [Fact]
+    public void Parse_OptionalCharacteristicsAbsent_LeavesTypedValuesNull()
+    {
+        var md = "---\nname: echo-agent\n---\nBody.";
+
+        var parsed = SubAgentMarkdownParser.Parse(md, "echo-agent");
+
+        parsed.Should().NotBeNull();
+        parsed!.ModelIntelligence.Should().BeNull();
+        parsed.Effort.Should().BeNull();
+        parsed.Diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParsedSubAgent_characteristics_do_not_change_legacy_equality_or_hash_code()
+    {
+        var legacy = new ParsedSubAgent("echo", "description", "model", ["Read"], "Body.");
+        var enriched = legacy with
+        {
+            ModelIntelligence = 6,
+            Effort = ReasoningEffort.Xhigh,
+            Diagnostics = ["diagnostic"],
+        };
+
+        enriched.Should().Be(legacy);
+        enriched.GetHashCode().Should().Be(legacy.GetHashCode());
+    }
+
+    [Fact]
+    public void ParsedSubAgent_Diagnostics_SnapshotsAssignedMutableList()
+    {
+        var source = new List<string> { "original" };
+        var parsed = new ParsedSubAgent("echo", null, null, null, "Body.") { Diagnostics = source };
+
+        source[0] = "mutated";
+        source.Add("added");
+
+        parsed.Diagnostics.Should().Equal("original");
+    }
+
+    [Fact]
+    public void ParsedSubAgent_Diagnostics_CannotBeMutatedThroughReturnedListCast()
+    {
+        List<string> source = ["original"];
+        var parsed = new ParsedSubAgent("echo", null, null, null, "Body.") { Diagnostics = source };
+        var returnedList = parsed.Diagnostics.Should().BeAssignableTo<IList<string>>().Subject;
+
+        var mutate = () => returnedList[0] = "mutated";
+
+        mutate.Should().Throw<NotSupportedException>();
+        parsed.Diagnostics.Should().Equal("original");
     }
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentMarkdownParserTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentMarkdownParserTests.cs
@@ -165,6 +165,7 @@ public class SubAgentMarkdownParserTests
     [InlineData("MEDIUM", ReasoningEffort.Medium)]
     [InlineData("High", ReasoningEffort.High)]
     [InlineData("ExTrA-HiGh", ReasoningEffort.Xhigh)]
+    [InlineData("XHIGH", ReasoningEffort.Xhigh)]
     public void Parse_ValidEffort_MapsCaseInsensitively(string yamlValue, ReasoningEffort expected)
     {
         var md = $"---\nname: echo-agent\neffort: {yamlValue}\n---\nBody.";
@@ -192,6 +193,27 @@ public class SubAgentMarkdownParserTests
             .ContainSingle(diagnostic =>
                 diagnostic.Contains("effort", StringComparison.OrdinalIgnoreCase)
             );
+    }
+
+    [Theory]
+    [InlineData("effort")]
+    [InlineData("modelintelligence")]
+    public void Parse_EmptyCharacteristic_IsInvalidWhileAbsenceRemainsUnset(string fieldName)
+    {
+        var empty = SubAgentMarkdownParser.Parse(
+            $"---\nname: echo-agent\n{fieldName}:\n---\nBody.",
+            "echo-agent");
+        var absent = SubAgentMarkdownParser.Parse(
+            "---\nname: echo-agent\n---\nBody.",
+            "echo-agent");
+
+        empty.Should().NotBeNull();
+        empty!.Diagnostics.Should().ContainSingle(diagnostic =>
+            diagnostic.Contains(fieldName, StringComparison.OrdinalIgnoreCase));
+        absent.Should().NotBeNull();
+        absent!.ModelIntelligence.Should().BeNull();
+        absent.Effort.Should().BeNull();
+        absent.Diagnostics.Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentModelResolverTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentModelResolverTests.cs
@@ -1,0 +1,148 @@
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Discovery;
+using LmStreaming.Sample.Tests.TestDoubles;
+using Microsoft.Extensions.Logging;
+
+namespace LmStreaming.Sample.Tests.Services.Discovery;
+
+public sealed class SubAgentModelResolverTests
+{
+    [Fact]
+    public void Resolve_ExplicitModelWinsOverTier()
+    {
+        var resolver = CreateResolver(
+            new Dictionary<int, string[]> { [3] = ["catalog-model"] },
+            Model("catalog-model", CopilotModelTransport.Responses)
+        );
+
+        var resolved = resolver.Resolve("explicit-model", 3);
+
+        resolved.Should().Be("explicit-model");
+    }
+
+    [Theory]
+    [InlineData("inherit")]
+    [InlineData(" InHeRiT ")]
+    public void Resolve_InheritModelUsesTier(string inheritModel)
+    {
+        var resolver = CreateResolver(
+            new Dictionary<int, string[]> { [3] = ["catalog-model"] },
+            Model("catalog-model", CopilotModelTransport.Responses)
+        );
+
+        var resolved = resolver.Resolve(inheritModel, 3);
+
+        resolved.Should().Be("catalog-model");
+    }
+
+    [Fact]
+    public void Resolve_ExplicitModelAndTierLogsIgnoredTierOncePerTier()
+    {
+        var logger = new CapturingLogger<SubAgentModelResolver>();
+        var resolver = CreateResolver(new SubAgentIntelligenceOptions(), logger);
+
+        resolver.Resolve(" explicit-model ", 3).Should().Be("explicit-model");
+        resolver.Resolve("EXPLICIT-MODEL", 3).Should().Be("EXPLICIT-MODEL");
+        resolver.Resolve("other-model", 3).Should().Be("other-model");
+        resolver.Resolve("explicit-model", 4).Should().Be("explicit-model");
+
+        var notices = logger.Entries.Where(entry => entry.Level == LogLevel.Information).ToArray();
+        notices.Should().HaveCount(2);
+        notices
+            .Should()
+            .Contain(entry =>
+                entry.Message.Contains("explicit-model")
+                && entry.Message.Contains("3")
+                && entry.Message.Contains("ignored")
+            );
+        notices
+            .Should()
+            .Contain(entry =>
+                entry.Message.Contains("explicit-model")
+                && entry.Message.Contains("4")
+                && entry.Message.Contains("ignored")
+            );
+    }
+
+    [Fact]
+    public void Resolve_UsesFirstRoutableCatalogCandidate()
+    {
+        var resolver = CreateResolver(
+            new Dictionary<int, string[]>
+            {
+                [3] = ["missing-model", "unsupported-model", "anthropic-model", "responses-model"],
+            },
+            Model("unsupported-model", CopilotModelTransport.Unsupported),
+            Model("anthropic-model", CopilotModelTransport.Anthropic),
+            Model("responses-model", CopilotModelTransport.Responses)
+        );
+
+        var resolved = resolver.Resolve(null, 3);
+
+        resolved.Should().Be("anthropic-model");
+    }
+
+    [Theory]
+    [InlineData(ResolutionFailure.EmptyMap)]
+    [InlineData(ResolutionFailure.MissingTier)]
+    [InlineData(ResolutionFailure.UnroutableCandidates)]
+    public void Resolve_UnresolvedTierReturnsNullAndWarnsOnce(ResolutionFailure failure)
+    {
+        var logger = new CapturingLogger<SubAgentModelResolver>();
+        var options = failure switch
+        {
+            ResolutionFailure.EmptyMap => new SubAgentIntelligenceOptions(),
+            ResolutionFailure.MissingTier => new SubAgentIntelligenceOptions
+            {
+                Tiers = new Dictionary<int, string[]> { [2] = ["responses-model"] },
+            },
+            ResolutionFailure.UnroutableCandidates => new SubAgentIntelligenceOptions
+            {
+                Tiers = new Dictionary<int, string[]> { [3] = ["missing-model", "unsupported-model"] },
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(failure)),
+        };
+        var resolver = CreateResolver(
+            options,
+            logger,
+            Model("unsupported-model", CopilotModelTransport.Unsupported),
+            Model("responses-model", CopilotModelTransport.Responses)
+        );
+
+        resolver.Resolve(null, 3).Should().BeNull();
+        resolver.Resolve(null, 3).Should().BeNull();
+
+        logger.Entries.Count(entry => entry.Level == LogLevel.Warning).Should().Be(1);
+    }
+
+    private static SubAgentModelResolver CreateResolver(
+        Dictionary<int, string[]> tiers,
+        params CopilotModelInfo[] models
+    ) =>
+        CreateResolver(
+            new SubAgentIntelligenceOptions { Tiers = tiers },
+            new CapturingLogger<SubAgentModelResolver>(),
+            models
+        );
+
+    private static SubAgentModelResolver CreateResolver(
+        SubAgentIntelligenceOptions options,
+        ILogger<SubAgentModelResolver> logger,
+        params CopilotModelInfo[] models
+    )
+    {
+        var registry = new ProviderRegistry(models, new Mock<IFileSystemProbe>().Object);
+        return new SubAgentModelResolver(registry, options, logger);
+    }
+
+    private static CopilotModelInfo Model(string id, CopilotModelTransport transport) =>
+        new(id, id, CopilotModelVendor.OpenAI, transport);
+
+    public enum ResolutionFailure
+    {
+        EmptyMap,
+        MissingTier,
+        UnroutableCandidates,
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentTemplateMapperTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentTemplateMapperTests.cs
@@ -1,4 +1,5 @@
 using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmSampleShared.Discovery;
 
 namespace LmStreaming.Sample.Tests.Services.Discovery;
@@ -31,6 +32,7 @@ public class SubAgentTemplateMapperTests
 
         template.DefaultOptions.Should().BeNull(
             "'inherit'/blank means inherit the parent model, not send a literal unsupported model id");
+        template.IsModelExplicitlySelected.Should().BeFalse();
     }
 
     [Fact]
@@ -40,5 +42,16 @@ public class SubAgentTemplateMapperTests
 
         template.DefaultOptions.Should().NotBeNull();
         template.DefaultOptions!.ModelId.Should().Be("claude-sonnet-5");
+        template.IsModelExplicitlySelected.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Map_Effort_CarriesTypedValue()
+    {
+        var parsed = Parsed("claude-sonnet-5") with { Effort = ReasoningEffort.Xhigh };
+
+        var template = SubAgentTemplateMapper.Map(parsed, AgentFactory, maxTurnsPerRun: 25);
+
+        template.Effort.Should().Be(ReasoningEffort.Xhigh);
     }
 }

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentTemplateMapperTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/SubAgentTemplateMapperTests.cs
@@ -46,6 +46,18 @@ public class SubAgentTemplateMapperTests
     }
 
     [Fact]
+    public void Map_TierResolvedModel_RetainsDistinctRoutingIntent()
+    {
+        var parsed = Parsed("gpt-tier") with { IsModelTierResolved = true };
+
+        var template = SubAgentTemplateMapper.Map(parsed, AgentFactory, maxTurnsPerRun: 25);
+
+        template.DefaultOptions!.ModelId.Should().Be("gpt-tier");
+        template.IsModelExplicitlySelected.Should().BeFalse();
+        template.IsModelTierResolved.Should().BeTrue();
+    }
+
+    [Fact]
     public void Map_Effort_CarriesTypedValue()
     {
         var parsed = Parsed("claude-sonnet-5") with { Effort = ReasoningEffort.Xhigh };

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/WorkspaceSubAgentLoaderIntelligenceTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/WorkspaceSubAgentLoaderIntelligenceTests.cs
@@ -44,7 +44,8 @@ public sealed class WorkspaceSubAgentLoaderIntelligenceTests
 
         template.Should().NotBeNull();
         template!.DefaultOptions!.ModelId.Should().Be("routable-model");
-        template.IsModelExplicitlySelected.Should().BeTrue();
+        template.IsModelExplicitlySelected.Should().BeFalse();
+        template.IsModelTierResolved.Should().BeTrue();
         template.CharacteristicsAgentFactory.Should().BeSameAs(characteristicsAgentFactory);
         logger.Entries.Should().ContainSingle(entry =>
             entry.Level == LogLevel.Warning
@@ -78,6 +79,7 @@ public sealed class WorkspaceSubAgentLoaderIntelligenceTests
         template.Should().NotBeNull();
         template!.DefaultOptions.Should().BeNull();
         template.IsModelExplicitlySelected.Should().BeFalse();
+        template.IsModelTierResolved.Should().BeFalse();
     }
 
     private static WorkspaceSubAgentLoader CreateLoader(

--- a/tests/LmStreaming.Sample.Tests/Services/Discovery/WorkspaceSubAgentLoaderIntelligenceTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/Discovery/WorkspaceSubAgentLoaderIntelligenceTests.cs
@@ -1,0 +1,124 @@
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Services.Discovery;
+using LmStreaming.Sample.Tests.TestDoubles;
+using Microsoft.Extensions.Logging;
+
+namespace LmStreaming.Sample.Tests.Services.Discovery;
+
+public sealed class WorkspaceSubAgentLoaderIntelligenceTests
+{
+    private const string GatewayBaseUrl = "http://localhost:3000";
+
+    [Fact]
+    public async Task LoadOneAsync_ResolvesTierLogsParserDiagnosticsAndAttachesFactory()
+    {
+        var logger = new CapturingLogger<WorkspaceSubAgentLoader>();
+        var characteristicsAgentFactory =
+            new Func<SubAgentCharacteristics, SubAgentProviderAgent>(_ =>
+                new SubAgentProviderAgent(
+                    new Mock<IStreamingAgent>().Object,
+                    System.Collections.Immutable.ImmutableDictionary<string, object?>.Empty));
+        var loader = CreateLoader(logger);
+        var item = new SandboxSessionRegistry.DiscoveredItem(
+            "subagent",
+            "tiered",
+            "Tiered agent",
+            "/marketplaces/example/tiered.md",
+            """
+            ---
+            name: tiered
+            modelintelligence: 3
+            effort: invalid
+            ---
+            Handle the task.
+            """);
+
+        var template = await loader.LoadOneWithCharacteristicsAsync(
+            new SandboxSession("default", "session", "default", "workspace"),
+            item,
+            () => new Mock<IStreamingAgent>().Object,
+            characteristicsAgentFactory);
+
+        template.Should().NotBeNull();
+        template!.DefaultOptions!.ModelId.Should().Be("routable-model");
+        template.IsModelExplicitlySelected.Should().BeTrue();
+        template.CharacteristicsAgentFactory.Should().BeSameAs(characteristicsAgentFactory);
+        logger.Entries.Should().ContainSingle(entry =>
+            entry.Level == LogLevel.Warning
+            && entry.Message.Contains("effort must be one of", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task LoadOneAsync_UnresolvedTierRemainsInherited()
+    {
+        var loader = CreateLoader(
+            new CapturingLogger<WorkspaceSubAgentLoader>());
+        var item = new SandboxSessionRegistry.DiscoveredItem(
+            "subagent",
+            "tiered",
+            "Tiered agent",
+            "/marketplaces/example/tiered.md",
+            """
+            ---
+            name: tiered
+            modelintelligence: 99
+            ---
+            Handle the task.
+            """);
+
+        var template = await loader.LoadOneWithCharacteristicsAsync(
+            new SandboxSession("default", "session", "default", "workspace"),
+            item,
+            () => new Mock<IStreamingAgent>().Object,
+            _ => throw new InvalidOperationException("Factory should not run while loading."));
+
+        template.Should().NotBeNull();
+        template!.DefaultOptions.Should().BeNull();
+        template.IsModelExplicitlySelected.Should().BeFalse();
+    }
+
+    private static WorkspaceSubAgentLoader CreateLoader(
+        ILogger<WorkspaceSubAgentLoader> logger)
+    {
+        var gateway = new SandboxGatewayLifetime(
+            new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl },
+            NullLogger<SandboxGatewayLifetime>.Instance,
+            new HttpClient(new StubHandler()));
+        var registry = new SandboxSessionRegistry(
+            gateway,
+            new SandboxGatewayOptions { BaseUrl = GatewayBaseUrl },
+            NullLogger<SandboxSessionRegistry>.Instance,
+            new HttpClient(new StubHandler()),
+            new AuthOptions(),
+            new AuthSharedSecret(new AuthOptions()));
+        var catalog = new ProviderRegistry(
+            [
+                new CopilotModelInfo(
+                    "routable-model",
+                    "Routable",
+                    CopilotModelVendor.OpenAI,
+                    CopilotModelTransport.Responses),
+            ],
+            new Mock<IFileSystemProbe>().Object);
+        var resolver = new SubAgentModelResolver(
+            catalog,
+            new SubAgentIntelligenceOptions
+            {
+                Tiers = new Dictionary<int, string[]> { [3] = ["routable-model"] },
+            },
+            new CapturingLogger<SubAgentModelResolver>());
+
+        return new WorkspaceSubAgentLoader(registry, logger, resolver);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("HTTP is not expected");
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistrySubAgentIsolationTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistrySubAgentIsolationTests.cs
@@ -91,14 +91,9 @@ public class SandboxSessionRegistrySubAgentIsolationTests
     }
 
     [Fact]
-    public async Task GetOrAddSubAgentBinding_BothOverloadsPreserveExpectedFactories()
+    public async Task GetOrAddSubAgentBinding_PreservesLegacyFactory()
     {
         await using var registry = CreateRegistry();
-        var providerAgent = new Mock<IStreamingAgent>().Object;
-        Func<SubAgentCharacteristics, SubAgentProviderAgent> characteristicsFactory =
-            _ => new SubAgentProviderAgent(
-                providerAgent,
-                ImmutableDictionary<string, object?>.Empty);
         var seed = new Dictionary<string, SubAgentTemplate>();
 
         var fourParameterOverload = typeof(SandboxSessionRegistry).GetMethod(
@@ -114,12 +109,6 @@ public class SandboxSessionRegistrySubAgentIsolationTests
             "legacy-conversation",
             seed,
             AgentFactory);
-        var characteristicsBinding = registry.GetOrAddSubAgentBinding(
-            SessionId,
-            "characteristics-conversation",
-            seed,
-            AgentFactory,
-            characteristicsFactory);
         var (source, agentFactory) = legacyBinding;
 
         fourParameterOverload.Should().NotBeNull("existing compiled callers require the original CLR signature");
@@ -127,8 +116,52 @@ public class SandboxSessionRegistrySubAgentIsolationTests
         agentFactory.Should().BeSameAs(AgentFactory);
         legacyBinding.AgentFactory.Should().BeSameAs(AgentFactory);
         legacyBinding.CharacteristicsAgentFactory.Should().BeNull();
-        characteristicsBinding.AgentFactory.Should().BeSameAs(AgentFactory);
-        characteristicsBinding.CharacteristicsAgentFactory.Should().BeSameAs(characteristicsFactory);
+    }
+
+    [Fact]
+    public async Task AddOrUpdateSubAgentBinding_RebindsFactoriesAndPreservesSourceIdentity()
+    {
+        await using var registry = CreateRegistry();
+        var firstAgent = new Mock<IStreamingAgent>().Object;
+        var latestAgent = new Mock<IStreamingAgent>().Object;
+        Func<IStreamingAgent> firstFactory = () => firstAgent;
+        Func<IStreamingAgent> latestFactory = () => latestAgent;
+        Func<SubAgentCharacteristics, SubAgentProviderAgent> latestCharacteristicsFactory =
+            _ => new SubAgentProviderAgent(
+                latestAgent,
+                ImmutableDictionary<string, object?>.Empty);
+        var seed = new Dictionary<string, SubAgentTemplate>
+        {
+            ["retained"] = new()
+            {
+                Name = "retained",
+                SystemPrompt = "retained",
+                AgentFactory = firstFactory,
+            },
+        };
+
+        var before = registry.AddOrUpdateSubAgentBinding(
+            SessionId,
+            "conversation",
+            seed,
+            firstFactory,
+            null);
+        var after = registry.AddOrUpdateSubAgentBinding(
+            SessionId,
+            "conversation",
+            seed,
+            latestFactory,
+            latestCharacteristicsFactory);
+
+        ReferenceEquals(before.Source, after.Source).Should().BeTrue();
+        after.AgentFactory.Should().BeSameAs(latestFactory);
+        after.CharacteristicsAgentFactory.Should().BeSameAs(latestCharacteristicsFactory);
+        after.Source.Templates["retained"].CharacteristicsAgentFactory!(
+                new SubAgentCharacteristics("explicit", null)
+                {
+                    IsModelExplicitlySelected = true,
+                })
+            .Agent.Should().BeSameAs(latestAgent);
     }
 
     /// <summary>

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistrySubAgentIsolationTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistrySubAgentIsolationTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Net;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
@@ -87,6 +88,47 @@ public class SandboxSessionRegistrySubAgentIsolationTests
             Template("AlphaDiscovered", "Discovered by conversation A.")).Should().BeTrue();
 
         bindingA.Source.Templates.Keys.Should().Contain("alpha_discovered");
+    }
+
+    [Fact]
+    public async Task GetOrAddSubAgentBinding_BothOverloadsPreserveExpectedFactories()
+    {
+        await using var registry = CreateRegistry();
+        var providerAgent = new Mock<IStreamingAgent>().Object;
+        Func<SubAgentCharacteristics, SubAgentProviderAgent> characteristicsFactory =
+            _ => new SubAgentProviderAgent(
+                providerAgent,
+                ImmutableDictionary<string, object?>.Empty);
+        var seed = new Dictionary<string, SubAgentTemplate>();
+
+        var fourParameterOverload = typeof(SandboxSessionRegistry).GetMethod(
+            nameof(SandboxSessionRegistry.GetOrAddSubAgentBinding),
+            [
+                typeof(string),
+                typeof(string),
+                typeof(IReadOnlyDictionary<string, SubAgentTemplate>),
+                typeof(Func<IStreamingAgent>),
+            ]);
+        var legacyBinding = registry.GetOrAddSubAgentBinding(
+            SessionId,
+            "legacy-conversation",
+            seed,
+            AgentFactory);
+        var characteristicsBinding = registry.GetOrAddSubAgentBinding(
+            SessionId,
+            "characteristics-conversation",
+            seed,
+            AgentFactory,
+            characteristicsFactory);
+        var (source, agentFactory) = legacyBinding;
+
+        fourParameterOverload.Should().NotBeNull("existing compiled callers require the original CLR signature");
+        source.Should().BeSameAs(legacyBinding.Source);
+        agentFactory.Should().BeSameAs(AgentFactory);
+        legacyBinding.AgentFactory.Should().BeSameAs(AgentFactory);
+        legacyBinding.CharacteristicsAgentFactory.Should().BeNull();
+        characteristicsBinding.AgentFactory.Should().BeSameAs(AgentFactory);
+        characteristicsBinding.CharacteristicsAgentFactory.Should().BeSameAs(characteristicsFactory);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Add typed `modelintelligence` and `effort` front matter with shared validation diagnostics.
- Resolve model characteristics once per spawn while preserving the existing agent factory fallback.
- Route Copilot sub-agents by configured tier and shape reasoning effort for the selected transport.
- Preserve characteristics through mid-session discovery and provider recreation; keep the daemon parse-only.

## Key Decisions
- The characteristics factory is additive, so existing `AgentFactory` callers remain compatible.
- Explicit model and spawn overrides win; unresolved tiers inherit the parent provider.
- Provider-specific effort clamping and wire shapes remain in `GithubCopilotProvider`.
- Session refresh publishes immutable template snapshots to prevent mixed-provider routing. `Templates` is a point-in-time snapshot; callers must reread it to observe later registrations or rebinds.
- New record properties preserve legacy constructors, deconstruction, equality, and hash behavior.

## Testing
- Solution build: 0 warnings, 0 errors.
- `LmMultiTurn.Tests`, `GithubCopilotProvider.Tests`, and `CodeReviewDaemon.Sample.Tests` pass on clean reruns.
- New parser, mapper, resolver, shaper, composition, session, and daemon parity regressions pass.
- `LmStreaming.Sample.Tests` retains pre-existing `origin/main` failures in context notification ordering and gateway auth-header expectations.

## Related Issues
Fixes #177