### PR TITLE
feat(#198): route sandbox-discovered directory context to the opening sub-agent

### DIFF
--- a/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
@@ -84,6 +84,10 @@ public sealed class ContextDiscoveryController(
                 Path = item.Path,
                 Content = item.Content,
                 Truncated = item.Truncated,
+                // Copy the triggering-agent id PER ITEM, not from the envelope: the gateway stamps it
+                // on the individual discovery (a batch can mix a sub-agent-triggered file with a
+                // session-level root file that carries none), so a batch-wide value would misroute.
+                AgentId = item.AgentId,
             };
 
             if (!IsValid(payload))
@@ -387,4 +391,10 @@ public sealed record ContextDiscoveryItem
 
     [JsonPropertyName("truncated")]
     public bool? Truncated { get; init; }
+
+    /// <summary>Optional id/name of the sub-agent that triggered this discovery (cf. #187). Stamped
+    /// per item, so the controller copies it onto the per-item <see cref="ContextDiscoveryPayload"/>
+    /// rather than reading a batch-wide value.</summary>
+    [JsonPropertyName("agent_id")]
+    public string? AgentId { get; init; }
 }

--- a/samples/LmStreaming.Sample/Controllers/ContextDiscoveryDiagnosticsController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ContextDiscoveryDiagnosticsController.cs
@@ -46,7 +46,8 @@ public sealed class ContextDiscoveryDiagnosticsController(
         return Ok(new ContextDiscoveryDiagnosticsResponse(
             DiscoveryEnabled: registry.DiscoveryEnabled,
             WebhookUrl: registry.DiscoveryWebhookUrl,
-            Sessions: sessions));
+            Sessions: sessions,
+            Routing: diagnostics.RoutingSnapshot()));
     }
 }
 
@@ -54,7 +55,8 @@ public sealed class ContextDiscoveryDiagnosticsController(
 public sealed record ContextDiscoveryDiagnosticsResponse(
     bool DiscoveryEnabled,
     string WebhookUrl,
-    IReadOnlyList<ContextDiscoverySessionInfo> Sessions);
+    IReadOnlyList<ContextDiscoverySessionInfo> Sessions,
+    RoutingOutcomeCounts Routing);
 
 /// <summary>Per-session discovery state. <see cref="ReceivedCount"/> is 0 (with null timestamps)
 /// for a live session that has not yet received any discovery webhook.</summary>

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -372,6 +372,13 @@ try
     // <context-discovery> wrapper tag shared by the boot-time system prompt and the mid-session
     // user-turn injection; the injector wires gateway webhook deliveries into every live agent
     // thread bound to the same sandbox session.
+    // Bind the routing options FIRST (default-off) so the injector resolves them from DI. Off ⇒
+    // discovery behaves byte-identically to today; on ⇒ a context_file carrying an agent_id is
+    // routed to the opening sub-agent (cf. #187/#198).
+    var contextDiscoveryOptions =
+        builder.Configuration.GetSection(ContextDiscoveryOptions.SectionName).Get<ContextDiscoveryOptions>()
+        ?? new ContextDiscoveryOptions();
+    _ = builder.Services.AddSingleton(contextDiscoveryOptions);
     _ = builder.Services.AddSingleton<ContextDiscoveryFormatter>();
     _ = builder.Services.AddSingleton<ContextDiscoveryInjector>();
     // Tracks received discovery webhooks per session for GET /api/diagnostics/context-discovery,
@@ -2235,8 +2242,14 @@ public partial class Program
 
             // Mark the seeded file as seen so a same-file delivery on the webhook side (the gateway
             // re-emits the root path right after session creation) is dropped by the injector —
