### PR TITLE
Conversation-wide token usage & cost accounting incl. sub-agents & workflows (#196)

### DIFF
--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/api/conversationUsageApi.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/api/conversationUsageApi.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { getConversationUsage } from '@/api/conversationsApi';
+
+function mockFetchOnce(status: number, body: unknown) {
+  const original = globalThis.fetch;
+  const fetchSpy = vi.fn(
+    async () =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+  );
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  return { fetchSpy, restore: () => (globalThis.fetch = original) };
+}
+
+// #196: the persisted usage aggregate is fetched on reload to restore the usage banner (including
+// sub-agent/workflow usage) instead of resetting to zero.
+describe('conversationsApi.getConversationUsage (#196)', () => {
+  let restore: (() => void) | undefined;
+  afterEach(() => restore?.());
+
+  it('returns the persisted aggregate on success', async () => {
+    const mock = mockFetchOnce(200, {
+      rootConversationId: 'thread-1',
+      totalTokens: 140,
+      completeness: 'Complete',
+      perModel: [
+        { modelId: 'model-A', inputTokens: 100, outputTokens: 40, cacheReadTokens: 0, cacheWriteTokens: 0, reasoningTokens: 0, totalTokens: 140, attemptCount: 1 },
+      ],
+      currency: 'USD',
+    });
+    restore = mock.restore;
+
+    const result = await getConversationUsage('thread-1');
+
+    expect(result?.totalTokens).toBe(140);
+    expect(result?.perModel[0].modelId).toBe('model-A');
+    expect(mock.fetchSpy).toHaveBeenCalledWith('/api/conversations/thread-1/usage');
+  });
+
+  it('returns null when no usage has been recorded (404)', async () => {
+    const mock = mockFetchOnce(404, {});
+    restore = mock.restore;
+
+    const result = await getConversationUsage('thread-1');
+
+    expect(result).toBeNull();
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChatUsage.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useChatUsage.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useChat } from '@/composables/useChat';
+import { uncachedInput, useChat } from '@/composables/useChat';
 import { MessageType } from '@/types';
 
 // Mock the transport + history APIs so useChat can open a (fake) connection and we can hand it
@@ -18,11 +18,26 @@ vi.mock('@/api/wsClient', () => ({
 
 const convMocks = vi.hoisted(() => ({
   loadConversationMessages: vi.fn(),
+  getConversationUsage: vi.fn(),
 }));
 
 vi.mock('@/api/conversationsApi', () => ({
   loadConversationMessages: convMocks.loadConversationMessages,
+  getConversationUsage: convMocks.getConversationUsage,
 }));
+
+function modelRow(modelId: string, inputTokens: number, outputTokens: number, cacheReadTokens: number, cacheWriteTokens = 0) {
+  return {
+    modelId,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    reasoningTokens: 0,
+    totalTokens: inputTokens + cacheWriteTokens + outputTokens,
+    attemptCount: 1,
+  };
+}
 
 function usageMessage(promptTokens: number, completionTokens: number, cachedTokens: number) {
   return {
@@ -49,6 +64,8 @@ describe('useChat — cumulative usage cached/uncached accounting', () => {
     wsMocks.sendWebSocketMessage.mockReset();
     wsMocks.closeWebSocketConnection.mockReset();
     convMocks.loadConversationMessages.mockReset();
+    convMocks.getConversationUsage.mockReset();
+    convMocks.getConversationUsage.mockResolvedValue(null);
 
     wsMocks.createWebSocketConnection.mockImplementation(async (options: any) => {
       captured.push(options);
@@ -104,5 +121,39 @@ describe('useChat — cumulative usage cached/uncached accounting', () => {
 
     const u = chat.cumulativeUsage.value;
     expect(u.uncachedInputTokens).toBe(200); // not -12800
+  });
+
+  it('reload: restores the banner using the SAME per-row uncached rule as the live stream', async () => {
+    // Persisted aggregate where one model row reports cacheRead > input (additive-cache provider) and
+    // another is the OpenAI-family subset shape. Per-row normalization must match the live rule.
+    convMocks.getConversationUsage.mockResolvedValue({
+      rootConversationId: 'thread-1',
+      totalTokens: 15307,
+      perModel: [
+        // OpenAI-family: cached (13696) is a subset of input (14986) -> uncached 1290.
+        modelRow('gpt-5.5', 14986, 121, 13696),
+        // Anthropic-style: input (200) excludes the additive cache read (13000) -> uncached 200, not -12800.
+        modelRow('claude', 200, 79, 13000),
+      ],
+      estimatedPublicCostMicros: null,
+      providerReportedCostMicros: null,
+      currency: 'USD',
+    });
+
+    const chat = useChat({ getModeId: () => 'default' });
+    await chat.loadMessagesFromBackend('thread-1');
+
+    const u = chat.cumulativeUsage.value;
+    // 1290 (subset row) + 200 (additive-cache row, floored to input, NOT (input - cached) = -12800).
+    expect(u.uncachedInputTokens).toBe(1490);
+    expect(u.promptTokens).toBe(15186); // 14986 + 200 summed input
+    expect(u.cachedTokens).toBe(26696); // 13696 + 13000
+    expect(u.completionTokens).toBe(200); // 121 + 79
+  });
+
+  it('uncachedInput: subtracts cached when it is a subset, floors to input otherwise', () => {
+    expect(uncachedInput(14986, 13696)).toBe(1290);
+    expect(uncachedInput(200, 13000)).toBe(200); // additive-cache: never negative
+    expect(uncachedInput(100, 100)).toBe(0);
   });
 });

--- a/samples/LmStreaming.Sample/ClientApp/src/api/conversationsApi.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/api/conversationsApi.ts
@@ -67,6 +67,51 @@ export async function getRunState(threadId: string): Promise<ConversationRunStat
   return response.json();
 }
 
+/** Per-model rollup row within a conversation usage aggregate (#196). */
+export interface ConversationUsageModelRow {
+  modelId: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  reasoningTokens: number;
+  totalTokens: number;
+  estimatedPublicCostMicros?: number | null;
+  providerReportedCostMicros?: number | null;
+  attemptCount: number;
+}
+
+/** Persisted conversation-wide token usage & cost, including sub-agent/workflow descendants (#196). */
+export interface ConversationUsageAggregate {
+  rootConversationId: string;
+  schemaVersion: number;
+  foldedRevision: number;
+  completeness: string;
+  perModel: ConversationUsageModelRow[];
+  totalTokens: number;
+  estimatedPublicCostMicros?: number | null;
+  providerReportedCostMicros?: number | null;
+  currency: string;
+}
+
+/**
+ * Fetches the persisted conversation-wide usage aggregate (#196), or null when none has been
+ * recorded yet (404). Used on reload to restore the usage banner from persisted totals — including
+ * usage spent inside sub-agents and workflow tasks — instead of resetting to zero.
+ */
+export async function getConversationUsage(
+  threadId: string
+): Promise<ConversationUsageAggregate | null> {
+  const response = await fetch(`/api/conversations/${encodeURIComponent(threadId)}/usage`);
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`Failed to fetch usage: ${response.statusText}`);
+  }
+  return response.json();
+}
+
 /**
  * Updates conversation metadata (title, preview).
  */

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
@@ -562,7 +562,7 @@ onBeforeUnmount(() => {
           {{ error }}
         </div>
 
-        <div v-if="cumulativeUsage.totalTokens > 0" class="usage-banner">
+        <div v-if="cumulativeUsage.totalTokens > 0" class="usage-banner" data-testid="usage-banner">
           Total: {{ cumulativeUsage.totalTokens }} |
           In: {{ cumulativeUsage.uncachedInputTokens }} |
           Out: {{ cumulativeUsage.completionTokens }}

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -1406,6 +1406,30 @@ export function useChat(options: UseChatOptions = {}) {
       }
     }
 
+    // Restore the persisted usage banner (#196): the loop above skips UsageMessages, so read the
+    // conversation's persisted aggregate — which includes sub-agent/workflow usage — and populate the
+    // banner from it instead of leaving it at zero on reload.
+    try {
+      const { getConversationUsage } = await import('@/api/conversationsApi');
+      const usageAggregate = await getConversationUsage(existingThreadId);
+      if (usageAggregate) {
+        const input = usageAggregate.perModel.reduce((sum, m) => sum + m.inputTokens, 0);
+        const output = usageAggregate.perModel.reduce((sum, m) => sum + m.outputTokens, 0);
+        const cached = usageAggregate.perModel.reduce((sum, m) => sum + m.cacheReadTokens, 0);
+        const cacheCreation = usageAggregate.perModel.reduce((sum, m) => sum + m.cacheWriteTokens, 0);
+        cumulativeUsage.value = {
+          promptTokens: input,
+          uncachedInputTokens: input - cached,
+          completionTokens: output,
+          totalTokens: usageAggregate.totalTokens,
+          cachedTokens: cached,
+          cacheCreationTokens: cacheCreation,
+        };
+      }
+    } catch (e) {
+      log.warn('Failed to restore persisted usage banner', { error: String(e) });
+    }
+
     log.info('Loaded messages into chat', {
       messageCount: messageIndex.value.size,
       toolResultCount: toolResults.value.size

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -1419,7 +1419,8 @@ export function useChat(options: UseChatOptions = {}) {
         const cacheCreation = usageAggregate.perModel.reduce((sum, m) => sum + m.cacheWriteTokens, 0);
         cumulativeUsage.value = {
           promptTokens: input,
-          uncachedInputTokens: input - cached,
+          // Clamp: some providers report cached >= input, which must not render a negative banner value.
+          uncachedInputTokens: Math.max(0, input - cached),
           completionTokens: output,
           totalTokens: usageAggregate.totalTokens,
           cachedTokens: cached,

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useChat.ts
@@ -183,6 +183,17 @@ export function getDisplayText(text: string): string {
 }
 
 /**
+ * Fresh (uncached) input tokens for one usage row. `cacheRead` is a SUBSET of `input` for the OpenAI
+ * family, so In = input - cacheRead; when a provider reports `cacheRead >= input` (some report cache reads
+ * additively) fall back to the full input so the banner value never goes negative. Shared by the live
+ * stream and the reload path so both normalize identically, and applied PER MODEL ROW before summing so a
+ * mix of rows (some with cacheRead > input) is handled correctly (#196).
+ */
+export function uncachedInput(input: number, cacheRead: number): number {
+  return cacheRead <= input ? input - cacheRead : input;
+}
+
+/**
  * Composable for managing chat state and interactions
  */
 export function useChat(options: UseChatOptions = {}) {
@@ -617,11 +628,9 @@ export function useChat(options: UseChatOptions = {}) {
       const totalTokens = u.total_tokens ?? (promptTokens + completionTokens);
       const cachedTokens = u.input_tokens_details?.cached_tokens ?? u.cacheReadTokens ?? 0;
       const cacheCreationTokens = u.cache_creation_input_tokens ?? u.cacheCreationTokens ?? 0;
-      // Fresh input for this turn = prompt minus the cached read. cachedTokens is a SUBSET of
-      // promptTokens for the OpenAI family; if it ever exceeds it (e.g. providers that report cache
-      // reads additively) fall back to the prompt so this never goes negative. Accumulate per-turn so
-      // In + Cached + Out == Total holds across the whole conversation.
-      const uncachedInputTokens = cachedTokens <= promptTokens ? promptTokens - cachedTokens : promptTokens;
+      // Fresh input for this turn = prompt minus the cached read (never negative; see uncachedInput).
+      // Accumulate per-turn so In + Cached + Out == Total holds across the whole conversation.
+      const uncachedInputTokens = uncachedInput(promptTokens, cachedTokens);
       cumulativeUsage.value = {
         promptTokens: cumulativeUsage.value.promptTokens + promptTokens,
         uncachedInputTokens: cumulativeUsage.value.uncachedInputTokens + uncachedInputTokens,
@@ -1417,10 +1426,15 @@ export function useChat(options: UseChatOptions = {}) {
         const output = usageAggregate.perModel.reduce((sum, m) => sum + m.outputTokens, 0);
         const cached = usageAggregate.perModel.reduce((sum, m) => sum + m.cacheReadTokens, 0);
         const cacheCreation = usageAggregate.perModel.reduce((sum, m) => sum + m.cacheWriteTokens, 0);
+        // Normalize uncached input PER MODEL ROW (then sum), matching the live rule — summing input/cached
+        // across rows first would mis-handle a mix where cacheRead exceeds input for only some rows.
+        const uncachedInputTokens = usageAggregate.perModel.reduce(
+          (sum, m) => sum + uncachedInput(m.inputTokens, m.cacheReadTokens),
+          0,
+        );
         cumulativeUsage.value = {
           promptTokens: input,
-          // Clamp: some providers report cached >= input, which must not render a negative banner value.
-          uncachedInputTokens: Math.max(0, input - cached),
+          uncachedInputTokens,
           completionTokens: output,
           totalTokens: usageAggregate.totalTokens,
           cachedTokens: cached,

--- a/samples/LmStreaming.Sample/Controllers/ConversationsController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ConversationsController.cs
@@ -6,6 +6,7 @@ using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Utils;
 using AchieveAi.LmDotnetTools.LmMultiTurn;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
+using AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
 using AchieveAi.LmDotnetTools.LmAgentInfra;
 using AchieveAi.LmDotnetTools.LmAgentInfra.Agents;
 using AchieveAi.LmDotnetTools.LmAgentInfra.Sandbox;
@@ -322,6 +323,19 @@ public class ConversationsController(
             .ToList();
 
         return Ok(normalized);
+    }
+
+    /// <summary>
+    /// Returns the persisted conversation-wide token usage &amp; cost aggregate (#196): totals plus the
+    /// per-model breakdown, including usage from sub-agents and workflow descendants. A client that
+    /// re-opens a conversation reads this to show real usage that survives reload; headless clients use
+    /// it to retrieve spend without a live stream. Returns 404 when no usage has been recorded yet.
+    /// </summary>
+    [HttpGet("{threadId}/usage")]
+    public async Task<IActionResult> GetUsage(string threadId, CancellationToken ct = default)
+    {
+        var usage = await ConversationUsageProjection.LoadAsync(store, threadId, ct);
+        return usage is null ? NotFound() : Ok(usage);
     }
 
     /// <summary>

--- a/samples/LmStreaming.Sample/PromptExamples.md
+++ b/samples/LmStreaming.Sample/PromptExamples.md
@@ -426,6 +426,34 @@ use a literal string, e.g. `a queued follow-up typed mid-stream`.
 
 ---
 
+## Usage banner (#196) UI tests
+
+Prompts for the conversation-wide token-usage banner
+([`playwright-scripts/usage-banner.mjs`](playwright-scripts/usage-banner.mjs) and the C# scenario
+`Scenarios/UsageBannerTests.cs`). Use the **`test-anthropic`** mock: its scripted SSE emits a fixed
+**100 input / 50 output** tokens per generation, so the banner totals are exact and deterministic.
+The banner (`data-testid="usage-banner"`) renders once cumulative total tokens > 0 and reads
+`Total: N | In: N | Out: N [| Cached: N] [| Cache created: N]`.
+
+### Single reply (one generation → Total 150 / In 100 / Out 50)
+
+<|instruction_start|>{"instruction_chain":[{"id":"u1","id_message":"Reply","messages":[{"text_message":{"length":20}}]}]}<|instruction_end|>
+
+Send it twice in one conversation to accumulate to **Total 300 / In 200 / Out 100** (additive, not
+max'd), then reload the page: the banner is restored to 300 from the persisted aggregate.
+
+### Sub-agent delegation (descendant tokens fold into the SAME banner total)
+
+Parent delegates via the `Agent` tool; the nested chain drives the sub-agent (`calculate` then text),
+whose usage is relayed into the root conversation's ledger — so the banner total exceeds the 300 the
+two parent turns alone would produce. Requires a mode where `calculate` + `Agent` are available
+(**General Assistant**). Escaping rule: inner `<|instruction_start|>`/`<|instruction_end|>` stay
+literal; only the inner JSON quotes are escaped.
+
+<|instruction_start|>{"instruction_chain":[{"id":"parent","id_message":"Delegate to sub-agent","messages":[{"tool_call":[{"name":"Agent","args":{"subagent_type":"general-purpose","prompt":"<|instruction_start|>{\"instruction_chain\":[{\"id\":\"sub-tool\",\"messages\":[{\"tool_call\":[{\"name\":\"calculate\",\"args\":{\"a\":2,\"operation\":\"add\",\"b\":3}}]}]},{\"id\":\"sub-text\",\"messages\":[{\"text\":\"hi from agent\"}]}]}<|instruction_end|>"}}]}]},{"id":"parent2","id_message":"Wrap up","messages":[{"text":"Parent done: sub-agent finished."}]}]}<|instruction_end|>
+
+---
+
 ## Codex Mode Prompt Examples
 
 These prompts are for `LM_PROVIDER_MODE=codex`.

--- a/samples/LmStreaming.Sample/playwright-scripts/README.md
+++ b/samples/LmStreaming.Sample/playwright-scripts/README.md
@@ -22,6 +22,7 @@ lists the failing step names and each `steps[].detail` has the observed values.
 |--------|--------------------|
 | `provider-switch.mjs` | Switch a conversation's provider when idle; selector locked (disabled) while streaming; no permanent lock badge; switch persists + recreates the agent. |
 | `queue-button.mjs` | Blue **Queue** button replaces red Stop while streaming when the composer has text; clicking Queue clears the box and enqueues the message. |
+| `usage-banner.mjs` | Token-usage banner (#196): single turn → Total 150/In 100/Out 50; two turns accumulate to 300; reload restores from the persisted aggregate; a sub-agent delegation folds the descendant's tokens into the persisted aggregate (600) visible via the REST usage endpoint + on reopen. |
 
 ## Conventions (so these stay fast + reliable)
 

--- a/samples/LmStreaming.Sample/playwright-scripts/usage-banner.mjs
+++ b/samples/LmStreaming.Sample/playwright-scripts/usage-banner.mjs
@@ -1,0 +1,117 @@
+// usage-banner.mjs — single-call Playwright smoke check for the conversation-wide token-usage banner
+// (#196). Runs the WHOLE flow in ONE call and returns structured JSON:
+//
+//   browser_run_code_unsafe({ filename: "samples/LmStreaming.Sample/playwright-scripts/usage-banner.mjs" })
+//
+// Returns { pass, failures, steps }. Assert only DETERMINISTIC, browser-observable state. Uses the
+// MOCK provider `test-anthropic`, whose scripted SSE emits a fixed 100 input / 50 output tokens per
+// generation (AnthropicSseStreamHttpContent), so token totals are exact.
+//
+// Scenarios (prompts from PromptExamples.md → "Usage banner (#196) UI tests"):
+//   1. single turn  -> banner "Total: 150 | In: 100 | Out: 50"
+//   2. second turn  -> accumulates to "Total: 300 | In: 200 | Out: 100" (additive, not max'd)
+//   3. reload       -> banner restored to Total 300 from the persisted aggregate (#196 persistence)
+//   4. sub-agent    -> a parent->Agent->sub-agent delegation folds the descendant's tokens into the
+//                      SAME banner total (> the 300 the two parent turns alone produce)
+//
+// Prereq: app running with the built SPA (non-Development serves wwwroot/dist). Adjust BASE to match.
+async (page) => {
+  const BASE = 'http://localhost:5000';
+  const PROVIDER = 'test-anthropic';
+  const SIMPLE =
+    '<|instruction_start|>{"instruction_chain":[{"id":"u1","id_message":"Reply","messages":[{"text_message":{"length":20}}]}]}<|instruction_end|>';
+  // Parent delegates via the Agent tool; the nested chain drives the sub-agent (calculate then text).
+  const SUBAGENT =
+    '<|instruction_start|>{"instruction_chain":[{"id":"parent","id_message":"Delegate to sub-agent","messages":[{"tool_call":[{"name":"Agent","args":{"subagent_type":"general-purpose","prompt":"<|instruction_start|>{\\"instruction_chain\\":[{\\"id\\":\\"sub-tool\\",\\"messages\\":[{\\"tool_call\\":[{\\"name\\":\\"calculate\\",\\"args\\":{\\"a\\":2,\\"operation\\":\\"add\\",\\"b\\":3}}]}]},{\\"id\\":\\"sub-text\\",\\"messages\\":[{\\"text\\":\\"hi from agent\\"}]}]}<|instruction_end|>"}}]}]},{"id":"parent2","id_message":"Wrap up","messages":[{"text":"Parent done: sub-agent finished."}]}]}<|instruction_end|>';
+
+  const steps = [];
+  const record = (name, pass, detail) => steps.push({ name, pass, detail });
+  const tid = (id) => page.locator(`[data-testid="${id}"]`);
+  const waitIdle = async () => {
+    await tid('stop-button').waitFor({ state: 'hidden', timeout: 90000 });
+    await tid('send-button').waitFor({ state: 'visible', timeout: 90000 });
+  };
+  const send = async (text) => {
+    await tid('chat-input-textarea').fill(text);
+    await tid('send-button').click();
+  };
+  const bannerText = async () => (await tid('usage-banner').textContent().catch(() => null)) ?? '';
+  const waitBanner = async (needle, timeout = 20000) => {
+    const deadline = Date.now() + timeout;
+    let text = '';
+    while (Date.now() < deadline) {
+      text = await bannerText();
+      if (text.includes(needle)) return text;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    return text;
+  };
+  const totalOf = (t) => parseInt((t.match(/Total:\s*(\d+)/) || [])[1] || '0', 10);
+  const newChat = async () => {
+    await page.getByRole('button', { name: '+ New Chat' }).click();
+    await tid('provider-selector-button').click();
+    await tid(`provider-option-${PROVIDER}`).click();
+  };
+
+  try {
+    await page.goto(BASE);
+    await tid('chat-input-textarea').waitFor({ timeout: 20000 });
+
+    // 1. Single turn -> Total 150 | In 100 | Out 50.
+    await newChat();
+    await send(SIMPLE);
+    await waitIdle();
+    const b1 = await waitBanner('Total: 150');
+    record(
+      'single-turn 150/100/50',
+      /Total:\s*150/.test(b1) && /In:\s*100/.test(b1) && /Out:\s*50/.test(b1),
+      b1
+    );
+
+    // 2. Second turn accumulates -> Total 300 | In 200 | Out 100.
+    await send(SIMPLE);
+    await waitIdle();
+    const b2 = await waitBanner('Total: 300');
+    record(
+      'two-turn accumulate 300/200/100',
+      /Total:\s*300/.test(b2) && /In:\s*200/.test(b2) && /Out:\s*100/.test(b2),
+      b2
+    );
+
+    // 3. Reload -> banner restored from the persisted aggregate.
+    await page.reload();
+    await tid('chat-input-textarea').waitFor({ timeout: 20000 });
+    const b3 = await waitBanner('Total: 300');
+    record('reload persists 300', /Total:\s*300/.test(b3), b3);
+
+    // 4. Sub-agent delegation -> the descendant's tokens fold into the PERSISTED aggregate (#196
+    //    "visible on reopen"). The live banner reflects only usage STREAMED to the client (parent =
+    //    300); the sub-agent's usage is relayed server-side into the root ledger, so it shows up in
+    //    the REST aggregate and on reload — which must exceed the 300 the two parent turns produce.
+    await newChat();
+    await send(SUBAGENT);
+    await waitIdle();
+    const liveTotal = totalOf(await bannerText());
+    const threadId = await page.evaluate(
+      () => document.querySelector('[data-testid=conversation-item]')?.getAttribute('data-thread-id') ?? null
+    );
+    const agg = await page.evaluate(async (id) => {
+      const r = await fetch(`/api/conversations/${id}/usage`);
+      return r.ok ? await r.json() : { status: r.status };
+    }, threadId);
+    // Reload -> banner restored from the persisted aggregate (includes the descendant).
+    await page.reload();
+    await tid('chat-input-textarea').waitFor({ timeout: 20000 });
+    const reloadedTotal = totalOf(await waitBanner('Total:', 20000));
+    record(
+      'sub-agent folds descendant tokens into persisted aggregate (>300)',
+      (agg?.totalTokens ?? 0) > 300 && reloadedTotal > 300,
+      { liveTotal, aggregateTotal: agg?.totalTokens, reloadedTotal, agg }
+    );
+  } catch (e) {
+    record('exception', false, String((e && e.stack) || e));
+  }
+
+  const failures = steps.filter((s) => !s.pass).map((s) => s.name);
+  return { pass: failures.length === 0, failures, steps };
+}

--- a/src/LmConfig/Pricing/PricingConfigResolver.cs
+++ b/src/LmConfig/Pricing/PricingConfigResolver.cs
@@ -1,0 +1,50 @@
+using AchieveAi.LmDotnetTools.LmConfig.Models;
+using AchieveAi.LmDotnetTools.LmCore.Models;
+
+namespace AchieveAi.LmDotnetTools.LmConfig.Pricing;
+
+/// <summary>
+///     <see cref="IPricingResolver" /> backed by a model → <see cref="PricingConfig" /> map (e.g. sourced
+///     from application config or OpenRouter's public pricing listing). Wires the previously-unused
+///     <see cref="PricingConfig" /> rates into the conversation usage accounting layer through LmCore's
+///     narrow resolver abstraction (#196), keeping the accounting core free of a direct LmConfig dependency.
+/// </summary>
+public sealed class PricingConfigResolver : IPricingResolver
+{
+    private readonly IReadOnlyDictionary<string, PricingConfig> _pricingByModel;
+    private readonly string? _source;
+    private readonly string? _version;
+
+    /// <summary>Creates a resolver over a snapshot of per-model pricing.</summary>
+    /// <param name="pricingByModel">Map of effective model id to its public pricing.</param>
+    /// <param name="source">Optional catalog source recorded on resolved pricing for provenance.</param>
+    /// <param name="version">Optional catalog version / effective date recorded for provenance.</param>
+    public PricingConfigResolver(
+        IReadOnlyDictionary<string, PricingConfig> pricingByModel,
+        string? source = null,
+        string? version = null)
+    {
+        ArgumentNullException.ThrowIfNull(pricingByModel);
+        _pricingByModel = pricingByModel;
+        _source = source;
+        _version = version;
+    }
+
+    /// <inheritdoc />
+    public ModelPricing? Resolve(string modelId)
+    {
+        if (string.IsNullOrEmpty(modelId) || !_pricingByModel.TryGetValue(modelId, out var config))
+        {
+            return null;
+        }
+
+        return new ModelPricing
+        {
+            ModelId = modelId,
+            PromptPerMillion = (decimal)config.PromptPerMillion,
+            CompletionPerMillion = (decimal)config.CompletionPerMillion,
+            Source = _source,
+            Version = _version,
+        };
+    }
+}

--- a/src/LmCore/Models/ConversationUsageAggregate.cs
+++ b/src/LmCore/Models/ConversationUsageAggregate.cs
@@ -1,0 +1,169 @@
+namespace AchieveAi.LmDotnetTools.LmCore.Models;
+
+/// <summary>
+///     Completeness of a <see cref="ConversationUsageAggregate" /> — whether it reflects every billable
+///     attempt for the root conversation, or is still being accumulated / known to be missing usage.
+/// </summary>
+public enum UsageCompleteness
+{
+    /// <summary>The conversation (or a descendant) is still running; more usage may arrive.</summary>
+    InProgress,
+
+    /// <summary>Terminal, but some incurred usage could not be captured — the total is a lower bound.</summary>
+    Partial,
+
+    /// <summary>Terminal and every known descendant's usage is durably recorded.</summary>
+    Complete,
+}
+
+/// <summary>
+///     Per-model rollup row within a <see cref="ConversationUsageAggregate" />.
+/// </summary>
+public sealed record ModelUsageRow
+{
+    /// <summary>The effective model id these totals belong to.</summary>
+    public required string ModelId { get; init; }
+
+    /// <summary>Summed input tokens.</summary>
+    public long InputTokens { get; init; }
+
+    /// <summary>Summed output tokens.</summary>
+    public long OutputTokens { get; init; }
+
+    /// <summary>Summed cached-read tokens (subset of input).</summary>
+    public long CacheReadTokens { get; init; }
+
+    /// <summary>Summed cache-creation tokens (additive).</summary>
+    public long CacheWriteTokens { get; init; }
+
+    /// <summary>Summed reasoning tokens (subset of output).</summary>
+    public long ReasoningTokens { get; init; }
+
+    /// <summary>Summed total tokens (input + cache-write + output).</summary>
+    public long TotalTokens { get; init; }
+
+    /// <summary>Known-cost subtotal for the public estimate, or null when no attempt had one.</summary>
+    public long? EstimatedPublicCostMicros { get; init; }
+
+    /// <summary>Known-cost subtotal for provider-reported cost, or null when no attempt had one.</summary>
+    public long? ProviderReportedCostMicros { get; init; }
+
+    /// <summary>Number of distinct billable attempts folded into this row.</summary>
+    public int AttemptCount { get; init; }
+}
+
+/// <summary>
+///     The authoritative, rebuildable read projection of a conversation's token usage and cost — the sum
+///     of every <see cref="UsageRecord" /> across the whole conversation tree (issue #196).
+/// </summary>
+/// <remarks>
+///     Aggregation is strictly additive and grouped by effective model — never overwritten or max'd the
+///     way the single-generation <see cref="Utils.UsageAccumulator" /> is. Cost fields are known-cost
+///     subtotals: a null means no contributing attempt had that cost dimension, so callers must render it
+///     as "unavailable" rather than <c>0</c>.
+/// </remarks>
+public sealed record ConversationUsageAggregate
+{
+    /// <summary>The root conversation these totals belong to.</summary>
+    public required string RootConversationId { get; init; }
+
+    /// <summary>Schema version of the persisted/serialized projection.</summary>
+    public int SchemaVersion { get; init; } = 1;
+
+    /// <summary>
+    ///     Watermark: the projection reflects a complete, gap-free prefix of every record revision through
+    ///     this value. Computed by the ledger's serialized fold; the pure <see cref="Fold" /> records
+    ///     whatever boundary the caller proved.
+    /// </summary>
+    public long FoldedRevision { get; init; }
+
+    /// <summary>Whether the projection is still accumulating, partial, or complete.</summary>
+    public UsageCompleteness Completeness { get; init; } = UsageCompleteness.InProgress;
+
+    /// <summary>Per-model rollup rows, ordered by model id.</summary>
+    public IReadOnlyList<ModelUsageRow> PerModel { get; init; } = [];
+
+    /// <summary>Grand total tokens across all models.</summary>
+    public long TotalTokens { get; init; }
+
+    /// <summary>Grand known-cost subtotal for the public estimate, or null when none is known.</summary>
+    public long? EstimatedPublicCostMicros { get; init; }
+
+    /// <summary>Grand known-cost subtotal for provider-reported cost, or null when none is known.</summary>
+    public long? ProviderReportedCostMicros { get; init; }
+
+    /// <summary>ISO currency code for the cost figures.</summary>
+    public string Currency { get; init; } = "USD";
+
+    /// <summary>
+    ///     Folds a set of atomic <see cref="UsageRecord" />s into a conversation aggregate: deduplicates by
+    ///     <see cref="UsageRecord.ProviderAttemptId" /> (latest <see cref="UsageRecord.Revision" /> wins),
+    ///     then sums additively grouped by <see cref="UsageRecord.EffectiveModelId" />.
+    /// </summary>
+    /// <param name="rootConversationId">The root conversation id.</param>
+    /// <param name="records">The atomic records to fold (may contain superseded revisions).</param>
+    /// <param name="foldedRevision">The proven gap-free watermark this fold covers.</param>
+    /// <param name="completeness">The completeness state to stamp on the projection.</param>
+    public static ConversationUsageAggregate Fold(
+        string rootConversationId,
+        IEnumerable<UsageRecord> records,
+        long foldedRevision,
+        UsageCompleteness completeness = UsageCompleteness.InProgress)
+    {
+        // Dedup by attempt id — the highest revision replaces earlier ones (cumulative streaming / retry).
+        var deduped = records
+            .GroupBy(r => r.ProviderAttemptId)
+            .Select(g => g.OrderByDescending(r => r.Revision).First())
+            .ToList();
+
+        var perModel = deduped
+            .GroupBy(r => r.EffectiveModelId)
+            .OrderBy(g => g.Key, StringComparer.Ordinal)
+            .Select(g => new ModelUsageRow
+            {
+                ModelId = g.Key,
+                InputTokens = g.Sum(r => r.InputTokens),
+                OutputTokens = g.Sum(r => r.OutputTokens),
+                CacheReadTokens = g.Sum(r => r.CacheReadTokens),
+                CacheWriteTokens = g.Sum(r => r.CacheWriteTokens),
+                ReasoningTokens = g.Sum(r => r.ReasoningTokens),
+                TotalTokens = g.Sum(r => r.TotalTokens),
+                EstimatedPublicCostMicros = SumKnown(g.Select(r => r.EstimatedPublicCostMicros)),
+                ProviderReportedCostMicros = SumKnown(g.Select(r => r.ProviderReportedCostMicros)),
+                AttemptCount = g.Count(),
+            })
+            .ToList();
+
+        return new ConversationUsageAggregate
+        {
+            RootConversationId = rootConversationId,
+            FoldedRevision = foldedRevision,
+            Completeness = completeness,
+            PerModel = perModel,
+            TotalTokens = perModel.Sum(m => m.TotalTokens),
+            EstimatedPublicCostMicros = SumKnown(perModel.Select(m => m.EstimatedPublicCostMicros)),
+            ProviderReportedCostMicros = SumKnown(perModel.Select(m => m.ProviderReportedCostMicros)),
+        };
+    }
+
+    /// <summary>
+    ///     Sums cost figures treating null as "unknown": null contributes nothing and the result is null
+    ///     only when every value is null (a known-cost subtotal — never surfaces <c>0</c> for entirely
+    ///     unknown pricing).
+    /// </summary>
+    private static long? SumKnown(IEnumerable<long?> values)
+    {
+        long sum = 0;
+        var anyKnown = false;
+        foreach (var value in values)
+        {
+            if (value.HasValue)
+            {
+                sum += value.Value;
+                anyKnown = true;
+            }
+        }
+
+        return anyKnown ? sum : null;
+    }
+}

--- a/src/LmCore/Models/ModelPricing.cs
+++ b/src/LmCore/Models/ModelPricing.cs
@@ -1,0 +1,50 @@
+namespace AchieveAi.LmDotnetTools.LmCore.Models;
+
+/// <summary>
+///     Immutable per-model public pricing snapshot used to estimate cost from token counts. Captured at
+///     execution time so a later catalog change never silently reprices a historical conversation (#196).
+///     Rates are per one million tokens; money is computed in integer micro-units (1e-6 of
+///     <see cref="Currency" />) for deterministic arithmetic.
+/// </summary>
+public sealed record ModelPricing
+{
+    /// <summary>The model these rates apply to.</summary>
+    public required string ModelId { get; init; }
+
+    /// <summary>Cost per one million input (prompt) tokens, in <see cref="Currency" /> units.</summary>
+    public required decimal PromptPerMillion { get; init; }
+
+    /// <summary>Cost per one million output (completion) tokens, in <see cref="Currency" /> units.</summary>
+    public required decimal CompletionPerMillion { get; init; }
+
+    /// <summary>ISO currency code for the rates.</summary>
+    public string Currency { get; init; } = "USD";
+
+    /// <summary>Pricing catalog source (e.g. provider name or "openrouter").</summary>
+    public string? Source { get; init; }
+
+    /// <summary>Catalog version or effective date, for provenance.</summary>
+    public string? Version { get; init; }
+
+    /// <summary>
+    ///     Estimates the cost of the given token counts in micro-units. Because a per-million rate times a
+    ///     token count already yields micro-units (tokens × rate ÷ 1e6 × 1e6), this is simply
+    ///     <c>input × PromptPerMillion + output × CompletionPerMillion</c>, rounded half-to-even.
+    /// </summary>
+    public long EstimateMicros(long inputTokens, long outputTokens)
+    {
+        var micros = (inputTokens * PromptPerMillion) + (outputTokens * CompletionPerMillion);
+        return (long)decimal.Round(micros, MidpointRounding.ToEven);
+    }
+}
+
+/// <summary>
+///     Narrow abstraction that resolves a model id to its <see cref="ModelPricing" />. Lets the usage
+///     accounting layer estimate public cost without taking a direct dependency on the configuration
+///     library (#196).
+/// </summary>
+public interface IPricingResolver
+{
+    /// <summary>Resolves pricing for a model, or null when no public pricing is available for it.</summary>
+    ModelPricing? Resolve(string modelId);
+}

--- a/src/LmCore/Models/UsageRecord.cs
+++ b/src/LmCore/Models/UsageRecord.cs
@@ -1,0 +1,131 @@
+namespace AchieveAi.LmDotnetTools.LmCore.Models;
+
+/// <summary>
+///     Provenance of a resolved cost figure.
+/// </summary>
+public enum CostProvenance
+{
+    /// <summary>No cost could be resolved (unknown / retired / free / reseller-priced model).</summary>
+    Unavailable,
+
+    /// <summary>Cost estimated from the public pricing catalog.</summary>
+    PublicEstimate,
+
+    /// <summary>Cost reported directly by the provider.</summary>
+    ProviderReported,
+}
+
+/// <summary>
+///     The execution context that produced a usage record, for attribution within a conversation tree.
+/// </summary>
+public enum UsageExecutionKind
+{
+    /// <summary>The primary (root) agent turn.</summary>
+    Primary,
+
+    /// <summary>A directly spawned sub-agent.</summary>
+    SubAgent,
+
+    /// <summary>An LmWorkflow controller loop.</summary>
+    WorkflowController,
+
+    /// <summary>An LmWorkflow task agent.</summary>
+    WorkflowTask,
+
+    /// <summary>A continuation / restart of an existing execution.</summary>
+    Continuation,
+}
+
+/// <summary>
+///     A durable, idempotent record of the token usage and cost for a single billable provider attempt.
+///     This is the canonical accounting fact for conversation-wide usage (issue #196): the parent
+///     conversation aggregate is a pure fold of these records.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Records are deduplicated by <see cref="ProviderAttemptId" />. Cumulative streaming updates,
+///         retries, reconnects, and replays for the same attempt <b>replace</b> (never add to) the prior
+///         record for that key — the highest <see cref="Revision" /> wins.
+///     </para>
+///     <para>
+///         Money is stored in integer micro-units (1e-6 of <see cref="Currency" />) for deterministic
+///         arithmetic — never cumulative binary floating point.
+///     </para>
+///     <para>
+///         Token semantics (normative): <see cref="CacheReadTokens" /> ⊆ <see cref="InputTokens" />,
+///         <see cref="ReasoningTokens" /> ⊆ <see cref="OutputTokens" />, and
+///         <see cref="CacheWriteTokens" /> is additive, so
+///         <see cref="TotalTokens" /> = input + cache-write + output.
+///     </para>
+/// </remarks>
+public sealed record UsageRecord
+{
+    // --- Identity ---
+
+    /// <summary>Identifier of the intended model call — stable across retries/fallbacks/replays.</summary>
+    public required string LogicalCallId { get; init; }
+
+    /// <summary>Identifier of a single separately-billable provider attempt. The dedup key.</summary>
+    public required string ProviderAttemptId { get; init; }
+
+    /// <summary>Per-conversation monotonic revision assigned when this record is (re)written.</summary>
+    public long Revision { get; init; }
+
+    // --- Lineage ---
+
+    /// <summary>The root conversation this attempt is attributed to.</summary>
+    public required string RootConversationId { get; init; }
+
+    /// <summary>The parent execution id (null for the root).</summary>
+    public string? ParentExecutionId { get; init; }
+
+    /// <summary>How this attempt was produced (primary / sub-agent / workflow / continuation).</summary>
+    public UsageExecutionKind ExecutionKind { get; init; } = UsageExecutionKind.Primary;
+
+    // --- Model ---
+
+    /// <summary>The model the caller requested.</summary>
+    public required string RequestedModel { get; init; }
+
+    /// <summary>The effective / actual provider model, when it differs from the requested one.</summary>
+    public string? EffectiveModel { get; init; }
+
+    /// <summary>The model id used for grouping — the effective model when present, else requested.</summary>
+    public string EffectiveModelId => string.IsNullOrEmpty(EffectiveModel) ? RequestedModel : EffectiveModel;
+
+    // --- Token counts (64-bit) ---
+
+    /// <summary>Billed input tokens (includes <see cref="CacheReadTokens" />).</summary>
+    public long InputTokens { get; init; }
+
+    /// <summary>Billed output tokens (includes <see cref="ReasoningTokens" />).</summary>
+    public long OutputTokens { get; init; }
+
+    /// <summary>Cached-read tokens — a subset of <see cref="InputTokens" />.</summary>
+    public long CacheReadTokens { get; init; }
+
+    /// <summary>Cache-creation tokens — billed separately, additive to the total.</summary>
+    public long CacheWriteTokens { get; init; }
+
+    /// <summary>Reasoning tokens — a subset of <see cref="OutputTokens" />.</summary>
+    public long ReasoningTokens { get; init; }
+
+    /// <summary>Total billable tokens: input + cache-write + output.</summary>
+    public long TotalTokens => InputTokens + CacheWriteTokens + OutputTokens;
+
+    // --- Cost (micro-units) ---
+
+    /// <summary>Public-pricing cost estimate in micro-units, or null when unavailable.</summary>
+    public long? EstimatedPublicCostMicros { get; init; }
+
+    /// <summary>Provider-reported cost in micro-units, or null when the provider reports none.</summary>
+    public long? ProviderReportedCostMicros { get; init; }
+
+    /// <summary>ISO currency code for the cost figures.</summary>
+    public string Currency { get; init; } = "USD";
+
+    // --- Finalization ---
+
+    /// <summary>True once the terminal (final accumulated) usage for this attempt has been observed.</summary>
+    public bool Finalized { get; init; }
+}

--- a/src/LmMultiTurn/MultiTurnAgentBase.cs
+++ b/src/LmMultiTurn/MultiTurnAgentBase.cs
@@ -351,21 +351,6 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
         EnsureUsageWriter()?.Schedule();
     }
 
-    private async Task PersistUsageSnapshotAsync(
-        IConversationStore store,
-        ConversationUsageAggregate snapshot,
-        IReadOnlyList<UsageRecord> records)
-    {
-        try
-        {
-            await ConversationUsageProjection.SaveAsync(store, snapshot, records, CancellationToken.None);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex, "Failed to persist usage snapshot for thread {ThreadId}", ThreadId);
-        }
-    }
-
     /// <summary>
     /// Schedules a durable write of the current usage ledger snapshot + records for the root conversation
     /// through the serialized writer. Handed to the SubAgentManager so a descendant's usage is made durable
@@ -402,7 +387,8 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
         lock (_usageWriterLock)
         {
             return _usageWriter ??= new UsagePersistenceWriter(
-                _ => PersistUsageSnapshotAsync(store, ledger.Snapshot(), ledger.SnapshotRecords()));
+                ct => ConversationUsageProjection.SaveAsync(store, ledger.Snapshot(), ledger.SnapshotRecords(), ct),
+                onError: ex => Logger.LogWarning(ex, "Failed to persist usage snapshot for thread {ThreadId}", ThreadId));
         }
     }
 
@@ -420,7 +406,13 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
 
         try
         {
-            await writer.FlushAsync();
+            var durable = await writer.FlushAsync();
+            if (!durable)
+            {
+                Logger.LogError(
+                    "Usage flush did not achieve durability for thread {ThreadId}; final usage may remain only in memory",
+                    ThreadId);
+            }
         }
         catch (Exception ex)
         {

--- a/src/LmMultiTurn/MultiTurnAgentBase.cs
+++ b/src/LmMultiTurn/MultiTurnAgentBase.cs
@@ -66,6 +66,12 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     // appends). Guards the "recover persisted history on (re)create" path used by the agent pool.
     private bool _historyRecovered;
     private bool _usageHydrated;
+
+    // Serialized/coalesced durable-usage writer, created lazily once both a ledger and store exist. Both
+    // the primary loop's own usage and every descendant relay route through it, so writes never interleave
+    // and run completion / disposal can await a final flush (#196).
+    private UsagePersistenceWriter? _usageWriter;
+    private readonly object _usageWriterLock = new();
     private volatile bool _isDisposed;
 
     // Set once run-ledger reconciliation has run for this process instance, so RunAsync never
@@ -342,11 +348,7 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
             DefaultOptions.ModelId);
         ledger.RecordUsage(record);
 
-        var store = Store;
-        if (store != null)
-        {
-            _ = PersistUsageSnapshotAsync(store, ledger.Snapshot(), ledger.SnapshotRecords());
-        }
+        EnsureUsageWriter()?.Schedule();
     }
 
     private async Task PersistUsageSnapshotAsync(
@@ -365,21 +367,65 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     }
 
     /// <summary>
-    /// Persists the current usage ledger snapshot + records for the root conversation. Handed to the
-    /// SubAgentManager so a descendant's usage is made durable when it is observed — including a
-    /// late/background descendant that finishes after the root's last provider call — rather than waiting
-    /// for a future primary usage event to flush it (#196).
+    /// Schedules a durable write of the current usage ledger snapshot + records for the root conversation
+    /// through the serialized writer. Handed to the SubAgentManager so a descendant's usage is made durable
+    /// when it is observed — including a late/background descendant that finishes after the root's last
+    /// provider call — rather than waiting for a future primary usage event to flush it. Coalesced with the
+    /// primary loop's own writes so the two paths cannot interleave or race an older snapshot (#196).
     /// </summary>
     protected Task PersistCurrentUsageAsync()
     {
+        EnsureUsageWriter()?.Schedule();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Lazily creates the per-conversation serialized usage writer once both a ledger and store exist. The
+    /// persist delegate reads the ledger's latest snapshot at write time, so coalesced writes always persist
+    /// the newest state. Returns null when usage accounting is not configured for this agent.
+    /// </summary>
+    private UsagePersistenceWriter? EnsureUsageWriter()
+    {
+        var existing = _usageWriter;
+        if (existing != null)
+        {
+            return existing;
+        }
+
         var ledger = UsageLedger;
         var store = Store;
         if (ledger is null || store is null)
         {
-            return Task.CompletedTask;
+            return null;
         }
 
-        return PersistUsageSnapshotAsync(store, ledger.Snapshot(), ledger.SnapshotRecords());
+        lock (_usageWriterLock)
+        {
+            return _usageWriter ??= new UsagePersistenceWriter(
+                _ => PersistUsageSnapshotAsync(store, ledger.Snapshot(), ledger.SnapshotRecords()));
+        }
+    }
+
+    /// <summary>
+    /// Awaits any pending/in-flight usage write so the latest snapshot is durable before run completion or
+    /// disposal proceeds. Best-effort: a persistence fault must not fault the caller's lifecycle (#196).
+    /// </summary>
+    private async Task FlushUsageAsync()
+    {
+        var writer = _usageWriter;
+        if (writer is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await writer.FlushAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Usage flush failed for thread {ThreadId}", ThreadId);
+        }
     }
 
     /// <summary>
@@ -1289,7 +1335,16 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
 
         Logger.LogInformation("{AgentType} started. ThreadId: {ThreadId}", GetType().Name, ThreadId);
 
-        await _runTask;
+        try
+        {
+            await _runTask;
+        }
+        finally
+        {
+            // Guarantee the conversation's final usage snapshot is durable before the run returns — a
+            // completed/cancelled run must not leave the latest aggregate only in memory (#196).
+            await FlushUsageAsync();
+        }
     }
 
     /// <inheritdoc />
@@ -1343,6 +1398,10 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
         _isDisposed = true;
 
         await StopAsync();
+
+        // Final durability boundary: flush any usage write scheduled by a late/background descendant that
+        // finished after the run stopped, so it is persisted rather than lost at shutdown (#196).
+        await FlushUsageAsync();
 
         _internalCts?.Dispose();
 

--- a/src/LmMultiTurn/MultiTurnAgentBase.cs
+++ b/src/LmMultiTurn/MultiTurnAgentBase.cs
@@ -3,8 +3,10 @@ using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Models;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
+using AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -115,6 +117,13 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     /// Optional persistence store for conversation state.
     /// </summary>
     protected IConversationStore? Store { get; }
+
+    /// <summary>
+    /// Conversation-wide usage ledger (#196). Set by a derived loop when usage accounting is enabled; it
+    /// is shared with the loop's <c>SubAgentManager</c> so the primary loop's own usage and every
+    /// descendant's usage accumulate into one root total. Null disables usage accounting.
+    /// </summary>
+    protected UsageLedger? UsageLedger { get; set; }
 
     /// <summary>
     /// Non-null only when the constructor's <c>persistRunLedger</c> flag is set, in which case
@@ -286,6 +295,13 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
             ConversationHistory.Add(message);
         }
 
+        // Capture the primary loop's own usage into the conversation-wide ledger (#196). Descendant
+        // usage is folded in separately via the SubAgentManager relay into the same ledger instance.
+        if (UsageLedger != null && message is UsageMessage usageMessage)
+        {
+            CaptureAndPersistUsage(usageMessage);
+        }
+
         // Fire-and-forget persistence
         if (Store != null)
         {
@@ -302,6 +318,45 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
             {
                 _ = PersistMessageAsync(message, runId, CancellationToken.None);
             }
+        }
+    }
+
+    /// <summary>
+    /// Records the primary loop's usage into the conversation-wide ledger and, when a store is configured,
+    /// persists the updated aggregate snapshot (fire-and-forget). The snapshot reflects both this primary
+    /// usage and any descendant usage already folded in via the SubAgentManager relay (#196).
+    /// </summary>
+    private void CaptureAndPersistUsage(UsageMessage usageMessage)
+    {
+        var ledger = UsageLedger;
+        if (ledger is null)
+        {
+            return;
+        }
+
+        var record = UsageRecordMapper.FromUsageMessage(
+            usageMessage,
+            ThreadId,
+            UsageExecutionKind.Primary,
+            DefaultOptions.ModelId);
+        ledger.RecordUsage(record);
+
+        var store = Store;
+        if (store != null)
+        {
+            _ = PersistUsageSnapshotAsync(store, ledger.Snapshot());
+        }
+    }
+
+    private async Task PersistUsageSnapshotAsync(IConversationStore store, ConversationUsageAggregate snapshot)
+    {
+        try
+        {
+            await ConversationUsageProjection.SaveAsync(store, snapshot, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to persist usage snapshot for thread {ThreadId}", ThreadId);
         }
     }
 

--- a/src/LmMultiTurn/MultiTurnAgentBase.cs
+++ b/src/LmMultiTurn/MultiTurnAgentBase.cs
@@ -65,6 +65,7 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     // startup recovery and any explicit RecoverAsync call never double-restore (RestoreHistory
     // appends). Guards the "recover persisted history on (re)create" path used by the agent pool.
     private bool _historyRecovered;
+    private bool _usageHydrated;
     private volatile bool _isDisposed;
 
     // Set once run-ledger reconciliation has run for this process instance, so RunAsync never
@@ -344,15 +345,18 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
         var store = Store;
         if (store != null)
         {
-            _ = PersistUsageSnapshotAsync(store, ledger.Snapshot());
+            _ = PersistUsageSnapshotAsync(store, ledger.Snapshot(), ledger.SnapshotRecords());
         }
     }
 
-    private async Task PersistUsageSnapshotAsync(IConversationStore store, ConversationUsageAggregate snapshot)
+    private async Task PersistUsageSnapshotAsync(
+        IConversationStore store,
+        ConversationUsageAggregate snapshot,
+        IReadOnlyList<UsageRecord> records)
     {
         try
         {
-            await ConversationUsageProjection.SaveAsync(store, snapshot, CancellationToken.None);
+            await ConversationUsageProjection.SaveAsync(store, snapshot, records, CancellationToken.None);
         }
         catch (Exception ex)
         {
@@ -1233,6 +1237,31 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
         {
             _runLedgerReconciled = true;
             await ReconcileRunLedgerAsync(ct);
+        }
+
+        // Rebuild conversation usage accounting from durable per-attempt records before processing input,
+        // so an agent recreated after a restart continues the running total (and dedups already-counted
+        // attempts) instead of overwriting the persisted aggregate with only post-restart usage (#196).
+        if (UsageLedger != null && Store != null && !_usageHydrated)
+        {
+            _usageHydrated = true;
+            try
+            {
+                var records = await ConversationUsageProjection.LoadRecordsAsync(Store, ThreadId, ct);
+                if (records.Count > 0)
+                {
+                    var aggregate = await ConversationUsageProjection.LoadAsync(Store, ThreadId, ct);
+                    UsageLedger.SeedFromRecords(records, aggregate?.FoldedRevision ?? 0);
+                }
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex, "Usage rebuild failed for thread {ThreadId}; starting usage empty", ThreadId);
+            }
         }
 
         await OnBeforeRunAsync();

--- a/src/LmMultiTurn/MultiTurnAgentBase.cs
+++ b/src/LmMultiTurn/MultiTurnAgentBase.cs
@@ -365,6 +365,24 @@ public abstract class MultiTurnAgentBase : IMultiTurnAgent
     }
 
     /// <summary>
+    /// Persists the current usage ledger snapshot + records for the root conversation. Handed to the
+    /// SubAgentManager so a descendant's usage is made durable when it is observed — including a
+    /// late/background descendant that finishes after the root's last provider call — rather than waiting
+    /// for a future primary usage event to flush it (#196).
+    /// </summary>
+    protected Task PersistCurrentUsageAsync()
+    {
+        var ledger = UsageLedger;
+        var store = Store;
+        if (ledger is null || store is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        return PersistUsageSnapshotAsync(store, ledger.Snapshot(), ledger.SnapshotRecords());
+    }
+
+    /// <summary>
     /// Gets a snapshot of the conversation history in a thread-safe manner.
     /// </summary>
     /// <returns>A read-only list containing the current conversation history</returns>

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -5,11 +5,13 @@ using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmCore.Models;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Middleware;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Triggers;
+using AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
 using Microsoft.Extensions.Logging;
 
 namespace AchieveAi.LmDotnetTools.LmMultiTurn;
@@ -111,6 +113,10 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase, ISubAgentContextSin
     ///     (with the built-in one-shot <c>timer</c> source plus any host registrations). When null,
     ///     no wait tools are exposed.
     /// </param>
+    /// <param name="pricingResolver">
+    ///     Optional public-pricing resolver for conversation-wide usage accounting (#196). When supplied,
+    ///     the usage ledger fills an estimated public cost per model; null still captures token totals.
+    /// </param>
     public MultiTurnAgentLoop(
         IStreamingAgent providerAgent,
         FunctionRegistry functionRegistry,
@@ -126,11 +132,17 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase, ISubAgentContextSin
         MutableSubAgentTemplateSource? subAgentTemplateSource = null,
         ILoggerFactory? loggerFactory = null,
         bool persistRunLedger = false,
-        TriggerOptions? triggerOptions = null)
+        TriggerOptions? triggerOptions = null,
+        IPricingResolver? pricingResolver = null)
         : base(threadId, systemPrompt, defaultOptions, maxTurnsPerRun, inputChannelCapacity, outputChannelCapacity, store, logger, persistRunLedger: persistRunLedger)
     {
         ArgumentNullException.ThrowIfNull(providerAgent);
         ArgumentNullException.ThrowIfNull(functionRegistry);
+
+        // Conversation-wide usage accounting (#196): one ledger per root conversation, shared below with
+        // the SubAgentManager so the primary loop's own usage and every descendant's usage accumulate
+        // into a single root total. Usage is captured in MultiTurnAgentBase.AddToHistory.
+        UsageLedger = new UsageLedger(threadId, pricingResolver);
 
         // When sub-agent orchestration is configured, snapshot the current tools
         // and register Agent/CheckAgent tools before building the middleware stack.
@@ -167,7 +179,9 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase, ISubAgentContextSin
                 logger: logger,
                 // Sub-agents whose template/override sets no model inherit the parent's model, so a
                 // built-in template doesn't fall back to the provider's stale hardcoded default.
-                parentModelId: DefaultOptions.ModelId);
+                parentModelId: DefaultOptions.ModelId,
+                // Share the root ledger so descendant usage folds into the same conversation total (#196).
+                usageSink: UsageLedger);
 
             var toolProvider = new SubAgentToolProvider(
                 SubAgentManager,

--- a/src/LmMultiTurn/MultiTurnAgentLoop.cs
+++ b/src/LmMultiTurn/MultiTurnAgentLoop.cs
@@ -181,7 +181,9 @@ public sealed class MultiTurnAgentLoop : MultiTurnAgentBase, ISubAgentContextSin
                 // built-in template doesn't fall back to the provider's stale hardcoded default.
                 parentModelId: DefaultOptions.ModelId,
                 // Share the root ledger so descendant usage folds into the same conversation total (#196).
-                usageSink: UsageLedger);
+                usageSink: UsageLedger,
+                // Persist immediately on each descendant observation (covers late/background descendants).
+                persistUsageAsync: PersistCurrentUsageAsync);
 
             var toolProvider = new SubAgentToolProvider(
                 SubAgentManager,

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -1516,42 +1516,16 @@ public sealed class SubAgentManager : IAsyncDisposable
     /// </summary>
     /// <summary>
     /// Maps a descendant's <see cref="UsageMessage"/> into a <see cref="UsageRecord"/> for the root
-    /// ledger. Token counts are captured verbatim (per-call field accuracy is tracked by #116); the model
-    /// is the sub-agent's resolved model (override, else inherited parent model). The
-    /// <c>RootConversationId</c> placeholder is re-stamped to the ledger's root by
-    /// <see cref="UsageLedger.RecordUsage"/>.
+    /// ledger via the shared <see cref="UsageRecordMapper"/>. The model is the sub-agent's resolved model
+    /// (override, else inherited parent model); the <c>RootConversationId</c> placeholder is re-stamped to
+    /// the ledger's root by <see cref="UsageLedger.RecordUsage"/>.
     /// </summary>
-    private UsageRecord BuildDescendantUsageRecord(UsageMessage message, SubAgentState state)
-    {
-        var usage = message.Usage;
-
-        // A generation is one provider call; combined with the sub-agent id it is a stable, globally
-        // unique dedup key across the conversation tree. Fall back to the run id, then a fixed token.
-        var attemptKey = message.GenerationId ?? message.RunId ?? "usage";
-        var attemptId = $"{state.AgentId}:{attemptKey}";
-        var model = state.ModelOverride ?? _parentModelId ?? "unknown";
-
-        return new UsageRecord
-        {
-            LogicalCallId = attemptId,
-            ProviderAttemptId = attemptId,
-            RootConversationId = state.AgentId,
-            ParentExecutionId = state.AgentId,
-            ExecutionKind = UsageExecutionKind.SubAgent,
-            RequestedModel = model,
-            InputTokens = usage.PromptTokens,
-            OutputTokens = usage.CompletionTokens,
-            CacheReadTokens = usage.TotalCachedTokens,
-            ReasoningTokens = usage.TotalReasoningTokens,
-            ProviderReportedCostMicros = ToMicros(usage.TotalCost),
-            Finalized = true,
-        };
-    }
-
-    private static long? ToMicros(double? cost)
-    {
-        return cost is null ? null : (long)Math.Round(cost.Value * 1_000_000d);
-    }
+    private UsageRecord BuildDescendantUsageRecord(UsageMessage message, SubAgentState state) =>
+        UsageRecordMapper.FromUsageMessage(
+            message,
+            state.AgentId,
+            UsageExecutionKind.SubAgent,
+            state.ModelOverride ?? _parentModelId);
 
     private static SubAgentTurnSummary? CreateTurnSummary(IMessage msg)
     {

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -7,8 +7,10 @@ using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmCore.Models;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
+using AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -27,6 +29,11 @@ public sealed class SubAgentManager : IAsyncDisposable
     private readonly SubAgentOptions _options;
     private readonly MutableSubAgentTemplateSource _source;
     private readonly ILogger _logger;
+
+    // Optional root-conversation usage sink. When set, every UsageMessage a sub-agent (or workflow
+    // task — same relay path) emits is folded into the root conversation's usage total (issue #196).
+    // Null keeps the historical behaviour (descendant usage not aggregated).
+    private readonly IUsageSink? _usageSink;
 
     private readonly ConcurrentDictionary<string, SubAgentState> _agents = new();
     private readonly ConcurrentDictionary<string, string> _namesToIds = new();
@@ -70,7 +77,8 @@ public sealed class SubAgentManager : IAsyncDisposable
         SubAgentOptions options,
         MutableSubAgentTemplateSource source,
         ILogger? logger = null,
-        string? parentModelId = null)
+        string? parentModelId = null,
+        IUsageSink? usageSink = null)
     {
         ArgumentNullException.ThrowIfNull(parentAgent);
         ArgumentNullException.ThrowIfNull(parentContracts);
@@ -84,6 +92,7 @@ public sealed class SubAgentManager : IAsyncDisposable
         _options = options;
         _source = source;
         _logger = logger ?? NullLogger.Instance;
+        _usageSink = usageSink;
         // The parent's model, inherited by sub-agents whose template/override sets none (see
         // ResolveSubAgentOptions). Null when the parent has no model (e.g. CLI-backed parents).
         _parentModelId = parentModelId;
@@ -1248,6 +1257,13 @@ public sealed class SubAgentManager : IAsyncDisposable
                     }
                 }
 
+                // Fold this descendant's usage into the root conversation total (issue #196). Without
+                // this, a sub-agent's (and workflow task's — same relay path) token spend was dropped.
+                if (_usageSink is not null && msg is UsageMessage usageMessage)
+                {
+                    _usageSink.RecordUsage(BuildDescendantUsageRecord(usageMessage, state));
+                }
+
                 // Track the last assistant text for the completion result. Subscribers
                 // receive raw deltas, so accumulate TextUpdateMessage deltas per
                 // generation; a consolidated TextMessage (non-streaming mock) is taken as-is.
@@ -1498,6 +1514,45 @@ public sealed class SubAgentManager : IAsyncDisposable
     /// Creates a lightweight turn summary from a message for the peek buffer.
     /// Returns null for internal/control messages that should be skipped.
     /// </summary>
+    /// <summary>
+    /// Maps a descendant's <see cref="UsageMessage"/> into a <see cref="UsageRecord"/> for the root
+    /// ledger. Token counts are captured verbatim (per-call field accuracy is tracked by #116); the model
+    /// is the sub-agent's resolved model (override, else inherited parent model). The
+    /// <c>RootConversationId</c> placeholder is re-stamped to the ledger's root by
+    /// <see cref="UsageLedger.RecordUsage"/>.
+    /// </summary>
+    private UsageRecord BuildDescendantUsageRecord(UsageMessage message, SubAgentState state)
+    {
+        var usage = message.Usage;
+
+        // A generation is one provider call; combined with the sub-agent id it is a stable, globally
+        // unique dedup key across the conversation tree. Fall back to the run id, then a fixed token.
+        var attemptKey = message.GenerationId ?? message.RunId ?? "usage";
+        var attemptId = $"{state.AgentId}:{attemptKey}";
+        var model = state.ModelOverride ?? _parentModelId ?? "unknown";
+
+        return new UsageRecord
+        {
+            LogicalCallId = attemptId,
+            ProviderAttemptId = attemptId,
+            RootConversationId = state.AgentId,
+            ParentExecutionId = state.AgentId,
+            ExecutionKind = UsageExecutionKind.SubAgent,
+            RequestedModel = model,
+            InputTokens = usage.PromptTokens,
+            OutputTokens = usage.CompletionTokens,
+            CacheReadTokens = usage.TotalCachedTokens,
+            ReasoningTokens = usage.TotalReasoningTokens,
+            ProviderReportedCostMicros = ToMicros(usage.TotalCost),
+            Finalized = true,
+        };
+    }
+
+    private static long? ToMicros(double? cost)
+    {
+        return cost is null ? null : (long)Math.Round(cost.Value * 1_000_000d);
+    }
+
     private static SubAgentTurnSummary? CreateTurnSummary(IMessage msg)
     {
         return msg switch

--- a/src/LmMultiTurn/SubAgents/SubAgentManager.cs
+++ b/src/LmMultiTurn/SubAgents/SubAgentManager.cs
@@ -35,6 +35,10 @@ public sealed class SubAgentManager : IAsyncDisposable
     // Null keeps the historical behaviour (descendant usage not aggregated).
     private readonly IUsageSink? _usageSink;
 
+    // Optional durable-persist callback invoked after a descendant observation, so late/background
+    // descendant usage is persisted immediately instead of waiting for a future primary usage event.
+    private readonly Func<Task>? _persistUsageAsync;
+
     private readonly ConcurrentDictionary<string, SubAgentState> _agents = new();
     private readonly ConcurrentDictionary<string, string> _namesToIds = new();
     private readonly SemaphoreSlim _concurrencyGate;
@@ -78,7 +82,8 @@ public sealed class SubAgentManager : IAsyncDisposable
         MutableSubAgentTemplateSource source,
         ILogger? logger = null,
         string? parentModelId = null,
-        IUsageSink? usageSink = null)
+        IUsageSink? usageSink = null,
+        Func<Task>? persistUsageAsync = null)
     {
         ArgumentNullException.ThrowIfNull(parentAgent);
         ArgumentNullException.ThrowIfNull(parentContracts);
@@ -93,6 +98,7 @@ public sealed class SubAgentManager : IAsyncDisposable
         _source = source;
         _logger = logger ?? NullLogger.Instance;
         _usageSink = usageSink;
+        _persistUsageAsync = persistUsageAsync;
         // The parent's model, inherited by sub-agents whose template/override sets none (see
         // ResolveSubAgentOptions). Null when the parent has no model (e.g. CLI-backed parents).
         _parentModelId = parentModelId;
@@ -1262,6 +1268,13 @@ public sealed class SubAgentManager : IAsyncDisposable
                 if (_usageSink is not null && msg is UsageMessage usageMessage)
                 {
                     _usageSink.RecordUsage(BuildDescendantUsageRecord(usageMessage, state));
+
+                    // Persist immediately so a late/background descendant's spend is durable even if no
+                    // further primary usage event follows to flush it (#196).
+                    if (_persistUsageAsync is not null)
+                    {
+                        _ = _persistUsageAsync();
+                    }
                 }
 
                 // Track the last assistant text for the completion result. Subscribers

--- a/src/LmMultiTurn/UsageAccounting/ConversationUsageProjection.cs
+++ b/src/LmMultiTurn/UsageAccounting/ConversationUsageProjection.cs
@@ -6,27 +6,36 @@ using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
 namespace AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
 
 /// <summary>
-///     Persists and reads the conversation usage aggregate as a projection inside
-///     <see cref="ThreadMetadata.Properties" /> — zero schema migration, uniform across every
-///     <see cref="IConversationStore" /> backend.
+///     Persists and reads conversation usage inside <see cref="ThreadMetadata.Properties" /> — zero schema
+///     migration, uniform across every <see cref="IConversationStore" /> backend. Two artifacts are stored:
+///     the canonical per-attempt <b>records</b> (the durable source of truth, deduped by provider attempt)
+///     and the derived <b>aggregate</b> projection folded from them (#196).
 /// </summary>
 /// <remarks>
-///     The value is stored as a JSON <b>string</b> so it round-trips identically whether the backing store
+///     Values are stored as JSON <b>strings</b> so they round-trip identically whether the backing store
 ///     keeps native CLR objects (in-memory) or re-hydrates property-bag values as <see cref="JsonElement" />
-///     (file / SQLite). This is the single property-bag adapter for usage data (issue #196).
+///     (file / SQLite) — the single property-bag adapter for usage data.
 /// </remarks>
 public static class ConversationUsageProjection
 {
     /// <summary>The metadata property-bag key under which the usage aggregate JSON is stored.</summary>
     public const string PropertyKey = "usage.aggregate";
 
+    /// <summary>The metadata property-bag key under which the canonical per-attempt records JSON is stored.</summary>
+    public const string RecordsPropertyKey = "usage.records";
+
     /// <summary>Highest usage-aggregate schema version this build understands; newer is treated as absent.</summary>
     private const int CurrentSchemaVersion = 1;
 
-    /// <summary>Atomically writes the aggregate into the conversation's metadata property bag.</summary>
+    /// <summary>
+    ///     Atomically persists the aggregate and (optionally) its canonical records into the conversation's
+    ///     metadata property bag, under a watermark guard so a stale/out-of-order/post-restart write cannot
+    ///     replace a newer aggregate with a lower-<see cref="ConversationUsageAggregate.FoldedRevision" /> one.
+    /// </summary>
     public static Task SaveAsync(
         IConversationStore store,
         ConversationUsageAggregate aggregate,
+        IReadOnlyList<UsageRecord>? records = null,
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(store);
@@ -36,18 +45,18 @@ public static class ConversationUsageProjection
             aggregate.RootConversationId,
             existing =>
             {
-                // Guard against stale/out-of-order writes and post-restart regressions: never let a
-                // snapshot with a lower complete-prefix watermark replace a newer persisted one. Because
-                // this runs under the store's write serialization, concurrent fire-and-forget writers
-                // cannot clobber a newer aggregate with an older one (#196).
+                // Runs under the store's write serialization, so concurrent fire-and-forget writers cannot
+                // clobber a newer aggregate with an older one; and a recreated writer after a restart cannot
+                // regress the persisted totals.
                 var current = FromMetadata(existing);
                 if (existing is not null && current is not null && current.FoldedRevision > aggregate.FoldedRevision)
                 {
                     return existing;
                 }
 
-                var json = JsonSerializer.Serialize(aggregate);
-                return WithProjection(existing, aggregate.RootConversationId, json);
+                var aggregateJson = JsonSerializer.Serialize(aggregate);
+                var recordsJson = records is null ? null : JsonSerializer.Serialize(records);
+                return WithProjection(existing, aggregate.RootConversationId, aggregateJson, recordsJson);
             },
             ct);
     }
@@ -63,34 +72,31 @@ public static class ConversationUsageProjection
         return FromMetadata(metadata);
     }
 
+    /// <summary>Loads the persisted canonical records for a conversation (empty when none), for rebuild.</summary>
+    public static async Task<IReadOnlyList<UsageRecord>> LoadRecordsAsync(
+        IConversationStore store,
+        string threadId,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        var metadata = await store.LoadMetadataAsync(threadId, ct);
+        return RecordsFromMetadata(metadata);
+    }
+
     /// <summary>
     ///     Extracts the aggregate from already-loaded metadata. Store-agnostic: accepts the value whether it
     ///     is a native JSON string (in-memory) or a re-hydrated <see cref="JsonElement" /> (file / SQLite).
     /// </summary>
     public static ConversationUsageAggregate? FromMetadata(ThreadMetadata? metadata)
     {
-        if (metadata?.Properties is null
-            || !metadata.Properties.TryGetValue(PropertyKey, out var raw)
-            || raw is null)
-        {
-            return null;
-        }
-
-        var json = raw switch
-        {
-            string s => s,
-            JsonElement { ValueKind: JsonValueKind.String } element => element.GetString(),
-            JsonElement element => element.GetRawText(),
-            _ => null,
-        };
-
+        var json = RawJson(metadata, PropertyKey);
         if (json is null)
         {
             return null;
         }
 
         // Tolerate corrupt or incompatible persisted usage rather than surfacing a 500 on the usage
-        // endpoint: treat unparseable metadata as "no usage recorded" (#196).
+        // endpoint: treat unparseable/newer-schema metadata as "no usage recorded" (#196).
         try
         {
             var aggregate = JsonSerializer.Deserialize<ConversationUsageAggregate>(json);
@@ -102,10 +108,56 @@ public static class ConversationUsageProjection
         }
     }
 
-    private static ThreadMetadata WithProjection(ThreadMetadata? existing, string threadId, string json)
+    /// <summary>Extracts the canonical records from already-loaded metadata (empty when absent/corrupt).</summary>
+    public static IReadOnlyList<UsageRecord> RecordsFromMetadata(ThreadMetadata? metadata)
+    {
+        var json = RawJson(metadata, RecordsPropertyKey);
+        if (json is null)
+        {
+            return [];
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<UsageRecord>>(json) ?? [];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static string? RawJson(ThreadMetadata? metadata, string key)
+    {
+        if (metadata?.Properties is null
+            || !metadata.Properties.TryGetValue(key, out var raw)
+            || raw is null)
+        {
+            return null;
+        }
+
+        return raw switch
+        {
+            string s => s,
+            JsonElement { ValueKind: JsonValueKind.String } element => element.GetString(),
+            JsonElement element => element.GetRawText(),
+            _ => null,
+        };
+    }
+
+    private static ThreadMetadata WithProjection(
+        ThreadMetadata? existing,
+        string threadId,
+        string aggregateJson,
+        string? recordsJson)
     {
         var properties = (existing?.Properties ?? ImmutableDictionary<string, object>.Empty)
-            .SetItem(PropertyKey, json);
+            .SetItem(PropertyKey, aggregateJson);
+
+        if (recordsJson is not null)
+        {
+            properties = properties.SetItem(RecordsPropertyKey, recordsJson);
+        }
 
         if (existing is not null)
         {

--- a/src/LmMultiTurn/UsageAccounting/ConversationUsageProjection.cs
+++ b/src/LmMultiTurn/UsageAccounting/ConversationUsageProjection.cs
@@ -1,0 +1,91 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Models;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
+
+/// <summary>
+///     Persists and reads the conversation usage aggregate as a projection inside
+///     <see cref="ThreadMetadata.Properties" /> — zero schema migration, uniform across every
+///     <see cref="IConversationStore" /> backend.
+/// </summary>
+/// <remarks>
+///     The value is stored as a JSON <b>string</b> so it round-trips identically whether the backing store
+///     keeps native CLR objects (in-memory) or re-hydrates property-bag values as <see cref="JsonElement" />
+///     (file / SQLite). This is the single property-bag adapter for usage data (issue #196).
+/// </remarks>
+public static class ConversationUsageProjection
+{
+    /// <summary>The metadata property-bag key under which the usage aggregate JSON is stored.</summary>
+    public const string PropertyKey = "usage.aggregate";
+
+    /// <summary>Atomically writes the aggregate into the conversation's metadata property bag.</summary>
+    public static Task SaveAsync(
+        IConversationStore store,
+        ConversationUsageAggregate aggregate,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(aggregate);
+
+        var json = JsonSerializer.Serialize(aggregate);
+        return store.UpdateMetadataAsync(
+            aggregate.RootConversationId,
+            existing => WithProjection(existing, aggregate.RootConversationId, json),
+            ct);
+    }
+
+    /// <summary>Loads the persisted aggregate for a conversation, or null when none has been stored.</summary>
+    public static async Task<ConversationUsageAggregate?> LoadAsync(
+        IConversationStore store,
+        string threadId,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        var metadata = await store.LoadMetadataAsync(threadId, ct);
+        return FromMetadata(metadata);
+    }
+
+    /// <summary>
+    ///     Extracts the aggregate from already-loaded metadata. Store-agnostic: accepts the value whether it
+    ///     is a native JSON string (in-memory) or a re-hydrated <see cref="JsonElement" /> (file / SQLite).
+    /// </summary>
+    public static ConversationUsageAggregate? FromMetadata(ThreadMetadata? metadata)
+    {
+        if (metadata?.Properties is null
+            || !metadata.Properties.TryGetValue(PropertyKey, out var raw)
+            || raw is null)
+        {
+            return null;
+        }
+
+        var json = raw switch
+        {
+            string s => s,
+            JsonElement { ValueKind: JsonValueKind.String } element => element.GetString(),
+            JsonElement element => element.GetRawText(),
+            _ => null,
+        };
+
+        return json is null ? null : JsonSerializer.Deserialize<ConversationUsageAggregate>(json);
+    }
+
+    private static ThreadMetadata WithProjection(ThreadMetadata? existing, string threadId, string json)
+    {
+        var properties = (existing?.Properties ?? ImmutableDictionary<string, object>.Empty)
+            .SetItem(PropertyKey, json);
+
+        if (existing is not null)
+        {
+            return existing with { Properties = properties };
+        }
+
+        return new ThreadMetadata
+        {
+            ThreadId = threadId,
+            LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            Properties = properties,
+        };
+    }
+}

--- a/src/LmMultiTurn/UsageAccounting/ConversationUsageProjection.cs
+++ b/src/LmMultiTurn/UsageAccounting/ConversationUsageProjection.cs
@@ -73,11 +73,25 @@ public static class ConversationUsageProjection
 
                 if (records is { Count: > 0 })
                 {
-                    var persisted = RecordsFromMetadata(existing);
-                    var merged = MergeRecords(persisted, records);
-                    var revision = Math.Max(aggregate.FoldedRevision, PersistedFoldedRevision(existing));
+                    var persistedAggregate = FromMetadata(existing);
+
+                    // The records artifact is the authoritative per-attempt history. If it is present but
+                    // unreadable while a valid aggregate exists, merging with an empty set would drop that
+                    // history and undercount — refuse the write rather than clobber authoritative usage.
+                    if (persistedAggregate is not null && RecordsArtifactCorrupt(existing))
+                    {
+                        return existing!;
+                    }
+
+                    var merged = MergeRecords(RecordsFromMetadata(existing), records);
+                    var revision = Math.Max(aggregate.FoldedRevision, persistedAggregate?.FoldedRevision ?? 0);
+
+                    // Merge completeness monotonically so a later InProgress writer (e.g. a rebuilt writer
+                    // after restart) cannot regress a previously Complete/Partial terminal state.
+                    var completeness = MaxCompleteness(persistedAggregate?.Completeness, aggregate.Completeness);
+
                     var foldedAggregate = ConversationUsageAggregate.Fold(
-                        aggregate.RootConversationId, merged, revision, aggregate.Completeness);
+                        aggregate.RootConversationId, merged, revision, completeness);
 
                     return WithProjection(
                         existing,
@@ -138,6 +152,37 @@ public static class ConversationUsageProjection
         return [.. byAttempt.Values];
     }
 
+    /// <summary>
+    ///     True when a records artifact is present but cannot be parsed. Absent records are not "corrupt":
+    ///     they legitimately mean no prior per-attempt history (first write / aggregate-only legacy).
+    /// </summary>
+    private static bool RecordsArtifactCorrupt(ThreadMetadata? metadata)
+    {
+        var json = RawJson(metadata, RecordsPropertyKey);
+        if (json is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            _ = JsonSerializer.Deserialize<List<UsageRecord>>(json);
+            return false;
+        }
+        catch (JsonException)
+        {
+            return true;
+        }
+    }
+
+    /// <summary>Returns the more-complete of two completeness states (Complete &gt; Partial &gt; InProgress).</summary>
+    private static UsageCompleteness MaxCompleteness(UsageCompleteness? persisted, UsageCompleteness incoming)
+    {
+        return persisted is null
+            ? incoming
+            : (UsageCompleteness)Math.Max((int)persisted.Value, (int)incoming);
+    }
+
     /// <summary>Reads the persisted schema version even when it is newer than this build understands.</summary>
     private static int PersistedSchemaVersion(ThreadMetadata? metadata)
     {
@@ -159,11 +204,6 @@ public static class ConversationUsageProjection
         {
             return 0; // corrupt — treat as absent, allow overwrite
         }
-    }
-
-    private static long PersistedFoldedRevision(ThreadMetadata? metadata)
-    {
-        return FromMetadata(metadata)?.FoldedRevision ?? 0;
     }
 
     /// <summary>Loads the persisted aggregate for a conversation, or null when none has been stored.</summary>

--- a/src/LmMultiTurn/UsageAccounting/ConversationUsageProjection.cs
+++ b/src/LmMultiTurn/UsageAccounting/ConversationUsageProjection.cs
@@ -28,9 +28,26 @@ public static class ConversationUsageProjection
     private const int CurrentSchemaVersion = 1;
 
     /// <summary>
-    ///     Atomically persists the aggregate and (optionally) its canonical records into the conversation's
-    ///     metadata property bag, under a watermark guard so a stale/out-of-order/post-restart write cannot
-    ///     replace a newer aggregate with a lower-<see cref="ConversationUsageAggregate.FoldedRevision" /> one.
+    ///     Atomically persists the aggregate and its canonical records into the conversation's metadata
+    ///     property bag. Durable across restarts, concurrent writers, and rollbacks:
+    ///     <list type="bullet">
+    ///         <item>
+    ///             Records are <b>merged</b> with what is already persisted — unioned by
+    ///             <see cref="UsageRecord.ProviderAttemptId" />, highest <see cref="UsageRecord.Revision" />
+    ///             winning per attempt — then the aggregate is re-folded from the union. This is the durable
+    ///             merge identity: no writer (post-restart, second instance, or out-of-order) can drop another
+    ///             writer's attempts, even when both reuse the same process-local revision.
+    ///         </item>
+    ///         <item>
+    ///             A projection written by a <b>newer schema version</b> is never overwritten, so an older
+    ///             build during a rollback / mixed-version deployment preserves forward-compatible data.
+    ///         </item>
+    ///         <item>
+    ///             When no records are supplied (aggregate-only save), it falls back to a
+    ///             <see cref="ConversationUsageAggregate.FoldedRevision" /> guard that rejects a strictly-lower
+    ///             write.
+    ///         </item>
+    ///     </list>
     /// </summary>
     public static Task SaveAsync(
         IConversationStore store,
@@ -45,20 +62,108 @@ public static class ConversationUsageProjection
             aggregate.RootConversationId,
             existing =>
             {
-                // Runs under the store's write serialization, so concurrent fire-and-forget writers cannot
-                // clobber a newer aggregate with an older one; and a recreated writer after a restart cannot
-                // regress the persisted totals.
+                // Runs under the store's write serialization, so the read-merge-write below is atomic per
+                // conversation: concurrent writers each union with the latest persisted state.
+
+                // Forward-compatibility: refuse to overwrite a projection a newer build wrote.
+                if (PersistedSchemaVersion(existing) > CurrentSchemaVersion)
+                {
+                    return existing!;
+                }
+
+                if (records is { Count: > 0 })
+                {
+                    var persisted = RecordsFromMetadata(existing);
+                    var merged = MergeRecords(persisted, records);
+                    var revision = Math.Max(aggregate.FoldedRevision, PersistedFoldedRevision(existing));
+                    var foldedAggregate = ConversationUsageAggregate.Fold(
+                        aggregate.RootConversationId, merged, revision, aggregate.Completeness);
+
+                    return WithProjection(
+                        existing,
+                        aggregate.RootConversationId,
+                        JsonSerializer.Serialize(foldedAggregate),
+                        JsonSerializer.Serialize(merged));
+                }
+
+                // Aggregate-only save: keep the strictly-lower-watermark guard.
                 var current = FromMetadata(existing);
                 if (existing is not null && current is not null && current.FoldedRevision > aggregate.FoldedRevision)
                 {
                     return existing;
                 }
 
-                var aggregateJson = JsonSerializer.Serialize(aggregate);
-                var recordsJson = records is null ? null : JsonSerializer.Serialize(records);
-                return WithProjection(existing, aggregate.RootConversationId, aggregateJson, recordsJson);
+                return WithProjection(
+                    existing,
+                    aggregate.RootConversationId,
+                    JsonSerializer.Serialize(aggregate),
+                    recordsJson: null);
             },
             ct);
+    }
+
+    /// <summary>
+    ///     Unions persisted and incoming records by <see cref="UsageRecord.ProviderAttemptId" />, keeping the
+    ///     highest <see cref="UsageRecord.Revision" /> per attempt (cumulative streaming / retry). Order-
+    ///     independent and idempotent, so it can never lose an attempt one writer knew about.
+    /// </summary>
+    private static IReadOnlyList<UsageRecord> MergeRecords(
+        IReadOnlyList<UsageRecord> persisted,
+        IReadOnlyList<UsageRecord> incoming)
+    {
+        if (persisted.Count == 0)
+        {
+            return incoming;
+        }
+
+        if (incoming.Count == 0)
+        {
+            return persisted;
+        }
+
+        var byAttempt = new Dictionary<string, UsageRecord>(StringComparer.Ordinal);
+        foreach (var record in persisted)
+        {
+            byAttempt[record.ProviderAttemptId] = record;
+        }
+
+        foreach (var record in incoming)
+        {
+            if (!byAttempt.TryGetValue(record.ProviderAttemptId, out var existing) || record.Revision >= existing.Revision)
+            {
+                byAttempt[record.ProviderAttemptId] = record;
+            }
+        }
+
+        return [.. byAttempt.Values];
+    }
+
+    /// <summary>Reads the persisted schema version even when it is newer than this build understands.</summary>
+    private static int PersistedSchemaVersion(ThreadMetadata? metadata)
+    {
+        var json = RawJson(metadata, PropertyKey);
+        if (json is null)
+        {
+            return 0;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            return document.RootElement.TryGetProperty("SchemaVersion", out var value)
+                && value.ValueKind == JsonValueKind.Number
+                ? value.GetInt32()
+                : CurrentSchemaVersion;
+        }
+        catch (JsonException)
+        {
+            return 0; // corrupt — treat as absent, allow overwrite
+        }
+    }
+
+    private static long PersistedFoldedRevision(ThreadMetadata? metadata)
+    {
+        return FromMetadata(metadata)?.FoldedRevision ?? 0;
     }
 
     /// <summary>Loads the persisted aggregate for a conversation, or null when none has been stored.</summary>

--- a/src/LmMultiTurn/UsageAccounting/ConversationUsageProjection.cs
+++ b/src/LmMultiTurn/UsageAccounting/ConversationUsageProjection.cs
@@ -20,6 +20,9 @@ public static class ConversationUsageProjection
     /// <summary>The metadata property-bag key under which the usage aggregate JSON is stored.</summary>
     public const string PropertyKey = "usage.aggregate";
 
+    /// <summary>Highest usage-aggregate schema version this build understands; newer is treated as absent.</summary>
+    private const int CurrentSchemaVersion = 1;
+
     /// <summary>Atomically writes the aggregate into the conversation's metadata property bag.</summary>
     public static Task SaveAsync(
         IConversationStore store,
@@ -29,10 +32,23 @@ public static class ConversationUsageProjection
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(aggregate);
 
-        var json = JsonSerializer.Serialize(aggregate);
         return store.UpdateMetadataAsync(
             aggregate.RootConversationId,
-            existing => WithProjection(existing, aggregate.RootConversationId, json),
+            existing =>
+            {
+                // Guard against stale/out-of-order writes and post-restart regressions: never let a
+                // snapshot with a lower complete-prefix watermark replace a newer persisted one. Because
+                // this runs under the store's write serialization, concurrent fire-and-forget writers
+                // cannot clobber a newer aggregate with an older one (#196).
+                var current = FromMetadata(existing);
+                if (existing is not null && current is not null && current.FoldedRevision > aggregate.FoldedRevision)
+                {
+                    return existing;
+                }
+
+                var json = JsonSerializer.Serialize(aggregate);
+                return WithProjection(existing, aggregate.RootConversationId, json);
+            },
             ct);
     }
 
@@ -68,7 +84,22 @@ public static class ConversationUsageProjection
             _ => null,
         };
 
-        return json is null ? null : JsonSerializer.Deserialize<ConversationUsageAggregate>(json);
+        if (json is null)
+        {
+            return null;
+        }
+
+        // Tolerate corrupt or incompatible persisted usage rather than surfacing a 500 on the usage
+        // endpoint: treat unparseable metadata as "no usage recorded" (#196).
+        try
+        {
+            var aggregate = JsonSerializer.Deserialize<ConversationUsageAggregate>(json);
+            return aggregate is { SchemaVersion: <= CurrentSchemaVersion } ? aggregate : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 
     private static ThreadMetadata WithProjection(ThreadMetadata? existing, string threadId, string json)

--- a/src/LmMultiTurn/UsageAccounting/IUsageSink.cs
+++ b/src/LmMultiTurn/UsageAccounting/IUsageSink.cs
@@ -1,0 +1,19 @@
+using AchieveAi.LmDotnetTools.LmCore.Models;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
+
+/// <summary>
+///     Receives usage observations from anywhere in a conversation tree — the primary loop, sub-agents,
+///     and workflow tasks — for accumulation into the root conversation's aggregate (issue #196). A single
+///     root-scoped sink is created by the root conversation and shared with descendants, so their usage is
+///     attributed to the same root regardless of nesting depth.
+/// </summary>
+public interface IUsageSink
+{
+    /// <summary>
+    ///     Records a usage observation for a single provider attempt. Idempotent per
+    ///     <see cref="UsageRecord.ProviderAttemptId" /> — cumulative streaming updates and replays for the
+    ///     same attempt collapse to one billable record.
+    /// </summary>
+    void RecordUsage(UsageRecord observation);
+}

--- a/src/LmMultiTurn/UsageAccounting/RevisionWatermark.cs
+++ b/src/LmMultiTurn/UsageAccounting/RevisionWatermark.cs
@@ -18,6 +18,31 @@ public sealed class RevisionWatermark
     private long _allocated;
     private long _prefix;
 
+    /// <summary>
+    ///     Restores the watermark to a durable baseline on rebuild (e.g. after a restart): every revision
+    ///     up to <paramref name="prefix" /> is treated as already committed, so new allocations continue
+    ///     strictly above it and a post-restart projection write cannot regress below the persisted
+    ///     watermark. No-op if the current prefix already meets or exceeds <paramref name="prefix" />.
+    /// </summary>
+    public void SeedPrefix(long prefix)
+    {
+        lock (_gate)
+        {
+            if (prefix <= _prefix)
+            {
+                return;
+            }
+
+            _prefix = prefix;
+            if (_allocated < prefix)
+            {
+                _allocated = prefix;
+            }
+
+            _ = _committedAbovePrefix.RemoveWhere(r => r <= prefix);
+        }
+    }
+
     /// <summary>Reserves the next revision. It does not count toward the prefix until committed.</summary>
     public long Allocate()
     {

--- a/src/LmMultiTurn/UsageAccounting/RevisionWatermark.cs
+++ b/src/LmMultiTurn/UsageAccounting/RevisionWatermark.cs
@@ -1,0 +1,62 @@
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
+
+/// <summary>
+///     Tracks a per-conversation monotonic revision sequence and the highest <b>gap-free prefix</b> that
+///     has been committed. Publishing prefix <c>N</c> proves every revision <c>1..N</c> is committed — the
+///     complete-prefix watermark invariant for conversation usage (issue #196): a projection stamped with
+///     <c>N</c> cannot have skipped an earlier revision.
+/// </summary>
+/// <remarks>
+///     Allocation and commit are deliberately separable so a caller can reserve a revision before its
+///     record is durably visible. The prefix only advances across a contiguous run of committed revisions,
+///     so an out-of-order or delayed commit never lets the watermark jump past a still-missing revision.
+/// </remarks>
+public sealed class RevisionWatermark
+{
+    private readonly object _gate = new();
+    private readonly SortedSet<long> _committedAbovePrefix = [];
+    private long _allocated;
+    private long _prefix;
+
+    /// <summary>Reserves the next revision. It does not count toward the prefix until committed.</summary>
+    public long Allocate()
+    {
+        lock (_gate)
+        {
+            return ++_allocated;
+        }
+    }
+
+    /// <summary>
+    ///     Marks <paramref name="revision" /> committed and advances the gap-free prefix as far as the
+    ///     contiguous run of committed revisions allows. Idempotent and safe out-of-order.
+    /// </summary>
+    public void Commit(long revision)
+    {
+        lock (_gate)
+        {
+            if (revision <= _prefix)
+            {
+                return;
+            }
+
+            _committedAbovePrefix.Add(revision);
+            while (_committedAbovePrefix.Remove(_prefix + 1))
+            {
+                _prefix++;
+            }
+        }
+    }
+
+    /// <summary>The highest <c>N</c> such that every revision <c>1..N</c> has been committed (no gaps).</summary>
+    public long Prefix
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _prefix;
+            }
+        }
+    }
+}

--- a/src/LmMultiTurn/UsageAccounting/RevisionWatermark.cs
+++ b/src/LmMultiTurn/UsageAccounting/RevisionWatermark.cs
@@ -40,7 +40,7 @@ public sealed class RevisionWatermark
                 return;
             }
 
-            _committedAbovePrefix.Add(revision);
+            _ = _committedAbovePrefix.Add(revision);
             while (_committedAbovePrefix.Remove(_prefix + 1))
             {
                 _prefix++;

--- a/src/LmMultiTurn/UsageAccounting/UsageLedger.cs
+++ b/src/LmMultiTurn/UsageAccounting/UsageLedger.cs
@@ -10,7 +10,6 @@ namespace AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
 /// </summary>
 public sealed class UsageLedger : IUsageSink
 {
-    private readonly string _rootConversationId;
     private readonly object _gate = new();
     private readonly Dictionary<string, UsageRecord> _byAttempt = new(StringComparer.Ordinal);
     private readonly RevisionWatermark _watermark = new();
@@ -24,12 +23,12 @@ public sealed class UsageLedger : IUsageSink
     /// </param>
     public UsageLedger(string rootConversationId, IPricingResolver? pricingResolver = null)
     {
-        _rootConversationId = rootConversationId;
+        RootConversationId = rootConversationId;
         _pricingResolver = pricingResolver;
     }
 
     /// <summary>The root conversation this ledger accumulates usage for.</summary>
-    public string RootConversationId => _rootConversationId;
+    public string RootConversationId { get; }
 
     /// <inheritdoc />
     public void RecordUsage(UsageRecord observation)
@@ -49,13 +48,13 @@ public sealed class UsageLedger : IUsageSink
 
         lock (_gate)
         {
-            _byAttempt.TryGetValue(observation.ProviderAttemptId, out var existing);
+            _ = _byAttempt.TryGetValue(observation.ProviderAttemptId, out var existing);
             var merged = Merge(existing, observation);
             var revision = _watermark.Allocate();
 
             // The ledger is scoped to one root conversation, so every observation it receives is
             // attributed to that root — callers (e.g. the sub-agent relay) need not know the root id.
-            merged = merged with { Revision = revision, RootConversationId = _rootConversationId };
+            merged = merged with { Revision = revision, RootConversationId = RootConversationId };
             merged = WithEstimatedCost(merged);
             _byAttempt[observation.ProviderAttemptId] = merged;
             _watermark.Commit(revision);
@@ -72,7 +71,7 @@ public sealed class UsageLedger : IUsageSink
         lock (_gate)
         {
             return ConversationUsageAggregate.Fold(
-                _rootConversationId,
+                RootConversationId,
                 _byAttempt.Values,
                 _watermark.Prefix,
                 completeness);

--- a/src/LmMultiTurn/UsageAccounting/UsageLedger.cs
+++ b/src/LmMultiTurn/UsageAccounting/UsageLedger.cs
@@ -14,11 +14,18 @@ public sealed class UsageLedger : IUsageSink
     private readonly object _gate = new();
     private readonly Dictionary<string, UsageRecord> _byAttempt = new(StringComparer.Ordinal);
     private readonly RevisionWatermark _watermark = new();
+    private readonly IPricingResolver? _pricingResolver;
 
     /// <summary>Creates a ledger scoped to a single root conversation.</summary>
-    public UsageLedger(string rootConversationId)
+    /// <param name="rootConversationId">The root conversation to accumulate usage for.</param>
+    /// <param name="pricingResolver">
+    ///     Optional public-pricing resolver. When supplied, an observation that arrives without an estimated
+    ///     public cost has one filled in from the resolved rates for its effective model.
+    /// </param>
+    public UsageLedger(string rootConversationId, IPricingResolver? pricingResolver = null)
     {
         _rootConversationId = rootConversationId;
+        _pricingResolver = pricingResolver;
     }
 
     /// <summary>The root conversation this ledger accumulates usage for.</summary>
@@ -49,6 +56,7 @@ public sealed class UsageLedger : IUsageSink
             // The ledger is scoped to one root conversation, so every observation it receives is
             // attributed to that root — callers (e.g. the sub-agent relay) need not know the root id.
             merged = merged with { Revision = revision, RootConversationId = _rootConversationId };
+            merged = WithEstimatedCost(merged);
             _byAttempt[observation.ProviderAttemptId] = merged;
             _watermark.Commit(revision);
             return merged;
@@ -69,6 +77,20 @@ public sealed class UsageLedger : IUsageSink
                 _watermark.Prefix,
                 completeness);
         }
+    }
+
+    private UsageRecord WithEstimatedCost(UsageRecord record)
+    {
+        // Only fill an estimate the observation didn't already carry — a provider-reported estimate wins.
+        if (_pricingResolver is null || record.EstimatedPublicCostMicros is not null)
+        {
+            return record;
+        }
+
+        var pricing = _pricingResolver.Resolve(record.EffectiveModelId);
+        return pricing is null
+            ? record
+            : record with { EstimatedPublicCostMicros = pricing.EstimateMicros(record.InputTokens, record.OutputTokens) };
     }
 
     private static UsageRecord Merge(UsageRecord? existing, UsageRecord observation)

--- a/src/LmMultiTurn/UsageAccounting/UsageLedger.cs
+++ b/src/LmMultiTurn/UsageAccounting/UsageLedger.cs
@@ -1,0 +1,101 @@
+using AchieveAi.LmDotnetTools.LmCore.Models;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
+
+/// <summary>
+///     Execution-scoped collector that normalizes many streaming usage observations into one durable
+///     <see cref="UsageRecord" /> per provider attempt, and produces the conversation aggregate snapshot
+///     with a complete-prefix watermark. Additive across the whole conversation tree (issue #196): the
+///     root conversation creates one ledger and every descendant relays its observations into it.
+/// </summary>
+public sealed class UsageLedger
+{
+    private readonly string _rootConversationId;
+    private readonly object _gate = new();
+    private readonly Dictionary<string, UsageRecord> _byAttempt = new(StringComparer.Ordinal);
+    private readonly RevisionWatermark _watermark = new();
+
+    /// <summary>Creates a ledger scoped to a single root conversation.</summary>
+    public UsageLedger(string rootConversationId)
+    {
+        _rootConversationId = rootConversationId;
+    }
+
+    /// <summary>The root conversation this ledger accumulates usage for.</summary>
+    public string RootConversationId => _rootConversationId;
+
+    /// <summary>
+    ///     Merges an observation into the record for its <see cref="UsageRecord.ProviderAttemptId" /> —
+    ///     cumulative MAX per count, finalized once any finalized observation is seen — assigns a fresh
+    ///     committed revision, and returns the merged record. Idempotent under replay and safe out-of-order,
+    ///     so cumulative streaming updates for one attempt collapse to a single billable record.
+    /// </summary>
+    public UsageRecord UpsertAttempt(UsageRecord observation)
+    {
+        ArgumentNullException.ThrowIfNull(observation);
+
+        lock (_gate)
+        {
+            _byAttempt.TryGetValue(observation.ProviderAttemptId, out var existing);
+            var merged = Merge(existing, observation);
+            var revision = _watermark.Allocate();
+            merged = merged with { Revision = revision };
+            _byAttempt[observation.ProviderAttemptId] = merged;
+            _watermark.Commit(revision);
+            return merged;
+        }
+    }
+
+    /// <summary>
+    ///     Produces the current aggregate snapshot folded over all attempts, stamped with the gap-free
+    ///     watermark and the given completeness state.
+    /// </summary>
+    public ConversationUsageAggregate Snapshot(UsageCompleteness completeness = UsageCompleteness.InProgress)
+    {
+        lock (_gate)
+        {
+            return ConversationUsageAggregate.Fold(
+                _rootConversationId,
+                _byAttempt.Values,
+                _watermark.Prefix,
+                completeness);
+        }
+    }
+
+    private static UsageRecord Merge(UsageRecord? existing, UsageRecord observation)
+    {
+        if (existing is null)
+        {
+            return observation;
+        }
+
+        return observation with
+        {
+            InputTokens = Math.Max(existing.InputTokens, observation.InputTokens),
+            OutputTokens = Math.Max(existing.OutputTokens, observation.OutputTokens),
+            CacheReadTokens = Math.Max(existing.CacheReadTokens, observation.CacheReadTokens),
+            CacheWriteTokens = Math.Max(existing.CacheWriteTokens, observation.CacheWriteTokens),
+            ReasoningTokens = Math.Max(existing.ReasoningTokens, observation.ReasoningTokens),
+            EstimatedPublicCostMicros =
+                MaxNullable(existing.EstimatedPublicCostMicros, observation.EstimatedPublicCostMicros),
+            ProviderReportedCostMicros =
+                MaxNullable(existing.ProviderReportedCostMicros, observation.ProviderReportedCostMicros),
+            Finalized = existing.Finalized || observation.Finalized,
+        };
+    }
+
+    private static long? MaxNullable(long? left, long? right)
+    {
+        if (left is null)
+        {
+            return right;
+        }
+
+        if (right is null)
+        {
+            return left;
+        }
+
+        return Math.Max(left.Value, right.Value);
+    }
+}

--- a/src/LmMultiTurn/UsageAccounting/UsageLedger.cs
+++ b/src/LmMultiTurn/UsageAccounting/UsageLedger.cs
@@ -78,6 +78,38 @@ public sealed class UsageLedger : IUsageSink
         }
     }
 
+    /// <summary>
+    ///     Returns the current deduped canonical records (one per provider attempt) under the lock, so a
+    ///     caller can persist them durably. These are the source of truth the aggregate is folded from.
+    /// </summary>
+    public IReadOnlyList<UsageRecord> SnapshotRecords()
+    {
+        lock (_gate)
+        {
+            return [.. _byAttempt.Values];
+        }
+    }
+
+    /// <summary>
+    ///     Rebuilds ledger state from durable records (e.g. after a process/agent restart), restoring the
+    ///     watermark to <paramref name="foldedRevision" /> so subsequent usage continues strictly above the
+    ///     persisted baseline. A live in-memory observation for an attempt is never overwritten by a seed.
+    /// </summary>
+    public void SeedFromRecords(IEnumerable<UsageRecord> records, long foldedRevision)
+    {
+        ArgumentNullException.ThrowIfNull(records);
+
+        lock (_gate)
+        {
+            foreach (var record in records)
+            {
+                _ = _byAttempt.TryAdd(record.ProviderAttemptId, record);
+            }
+
+            _watermark.SeedPrefix(foldedRevision);
+        }
+    }
+
     private UsageRecord WithEstimatedCost(UsageRecord record)
     {
         // Only fill an estimate the observation didn't already carry — a provider-reported estimate wins.

--- a/src/LmMultiTurn/UsageAccounting/UsageLedger.cs
+++ b/src/LmMultiTurn/UsageAccounting/UsageLedger.cs
@@ -8,7 +8,7 @@ namespace AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
 ///     with a complete-prefix watermark. Additive across the whole conversation tree (issue #196): the
 ///     root conversation creates one ledger and every descendant relays its observations into it.
 /// </summary>
-public sealed class UsageLedger
+public sealed class UsageLedger : IUsageSink
 {
     private readonly string _rootConversationId;
     private readonly object _gate = new();
@@ -23,6 +23,12 @@ public sealed class UsageLedger
 
     /// <summary>The root conversation this ledger accumulates usage for.</summary>
     public string RootConversationId => _rootConversationId;
+
+    /// <inheritdoc />
+    public void RecordUsage(UsageRecord observation)
+    {
+        _ = UpsertAttempt(observation);
+    }
 
     /// <summary>
     ///     Merges an observation into the record for its <see cref="UsageRecord.ProviderAttemptId" /> —
@@ -39,7 +45,10 @@ public sealed class UsageLedger
             _byAttempt.TryGetValue(observation.ProviderAttemptId, out var existing);
             var merged = Merge(existing, observation);
             var revision = _watermark.Allocate();
-            merged = merged with { Revision = revision };
+
+            // The ledger is scoped to one root conversation, so every observation it receives is
+            // attributed to that root — callers (e.g. the sub-agent relay) need not know the root id.
+            merged = merged with { Revision = revision, RootConversationId = _rootConversationId };
             _byAttempt[observation.ProviderAttemptId] = merged;
             _watermark.Commit(revision);
             return merged;

--- a/src/LmMultiTurn/UsageAccounting/UsageLedger.cs
+++ b/src/LmMultiTurn/UsageAccounting/UsageLedger.cs
@@ -68,14 +68,17 @@ public sealed class UsageLedger : IUsageSink
     /// </summary>
     public ConversationUsageAggregate Snapshot(UsageCompleteness completeness = UsageCompleteness.InProgress)
     {
+        UsageRecord[] records;
+        long prefix;
         lock (_gate)
         {
-            return ConversationUsageAggregate.Fold(
-                RootConversationId,
-                _byAttempt.Values,
-                _watermark.Prefix,
-                completeness);
+            // Copy the records and watermark under the lock, then fold (group/sort) OUTSIDE it, so reporting
+            // cost does not hold the mutation lock and block concurrent usage updates as history grows.
+            records = [.. _byAttempt.Values];
+            prefix = _watermark.Prefix;
         }
+
+        return ConversationUsageAggregate.Fold(RootConversationId, records, prefix, completeness);
     }
 
     /// <summary>

--- a/src/LmMultiTurn/UsageAccounting/UsagePersistenceWriter.cs
+++ b/src/LmMultiTurn/UsageAccounting/UsagePersistenceWriter.cs
@@ -10,21 +10,24 @@ namespace AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
 /// <remarks>
 ///     The persist delegate is invoked with the <b>latest</b> ledger state at write time, so a burst of
 ///     <see cref="Schedule" /> calls collapses into a single in-flight write plus at most one trailing write
-///     — reporting cost does not scale with the number of observations. The delegate is responsible for its
-///     own error handling; a fault it surfaces is swallowed here so a persistence failure can neither wedge
-///     the drain loop nor fault a lifecycle <see cref="FlushAsync" />.
+///     — reporting cost does not scale with the number of observations. When the delegate <b>throws</b>, the
+///     write is kept pending (so a later <see cref="Schedule" /> / <see cref="FlushAsync" /> retries it) and
+///     <see cref="FlushAsync" /> returns <c>false</c>, so a failed authoritative write is never silently
+///     reported as a clean durability boundary. The failure is reported once via <c>onError</c>.
 /// </remarks>
 internal sealed class UsagePersistenceWriter
 {
     private readonly Func<CancellationToken, Task> _persist;
+    private readonly Action<Exception>? _onError;
     private readonly object _gate = new();
     private bool _pending;
     private Task _drain = Task.CompletedTask;
 
-    public UsagePersistenceWriter(Func<CancellationToken, Task> persist)
+    public UsagePersistenceWriter(Func<CancellationToken, Task> persist, Action<Exception>? onError = null)
     {
         ArgumentNullException.ThrowIfNull(persist);
         _persist = persist;
+        _onError = onError;
     }
 
     /// <summary>
@@ -45,10 +48,14 @@ internal sealed class UsagePersistenceWriter
 
     /// <summary>
     ///     Awaits any pending or in-flight write so the latest scheduled snapshot is durable before the
-    ///     caller (run completion / disposal) proceeds. A no-op when nothing has been scheduled.
+    ///     caller (run completion / disposal) proceeds. Returns <c>true</c> when no write remains pending
+    ///     (durable), or <c>false</c> when a write failed and is still outstanding — so the caller can log a
+    ///     genuine error rather than treat the boundary as clean. A no-op returning <c>true</c> when nothing
+    ///     was scheduled.
     /// </summary>
-    public Task FlushAsync()
+    public async Task<bool> FlushAsync()
     {
+        Task drain;
         lock (_gate)
         {
             if (_pending && _drain.IsCompleted)
@@ -56,7 +63,14 @@ internal sealed class UsagePersistenceWriter
                 _drain = DrainAsync();
             }
 
-            return _drain;
+            drain = _drain;
+        }
+
+        await drain;
+
+        lock (_gate)
+        {
+            return !_pending;
         }
     }
 
@@ -81,10 +95,17 @@ internal sealed class UsagePersistenceWriter
             {
                 await _persist(CancellationToken.None);
             }
-            catch
+            catch (Exception ex)
             {
-                // The delegate logs its own failures; swallow so a persistence fault cannot wedge the
-                // loop or fault a lifecycle flush. A later Schedule() re-attempts with the newest state.
+                // Persist failed: retain the pending write so a later Schedule()/FlushAsync() retries it and
+                // so FlushAsync reports a non-durable boundary. Stop draining so Flush cannot spin.
+                lock (_gate)
+                {
+                    _pending = true;
+                }
+
+                _onError?.Invoke(ex);
+                return;
             }
         }
     }

--- a/src/LmMultiTurn/UsageAccounting/UsagePersistenceWriter.cs
+++ b/src/LmMultiTurn/UsageAccounting/UsagePersistenceWriter.cs
@@ -1,0 +1,91 @@
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
+
+/// <summary>
+///     Serializes and coalesces conversation-usage persistence for one root conversation. Every observation
+///     — the primary loop's own usage and each descendant (sub-agent / workflow) relay — is routed through
+///     the same writer, so durable writes never interleave, and the owner can <see cref="FlushAsync" /> at
+///     run completion / disposal to guarantee the latest ledger snapshot is durable rather than left in
+///     memory when the process shuts down (#196).
+/// </summary>
+/// <remarks>
+///     The persist delegate is invoked with the <b>latest</b> ledger state at write time, so a burst of
+///     <see cref="Schedule" /> calls collapses into a single in-flight write plus at most one trailing write
+///     — reporting cost does not scale with the number of observations. The delegate is responsible for its
+///     own error handling; a fault it surfaces is swallowed here so a persistence failure can neither wedge
+///     the drain loop nor fault a lifecycle <see cref="FlushAsync" />.
+/// </remarks>
+internal sealed class UsagePersistenceWriter
+{
+    private readonly Func<CancellationToken, Task> _persist;
+    private readonly object _gate = new();
+    private bool _pending;
+    private Task _drain = Task.CompletedTask;
+
+    public UsagePersistenceWriter(Func<CancellationToken, Task> persist)
+    {
+        ArgumentNullException.ThrowIfNull(persist);
+        _persist = persist;
+    }
+
+    /// <summary>
+    ///     Requests a durable write of the current ledger state. Non-blocking; coalesces into the in-flight
+    ///     drain when one is already running.
+    /// </summary>
+    public void Schedule()
+    {
+        lock (_gate)
+        {
+            _pending = true;
+            if (_drain.IsCompleted)
+            {
+                _drain = DrainAsync();
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Awaits any pending or in-flight write so the latest scheduled snapshot is durable before the
+    ///     caller (run completion / disposal) proceeds. A no-op when nothing has been scheduled.
+    /// </summary>
+    public Task FlushAsync()
+    {
+        lock (_gate)
+        {
+            if (_pending && _drain.IsCompleted)
+            {
+                _drain = DrainAsync();
+            }
+
+            return _drain;
+        }
+    }
+
+    private async Task DrainAsync()
+    {
+        // Detach from the caller's stack/lock before doing any IO.
+        await Task.Yield();
+
+        while (true)
+        {
+            lock (_gate)
+            {
+                if (!_pending)
+                {
+                    return;
+                }
+
+                _pending = false;
+            }
+
+            try
+            {
+                await _persist(CancellationToken.None);
+            }
+            catch
+            {
+                // The delegate logs its own failures; swallow so a persistence fault cannot wedge the
+                // loop or fault a lifecycle flush. A later Schedule() re-attempts with the newest state.
+            }
+        }
+    }
+}

--- a/src/LmMultiTurn/UsageAccounting/UsageRecordMapper.cs
+++ b/src/LmMultiTurn/UsageAccounting/UsageRecordMapper.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Models;
 
@@ -27,8 +28,12 @@ public static class UsageRecordMapper
         var usage = message.Usage;
 
         // A generation is one provider call; combined with the emitter id it is a stable, globally unique
-        // dedup key across the conversation tree. Fall back to the run id, then a fixed token.
-        var attemptKey = message.GenerationId ?? message.RunId ?? "usage";
+        // dedup key across the conversation tree. Fall back to the run id, then — when the producer supplies
+        // neither — to a key derived from the call's observable usage scope, so distinct provider calls are
+        // not silently collapsed into one attempt (a shared constant would MAX-merge and undercount) while an
+        // exact replay of the same observation still dedups. A provider-minted attempt id (#116-adjacent)
+        // remains the fully-correct source.
+        var attemptKey = message.GenerationId ?? message.RunId ?? DeriveCallScopeKey(message);
         var attemptId = $"{ownerExecutionId}:{attemptKey}";
 
         return new UsageRecord
@@ -49,6 +54,19 @@ public static class UsageRecordMapper
             ProviderReportedCostMicros = ToMicros(usage.TotalCost),
             Finalized = true,
         };
+    }
+
+    /// <summary>
+    ///     Derives a dedup key from a usage message's observable scope when the producer supplies no
+    ///     generation or run id. Deterministic, so an exact replay dedups; distinct-usage calls get distinct
+    ///     keys, so they are counted separately rather than MAX-collapsed by a shared constant.
+    /// </summary>
+    private static string DeriveCallScopeKey(UsageMessage message)
+    {
+        var usage = message.Usage;
+        var order = message.MessageOrderIdx?.ToString(CultureInfo.InvariantCulture) ?? "-";
+        return FormattableString.Invariant(
+            $"derived:{usage.PromptTokens}-{usage.CompletionTokens}-{usage.TotalCachedTokens}-{usage.TotalReasoningTokens}-{usage.TotalCost ?? 0d}-{order}");
     }
 
     private static long? ToMicros(double? cost)

--- a/src/LmMultiTurn/UsageAccounting/UsageRecordMapper.cs
+++ b/src/LmMultiTurn/UsageAccounting/UsageRecordMapper.cs
@@ -42,6 +42,9 @@ public static class UsageRecordMapper
             InputTokens = usage.PromptTokens,
             OutputTokens = usage.CompletionTokens,
             CacheReadTokens = usage.TotalCachedTokens,
+            // Cache-creation tokens are billed separately (additive to the total). Anthropic and related
+            // providers surface them via Usage.ExtraProperties; 0 when absent.
+            CacheWriteTokens = usage.GetExtraProperty<int>("cache_creation_input_tokens"),
             ReasoningTokens = usage.TotalReasoningTokens,
             ProviderReportedCostMicros = ToMicros(usage.TotalCost),
             Finalized = true,

--- a/src/LmMultiTurn/UsageAccounting/UsageRecordMapper.cs
+++ b/src/LmMultiTurn/UsageAccounting/UsageRecordMapper.cs
@@ -1,0 +1,55 @@
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Models;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
+
+/// <summary>
+///     Maps a provider <see cref="UsageMessage" /> to a durable <see cref="UsageRecord" /> for the usage
+///     ledger. Shared by the primary loop's own-usage capture and the sub-agent/workflow relay so both
+///     produce identically-shaped records (#196). Token counts are captured verbatim (per-call field
+///     accuracy is #116); the <c>RootConversationId</c> placeholder is re-stamped by the ledger.
+/// </summary>
+public static class UsageRecordMapper
+{
+    /// <summary>
+    ///     Builds a record from a usage message. <paramref name="ownerExecutionId" /> is the emitter's id
+    ///     (the root thread id for the primary loop, the sub-agent id for a descendant) and forms the
+    ///     dedup key together with the message's generation id.
+    /// </summary>
+    public static UsageRecord FromUsageMessage(
+        UsageMessage message,
+        string ownerExecutionId,
+        UsageExecutionKind kind,
+        string? model)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var usage = message.Usage;
+
+        // A generation is one provider call; combined with the emitter id it is a stable, globally unique
+        // dedup key across the conversation tree. Fall back to the run id, then a fixed token.
+        var attemptKey = message.GenerationId ?? message.RunId ?? "usage";
+        var attemptId = $"{ownerExecutionId}:{attemptKey}";
+
+        return new UsageRecord
+        {
+            LogicalCallId = attemptId,
+            ProviderAttemptId = attemptId,
+            RootConversationId = ownerExecutionId,
+            ParentExecutionId = kind == UsageExecutionKind.Primary ? null : ownerExecutionId,
+            ExecutionKind = kind,
+            RequestedModel = string.IsNullOrEmpty(model) ? "unknown" : model,
+            InputTokens = usage.PromptTokens,
+            OutputTokens = usage.CompletionTokens,
+            CacheReadTokens = usage.TotalCachedTokens,
+            ReasoningTokens = usage.TotalReasoningTokens,
+            ProviderReportedCostMicros = ToMicros(usage.TotalCost),
+            Finalized = true,
+        };
+    }
+
+    private static long? ToMicros(double? cost)
+    {
+        return cost is null ? null : (long)Math.Round(cost.Value * 1_000_000d);
+    }
+}

--- a/tests/LmConfig.Tests/Pricing/PricingConfigResolverTests.cs
+++ b/tests/LmConfig.Tests/Pricing/PricingConfigResolverTests.cs
@@ -1,0 +1,37 @@
+using AchieveAi.LmDotnetTools.LmConfig.Models;
+using AchieveAi.LmDotnetTools.LmConfig.Pricing;
+
+namespace AchieveAi.LmDotnetTools.LmConfig.Tests.Pricing;
+
+public class PricingConfigResolverTests
+{
+    private static PricingConfigResolver Resolver() =>
+        new(
+            new Dictionary<string, PricingConfig>
+            {
+                ["model-A"] = new() { PromptPerMillion = 2.0, CompletionPerMillion = 8.0 },
+            },
+            source: "test-catalog",
+            version: "2026-07-19");
+
+    [Fact]
+    public void Resolve_KnownModel_ReturnsPricingWithProvenance()
+    {
+        var pricing = Resolver().Resolve("model-A");
+
+        Assert.NotNull(pricing);
+        Assert.Equal(2.0m, pricing!.PromptPerMillion);
+        Assert.Equal(8.0m, pricing.CompletionPerMillion);
+        Assert.Equal("test-catalog", pricing.Source);
+        Assert.Equal("2026-07-19", pricing.Version);
+
+        // 1000 input + 500 output at $2/M + $8/M => 6000 micro-units.
+        Assert.Equal(6000, pricing.EstimateMicros(1000, 500));
+    }
+
+    [Fact]
+    public void Resolve_UnknownModel_ReturnsNull()
+    {
+        Assert.Null(Resolver().Resolve("no-such-model"));
+    }
+}

--- a/tests/LmCore.Tests/Models/ConversationUsageAggregateTests.cs
+++ b/tests/LmCore.Tests/Models/ConversationUsageAggregateTests.cs
@@ -1,0 +1,127 @@
+using AchieveAi.LmDotnetTools.LmCore.Models;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.Models;
+
+public class ConversationUsageAggregateTests
+{
+    private static UsageRecord Record(
+        string attemptId,
+        string model,
+        long input,
+        long output,
+        long revision = 0,
+        long cacheWrite = 0,
+        long? estimated = null,
+        long? reported = null) =>
+        new()
+        {
+            LogicalCallId = attemptId,
+            ProviderAttemptId = attemptId,
+            RootConversationId = "conv-1",
+            RequestedModel = model,
+            Revision = revision,
+            InputTokens = input,
+            OutputTokens = output,
+            CacheWriteTokens = cacheWrite,
+            EstimatedPublicCostMicros = estimated,
+            ProviderReportedCostMicros = reported,
+        };
+
+    [Fact]
+    public void Fold_SumsAdditively_GroupedByModel()
+    {
+        var records = new[]
+        {
+            Record("a1", "model-A", input: 100, output: 40),
+            Record("a2", "model-A", input: 200, output: 60),
+            Record("b1", "model-B", input: 10, output: 5),
+        };
+
+        var agg = ConversationUsageAggregate.Fold("conv-1", records, foldedRevision: 3);
+
+        agg.PerModel.Should().HaveCount(2);
+        var a = agg.PerModel.Single(m => m.ModelId == "model-A");
+        a.InputTokens.Should().Be(300);
+        a.OutputTokens.Should().Be(100);
+        a.TotalTokens.Should().Be(400);
+        a.AttemptCount.Should().Be(2);
+        agg.TotalTokens.Should().Be(415); // 400 (A) + 15 (B)
+    }
+
+    [Fact]
+    public void Fold_DedupsByProviderAttemptId_LatestRevisionWins()
+    {
+        // Same attempt seen twice (cumulative streaming): rev 1 then rev 2 — only the latest counts.
+        var records = new[]
+        {
+            Record("a1", "model-A", input: 50, output: 20, revision: 1),
+            Record("a1", "model-A", input: 120, output: 55, revision: 2),
+        };
+
+        var agg = ConversationUsageAggregate.Fold("conv-1", records, foldedRevision: 2);
+
+        agg.PerModel.Should().ContainSingle();
+        agg.PerModel[0].InputTokens.Should().Be(120);
+        agg.PerModel[0].OutputTokens.Should().Be(55);
+        agg.PerModel[0].AttemptCount.Should().Be(1);
+        agg.TotalTokens.Should().Be(175);
+    }
+
+    [Fact]
+    public void Fold_GroupsByEffectiveModel_NotRequestedModel()
+    {
+        var records = new[]
+        {
+            Record("a1", "alias", input: 10, output: 10) with { EffectiveModel = "real-model" },
+            Record("a2", "real-model", input: 5, output: 5),
+        };
+
+        var agg = ConversationUsageAggregate.Fold("conv-1", records, foldedRevision: 2);
+
+        agg.PerModel.Should().ContainSingle(m => m.ModelId == "real-model");
+        agg.PerModel[0].TotalTokens.Should().Be(30);
+    }
+
+    [Fact]
+    public void Fold_UnknownCosts_YieldNull_NotZero()
+    {
+        UsageRecord[] records = [Record("a1", "model-A", input: 100, output: 40)];
+
+        var agg = ConversationUsageAggregate.Fold("conv-1", records, foldedRevision: 1);
+
+        agg.EstimatedPublicCostMicros.Should().BeNull();
+        agg.ProviderReportedCostMicros.Should().BeNull();
+        agg.PerModel[0].EstimatedPublicCostMicros.Should().BeNull();
+    }
+
+    [Fact]
+    public void Fold_DualCosts_TrackedIndependently()
+    {
+        // One attempt has only a public estimate, another only a provider-reported cost.
+        var records = new[]
+        {
+            Record("a1", "model-A", input: 100, output: 40, estimated: 6000),
+            Record("a2", "model-A", input: 100, output: 40, reported: 5000),
+        };
+
+        var agg = ConversationUsageAggregate.Fold("conv-1", records, foldedRevision: 2);
+
+        agg.EstimatedPublicCostMicros.Should().Be(6000);
+        agg.ProviderReportedCostMicros.Should().Be(5000);
+    }
+
+    [Fact]
+    public void Fold_StampsWatermarkAndCompleteness()
+    {
+        var agg = ConversationUsageAggregate.Fold(
+            "conv-1",
+            [Record("a1", "model-A", input: 1, output: 1)],
+            foldedRevision: 42,
+            completeness: UsageCompleteness.Complete);
+
+        agg.FoldedRevision.Should().Be(42);
+        agg.Completeness.Should().Be(UsageCompleteness.Complete);
+        agg.RootConversationId.Should().Be("conv-1");
+    }
+}

--- a/tests/LmCore.Tests/Models/ModelPricingTests.cs
+++ b/tests/LmCore.Tests/Models/ModelPricingTests.cs
@@ -1,0 +1,34 @@
+using AchieveAi.LmDotnetTools.LmCore.Models;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.Models;
+
+public class ModelPricingTests
+{
+    [Fact]
+    public void EstimateMicros_ComputesCostInMicroUnits()
+    {
+        // $2 / M input, $8 / M output. 1000 input + 500 output => $0.006 => 6000 micro-units.
+        var pricing = new ModelPricing
+        {
+            ModelId = "model-A",
+            PromptPerMillion = 2m,
+            CompletionPerMillion = 8m,
+        };
+
+        pricing.EstimateMicros(inputTokens: 1000, outputTokens: 500).Should().Be(6000);
+    }
+
+    [Fact]
+    public void EstimateMicros_IsZero_ForNoTokens()
+    {
+        var pricing = new ModelPricing
+        {
+            ModelId = "model-A",
+            PromptPerMillion = 2m,
+            CompletionPerMillion = 8m,
+        };
+
+        pricing.EstimateMicros(0, 0).Should().Be(0);
+    }
+}

--- a/tests/LmCore.Tests/Models/UsageRecordTests.cs
+++ b/tests/LmCore.Tests/Models/UsageRecordTests.cs
@@ -1,0 +1,63 @@
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Models;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.LmCore.Tests.Models;
+
+public class UsageRecordTests
+{
+    private static UsageRecord Sample() =>
+        new()
+        {
+            LogicalCallId = "call-1",
+            ProviderAttemptId = "attempt-1",
+            RootConversationId = "conv-1",
+            RequestedModel = "gpt-5",
+        };
+
+    [Fact]
+    public void TotalTokens_IsInputPlusCacheWritePlusOutput_ExcludingSubsets()
+    {
+        // cache-read is a subset of input and reasoning a subset of output — neither is re-added.
+        var record = Sample() with
+        {
+            InputTokens = 100,
+            CacheReadTokens = 30,
+            CacheWriteTokens = 20,
+            OutputTokens = 50,
+            ReasoningTokens = 10,
+        };
+
+        record.TotalTokens.Should().Be(170); // 100 + 20 + 50
+    }
+
+    [Fact]
+    public void EffectiveModelId_FallsBackToRequestedModel_WhenEffectiveMissing()
+    {
+        Sample().EffectiveModelId.Should().Be("gpt-5");
+        (Sample() with { EffectiveModel = "gpt-5-2026" }).EffectiveModelId.Should().Be("gpt-5-2026");
+    }
+
+    [Fact]
+    public void RoundTrips_ThroughJson_PreservingCoreFields()
+    {
+        var record = Sample() with
+        {
+            Revision = 7,
+            InputTokens = 100,
+            OutputTokens = 50,
+            CacheWriteTokens = 20,
+            EstimatedPublicCostMicros = 6000,
+            ExecutionKind = UsageExecutionKind.SubAgent,
+        };
+
+        var json = JsonSerializer.Serialize(record);
+        var back = JsonSerializer.Deserialize<UsageRecord>(json)!;
+
+        back.ProviderAttemptId.Should().Be("attempt-1");
+        back.Revision.Should().Be(7);
+        back.TotalTokens.Should().Be(170);
+        back.EstimatedPublicCostMicros.Should().Be(6000);
+        back.ExecutionKind.Should().Be(UsageExecutionKind.SubAgent);
+    }
+}

--- a/tests/LmMultiTurn.Tests/Persistence/RunLedgerRoundTripTests.cs
+++ b/tests/LmMultiTurn.Tests/Persistence/RunLedgerRoundTripTests.cs
@@ -86,10 +86,16 @@ public class RunLedgerRoundTripTests
             persistRunLedger: true,
             pauseBeforeComplete: true);
         using var cts = new CancellationTokenSource();
-        _ = agent.RunAsync(cts.Token);
 
+        // Enqueue BOTH inputs before starting the loop so they drain into a single batch deterministically.
+        // Starting the loop first races the second send against the loop's first WaitToRead/TryDrainInputs:
+        // under load the loop can drain input-A alone and start a run before input-B is enqueued, leaving an
+        // InProgress row with only ["input-A"]. SendAsync writes to the channel synchronously and does not
+        // require the loop to be running, and a fresh agent's channel is open (not recreated on RunAsync).
         await agent.SendAsync([new TextMessage { Text = "Hi", Role = Role.User }], inputId: "input-A");
         await agent.SendAsync([new TextMessage { Text = "There", Role = Role.User }], inputId: "input-B");
+
+        _ = agent.RunAsync(cts.Token);
 
         await agent.RunStarted.WaitAsync(TimeSpan.FromSeconds(5));
 

--- a/tests/LmMultiTurn.Tests/SubAgents/SubAgentManagerUsageRelayTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgents/SubAgentManagerUsageRelayTests.cs
@@ -1,0 +1,144 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmCore.Models;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace LmMultiTurn.Tests.SubAgents;
+
+/// <summary>
+/// Verifies the SubAgentManager usage relay (#196): a sub-agent's UsageMessage is folded into the
+/// root conversation's <see cref="UsageLedger"/>, and the relay is a no-op when no sink is supplied.
+/// </summary>
+public class SubAgentManagerUsageRelayTests : IAsyncLifetime
+{
+    private readonly Mock<IMultiTurnAgent> _parentMock = new();
+    private readonly Mock<IStreamingAgent> _subAgentMock = new();
+    private SubAgentManager? _manager;
+
+    public Task InitializeAsync()
+    {
+        _parentMock
+            .Setup(p => p.SendAsync(
+                It.IsAny<List<IMessage>>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SendReceipt("receipt-1", null, DateTimeOffset.UtcNow));
+
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_manager != null)
+        {
+            await _manager.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task SubAgentUsage_IsFoldedIntoRootLedger()
+    {
+        var ledger = new UsageLedger("root-conv");
+        SetupSubAgentResponse([
+            new UsageMessage
+            {
+                Usage = new Usage { PromptTokens = 100, CompletionTokens = 40 },
+                GenerationId = "gen-1",
+            },
+            new TextMessage { Text = "done", Role = Role.Assistant },
+        ]);
+
+        var agentId = await SpawnAsync(ledger);
+        _ = await _manager!.ObserveCompletionAsync(agentId, CancellationToken.None);
+
+        var snapshot = ledger.Snapshot();
+        snapshot.TotalTokens.Should().Be(140);
+        snapshot.RootConversationId.Should().Be("root-conv");
+        snapshot.PerModel.Should().ContainSingle();
+        snapshot.PerModel[0].AttemptCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Relay_IsNoOp_WhenNoSinkSupplied()
+    {
+        SetupSubAgentResponse([new TextMessage { Text = "done", Role = Role.Assistant }]);
+
+        var agentId = await SpawnAsync(usageSink: null);
+        var result = await _manager!.ObserveCompletionAsync(agentId, CancellationToken.None);
+
+        result.Should().Be("done");
+    }
+
+    private async Task<string> SpawnAsync(IUsageSink? usageSink)
+    {
+        var manager = CreateManager(usageSink);
+        _manager = manager;
+
+        var spawnJson = await manager.SpawnAsync("test-agent", "Do some work", runInBackground: true);
+        using var spawnDoc = JsonDocument.Parse(spawnJson);
+        return spawnDoc.RootElement.GetProperty("agent_id").GetString()!;
+    }
+
+    private SubAgentManager CreateManager(IUsageSink? usageSink)
+    {
+        var options = CreateOptions();
+        return new SubAgentManager(
+            parentAgent: _parentMock.Object,
+            parentContracts: [],
+            parentHandlers: new Dictionary<string, ToolHandler>(),
+            options: options,
+            source: new MutableSubAgentTemplateSource(options.Templates),
+            usageSink: usageSink);
+    }
+
+    private SubAgentOptions CreateOptions()
+    {
+        var template = new SubAgentTemplate
+        {
+            SystemPrompt = "You are a test agent.",
+            AgentFactory = () => _subAgentMock.Object,
+        };
+
+        return new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate>
+            {
+                ["test-agent"] = template,
+            },
+            MaxConcurrentSubAgents = 5,
+        };
+    }
+
+    private void SetupSubAgentResponse(List<IMessage> messages)
+    {
+        _subAgentMock
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(ToAsyncEnumerable(messages)));
+    }
+
+    private static async IAsyncEnumerable<IMessage> ToAsyncEnumerable(
+        List<IMessage> messages,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        foreach (var msg in messages)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return msg;
+            await Task.Yield();
+        }
+    }
+}

--- a/tests/LmMultiTurn.Tests/SubAgents/SubAgentManagerUsageRelayTests.cs
+++ b/tests/LmMultiTurn.Tests/SubAgents/SubAgentManagerUsageRelayTests.cs
@@ -80,9 +80,33 @@ public class SubAgentManagerUsageRelayTests : IAsyncLifetime
         result.Should().Be("done");
     }
 
-    private async Task<string> SpawnAsync(IUsageSink? usageSink)
+    [Fact]
+    public async Task DescendantUsage_TriggersDurablePersist()
     {
-        var manager = CreateManager(usageSink);
+        var ledger = new UsageLedger("root-conv");
+        var persistCount = 0;
+        SetupSubAgentResponse([
+            new UsageMessage
+            {
+                Usage = new Usage { PromptTokens = 100, CompletionTokens = 40 },
+                GenerationId = "gen-1",
+            },
+            new TextMessage { Text = "done", Role = Role.Assistant },
+        ]);
+
+        var agentId = await SpawnAsync(ledger, () =>
+        {
+            _ = Interlocked.Increment(ref persistCount);
+            return Task.CompletedTask;
+        });
+        _ = await _manager!.ObserveCompletionAsync(agentId, CancellationToken.None);
+
+        persistCount.Should().BeGreaterThan(0);
+    }
+
+    private async Task<string> SpawnAsync(IUsageSink? usageSink, Func<Task>? persistUsageAsync = null)
+    {
+        var manager = CreateManager(usageSink, persistUsageAsync);
         _manager = manager;
 
         var spawnJson = await manager.SpawnAsync("test-agent", "Do some work", runInBackground: true);
@@ -90,7 +114,7 @@ public class SubAgentManagerUsageRelayTests : IAsyncLifetime
         return spawnDoc.RootElement.GetProperty("agent_id").GetString()!;
     }
 
-    private SubAgentManager CreateManager(IUsageSink? usageSink)
+    private SubAgentManager CreateManager(IUsageSink? usageSink, Func<Task>? persistUsageAsync = null)
     {
         var options = CreateOptions();
         return new SubAgentManager(
@@ -99,7 +123,8 @@ public class SubAgentManagerUsageRelayTests : IAsyncLifetime
             parentHandlers: new Dictionary<string, ToolHandler>(),
             options: options,
             source: new MutableSubAgentTemplateSource(options.Templates),
-            usageSink: usageSink);
+            usageSink: usageSink,
+            persistUsageAsync: persistUsageAsync);
     }
 
     private SubAgentOptions CreateOptions()

--- a/tests/LmMultiTurn.Tests/Triggers/WaitTriggerLoopIntegrationTests.cs
+++ b/tests/LmMultiTurn.Tests/Triggers/WaitTriggerLoopIntegrationTests.cs
@@ -31,12 +31,19 @@ public class WaitTriggerLoopIntegrationTests
     [Fact]
     public async Task Wait_Timer_ParksThenAutoResumes_WithFiredPayload()
     {
-        // Turn 1: the LLM asks to wait on a short one-shot timer. Turn 2 (after the timer fires and
-        // the run auto-resumes) returns final text and must see the resolved "fired" payload.
+        // Turn 1: the LLM asks to wait on a one-shot timer. Turn 2 (after the timer fires and the run
+        // auto-resumes) returns final text and must see the resolved "fired" payload.
+        //
+        // The delay must comfortably exceed the window between firstDone completing and the parked-state
+        // assertions (callCount==1 / deferred registered) executing. A 150ms delay was comparable to a
+        // single thread-pool scheduling hiccup: under full-suite load the timer could fire and auto-resume
+        // (callCount->2, deferred cleared) before those assertions ran, failing intermittently. 1s is
+        // robust — the parked assertions take microseconds, and both they and the timer-fire callback share
+        // the same thread-pool/timer queue, so any load that delays the assertions delays the fire too.
         var waitCall = new ToolCallMessage
         {
             FunctionName = WaitToolProvider.WaitToolName,
-            FunctionArgs = WaitArgs(new { kind = "timer", args = new { delay = "150ms" }, timeout = "10m" }),
+            FunctionArgs = WaitArgs(new { kind = "timer", args = new { delay = "1s" }, timeout = "10m" }),
             ToolCallId = "tc_wait",
             Role = Role.Assistant,
         };

--- a/tests/LmMultiTurn.Tests/UsageAccounting/ConversationUsageProjectionTests.cs
+++ b/tests/LmMultiTurn.Tests/UsageAccounting/ConversationUsageProjectionTests.cs
@@ -100,6 +100,21 @@ public class ConversationUsageProjectionTests
         ConversationUsageProjection.FromMetadata(empty).Should().BeNull();
     }
 
+    [Fact]
+    public async Task SaveAsync_DoesNotReplaceNewerAggregate_WithStaleLowerWatermarkWrite()
+    {
+        var store = new InMemoryConversationStore();
+        var newer = SampleAggregate() with { FoldedRevision = 50, TotalTokens = 900 };
+        var stale = SampleAggregate() with { FoldedRevision = 5, TotalTokens = 100 };
+
+        await ConversationUsageProjection.SaveAsync(store, newer);
+        await ConversationUsageProjection.SaveAsync(store, stale); // out-of-order / post-restart write
+
+        var loaded = await ConversationUsageProjection.LoadAsync(store, "conv-1");
+        loaded!.FoldedRevision.Should().Be(50);
+        loaded.TotalTokens.Should().Be(900);
+    }
+
     private static void TryDelete(string path)
     {
         try

--- a/tests/LmMultiTurn.Tests/UsageAccounting/ConversationUsageProjectionTests.cs
+++ b/tests/LmMultiTurn.Tests/UsageAccounting/ConversationUsageProjectionTests.cs
@@ -101,6 +101,29 @@ public class ConversationUsageProjectionTests
     }
 
     [Fact]
+    public async Task SaveAsync_PersistsRecords_LoadableForRebuild()
+    {
+        var store = new InMemoryConversationStore();
+        var ledger = new UsageLedger("conv-1");
+        ledger.UpsertAttempt(new UsageRecord
+        {
+            LogicalCallId = "a1",
+            ProviderAttemptId = "a1",
+            RootConversationId = "conv-1",
+            RequestedModel = "model-A",
+            InputTokens = 100,
+            OutputTokens = 40,
+        });
+
+        await ConversationUsageProjection.SaveAsync(store, ledger.Snapshot(), ledger.SnapshotRecords());
+
+        var records = await ConversationUsageProjection.LoadRecordsAsync(store, "conv-1");
+        records.Should().ContainSingle();
+        records[0].ProviderAttemptId.Should().Be("a1");
+        records[0].InputTokens.Should().Be(100);
+    }
+
+    [Fact]
     public async Task SaveAsync_DoesNotReplaceNewerAggregate_WithStaleLowerWatermarkWrite()
     {
         var store = new InMemoryConversationStore();

--- a/tests/LmMultiTurn.Tests/UsageAccounting/ConversationUsageProjectionTests.cs
+++ b/tests/LmMultiTurn.Tests/UsageAccounting/ConversationUsageProjectionTests.cs
@@ -1,0 +1,117 @@
+using AchieveAi.LmDotnetTools.LmCore.Models;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence.Sqlite;
+using AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Tests.UsageAccounting;
+
+public class ConversationUsageProjectionTests
+{
+    private static ConversationUsageAggregate SampleAggregate()
+    {
+        var ledger = new UsageLedger("conv-1");
+        ledger.UpsertAttempt(new UsageRecord
+        {
+            LogicalCallId = "a1",
+            ProviderAttemptId = "a1",
+            RootConversationId = "conv-1",
+            RequestedModel = "model-A",
+            InputTokens = 100,
+            OutputTokens = 40,
+            CacheWriteTokens = 10,
+            EstimatedPublicCostMicros = 6000,
+        });
+        ledger.UpsertAttempt(new UsageRecord
+        {
+            LogicalCallId = "b1",
+            ProviderAttemptId = "b1",
+            RootConversationId = "conv-1",
+            RequestedModel = "model-B",
+            InputTokens = 20,
+            OutputTokens = 10,
+            ProviderReportedCostMicros = 5000,
+            Finalized = true,
+        });
+        return ledger.Snapshot(UsageCompleteness.Complete);
+    }
+
+    private static async Task AssertRoundTripsAsync(IConversationStore store)
+    {
+        var original = SampleAggregate();
+
+        await ConversationUsageProjection.SaveAsync(store, original);
+        var loaded = await ConversationUsageProjection.LoadAsync(store, "conv-1");
+
+        loaded.Should().NotBeNull();
+        loaded.Should().BeEquivalentTo(original);
+    }
+
+    [Fact]
+    public async Task RoundTrips_ThroughInMemoryStore()
+    {
+        await AssertRoundTripsAsync(new InMemoryConversationStore());
+    }
+
+    [Fact]
+    public async Task RoundTrips_ThroughFileStore()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"usage_proj_{Guid.NewGuid():N}");
+        try
+        {
+            await AssertRoundTripsAsync(new FileConversationStore(dir));
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task RoundTrips_ThroughSqliteStore()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"usage_proj_{Guid.NewGuid():N}.db");
+        var store = new SqliteConversationStore(dbPath);
+        try
+        {
+            await AssertRoundTripsAsync(store);
+        }
+        finally
+        {
+            await store.DisposeAsync();
+            SqliteConnection.ClearAllPools();
+            TryDelete(dbPath);
+            TryDelete(dbPath + "-wal");
+            TryDelete(dbPath + "-shm");
+        }
+    }
+
+    [Fact]
+    public void FromMetadata_ReturnsNull_WhenNoProjectionPresent()
+    {
+        ConversationUsageProjection.FromMetadata(null).Should().BeNull();
+
+        var empty = new ThreadMetadata { ThreadId = "conv-1", LastUpdated = 0 };
+        ConversationUsageProjection.FromMetadata(empty).Should().BeNull();
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (IOException)
+        {
+            // best-effort cleanup
+        }
+    }
+}

--- a/tests/LmMultiTurn.Tests/UsageAccounting/ConversationUsageProjectionTests.cs
+++ b/tests/LmMultiTurn.Tests/UsageAccounting/ConversationUsageProjectionTests.cs
@@ -208,6 +208,114 @@ public class ConversationUsageProjectionTests
     }
 
     [Fact]
+    public async Task SaveAsync_PreservesCompleteCompleteness_WhenLaterWriterMergesInProgress()
+    {
+        // A post-restart / second writer that merges an InProgress snapshot (its rebuilt local records) at
+        // an equal revision must not regress a previously Complete projection's completeness (#196).
+        var store = new InMemoryConversationStore();
+
+        var a1 = new UsageRecord
+        {
+            LogicalCallId = "a1",
+            ProviderAttemptId = "a1",
+            RootConversationId = "conv-1",
+            RequestedModel = "m",
+            InputTokens = 100,
+            OutputTokens = 10,
+            Revision = 1,
+        };
+        await ConversationUsageProjection.SaveAsync(
+            store, ConversationUsageAggregate.Fold("conv-1", [a1], 1, UsageCompleteness.Complete), [a1]);
+
+        var b1 = new UsageRecord
+        {
+            LogicalCallId = "b1",
+            ProviderAttemptId = "b1",
+            RootConversationId = "conv-1",
+            RequestedModel = "m",
+            InputTokens = 50,
+            OutputTokens = 5,
+            Revision = 1,
+        };
+        await ConversationUsageProjection.SaveAsync(
+            store, ConversationUsageAggregate.Fold("conv-1", [b1], 1, UsageCompleteness.InProgress), [b1]);
+
+        var loaded = await ConversationUsageProjection.LoadAsync(store, "conv-1");
+        loaded!.Completeness.Should().Be(UsageCompleteness.Complete); // not regressed to InProgress
+        loaded.TotalTokens.Should().Be(165); // records still merged
+    }
+
+    [Fact]
+    public async Task SaveAsync_UpgradesCompleteness_WhenIncomingIsMoreComplete()
+    {
+        var store = new InMemoryConversationStore();
+        var a1 = new UsageRecord
+        {
+            LogicalCallId = "a1",
+            ProviderAttemptId = "a1",
+            RootConversationId = "conv-1",
+            RequestedModel = "m",
+            InputTokens = 100,
+            OutputTokens = 10,
+            Revision = 1,
+        };
+
+        await ConversationUsageProjection.SaveAsync(
+            store, ConversationUsageAggregate.Fold("conv-1", [a1], 1, UsageCompleteness.InProgress), [a1]);
+        await ConversationUsageProjection.SaveAsync(
+            store, ConversationUsageAggregate.Fold("conv-1", [a1 with { Revision = 2 }], 2, UsageCompleteness.Complete), [a1 with { Revision = 2 }]);
+
+        var loaded = await ConversationUsageProjection.LoadAsync(store, "conv-1");
+        loaded!.Completeness.Should().Be(UsageCompleteness.Complete);
+    }
+
+    [Fact]
+    public async Task SaveAsync_RefusesWrite_WhenRecordsArtifactCorrupt_ButAggregateValid()
+    {
+        // The records artifact is the authoritative per-attempt history. If it is unreadable while the
+        // aggregate is valid, merging would treat history as empty and undercount — refuse instead (#196).
+        var store = new InMemoryConversationStore();
+        var a1 = new UsageRecord
+        {
+            LogicalCallId = "a1",
+            ProviderAttemptId = "a1",
+            RootConversationId = "conv-1",
+            RequestedModel = "m",
+            InputTokens = 100,
+            OutputTokens = 10,
+            Revision = 5,
+        };
+        await ConversationUsageProjection.SaveAsync(
+            store, ConversationUsageAggregate.Fold("conv-1", [a1], 5), [a1]);
+
+        // Corrupt ONLY the records artifact; the aggregate stays valid.
+        await store.UpdateMetadataAsync(
+            "conv-1",
+            existing => existing! with
+            {
+                Properties = existing.Properties!.SetItem(
+                    ConversationUsageProjection.RecordsPropertyKey, "{ not valid json"),
+            });
+
+        var b1 = new UsageRecord
+        {
+            LogicalCallId = "b1",
+            ProviderAttemptId = "b1",
+            RootConversationId = "conv-1",
+            RequestedModel = "m",
+            InputTokens = 30,
+            OutputTokens = 5,
+            Revision = 6,
+        };
+        await ConversationUsageProjection.SaveAsync(
+            store, ConversationUsageAggregate.Fold("conv-1", [b1], 6), [b1]);
+
+        // The authoritative aggregate must be preserved, not overwritten with only b1's usage.
+        var loaded = await ConversationUsageProjection.LoadAsync(store, "conv-1");
+        loaded!.TotalTokens.Should().Be(110); // a1's 100+10, NOT b1's 35
+    }
+
+    [Fact]
     public async Task SaveAsync_DoesNotOverwrite_NewerSchemaProjection()
     {
         // During a rollback / mixed-version deployment an older (v1) writer must not clobber a projection

--- a/tests/LmMultiTurn.Tests/UsageAccounting/ConversationUsageProjectionTests.cs
+++ b/tests/LmMultiTurn.Tests/UsageAccounting/ConversationUsageProjectionTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+using System.Text.Json;
 using AchieveAi.LmDotnetTools.LmCore.Models;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
 using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence.Sqlite;
@@ -136,6 +138,102 @@ public class ConversationUsageProjectionTests
         var loaded = await ConversationUsageProjection.LoadAsync(store, "conv-1");
         loaded!.FoldedRevision.Should().Be(50);
         loaded.TotalTokens.Should().Be(900);
+    }
+
+    [Fact]
+    public async Task SaveAsync_MergesRecords_AcrossWritersWithEqualRevision()
+    {
+        // Two writers (e.g. a post-restart writer, or a second instance) can legitimately reuse the same
+        // process-local revision for DIFFERENT attempts. A revision-`>`-guard alone would let the second
+        // write clobber the first; a durable merge-by-attempt-id must preserve both (#196).
+        var store = new InMemoryConversationStore();
+
+        var a1 = new UsageRecord
+        {
+            LogicalCallId = "a1",
+            ProviderAttemptId = "a1",
+            RootConversationId = "conv-1",
+            RequestedModel = "m",
+            InputTokens = 100,
+            OutputTokens = 10,
+            Revision = 1,
+        };
+        var b1 = new UsageRecord
+        {
+            LogicalCallId = "b1",
+            ProviderAttemptId = "b1",
+            RootConversationId = "conv-1",
+            RequestedModel = "m",
+            InputTokens = 50,
+            OutputTokens = 5,
+            Revision = 1,
+        };
+
+        await ConversationUsageProjection.SaveAsync(
+            store, ConversationUsageAggregate.Fold("conv-1", [a1], foldedRevision: 1), [a1]);
+        await ConversationUsageProjection.SaveAsync(
+            store, ConversationUsageAggregate.Fold("conv-1", [b1], foldedRevision: 1), [b1]);
+
+        var records = await ConversationUsageProjection.LoadRecordsAsync(store, "conv-1");
+        records.Select(r => r.ProviderAttemptId).Should().BeEquivalentTo(["a1", "b1"]);
+
+        var loaded = await ConversationUsageProjection.LoadAsync(store, "conv-1");
+        loaded!.TotalTokens.Should().Be(165); // (100+10) + (50+5)
+    }
+
+    [Fact]
+    public async Task SaveAsync_MergesRecords_HigherRevisionWins_ForSameAttempt()
+    {
+        var store = new InMemoryConversationStore();
+
+        var early = new UsageRecord
+        {
+            LogicalCallId = "a1",
+            ProviderAttemptId = "a1",
+            RootConversationId = "conv-1",
+            RequestedModel = "m",
+            InputTokens = 40,
+            OutputTokens = 5,
+            Revision = 1,
+        };
+        var final = early with { InputTokens = 100, OutputTokens = 20, Revision = 7 };
+
+        await ConversationUsageProjection.SaveAsync(
+            store, ConversationUsageAggregate.Fold("conv-1", [early], foldedRevision: 1), [early]);
+        await ConversationUsageProjection.SaveAsync(
+            store, ConversationUsageAggregate.Fold("conv-1", [final], foldedRevision: 7), [final]);
+
+        var loaded = await ConversationUsageProjection.LoadAsync(store, "conv-1");
+        loaded!.TotalTokens.Should().Be(120); // final revision (100+20), not the sum of both revisions
+    }
+
+    [Fact]
+    public async Task SaveAsync_DoesNotOverwrite_NewerSchemaProjection()
+    {
+        // During a rollback / mixed-version deployment an older (v1) writer must not clobber a projection
+        // written by a newer (v2) build — the forward-compatible data must be preserved intact (#196).
+        var store = new InMemoryConversationStore();
+        var futureJson = JsonSerializer.Serialize(SampleAggregate() with { SchemaVersion = 2, TotalTokens = 777 });
+
+        await store.UpdateMetadataAsync(
+            "conv-1",
+            existing =>
+            {
+                var props = (existing?.Properties ?? ImmutableDictionary<string, object>.Empty)
+                    .SetItem(ConversationUsageProjection.PropertyKey, futureJson);
+                return existing is not null
+                    ? existing with { Properties = props }
+                    : new ThreadMetadata { ThreadId = "conv-1", LastUpdated = 0, Properties = props };
+            });
+
+        // A current (v1) writer attempts to save a smaller total.
+        await ConversationUsageProjection.SaveAsync(store, SampleAggregate() with { TotalTokens = 5 });
+
+        var metadata = await store.LoadMetadataAsync("conv-1");
+        var raw = (string)metadata!.Properties![ConversationUsageProjection.PropertyKey];
+        var preserved = JsonSerializer.Deserialize<ConversationUsageAggregate>(raw);
+        preserved!.SchemaVersion.Should().Be(2);
+        preserved.TotalTokens.Should().Be(777);
     }
 
     private static void TryDelete(string path)

--- a/tests/LmMultiTurn.Tests/UsageAccounting/MultiTurnAgentLoopUsageActivationTests.cs
+++ b/tests/LmMultiTurn.Tests/UsageAccounting/MultiTurnAgentLoopUsageActivationTests.cs
@@ -72,6 +72,48 @@ public class MultiTurnAgentLoopUsageActivationTests
         await cts.CancelAsync();
     }
 
+    [Fact]
+    public async Task Dispose_FlushesUsage_MakingItDurableWithoutPolling()
+    {
+        // The awaited flush at disposal is the durability boundary: a run's final usage must be persisted
+        // synchronously by DisposeAsync, not left to a fire-and-forget write that may be lost at shutdown.
+        SetupMockAgentResponse([
+            new UsageMessage
+            {
+                Usage = new Usage { PromptTokens = 100, CompletionTokens = 40 },
+                GenerationId = "gen-1",
+            },
+            new TextMessage { Text = "done", Role = Role.Assistant },
+        ]);
+
+        var store = new InMemoryConversationStore();
+        var registry = new FunctionRegistry();
+        var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            registry,
+            "usage-thread",
+            store: store);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        _ = loop.RunAsync(cts.Token);
+
+        var userInput = new UserInput(
+            [new TextMessage { Text = "Hi", Role = Role.User }],
+            InputId: "input-1");
+
+        await foreach (var _ in loop.ExecuteRunAsync(userInput, cts.Token))
+        {
+            // drain the run to completion
+        }
+
+        await loop.DisposeAsync();
+
+        // No polling: if the disposal flush works, usage is durable the instant DisposeAsync returns.
+        var aggregate = await ConversationUsageProjection.LoadAsync(store, "usage-thread");
+        aggregate.Should().NotBeNull();
+        aggregate!.TotalTokens.Should().Be(140);
+    }
+
     private void SetupMockAgentResponse(List<IMessage> messages)
     {
         _mockAgent

--- a/tests/LmMultiTurn.Tests/UsageAccounting/MultiTurnAgentLoopUsageActivationTests.cs
+++ b/tests/LmMultiTurn.Tests/UsageAccounting/MultiTurnAgentLoopUsageActivationTests.cs
@@ -1,0 +1,96 @@
+using System.Runtime.CompilerServices;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmCore.Models;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
+using AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Tests.UsageAccounting;
+
+/// <summary>
+/// End-to-end activation of conversation usage accounting in the live loop (#196): a run whose provider
+/// reports a UsageMessage results in a persisted usage aggregate on the conversation.
+/// </summary>
+public class MultiTurnAgentLoopUsageActivationTests
+{
+    private readonly Mock<IStreamingAgent> _mockAgent = new();
+
+    [Fact]
+    public async Task Run_PersistsUsageAggregate_FromPrimaryUsageMessage()
+    {
+        SetupMockAgentResponse([
+            new UsageMessage
+            {
+                Usage = new Usage { PromptTokens = 100, CompletionTokens = 40 },
+                GenerationId = "gen-1",
+            },
+            new TextMessage { Text = "done", Role = Role.Assistant },
+        ]);
+
+        var store = new InMemoryConversationStore();
+        var registry = new FunctionRegistry();
+        await using var loop = new MultiTurnAgentLoop(
+            _mockAgent.Object,
+            registry,
+            "usage-thread",
+            store: store);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        _ = loop.RunAsync(cts.Token);
+
+        var userInput = new UserInput(
+            [new TextMessage { Text = "Hi", Role = Role.User }],
+            InputId: "input-1");
+
+        await foreach (var _ in loop.ExecuteRunAsync(userInput, cts.Token))
+        {
+            // drain the run to completion
+        }
+
+        // Persistence of the aggregate is fire-and-forget, so poll briefly for it to land.
+        ConversationUsageAggregate? aggregate = null;
+        for (var attempt = 0; attempt < 100 && aggregate is null; attempt++)
+        {
+            aggregate = await ConversationUsageProjection.LoadAsync(store, "usage-thread");
+            if (aggregate is null)
+            {
+                await Task.Delay(20, cts.Token);
+            }
+        }
+
+        aggregate.Should().NotBeNull();
+        aggregate!.TotalTokens.Should().Be(140);
+        aggregate.RootConversationId.Should().Be("usage-thread");
+        aggregate.PerModel.Should().ContainSingle();
+
+        await cts.CancelAsync();
+    }
+
+    private void SetupMockAgentResponse(List<IMessage> messages)
+    {
+        _mockAgent
+            .Setup(a => a.GenerateReplyStreamingAsync(
+                It.IsAny<IEnumerable<IMessage>>(),
+                It.IsAny<GenerateReplyOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(ToAsyncEnumerable(messages)));
+    }
+
+    private static async IAsyncEnumerable<IMessage> ToAsyncEnumerable(
+        List<IMessage> messages,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        foreach (var msg in messages)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return msg;
+            await Task.Yield();
+        }
+    }
+}

--- a/tests/LmMultiTurn.Tests/UsageAccounting/RevisionWatermarkTests.cs
+++ b/tests/LmMultiTurn.Tests/UsageAccounting/RevisionWatermarkTests.cs
@@ -1,0 +1,55 @@
+using AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
+using FluentAssertions;
+using Xunit;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Tests.UsageAccounting;
+
+public class RevisionWatermarkTests
+{
+    [Fact]
+    public void Prefix_AdvancesContiguously_AsRevisionsCommit()
+    {
+        var w = new RevisionWatermark();
+        var r1 = w.Allocate();
+        var r2 = w.Allocate();
+        var r3 = w.Allocate();
+
+        w.Prefix.Should().Be(0);
+        w.Commit(r1);
+        w.Prefix.Should().Be(1);
+        w.Commit(r2);
+        w.Commit(r3);
+        w.Prefix.Should().Be(3);
+    }
+
+    [Fact]
+    public void Prefix_DoesNotAdvancePastGap_UntilEarlierRevisionCommitted()
+    {
+        // Revobot's required adversarial case: revision 2 becomes visible while revision 1 is delayed.
+        var w = new RevisionWatermark();
+        var r1 = w.Allocate();
+        var r2 = w.Allocate();
+
+        w.Commit(r2); // rev 2 committed, rev 1 still pending
+        w.Prefix.Should().Be(0, "publishing N=2 without revision 1 would drop a record");
+
+        w.Commit(r1); // gap fills
+        w.Prefix.Should().Be(2);
+    }
+
+    [Fact]
+    public void Commit_IsIdempotent_AndSafeOutOfOrder()
+    {
+        var w = new RevisionWatermark();
+        var r1 = w.Allocate();
+        var r2 = w.Allocate();
+
+        w.Commit(r2);
+        w.Commit(r2); // duplicate commit
+        w.Prefix.Should().Be(0);
+
+        w.Commit(r1);
+        w.Commit(r1); // duplicate below prefix
+        w.Prefix.Should().Be(2);
+    }
+}

--- a/tests/LmMultiTurn.Tests/UsageAccounting/UsageLedgerTests.cs
+++ b/tests/LmMultiTurn.Tests/UsageAccounting/UsageLedgerTests.cs
@@ -85,4 +85,32 @@ public class UsageLedgerTests
         snap.FoldedRevision.Should().Be(3); // three committed, gap-free
         snap.Completeness.Should().Be(UsageCompleteness.Complete);
     }
+
+    [Fact]
+    public void UpsertAttempt_FillsEstimatedPublicCost_FromResolver()
+    {
+        var ledger = new UsageLedger(
+            "conv-1",
+            new StubResolver("model-A", promptPerMillion: 2m, completionPerMillion: 8m));
+
+        ledger.UpsertAttempt(Obs("a1", "model-A", input: 1000, output: 500));
+
+        var snap = ledger.Snapshot();
+        snap.EstimatedPublicCostMicros.Should().Be(6000); // 1000*$2/M + 500*$8/M => $0.006
+        snap.ProviderReportedCostMicros.Should().BeNull();
+    }
+
+    private sealed class StubResolver(string model, decimal promptPerMillion, decimal completionPerMillion)
+        : IPricingResolver
+    {
+        private readonly ModelPricing _pricing = new()
+        {
+            ModelId = model,
+            PromptPerMillion = promptPerMillion,
+            CompletionPerMillion = completionPerMillion,
+        };
+
+        public ModelPricing? Resolve(string modelId) =>
+            string.Equals(modelId, model, StringComparison.Ordinal) ? _pricing : null;
+    }
 }

--- a/tests/LmMultiTurn.Tests/UsageAccounting/UsageLedgerTests.cs
+++ b/tests/LmMultiTurn.Tests/UsageAccounting/UsageLedgerTests.cs
@@ -1,0 +1,88 @@
+using AchieveAi.LmDotnetTools.LmCore.Models;
+using AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
+using FluentAssertions;
+using Xunit;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Tests.UsageAccounting;
+
+public class UsageLedgerTests
+{
+    private static UsageRecord Obs(
+        string attemptId,
+        string model,
+        long input,
+        long output,
+        bool finalized = false) =>
+        new()
+        {
+            LogicalCallId = attemptId,
+            ProviderAttemptId = attemptId,
+            RootConversationId = "conv-1",
+            RequestedModel = model,
+            InputTokens = input,
+            OutputTokens = output,
+            Finalized = finalized,
+        };
+
+    [Fact]
+    public void UpsertAttempt_CollapsesCumulativeObservations_ToOneRecordPerAttempt()
+    {
+        var ledger = new UsageLedger("conv-1");
+
+        // Three cumulative streaming observations for the same attempt.
+        ledger.UpsertAttempt(Obs("a1", "model-A", input: 40, output: 0));
+        ledger.UpsertAttempt(Obs("a1", "model-A", input: 100, output: 30));
+        ledger.UpsertAttempt(Obs("a1", "model-A", input: 100, output: 55, finalized: true));
+
+        var snap = ledger.Snapshot();
+
+        snap.PerModel.Should().ContainSingle();
+        snap.PerModel[0].AttemptCount.Should().Be(1);
+        snap.PerModel[0].InputTokens.Should().Be(100);
+        snap.PerModel[0].OutputTokens.Should().Be(55);
+        snap.TotalTokens.Should().Be(155);
+    }
+
+    [Fact]
+    public void UpsertAttempt_Replay_IsIdempotent()
+    {
+        var ledger = new UsageLedger("conv-1");
+        var final = Obs("a1", "model-A", input: 100, output: 55, finalized: true);
+
+        ledger.UpsertAttempt(final);
+        ledger.UpsertAttempt(final); // replay
+
+        var snap = ledger.Snapshot();
+        snap.PerModel[0].AttemptCount.Should().Be(1);
+        snap.TotalTokens.Should().Be(155);
+    }
+
+    [Fact]
+    public void UpsertAttempt_OutOfOrder_FinalThenLateInterim_KeepsMax()
+    {
+        var ledger = new UsageLedger("conv-1");
+
+        ledger.UpsertAttempt(Obs("a1", "model-A", input: 100, output: 55, finalized: true));
+        ledger.UpsertAttempt(Obs("a1", "model-A", input: 90, output: 40)); // stale late interim
+
+        var snap = ledger.Snapshot();
+        snap.PerModel[0].InputTokens.Should().Be(100);
+        snap.PerModel[0].OutputTokens.Should().Be(55);
+    }
+
+    [Fact]
+    public void Snapshot_SumsAcrossAttemptsAndModels_WithWatermarkAtCommittedPrefix()
+    {
+        var ledger = new UsageLedger("conv-1");
+        ledger.UpsertAttempt(Obs("a1", "model-A", input: 100, output: 40));
+        ledger.UpsertAttempt(Obs("a2", "model-B", input: 10, output: 5));
+        ledger.UpsertAttempt(Obs("a3", "model-A", input: 20, output: 10, finalized: true));
+
+        var snap = ledger.Snapshot(UsageCompleteness.Complete);
+
+        snap.PerModel.Should().HaveCount(2);
+        snap.TotalTokens.Should().Be(185); // A: 170, B: 15
+        snap.FoldedRevision.Should().Be(3); // three committed, gap-free
+        snap.Completeness.Should().Be(UsageCompleteness.Complete);
+    }
+}

--- a/tests/LmMultiTurn.Tests/UsageAccounting/UsageLedgerTests.cs
+++ b/tests/LmMultiTurn.Tests/UsageAccounting/UsageLedgerTests.cs
@@ -100,6 +100,32 @@ public class UsageLedgerTests
         snap.ProviderReportedCostMicros.Should().BeNull();
     }
 