-            // otherwise the model would see the file twice on turn 1.
-            _ = sandboxRegistry.TryMarkDiscoverySeen(sandboxSession.SessionId, ContextFileKind, path);
+            // otherwise the model would see the file twice on turn 1. Marked under the session-level
+            // sentinel (the root seed is not attributed to any sub-agent), matching the injector's
+            // fallback-path dedup target.
+            _ = sandboxRegistry.TryMarkDiscoverySeen(
+                sandboxSession.SessionId,
+                SandboxSessionRegistry.SessionDiscoveryTarget,
+                ContextFileKind,
+                path);
 
             logger.LogInformation(
                 "Seeded workspace root context file {Path} ({Length} chars) into the system prompt for session {SessionId}.",

--- a/samples/LmStreaming.Sample/PromptExamples.md
+++ b/samples/LmStreaming.Sample/PromptExamples.md
@@ -125,6 +125,26 @@ chat; the `hi from agent` result is the proof it executed the nested chain end t
 
 Nested-tag handling lives in `src/LmTestUtils/TestMode/InstructionChainParser.cs`.
 
+### Backgrounded sub-agent parked on a long wait (webhook-routing fixture)
+
+Fixture for the directory-context routing feature (#198): background-spawns a **named** sub-agent
+(`name: "ctx-probe"`) with `run_in_background: true`, whose nested chain immediately arms a **30s**
+`Wait`. The parent chain returns right away while `ctx-probe` stays **Running-but-parked** — a stable
+window in which a synthetic `context_discovery` webhook carrying `agent_id: "ctx-probe"` (with
+`ContextDiscovery:RouteToOpeningSubAgent=true`) can be routed into that sub-agent's own conversation
+instead of the primary. Requires `test` / `test-anthropic` mode with the `Agent` + `Wait` tools wired.
+
+<|instruction_start|>{"instruction_chain":[{"id":"spawn-probe","id_message":"Background-spawn ctx-probe parked on a 30s wait","messages":[{"tool_call":[{"name":"Agent","args":{"subagent_type":"general-purpose","name":"ctx-probe","run_in_background":true,"prompt":"<|instruction_start|>{\"instruction_chain\":[{\"id\":\"probe-arm\",\"messages\":[{\"tool_call\":[{\"name\":\"Wait\",\"args\":{\"kind\":\"timer\",\"args\":{\"delay\":\"30s\"},\"timeout\":\"60s\",\"label\":\"ctx-probe-park\"}}]}]},{\"id\":\"probe-done\",\"messages\":[{\"text\":\"ctx-probe resumed after its wait\"}]}]}<|instruction_end|>"}}]}]},{"id":"parent-ack","id_message":"Parent continues while ctx-probe is parked","messages":[{"text":"ctx-probe spawned in the background and parked on its wait — ready to receive routed directory context."}]}]}<|instruction_end|>
+
+Expected behavior:
+1. An `Agent` tool-call pill for `ctx-probe` returns immediately (background spawn); the parent's final
+   text lands while `ctx-probe` is still parked on its 30s timer.
+2. POST a synthetic `context_discovery` webhook for this session with an item carrying
+   `agent_id: "ctx-probe"` while the flag is on ⇒ the injector routes it into `ctx-probe`'s conversation
+   (the primary store gets no context turn); `GET /api/diagnostics/context-discovery` shows the
+   `routing.routed` counter increment.
+3. After ~30s the timer fires and `ctx-probe` resumes — proof it was genuinely parked, not finished.
+
 ---
 
 ## Wait / Trigger (Park-and-Wake)

--- a/src/LmAgentInfra/Context/ContextDiscoveryDiagnostics.cs
+++ b/src/LmAgentInfra/Context/ContextDiscoveryDiagnostics.cs
@@ -19,6 +19,10 @@ public sealed class ContextDiscoveryDiagnostics
     private readonly ConcurrentDictionary<string, SessionReceived> _received =
         new(StringComparer.Ordinal);
 
+    private long _routedCount;
+    private long _droppedCount;
+    private long _fallbackCount;
+
     /// <summary>
     /// Records one authenticated, well-formed discovery webhook for <paramref name="sessionId"/>.
     /// No-op when the session id is blank (the arrival can't be attributed to a session). Thread
@@ -45,12 +49,61 @@ public sealed class ContextDiscoveryDiagnostics
     }
 
     /// <summary>
+    /// Records the routing decision the injector made for one <c>context_file</c> discovery. A
+    /// routed delivery renders no "Context loaded" pill in the primary view, so this per-outcome
+    /// counter is the operator's only signal that sub-agent routing is happening (vs. today's
+    /// session fan-out or an unresolved drop). Thread safe.
+    /// </summary>
+    public void RecordRoutingOutcome(ContextRoutingOutcome outcome)
+    {
+        switch (outcome)
+        {
+            case ContextRoutingOutcome.Routed:
+                _ = Interlocked.Increment(ref _routedCount);
+                break;
+            case ContextRoutingOutcome.Dropped:
+                _ = Interlocked.Increment(ref _droppedCount);
+                break;
+            case ContextRoutingOutcome.Fallback:
+                _ = Interlocked.Increment(ref _fallbackCount);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /// <summary>
     /// Point-in-time copy of every session's received-discovery state. The returned dictionary is a
     /// snapshot — safe to iterate without holding any lock.
     /// </summary>
     public IReadOnlyDictionary<string, SessionReceived> Snapshot() =>
         new Dictionary<string, SessionReceived>(_received, StringComparer.Ordinal);
+
+    /// <summary>
+    /// Point-in-time copy of the per-outcome routing counters (routed / dropped / fallback).
+    /// </summary>
+    public RoutingOutcomeCounts RoutingSnapshot() =>
+        new(
+            Interlocked.Read(ref _routedCount),
+            Interlocked.Read(ref _droppedCount),
+            Interlocked.Read(ref _fallbackCount));
 }
+
+/// <summary>
+/// Outcome of routing one <c>context_file</c> discovery: <see cref="Routed"/> = delivered to the
+/// opening sub-agent; <see cref="Dropped"/> = a routed discovery whose target could not receive it
+/// (finished/disposed/never-registered) — NOT redirected to the primary; <see cref="Fallback"/> =
+/// today's session fan-out (no/blank <c>agent_id</c> or the flag is off).
+/// </summary>
+public enum ContextRoutingOutcome
+{
+    Routed,
+    Dropped,
+    Fallback,
+}
+
+/// <summary>Per-outcome routing tally surfaced by the context-discovery diagnostics endpoint.</summary>
+public sealed record RoutingOutcomeCounts(long Routed, long Dropped, long Fallback);
 
 /// <summary>
 /// Per-session tally of received context-discovery webhooks. <see cref="LastKind"/> /

--- a/src/LmAgentInfra/Context/ContextDiscoveryInjector.cs
+++ b/src/LmAgentInfra/Context/ContextDiscoveryInjector.cs
@@ -198,13 +198,21 @@ public sealed class ContextDiscoveryInjector
     /// <summary>
     /// Routes the discovery to the sub-agent identified by <c>agent_id</c>. Marks the dedup ledger
     /// under the agent id FIRST (so a redelivery of an already-resolved discovery drops); then asks
-    /// each session thread's <see cref="ISubAgentContextSink"/> in turn. Aggregation: the first
-    /// <see cref="SubAgentContextDeliveryResult.Delivered"/> wins (routed); otherwise if any sink
-    /// owns the id but can't take it (<see cref="SubAgentContextDeliveryResult.TargetNotDeliverable"/>)
-    /// the discovery is dropped WITHOUT fan-out and the mark kept (terminal); if no sink owns it
-    /// (all <see cref="SubAgentContextDeliveryResult.NotOwned"/>) the discovery is dropped and the
-    /// mark REMOVED so a gateway redelivery can retry once the sub-agent registers (pre-registration
-    /// race). A present-but-unresolved <c>agent_id</c> never falls back to the primary.
+    /// each session thread's <see cref="ISubAgentContextSink"/> in turn. Aggregation across the
+    /// non-delivered outcomes: the first <see cref="SubAgentContextDeliveryResult.Delivered"/> wins
+    /// (routed); otherwise, in priority order —
+    /// <list type="number">
+    ///   <item>if any sink owns the id but can't take it
+    ///   (<see cref="SubAgentContextDeliveryResult.TargetNotDeliverable"/>) the discovery is dropped
+    ///   WITHOUT fan-out and the mark KEPT (terminal — a retry can't succeed);</item>
+    ///   <item>else if any sink THREW, the mark is likewise KEPT: a throwing sink may already have
+    ///   accepted (delivered) the send, so un-marking could DOUBLE-INJECT the same context on a
+    ///   gateway retry — safer to drop-and-hold;</item>
+    ///   <item>else (every sink cleanly returned <see cref="SubAgentContextDeliveryResult.NotOwned"/>)
+    ///   the discovery is dropped and the mark REMOVED so a gateway redelivery can retry once the
+    ///   sub-agent registers (pre-registration race).</item>
+    /// </list>
+    /// A present-but-unresolved <c>agent_id</c> never falls back to the primary.
     /// </summary>
     private async Task<int> RouteToSubAgentAsync(ContextDiscoveryPayload body, CancellationToken ct)
     {
@@ -225,6 +233,7 @@ public sealed class ContextDiscoveryInjector
         IReadOnlyList<IMessage> messages = [message];
 
         var anyNotDeliverable = false;
+        var anyAmbiguous = false;
         foreach (var threadId in _registry.GetThreads(body.SessionId!))
         {
             if (!_pool.TryGet(threadId, out var agent) || agent is not ISubAgentContextSink sink)
@@ -243,13 +252,18 @@ public sealed class ContextDiscoveryInjector
             }
             catch (Exception ex)
             {
-                // A misbehaving sink must not strand routing — treat it as not-owned and keep scanning.
+                // A misbehaving sink must not strand routing — keep scanning the other threads so a
+                // healthy sink can still Deliver. But flag the failure as AMBIGUOUS: because the throw
+                // could have happened AFTER the sink accepted (delivered) the send, we can no longer be
+                // sure this discovery wasn't delivered. The final aggregation uses this to KEEP the mark
+                // rather than un-marking, so a gateway retry can't double-inject.
                 _logger.LogWarning(
                     ex,
                     "ContextDiscovery context_file: sink delivery threw for agent {AgentId} on thread {ThreadId}; "
-                    + "treating as not-owned.",
+                    + "treating as ambiguous (delivery may have occurred).",
                     agentId,
                     threadId);
+                anyAmbiguous = true;
                 continue;
             }
 
@@ -286,10 +300,28 @@ public sealed class ContextDiscoveryInjector
             return 0;
         }
 
-        // No sink owns the id: the sub-agent hasn't registered yet (pre-registration race), or it is a
-        // nested / cross-session agent. Drop and un-mark ONLY this discovery's (target, kind, path) so the
-        // gateway's redelivery can retry once the sub-agent is live — precise so a concurrent delivery's
-        // mark for another path of the same agent survives — but still never fall back to the primary.
+        if (anyAmbiguous)
+        {
+            // A sink THREW after being asked to deliver, and no other sink Delivered. We cannot tell
+            // whether the throwing sink already accepted (delivered) the send, so KEEP the mark rather
+            // than un-marking: un-marking would let a gateway redelivery retry and could DOUBLE-INJECT
+            // the same context if that sink had in fact delivered. Drop-and-hold (no retry) is the safe
+            // choice — still never fall back to the primary.
+            _logger.LogWarning(
+                "ContextDiscovery context_file: ambiguous sink failure for {AgentId} on {Path} in session "
+                + "{SessionId}; keeping the dedup mark (no gateway retry) to avoid a possible double-inject.",
+                agentId,
+                body.Path,
+                body.SessionId);
+            _diagnostics.RecordRoutingOutcome(ContextRoutingOutcome.Dropped);
+            return 0;
+        }
+
+        // No sink owns the id AND none threw: the sub-agent hasn't registered yet (pre-registration
+        // race), or it is a nested / cross-session agent. Drop and un-mark ONLY this discovery's
+        // (target, kind, path) so the gateway's redelivery can retry once the sub-agent is live —
+        // precise so a concurrent delivery's mark for another path of the same agent survives — but
+        // still never fall back to the primary.
         _registry.UnmarkDiscoverySeen(body.SessionId!, agentId, body.Kind!, body.Path!);
         _logger.LogDebug(
             "ContextDiscovery context_file: no live sub-agent owns {AgentId} for {Path} in session {SessionId}; "

--- a/src/LmAgentInfra/Context/ContextDiscoveryInjector.cs
+++ b/src/LmAgentInfra/Context/ContextDiscoveryInjector.cs
@@ -69,6 +69,19 @@ public sealed class ContextDiscoveryInjector
     }
 
     /// <summary>
+    /// Back-compat constructor matching the pre-#198 signature: routing defaults OFF (behaviour
+    /// identical to pre-#198) for callers that do not supply options/diagnostics.
+    /// </summary>
+    public ContextDiscoveryInjector(
+        SandboxSessionRegistry registry,
+        MultiTurnAgentPool pool,
+        ContextDiscoveryFormatter formatter,
+        ILogger<ContextDiscoveryInjector> logger)
+        : this(registry, pool, formatter, new ContextDiscoveryOptions(), new ContextDiscoveryDiagnostics(), logger)
+    {
+    }
+
+    /// <summary>
     /// Best-effort: delivers the formatted file body to its target — the opening sub-agent (routed)
     /// or every live thread of the session (fallback). Returns the number of conversations the
     /// message was actually delivered to (0 when nothing is live, the discovery is a duplicate, the
@@ -274,9 +287,10 @@ public sealed class ContextDiscoveryInjector
         }
 
         // No sink owns the id: the sub-agent hasn't registered yet (pre-registration race), or it is a
-        // nested / cross-session agent. Drop and UN-mark so the gateway's redelivery can retry once the
-        // sub-agent is live — but still never fall back to the primary.
-        _registry.EvictDiscoverySeenForTarget(body.SessionId!, agentId);
+        // nested / cross-session agent. Drop and un-mark ONLY this discovery's (target, kind, path) so the
+        // gateway's redelivery can retry once the sub-agent is live — precise so a concurrent delivery's
+        // mark for another path of the same agent survives — but still never fall back to the primary.
+        _registry.UnmarkDiscoverySeen(body.SessionId!, agentId, body.Kind!, body.Path!);
         _logger.LogDebug(
             "ContextDiscovery context_file: no live sub-agent owns {AgentId} for {Path} in session {SessionId}; "
             + "dropping and allowing gateway retry.",

--- a/src/LmAgentInfra/Context/ContextDiscoveryInjector.cs
+++ b/src/LmAgentInfra/Context/ContextDiscoveryInjector.cs
@@ -1,15 +1,17 @@
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmAgentInfra.Agents;
 using AchieveAi.LmDotnetTools.LmAgentInfra.Sandbox;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
 
 namespace AchieveAi.LmDotnetTools.LmAgentInfra.Context;
 
 /// <summary>
-/// Routes a <c>context_file</c> discovery from the gateway webhook into every live agent thread
-/// bound to the same sandbox session: looks up the thread set, dedups gateway retries, and
-/// enqueues a <see cref="NotifyMessage"/> (kind <c>context-discovery</c>) carrying the formatted
-/// file body — delivered to the model via <c>ICanGetText</c> and rendered as a distinct pill by the
-/// chat UI.
+/// Routes a <c>context_file</c> discovery from the gateway webhook to its target conversation(s):
+/// either the specific sub-agent that opened the file (when routing is enabled and the gateway
+/// stamped an <c>agent_id</c>) or — the fallback, and all traffic today — every live agent thread
+/// bound to the same sandbox session. It dedups gateway retries and enqueues a
+/// <see cref="NotifyMessage"/> (kind <c>context-discovery</c>) carrying the formatted file body —
+/// delivered to the model via <c>ICanGetText</c> and rendered as a distinct pill by the chat UI.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -19,9 +21,18 @@ namespace AchieveAi.LmDotnetTools.LmAgentInfra.Context;
 /// switch in flight cannot translate into a webhook retry storm.
 /// </para>
 /// <para>
-/// Dedup is per <c>(sessionId, kind, path)</c>: redelivery of the same discovery is dropped for
-/// the session as a whole, so multi-threaded sessions only inject the file once (on first
-/// delivery, fanned out across every registered thread).
+/// Dedup is per <c>(target, kind, path)</c> where <c>target</c> is the resolved sub-agent
+/// <c>agent_id</c> for a routed delivery, or <see cref="SandboxSessionRegistry.SessionDiscoveryTarget"/>
+/// for the session fan-out: the primary and a sub-agent (or two sub-agents) entering the same
+/// directory each receive that directory's context once.
+/// </para>
+/// <para>
+/// Routing (gated by <see cref="ContextDiscoveryOptions.RouteToOpeningSubAgent"/>) is deliberately
+/// sub-agent-only: a discovery whose <c>agent_id</c> resolves to a sub-agent that is no longer
+/// running is DROPPED, and one that resolves to no owner at all (the pre-registration race, or a
+/// nested/cross-session sub-agent) is also dropped — NEVER redirected to the primary, which would
+/// re-introduce the exact context pollution this feature fixes. Only a null/blank <c>agent_id</c>
+/// (or the flag being off) fans out to the primary.
 /// </para>
 /// </remarks>
 public sealed class ContextDiscoveryInjector
@@ -37,24 +48,31 @@ public sealed class ContextDiscoveryInjector
     private readonly SandboxSessionRegistry _registry;
     private readonly MultiTurnAgentPool _pool;
     private readonly ContextDiscoveryFormatter _formatter;
+    private readonly ContextDiscoveryOptions _options;
+    private readonly ContextDiscoveryDiagnostics _diagnostics;
     private readonly ILogger<ContextDiscoveryInjector> _logger;
 
     public ContextDiscoveryInjector(
         SandboxSessionRegistry registry,
         MultiTurnAgentPool pool,
         ContextDiscoveryFormatter formatter,
+        ContextDiscoveryOptions options,
+        ContextDiscoveryDiagnostics diagnostics,
         ILogger<ContextDiscoveryInjector> logger)
     {
         _registry = registry ?? throw new ArgumentNullException(nameof(registry));
         _pool = pool ?? throw new ArgumentNullException(nameof(pool));
         _formatter = formatter ?? throw new ArgumentNullException(nameof(formatter));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     /// <summary>
-    /// Best-effort: enqueues the formatted file body into every agent thread that the session is
-    /// currently routing. Returns the number of threads the message was actually sent to (0 when
-    /// no thread is live, the discovery is a duplicate, or the session is unknown).
+    /// Best-effort: delivers the formatted file body to its target — the opening sub-agent (routed)
+    /// or every live thread of the session (fallback). Returns the number of conversations the
+    /// message was actually delivered to (0 when nothing is live, the discovery is a duplicate, the
+    /// routed target isn't running, or the session is unknown).
     /// </summary>
     public async Task<int> InjectAsync(ContextDiscoveryPayload body, CancellationToken ct)
     {
@@ -78,7 +96,28 @@ public sealed class ContextDiscoveryInjector
             return 0;
         }
 
-        if (!_registry.TryMarkDiscoverySeen(body.SessionId, body.Kind!, body.Path!))
+        // Route only when the flag is on AND the gateway stamped a NON-BLANK agent_id. Using
+        // IsNullOrWhiteSpace (not just != null) is load-bearing: a blank id would otherwise create a
+        // rogue "" dedup bucket distinct from __session__ and double-inject into the primary.
+        var routeEnabled = _options.RouteToOpeningSubAgent && !string.IsNullOrWhiteSpace(body.AgentId);
+
+        return routeEnabled
+            ? await RouteToSubAgentAsync(body, ct).ConfigureAwait(false)
+            : await FanOutToSessionAsync(body, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Today's behavior (and every real delivery until the gateway stamps <c>agent_id</c>): dedup
+    /// under <see cref="SandboxSessionRegistry.SessionDiscoveryTarget"/>, then fan the file out to
+    /// every live thread the session is routing.
+    /// </summary>
+    private async Task<int> FanOutToSessionAsync(ContextDiscoveryPayload body, CancellationToken ct)
+    {
+        if (!_registry.TryMarkDiscoverySeen(
+                body.SessionId!,
+                SandboxSessionRegistry.SessionDiscoveryTarget,
+                body.Kind!,
+                body.Path!))
         {
             _logger.LogDebug(
                 "ContextDiscovery context_file: duplicate delivery for {Path} in session {SessionId}; dropping.",
@@ -87,7 +126,9 @@ public sealed class ContextDiscoveryInjector
             return 0;
         }
 
-        var threads = _registry.GetThreads(body.SessionId);
+        _diagnostics.RecordRoutingOutcome(ContextRoutingOutcome.Fallback);
+
+        var threads = _registry.GetThreads(body.SessionId!);
         if (threads.Count == 0)
         {
             // No live agent thread for this session yet. Discovery arrived between session
@@ -101,8 +142,7 @@ public sealed class ContextDiscoveryInjector
             return 0;
         }
 
-        var truncated = body.Truncated ?? false;
-        var text = _formatter.BuildInjectedMessage(body.Path!, body.Content!, truncated);
+        var message = BuildMessage(body);
 
         var injected = 0;
         foreach (var threadId in threads)
@@ -116,13 +156,6 @@ public sealed class ContextDiscoveryInjector
 
             try
             {
-                // Emit a typed notification (kind=context-discovery). The formatted file body stays in
-                // Detail so it still reaches the LLM (via ICanGetText), and the UI renders it as a pill.
-                var message = NotifyMessage.Create(
-                    NotifyKinds.ContextDiscovery,
-                    detail: text,
-                    label: body.Path);
-
                 _ = await agent.SendAsync([message], inputId: null, parentRunId: null, ct).ConfigureAwait(false);
                 injected++;
             }
@@ -147,5 +180,122 @@ public sealed class ContextDiscoveryInjector
             body.SessionId);
 
         return injected;
+    }
+
+    /// <summary>
+    /// Routes the discovery to the sub-agent identified by <c>agent_id</c>. Marks the dedup ledger
+    /// under the agent id FIRST (so a redelivery of an already-resolved discovery drops); then asks
+    /// each session thread's <see cref="ISubAgentContextSink"/> in turn. Aggregation: the first
+    /// <see cref="SubAgentContextDeliveryResult.Delivered"/> wins (routed); otherwise if any sink
+    /// owns the id but can't take it (<see cref="SubAgentContextDeliveryResult.TargetNotDeliverable"/>)
+    /// the discovery is dropped WITHOUT fan-out and the mark kept (terminal); if no sink owns it
+    /// (all <see cref="SubAgentContextDeliveryResult.NotOwned"/>) the discovery is dropped and the
+    /// mark REMOVED so a gateway redelivery can retry once the sub-agent registers (pre-registration
+    /// race). A present-but-unresolved <c>agent_id</c> never falls back to the primary.
+    /// </summary>
+    private async Task<int> RouteToSubAgentAsync(ContextDiscoveryPayload body, CancellationToken ct)
+    {
+        var agentId = body.AgentId!; // routeEnabled guarantees non-blank
+
+        if (!_registry.TryMarkDiscoverySeen(body.SessionId!, agentId, body.Kind!, body.Path!))
+        {
+            _logger.LogDebug(
+                "ContextDiscovery context_file: duplicate routed delivery for {Path} to agent {AgentId} "
+                + "in session {SessionId}; dropping.",
+                body.Path,
+                agentId,
+                body.SessionId);
+            return 0;
+        }
+
+        var message = BuildMessage(body);
+        IReadOnlyList<IMessage> messages = [message];
+
+        var anyNotDeliverable = false;
+        foreach (var threadId in _registry.GetThreads(body.SessionId!))
+        {
+            if (!_pool.TryGet(threadId, out var agent) || agent is not ISubAgentContextSink sink)
+            {
+                continue;
+            }
+
+            SubAgentContextDeliveryResult result;
+            try
+            {
+                result = await sink.TryDeliverContextAsync(agentId, messages, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // A misbehaving sink must not strand routing — treat it as not-owned and keep scanning.
+                _logger.LogWarning(
+                    ex,
+                    "ContextDiscovery context_file: sink delivery threw for agent {AgentId} on thread {ThreadId}; "
+                    + "treating as not-owned.",
+                    agentId,
+                    threadId);
+                continue;
+            }
+
+            if (result == SubAgentContextDeliveryResult.Delivered)
+            {
+                _logger.LogInformation(
+                    "ContextDiscovery context_file: routed {Path} to sub-agent {AgentId} in session {SessionId}.",
+                    body.Path,
+                    agentId,
+                    body.SessionId);
+                _diagnostics.RecordRoutingOutcome(ContextRoutingOutcome.Routed);
+                return 1;
+            }
+
+            if (result == SubAgentContextDeliveryResult.TargetNotDeliverable)
+            {
+                // Scan the rest before deciding — do NOT short-circuit; another thread's sink may still
+                // Deliver (aggregation contract: any Delivered wins).
+                anyNotDeliverable = true;
+            }
+        }
+
+        if (anyNotDeliverable)
+        {
+            // A sink owns the id but it is not safely running (finished / disposing). Drop cleanly —
+            // never redirect to the primary. Keep the mark: terminal, so a retry can't succeed.
+            _logger.LogInformation(
+                "ContextDiscovery context_file: sub-agent {AgentId} owned but not deliverable for {Path} "
+                + "in session {SessionId}; dropping (no fan-out to primary).",
+                agentId,
+                body.Path,
+                body.SessionId);
+            _diagnostics.RecordRoutingOutcome(ContextRoutingOutcome.Dropped);
+            return 0;
+        }
+
+        // No sink owns the id: the sub-agent hasn't registered yet (pre-registration race), or it is a
+        // nested / cross-session agent. Drop and UN-mark so the gateway's redelivery can retry once the
+        // sub-agent is live — but still never fall back to the primary.
+        _registry.EvictDiscoverySeenForTarget(body.SessionId!, agentId);
+        _logger.LogDebug(
+            "ContextDiscovery context_file: no live sub-agent owns {AgentId} for {Path} in session {SessionId}; "
+            + "dropping and allowing gateway retry.",
+            agentId,
+            body.Path,
+            body.SessionId);
+        _diagnostics.RecordRoutingOutcome(ContextRoutingOutcome.Dropped);
+        return 0;
+    }
+
+    /// <summary>
+    /// Builds the typed context-discovery notification. The formatted file body stays in
+    /// <c>Detail</c> so it still reaches the LLM (via <c>ICanGetText</c>), and the UI renders it as a
+    /// pill; <c>Label</c> carries the file path.
+    /// </summary>
+    private NotifyMessage BuildMessage(ContextDiscoveryPayload body)
+    {
+        var truncated = body.Truncated ?? false;
+        var text = _formatter.BuildInjectedMessage(body.Path!, body.Content!, truncated);
+        return NotifyMessage.Create(NotifyKinds.ContextDiscovery, detail: text, label: body.Path);
     }
 }

--- a/src/LmAgentInfra/Context/ContextDiscoveryInjector.cs
+++ b/src/LmAgentInfra/Context/ContextDiscoveryInjector.cs
@@ -91,6 +91,11 @@ public sealed class ContextDiscoveryInjector
     {
         ArgumentNullException.ThrowIfNull(body);
 
+        // Fail fast on an already-cancelled call BEFORE any validation or dedup mark. Marking first and
+        // then throwing on the first sink call would strand a dedup mark under which nothing was
+        // delivered, causing a later gateway redelivery to be wrongly deduped/dropped.
+        ct.ThrowIfCancellationRequested();
+
         if (string.IsNullOrWhiteSpace(body.SessionId))
         {
             _logger.LogInformation("ContextDiscovery context_file: payload missing session_id; dropping.");
@@ -205,9 +210,10 @@ public sealed class ContextDiscoveryInjector
     ///   <item>if any sink owns the id but can't take it
     ///   (<see cref="SubAgentContextDeliveryResult.TargetNotDeliverable"/>) the discovery is dropped
     ///   WITHOUT fan-out and the mark KEPT (terminal — a retry can't succeed);</item>
-    ///   <item>else if any sink THREW, the mark is likewise KEPT: a throwing sink may already have
-    ///   accepted (delivered) the send, so un-marking could DOUBLE-INJECT the same context on a
-    ///   gateway retry — safer to drop-and-hold;</item>
+    ///   <item>else if any sink THREW, the scan STOPS at that sink and the mark is likewise KEPT: a
+    ///   throwing sink may already have accepted (delivered) the send, so both consulting a later sink
+    ///   (double-inject in one request) and un-marking (double-inject on a gateway retry) are unsafe —
+    ///   drop-and-hold;</item>
     ///   <item>else (every sink cleanly returned <see cref="SubAgentContextDeliveryResult.NotOwned"/>)
     ///   the discovery is dropped and the mark REMOVED so a gateway redelivery can retry once the
     ///   sub-agent registers (pre-registration race).</item>
@@ -248,23 +254,28 @@ public sealed class ContextDiscoveryInjector
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
+                // Cancellation reached us AFTER we optimistically placed the routed dedup mark but
+                // before any sink completed a delivery. Roll the mark back (mirroring the all-NotOwned
+                // rollback below) so a later gateway redelivery is NOT wrongly deduped/dropped — nothing
+                // was delivered under this mark.
+                _registry.UnmarkDiscoverySeen(body.SessionId!, agentId, body.Kind!, body.Path!);
                 throw;
             }
             catch (Exception ex)
             {
-                // A misbehaving sink must not strand routing — keep scanning the other threads so a
-                // healthy sink can still Deliver. But flag the failure as AMBIGUOUS: because the throw
-                // could have happened AFTER the sink accepted (delivered) the send, we can no longer be
-                // sure this discovery wasn't delivered. The final aggregation uses this to KEEP the mark
-                // rather than un-marking, so a gateway retry can't double-inject.
+                // Once a sink MAY have accepted (delivered) the send we must STOP scanning: the throw
+                // could have happened AFTER the sink delivered, so consulting a later sink that then
+                // returns Delivered would inject the SAME context TWICE in this one request. Flag the
+                // failure AMBIGUOUS and break — the post-loop aggregation KEEPS the mark and drops
+                // (no fan-out, returns 0), which also stops a gateway retry from double-injecting.
                 _logger.LogWarning(
                     ex,
                     "ContextDiscovery context_file: sink delivery threw for agent {AgentId} on thread {ThreadId}; "
-                    + "treating as ambiguous (delivery may have occurred).",
+                    + "treating as ambiguous (delivery may have occurred) and stopping the scan.",
                     agentId,
                     threadId);
                 anyAmbiguous = true;
-                continue;
+                break;
             }
 
             if (result == SubAgentContextDeliveryResult.Delivered)

--- a/src/LmAgentInfra/Context/ContextDiscoveryInjector.cs
+++ b/src/LmAgentInfra/Context/ContextDiscoveryInjector.cs
@@ -254,11 +254,12 @@ public sealed class ContextDiscoveryInjector
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
-                // Cancellation reached us AFTER we optimistically placed the routed dedup mark but
-                // before any sink completed a delivery. Roll the mark back (mirroring the all-NotOwned
-                // rollback below) so a later gateway redelivery is NOT wrongly deduped/dropped — nothing
-                // was delivered under this mark.
-                _registry.UnmarkDiscoverySeen(body.SessionId!, agentId, body.Kind!, body.Path!);
+                // Cancellation reached us AFTER the sink was invoked. The sink ultimately calls SendAsync,
+                // which may have accepted/enqueued the message before observing cancellation — so whether
+                // this context was delivered is AMBIGUOUS. KEEP the routed dedup mark (do NOT roll it back)
+                // so a gateway retry can't inject the same context twice. Cancellation that arrives BEFORE
+                // delivery begins is handled at the top of InjectAsync (ThrowIfCancellationRequested throws
+                // before the mark is ever created), so there is no stale-mark case to roll back here.
                 throw;
             }
             catch (Exception ex)

--- a/src/LmAgentInfra/Context/ContextDiscoveryOptions.cs
+++ b/src/LmAgentInfra/Context/ContextDiscoveryOptions.cs
@@ -1,0 +1,24 @@
+namespace AchieveAi.LmDotnetTools.LmAgentInfra.Context;
+
+/// <summary>
+/// Strongly-typed configuration for context-discovery routing. Bound from the
+/// <c>ContextDiscovery</c> configuration section. Follows the same idiom as
+/// <see cref="AchieveAi.LmDotnetTools.LmAgentInfra.Sandbox.SandboxGatewayOptions"/> /
+/// <see cref="AchieveAi.LmDotnetTools.LmAgentInfra.Auth.AuthOptions"/> (<c>sealed class</c> with
+/// mutable <c>{ get; set; }</c> properties so the configuration binder can populate them).
+/// </summary>
+public sealed class ContextDiscoveryOptions
+{
+    /// <summary>
+    /// Configuration section name these options are bound from.
+    /// </summary>
+    public const string SectionName = "ContextDiscovery";
+
+    /// <summary>
+    /// When true, a <c>context_file</c> discovery carrying a non-blank <c>agent_id</c> is routed to
+    /// the sub-agent that opened the file instead of fanned out to the primary conversation. Default
+    /// <c>false</c> so the routing path is dormant-but-correct until the gateway actually stamps
+    /// <c>agent_id</c> (cf. #187): with the flag off, discovery behaves byte-identically to today.
+    /// </summary>
+    public bool RouteToOpeningSubAgent { get; set; } = false;
+}

--- a/src/LmAgentInfra/Context/ContextDiscoveryPayload.cs
+++ b/src/LmAgentInfra/Context/ContextDiscoveryPayload.cs
@@ -40,4 +40,15 @@ public sealed record ContextDiscoveryPayload
     /// </summary>
     [JsonPropertyName("truncated")]
     public bool? Truncated { get; init; }
+
+    /// <summary>
+    /// Optional id (or caller-supplied name) of the sub-agent that triggered this discovery by
+    /// opening a file in the directory it carries. Stamped per-item by the gateway (cf. #187). When
+    /// present and routing is enabled, the injector delivers the context to that sub-agent instead of
+    /// the primary conversation; when null/blank it falls back to today's session fan-out. Optional +
+    /// no <c>[JsonRequired]</c> (mirrors <see cref="Truncated"/>) so older gateway builds that never
+    /// stamp it still bind.
+    /// </summary>
+    [JsonPropertyName("agent_id")]
+    public string? AgentId { get; init; }
 }

--- a/src/LmAgentInfra/Sandbox/SandboxSessionRegistry.cs
+++ b/src/LmAgentInfra/Sandbox/SandboxSessionRegistry.cs
@@ -86,7 +86,7 @@ public sealed partial class SandboxSessionRegistry : IAsyncDisposable
     /// Dedup-ledger target sentinel for a discovery that is NOT routed to a specific sub-agent —
     /// i.e. the fallback session fan-out and the boot-time root-file seed. Kept distinct from any
     /// real <c>agent_id</c> so the primary conversation and a sub-agent that enter the SAME
-    /// directory each dedup independently (see <see cref="TryMarkDiscoverySeen"/>).
+    /// directory each dedup independently (see <see cref="TryMarkDiscoverySeen(string, string, string, string)"/>).
     /// </summary>
     public const string SessionDiscoveryTarget = "__session__";
 
@@ -1128,22 +1128,16 @@ public sealed partial class SandboxSessionRegistry : IAsyncDisposable
             return;
         }
 
-        foreach (var (sessionId, set) in _sessionThreads)
+        // Drop this thread's membership from every session it was routed to. The discovery dedup
+        // ledger is intentionally NOT cleared here: as before #198 it is cleared only on session
+        // destroy/dispose (DestroyWorkspaceSessionAsync / DisposeAsync). Removing the old
+        // clear-on-last-thread step also removes its check-then-act race against a concurrent
+        // RegisterThread. Per-target growth within a long-lived session is bounded by the session's
+        // own lifetime; per-sub-agent reclamation is deferred until the gateway can signal sub-agent
+        // teardown (tracked with the gateway dependency #187).
+        foreach (var set in _sessionThreads.Values)
         {
-            if (!set.TryRemove(threadId, out _))
-            {
-                continue;
-            }
-
-            // Once a session has lost its last live thread, no primary conversation OR sub-agent
-            // remains that a dedup mark could protect, so drop the whole session's dedup ledger to
-            // bound its per-target growth (blind-spot #5). A later conversation on the same session
-            // legitimately re-receives that directory's context. Guarded by IsEmpty so a session
-            // that still routes another live conversation keeps its (shared + sub-agent) marks.
-            if (set.IsEmpty)
-            {
-                _ = _discoverySeen.TryRemove(sessionId, out _);
-            }
+            _ = set.TryRemove(threadId, out _);
         }
 
         // Release the conversation's per-conversation sub-agent binding (keyed by conversation ==
@@ -1199,40 +1193,50 @@ public sealed partial class SandboxSessionRegistry : IAsyncDisposable
         var set = _discoverySeen.GetOrAdd(
             sessionId,
             _ => new ConcurrentDictionary<string, byte>(StringComparer.Ordinal));
-        return set.TryAdd($"{target}\0{kind}\0{path}", 0);
+        return set.TryAdd(DiscoverySeenKey(target, kind, path), 0);
     }
 
     /// <summary>
-    /// Evicts every dedup-ledger entry recorded under <paramref name="target"/> for
-    /// <paramref name="sessionId"/> (all <c>(kind, path)</c> tuples for that target). Two uses:
-    /// (1) the caller un-marks a routed discovery it optimistically marked but could NOT deliver to a
-    /// live sub-agent (all sinks returned <c>NotOwned</c>), so a later gateway redelivery can retry
-    /// once the sub-agent is registered — healing the pre-registration race; and (2) LmMultiTurn
-    /// reclaims a sub-agent's entries when it tears down (invoked post-merge), bounding per-agent
-    /// growth within a long-lived session. Idempotent + best-effort; a no-op for an unknown session
-    /// or after disposal.
+    /// Back-compat overload that marks <c>(kind, path)</c> under the session-level
+    /// <see cref="SessionDiscoveryTarget"/> sentinel — the pre-#198 signature. Preserves the
+    /// session-scoped dedup behaviour for existing/external callers that do not route to a sub-agent.
     /// </summary>
-    public void EvictDiscoverySeenForTarget(string sessionId, string target)
+    public bool TryMarkDiscoverySeen(string sessionId, string kind, string path) =>
+        TryMarkDiscoverySeen(sessionId, SessionDiscoveryTarget, kind, path);
+
+    /// <summary>
+    /// Removes exactly the one <c>(target, kind, path)</c> dedup entry for <paramref name="sessionId"/>,
+    /// undoing a single <see cref="TryMarkDiscoverySeen(string, string, string, string)"/> mark. Used by
+    /// the router to roll back a routed discovery it optimistically marked but could NOT deliver to a live
+    /// sub-agent (all sinks returned <c>NotOwned</c>), so a later gateway redelivery can retry once the
+    /// sub-agent registers — healing the pre-registration race. Precise by design: it must NOT disturb a
+    /// mark a concurrent delivery placed for another path (or another target) of the same session.
+    /// Thread-safe; best-effort no-op for an unknown session/key or after disposal.
+    /// </summary>
+    public void UnmarkDiscoverySeen(string sessionId, string target, string kind, string path)
     {
-        if (_disposed || string.IsNullOrWhiteSpace(sessionId) || string.IsNullOrWhiteSpace(target))
+        if (_disposed
+            || string.IsNullOrWhiteSpace(sessionId)
+            || string.IsNullOrWhiteSpace(target)
+            || string.IsNullOrWhiteSpace(kind)
+            || string.IsNullOrWhiteSpace(path))
         {
             return;
         }
 
-        if (!_discoverySeen.TryGetValue(sessionId, out var set))
+        if (_discoverySeen.TryGetValue(sessionId, out var set))
         {
-            return;
-        }
-
-        var prefix = $"{target}\0";
-        foreach (var key in set.Keys)
-        {
-            if (key.StartsWith(prefix, StringComparison.Ordinal))
-            {
-                _ = set.TryRemove(key, out _);
-            }
+            _ = set.TryRemove(DiscoverySeenKey(target, kind, path), out _);
         }
     }
+
+    /// <summary>
+    /// Builds the <see cref="_discoverySeen"/> inner-set key for a <c>(target, kind, path)</c> tuple. A
+    /// single builder keeps <see cref="TryMarkDiscoverySeen(string, string, string, string)"/> and
+    /// <see cref="UnmarkDiscoverySeen"/> on the exact same key shape.
+    /// </summary>
+    private static string DiscoverySeenKey(string target, string kind, string path) =>
+        $"{target}\0{kind}\0{path}";
 
     /// <summary>
     /// The exact URL the gateway is told to deliver context-discovery webhooks to (the auth-callback

--- a/src/LmAgentInfra/Sandbox/SandboxSessionRegistry.cs
+++ b/src/LmAgentInfra/Sandbox/SandboxSessionRegistry.cs
@@ -83,6 +83,14 @@ public sealed partial class SandboxSessionRegistry : IAsyncDisposable
     public const string DefaultWorkspaceId = "default";
 
     /// <summary>
+    /// Dedup-ledger target sentinel for a discovery that is NOT routed to a specific sub-agent —
+    /// i.e. the fallback session fan-out and the boot-time root-file seed. Kept distinct from any
+    /// real <c>agent_id</c> so the primary conversation and a sub-agent that enter the SAME
+    /// directory each dedup independently (see <see cref="TryMarkDiscoverySeen"/>).
+    /// </summary>
+    public const string SessionDiscoveryTarget = "__session__";
+
+    /// <summary>
     /// Upper bound on the gateway session-liveness probe so a wedged gateway degrades to "assume
     /// alive" quickly rather than blocking the turn for the full shared-client timeout.
     /// </summary>
@@ -1120,9 +1128,22 @@ public sealed partial class SandboxSessionRegistry : IAsyncDisposable
             return;
         }
 
-        foreach (var set in _sessionThreads.Values)
+        foreach (var (sessionId, set) in _sessionThreads)
         {
-            _ = set.TryRemove(threadId, out _);
+            if (!set.TryRemove(threadId, out _))
+            {
+                continue;
+            }
+
+            // Once a session has lost its last live thread, no primary conversation OR sub-agent
+            // remains that a dedup mark could protect, so drop the whole session's dedup ledger to
+            // bound its per-target growth (blind-spot #5). A later conversation on the same session
+            // legitimately re-receives that directory's context. Guarded by IsEmpty so a session
+            // that still routes another live conversation keeps its (shared + sub-agent) marks.
+            if (set.IsEmpty)
+            {
+                _ = _discoverySeen.TryRemove(sessionId, out _);
+            }
         }
 
         // Release the conversation's per-conversation sub-agent binding (keyed by conversation ==
@@ -1153,15 +1174,24 @@ public sealed partial class SandboxSessionRegistry : IAsyncDisposable
     }
 
     /// <summary>
-    /// Atomically marks <c>(kind, path)</c> as seen for <paramref name="sessionId"/>. Returns
-    /// true on the first call (caller proceeds with injection) and false on every subsequent
-    /// call for the same tuple (caller drops the duplicate). Used to defend against gateway
-    /// retry storms re-firing the same discovery event.
+    /// Atomically marks <c>(target, kind, path)</c> as seen for <paramref name="sessionId"/>.
+    /// Returns true on the first call (caller proceeds with injection) and false on every subsequent
+    /// call for the same tuple (caller drops the duplicate). Used to defend against gateway retry
+    /// storms re-firing the same discovery event.
     /// </summary>
-    public bool TryMarkDiscoverySeen(string sessionId, string kind, string path)
+    /// <remarks>
+    /// <paramref name="target"/> discriminates WHO the discovery was delivered to: a sub-agent's
+    /// <c>agent_id</c> for a routed delivery, or <see cref="SessionDiscoveryTarget"/> for the session
+    /// fan-out / root-file seed. Keying on it lets the primary and a sub-agent (or two sub-agents)
+    /// entering the same directory each receive that directory's context exactly once.
+    /// </remarks>
+    public bool TryMarkDiscoverySeen(string sessionId, string target, string kind, string path)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        if (string.IsNullOrWhiteSpace(sessionId) || string.IsNullOrWhiteSpace(kind) || string.IsNullOrWhiteSpace(path))
+        if (string.IsNullOrWhiteSpace(sessionId)
+            || string.IsNullOrWhiteSpace(target)
+            || string.IsNullOrWhiteSpace(kind)
+            || string.IsNullOrWhiteSpace(path))
         {
             return false;
         }
@@ -1169,7 +1199,39 @@ public sealed partial class SandboxSessionRegistry : IAsyncDisposable
         var set = _discoverySeen.GetOrAdd(
             sessionId,
             _ => new ConcurrentDictionary<string, byte>(StringComparer.Ordinal));
-        return set.TryAdd($"{kind}\0{path}", 0);
+        return set.TryAdd($"{target}\0{kind}\0{path}", 0);
+    }
+
+    /// <summary>
+    /// Evicts every dedup-ledger entry recorded under <paramref name="target"/> for
+    /// <paramref name="sessionId"/> (all <c>(kind, path)</c> tuples for that target). Two uses:
+    /// (1) the caller un-marks a routed discovery it optimistically marked but could NOT deliver to a
+    /// live sub-agent (all sinks returned <c>NotOwned</c>), so a later gateway redelivery can retry
+    /// once the sub-agent is registered — healing the pre-registration race; and (2) LmMultiTurn
+    /// reclaims a sub-agent's entries when it tears down (invoked post-merge), bounding per-agent
+    /// growth within a long-lived session. Idempotent + best-effort; a no-op for an unknown session
+    /// or after disposal.
+    /// </summary>
+    public void EvictDiscoverySeenForTarget(string sessionId, string target)
+    {
+        if (_disposed || string.IsNullOrWhiteSpace(sessionId) || string.IsNullOrWhiteSpace(target))
+        {
+            return;
+        }
+
+        if (!_discoverySeen.TryGetValue(sessionId, out var set))
+        {
+            return;
+        }
+
+        var prefix = $"{target}\0";
+        foreach (var key in set.Keys)
+        {
+            if (key.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                _ = set.TryRemove(key, out _);
+            }
+        }
     }
 
     /// <summary>

--- a/src/LmMultiTurn/ISubAgentContextSink.cs
+++ b/src/LmMultiTurn/ISubAgentContextSink.cs
@@ -1,0 +1,54 @@
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn;
+
+/// <summary>
+/// Outcome of attempting to deliver out-of-band context (e.g. a sandbox-discovered
+/// directory <c>CLAUDE.md</c>/<c>AGENTS.md</c>) to a specific sub-agent that is owned
+/// by an <see cref="ISubAgentContextSink"/>.
+/// </summary>
+public enum SubAgentContextDeliveryResult
+{
+    /// <summary>The context was injected into the target sub-agent, which was running.</summary>
+    Delivered,
+
+    /// <summary>
+    /// This sink owns the target sub-agent, but it was not in a state that could accept
+    /// the delivery (finished, disposing, or otherwise not safely running). The caller
+    /// should drop the delivery — it must NOT fall back to the primary conversation.
+    /// </summary>
+    TargetNotDeliverable,
+
+    /// <summary>This sink does not own the target sub-agent; the caller should keep looking.</summary>
+    NotOwned,
+}
+
+/// <summary>
+/// A capability implemented by agents that own sub-agents (currently
+/// <see cref="MultiTurnAgentLoop"/> via its <c>SubAgentManager</c>), allowing an external
+/// caller — the context-discovery injector — to route a discovered directory context file
+/// to the specific sub-agent that opened it, rather than the primary conversation.
+/// </summary>
+/// <remarks>
+/// This is deliberately a narrow role interface probed with <c>is ISubAgentContextSink</c>,
+/// NOT a member of <see cref="IMultiTurnAgent"/>: CLI-backed loops (e.g. <c>ClaudeAgentLoop</c>)
+/// own no sub-agents and must not be forced to implement it.
+/// </remarks>
+public interface ISubAgentContextSink
+{
+    /// <summary>
+    /// Attempts to deliver <paramref name="messages"/> into a currently-running sub-agent
+    /// identified by <paramref name="agentId"/> (matched by id or caller-supplied name).
+    /// Never restarts a finished sub-agent and never triggers a spurious extra run.
+    /// </summary>
+    /// <returns>
+    /// <see cref="SubAgentContextDeliveryResult.Delivered"/> if injected into a running sub-agent;
+    /// <see cref="SubAgentContextDeliveryResult.TargetNotDeliverable"/> if this sink owns the id but
+    /// it is not safely running (caller drops);
+    /// <see cref="SubAgentContextDeliveryResult.NotOwned"/> if this sink does not own the id.
+    /// </returns>
+    Task<SubAgentContextDeliveryResult> TryDeliverContextAsync(
+        string agentId,
+        IReadOnlyList<IMessage> messages,
+        CancellationToken cancellationToken = default);
+}

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -32,7 +32,7 @@ namespace AchieveAi.LmDotnetTools.LmMultiTurn;
 /// - MessageUpdateJoinerMiddleware (joins update messages into full messages for history)
 /// - ToolCallInjectionMiddleware (injects function contracts for tool calling)
 /// </remarks>
-public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
+public sealed class MultiTurnAgentLoop : MultiTurnAgentBase, ISubAgentContextSink
 {
     private readonly IStreamingAgent _agent;
     private readonly IDictionary<string, ToolHandler> _toolHandlers;
@@ -41,6 +41,18 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase
     /// Exposed so a host-side trigger source (e.g. the sample's subagent-completion source) can observe
     /// sub-agent completions; the manager itself is still owned and disposed by the loop.</summary>
     public SubAgentManager? SubAgentManager { get; }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Delegates to <see cref="SubAgents.SubAgentManager.TryDeliverToRunningAsync"/>. A loop with no
+    /// sub-agent manager owns no sub-agents, so every id is <see cref="SubAgentContextDeliveryResult.NotOwned"/>.
+    /// </remarks>
+    public Task<SubAgentContextDeliveryResult> TryDeliverContextAsync(
+        string agentId,
+        IReadOnlyList<IMessage> messages,
+        CancellationToken cancellationToken = default) =>
+        SubAgentManager?.TryDeliverToRunningAsync(agentId, messages, cancellationToken)
+        ?? Task.FromResult(SubAgentContextDeliveryResult.NotOwned);
 
     /// <summary>
     /// The names of every tool registered on this loop after the middleware stack was built —

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -355,29 +355,13 @@ public sealed class SubAgentManager : IAsyncDisposable
                 // (running agent) is kept so existing waiters observe the next resolution.
                 state.ResetCompletionIfFinished();
 
-                var injectCancelledByLifecycle = false;
+                // The caller owns BeginContinuation/EndInjectLease; the helper performs the send under
+                // that already-held lease and reports whether the run's lifecycle cancelled it.
+                bool injectCancelledByLifecycle;
+                List<IMessage> injected = [new TextMessage { Role = Role.User, Text = prompt }];
                 try
                 {
-                    // Inject the message into the currently running agent while holding the send lease.
-                    // Link the caller token with the run's lifecycle token so a terminal owned-provider
-                    // disposal can unblock this send if it wedges — otherwise the lease (which the
-                    // disposal waits to drain) could be held forever on a caller token that never cancels.
-                    using var linkedCts = state.LinkLifecycleToken(ct);
-                    try
-                    {
-                        _ = await state.Agent.SendAsync(
-                            [new TextMessage { Role = Role.User, Text = prompt }], ct: linkedCts.Token);
-                    }
-                    catch (OperationCanceledException) when (!ct.IsCancellationRequested && linkedCts.IsCancellationRequested)
-                    {
-                        // The send was cancelled specifically by the run's LIFECYCLE token (terminal
-                        // disposal began) — NOT by the caller, and NOT an internal SendAsync
-                        // timeout/cancellation unrelated to either supplied token (which must propagate
-                        // rather than be retried, to avoid duplicate delivery / an unbounded retry loop).
-                        // The loop we injected into is finishing, so re-evaluate the continuation to
-                        // deliver the prompt to the restarted run instead of dropping the user's message.
-                        injectCancelledByLifecycle = true;
-                    }
+                    injectCancelledByLifecycle = await InjectIntoRunningLoopAsync(state, injected, ct);
                 }
                 finally
                 {
@@ -437,23 +421,127 @@ public sealed class SubAgentManager : IAsyncDisposable
     }
 
     /// <summary>
+    /// Attempts to deliver out-of-band context (a sandbox-discovered directory <c>CLAUDE.md</c>/
+    /// <c>AGENTS.md</c>) into a currently-running sub-agent identified by id or caller-supplied name.
+    /// Implements the running-branch half of <see cref="ISubAgentContextSink"/>: it delivers ONLY into a
+    /// genuinely-running loop under a side-effect-free inject lease, and NEVER restarts a finished run,
+    /// mutates the parent-relay preference, or relays a spurious completion. A target that is not safely
+    /// running is refused so the caller drops the delivery (it must not fall back to the primary).
+    /// </summary>
+    /// <returns>
+    /// <see cref="SubAgentContextDeliveryResult.NotOwned"/> when no live sub-agent matches
+    /// <paramref name="agentId"/>; <see cref="SubAgentContextDeliveryResult.Delivered"/> when injected into
+    /// a running loop; <see cref="SubAgentContextDeliveryResult.TargetNotDeliverable"/> when the matched
+    /// sub-agent is finished/terminating (dropped, never restarted).
+    /// </returns>
+    public async Task<SubAgentContextDeliveryResult> TryDeliverToRunningAsync(
+        string agentId,
+        IReadOnlyList<IMessage> messages,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+
+        if (!TryResolveAgentId(agentId, out var resolvedId)
+            || !_agents.TryGetValue(resolvedId, out var state))
+        {
+            // Not one of this sink's sub-agents (unknown id/name, or a pre-registration race). The caller
+            // keeps looking / drops without marking-seen so a gateway redelivery can still route it.
+            return SubAgentContextDeliveryResult.NotOwned;
+        }
+
+        // Admit ONLY under a side-effect-free inject lease — NOT BeginContinuation, which would clobber the
+        // relay preference and claim the restart. A finished/terminating target refuses the lease: the
+        // context is dropped, never restarted, never relayed, never run through a disposing provider.
+        if (!state.TryBeginInjectLease())
+        {
+            return SubAgentContextDeliveryResult.TargetNotDeliverable;
+        }
+
+        try
+        {
+            var injectCancelledByLifecycle = await InjectIntoRunningLoopAsync(state, messages, ct);
+
+            // A lifecycle cancel means a terminal disposal began mid-send, so the send did not land: drop
+            // the context. Unlike SendMessageAsync, a context delivery does NOT re-evaluate into a restart.
+            return injectCancelledByLifecycle
+                ? SubAgentContextDeliveryResult.TargetNotDeliverable
+                : SubAgentContextDeliveryResult.Delivered;
+        }
+        finally
+        {
+            state.EndInjectLease();
+        }
+    }
+
+    /// <summary>
+    /// Performs an inject send into the sub-agent's currently-running loop under a send lease the CALLER
+    /// already holds (via <see cref="SubAgentState.BeginContinuation"/> or
+    /// <see cref="SubAgentState.TryBeginInjectLease"/>) and releases (via
+    /// <see cref="SubAgentState.EndInjectLease"/>). Links the caller token with the run's lifecycle token
+    /// so a terminal owned-provider disposal can unblock a wedged send. Carries NEITHER a
+    /// <see cref="SubAgentState.NotifyParentOnCompletion"/> mutation NOR
+    /// <see cref="SubAgentState.ResetCompletionIfFinished"/> — those are the caller's concern.
+    /// </summary>
+    /// <returns><c>true</c> when the send was cancelled specifically by the run's LIFECYCLE token (terminal
+    /// disposal began) so the loop is finishing — the caller re-evaluates (SendMessage restart) or drops
+    /// (context delivery); <c>false</c> when the send landed.</returns>
+    private static async Task<bool> InjectIntoRunningLoopAsync(
+        SubAgentState state,
+        IReadOnlyList<IMessage> messages,
+        CancellationToken ct)
+    {
+        using var linkedCts = state.LinkLifecycleToken(ct);
+        var payload = messages as List<IMessage> ?? [.. messages];
+        try
+        {
+            _ = await state.Agent.SendAsync(payload, ct: linkedCts.Token);
+            return false;
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested && linkedCts.IsCancellationRequested)
+        {
+            // Cancelled specifically by the run's LIFECYCLE token (terminal disposal began) — NOT by the
+            // caller, and NOT an internal SendAsync cancellation unrelated to either supplied token (which
+            // must propagate rather than be swallowed, to avoid duplicate delivery / an unbounded retry).
+            return true;
+        }
+    }
+
+    /// <summary>
     /// Resolves a caller-supplied target (agent id or name) to a concrete agent id.
     /// </summary>
     private string ResolveAgentId(string target)
     {
-        if (_agents.ContainsKey(target))
+        if (TryResolveAgentId(target, out var agentId))
         {
-            return target;
-        }
-
-        if (_namesToIds.TryGetValue(target, out var id) && _agents.ContainsKey(id))
-        {
-            return id;
+            return agentId;
         }
 
         throw new ArgumentException(
             $"Unknown sub-agent '{target}'. Provide a valid agent id or name.",
             nameof(target));
+    }
+
+    /// <summary>
+    /// Non-throwing counterpart to <see cref="ResolveAgentId"/>: resolves a target (agent id or name) to a
+    /// concrete, still-registered agent id. Returns false (rather than throwing) when the target matches no
+    /// live sub-agent, so a caller can distinguish "not ours" from a deliverable target without exceptions.
+    /// </summary>
+    private bool TryResolveAgentId(string target, out string agentId)
+    {
+        if (_agents.ContainsKey(target))
+        {
+            agentId = target;
+            return true;
+        }
+
+        if (_namesToIds.TryGetValue(target, out var id) && _agents.ContainsKey(id))
+        {
+            agentId = id;
+            return true;
+        }
+
+        agentId = string.Empty;
+        return false;
     }
 
     /// <summary>

--- a/src/LmMultiTurn/SubAgents/SubAgentState.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentState.cs
@@ -199,9 +199,9 @@ internal class SubAgentState
     }
 
     /// <summary>
-    /// Releases an inject send lease taken by <see cref="BeginContinuation"/> (call in a finally after
-    /// the inject SendAsync). When the last lease drains during a terminal disposal, the waiting
-    /// disposal is signalled so it can proceed.
+    /// Releases an inject send lease taken by <see cref="BeginContinuation"/> or
+    /// <see cref="TryBeginInjectLease"/> (call in a finally after the inject SendAsync). When the last
+    /// lease drains during a terminal disposal, the waiting disposal is signalled so it can proceed.
     /// </summary>
     public void EndInjectLease()
     {
@@ -212,6 +212,34 @@ internal class SubAgentState
             {
                 _ = _sendLeasesDrained.TrySetResult(true);
             }
+        }
+    }
+
+    /// <summary>
+    /// Side-effect-free inject-lease acquire for OUT-OF-BAND context delivery (a sandbox-discovered
+    /// directory <c>CLAUDE.md</c>/<c>AGENTS.md</c> routed to the sub-agent that opened the file), used by
+    /// <c>SubAgentManager.TryDeliverToRunningAsync</c>. Unlike <see cref="BeginContinuation"/>, it does NOT
+    /// mutate <see cref="NotifyParentOnCompletion"/> and does NOT claim the single-flight restart: a
+    /// context delivery must never alter the sub-agent's parent-relay preference nor race the Wait/trigger
+    /// state machine. Admits ONLY when the loop is genuinely Running and no terminal disposal has begun —
+    /// conservatively refusing the completion boundary so late context is dropped, never restarted — and
+    /// takes a send lease on the SAME counter <see cref="EndInjectLease"/> releases, so a terminal disposal
+    /// drains it before disposing the owned provider. Pair a <c>true</c> return with
+    /// <see cref="EndInjectLease"/> in a finally.
+    /// </summary>
+    /// <returns><c>true</c> if a lease was granted (caller must inject then <see cref="EndInjectLease"/>);
+    /// <c>false</c> if the target is finished or terminating (caller drops the delivery).</returns>
+    internal bool TryBeginInjectLease()
+    {
+        lock (_lifecycleLock)
+        {
+            if (_status == SubAgentStatus.Running && !_terminating)
+            {
+                _activeSendLeases++;
+                return true;
+            }
+
+            return false;
         }
     }
 