+    [Fact]
+    public void SeedFromRecords_RestoresTotals_DedupsSeededAttempts_AndContinuesWatermark()
+    {
+        var original = new UsageLedger("conv-1");
+        original.UpsertAttempt(Obs("a1", "model-A", input: 100, output: 40));
+        original.UpsertAttempt(Obs("a2", "model-B", input: 10, output: 5));
+        var records = original.SnapshotRecords();
+        var originalSnapshot = original.Snapshot();
+
+        // A recreated ledger (e.g. after restart) rebuilds from the durable records.
+        var rebuilt = new UsageLedger("conv-1");
+        rebuilt.SeedFromRecords(records, originalSnapshot.FoldedRevision);
+
+        rebuilt.Snapshot().TotalTokens.Should().Be(155);
+        rebuilt.Snapshot().FoldedRevision.Should().Be(originalSnapshot.FoldedRevision);
+
+        // Re-observing a seeded attempt does not double-count.
+        rebuilt.UpsertAttempt(Obs("a1", "model-A", input: 100, output: 40));
+        rebuilt.Snapshot().TotalTokens.Should().Be(155);
+
+        // A genuinely new attempt adds and advances the watermark above the seeded baseline.
+        rebuilt.UpsertAttempt(Obs("a3", "model-A", input: 20, output: 10));
+        rebuilt.Snapshot().TotalTokens.Should().Be(185);
+        rebuilt.Snapshot().FoldedRevision.Should().BeGreaterThan(originalSnapshot.FoldedRevision);
+    }
+
     private sealed class StubResolver(string model, decimal promptPerMillion, decimal completionPerMillion)
         : IPricingResolver
     {

--- a/tests/LmMultiTurn.Tests/UsageAccounting/UsagePersistenceWriterTests.cs
+++ b/tests/LmMultiTurn.Tests/UsageAccounting/UsagePersistenceWriterTests.cs
@@ -22,8 +22,9 @@ public class UsagePersistenceWriterTests
         });
 
         writer.Schedule();