--- a/tests/LmMultiTurn.Tests/SubAgentManagerTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentManagerTests.cs
@@ -756,7 +756,7 @@ public class SubAgentManagerTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task TryDeliverToRunningAsync_AtCompletionBoundary_ParentRelayHappensExactlyOnce()
+    public async Task TryDeliverToRunningAsync_AfterCompletion_ParentRelayHappensExactlyOnce()
     {
         // Completion-boundary contract (blind-spot #2): a context delivery racing a just-finished
         // background sub-agent must never spawn a second run, relay a second completion, or run against a

--- a/tests/LmMultiTurn.Tests/SubAgentManagerTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgentManagerTests.cs
@@ -586,8 +586,233 @@ public class SubAgentManagerTests : IAsyncLifetime
             .WithMessage("*Cannot specify removeTools without enabledTools or addTools*");
     }
 
-    #region Helpers
+    [Fact]
+    public async Task TryDeliverToRunningAsync_RunningAgent_DeliversContextToSubAgentNotParent()
+    {
+        // AC2: directory context routed to a Running sub-agent lands in THAT sub-agent's conversation
+        // (its next model call), and never on the parent. The sub-agent's first turn blocks (so it stays
+        // Running while we deliver) then makes a tool call, forcing a SECOND turn whose
+        // GenerateReplyStreamingAsync argument must carry the injected context.
+        var call1Entered = new TaskCompletionSource<bool>();
+        var releaseCall1 = new TaskCompletionSource<bool>();
+        var call2Entered = new TaskCompletionSource<bool>();
+        var releaseCall2 = new TaskCompletionSource<bool>();
+        List<IMessage>? secondCallMessages = null;
+        var callCount = 0;
 
+        _subAgentMock
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>(
+                async (msgs, options, ct) =>
+                {
+                    var n = Interlocked.Increment(ref callCount);
+                    if (n == 1)
+                    {
+                        _ = call1Entered.TrySetResult(true);
+                        await releaseCall1.Task.WaitAsync(ct);
+                        return ToAsyncEnumerable([
+                            new ToolCallMessage
+                            {
+                                FunctionName = "noop",
+                                FunctionArgs = "{}",
+                                ToolCallId = "call_1",
+                                Role = Role.Assistant,
+                            },
+                        ]);
+                    }
+
+                    secondCallMessages = [.. msgs];
+                    _ = call2Entered.TrySetResult(true);
+                    await releaseCall2.Task.WaitAsync(ct);
+                    return ToAsyncEnumerable([
+                        new TextMessage { Text = "done", Role = Role.Assistant },
+                    ]);
+                });
+
+        _manager = CreateManager();
+        var spawnJson = await _manager.SpawnAsync("test-agent", "initial task", runInBackground: true);
+        using var spawnDoc = JsonDocument.Parse(spawnJson);
+        var agentId = spawnDoc.RootElement.GetProperty("agent_id").GetString()!;
+
+        // Wait until the first turn is in-flight (sub-agent Running).
+        (await call1Entered.Task.WaitAsync(TimeSpan.FromSeconds(10))).Should().BeTrue();
+
+        // Act: deliver directory context to the running sub-agent.
+        const string contextMarker = "CTX_MARKER directory rules";
+        var result = await _manager.TryDeliverToRunningAsync(
+            agentId,
+            [new TextMessage { Role = Role.User, Text = contextMarker }],
+            CancellationToken.None);
+
+        // Assert: accepted for the running target.
+        result.Should().Be(SubAgentContextDeliveryResult.Delivered);
+
+        // Let the first turn finish with a tool call so the loop polls the injected context and runs turn 2.
+        releaseCall1.SetResult(true);
+        (await call2Entered.Task.WaitAsync(TimeSpan.FromSeconds(10))).Should().BeTrue();
+
+        // The injected context reached the SUB-AGENT's next model call...
+        secondCallMessages.Should().NotBeNull();
+        secondCallMessages!
+            .OfType<TextMessage>()
+            .Any(m => m.Text != null && m.Text.Contains(contextMarker))
+            .Should().BeTrue("routed context must be delivered into the sub-agent's own conversation");
+
+        // ...and NOT to the parent conversation (no fan-out / no relay for a still-running sub-agent).
+        _parentMock.Verify(
+            p => p.SendAsync(
+                It.IsAny<List<IMessage>>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Cleanup: let the run finish.
+        releaseCall2.SetResult(true);
+    }
+
+    [Fact]
+    public async Task TryDeliverToRunningAsync_CompletedAgent_ReturnsTargetNotDeliverable_NoRestartNoRelay()
+    {
+        // AC3/AC5: a delivery to a completed sub-agent is dropped — the sub-agent is NOT restarted and no
+        // spurious completion is relayed to the parent.
+        SetupSubAgentResponse([
+            new TextMessage { Text = "First result", Role = Role.Assistant },
+        ]);
+
+        _manager = CreateManager();
+        var spawnJson = await _manager.SpawnAsync("test-agent", "initial task", runInBackground: true);
+        using var spawnDoc = JsonDocument.Parse(spawnJson);
+        var agentId = spawnDoc.RootElement.GetProperty("agent_id").GetString()!;
+
+        // Wait for the background completion to relay to the parent (so the run is genuinely finished).
+        await WaitForConditionAsync(
+            () =>
+            {
+                try
+                {
+                    _parentMock.Verify(
+                        p => p.SendAsync(
+                            It.IsAny<List<IMessage>>(),
+                            It.IsAny<string?>(),
+                            It.IsAny<string?>(),
+                            It.IsAny<CancellationToken>()),
+                        Times.AtLeastOnce);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            },
+            TimeSpan.FromSeconds(10));
+
+        // Ignore the legitimate completion relay; assert the delivery adds none.
+        _parentMock.Invocations.Clear();
+
+        // Act
+        var result = await _manager.TryDeliverToRunningAsync(
+            agentId,
+            [new TextMessage { Role = Role.User, Text = "late context" }],
+            CancellationToken.None);
+
+        // Assert: dropped (never restarted), no spurious relay.
+        result.Should().Be(SubAgentContextDeliveryResult.TargetNotDeliverable);
+
+        _subAgentMock.Verify(
+            a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "a completed target must not be restarted");
+
+        _parentMock.Verify(
+            p => p.SendAsync(
+                It.IsAny<List<IMessage>>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "dropping late context must not relay a spurious completion to the parent");
+    }
+
+    [Fact]
+    public async Task TryDeliverToRunningAsync_UnknownId_ReturnsNotOwned()
+    {
+        // A discovery whose agent_id matches no sub-agent of this manager is NotOwned — the injector keeps
+        // looking / drops without marking-seen so a gateway redelivery can still route it later.
+        _manager = CreateManager();
+
+        var result = await _manager.TryDeliverToRunningAsync(
+            "no-such-agent",
+            [new TextMessage { Role = Role.User, Text = "ctx" }],
+            CancellationToken.None);
+
+        result.Should().Be(SubAgentContextDeliveryResult.NotOwned);
+    }
+
+    [Fact]
+    public async Task TryDeliverToRunningAsync_AtCompletionBoundary_ParentRelayHappensExactlyOnce()
+    {
+        // Completion-boundary contract (blind-spot #2): a context delivery racing a just-finished
+        // background sub-agent must never spawn a second run, relay a second completion, or run against a
+        // disposed provider. Proven deterministically: after the legitimate completion relay, a delivery is
+        // refused and the total parent relay count stays exactly one, with the agent settled 'completed'.
+        SetupSubAgentResponse([
+            new TextMessage { Text = "boundary result", Role = Role.Assistant },
+        ]);
+
+        _manager = CreateManager();
+        var spawnJson = await _manager.SpawnAsync("test-agent", "boundary task", runInBackground: true);
+        using var spawnDoc = JsonDocument.Parse(spawnJson);
+        var agentId = spawnDoc.RootElement.GetProperty("agent_id").GetString()!;
+
+        await WaitForConditionAsync(
+            () =>
+            {
+                try
+                {
+                    _parentMock.Verify(
+                        p => p.SendAsync(
+                            It.IsAny<List<IMessage>>(),
+                            It.IsAny<string?>(),
+                            It.IsAny<string?>(),
+                            It.IsAny<CancellationToken>()),
+                        Times.AtLeastOnce);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            },
+            TimeSpan.FromSeconds(10));
+
+        var result = await _manager.TryDeliverToRunningAsync(
+            agentId,
+            [new TextMessage { Role = Role.User, Text = "boundary context" }],
+            CancellationToken.None);
+        result.Should().Be(SubAgentContextDeliveryResult.TargetNotDeliverable);
+
+        // Exactly one parent relay total (the legitimate completion) — no double relay.
+        _parentMock.Verify(
+            p => p.SendAsync(
+                It.IsAny<List<IMessage>>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // The sub-agent settled 'completed', not 'error' (no run against a disposed provider).
+        using var peekDoc = JsonDocument.Parse(_manager.Peek(agentId));
+        peekDoc.RootElement.GetProperty("status").GetString().Should().Be("completed");
+    }
+
+    #region Helpers
     private static async Task WaitForConditionAsync(
         Func<bool> condition,
         TimeSpan timeout)

--- a/tests/LmMultiTurn.Tests/SubAgents/SubAgentStateLifecycleTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgents/SubAgentStateLifecycleTests.cs
@@ -220,6 +220,76 @@ public class SubAgentStateLifecycleTests
             "a throwing cancellation callback must not abort the terminal transition");
     }
 
+    [Fact]
+    public void TryBeginInjectLease_WhileRunning_GrantsLease_WithoutMutatingNotifyOrClaimingRestart()
+    {
+        // The out-of-band context-delivery lease (WI #198) admits into a genuinely-running sub-agent, but —
+        // unlike BeginContinuation(bool) — must NOT overwrite the parent-relay preference (which would
+        // silently drop or double the sub-agent's own completion relay).
+        var state = NewOwnedProviderState();
+        state.NotifyParentOnCompletion = true;
+
+        state.TryBeginInjectLease().Should().BeTrue("a running, non-terminating sub-agent accepts context");
+        state.NotifyParentOnCompletion.Should().BeTrue(
+            "TryBeginInjectLease must not mutate NotifyParentOnCompletion");
+
+        state.EndInjectLease();
+    }
+
+    [Fact]
+    public async Task TryBeginInjectLease_TakesTheSameLeaseTerminalDisposalDrains()
+    {
+        // The inject lease shares the counter BeginTerminalDisposalAsync awaits, so a disposal cannot flip
+        // terminal (and dispose the owned provider) while an admitted context send is still in flight.
+        var state = NewOwnedProviderState();
+
+        state.TryBeginInjectLease().Should().BeTrue();
+
+        var disposal = state.BeginTerminalDisposalAsync(isError: false);
+        await Task.Delay(100);
+        disposal.IsCompleted.Should().BeFalse("terminal disposal must await the in-flight inject lease");
+        state.Status.Should().Be(SubAgentStatus.Running);
+
+        state.EndInjectLease();
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+        state.Status.Should().Be(SubAgentStatus.Completed);
+    }
+
+    [Fact]
+    public void TryBeginInjectLease_WhenCompleted_Refused_AndDoesNotClaimRestart()
+    {
+        // A finished sub-agent refuses context (dropped, never restarted). The refusal must also leave the
+        // single-flight restart claim untouched, so a real continuation still owns the restart.
+        var state = NewOwnedProviderState();
+        state.Status = SubAgentStatus.Completed;
+
+        state.TryBeginInjectLease().Should().BeFalse("a finished sub-agent must not accept context");
+
+        state.BeginContinuation(notifyParentOnCompletion: false).Mode
+            .Should().Be(ContinuationMode.Restart, "TryBeginInjectLease must not consume the restart claim");
+        state.EndRestart();
+    }
+
+    [Fact]
+    public async Task TryBeginInjectLease_WhileTerminating_Refused_TeardownRace()
+    {
+        // Teardown race: a context delivery arriving after a terminal owned-provider disposal has begun
+        // (status still Running, but _terminating set) must be refused, never resurrecting the finishing
+        // sub-agent into an extra run against a provider that is being torn down.
+        var state = NewOwnedProviderState();
+
+        // Hold a lease so the terminal disposal parks in the "terminating" state (status still Running).
+        state.BeginContinuation(notifyParentOnCompletion: false).Mode.Should().Be(ContinuationMode.Inject);
+        var disposal = state.BeginTerminalDisposalAsync(isError: false);
+        await Task.Delay(50);
+
+        state.TryBeginInjectLease().Should().BeFalse(
+            "context must not be injected into a sub-agent whose terminal disposal has begun");
+
+        state.EndInjectLease();
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
     private static SubAgentState NewOwnedProviderState()
     {
         var state = new SubAgentState

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
@@ -68,6 +68,8 @@ public class ContextDiscoveryControllerTests
             registry,
             pool,
             new ContextDiscoveryFormatter(),
+            new ContextDiscoveryOptions(),
+            new ContextDiscoveryDiagnostics(),
             NullLogger<ContextDiscoveryInjector>.Instance);
     }
 
@@ -220,7 +222,7 @@ public class ContextDiscoveryControllerTests
 
         result.Should().BeOfType<OkResult>();
         registry
-            .TryMarkDiscoverySeen("session-dispatch", "context_file", "CLAUDE.md")
+            .TryMarkDiscoverySeen("session-dispatch", SandboxSessionRegistry.SessionDiscoveryTarget, "context_file", "CLAUDE.md")
             .Should().BeFalse("the injector should have already marked this entry as seen during dispatch");
     }
 

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryDiagnosticsControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryDiagnosticsControllerTests.cs
@@ -65,6 +65,30 @@ public sealed class ContextDiscoveryDiagnosticsControllerTests
         response.Sessions.Single(s => s.SessionId == "sess-b").ReceivedCount.Should().Be(1);
     }
 
+    [Fact]
+    public async Task Get_SurfacesRoutingOutcomeCounts()
+    {
+        // The controller must expose the per-outcome sub-agent routing tally: a routed delivery renders
+        // no "Context loaded" pill in the primary view, so these counters are an operator's only signal
+        // that routing (vs. today's fan-out or an unresolved drop) is actually happening.
+        await using var registry = CreateRegistry();
+        var diagnostics = new ContextDiscoveryDiagnostics();
+        diagnostics.RecordRoutingOutcome(ContextRoutingOutcome.Routed);
+        diagnostics.RecordRoutingOutcome(ContextRoutingOutcome.Routed);
+        diagnostics.RecordRoutingOutcome(ContextRoutingOutcome.Dropped);
+        diagnostics.RecordRoutingOutcome(ContextRoutingOutcome.Fallback);
+        diagnostics.RecordRoutingOutcome(ContextRoutingOutcome.Fallback);
+        diagnostics.RecordRoutingOutcome(ContextRoutingOutcome.Fallback);
+        var controller = new ContextDiscoveryDiagnosticsController(registry, diagnostics);
+
+        var response = GetResponse(controller);
+
+        response.Routing.Should().NotBeNull();
+        response.Routing.Routed.Should().Be(2);
+        response.Routing.Dropped.Should().Be(1);
+        response.Routing.Fallback.Should().Be(3);
+    }
+
     private static ContextDiscoveryDiagnosticsResponse GetResponse(ContextDiscoveryDiagnosticsController controller)
     {
         var result = controller.Get();

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryEndToEndTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryEndToEndTests.cs
@@ -46,12 +46,12 @@ public sealed class ContextDiscoveryEndToEndTests
 
         result.Should().BeOfType<OkResult>();
         var message = agent.SentMessages.Should().ContainSingle().Which
-            .Should().BeOfType<TextMessage>().Subject;
+            .Should().BeOfType<NotifyMessage>().Subject;
         message.Role.Should().Be(Role.User);
+        message.NotifyKind.Should().Be(NotifyKinds.ContextDiscovery);
+        message.Label.Should().Be("CLAUDE.md");
         message.Text.Should().Contain("<context-discovery path=\"CLAUDE.md\">");
         message.Text.Should().Contain("Always be concise.");
-        message.Metadata.Should().NotBeNull();
-        message.Metadata!.Should().ContainKey(ContextDiscoveryInjector.MetadataKey);
     }
 
     [Fact]
@@ -78,8 +78,8 @@ public sealed class ContextDiscoveryEndToEndTests
 
         result.Should().BeOfType<OkResult>();
         agent.SentMessages.Should().SatisfyRespectively(
-            first => first.Should().BeOfType<TextMessage>().Which.Text.Should().Contain("ROOT_MARKER"),
-            second => second.Should().BeOfType<TextMessage>().Which.Text.Should().Contain("NESTED_MARKER"));
+            first => first.Should().BeOfType<NotifyMessage>().Which.Text.Should().Contain("ROOT_MARKER"),
+            second => second.Should().BeOfType<NotifyMessage>().Which.Text.Should().Contain("NESTED_MARKER"));
     }
 
     [Fact]
@@ -107,8 +107,8 @@ public sealed class ContextDiscoveryEndToEndTests
 
         result.Should().BeOfType<OkResult>();
         agent.SentMessages.Should().SatisfyRespectively(
-            first => first.Should().BeOfType<TextMessage>().Which.Text.Should().Contain("ROOT_MARKER"),
-            second => second.Should().BeOfType<TextMessage>().Which.Text.Should().Contain("NESTED_MARKER"));
+            first => first.Should().BeOfType<NotifyMessage>().Which.Text.Should().Contain("ROOT_MARKER"),
+            second => second.Should().BeOfType<NotifyMessage>().Which.Text.Should().Contain("NESTED_MARKER"));
     }
 
     [Fact]
@@ -211,6 +211,8 @@ public sealed class ContextDiscoveryEndToEndTests
                 Registry,
                 Pool,
                 new ContextDiscoveryFormatter(),
+                new ContextDiscoveryOptions(),
+                new ContextDiscoveryDiagnostics(),
                 NullLogger<ContextDiscoveryInjector>.Instance);
             Loader = new WorkspaceSubAgentLoader(Registry, NullLogger<WorkspaceSubAgentLoader>.Instance);
             SharedSecret = new AuthSharedSecret(new AuthOptions

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryWebhookHttpTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryWebhookHttpTests.cs
@@ -1,5 +1,9 @@
 using System.Net;
 using System.Text;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using LmStreaming.Sample.Services.Discovery;
 using LmStreaming.Sample.Tests.TestDoubles;
 using Microsoft.AspNetCore.Builder;
@@ -57,7 +61,7 @@ public sealed class ContextDiscoveryWebhookHttpTests
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var message = app.Agent.SentMessages.Should().ContainSingle().Which
-            .Should().BeOfType<TextMessage>().Subject;
+            .Should().BeOfType<NotifyMessage>().Subject;
         message.Role.Should().Be(Role.User);
         message.Text.Should().Contain("<context-discovery path=\"CLAUDE.md\">");
         message.Text.Should().Contain("Be terse.");
@@ -93,6 +97,180 @@ public sealed class ContextDiscoveryWebhookHttpTests
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         app.Agent.SentMessages.Should().BeEmpty();
+    }
+
+    // Deterministic end-to-end proof of the #198 ROUTED path over real HTTP: a live gateway webhook
+    // (agent_id: "ctx-probe") flows POST /api/discovery/context_discovery → ContextDiscoveryController →
+    // ContextDiscoveryInjector → pool.TryGet → the REAL MultiTurnAgentLoop (which IS an
+    // ISubAgentContextSink) → SubAgentManager.TryDeliverToRunningAsync → the live "ctx-probe" sub-agent,
+    // and is Delivered (Routed == 1) WITHOUT touching the primary conversation.
+    //
+    // The sub-agent is spawned DETERMINISTICALLY here rather than via a background instruction chain: the
+    // pooled primary loop owns a SubAgentManager whose "probe" template is backed by a mock provider that
+    // blocks on its first turn, so the sub-agent — spawned under the caller-name "ctx-probe", resolvable
+    // via TryResolveAgentId's id-or-name path — stays Running with no 30s timer and no async race. The
+    // equivalent manual/browser instruction-chain flow (a backgrounded sub-agent parked on a long Wait) is
+    // documented in samples/LmStreaming.Sample/PromptExamples.md → "Backgrounded sub-agent parked on a long
+    // wait (webhook-routing fixture)".
+    [Fact]
+    public async Task PostRoutedContextFileWebhook_ToLiveSubAgent_DeliversWithoutTouchingPrimary()
+    {
+        const string ProbeAgentId = "ctx-probe";
+
+        static HttpResponseMessage Unused(HttpRequestMessage _) => new(HttpStatusCode.OK);
+        var authOptions = new AuthOptions();
+        var gateway = new SandboxGatewayLifetime(
+            new SandboxGatewayOptions { BaseUrl = "http://localhost:3000" },
+            NullLogger<SandboxGatewayLifetime>.Instance,
+            new HttpClient(new StubHandler(Unused)));
+        var registry = new SandboxSessionRegistry(
+            gateway,
+            new SandboxGatewayOptions { BaseUrl = "http://localhost:3000" },
+            NullLogger<SandboxSessionRegistry>.Instance,
+            new HttpClient(new StubHandler(Unused)),
+            authOptions,
+            new AuthSharedSecret(authOptions));
+
+        // The sub-agent's provider BLOCKS on its first turn, so the spawned "ctx-probe" sub-agent stays
+        // deterministically Running (no timer) for the whole routed delivery.
+        var subAgentBlock = new TaskCompletionSource<bool>();
+        var subAgentProvider = new Mock<IStreamingAgent>();
+        subAgentProvider
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IMessage>, GenerateReplyOptions, CancellationToken>(
+                async (_, _, ct) =>
+                {
+                    await subAgentBlock.Task.WaitAsync(ct);
+                    return EmptyMessageStream();
+                });
+
+        var subAgentOptions = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate>
+            {
+                ["probe"] = new SubAgentTemplate
+                {
+                    SystemPrompt = "You are the ctx-probe sub-agent.",
+                    AgentFactory = () => subAgentProvider.Object,
+                },
+            },
+        };
+
+        // The primary loop's own provider is never invoked (we never send it a user turn), so a bare mock
+        // suffices. Its InMemoryConversationStore is what lets us prove the routed context never lands here.
+        var primaryProvider = new Mock<IStreamingAgent>();
+        var primaryStore = new InMemoryConversationStore();
+        MultiTurnAgentLoop? primaryLoop = null;
+        var pool = new MultiTurnAgentPool(
+            (threadId, _, _) =>
+            {
+                primaryLoop = new MultiTurnAgentLoop(
+                    primaryProvider.Object,
+                    new FunctionRegistry(),
+                    threadId,
+                    store: primaryStore,
+                    logger: NullLogger<MultiTurnAgentLoop>.Instance,
+                    subAgentOptions: subAgentOptions);
+                return new MultiTurnAgentPool.AgentCreationResult(primaryLoop);
+            },
+            NullLogger<MultiTurnAgentPool>.Instance);
+        pool.ThreadRemoved += threadId => registry.UnregisterThreadFromAllSessions(threadId);
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        _ = pool.GetOrCreateAgent(ThreadId, mode);
+        registry.RegisterThread(SessionId, ThreadId);
+
+        primaryLoop.Should().NotBeNull();
+
+        // Spawn the live sub-agent under the caller-name "ctx-probe"; the blocking provider holds it
+        // Running so the webhook below routes into it deterministically (id-or-name resolution).
+        _ = await primaryLoop!.SubAgentManager!.SpawnAsync(
+            "probe", "probe task", name: ProbeAgentId, runInBackground: true);
+
+        var sharedSecret = new AuthSharedSecret(new AuthOptions
+        {
+            Webhook = new WebhookOptions { GatewaySharedSecret = Secret },
+        });
+        var diagnostics = new ContextDiscoveryDiagnostics();
+
+        using var host = await new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                webBuilder.UseTestServer();
+                webBuilder.ConfigureServices(services =>
+                {
+                    services.AddControllers().AddApplicationPart(typeof(ContextDiscoveryController).Assembly);
+                    services.AddSingleton(registry);
+                    services.AddSingleton(pool);
+                    services.AddSingleton(sharedSecret);
+                    services.AddSingleton<ContextDiscoveryFormatter>();
+                    // Flag ON so the routed path is exercised end to end.
+                    services.AddSingleton(new ContextDiscoveryOptions { RouteToOpeningSubAgent = true });
+                    services.AddSingleton(diagnostics);
+                    services.AddSingleton<ContextDiscoveryInjector>();
+                    services.AddSingleton<WorkspaceSubAgentLoader>();
+                });
+                webBuilder.Configure(appBuilder =>
+                {
+                    appBuilder.UseRouting();
+                    appBuilder.UseEndpoints(endpoints => endpoints.MapControllers());
+                });
+            })
+            .StartAsync();
+
+        using var client = host.GetTestClient();
+
+        // The gateway stamps agent_id: "ctx-probe" on the discovery; the injector routes it into
+        // ctx-probe's own conversation rather than fanning it out to the primary.
+        var json = $$"""
+            {
+              "event": "context_discovery",
+              "session_id": "{{SessionId}}",
+              "discoveries": [
+                { "kind": "context_file", "path": "sub/CLAUDE.md", "content": "# Sub rules", "agent_id": "{{ProbeAgentId}}" }
+              ]
+            }
+            """;
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/discovery/context_discovery")
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+        request.Headers.TryAddWithoutValidation("Authorization", Secret);
+
+        var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // With ctx-probe live, the discovery is ROUTED to the sub-agent (Delivered) — never fanned out.
+        diagnostics.RoutingSnapshot().Routed.Should().Be(1);
+        diagnostics.RoutingSnapshot().Fallback.Should().Be(0);
+
+        // The primary loop's conversation store never received the routed context turn.
+        var primaryMessages = await primaryStore.LoadMessagesAsync(ThreadId);
+        primaryMessages.Should().NotContain(
+            m => m.MessageJson.Contains("Sub rules", StringComparison.Ordinal),
+            "a routed delivery reaches the sub-agent's own conversation, never the primary");
+
+        // Cleanup: disposal cancels the still-blocked sub-agent. We deliberately do NOT release the block
+        // before disposing — releasing would let the sub-agent complete and relay a NotifyMessage to the
+        // un-stubbed primary provider, spawning a spurious primary run during teardown. The trailing
+        // TrySetResult is a belt-and-suspenders unblock in case disposal ever awaits the send.
+        await registry.DisposeAsync();
+        await pool.DisposeAsync();
+        _ = subAgentBlock.TrySetResult(true);
+    }
+
+    /// <summary>
+    /// A minimal empty assistant stream the blocking sub-agent provider mock returns once released.
+    /// The sub-agent never actually enumerates it (it is cancelled at disposal while still blocked);
+    /// it only exists to satisfy the <c>Task&lt;IAsyncEnumerable&lt;IMessage&gt;&gt;</c> return shape.
+    /// </summary>
+    private static async IAsyncEnumerable<IMessage> EmptyMessageStream()
+    {
+        await Task.CompletedTask;
+        yield break;
     }
 
     private sealed class TestApp : IAsyncDisposable
@@ -147,6 +325,7 @@ public sealed class ContextDiscoveryWebhookHttpTests
                         services.AddSingleton(pool);
                         services.AddSingleton(sharedSecret);
                         services.AddSingleton<ContextDiscoveryFormatter>();
+                        services.AddSingleton(new ContextDiscoveryOptions());
                         services.AddSingleton<ContextDiscoveryInjector>();
                         services.AddSingleton<ContextDiscoveryDiagnostics>();
                         services.AddSingleton<WorkspaceSubAgentLoader>();

--- a/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorRoutingTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorRoutingTests.cs
@@ -264,12 +264,13 @@ public sealed class ContextDiscoveryInjectorRoutingTests
     }
 
     [Fact]