-        await writer.FlushAsync();
+        var durable = await writer.FlushAsync();
 
+        durable.Should().BeTrue();
         count.Should().BeGreaterThan(0);
     }
 
@@ -37,8 +38,9 @@ public class UsagePersistenceWriterTests
             return Task.CompletedTask;
         });
 
-        await writer.FlushAsync();
+        var durable = await writer.FlushAsync();
 
+        durable.Should().BeTrue();
         count.Should().Be(0);
     }
 
@@ -57,8 +59,9 @@ public class UsagePersistenceWriterTests
             writer.Schedule();
         }
 
-        await writer.FlushAsync();
+        var durable = await writer.FlushAsync();
 
+        durable.Should().BeTrue();
         persisted.Should().BeGreaterThan(0);
         persisted.Should().BeLessThan(50);
     }
@@ -74,23 +77,51 @@ public class UsagePersistenceWriterTests
         });
 
         writer.Schedule();
-        await writer.FlushAsync();
+        _ = await writer.FlushAsync();
         var first = count;
 
         writer.Schedule();
-        await writer.FlushAsync();
+        _ = await writer.FlushAsync();
 
         count.Should().BeGreaterThan(first);
     }
 
     [Fact]
-    public async Task FlushAsync_DoesNotThrow_WhenPersistFaults()
+    public async Task FlushAsync_ReportsNotDurable_AndInvokesOnError_WhenPersistFails()
     {
-        var writer = new UsagePersistenceWriter(ct => throw new InvalidOperationException("boom"));
+        // A failed authoritative write must NOT be reported as a clean durability boundary — Flush returns
+        // false and the failure is surfaced once via onError.
+        var errors = 0;
+        var writer = new UsagePersistenceWriter(
+            ct => throw new InvalidOperationException("boom"),
+            onError: _ => Interlocked.Increment(ref errors));
 
         writer.Schedule();
-        var flush = async () => await writer.FlushAsync();
+        var durable = await writer.FlushAsync();
 
-        await flush.Should().NotThrowAsync();
+        durable.Should().BeFalse();
+        errors.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task FlushAsync_BecomesDurable_WhenAFailedWriteLaterSucceeds()
+    {
+        // The failed write is retained; once the store recovers, a later flush persists it and reports true.
+        var fail = true;
+        var writer = new UsagePersistenceWriter(ct =>
+        {
+            if (Volatile.Read(ref fail))
+            {
+                throw new InvalidOperationException("boom");
+            }
+
+            return Task.CompletedTask;
+        });
+
+        writer.Schedule();
+        (await writer.FlushAsync()).Should().BeFalse();
+
+        Volatile.Write(ref fail, false);
+        (await writer.FlushAsync()).Should().BeTrue();
     }
 }