-    public async Task CancelledDuringSinkDelivery_UnmarksRoutedMark_AndThrows()
+    public async Task CancelledDuringSinkDelivery_KeepsMark_AsAmbiguous_AndThrows()
     {
-        // If cancellation lands AFTER the routed mark is placed but at/before the first sink delivery,
-        // the OperationCanceledException catch must un-mark before rethrowing — else the stranded mark
-        // wrongly dedups a later gateway redelivery. Modelled by a delivery hook that cancels the token
-        // and throws OCE mid-delivery.
+        // Cancellation that lands AFTER a sink was invoked is AMBIGUOUS: the sink ultimately calls
+        // SendAsync, which may have accepted/enqueued the message before observing cancellation. The
+        // routed mark must be KEPT (not rolled back) so a gateway retry can't inject the same context
+        // twice. (A pre-delivery cancellation never reaches this branch — it throws at the top of
+        // InjectAsync before the mark is created.) Modelled by a hook that cancels + throws OCE mid-delivery.
         using var harness = new Harness(routeToSubAgent: true);
         using var cts = new CancellationTokenSource();
         var sink = harness.RegisterSinkThread(SessionId, "thread-sub", SubAgentContextDeliveryResult.TargetNotDeliverable);
@@ -283,7 +284,7 @@ public sealed class ContextDiscoveryInjectorRoutingTests
 
         await act.Should().ThrowAsync<OperationCanceledException>();
         harness.Registry.TryMarkDiscoverySeen(SessionId, AgentId, Kind, Path)
-            .Should().BeTrue("cancellation before any delivery rolls back the routed mark so a gateway retry can heal");
+            .Should().BeFalse("cancellation after sink invocation is ambiguous, so the mark is KEPT to prevent a retry double-inject");
     }
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorRoutingTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorRoutingTests.cs
@@ -1,0 +1,392 @@
+using System.Collections.Concurrent;
+using System.Net;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using LmStreaming.Sample.Services.Discovery;
+using LmStreaming.Sample.Tests.TestDoubles;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// Pins the #198 sub-agent routing behaviour of <see cref="ContextDiscoveryInjector.InjectAsync"/>:
+/// the flag-gated route/fallback split, the tri-state aggregation across
+/// <see cref="ISubAgentContextSink"/>s, mark-seen-by-outcome (retry-friendly for the
+/// pre-registration race), per-item projection, the diagnostics counter, and the AC7 log line. All
+/// routed tests reach the sink through the REAL <see cref="MultiTurnAgentPool"/> (only the pooled
+/// agent is a <see cref="RecordingSinkAgent"/> double), so the injector's
+/// <c>is ISubAgentContextSink</c> cast is exercised against the pool's real return value.
+/// </summary>
+public sealed class ContextDiscoveryInjectorRoutingTests
+{
+    private const string Secret = "route-shared-secret-51ab";
+    private const string SessionId = "session-route";
+    private const string Kind = "context_file";
+    private const string Path = "sub/CLAUDE.md";
+    private const string Content = "Sub-directory rules.";
+    private const string AgentId = "ctx-probe";
+
+    // --- Flag / normalization (AC1, blank-id bug guard) ---
+
+    [Fact]
+    public async Task FlagOff_AgentIdPresent_FansOutToPrimary_NotRouted()
+    {
+        // AC1 revert path: with the flag OFF a discovery behaves byte-identically to today —
+        // fan-out via SendAsync regardless of a present agent_id; the sink is never consulted.
+        using var harness = new Harness(routeToSubAgent: false);
+        var sink = harness.RegisterSinkThread(SessionId, "thread-1", SubAgentContextDeliveryResult.Delivered);
+
+        var sent = await harness.Injector.InjectAsync(Payload(agentId: AgentId), CancellationToken.None);
+
+        sent.Should().Be(1);
+        sink.SentMessages.Should().ContainSingle();
+        sink.DeliverCallCount.Should().Be(0);
+        harness.Diagnostics.RoutingSnapshot().Fallback.Should().Be(1);
+        harness.Diagnostics.RoutingSnapshot().Routed.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task FlagOn_AgentIdNull_FansOutToPrimary()
+    {
+        using var harness = new Harness(routeToSubAgent: true);
+        var sink = harness.RegisterSinkThread(SessionId, "thread-1", SubAgentContextDeliveryResult.Delivered);
+
+        var sent = await harness.Injector.InjectAsync(Payload(agentId: null), CancellationToken.None);
+
+        sent.Should().Be(1);
+        sink.SentMessages.Should().ContainSingle();
+        sink.DeliverCallCount.Should().Be(0);
+        harness.Diagnostics.RoutingSnapshot().Fallback.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task FlagOn_BlankAgentId_TreatedAsSession_FansOutAndDedups()
+    {
+        // Guards a real double-inject bug: the route predicate MUST use IsNullOrWhiteSpace, so a
+        // blank agent_id folds into the __session__ dedup target instead of a rogue "" bucket.
+        using var harness = new Harness(routeToSubAgent: true);
+        var sink = harness.RegisterSinkThread(SessionId, "thread-1", SubAgentContextDeliveryResult.Delivered);
+
+        var first = await harness.Injector.InjectAsync(Payload(agentId: "   "), CancellationToken.None);
+        var second = await harness.Injector.InjectAsync(Payload(agentId: "   "), CancellationToken.None);
+
+        first.Should().Be(1);
+        sink.SentMessages.Should().ContainSingle();
+        sink.DeliverCallCount.Should().Be(0, "a blank agent_id must fall back, not create a routing bucket");
+        second.Should().Be(0, "the blank id dedups under __session__, not a rogue \"\" target");
+        harness.Registry.TryMarkDiscoverySeen(SessionId, SandboxSessionRegistry.SessionDiscoveryTarget, Kind, Path)
+            .Should().BeFalse();
+    }
+
+    // --- Routed aggregation (AC2 / AC4 / AC5) ---
+
+    [Fact]
+    public async Task Delivered_RoutesToSubAgent_PrimaryNotTouched_MarksAndDedups()
+    {
+        using var harness = new Harness(routeToSubAgent: true);
+        var primary = harness.RegisterPrimaryThread(SessionId, "thread-primary");
+        var sink = harness.RegisterSinkThread(SessionId, "thread-sub", SubAgentContextDeliveryResult.Delivered);
+
+        var sent = await harness.Injector.InjectAsync(Payload(agentId: AgentId), CancellationToken.None);
+
+        sent.Should().Be(1);
+        sink.DeliverCallCount.Should().Be(1);
+        sink.LastDeliveredAgentId.Should().Be(AgentId);
+        sink.DeliveredMessages.Should().ContainSingle().Which.Should().BeOfType<NotifyMessage>()
+            .Which.Text.Should().Contain(Content);
+        primary.SentMessages.Should().BeEmpty("routed delivery must not also pollute the primary");
+        sink.SentMessages.Should().BeEmpty("routed delivery goes via TryDeliverContextAsync, not SendAsync");
+        harness.Diagnostics.RoutingSnapshot().Routed.Should().Be(1);
+
+        // Dedup marked under agent_id: a redelivery drops WITHOUT re-delivering.
+        var second = await harness.Injector.InjectAsync(Payload(agentId: AgentId), CancellationToken.None);
+        second.Should().Be(0);
+        sink.DeliverCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task TargetNotDeliverable_Drops_NoFanOut_KeepsMark()
+    {
+        // AC3/AC5: a known sub-agent that is finished/disposing ⇒ drop, never redirect to the primary.
+        using var harness = new Harness(routeToSubAgent: true);
+        var primary = harness.RegisterPrimaryThread(SessionId, "thread-primary");
+        var sink = harness.RegisterSinkThread(SessionId, "thread-sub", SubAgentContextDeliveryResult.TargetNotDeliverable);
+
+        var sent = await harness.Injector.InjectAsync(Payload(agentId: AgentId), CancellationToken.None);
+
+        sent.Should().Be(0);
+        primary.SentMessages.Should().BeEmpty("a known-but-dead sub-agent must never fall back to the primary");
+        sink.SentMessages.Should().BeEmpty();
+        harness.Diagnostics.RoutingSnapshot().Dropped.Should().Be(1);
+        // Terminal ⇒ the mark is kept, so a redelivery is deduped (returns false = already seen).
+        harness.Registry.TryMarkDiscoverySeen(SessionId, AgentId, Kind, Path).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AllNotOwned_Drops_PrimaryUntouched_NotMarked_AllowsRetry()
+    {
+        // AC4/blind-spot #4: present-but-unresolved agent_id ⇒ drop, NEVER fall back to the primary,
+        // and DON'T keep the mark so the gateway's redelivery heals the pre-registration race.
+        using var harness = new Harness(routeToSubAgent: true);
+        var primary = harness.RegisterPrimaryThread(SessionId, "thread-primary");
+        var sink = harness.RegisterSinkThread(SessionId, "thread-sub", SubAgentContextDeliveryResult.NotOwned);
+
+        var sent = await harness.Injector.InjectAsync(Payload(agentId: AgentId), CancellationToken.None);
+
+        sent.Should().Be(0);
+        primary.SentMessages.Should().BeEmpty("present-but-unresolved agent_id must never fall back to the primary");
+        sink.SentMessages.Should().BeEmpty();
+        harness.Diagnostics.RoutingSnapshot().Dropped.Should().Be(1);
+        harness.Registry.TryMarkDiscoverySeen(SessionId, AgentId, Kind, Path)
+            .Should().BeTrue("the un-delivered routed discovery was un-marked so a gateway retry can heal the race");
+    }
+
+    [Fact]
+    public async Task Aggregation_DeliveredWins_OverNotDeliverable_RegardlessOfOrder()
+    {
+        using var harness = new Harness(routeToSubAgent: true);
+        _ = harness.RegisterSinkThread(SessionId, "thread-a", SubAgentContextDeliveryResult.TargetNotDeliverable);
+        var delivered = harness.RegisterSinkThread(SessionId, "thread-b", SubAgentContextDeliveryResult.Delivered);
+
+        var sent = await harness.Injector.InjectAsync(Payload(agentId: AgentId), CancellationToken.None);
+
+        sent.Should().Be(1);
+        delivered.DeliveredMessages.Should().ContainSingle("a Delivered result wins the aggregation regardless of thread order");
+        harness.Diagnostics.RoutingSnapshot().Routed.Should().Be(1);
+        harness.Diagnostics.RoutingSnapshot().Dropped.Should().Be(0);
+    }
+
+    // --- AC7 logging ---
+
+    [Fact]
+    public async Task Delivered_LogsRoutedOutcome_AtInformation_WithAgentToken()
+    {
+        var capturing = new CapturingLogger<ContextDiscoveryInjector>();
+        using var harness = new Harness(routeToSubAgent: true, injectorLogger: capturing);
+        _ = harness.RegisterSinkThread(SessionId, "thread-1", SubAgentContextDeliveryResult.Delivered);
+
+        _ = await harness.Injector.InjectAsync(Payload(agentId: AgentId), CancellationToken.None);
+
+        // AC7: assert level + a contained token, not an exact string.
+        capturing.Entries.Should().Contain(e =>
+            e.Level == LogLevel.Information
+            && e.Message.Contains("routed", StringComparison.OrdinalIgnoreCase)
+            && e.Message.Contains(AgentId, StringComparison.Ordinal));
+    }
+
+    // --- Contract / per-item projection ---
+
+    [Fact]
+    public void Envelope_MixedAgentId_BindsPerItem()
+    {
+        const string json = """
+            {
+              "session_id": "sess-1",
+              "discoveries": [
+                { "kind": "context_file", "path": "sub/CLAUDE.md", "content": "x", "agent_id": "ctx-probe" },
+                { "kind": "context_file", "path": "AGENTS.md", "content": "y" }
+              ]
+            }
+            """;
+
+        var envelope = JsonSerializer.Deserialize<ContextDiscoveryEnvelope>(json);
+
+        envelope.Should().NotBeNull();
+        envelope!.Discoveries.Should().HaveCount(2);
+        envelope.Discoveries![0].AgentId.Should().Be("ctx-probe");
+        envelope.Discoveries[1].AgentId.Should().BeNull("the second item carried no agent_id — projection is per item");
+    }
+
+    [Fact]
+    public async Task MixedBatch_PerItemProjection_ARoutes_BFallsBack()
+    {
+        // The controller projects agent_id PER ITEM. Item A carries agent_id (routes via the sink);
+        // item B carries none (falls back via SendAsync into the same thread). If projection copied
+        // agent_id from the envelope onto every item, B would also route and SentMessages would be
+        // empty — so proving both paths ran on distinct items proves the per-item copy.
+        using var harness = new Harness(routeToSubAgent: true);
+        var sink = harness.RegisterSinkThread(SessionId, "thread-1", SubAgentContextDeliveryResult.Delivered);
+        var controller = harness.CreateController();
+
+        var result = await controller.NotifyAsync(
+            new ContextDiscoveryEnvelope
+            {
+                SessionId = SessionId,
+                Discoveries =
+                [
+                    new ContextDiscoveryItem { Kind = Kind, Path = "sub/CLAUDE.md", Content = "SUB_MARKER", AgentId = AgentId },
+                    new ContextDiscoveryItem { Kind = Kind, Path = "AGENTS.md", Content = "ROOT_MARKER" },
+                ],
+            },
+            CancellationToken.None);
+
+        result.Should().BeOfType<OkResult>();
+        sink.DeliveredMessages.Should().ContainSingle().Which.Should().BeOfType<NotifyMessage>()
+            .Which.Text.Should().Contain("SUB_MARKER");
+        sink.SentMessages.Should().ContainSingle().Which.Should().BeOfType<NotifyMessage>()
+            .Which.Text.Should().Contain("ROOT_MARKER");
+        harness.Diagnostics.RoutingSnapshot().Routed.Should().Be(1);
+        harness.Diagnostics.RoutingSnapshot().Fallback.Should().Be(1);
+    }
+
+    // --- Post-merge (skipped): the injector's is-cast against the REAL MultiTurnAgentLoop ---
+
+    [Fact]
+    public async Task Routing_ReachesSink_ThroughRealMultiTurnAgentLoop()
+    {
+        // Pre-merge a real MultiTurnAgentLoop is NOT an ISubAgentContextSink, so BeAssignableTo fails
+        // and this stays skipped. Post-merge the loop implements the sink and the injector routes to
+        // the real return type of the real pool. A fresh loop owns no sub-agent named ctx-probe, so
+        // the delivery resolves NotOwned ⇒ dropped (never routed to the primary) — the point is the
+        // REAL sink is consulted at all.
+        var mockAgent = new Mock<IStreamingAgent>();
+        var functions = new FunctionRegistry();
+        await using var pool = new MultiTurnAgentPool(
+            (threadId, _, _) => new MultiTurnAgentPool.AgentCreationResult(
+                new MultiTurnAgentLoop(
+                    mockAgent.Object,
+                    functions,
+                    threadId,
+                    logger: NullLogger<MultiTurnAgentLoop>.Instance)),
+            NullLogger<MultiTurnAgentPool>.Instance);
+
+        var mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+        var agent = pool.GetOrCreateAgent("thread-loop", mode);
+        agent.Should().BeAssignableTo<ISubAgentContextSink>();
+
+        await using var registry = CreateRegistry();
+        registry.RegisterThread(SessionId, "thread-loop");
+        var injector = new ContextDiscoveryInjector(
+            registry,
+            pool,
+            new ContextDiscoveryFormatter(),
+            new ContextDiscoveryOptions { RouteToOpeningSubAgent = true },
+            new ContextDiscoveryDiagnostics(),
+            NullLogger<ContextDiscoveryInjector>.Instance);
+
+        var sent = await injector.InjectAsync(Payload(agentId: AgentId), CancellationToken.None);
+        sent.Should().Be(0);
+    }
+
+    private static ContextDiscoveryPayload Payload(string? agentId) => new()
+    {
+        SessionId = SessionId,
+        Kind = Kind,
+        Path = Path,
+        Content = Content,
+        AgentId = agentId,
+    };
+
+    private sealed class Harness : IDisposable
+    {
+        private readonly ConcurrentDictionary<string, IMultiTurnAgent> _agents = new();
+        private readonly ConcurrentDictionary<string, Func<string, IMultiTurnAgent>> _factories = new();
+
+        public Harness(bool routeToSubAgent, ILogger<ContextDiscoveryInjector>? injectorLogger = null)
+        {
+            Registry = CreateRegistry();
+            Pool = new MultiTurnAgentPool(
+                (threadId, _, _) =>
+                {
+                    var agent = _agents.GetOrAdd(
+                        threadId,
+                        id => _factories.TryGetValue(id, out var factory) ? factory(id) : new RecordingMultiTurnAgent(id));
+                    return new MultiTurnAgentPool.AgentCreationResult(agent);
+                },
+                NullLogger<MultiTurnAgentPool>.Instance);
+            Pool.ThreadRemoved += threadId => Registry.UnregisterThreadFromAllSessions(threadId);
+
+            Diagnostics = new ContextDiscoveryDiagnostics();
+            SharedSecret = new AuthSharedSecret(new AuthOptions
+            {
+                Webhook = new WebhookOptions { GatewaySharedSecret = Secret },
+            });
+            Injector = new ContextDiscoveryInjector(
+                Registry,
+                Pool,
+                new ContextDiscoveryFormatter(),
+                new ContextDiscoveryOptions { RouteToOpeningSubAgent = routeToSubAgent },
+                Diagnostics,
+                injectorLogger ?? NullLogger<ContextDiscoveryInjector>.Instance);
+        }
+
+        public SandboxSessionRegistry Registry { get; }
+        public MultiTurnAgentPool Pool { get; }
+        public ContextDiscoveryInjector Injector { get; }
+        public ContextDiscoveryDiagnostics Diagnostics { get; }
+        public AuthSharedSecret SharedSecret { get; }
+
+        public RecordingMultiTurnAgent RegisterPrimaryThread(string sessionId, string threadId)
+        {
+            _factories[threadId] = id => new RecordingMultiTurnAgent(id);
+            _ = Pool.GetOrCreateAgent(threadId, Mode);
+            Registry.RegisterThread(sessionId, threadId);
+            return (RecordingMultiTurnAgent)_agents[threadId];
+        }
+
+        public RecordingSinkAgent RegisterSinkThread(
+            string sessionId,
+            string threadId,
+            SubAgentContextDeliveryResult result)
+        {
+            _factories[threadId] = id => new RecordingSinkAgent(id, result);
+            _ = Pool.GetOrCreateAgent(threadId, Mode);
+            Registry.RegisterThread(sessionId, threadId);
+            return (RecordingSinkAgent)_agents[threadId];
+        }
+
+        public ContextDiscoveryController CreateController()
+        {
+            var loader = new WorkspaceSubAgentLoader(Registry, NullLogger<WorkspaceSubAgentLoader>.Instance);
+            var controller = new ContextDiscoveryController(
+                SharedSecret,
+                Registry,
+                loader,
+                Injector,
+                Diagnostics,
+                NullLogger<ContextDiscoveryController>.Instance);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers.Authorization = Secret;
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+            return controller;
+        }
+
+        private static AgentProfile Mode => SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+
+        public void Dispose()
+        {
+            Pool.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            Registry.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
+
+    private static SandboxSessionRegistry CreateRegistry()
+    {
+        static HttpResponseMessage Unused(HttpRequestMessage _) => new(HttpStatusCode.OK);
+
+        var gateway = new SandboxGatewayLifetime(
+            new SandboxGatewayOptions { BaseUrl = "http://localhost:3000" },
+            NullLogger<SandboxGatewayLifetime>.Instance,
+            new HttpClient(new StubHandler(Unused)));
+
+        return new SandboxSessionRegistry(
+            gateway,
+            new SandboxGatewayOptions { BaseUrl = "http://localhost:3000" },
+            NullLogger<SandboxSessionRegistry>.Instance,
+            new HttpClient(new StubHandler(Unused)),
+            new AuthOptions(),
+            new AuthSharedSecret(new AuthOptions()));
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(respond(request));
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorRoutingTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorRoutingTests.cs
@@ -193,6 +193,55 @@ public sealed class ContextDiscoveryInjectorRoutingTests
         harness.Diagnostics.RoutingSnapshot().Dropped.Should().Be(0);
     }
 
+    [Fact]
+    public async Task AmbiguousSinkException_KeepsMark_NoRetryDoubleInject()
+    {
+        // SHOULD-1 regression: a sink whose TryDeliverContextAsync THROWS is AMBIGUOUS — it may have
+        // accepted (delivered) the send before throwing. The injector must DROP (never fall back to the
+        // primary) AND KEEP the dedup mark: un-marking would let a gateway redelivery retry and
+        // double-inject the same context. Contrast AllNotOwned_…_AllowsRetry, which un-marks on a clean
+        // NotOwned so the pre-registration race can heal.
+        using var harness = new Harness(routeToSubAgent: true);
+        var primary = harness.RegisterPrimaryThread(SessionId, "thread-primary");
+        var sink = harness.RegisterSinkThread(SessionId, "thread-sub", SubAgentContextDeliveryResult.NotOwned);
+        sink.ThrowOnDeliver = new InvalidOperationException("sink boom (may already have delivered)");
+
+        var sent = await harness.Injector.InjectAsync(Payload(agentId: AgentId), CancellationToken.None);
+
+        sent.Should().Be(0);
+        primary.SentMessages.Should().BeEmpty("an ambiguous sink failure must never fall back to the primary");
+        sink.SentMessages.Should().BeEmpty();
+        harness.Diagnostics.RoutingSnapshot().Dropped.Should().Be(1);
+        // The mark is KEPT (returns false = already seen), so a gateway redelivery is deduped instead of
+        // risking a second inject of a context the throwing sink may already have delivered.
+        harness.Registry.TryMarkDiscoverySeen(SessionId, AgentId, Kind, Path)
+            .Should().BeFalse("an ambiguous sink failure keeps the dedup mark so a retry can't double-inject");
+    }
+
+    // --- Back-compat constructor (SHOULD-2) ---
+
+    [Fact]
+    public async Task CompatCtor_RoutingDefaultsOff_PresentAgentId_FansOutToPrimary()
+    {
+        // The restored 4-arg (registry, pool, formatter, logger) constructor defaults routing OFF, so a
+        // discovery carrying a present agent_id must fan out to the primary via SendAsync — the sink's
+        // routed TryDeliverContextAsync path is never consulted.
+        using var harness = new Harness(routeToSubAgent: true);
+        var sink = harness.RegisterSinkThread(SessionId, "thread-1", SubAgentContextDeliveryResult.Delivered);
+
+        var compatInjector = new ContextDiscoveryInjector(
+            harness.Registry,
+            harness.Pool,
+            new ContextDiscoveryFormatter(),
+            NullLogger<ContextDiscoveryInjector>.Instance);
+
+        var sent = await compatInjector.InjectAsync(Payload(agentId: AgentId), CancellationToken.None);
+
+        sent.Should().Be(1);
+        sink.SentMessages.Should().ContainSingle("the compat ctor defaults routing OFF, so a present agent_id fans out to the primary");
+        sink.DeliverCallCount.Should().Be(0, "routing is off, so the sink's routed delivery path is never consulted");
+    }
+
     // --- AC7 logging ---
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorRoutingTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorRoutingTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Net;
-using System.Runtime.CompilerServices;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using LmStreaming.Sample.Services.Discovery;
@@ -127,8 +126,8 @@ public sealed class ContextDiscoveryInjectorRoutingTests
     [Fact]
     public async Task AllNotOwned_Drops_PrimaryUntouched_NotMarked_AllowsRetry()
     {
-        // AC4/blind-spot #4: present-but-unresolved agent_id ⇒ drop, NEVER fall back to the primary,
-        // and DON'T keep the mark so the gateway's redelivery heals the pre-registration race.
+        // AC4: a present-but-unresolved agent_id ⇒ drop, NEVER fall back to the primary, and DON'T keep
+        // the mark so the gateway's redelivery heals the pre-registration race.
         using var harness = new Harness(routeToSubAgent: true);
         var primary = harness.RegisterPrimaryThread(SessionId, "thread-primary");
         var sink = harness.RegisterSinkThread(SessionId, "thread-sub", SubAgentContextDeliveryResult.NotOwned);
@@ -146,9 +145,9 @@ public sealed class ContextDiscoveryInjectorRoutingTests
     [Fact]
     public async Task AllNotOwned_UnmarksOnlyItsPath_LeavingConcurrentDeliveredPathIntact()
     {
-        // FIX 1 (C5): the all-NotOwned rollback must un-mark ONLY the current (target, kind, path), never
+        // The all-NotOwned rollback must un-mark ONLY the current (target, kind, path), never
         // every path recorded under the same agent_id. A concurrent delivery's mark for a DIFFERENT path
-        // of the SAME sub-agent must survive the rollback (the old target-wide eviction erased it).
+        // of the SAME sub-agent must survive the rollback (a target-wide eviction would erase it).
         const string DeliveredPath = "sub/CLAUDE.md";
         const string NotOwnedPath = "sub/AGENTS.md";
 
@@ -197,7 +196,7 @@ public sealed class ContextDiscoveryInjectorRoutingTests
     [Fact]
     public async Task AmbiguousSinkException_KeepsMark_NoRetryDoubleInject()
     {
-        // SHOULD-1 regression: a sink whose TryDeliverContextAsync THROWS is AMBIGUOUS — it may have
+        // A sink whose TryDeliverContextAsync THROWS is AMBIGUOUS — it may have
         // accepted (delivered) the send before throwing. The injector must DROP (never fall back to the
         // primary) AND KEEP the dedup mark: un-marking would let a gateway redelivery retry and
         // double-inject the same context. Contrast AllNotOwned_…_AllowsRetry, which un-marks on a clean
@@ -219,16 +218,16 @@ public sealed class ContextDiscoveryInjectorRoutingTests
             .Should().BeFalse("an ambiguous sink failure keeps the dedup mark so a retry can't double-inject");
     }
 
-    // --- Cancellation & stop-scanning (Must-4 / Must-5) ---
+    // --- Cancellation & stop-scanning ---
 
     [Fact]
     public async Task PreCancelledToken_DoesNotMark_AndThrows()
     {
-        // Must-4 (FIX A, edit 1): an already-cancelled call must throw BEFORE placing the routed dedup
-        // mark. Marking first and then throwing on the first sink call would strand a mark under which
-        // nothing was delivered, wrongly deduping a later gateway redelivery. The sink returns
-        // TargetNotDeliverable, which (absent the guard) would KEEP the mark — so this pins that the
-        // start-of-method guard, not a rollback, is what leaves the ledger clean.
+        // An already-cancelled call must throw BEFORE placing the routed dedup mark: cancellation is
+        // checked before the dedup mark is claimed, so a cancelled request leaves no stale mark that
+        // would suppress a later gateway redelivery. The sink returns TargetNotDeliverable, which
+        // (absent the guard) would KEEP the mark — so this pins that the start-of-method guard, not a
+        // rollback, is what leaves the ledger clean on the routed path.
         using var harness = new Harness(routeToSubAgent: true);
         _ = harness.RegisterSinkThread(SessionId, "thread-sub", SubAgentContextDeliveryResult.TargetNotDeliverable);
 
@@ -243,22 +242,42 @@ public sealed class ContextDiscoveryInjectorRoutingTests
     }
 
     [Fact]
+    public async Task PreCancelledToken_FallbackPath_DoesNotMarkSession()
+    {
+        // The same start-of-method guard covers the fallback (__session__) path: with routing OFF a
+        // present agent_id fans out to the primary, and an already-cancelled call must throw before the
+        // session dedup mark is claimed — so a cancelled request leaves no stale __session__ mark that
+        // would suppress a later gateway redelivery. The sink is registered so a live thread exists;
+        // the guard fires before it is ever consulted.
+        using var harness = new Harness(routeToSubAgent: false);
+        var sink = harness.RegisterSinkThread(SessionId, "thread-1", SubAgentContextDeliveryResult.Delivered);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await harness.Injector.InjectAsync(Payload(agentId: AgentId), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        sink.SentMessages.Should().BeEmpty("the cancellation guard fires before any fan-out send");
+        harness.Registry.TryMarkDiscoverySeen(SessionId, SandboxSessionRegistry.SessionDiscoveryTarget, Kind, Path)
+            .Should().BeTrue("a cancelled call must throw before marking, leaving the __session__ dedup slot free");
+    }
+
+    [Fact]
     public async Task CancelledDuringSinkDelivery_UnmarksRoutedMark_AndThrows()
     {
-        // Must-4 (FIX A, edit 2): if cancellation lands AFTER the routed mark is placed but at/before the
-        // first sink delivery, the OperationCanceledException catch must un-mark before rethrowing —
-        // else the stranded mark wrongly dedups a later gateway redelivery. Modelled by a sink that
-        // cancels the token and throws OCE mid-delivery.
+        // If cancellation lands AFTER the routed mark is placed but at/before the first sink delivery,
+        // the OperationCanceledException catch must un-mark before rethrowing — else the stranded mark
+        // wrongly dedups a later gateway redelivery. Modelled by a delivery hook that cancels the token
+        // and throws OCE mid-delivery.
         using var harness = new Harness(routeToSubAgent: true);
         using var cts = new CancellationTokenSource();
-        _ = harness.RegisterProgrammableSinkThread(
-            SessionId,
-            "thread-sub",
-            _ =>
-            {
-                cts.Cancel();
-                throw new OperationCanceledException(cts.Token);
-            });
+        var sink = harness.RegisterSinkThread(SessionId, "thread-sub", SubAgentContextDeliveryResult.TargetNotDeliverable);
+        sink.DeliverBehavior = (_, _) =>
+        {
+            cts.Cancel();
+            throw new OperationCanceledException(cts.Token);
+        };
 
         var act = async () => await harness.Injector.InjectAsync(Payload(agentId: AgentId), cts.Token);
 
@@ -270,19 +289,19 @@ public sealed class ContextDiscoveryInjectorRoutingTests
     [Fact]
     public async Task AmbiguousSink_StopsScanning_NoDeliveryToLaterSink()
     {
-        // Must-5 (FIX B): once a sink throws (ambiguous — it may already have delivered), the injector
-        // must STOP scanning; a later sink that would return Delivered must NEVER be consulted, else the
-        // same context injects twice in one request. Registry thread order is non-deterministic, so the
+        // Once a sink throws (ambiguous — it may already have delivered), the injector must STOP
+        // scanning; a later sink that would return Delivered must NEVER be consulted, else the same
+        // context injects twice in one request. Registry thread order is non-deterministic, so the
         // contract is pinned to CONSULT order via a shared counter: whichever sink is consulted FIRST
-        // throws; a would-be SECOND consult flips a flag and would Deliver. With the fix, the second
-        // consult never happens. (In practice only one sink owns an id — this pins the defensive
-        // contract.)
+        // throws; a would-be SECOND consult flips a flag and would Deliver. With the stop-scan behaviour
+        // the second consult never happens. (In practice only one sink owns an id — this pins the
+        // defensive contract.)
         using var harness = new Harness(routeToSubAgent: true);
         var primary = harness.RegisterPrimaryThread(SessionId, "thread-primary");
 
         var consultCount = 0;
         var laterSinkConsulted = false;
-        Func<CancellationToken, Task<SubAgentContextDeliveryResult>> onDeliver = _ =>
+        Func<string, IReadOnlyList<IMessage>, SubAgentContextDeliveryResult> onDeliver = (_, _) =>
         {
             if (Interlocked.Increment(ref consultCount) == 1)
             {
@@ -290,11 +309,13 @@ public sealed class ContextDiscoveryInjectorRoutingTests
             }
 
             laterSinkConsulted = true;
-            return Task.FromResult(SubAgentContextDeliveryResult.Delivered);
+            return SubAgentContextDeliveryResult.Delivered;
         };
 
-        var sinkA = harness.RegisterProgrammableSinkThread(SessionId, "thread-a", onDeliver);
-        var sinkB = harness.RegisterProgrammableSinkThread(SessionId, "thread-b", onDeliver);
+        var sinkA = harness.RegisterSinkThread(SessionId, "thread-a", SubAgentContextDeliveryResult.Delivered);
+        var sinkB = harness.RegisterSinkThread(SessionId, "thread-b", SubAgentContextDeliveryResult.Delivered);
+        sinkA.DeliverBehavior = onDeliver;
+        sinkB.DeliverBehavior = onDeliver;
 
         var sent = await harness.Injector.InjectAsync(Payload(agentId: AgentId), CancellationToken.None);
 
@@ -310,7 +331,7 @@ public sealed class ContextDiscoveryInjectorRoutingTests
             .Should().BeFalse("the ambiguous drop keeps the dedup mark so a gateway retry can't double-inject");
     }
 
-    // --- Back-compat constructor (SHOULD-2) ---
+    // --- Back-compat constructor ---
 
     [Fact]
     public async Task CompatCtor_RoutingDefaultsOff_PresentAgentId_FansOutToPrimary()
@@ -513,22 +534,6 @@ public sealed class ContextDiscoveryInjectorRoutingTests
             return (RecordingSinkAgent)_agents[threadId];
         }
 
-        /// <summary>
-        /// Registers a sink thread whose <see cref="ISubAgentContextSink.TryDeliverContextAsync"/> runs
-        /// <paramref name="onDeliver"/> — lets a test drive delivery by CONSULT order (shared counter)
-        /// or throw mid-delivery, both of which the canned <see cref="RecordingSinkAgent"/> cannot do.
-        /// </summary>
-        public ProgrammableSink RegisterProgrammableSinkThread(
-            string sessionId,
-            string threadId,
-            Func<CancellationToken, Task<SubAgentContextDeliveryResult>> onDeliver)
-        {
-            _factories[threadId] = id => new ProgrammableSink(id, onDeliver);
-            _ = Pool.GetOrCreateAgent(threadId, Mode);
-            Registry.RegisterThread(sessionId, threadId);
-            return (ProgrammableSink)_agents[threadId];
-        }
-
         public ContextDiscoveryController CreateController()
         {
             var loader = new WorkspaceSubAgentLoader(Registry, NullLogger<WorkspaceSubAgentLoader>.Instance);
@@ -581,74 +586,5 @@ public sealed class ContextDiscoveryInjectorRoutingTests
         {
             return Task.FromResult(respond(request));
         }
-    }
-
-    /// <summary>
-    /// An <see cref="IMultiTurnAgent"/> + <see cref="ISubAgentContextSink"/> whose routed delivery is
-    /// driven by a caller-supplied callback, so a test can throw mid-delivery or decide the result by
-    /// consult order. Every other member is an inert no-op — only the sink path is exercised.
-    /// </summary>
-    private sealed class ProgrammableSink : IMultiTurnAgent, ISubAgentContextSink
-    {
-        private readonly Func<CancellationToken, Task<SubAgentContextDeliveryResult>> _onDeliver;
-
-        public ProgrammableSink(string threadId, Func<CancellationToken, Task<SubAgentContextDeliveryResult>> onDeliver)
-        {
-            ThreadId = threadId;
-            _onDeliver = onDeliver;
-        }
-
-        public string ThreadId { get; }
-
-        public string? CurrentRunId => null;
-
-        public bool IsRunning => true;
-
-        /// <summary>Number of times <see cref="TryDeliverContextAsync"/> was invoked.</summary>
-        public int DeliverCallCount { get; private set; }
-
-        public Task<SubAgentContextDeliveryResult> TryDeliverContextAsync(
-            string agentId,
-            IReadOnlyList<IMessage> messages,
-            CancellationToken cancellationToken = default)
-        {
-            DeliverCallCount++;
-            return _onDeliver(cancellationToken);
-        }
-
-        public ValueTask<SendReceipt> SendAsync(
-            List<IMessage> messages,
-            string? inputId = null,
-            string? parentRunId = null,
-            CancellationToken ct = default) =>
-            ValueTask.FromResult(new SendReceipt(inputId ?? Guid.NewGuid().ToString("N"), inputId, DateTimeOffset.UtcNow));
-
-        public async ValueTask<SendReceipt?> TrySendAsync(
-            List<IMessage> messages,
-            string? inputId = null,
-            string? parentRunId = null,
-            CancellationToken ct = default) =>
-            await SendAsync(messages, inputId, parentRunId, ct);
-
-#pragma warning disable CS1998, IDE0391
-        public async IAsyncEnumerable<IMessage> ExecuteRunAsync(
-            UserInput userInput,
-            [EnumeratorCancellation] CancellationToken ct = default)
-        {
-            yield break;
-        }
-
-        public async IAsyncEnumerable<IMessage> SubscribeAsync(
-            [EnumeratorCancellation] CancellationToken ct = default)
-        {
-            yield break;
-        }
-#pragma warning restore CS1998, IDE0391
-
-        public Task RunAsync(CancellationToken ct = default) => Task.CompletedTask;
-
-        public Task StopAsync(TimeSpan? timeout = null) => Task.CompletedTask;
-
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorRoutingTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorRoutingTests.cs
@@ -143,6 +143,42 @@ public sealed class ContextDiscoveryInjectorRoutingTests
     }
 
     [Fact]
+    public async Task AllNotOwned_UnmarksOnlyItsPath_LeavingConcurrentDeliveredPathIntact()
+    {
+        // FIX 1 (C5): the all-NotOwned rollback must un-mark ONLY the current (target, kind, path), never
+        // every path recorded under the same agent_id. A concurrent delivery's mark for a DIFFERENT path
+        // of the SAME sub-agent must survive the rollback (the old target-wide eviction erased it).
+        const string DeliveredPath = "sub/CLAUDE.md";
+        const string NotOwnedPath = "sub/AGENTS.md";
+
+        using var harness = new Harness(routeToSubAgent: true);
+        _ = harness.RegisterSinkThread(SessionId, "thread-sub", SubAgentContextDeliveryResult.NotOwned);
+
+        // Simulate a concurrent delivery having already marked DeliveredPath under the same agent_id.
+        harness.Registry.TryMarkDiscoverySeen(SessionId, AgentId, Kind, DeliveredPath).Should().BeTrue();
+
+        // This routed discovery for NotOwnedPath resolves NotOwned ⇒ dropped and un-marked (retry-friendly).
+        var sent = await harness.Injector.InjectAsync(
+            new ContextDiscoveryPayload
+            {
+                SessionId = SessionId,
+                Kind = Kind,
+                Path = NotOwnedPath,
+                Content = Content,
+                AgentId = AgentId,
+            },
+            CancellationToken.None);
+        sent.Should().Be(0);
+
+        // The concurrent DeliveredPath mark MUST still be present — precise un-mark, not target-wide wipe.
+        harness.Registry.TryMarkDiscoverySeen(SessionId, AgentId, Kind, DeliveredPath)
+            .Should().BeFalse("the precise rollback must not erase a concurrent path's mark for the same agent_id");
+        // …while NotOwnedPath's own mark WAS rolled back so a gateway redelivery can heal the race.
+        harness.Registry.TryMarkDiscoverySeen(SessionId, AgentId, Kind, NotOwnedPath)
+            .Should().BeTrue("the un-delivered path was un-marked so a gateway retry can heal the pre-registration race");
+    }
+
+    [Fact]
     public async Task Aggregation_DeliveredWins_OverNotDeliverable_RegardlessOfOrder()
     {
         using var harness = new Harness(routeToSubAgent: true);

--- a/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorRoutingTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorRoutingTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Net;
+using System.Runtime.CompilerServices;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using LmStreaming.Sample.Services.Discovery;
@@ -218,6 +219,97 @@ public sealed class ContextDiscoveryInjectorRoutingTests
             .Should().BeFalse("an ambiguous sink failure keeps the dedup mark so a retry can't double-inject");
     }
 
+    // --- Cancellation & stop-scanning (Must-4 / Must-5) ---
+
+    [Fact]
+    public async Task PreCancelledToken_DoesNotMark_AndThrows()
+    {
+        // Must-4 (FIX A, edit 1): an already-cancelled call must throw BEFORE placing the routed dedup
+        // mark. Marking first and then throwing on the first sink call would strand a mark under which
+        // nothing was delivered, wrongly deduping a later gateway redelivery. The sink returns
+        // TargetNotDeliverable, which (absent the guard) would KEEP the mark — so this pins that the
+        // start-of-method guard, not a rollback, is what leaves the ledger clean.
+        using var harness = new Harness(routeToSubAgent: true);
+        _ = harness.RegisterSinkThread(SessionId, "thread-sub", SubAgentContextDeliveryResult.TargetNotDeliverable);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await harness.Injector.InjectAsync(Payload(agentId: AgentId), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        harness.Registry.TryMarkDiscoverySeen(SessionId, AgentId, Kind, Path)
+            .Should().BeTrue("a cancelled call must throw before marking, leaving the routed dedup slot free");
+    }
+
+    [Fact]
+    public async Task CancelledDuringSinkDelivery_UnmarksRoutedMark_AndThrows()
+    {
+        // Must-4 (FIX A, edit 2): if cancellation lands AFTER the routed mark is placed but at/before the
+        // first sink delivery, the OperationCanceledException catch must un-mark before rethrowing —
+        // else the stranded mark wrongly dedups a later gateway redelivery. Modelled by a sink that
+        // cancels the token and throws OCE mid-delivery.
+        using var harness = new Harness(routeToSubAgent: true);
+        using var cts = new CancellationTokenSource();
+        _ = harness.RegisterProgrammableSinkThread(
+            SessionId,
+            "thread-sub",
+            _ =>
+            {
+                cts.Cancel();
+                throw new OperationCanceledException(cts.Token);
+            });
+
+        var act = async () => await harness.Injector.InjectAsync(Payload(agentId: AgentId), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        harness.Registry.TryMarkDiscoverySeen(SessionId, AgentId, Kind, Path)
+            .Should().BeTrue("cancellation before any delivery rolls back the routed mark so a gateway retry can heal");
+    }
+
+    [Fact]
+    public async Task AmbiguousSink_StopsScanning_NoDeliveryToLaterSink()
+    {
+        // Must-5 (FIX B): once a sink throws (ambiguous — it may already have delivered), the injector
+        // must STOP scanning; a later sink that would return Delivered must NEVER be consulted, else the
+        // same context injects twice in one request. Registry thread order is non-deterministic, so the
+        // contract is pinned to CONSULT order via a shared counter: whichever sink is consulted FIRST
+        // throws; a would-be SECOND consult flips a flag and would Deliver. With the fix, the second
+        // consult never happens. (In practice only one sink owns an id — this pins the defensive
+        // contract.)
+        using var harness = new Harness(routeToSubAgent: true);
+        var primary = harness.RegisterPrimaryThread(SessionId, "thread-primary");
+
+        var consultCount = 0;
+        var laterSinkConsulted = false;
+        Func<CancellationToken, Task<SubAgentContextDeliveryResult>> onDeliver = _ =>
+        {
+            if (Interlocked.Increment(ref consultCount) == 1)
+            {
+                throw new InvalidOperationException("first consulted sink threw (may already have delivered)");
+            }
+
+            laterSinkConsulted = true;
+            return Task.FromResult(SubAgentContextDeliveryResult.Delivered);
+        };
+
+        var sinkA = harness.RegisterProgrammableSinkThread(SessionId, "thread-a", onDeliver);
+        var sinkB = harness.RegisterProgrammableSinkThread(SessionId, "thread-b", onDeliver);
+
+        var sent = await harness.Injector.InjectAsync(Payload(agentId: AgentId), CancellationToken.None);
+
+        sent.Should().Be(0, "an ambiguous throw drops the discovery — never routes to a later sink");
+        consultCount.Should().Be(1, "the scan must stop at the first (throwing) sink");
+        laterSinkConsulted.Should().BeFalse("no later sink may be consulted after an ambiguous throw");
+        (sinkA.DeliverCallCount + sinkB.DeliverCallCount)
+            .Should().Be(1, "exactly one sink is consulted before the scan stops");
+        primary.SentMessages.Should().BeEmpty("an ambiguous sink failure must never fall back to the primary");
+        harness.Diagnostics.RoutingSnapshot().Dropped.Should().Be(1);
+        harness.Diagnostics.RoutingSnapshot().Routed.Should().Be(0);
+        harness.Registry.TryMarkDiscoverySeen(SessionId, AgentId, Kind, Path)
+            .Should().BeFalse("the ambiguous drop keeps the dedup mark so a gateway retry can't double-inject");
+    }
+
     // --- Back-compat constructor (SHOULD-2) ---
 
     [Fact]
@@ -421,6 +513,22 @@ public sealed class ContextDiscoveryInjectorRoutingTests
             return (RecordingSinkAgent)_agents[threadId];
         }
 
+        /// <summary>
+        /// Registers a sink thread whose <see cref="ISubAgentContextSink.TryDeliverContextAsync"/> runs
+        /// <paramref name="onDeliver"/> — lets a test drive delivery by CONSULT order (shared counter)
+        /// or throw mid-delivery, both of which the canned <see cref="RecordingSinkAgent"/> cannot do.
+        /// </summary>
+        public ProgrammableSink RegisterProgrammableSinkThread(
+            string sessionId,
+            string threadId,
+            Func<CancellationToken, Task<SubAgentContextDeliveryResult>> onDeliver)
+        {
+            _factories[threadId] = id => new ProgrammableSink(id, onDeliver);
+            _ = Pool.GetOrCreateAgent(threadId, Mode);
+            Registry.RegisterThread(sessionId, threadId);
+            return (ProgrammableSink)_agents[threadId];
+        }
+
         public ContextDiscoveryController CreateController()
         {
             var loader = new WorkspaceSubAgentLoader(Registry, NullLogger<WorkspaceSubAgentLoader>.Instance);
@@ -473,5 +581,74 @@ public sealed class ContextDiscoveryInjectorRoutingTests
         {
             return Task.FromResult(respond(request));
         }
+    }
+
+    /// <summary>
+    /// An <see cref="IMultiTurnAgent"/> + <see cref="ISubAgentContextSink"/> whose routed delivery is
+    /// driven by a caller-supplied callback, so a test can throw mid-delivery or decide the result by
+    /// consult order. Every other member is an inert no-op — only the sink path is exercised.
+    /// </summary>
+    private sealed class ProgrammableSink : IMultiTurnAgent, ISubAgentContextSink
+    {
+        private readonly Func<CancellationToken, Task<SubAgentContextDeliveryResult>> _onDeliver;
+
+        public ProgrammableSink(string threadId, Func<CancellationToken, Task<SubAgentContextDeliveryResult>> onDeliver)
+        {
+            ThreadId = threadId;
+            _onDeliver = onDeliver;
+        }
+
+        public string ThreadId { get; }
+
+        public string? CurrentRunId => null;
+
+        public bool IsRunning => true;
+
+        /// <summary>Number of times <see cref="TryDeliverContextAsync"/> was invoked.</summary>
+        public int DeliverCallCount { get; private set; }
+
+        public Task<SubAgentContextDeliveryResult> TryDeliverContextAsync(
+            string agentId,
+            IReadOnlyList<IMessage> messages,
+            CancellationToken cancellationToken = default)
+        {
+            DeliverCallCount++;
+            return _onDeliver(cancellationToken);
+        }
+
+        public ValueTask<SendReceipt> SendAsync(
+            List<IMessage> messages,
+            string? inputId = null,
+            string? parentRunId = null,
+            CancellationToken ct = default) =>
+            ValueTask.FromResult(new SendReceipt(inputId ?? Guid.NewGuid().ToString("N"), inputId, DateTimeOffset.UtcNow));
+
+        public async ValueTask<SendReceipt?> TrySendAsync(
+            List<IMessage> messages,
+            string? inputId = null,
+            string? parentRunId = null,
+            CancellationToken ct = default) =>
+            await SendAsync(messages, inputId, parentRunId, ct);
+
+#pragma warning disable CS1998, IDE0391
+        public async IAsyncEnumerable<IMessage> ExecuteRunAsync(
+            UserInput userInput,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            yield break;
+        }
+
+        public async IAsyncEnumerable<IMessage> SubscribeAsync(
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            yield break;
+        }
+#pragma warning restore CS1998, IDE0391
+
+        public Task RunAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task StopAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorTests.cs
@@ -128,8 +128,10 @@ public class ContextDiscoveryInjectorTests
 
         sent.Should().Be(0);
         // Dedup MUST be marked even when no thread received the injection — by design, so a later
-        // redelivery doesn't surprise a freshly-spun-up thread with stale content.
-        harness.Registry.TryMarkDiscoverySeen(SessionId, Kind, Path).Should().BeFalse();
+        // redelivery doesn't surprise a freshly-spun-up thread with stale content. The fallback path
+        // marks under the session-level sentinel target.
+        harness.Registry.TryMarkDiscoverySeen(
+            SessionId, SandboxSessionRegistry.SessionDiscoveryTarget, Kind, Path).Should().BeFalse();
     }
 
     [Fact]
@@ -243,6 +245,8 @@ public class ContextDiscoveryInjectorTests
                 Registry,
                 Pool,
                 new ContextDiscoveryFormatter(),
+                new ContextDiscoveryOptions(),
+                new ContextDiscoveryDiagnostics(),
                 NullLogger<ContextDiscoveryInjector>.Instance);
         }
 

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryThreadTrackingTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryThreadTrackingTests.cs
@@ -121,6 +121,22 @@ public class SandboxSessionRegistryThreadTrackingTests
     }
 
     [Fact]
+    public async Task TryMarkDiscoverySeen_ThreeArgOverload_DedupsUnderSessionSentinel_SharingTheBucket()
+    {
+        // SHOULD-2: the restored 3-arg (sessionId, kind, path) overload marks under the __session__
+        // sentinel, deduping identically to the 4-arg form: first true, repeat false…
+        await using var registry = CreateRegistry();
+
+        registry.TryMarkDiscoverySeen(SessionA, "context_file", "CLAUDE.md").Should().BeTrue();
+        registry.TryMarkDiscoverySeen(SessionA, "context_file", "CLAUDE.md").Should().BeFalse();
+
+        // …and it shares the SAME bucket as the explicit 4-arg __session__ form, so a caller mixing the
+        // two overloads still dedups the same discovery exactly once (no rogue second bucket).
+        registry.TryMarkDiscoverySeen(SessionA, SandboxSessionRegistry.SessionDiscoveryTarget, "context_file", "CLAUDE.md")
+            .Should().BeFalse("the 3-arg overload and the 4-arg __session__ form share one dedup bucket");
+    }
+
+    [Fact]
     public async Task TryMarkDiscoverySeen_RejectsBlankInputs()
     {
         await using var registry = CreateRegistry();

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryThreadTrackingTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryThreadTrackingTests.cs
@@ -8,7 +8,7 @@ namespace LmStreaming.Sample.Tests.Services;
 /// <see cref="SandboxSessionRegistry.UnregisterThread"/>,
 /// <see cref="SandboxSessionRegistry.UnregisterThreadFromAllSessions"/>,
 /// <see cref="SandboxSessionRegistry.GetThreads"/>, and
-/// <see cref="SandboxSessionRegistry.TryMarkDiscoverySeen"/>.
+/// <see cref="SandboxSessionRegistry.TryMarkDiscoverySeen(string, string, string, string)"/>.
 /// </summary>
 public class SandboxSessionRegistryThreadTrackingTests
 {
@@ -133,45 +133,58 @@ public class SandboxSessionRegistryThreadTrackingTests
     }
 
     [Fact]
-    public async Task EvictDiscoverySeenForTarget_ClearsOnlyThatTargetsEntries()
+    public async Task UnmarkDiscoverySeen_RemovesOnlyThatKey_LeavingSiblingPathsAndTargets()
     {
         await using var registry = CreateRegistry();
         const string Kind = "context_file";
-        const string DirPath = "sub/CLAUDE.md";
+        const string PathX = "sub/CLAUDE.md";
+        const string PathY = "sub/AGENTS.md";
 
-        registry.TryMarkDiscoverySeen(SessionA, "agent-A", Kind, DirPath).Should().BeTrue();
-        registry.TryMarkDiscoverySeen(SessionA, "agent-B", Kind, DirPath).Should().BeTrue();
+        registry.TryMarkDiscoverySeen(SessionA, "agent-A", Kind, PathX).Should().BeTrue();
+        registry.TryMarkDiscoverySeen(SessionA, "agent-A", Kind, PathY).Should().BeTrue();
+        registry.TryMarkDiscoverySeen(SessionA, "agent-B", Kind, PathX).Should().BeTrue();
 
-        // Per-sub-agent eviction — invoked by LmMultiTurn on sub-agent teardown (post-merge) and by the
-        // injector to un-mark an undeliverable routed discovery. Only agent-A's entries clear.
-        registry.EvictDiscoverySeenForTarget(SessionA, "agent-A");
+        // Precise per-(target, kind, path) rollback — used by the injector to un-mark an undeliverable
+        // routed discovery. ONLY agent-A's PathX key clears; a sibling path of the same target and a
+        // different target are both untouched (the C5 regression this replaces used a target-wide prefix
+        // wipe that also erased a concurrent path's mark).
+        registry.UnmarkDiscoverySeen(SessionA, "agent-A", Kind, PathX);
 
-        registry.TryMarkDiscoverySeen(SessionA, "agent-A", Kind, DirPath).Should().BeTrue("agent-A's entry was evicted");
-        registry.TryMarkDiscoverySeen(SessionA, "agent-B", Kind, DirPath).Should().BeFalse("agent-B was untouched");
+        registry.TryMarkDiscoverySeen(SessionA, "agent-A", Kind, PathX).Should().BeTrue("only agent-A's PathX key was un-marked");
+        registry.TryMarkDiscoverySeen(SessionA, "agent-A", Kind, PathY).Should().BeFalse("a sibling path of the same target is untouched");
+        registry.TryMarkDiscoverySeen(SessionA, "agent-B", Kind, PathX).Should().BeFalse("another target is untouched");
     }
 
     [Fact]
-    public async Task EvictDiscoverySeenForTarget_UnknownSessionOrTarget_IsNoOp()
+    public async Task UnmarkDiscoverySeen_UnknownSessionOrKey_IsNoOp()
     {
         await using var registry = CreateRegistry();
+        registry.TryMarkDiscoverySeen(SessionA, "agent-A", "context_file", "CLAUDE.md").Should().BeTrue();
 
-        // Must not throw for an unknown session or a never-marked target.
-        registry.EvictDiscoverySeenForTarget("ghost-session", "agent-A");
-        registry.EvictDiscoverySeenForTarget(SessionA, "agent-never-marked");
+        // Must not throw for an unknown session, a never-marked target, or a never-marked path, and
+        // must leave the one real mark intact.
+        registry.UnmarkDiscoverySeen("ghost-session", "agent-A", "context_file", "CLAUDE.md");
+        registry.UnmarkDiscoverySeen(SessionA, "agent-never-marked", "context_file", "CLAUDE.md");
+        registry.UnmarkDiscoverySeen(SessionA, "agent-A", "context_file", "other/path.md");
+
+        registry.TryMarkDiscoverySeen(SessionA, "agent-A", "context_file", "CLAUDE.md")
+            .Should().BeFalse("no-op un-marks must leave the real mark intact");
     }
 
     [Fact]
-    public async Task UnregisterThreadFromAllSessions_ClearsDedupWhenSessionLosesLastThread()
+    public async Task UnregisterThreadFromAllSessions_KeepsDedupLedger_UntilSessionDestroy()
     {
         await using var registry = CreateRegistry();
         registry.RegisterThread(SessionA, "thread-1");
         registry.TryMarkDiscoverySeen(SessionA, "agent-A", "context_file", "CLAUDE.md").Should().BeTrue();
 
-        // Removing the session's last thread evicts its (now-dead) sub-agents' dedup entries.
+        // Removing the session's last thread must NOT clear its discovery ledger (the pre-#198
+        // behaviour, restored to drop the check-then-act race vs a concurrent RegisterThread). The
+        // ledger is cleared only on session destroy/dispose, so a redelivery still dedups.
         registry.UnregisterThreadFromAllSessions("thread-1");
 
         registry.TryMarkDiscoverySeen(SessionA, "agent-A", "context_file", "CLAUDE.md")
-            .Should().BeTrue("a fresh conversation on the session legitimately re-receives context");
+            .Should().BeFalse("the dedup ledger persists until the session is destroyed/disposed");
     }
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryThreadTrackingTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryThreadTrackingTests.cs
@@ -80,33 +80,114 @@ public class SandboxSessionRegistryThreadTrackingTests
     public async Task TryMarkDiscoverySeen_FirstCallTrue_RepeatFalse()
     {
         await using var registry = CreateRegistry();
+        var target = SandboxSessionRegistry.SessionDiscoveryTarget;
 
-        registry.TryMarkDiscoverySeen(SessionA, "context_file", "CLAUDE.md").Should().BeTrue();
-        registry.TryMarkDiscoverySeen(SessionA, "context_file", "CLAUDE.md").Should().BeFalse();
+        registry.TryMarkDiscoverySeen(SessionA, target, "context_file", "CLAUDE.md").Should().BeTrue();
+        registry.TryMarkDiscoverySeen(SessionA, target, "context_file", "CLAUDE.md").Should().BeFalse();
     }
 
     [Fact]
-    public async Task TryMarkDiscoverySeen_ScopedByKindAndPathAndSession()
+    public async Task TryMarkDiscoverySeen_ScopedByTargetKindPathAndSession()
     {
         await using var registry = CreateRegistry();
+        var target = SandboxSessionRegistry.SessionDiscoveryTarget;
 
-        registry.TryMarkDiscoverySeen(SessionA, "context_file", "CLAUDE.md").Should().BeTrue();
+        registry.TryMarkDiscoverySeen(SessionA, target, "context_file", "CLAUDE.md").Should().BeTrue();
         // Same path different kind: distinct entry.
-        registry.TryMarkDiscoverySeen(SessionA, "subagent", "CLAUDE.md").Should().BeTrue();
+        registry.TryMarkDiscoverySeen(SessionA, target, "subagent", "CLAUDE.md").Should().BeTrue();
         // Same kind+path, different session: distinct entry.
-        registry.TryMarkDiscoverySeen(SessionB, "context_file", "CLAUDE.md").Should().BeTrue();
+        registry.TryMarkDiscoverySeen(SessionB, target, "context_file", "CLAUDE.md").Should().BeTrue();
         // Repeat of the original — must be deduped.
-        registry.TryMarkDiscoverySeen(SessionA, "context_file", "CLAUDE.md").Should().BeFalse();
+        registry.TryMarkDiscoverySeen(SessionA, target, "context_file", "CLAUDE.md").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TryMarkDiscoverySeen_DistinctByTarget_PrimaryVsSubAgents_SameDirectory()
+    {
+        await using var registry = CreateRegistry();
+        const string Kind = "context_file";
+        const string DirPath = "sub/CLAUDE.md";
+
+        // The primary (session sentinel) and two DISTINCT sub-agents entering the SAME directory each
+        // get their own first-sight true — dedup is per (target, kind, path).
+        registry.TryMarkDiscoverySeen(SessionA, SandboxSessionRegistry.SessionDiscoveryTarget, Kind, DirPath).Should().BeTrue();
+        registry.TryMarkDiscoverySeen(SessionA, "agent-A", Kind, DirPath).Should().BeTrue();
+        registry.TryMarkDiscoverySeen(SessionA, "agent-B", Kind, DirPath).Should().BeTrue();
+
+        // …and each independently dedups on repeat.
+        registry.TryMarkDiscoverySeen(SessionA, "agent-A", Kind, DirPath).Should().BeFalse();
+        registry.TryMarkDiscoverySeen(SessionA, "agent-B", Kind, DirPath).Should().BeFalse();
+        registry.TryMarkDiscoverySeen(SessionA, SandboxSessionRegistry.SessionDiscoveryTarget, Kind, DirPath).Should().BeFalse();
     }
 
     [Fact]
     public async Task TryMarkDiscoverySeen_RejectsBlankInputs()
     {
         await using var registry = CreateRegistry();
+        var target = SandboxSessionRegistry.SessionDiscoveryTarget;
 
-        registry.TryMarkDiscoverySeen("", "context_file", "CLAUDE.md").Should().BeFalse();
-        registry.TryMarkDiscoverySeen(SessionA, "", "CLAUDE.md").Should().BeFalse();
-        registry.TryMarkDiscoverySeen(SessionA, "context_file", "").Should().BeFalse();
+        registry.TryMarkDiscoverySeen("", target, "context_file", "CLAUDE.md").Should().BeFalse();
+        registry.TryMarkDiscoverySeen(SessionA, "", "context_file", "CLAUDE.md").Should().BeFalse();
+        registry.TryMarkDiscoverySeen(SessionA, target, "", "CLAUDE.md").Should().BeFalse();
+        registry.TryMarkDiscoverySeen(SessionA, target, "context_file", "").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EvictDiscoverySeenForTarget_ClearsOnlyThatTargetsEntries()
+    {
+        await using var registry = CreateRegistry();
+        const string Kind = "context_file";
+        const string DirPath = "sub/CLAUDE.md";
+
+        registry.TryMarkDiscoverySeen(SessionA, "agent-A", Kind, DirPath).Should().BeTrue();
+        registry.TryMarkDiscoverySeen(SessionA, "agent-B", Kind, DirPath).Should().BeTrue();
+
+        // Per-sub-agent eviction — invoked by LmMultiTurn on sub-agent teardown (post-merge) and by the
+        // injector to un-mark an undeliverable routed discovery. Only agent-A's entries clear.
+        registry.EvictDiscoverySeenForTarget(SessionA, "agent-A");
+
+        registry.TryMarkDiscoverySeen(SessionA, "agent-A", Kind, DirPath).Should().BeTrue("agent-A's entry was evicted");
+        registry.TryMarkDiscoverySeen(SessionA, "agent-B", Kind, DirPath).Should().BeFalse("agent-B was untouched");
+    }
+
+    [Fact]
+    public async Task EvictDiscoverySeenForTarget_UnknownSessionOrTarget_IsNoOp()
+    {
+        await using var registry = CreateRegistry();
+
+        // Must not throw for an unknown session or a never-marked target.
+        registry.EvictDiscoverySeenForTarget("ghost-session", "agent-A");
+        registry.EvictDiscoverySeenForTarget(SessionA, "agent-never-marked");
+    }
+
+    [Fact]
+    public async Task UnregisterThreadFromAllSessions_ClearsDedupWhenSessionLosesLastThread()
+    {
+        await using var registry = CreateRegistry();
+        registry.RegisterThread(SessionA, "thread-1");
+        registry.TryMarkDiscoverySeen(SessionA, "agent-A", "context_file", "CLAUDE.md").Should().BeTrue();
+
+        // Removing the session's last thread evicts its (now-dead) sub-agents' dedup entries.
+        registry.UnregisterThreadFromAllSessions("thread-1");
+
+        registry.TryMarkDiscoverySeen(SessionA, "agent-A", "context_file", "CLAUDE.md")
+            .Should().BeTrue("a fresh conversation on the session legitimately re-receives context");
+    }
+
+    [Fact]
+    public async Task UnregisterThreadFromAllSessions_KeepsDedupWhileAnotherThreadIsLive()
+    {
+        await using var registry = CreateRegistry();
+        registry.RegisterThread(SessionA, "thread-stays");
+        registry.RegisterThread(SessionA, "thread-goes");
+        registry.TryMarkDiscoverySeen(SessionA, SandboxSessionRegistry.SessionDiscoveryTarget, "context_file", "CLAUDE.md")
+            .Should().BeTrue();
+
+        registry.UnregisterThreadFromAllSessions("thread-goes");
+
+        // The session still routes thread-stays, so its dedup ledger must survive (else double-inject).
+        registry.TryMarkDiscoverySeen(SessionA, SandboxSessionRegistry.SessionDiscoveryTarget, "context_file", "CLAUDE.md")
+            .Should().BeFalse();
     }
 
     [Fact]
@@ -114,7 +195,8 @@ public class SandboxSessionRegistryThreadTrackingTests
     {
         var registry = CreateRegistry();
         registry.RegisterThread(SessionA, "thread-1");
-        _ = registry.TryMarkDiscoverySeen(SessionA, "context_file", "CLAUDE.md");
+        _ = registry.TryMarkDiscoverySeen(
+            SessionA, SandboxSessionRegistry.SessionDiscoveryTarget, "context_file", "CLAUDE.md");
 
         await registry.DisposeAsync();
 

--- a/tests/LmStreaming.Sample.Tests/TestDoubles/RecordingSinkAgent.cs
+++ b/tests/LmStreaming.Sample.Tests/TestDoubles/RecordingSinkAgent.cs
@@ -9,7 +9,9 @@ namespace LmStreaming.Sample.Tests.TestDoubles;
 /// and routed deliveries (<see cref="TryDeliverContextAsync"/> → <see cref="DeliveredMessages"/>),
 /// and returns a canned <see cref="SubAgentContextDeliveryResult"/> so a test can drive each branch
 /// of the injector's aggregation (Delivered / TargetNotDeliverable / NotOwned) deterministically —
-/// without needing the real <c>MultiTurnAgentLoop</c> sink (that lands in the LmMultiTurn half).
+/// without needing the real <c>MultiTurnAgentLoop</c> sink (that lands in the LmMultiTurn half). A
+/// test that must decide the result by consult order or throw mid-delivery sets
+/// <see cref="DeliverBehavior"/>, a per-call hook that overrides the canned result.
 /// </summary>
 internal sealed class RecordingSinkAgent : IMultiTurnAgent, ISubAgentContextSink
 {
@@ -38,6 +40,15 @@ internal sealed class RecordingSinkAgent : IMultiTurnAgent, ISubAgentContextSink
     /// delivery (the "ambiguous" outcome).
     /// </summary>
     public Exception? ThrowOnDeliver { get; set; }
+
+    /// <summary>
+    /// Optional per-call delivery hook. When set, <see cref="TryDeliverContextAsync"/> invokes it
+    /// (after bumping <see cref="DeliverCallCount"/>/<see cref="LastDeliveredAgentId"/>) and uses its
+    /// return value instead of <see cref="CannedResult"/>; if the hook THROWS, that throw propagates —
+    /// modelling a sink that decides its outcome by consult order or fails mid-delivery. This lets one
+    /// double serve both the canned-result and programmable-sink test needs.
+    /// </summary>
+    public Func<string, IReadOnlyList<IMessage>, SubAgentContextDeliveryResult>? DeliverBehavior { get; set; }
 
     /// <summary>Number of times <see cref="TryDeliverContextAsync"/> was invoked.</summary>
     public int DeliverCallCount { get; private set; }
@@ -85,13 +96,18 @@ internal sealed class RecordingSinkAgent : IMultiTurnAgent, ISubAgentContextSink
                 throw ThrowOnDeliver;
             }
 
-            if (CannedResult == SubAgentContextDeliveryResult.Delivered)
+            // A per-call behaviour hook lets a test decide the result by consult order or throw
+            // mid-delivery (its throw propagates unchanged, modelling the ambiguous sink); with no
+            // hook the canned result stands.
+            var result = DeliverBehavior is not null ? DeliverBehavior(agentId, messages) : CannedResult;
+
+            if (result == SubAgentContextDeliveryResult.Delivered)
             {
                 _delivered.AddRange(messages);
             }
-        }
 
-        return Task.FromResult(CannedResult);
+            return Task.FromResult(result);
+        }
     }
 
     public ValueTask<SendReceipt> SendAsync(

--- a/tests/LmStreaming.Sample.Tests/TestDoubles/RecordingSinkAgent.cs
+++ b/tests/LmStreaming.Sample.Tests/TestDoubles/RecordingSinkAgent.cs
@@ -32,6 +32,13 @@ internal sealed class RecordingSinkAgent : IMultiTurnAgent, ISubAgentContextSink
     /// <summary>Result <see cref="TryDeliverContextAsync"/> returns for every call.</summary>
     public SubAgentContextDeliveryResult CannedResult { get; set; }
 
+    /// <summary>
+    /// When set, <see cref="TryDeliverContextAsync"/> THROWS this instead of returning a result —
+    /// modelling a misbehaving sink whose failure the injector cannot disambiguate from a partial
+    /// delivery (the "ambiguous" outcome).
+    /// </summary>
+    public Exception? ThrowOnDeliver { get; set; }
+
     /// <summary>Number of times <see cref="TryDeliverContextAsync"/> was invoked.</summary>
     public int DeliverCallCount { get; private set; }
 
@@ -73,6 +80,11 @@ internal sealed class RecordingSinkAgent : IMultiTurnAgent, ISubAgentContextSink
         {
             DeliverCallCount++;
             LastDeliveredAgentId = agentId;
+            if (ThrowOnDeliver is not null)
+            {
+                throw ThrowOnDeliver;
+            }
+
             if (CannedResult == SubAgentContextDeliveryResult.Delivered)
             {
                 _delivered.AddRange(messages);

--- a/tests/LmStreaming.Sample.Tests/TestDoubles/RecordingSinkAgent.cs
+++ b/tests/LmStreaming.Sample.Tests/TestDoubles/RecordingSinkAgent.cs
@@ -1,0 +1,144 @@
+using System.Runtime.CompilerServices;
+
+namespace LmStreaming.Sample.Tests.TestDoubles;
+
+/// <summary>
+/// An <see cref="IMultiTurnAgent"/> that ALSO implements <see cref="ISubAgentContextSink"/> — the
+/// role interface the context-discovery injector probes to route a discovery to the opening
+/// sub-agent. It records both fallback fan-out sends (<see cref="SendAsync"/> → <see cref="SentMessages"/>)
+/// and routed deliveries (<see cref="TryDeliverContextAsync"/> → <see cref="DeliveredMessages"/>),
+/// and returns a canned <see cref="SubAgentContextDeliveryResult"/> so a test can drive each branch
+/// of the injector's aggregation (Delivered / TargetNotDeliverable / NotOwned) deterministically —
+/// without needing the real <c>MultiTurnAgentLoop</c> sink (that lands in the LmMultiTurn half).
+/// </summary>
+internal sealed class RecordingSinkAgent : IMultiTurnAgent, ISubAgentContextSink
+{
+    private readonly List<IMessage> _sent = [];
+    private readonly List<IMessage> _delivered = [];
+    private readonly Lock _lock = new();
+
+    public RecordingSinkAgent(string threadId, SubAgentContextDeliveryResult cannedResult)
+    {
+        ThreadId = threadId;
+        CannedResult = cannedResult;
+    }
+
+    public string ThreadId { get; }
+
+    public string? CurrentRunId { get; set; }
+
+    public bool IsRunning { get; set; } = true;
+
+    /// <summary>Result <see cref="TryDeliverContextAsync"/> returns for every call.</summary>
+    public SubAgentContextDeliveryResult CannedResult { get; set; }
+
+    /// <summary>Number of times <see cref="TryDeliverContextAsync"/> was invoked.</summary>
+    public int DeliverCallCount { get; private set; }
+
+    /// <summary>The <c>agentId</c> passed to the most recent <see cref="TryDeliverContextAsync"/>.</summary>
+    public string? LastDeliveredAgentId { get; private set; }
+
+    /// <summary>Messages delivered via the routed path (only recorded when the canned result is
+    /// <see cref="SubAgentContextDeliveryResult.Delivered"/>).</summary>
+    public IReadOnlyList<IMessage> DeliveredMessages
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return [.. _delivered];
+            }
+        }
+    }
+
+    /// <summary>Messages enqueued via the fallback fan-out path (<see cref="SendAsync"/>).</summary>
+    public IReadOnlyList<IMessage> SentMessages
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return [.. _sent];
+            }
+        }
+    }
+
+    public Task<SubAgentContextDeliveryResult> TryDeliverContextAsync(
+        string agentId,
+        IReadOnlyList<IMessage> messages,
+        CancellationToken cancellationToken = default)
+    {
+        _ = cancellationToken;
+        lock (_lock)
+        {
+            DeliverCallCount++;
+            LastDeliveredAgentId = agentId;
+            if (CannedResult == SubAgentContextDeliveryResult.Delivered)
+            {
+                _delivered.AddRange(messages);
+            }
+        }
+
+        return Task.FromResult(CannedResult);
+    }
+
+    public ValueTask<SendReceipt> SendAsync(
+        List<IMessage> messages,
+        string? inputId = null,
+        string? parentRunId = null,
+        CancellationToken ct = default)
+    {
+        _ = parentRunId;
+        _ = ct;
+        lock (_lock)
+        {
+            _sent.AddRange(messages);
+        }
+
+        var receiptId = inputId ?? Guid.NewGuid().ToString("N");
+        return ValueTask.FromResult(new SendReceipt(receiptId, inputId, DateTimeOffset.UtcNow));
+    }
+
+    public async ValueTask<SendReceipt?> TrySendAsync(
+        List<IMessage> messages,
+        string? inputId = null,
+        string? parentRunId = null,
+        CancellationToken ct = default)
+    {
+        return await SendAsync(messages, inputId, parentRunId, ct);
+    }
+
+#pragma warning disable CS1998, IDE0391
+    public async IAsyncEnumerable<IMessage> ExecuteRunAsync(
+        UserInput userInput,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        _ = userInput;
+        _ = ct;
+        yield break;
+    }
+
+    public async IAsyncEnumerable<IMessage> SubscribeAsync(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        _ = ct;
+        yield break;
+    }
+#pragma warning restore CS1998, IDE0391
+
+    public Task RunAsync(CancellationToken ct = default)
+    {
+        return Task.Delay(Timeout.InfiniteTimeSpan, ct);
+    }
+
+    public Task StopAsync(TimeSpan? timeout = null)
+    {
+        _ = timeout;
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary

When a **sub-agent** opens a file in a sub-directory, the directory-level context file (`CLAUDE.md`/`AGENTS.md`) discovered there was injected into the **primary/parent** conversation instead of the sub-agent that opened it — because discovery is keyed only by `session_id` and the injector fanned out to registered top-level threads only. This routes such a discovery to the **sub-agent that opened the file**, while preserving today's behavior for boot/root context and for any discovery without a triggering-agent id.

This is the **app-side** half. It is gated behind a **default-off** flag and is dormant in production until the sandbox gateway starts stamping `agent_id` (tracked separately as #187); it is fully proven now via synthetic-webhook and instruction-based tests.

Fixes #198.

## How it works

- Optional `agent_id` rides the discovery webhook (`ContextDiscoveryItem` → per-item projection → `ContextDiscoveryPayload`), backward compatible.
- A new role interface **`ISubAgentContextSink`** (LmMultiTurn, implemented by `MultiTurnAgentLoop`) lets `ContextDiscoveryInjector` reach a running sub-agent via `is`-check — no concrete cast, not on `IMultiTurnAgent`.
- Delivery goes through a new side-effect-free **`SubAgentState.TryBeginInjectLease()`** + `SubAgentManager.TryDeliverToRunningAsync` returning a tri-state `{Delivered, TargetNotDeliverable, NotOwned}`; it never restarts a finished sub-agent and never mutates the sub-agent's parent-relay state.
- The injector aggregates across the session's sinks and routes/drops/falls-back accordingly; dedup key becomes `(target, kind, path)`; a per-outcome diagnostics counter (routed/dropped/fallback) is the operator signal (routed context renders no "Context loaded" pill).

## Key Decisions

1. **Deliver via a purpose-built inject-only lease, not `BeginContinuation`.** `BeginContinuation` mutates `_notifyParentOnCompletion` and claims the restart lock as its first act; a context delivery through it would silently drop/double the sub-agent's parent relay and race the Wait/trigger state machine. `TryBeginInjectLease()` admits only `Running && !terminating`, touches neither.
2. **Drop-clean-when-done (owner decision).** A context delivery to a finishing/finished sub-agent is dropped — it must never cause a spurious extra run, a second parent relay, or a run against a disposed provider.
3. **Sub-agent only; present-but-unresolved drops (does not fall back to primary).** Because completed sub-agents linger in the manager, "unresolved" means the pre-registration race or a nested sub-agent — falling back to the primary there would re-introduce the exact #198 pollution. Only a `null`/blank `agent_id` fans out to the primary.
4. **Retry-friendly dedup.** An all-`NotOwned` result is dropped **without** marking-seen, so the gateway's redelivery heals the pre-registration race; `Delivered`/`TargetNotDeliverable` mark under `agent_id`; fallback marks under the `__session__` sentinel. The flag gates routing **and** the dedup-target predicate together, so flag-off is byte-identical to today.
5. **Blank-`agent_id` normalization** (`!IsNullOrWhiteSpace`) so a blank id can't create a rogue `""` dedup bucket.

## Testing

- **LmMultiTurn.Tests: 473/473.** Lease grant/refuse (+ notify/restart untouched), `Delivered` with the context text on the sub-agent's next turn (parent untouched), completed ⇒ `TargetNotDeliverable` with no restart and no second parent relay, unknown ⇒ `NotOwned`, teardown-race ⇒ not resurrected.
- **LmStreaming.Sample.Tests: 656 passed** (+1 skipped). Contract round-trip + mixed-batch per-item projection, registry dedup (two sub-agents, back-compat, per-sub-agent eviction), full injector routing/aggregation suite (flag-off-with-`agent_id`-present byte-identical, present-unresolved-drop, blank-id, not-marked-on-`NotOwned` retry), real-loop cast, and a deterministic routed-path HTTP integration test that drives HTTP → injector → real `MultiTurnAgentLoop` → `SubAgentManager` → a live `ctx-probe` sub-agent and asserts routed + primary-untouched.
- A `PromptExamples.md` **webhook-routing fixture** (backgrounded sub-agent parked on a long `Wait`) documents the equivalent instruction-chain flow for manual/browser testing.
- `dotnet format whitespace` clean.

Two failing tests were confirmed **pre-existing and unrelated** (not touched by this change): the `CodeReviewDaemon.Sample.Tests` build break (stale `DiscoveredSubAgentTemplateBuilder.Build(...)` call after the #186 merge) and `GatewayAppAuthWiringTests.Catalog_client_sends_no_bearer_headers_when_key_is_unset`.

## Known limitation

The completion-boundary guard closes the common case (once terminal disposal begins, delivery is refused). One tiny residual window remains — between the loop publishing the final `RunCompletedMessage` and the monitor calling `BeginTerminalDisposalAsync` (status still `Running`, `_terminating` not yet set) — where a delivery could still wake one spurious run. Fully closing it needs tagging context injections inside `MultiTurnAgentLoop.RunLoopAsync` (an invasive loop change) and is deferred; the routed path is dormant (flag-off) until #187, so this is not reachable in production today.

## Dependencies / out of scope

- **#187** — the gateway must stamp the triggering `agent_id` on the discovery webhook (and leave it null on the session-level root file). Until then the routed path is dormant.
- Out of scope: nested sub-agent routing (documented drop), a per-sub-agent MCP file-op header, a user-visible pill for sub-agent context.