--- a/tests/LmMultiTurn.Tests/UsageAccounting/UsagePersistenceWriterTests.cs
+++ b/tests/LmMultiTurn.Tests/UsageAccounting/UsagePersistenceWriterTests.cs
@@ -1,0 +1,96 @@
+using AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
+using FluentAssertions;
+using Xunit;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Tests.UsageAccounting;
+
+/// <summary>
+///     Verifies the serialized/coalesced usage writer (#196): a scheduled write becomes durable only once
+///     awaited via <see cref="UsagePersistenceWriter.FlushAsync" />, bursts coalesce rather than running one
+///     write per observation, and a later schedule after a drain triggers a fresh write.
+/// </summary>
+public class UsagePersistenceWriterTests
+{
+    [Fact]
+    public async Task FlushAsync_AwaitsScheduledWrite()
+    {
+        var count = 0;
+        var writer = new UsagePersistenceWriter(ct =>
+        {
+            _ = Interlocked.Increment(ref count);
+            return Task.CompletedTask;
+        });
+
+        writer.Schedule();
+        await writer.FlushAsync();
+
+        count.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task FlushAsync_IsNoOp_WhenNothingScheduled()
+    {
+        var count = 0;
+        var writer = new UsagePersistenceWriter(ct =>
+        {
+            _ = Interlocked.Increment(ref count);
+            return Task.CompletedTask;
+        });
+
+        await writer.FlushAsync();
+
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Schedule_CoalescesBurst_IntoFarFewerWrites()
+    {
+        var persisted = 0;
+        var writer = new UsagePersistenceWriter(async ct =>
+        {
+            _ = Interlocked.Increment(ref persisted);
+            await Task.Yield();
+        });
+
+        for (var i = 0; i < 50; i++)
+        {
+            writer.Schedule();
+        }
+
+        await writer.FlushAsync();
+
+        persisted.Should().BeGreaterThan(0);
+        persisted.Should().BeLessThan(50);
+    }
+
+    [Fact]
+    public async Task Schedule_AfterDrain_TriggersAnotherWrite()
+    {
+        var count = 0;
+        var writer = new UsagePersistenceWriter(ct =>
+        {
+            _ = Interlocked.Increment(ref count);
+            return Task.CompletedTask;
+        });
+
+        writer.Schedule();
+        await writer.FlushAsync();
+        var first = count;
+
+        writer.Schedule();
+        await writer.FlushAsync();
+
+        count.Should().BeGreaterThan(first);
+    }
+
+    [Fact]
+    public async Task FlushAsync_DoesNotThrow_WhenPersistFaults()
+    {
+        var writer = new UsagePersistenceWriter(ct => throw new InvalidOperationException("boom"));
+
+        writer.Schedule();
+        var flush = async () => await writer.FlushAsync();
+
+        await flush.Should().NotThrowAsync();
+    }
+}

--- a/tests/LmMultiTurn.Tests/UsageAccounting/UsageRecordMapperTests.cs
+++ b/tests/LmMultiTurn.Tests/UsageAccounting/UsageRecordMapperTests.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Models;
+using AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
+using FluentAssertions;
+using Xunit;
+
+namespace AchieveAi.LmDotnetTools.LmMultiTurn.Tests.UsageAccounting;
+
+/// <summary>
+///     Verifies <see cref="UsageRecordMapper" /> (#196): cache-creation tokens map into the additive
+///     cache-write dimension (both CLR-int and provider JsonElement shapes), and id-less usage messages get
+///     a distinct-per-call attempt identity rather than a shared constant that silently undercounts.
+/// </summary>
+public class UsageRecordMapperTests
+{
+    [Fact]
+    public void FromUsageMessage_MapsCacheCreationTokens_FromClrInt()
+    {
+        var usage = new Usage { PromptTokens = 100, CompletionTokens = 40 }
+            .SetExtraProperty("cache_creation_input_tokens", 25);
+        var message = new UsageMessage { Usage = usage, GenerationId = "gen-1" };
+
+        var record = UsageRecordMapper.FromUsageMessage(message, "root", UsageExecutionKind.Primary, "model-A");
+
+        record.CacheWriteTokens.Should().Be(25);
+        record.TotalTokens.Should().Be(165); // 100 input + 25 cache-write + 40 output
+    }
+
+    [Fact]
+    public void FromUsageMessage_MapsCacheCreationTokens_FromJsonElement()
+    {
+        // Providers/persistence re-hydrate ExtraProperties values as JsonElement — the mapper must read the
+        // cache-creation count in that shape too.
+        var usage = new Usage { PromptTokens = 100, CompletionTokens = 40 }
+            .SetExtraProperty("cache_creation_input_tokens", JsonSerializer.SerializeToElement(25));
+        var message = new UsageMessage { Usage = usage, GenerationId = "gen-1" };
+
+        var record = UsageRecordMapper.FromUsageMessage(message, "root", UsageExecutionKind.Primary, "model-A");
+
+        record.CacheWriteTokens.Should().Be(25);
+    }
+
+    [Fact]
+    public void CacheCreationTokens_FoldAdditively_IntoAggregateTotal()
+    {
+        var ledger = new UsageLedger("root");
+        ledger.RecordUsage(UsageRecordMapper.FromUsageMessage(
+            new UsageMessage
+            {
+                Usage = new Usage { PromptTokens = 100, CompletionTokens = 40 }
+                    .SetExtraProperty("cache_creation_input_tokens", 25),
+                GenerationId = "gen-1",
+            },
+            "root",
+            UsageExecutionKind.Primary,
+            "model-A"));
+
+        var snapshot = ledger.Snapshot();
+        snapshot.PerModel.Should().ContainSingle();
+        snapshot.PerModel[0].CacheWriteTokens.Should().Be(25);
+        snapshot.TotalTokens.Should().Be(165);
+    }
+
+    [Fact]
+    public void FromUsageMessage_WithoutIds_DoesNotCollapseDistinctCalls()
+    {
+        // Two separate provider calls arriving without a generation/run id but with different usage must NOT
+        // be merged into one attempt by a shared constant key — that would MAX-collapse and undercount (#196).
+        var first = new UsageMessage { Usage = new Usage { PromptTokens = 100, CompletionTokens = 40 } };
+        var second = new UsageMessage { Usage = new Usage { PromptTokens = 30, CompletionTokens = 10 } };
+
+        var ledger = new UsageLedger("root");
+        ledger.RecordUsage(UsageRecordMapper.FromUsageMessage(first, "root", UsageExecutionKind.Primary, "m"));
+        ledger.RecordUsage(UsageRecordMapper.FromUsageMessage(second, "root", UsageExecutionKind.Primary, "m"));
+
+        var snapshot = ledger.Snapshot();
+        snapshot.PerModel.Should().ContainSingle();
+        snapshot.PerModel[0].AttemptCount.Should().Be(2);
+        snapshot.TotalTokens.Should().Be(180); // 140 + 40, not MAX-collapsed to 140
+    }
+
+    [Fact]
+    public void FromUsageMessage_WithoutIds_SameObservationDedups()
+    {
+        // An exact replay of the same id-less observation must still resolve to one attempt.
+        var message = new UsageMessage { Usage = new Usage { PromptTokens = 100, CompletionTokens = 40 } };
+
+        var first = UsageRecordMapper.FromUsageMessage(message, "root", UsageExecutionKind.Primary, "m");
+        var second = UsageRecordMapper.FromUsageMessage(message, "root", UsageExecutionKind.Primary, "m");
+
+        first.ProviderAttemptId.Should().Be(second.ProviderAttemptId);
+    }
+}

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs
@@ -55,6 +55,15 @@ public static class UiHelpers
         return page.GetByTestId("error-banner");
     }
 
+    /// <summary>
+    /// Conversation-wide token-usage banner (#196) — rendered only once cumulative total tokens &gt; 0.
+    /// Text shape: <c>Total: N | In: N | Out: N [| Cached: N] [| Cache created: N]</c>.
+    /// </summary>
+    public static ILocator UsageBanner(this IPage page)
+    {
+        return page.GetByTestId("usage-banner");
+    }
+
     /// <summary>Deferred-auth banner — rendered while the backend holds a webhook call awaiting sign-in (one per provider, see <c>data-provider-id</c>).</summary>
     public static ILocator AuthRequiredBanner(this IPage page)
     {

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/UsageBannerTests.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/UsageBannerTests.cs
@@ -1,0 +1,165 @@
+using System.Text.RegularExpressions;
+using AchieveAi.LmDotnetTools.AnthropicProvider.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using FluentAssertions;
+using LmStreaming.Sample.Browser.E2E.Tests.Infrastructure;
+
+namespace LmStreaming.Sample.Browser.E2E.Tests.Scenarios;
+
+/// <summary>
+/// #196 — conversation-wide token-usage banner. Drives the real Vue client against the scripted
+/// <c>test-anthropic</c> backend, whose SSE emits a fixed <b>100 input / 50 output</b> tokens per
+/// generation (<see cref="AnthropicSseStreamHttpContent"/>), so the banner totals are exact.
+/// Covers: single-turn exact counts, additive multi-turn accumulation (never max'd), reload
+/// restoration from the persisted aggregate, and sub-agent descendant usage folding into that
+/// aggregate (the headline "incl. sub-agents" requirement).
+/// </summary>
+[Collection(PlaywrightCollection.Name)]
+public sealed class UsageBannerTests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public UsageBannerTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    // Nested chain the sub-agent runs via the Agent tool's `prompt`: a `calculate` turn then a text
+    // turn. Each generation emits 100/50, so the sub-agent contributes usage above the parent's own.
+    private const string InnerChain =
+        """<|instruction_start|>{"instruction_chain":[{"id":"sub-tool","id_message":"Sub-agent uses calculate","messages":[{"tool_call":[{"name":"calculate","args":{"a":2,"operation":"add","b":3}}]}]},{"id":"sub-text","id_message":"Sub-agent replies","messages":[{"text":"hi from agent"}]}]}<|instruction_end|>""";
+
+    [Fact]
+    public async Task Banner_shows_exact_tokens_accumulates_additively_and_survives_reload()
+    {
+        var responder = ScriptedSseResponder
+            .New()
+            .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
+            .Turn(t => t.Text("First answer."))
+            .Turn(t => t.Text("Second answer."))
+            .Build();
+
+        await using var session = await _fixture.OpenAsync("test-anthropic", responder.HandlerFor("test-anthropic"));
+        var page = session.Page;
+
+        // Turn 1: one generation = 100 in / 50 out -> Total 150.
+        await page.SendMessageAsync("hello");
+        await page.WaitForStreamIdleAsync();
+        await page.UsageBanner().WaitForTextContainsAsync("Total: 150");
+        var banner1 = await page.UsageBanner().InnerTextAsync();
+        banner1.Should().Contain("In: 100").And.Contain("Out: 50");
+
+        // Turn 2: additive across attempts -> 300 / 200 / 100 (NOT max'd like a single generation).
+        await page.SendMessageAsync("again");
+        await page.WaitForStreamIdleAsync();
+        await page.UsageBanner().WaitForTextContainsAsync("Total: 300");
+        var banner2 = await page.UsageBanner().InnerTextAsync();
+        banner2.Should().Contain("In: 200").And.Contain("Out: 100");
+
+        // Reload -> banner restored from the persisted aggregate (not recomputed from the empty stream).
+        await page.ReloadAsync();
+        await page.Textarea().WaitForAsync();
+        await page.UsageBanner().WaitForTextContainsAsync("Total: 300");
+
+        await session.SaveSuccessScreenshotAsync("UsageBanner.exact_accumulate_reload");
+    }
+
+    [Fact]
+    public async Task Sub_agent_usage_folds_into_the_conversation_wide_aggregate()
+    {
+        var responder = ScriptedSseResponder
+            .New()
+            .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
+            .Turn(t => t.ToolCall("Agent", new { subagent_type = "general-purpose", prompt = InnerChain }))
+            .Turn(t => t.Text("Parent summary: delegation finished."))
+            .Build();
+
+        await using var session = await _fixture.OpenAsync(
+            "test-anthropic",
+            responder.HandlerFor("test-anthropic"),
+            subAgentFactory: (loggerFactory, _) => BuildSubAgentOptions(loggerFactory));
+        var page = session.Page;
+
+        await page.SendMessageAsync("delegate to the sub-agent");
+        // The synchronous Agent call blocks until the sub-agent runs its nested chain, so allow extra time.
+        await page.WaitForStreamIdleAsync(timeoutMs: 30_000);
+
+        // The LIVE banner reflects the usage streamed to the client — at minimum the parent's own two
+        // generations (300). (Today descendant usage is folded server-side and not streamed, so the live
+        // value is exactly 300; asserting ">= 300" keeps this robust if live descendant streaming is added.)
+        await page.UsageBanner().WaitForTextContainsAsync("Total:");
+        var liveTotal = ParseTotal(await page.UsageBanner().InnerTextAsync());
+        liveTotal.Should().BeGreaterThanOrEqualTo(300, "the parent's own generations are streamed to the banner");
+
+        // Server-side ground truth: the persisted aggregate exceeds the parent-only 300 because the
+        // sub-agent's generations were folded into the root conversation's total (#196 "incl. sub-agents").
+        // Read the thread id from the conversations API (robust to sidebar rendering), then its usage.
+        var aggregateTotal = await page.EvaluateAsync<long>(
+            @"async () => {
+                const lr = await fetch('/api/conversations');
+                const body = await lr.json();
+                const list = body.conversations ?? body ?? [];
+                if (!list.length) return -2;
+                const id = list[list.length - 1].threadId;
+                const r = await fetch(`/api/conversations/${id}/usage`);
+                if (!r.ok) return -1;
+                return (await r.json()).totalTokens;
+            }");
+        aggregateTotal.Should().BeGreaterThan(
+            300,
+            "the sub-agent's relayed usage must fold into the conversation-wide aggregate, above the parent's own 300");
+
+        // On reopen the banner is restored from that aggregate, so it now includes the descendant's tokens.
+        await page.ReloadAsync();
+        await page.Textarea().WaitForAsync();
+        await page.UsageBanner().WaitForTextContainsAsync("Total:");
+        var reloadedTotal = ParseTotal(await page.UsageBanner().InnerTextAsync());
+        reloadedTotal.Should().Be((int)aggregateTotal, "reopen renders the same persisted aggregate total");
+
+        responder.RemainingTurns["parent"].Should().Be(0);
+        await session.SaveSuccessScreenshotAsync("UsageBanner.sub_agent_folds_into_aggregate");
+    }
+
+    private static int ParseTotal(string bannerText)
+    {
+        var match = Regex.Match(bannerText, @"Total:\s*(\d+)");
+        return match.Success ? int.Parse(match.Groups[1].Value) : -1;
+    }
+
+    private static SubAgentOptions BuildSubAgentOptions(ILoggerFactory loggerFactory)
+    {
+        return new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate>
+            {
+                ["general-purpose"] = new SubAgentTemplate
+                {
+                    Name = "UsageSub",
+                    SystemPrompt = "You are an embedded-chain sub-agent.",
+                    AgentFactory = () => BuildEmbeddedChainAgent(loggerFactory),
+                    MaxTurnsPerRun = 5,
+                },
+            },
+            MaxConcurrentSubAgents = 5,
+        };
+    }
+
+    // Sub-agent backed by the embedded-chain Anthropic test handler, which emits the same fixed
+    // 100/50 usage per generation as the parent — so the descendant's contribution is measurable.
+    private static IStreamingAgent BuildEmbeddedChainAgent(ILoggerFactory loggerFactory)
+    {
+        var handler = new AnthropicTestSseMessageHandler(
+            loggerFactory.CreateLogger<AnthropicTestSseMessageHandler>());
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://test-mode/v1") };
+        var anthropicClient = new AnthropicClient(
+            httpClient,
+            baseUrl: "http://test-mode/v1",
+            logger: loggerFactory.CreateLogger<AnthropicClient>());
+        return new AnthropicAgent(
+            "MockAnthropicUsageSub",
+            anthropicClient,
+            loggerFactory.CreateLogger<AnthropicAgent>());
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Immutable;
+using AchieveAi.LmDotnetTools.LmCore.Models;
+using AchieveAi.LmDotnetTools.LmMultiTurn.UsageAccounting;
 using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Tests.Agents;
 using LmStreaming.Sample.Tests.TestDoubles;
@@ -146,6 +148,45 @@ public class ConversationsControllerTests
         var notFound = Assert.IsType<NotFoundObjectResult>(result);
         var payload = JsonSerializer.Serialize(notFound.Value);
         payload.Should().Contain("missing-mode");
+    }
+
+    [Fact]
+    public async Task GetUsage_ReturnsPersistedAggregate_IncludingTotals()
+    {
+        var store = new InMemoryConversationStore();
+        var ledger = new UsageLedger("usage-thread");
+        ledger.UpsertAttempt(new UsageRecord
+        {
+            LogicalCallId = "a1",
+            ProviderAttemptId = "a1",
+            RootConversationId = "usage-thread",
+            RequestedModel = "model-A",
+            InputTokens = 100,
+            OutputTokens = 40,
+        });
+        await ConversationUsageProjection.SaveAsync(store, ledger.Snapshot());
+
+        await using var pool = CreatePool();
+        var controller = CreateController(store, pool, ModeStoreResolvingSystemModes());
+
+        var result = await controller.GetUsage("usage-thread");
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var aggregate = Assert.IsType<ConversationUsageAggregate>(ok.Value);
+        aggregate.TotalTokens.Should().Be(140);
+        aggregate.PerModel.Should().ContainSingle(m => m.ModelId == "model-A");
+    }
+
+    [Fact]
+    public async Task GetUsage_ReturnsNotFound_WhenNoUsageRecorded()
+    {
+        var store = new InMemoryConversationStore();
+        await using var pool = CreatePool();
+        var controller = CreateController(store, pool, ModeStoreResolvingSystemModes());
+
+        var result = await controller.GetUsage("no-usage-thread");
+
+        Assert.IsType<NotFoundResult>(result);
     }
 
     private static MultiTurnAgentPool CreatePool()


### PR DESCRIPTION
## Summary

Implements conversation-wide token usage & cost accounting (#196): every billable provider call —
the primary agent **and** every descendant sub-agent / LmWorkflow task, at any nesting depth — is
captured, aggregated per model with a gap-free watermark, priced from public rates, persisted with
the conversation, and surfaced via REST and the chat UI. Delivers all four of the issue's asks:
total tokens counted (incl. sub-agents/workflows), public-pricing cost per model, a
`(model, tokens)` breakdown, and persisted counts visible when re-viewing a conversation.

Built against the approved functional spec (the #196 body) and the reviewed implementation plan,
as a series of small, TDD'd, individually-committed increments.

## Changes

- **Core model** (`src/LmCore`): `UsageRecord` (durable per-attempt fact, dedup key
  `ProviderAttemptId`, 64-bit counts, micro-unit dual-cost) and `ConversationUsageAggregate.Fold`
  (additive, grouped by effective model; known-cost subtotals that are `null`, not `0`, when a cost
  is unknown). `ModelPricing` + narrow `IPricingResolver` so the accounting core has no LmConfig
  dependency.
- **Ledger + watermark** (`src/LmMultiTurn/UsageAccounting`): `UsageLedger` normalizes many
  streaming observations into one record per attempt (cumulative MAX, replay/out-of-order safe);
  `RevisionWatermark` guarantees publishing watermark `N` covers a complete, gap-free prefix.
- **Capture**: `SubAgentManager` relays every descendant `UsageMessage` (previously dropped) into
  the root ledger — one hook covers sub-agents and workflow tasks. `MultiTurnAgentBase.AddToHistory`
  captures the primary loop's own usage. `MultiTurnAgentLoop` creates one ledger per root and shares
  it, then persists the aggregate into `ThreadMetadata.Properties` (zero schema migration).
- **Pricing** (`src/LmConfig`): `PricingConfigResolver` wires the previously-unused `PricingConfig`
  rates through the resolver.
- **Surfaces** (`samples/LmStreaming.Sample`): `GET /api/conversations/{id}/usage` returns the
  persisted aggregate; the Vue client restores the usage banner from it on reload (fixing the
  reset-to-zero behavior where `loadMessagesFromBackend` skipped usage messages).

## Testing

- `src/LmCore` / `src/LmMultiTurn` / `src/LmConfig` build clean (both `net8.0` and `net9.0`).
- LmMultiTurn suite **488/488** (a full run); the ~40 new tests pass in isolation, incl. an
  end-to-end test where a real loop run persists a 140-token aggregate, and the Revobot-required
  delayed-revision watermark case.
- LmStreaming.Sample: REST endpoint tests (aggregate / 404); Vue client `vue-tsc` clean, `getConversationUsage`
  vitest + **107** composable/api client tests green.
- Note: a couple of pre-existing `RunLedger`/timer tests are flaky under full-suite load (they pass
  in isolation); they are unrelated to this change.

## Key Decisions

1. **Reuse over new infrastructure** — persist in the existing `ThreadMetadata.Properties` bag (no
   migration); a single relay path (`SubAgentManager`) covers both sub-agents and workflow tasks;
   the dead `PricingConfig` rates are wired up rather than re-implemented.
2. **Records canonical, aggregate is a rebuildable projection** with a complete-prefix watermark, so
   crashes / concurrent late descendants converge without lying about coverage.
3. **Dual cost captured, never collapsed** — `estimated_public_cost` (resolver) and
   `provider_reported_cost` are stored independently, each with its own availability.
4. **Money in integer micro-units** (deterministic), token totals 64-bit.
5. **Legacy reconciliation intentionally out of scope** (owner: OK to break legacy).

## Deferred follow-ups (documented, not blockers to the four asks above)

- **Completeness state** (`in_progress/partial/complete`): the aggregate currently persists
  `InProgress` (safe — never falsely "Complete"). Marking `Complete` correctly needs a
  run-lifecycle hook + an outstanding-descendant check + late-async-descendant persist convergence.
- **Provider-stamped effective model**: `Usage` has no `ModelId`, so model attribution is
  best-effort from the loop/template today; true per-call model is adjacent to #116.
- **Durable `usage_records` audit table** and its public endpoint: the projection already delivers
  the user-visible persist/reload; the atomic-records audit surface remains a follow-up.

Relates to #196.
