### PR TITLE
feat(#210): pre-defined egress keys for sandbox egress auth

### DIFF
--- a/samples/LmStreaming.Sample/AuthProviderGuide.md
+++ b/samples/LmStreaming.Sample/AuthProviderGuide.md
@@ -437,6 +437,223 @@ own gateway, you must set this yourself (or serve the webhook over HTTPS).
 
 ---
 
+## Pre-defined egress keys (issue #210)
+
+OAuth sign-in (above) is one way the gateway injects credentials on sandbox egress; **pre-defined
+egress keys** are a **second** kind that sits alongside it. Instead of an interactive
+authorization-code flow, you register a **per-entry credential for a host you name**, and the gateway
+injects it as an outbound header — no browser, no sign-in. Entries are created and edited **at
+runtime** through the **"Egress Auth"** dialog in the chat header (or the REST API below), and they
+ride the **same webhook mechanism** the OAuth providers use, so the sandbox still never sees the
+secret.
+
+Use these when the destination is not GitHub / Azure DevOps / Microsoft 365 — an internal API behind
+a session cookie, a SaaS endpoint keyed by an API-key header, or any host reachable with a generic
+OAuth2 client. Each entry is **generic OAuth2, self-contained**: the token endpoint URL, client id,
+client secret, refresh token and scopes all live on the entry — there are **no provider presets**.
+
+### Three credential kinds
+
+| Kind (`kind` on the wire) | What it injects | Auto-refreshes |
+| --- | --- | --- |
+| **Custom Headers** (`custom-headers`) | A **list** of `{ headerName, value }` pairs injected **verbatim** — a session `Cookie`, an `Authorization` token, an `X-Api-Key`, any custom header(s). | n/a (static values) |
+| **OAuth2 Refresh Token** (`refresh-token`) | The app runs `grant_type=refresh_token` against the entry's token endpoint and injects `Bearer <access>`. | Yes — re-mints ~120s before expiry; a rotated `refresh_token` is persisted and reused. |
+| **OAuth2 Client-Credentials** (`client-credentials`) | The app runs `grant_type=client_credentials` (client id + secret) and injects `Bearer <access>`. | Yes — re-mints ~120s before expiry. |
+
+For the OAuth kinds the minted `Bearer` is injected under the entry's `headerName` (default
+`Authorization`).
+
+### How it plugs into the sandbox
+
+The wiring mirrors the OAuth webhook exactly. When at least one entry is configured,
+`Services/SandboxSessionRegistry.cs` adds — **per entry** — the same two blocks it adds per OAuth
+provider to the sandbox-create request:
+
+- **`auth_providers`** — one `webhook`-type provider with id **`predefined-<id>`**, pointing at
+  `{PublicBaseUrl}/api/auth/webhook/predefined-<id>`, carrying the shared secret as `gateway_auth`.
+  Custom-header entries use a short 30-second cache TTL so an edited/rotated key takes effect
+  promptly; the token-minting kinds carry the minted token's **real expiry** so the gateway caches on
+  it.
+- **`network.rules`** — a single `action: "allow"` rule scoping **only that entry's host** (**port
+  443 only**) through the matching `predefined-<id>` auth provider.
+
+When the gateway intercepts a sandboxed request to that host, it calls back
+`Controllers/AuthWebhookController.cs`, which returns the entry's **header list** (custom-headers) or
+a freshly-minted **`Bearer` token** (OAuth kinds). **The sandbox never sees the secret** — it is
+added by the gateway proxy outside the sandbox boundary. **Default-deny egress is preserved**: an
+entry opens **only its own host**, nothing else.
+
+> **Changes apply to sessions created afterward.** Adding, editing, or deleting an entry rebuilds the
+> `auth_providers`/`network` blocks for the **next** sandbox-create; **existing sessions are
+> unchanged** — the same behavior as signing in / out of an OAuth provider mid-session.
+
+### The CRUD REST API
+
+Entries are managed by `Controllers/EgressKeysController.cs` on the route `api/auth/egress-keys` —
+from the **"Egress Auth"** dialog in the chat header, or with `curl`. The API **never returns secret
+values**.
+
+#### `GET /api/auth/egress-keys` — masked list
+
+Returns every configured entry with all secret material masked or omitted:
+
+```json
+[
+  {
+    "id": "3f2c…",
+    "host": "api.example.com",
+    "kind": "client-credentials",
+    "headerName": "Authorization",
+    "headerNames": [],
+    "hasClientSecret": true,
+    "hasRefreshToken": false,
+    "scopes": ["https://api.example.com/.default"]
+  }
+]
+```
+
+`headerNames[]` lists the custom-header **names** (values never appear); `hasClientSecret` /
+`hasRefreshToken` are booleans, never the secrets themselves.
+
+```bash
+curl -s http://127.0.0.1:5000/api/auth/egress-keys | jq
+```
+
+#### `POST /api/auth/egress-keys` — create or update
+
+`id` **null / omitted → create**; `id` **set → update** that entry (**404** if the id is unknown).
+On an update, **secret fields left blank are preserved** (the stored value stays), so you can change
+the host or scopes without re-entering the secret. `host` and `kind` are always required; the other
+OAuth fields fall back to the stored entry when omitted on an update.
+
+| Field | Required for | Notes |
+| --- | --- | --- |
+| `id` | — | Null/omitted = create; set = update an existing entry (404 if unknown). |
+| `host` | all | Exact host or `*.suffix` — SSRF-validated (see Security). |
+| `kind` | all | `custom-headers` \| `refresh-token` \| `client-credentials`. |
+| `headers` | custom-headers | List of `{ name, value }`. Omit on an update to keep the stored list. |
+| `headerName` | oauth kinds (optional) | Header the minted `Bearer` is injected under. Defaults to `Authorization`. |
+| `tokenEndpoint` | oauth kinds | Absolute **https** token endpoint URL. |
+| `clientId` | oauth kinds | OAuth2 client id. |
+| `clientSecret` | client-credentials (always); refresh-token (when the endpoint requires it) | **SECRET.** Blank on an update preserves the stored value. |
+| `refreshToken` | refresh-token | **SECRET.** Blank on an update preserves the stored value. |
+| `scopes` | oauth kinds (optional) | Scopes requested when minting. |
+
+On success it returns the **masked view** (same shape as `GET`); on a validation failure it returns
+`{ "error": "…" }` with **400** (bad host / header / kind / missing required field) or **404**
+(update of an unknown id).
+
+Create a **custom-headers** entry (injects an API-key header):
+
+```bash
+curl -s -X POST http://127.0.0.1:5000/api/auth/egress-keys \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "host": "api.example.com",
+    "kind": "custom-headers",
+    "headers": [{ "name": "X-Api-Key", "value": "<secret api key>" }]
+  }' | jq
+```
+
+Create a **refresh-token** entry:
+
+```bash
+curl -s -X POST http://127.0.0.1:5000/api/auth/egress-keys \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "host": "api.example.com",
+    "kind": "refresh-token",
+    "tokenEndpoint": "https://login.example.com/oauth2/token",
+    "clientId": "my-client",
+    "clientSecret": "<secret>",
+    "refreshToken": "<refresh token>",
+    "scopes": ["read"]
+  }' | jq
+```
+
+Create a **client-credentials** entry:
+
+```bash
+curl -s -X POST http://127.0.0.1:5000/api/auth/egress-keys \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "host": "api.example.com",
+    "kind": "client-credentials",
+    "tokenEndpoint": "https://login.example.com/oauth2/token",
+    "clientId": "my-client",
+    "clientSecret": "<secret>",
+    "scopes": ["https://api.example.com/.default"]
+  }' | jq
+```
+
+Update an entry **without re-entering the secret** — pass the `id` and leave `clientSecret` out (the
+stored one is preserved):
+
+```bash
+curl -s -X POST http://127.0.0.1:5000/api/auth/egress-keys \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "id": "<id>",
+    "host": "api2.example.com",
+    "kind": "client-credentials",
+    "tokenEndpoint": "https://login.example.com/oauth2/token",
+    "clientId": "my-client"
+  }' | jq
+```
+
+#### `DELETE /api/auth/egress-keys/{id}` — remove
+
+Deletes the entry and its persisted secret (and drops any minted-token record). **204 No Content** on
+success, **404** for an unknown id.
+
+```bash
+curl -s -X DELETE http://127.0.0.1:5000/api/auth/egress-keys/<id> -o /dev/null -w "%{http_code}\n"
+```
+
+### Security notes (pre-defined keys)
+
+- **Secrets persist locally, never in logs.** Entry definitions (including header values, client
+  secret, and refresh token) are written to `oauth-tokens/predefined-keys.json`, and minted OAuth
+  access/refresh tokens ride the shared token store keyed **`predefined-<id>`** — both under the
+  gitignored `oauth-tokens/` directory (default; overridable via `Auth:TokenStoreDir`). None of this
+  material is ever logged, and `GET` masks it (booleans + header **names** only). `DELETE` removes the
+  persisted secret.
+- **Host validation is an SSRF trust boundary.** A user-entered host **widens a default-deny egress
+  boundary**, so it is validated (`EgressHostMatcher.ValidateHostPattern`) before an entry is
+  accepted. It allows an **exact host** or a single leading `*.suffix` wildcard, and **rejects**: a
+  bare `*`; loopback (`127.*` / `localhost` / `::1` / `[::1]`); link-local & cloud metadata
+  (`169.254.*`, `169.254.169.254`, `metadata.google.internal`); `0.0.0.0`; an embedded
+  scheme / port / path; a trailing dot; a bare-TLD wildcard (`*.com`); anything that is not a valid
+  DNS host; and any host that **collides with a managed OAuth provider's egress scope**
+  (GitHub / ADO / M365) so a static key can never shadow — or be shadowed by — a managed credential
+  on the same host.
+- **Header names are constrained.** A header name must be an **RFC 7230 token** and may **not** be a
+  hop-by-hop / framing header — `Host`, `Content-Length`, `Connection`, `Transfer-Encoding`,
+  `Content-Type` are rejected; `Cookie` and `Authorization` are allowed. Header **values** may not
+  contain CR/LF or control characters (a header-injection guard).
+- **HTTPS/443 only.** Every allow rule is scoped to port 443, so an injected secret never egresses in
+  cleartext.
+- **The headless daemon fails closed.** `CodeReviewDaemon` constructs the registry as **absent**
+  (`predefinedKeys: null`) — no entries, no dialog, no prompt. Pre-defined keys are an
+  attended-app-only feature.
+
+### Missing / invalid key re-prompt
+
+Token-minting entries can go stale — a credential is missing, or the token endpoint rejects it
+(`invalid_grant`, `invalid_client`, `unauthorized_client`, `access_denied`, `invalid_scope`). When
+that happens the entry is **marked invalid**, the webhook **holds** the gateway's call (the same
+deferred-auth hold the OAuth providers use), and the chat client shows a **banner** whose CTA opens
+the **Egress Auth** dialog to re-enter the credential. Saving a corrected entry clears the invalid
+flag and the held call resolves **allow** — no session restart needed.
+
+> **A post-egress `401` from the target is not auto-detected.** If the injected value is *accepted* by
+> the app but *rejected downstream* by the target host, the gateway currently has no way to feed that
+> `401` back into this re-prompt loop — detecting it needs a gateway change and is tracked as a
+> separate follow-up. Only a **missing credential or a token-endpoint rejection** (above) triggers the
+> re-prompt today.
+
+---
+
 ## Security notes
 
 - **Tokens and the shared secret are sensitive.** GitHub tokens are persisted as one JSON file per

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/api/egressAuthApi.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/api/egressAuthApi.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { listEgressKeys, upsertEgressKey, deleteEgressKey } from '@/api/egressAuthApi';
+import type { EgressKeyRequest, EgressKeyView } from '@/types/egressAuth';
+
+function mockFetchOnce(ok: boolean, body: unknown, status = ok ? 200 : 400) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Bad Request',
+    json: async () => body,
+  } as Response);
+}
+
+const sampleView: EgressKeyView = {
+  id: 'key-1',
+  host: 'api.example.com',
+  kind: 'custom-headers',
+  headerName: 'Authorization',
+  headerNames: ['Authorization'],
+  hasClientSecret: false,
+  hasRefreshToken: false,
+  scopes: [],
+};
+
+describe('egressAuthApi.listEgressKeys', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('GETs the egress-keys endpoint and returns the catalog', async () => {
+    const fetchSpy = mockFetchOnce(true, [sampleView]);
+
+    const keys = await listEgressKeys();
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/auth/egress-keys');
+    expect(keys).toEqual([sampleView]);
+  });
+
+  it('throws with the status text on a non-ok response', async () => {
+    mockFetchOnce(false, {}, 500);
+    await expect(listEgressKeys()).rejects.toThrow(/Failed to fetch egress keys/);
+  });
+});
+
+describe('egressAuthApi.upsertEgressKey', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('POSTs the request body and returns the saved view', async () => {
+    const fetchSpy = mockFetchOnce(true, sampleView);
+    const req: EgressKeyRequest = {
+      id: null,
+      host: 'api.example.com',
+      kind: 'custom-headers',
+      headers: [{ name: 'Authorization', value: 'Bearer x' }],
+    };
+
+    const saved = await upsertEgressKey(req);
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/auth/egress-keys', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+    });
+    expect(saved).toEqual(sampleView);
+  });
+
+  it('surfaces the server {error} body on a 400', async () => {
+    mockFetchOnce(false, { error: 'host is required' }, 400);
+
+    await expect(
+      upsertEgressKey({ id: null, host: '', kind: 'custom-headers' })
+    ).rejects.toThrow(/host is required/);
+  });
+
+  it('falls back to the status text when no error body is present', async () => {
+    mockFetchOnce(false, {}, 404);
+
+    await expect(
+      upsertEgressKey({ id: 'missing', host: 'h', kind: 'custom-headers' })
+    ).rejects.toThrow(/Failed to save egress key/);
+  });
+});
+
+describe('egressAuthApi.deleteEgressKey', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('DELETEs the id-scoped endpoint (encoded) and resolves on 204', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      statusText: 'No Content',
+      json: async () => ({}),
+    } as Response);
+
+    await expect(deleteEgressKey('key/1')).resolves.toBeUndefined();
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/auth/egress-keys/key%2F1', {
+      method: 'DELETE',
+    });
+  });
+
+  it('surfaces the server {error} body on a 404', async () => {
+    mockFetchOnce(false, { error: 'not found' }, 404);
+    await expect(deleteEgressKey('nope')).rejects.toThrow(/not found/);
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/AuthRequiredBanner.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/AuthRequiredBanner.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import AuthRequiredBanner from '@/components/AuthRequiredBanner.vue';
+import type { AuthRequiredEvent } from '@/types/auth';
+
+// The banner routes a pre-defined-key failure to the Egress Auth dialog (openEgressDialog) and an
+// OAuth provider to the same-origin sign-in popup (window.open). Pin both branches.
+const mocks = vi.hoisted(() => ({ openEgressDialog: vi.fn() }));
+
+vi.mock('@/composables/useEgressAuth', () => ({
+  openEgressDialog: mocks.openEgressDialog,
+}));
+
+function oauthRequest(): AuthRequiredEvent {
+  return { $type: 'auth_required', providerId: 'github', signinUrl: '/auth/github', reason: 'sign in' };
+}
+
+function predefinedRequest(): AuthRequiredEvent {
+  return { $type: 'auth_required', providerId: 'predefined-abc', signinUrl: '/auth/predefined-abc', reason: 'key invalid' };
+}
+
+describe('AuthRequiredBanner routing', () => {
+  beforeEach(() => {
+    mocks.openEgressDialog.mockClear();
+  });
+
+  it('opens the OAuth sign-in popup for a managed provider', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const wrapper = mount(AuthRequiredBanner, { props: { requests: [oauthRequest()] } });
+
+    expect(wrapper.find('[data-testid="auth-signin-button"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="auth-update-key-button"]').exists()).toBe(false);
+
+    wrapper.find('[data-testid="auth-signin-button"]').trigger('click');
+    expect(openSpy).toHaveBeenCalledWith('/auth/github', expect.any(String), expect.any(String));
+    expect(mocks.openEgressDialog).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+
+  it('opens the Egress Auth dialog for a pre-defined key', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const wrapper = mount(AuthRequiredBanner, { props: { requests: [predefinedRequest()] } });
+
+    expect(wrapper.find('[data-testid="auth-update-key-button"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="auth-signin-button"]').exists()).toBe(false);
+
+    await wrapper.find('[data-testid="auth-update-key-button"]').trigger('click');
+    expect(mocks.openEgressDialog).toHaveBeenCalledTimes(1);
+    expect(openSpy).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/EgressAuthModal.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/EgressAuthModal.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import EgressAuthModal from '@/components/EgressAuthModal.vue';
+import type { EgressKeyView } from '@/types/egressAuth';
+
+const mocks = vi.hoisted(() => ({
+  egressKeys: null as any,
+  isLoading: null as any,
+  egressDialogRequest: null as any,
+  loadEgressKeys: vi.fn(),
+  saveEgressKey: vi.fn(),
+  removeEgressKey: vi.fn(),
+}));
+
+vi.mock('@/composables/useEgressAuth', async () => {
+  const { ref } = await import('vue');
+  mocks.egressKeys = ref<EgressKeyView[]>([]);
+  mocks.isLoading = ref(false);
+  mocks.egressDialogRequest = ref({ open: false, prefillHost: undefined as string | undefined });
+  return {
+    useEgressAuth: () => ({
+      egressKeys: mocks.egressKeys,
+      isLoading: mocks.isLoading,
+      loadEgressKeys: mocks.loadEgressKeys,
+      saveEgressKey: mocks.saveEgressKey,
+      removeEgressKey: mocks.removeEgressKey,
+    }),
+    egressDialogRequest: mocks.egressDialogRequest,
+    openEgressDialog: vi.fn(),
+    closeEgressDialog: vi.fn(),
+  };
+});
+
+const keyA: EgressKeyView = {
+  id: 'a',
+  host: 'a.example.com',
+  kind: 'custom-headers',
+  headerName: 'Authorization',
+  headerNames: ['Authorization', 'X-Api-Key'],
+  hasClientSecret: false,
+  hasRefreshToken: false,
+  scopes: [],
+};
+
+const keyB: EgressKeyView = {
+  id: 'b',
+  host: 'b.example.com',
+  kind: 'refresh-token',
+  headerName: 'Authorization',
+  headerNames: [],
+  hasClientSecret: true,
+  hasRefreshToken: true,
+  scopes: ['read', 'write'],
+};
+
+let activeWrapper: VueWrapper | null = null;
+
+function mountModal() {
+  const wrapper = mount(EgressAuthModal, { attachTo: document.body });
+  activeWrapper = wrapper;
+  return wrapper;
+}
+
+describe('EgressAuthModal', () => {
+  beforeEach(() => {
+    mocks.loadEgressKeys.mockReset();
+    mocks.saveEgressKey.mockReset().mockResolvedValue(keyA);
+    mocks.removeEgressKey.mockReset().mockResolvedValue(undefined);
+    mocks.egressKeys.value = [keyA, keyB];
+    mocks.isLoading.value = false;
+    mocks.egressDialogRequest.value = { open: false, prefillHost: undefined };
+  });
+
+  afterEach(() => {
+    activeWrapper?.unmount();
+    activeWrapper = null;
+  });
+
+  it('loads keys on mount and renders one item per key with data-key-id', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+
+    expect(mocks.loadEgressKeys).toHaveBeenCalledTimes(1);
+    const items = wrapper.findAll('[data-testid="egress-key-item"]');
+    expect(items).toHaveLength(2);
+    expect(items[0].attributes('data-key-id')).toBe('a');
+    expect(items[1].attributes('data-key-id')).toBe('b');
+    // Masked indicators, never secret values.
+    expect(wrapper.text()).toContain('client secret set');
+    expect(wrapper.text()).toContain('refresh token set');
+  });
+
+  it('opens the editor in create mode when the add button is clicked', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="egress-host-input"]').exists()).toBe(false);
+    await wrapper.get('[data-testid="egress-add-button"]').trigger('click');
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="egress-host-input"]').exists()).toBe(true);
+    // Default kind is custom-headers -> a header row is present.
+    expect(wrapper.findAll('[data-testid="egress-header-name-input"]')).toHaveLength(1);
+  });
+
+  it('adds header rows with the add-header-row button', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    await wrapper.get('[data-testid="egress-add-button"]').trigger('click');
+    await nextTick();
+
+    await wrapper.get('[data-testid="egress-add-header-row"]').trigger('click');
+    await nextTick();
+
+    expect(wrapper.findAll('[data-testid="egress-header-name-input"]')).toHaveLength(2);
+  });
+
+  it('saves a custom-headers key with the host and header rows', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    await wrapper.get('[data-testid="egress-add-button"]').trigger('click');
+    await nextTick();
+
+    await wrapper.get('[data-testid="egress-host-input"]').setValue('api.example.com');
+    await wrapper.get('[data-testid="egress-header-name-input"]').setValue('Authorization');
+    await wrapper.get('[data-testid="egress-header-value-input"]').setValue('Bearer xyz');
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+
+    expect(mocks.saveEgressKey).toHaveBeenCalledWith({
+      id: null,
+      host: 'api.example.com',
+      kind: 'custom-headers',
+      headers: [{ name: 'Authorization', value: 'Bearer xyz' }],
+    });
+  });
+
+  it('builds an OAuth request when the kind is switched to refresh-token', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    await wrapper.get('[data-testid="egress-add-button"]').trigger('click');
+    await nextTick();
+
+    await wrapper.get('[data-testid="egress-kind-select"]').setValue('refresh-token');
+    await nextTick();
+    await wrapper.get('[data-testid="egress-host-input"]').setValue('auth.example.com');
+    await wrapper.get('#egress-token-endpoint').setValue('https://auth.example.com/token');
+    await wrapper.get('#egress-client-id').setValue('cid');
+    await wrapper.get('#egress-client-secret').setValue('csecret');
+    await wrapper.get('#egress-refresh-token').setValue('rtoken');
+    await wrapper.get('#egress-scopes').setValue('read write');
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+
+    expect(mocks.saveEgressKey).toHaveBeenCalledWith({
+      id: null,
+      host: 'auth.example.com',
+      kind: 'refresh-token',
+      headerName: 'Authorization',
+      scopes: ['read', 'write'],
+      tokenEndpoint: 'https://auth.example.com/token',
+      clientId: 'cid',
+      clientSecret: 'csecret',
+      refreshToken: 'rtoken',
+    });
+  });
+
+  it('validates that host is required before saving', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    await wrapper.get('[data-testid="egress-add-button"]').trigger('click');
+    await nextTick();
+
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+
+    expect(mocks.saveEgressKey).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('Host is required');
+  });
+
+  it('prefills non-secret fields on edit and leaves the header value blank', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+
+    // Second Edit button belongs to keyB; edit keyA (custom-headers) via its Edit button.
+    const items = wrapper.findAll('[data-testid="egress-key-item"]');
+    await items[0].get('.btn-secondary').trigger('click');
+    await nextTick();
+
+    const hostInput = wrapper.get<HTMLInputElement>('[data-testid="egress-host-input"]');
+    expect(hostInput.element.value).toBe('a.example.com');
+    const nameInputs = wrapper.findAll<HTMLInputElement>('[data-testid="egress-header-name-input"]');
+    expect(nameInputs.map((n) => n.element.value)).toEqual(['Authorization', 'X-Api-Key']);
+    const valueInputs = wrapper.findAll<HTMLInputElement>('[data-testid="egress-header-value-input"]');
+    expect(valueInputs.every((v) => v.element.value === '')).toBe(true);
+
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+
+    // Update carries the id and preserves blank header values (server keeps stored secret).
+    expect(mocks.saveEgressKey).toHaveBeenCalledWith({
+      id: 'a',
+      host: 'a.example.com',
+      kind: 'custom-headers',
+      headers: [
+        { name: 'Authorization', value: '' },
+        { name: 'X-Api-Key', value: '' },
+      ],
+    });
+  });
+
+  it('deletes a key via its delete button', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+
+    const deleteButtons = wrapper.findAll('[data-testid="egress-delete-button"]');
+    await deleteButtons[1].trigger('click');
+    await flushPromises();
+
+    expect(mocks.removeEgressKey).toHaveBeenCalledWith('b');
+  });
+
+  it('surfaces a server validation error inline on save failure', async () => {
+    mocks.saveEgressKey.mockRejectedValueOnce(new Error('host already configured'));
+    const wrapper = mountModal();
+    await flushPromises();
+    await wrapper.get('[data-testid="egress-add-button"]').trigger('click');
+    await nextTick();
+
+    await wrapper.get('[data-testid="egress-host-input"]').setValue('dup.example.com');
+    await wrapper.get('[data-testid="egress-header-name-input"]').setValue('Authorization');
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+
+    const error = wrapper.find('[data-testid="egress-error"]');
+    expect(error.exists()).toBe(true);
+    expect(error.text()).toContain('host already configured');
+  });
+
+  it('opens prefilled in create mode when egressDialogRequest carries a host', async () => {
+    mocks.egressDialogRequest.value = { open: true, prefillHost: 'prefill.example.com' };
+    const wrapper = mountModal();
+    await flushPromises();
+
+    const hostInput = wrapper.get<HTMLInputElement>('[data-testid="egress-host-input"]');
+    expect(hostInput.element.value).toBe('prefill.example.com');
+  });
+
+  it('emits close when the close button is clicked', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+
+    await wrapper.get('[data-testid="egress-auth-modal-close"]').trigger('click');
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useEgressAuth.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useEgressAuth.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { EgressKeyRequest, EgressKeyView } from '@/types/egressAuth';
+
+const apiMocks = vi.hoisted(() => ({
+  listEgressKeys: vi.fn(),
+  upsertEgressKey: vi.fn(),
+  deleteEgressKey: vi.fn(),
+}));
+
+vi.mock('@/api/egressAuthApi', () => ({
+  listEgressKeys: apiMocks.listEgressKeys,
+  upsertEgressKey: apiMocks.upsertEgressKey,
+  deleteEgressKey: apiMocks.deleteEgressKey,
+}));
+
+import {
+  useEgressAuth,
+  egressDialogRequest,
+  openEgressDialog,
+  closeEgressDialog,
+} from '@/composables/useEgressAuth';
+
+const keyA: EgressKeyView = {
+  id: 'a',
+  host: 'a.example.com',
+  kind: 'custom-headers',
+  headerName: 'Authorization',
+  headerNames: ['Authorization'],
+  hasClientSecret: false,
+  hasRefreshToken: false,
+  scopes: [],
+};
+
+const keyB: EgressKeyView = {
+  id: 'b',
+  host: 'b.example.com',
+  kind: 'refresh-token',
+  headerName: 'Authorization',
+  headerNames: [],
+  hasClientSecret: true,
+  hasRefreshToken: true,
+  scopes: ['read', 'write'],
+};
+
+describe('useEgressAuth', () => {
+  beforeEach(() => {
+    apiMocks.listEgressKeys.mockReset();
+    apiMocks.upsertEgressKey.mockReset();
+    apiMocks.deleteEgressKey.mockReset();
+    // Reset module-singleton state between tests.
+    const { egressKeys, error } = useEgressAuth();
+    egressKeys.value = [];
+    error.value = null;
+    closeEgressDialog();
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('loadEgressKeys populates the reactive list and toggles loading', async () => {
+    apiMocks.listEgressKeys.mockResolvedValueOnce([keyA, keyB]);
+    const { egressKeys, isLoading, loadEgressKeys } = useEgressAuth();
+
+    const promise = loadEgressKeys();
+    expect(isLoading.value).toBe(true);
+    await promise;
+
+    expect(isLoading.value).toBe(false);
+    expect(egressKeys.value).toEqual([keyA, keyB]);
+  });
+
+  it('loadEgressKeys captures the error message without throwing', async () => {
+    apiMocks.listEgressKeys.mockRejectedValueOnce(new Error('boom'));
+    const { error, loadEgressKeys } = useEgressAuth();
+
+    await loadEgressKeys();
+
+    expect(error.value).toBe('boom');
+  });
+
+  it('saveEgressKey upserts then reloads the catalog', async () => {
+    apiMocks.upsertEgressKey.mockResolvedValueOnce(keyA);
+    apiMocks.listEgressKeys.mockResolvedValueOnce([keyA]);
+    const { egressKeys, saveEgressKey } = useEgressAuth();
+
+    const req: EgressKeyRequest = { id: null, host: 'a.example.com', kind: 'custom-headers' };
+    const saved = await saveEgressKey(req);
+
+    expect(apiMocks.upsertEgressKey).toHaveBeenCalledWith(req);
+    expect(apiMocks.listEgressKeys).toHaveBeenCalledTimes(1);
+    expect(saved).toEqual(keyA);
+    expect(egressKeys.value).toEqual([keyA]);
+  });
+
+  it('saveEgressKey re-throws and sets error on failure', async () => {
+    apiMocks.upsertEgressKey.mockRejectedValueOnce(new Error('host is required'));
+    const { error, saveEgressKey } = useEgressAuth();
+
+    await expect(
+      saveEgressKey({ id: null, host: '', kind: 'custom-headers' })
+    ).rejects.toThrow(/host is required/);
+    expect(error.value).toBe('host is required');
+    expect(apiMocks.listEgressKeys).not.toHaveBeenCalled();
+  });
+
+  it('removeEgressKey deletes then reloads the catalog', async () => {
+    apiMocks.deleteEgressKey.mockResolvedValueOnce(undefined);
+    apiMocks.listEgressKeys.mockResolvedValueOnce([]);
+    const { egressKeys, removeEgressKey } = useEgressAuth();
+
+    await removeEgressKey('a');
+
+    expect(apiMocks.deleteEgressKey).toHaveBeenCalledWith('a');
+    expect(apiMocks.listEgressKeys).toHaveBeenCalledTimes(1);
+    expect(egressKeys.value).toEqual([]);
+  });
+
+  it('removeEgressKey re-throws and sets error on failure', async () => {
+    apiMocks.deleteEgressKey.mockRejectedValueOnce(new Error('not found'));
+    const { error, removeEgressKey } = useEgressAuth();
+
+    await expect(removeEgressKey('missing')).rejects.toThrow(/not found/);
+    expect(error.value).toBe('not found');
+  });
+
+  it('openEgressDialog sets the dialog request with the prefill host', () => {
+    openEgressDialog('api.example.com');
+
+    expect(egressDialogRequest.value.open).toBe(true);
+    expect(egressDialogRequest.value.prefillHost).toBe('api.example.com');
+  });
+
+  it('openEgressDialog with no host opens with an undefined prefill', () => {
+    openEgressDialog();
+
+    expect(egressDialogRequest.value.open).toBe(true);
+    expect(egressDialogRequest.value.prefillHost).toBeUndefined();
+  });
+
+  it('closeEgressDialog clears the dialog request', () => {
+    openEgressDialog('api.example.com');
+    closeEgressDialog();
+
+    expect(egressDialogRequest.value.open).toBe(false);
+    expect(egressDialogRequest.value.prefillHost).toBeUndefined();
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/types/auth.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/types/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isAuthEventPayload } from '@/types/auth';
+import { isAuthEventPayload, isPredefinedKeyProvider } from '@/types/auth';
 
 /**
  * `isAuthEventPayload` is the single routing gate for the whole deferred-auth client feature and
@@ -35,5 +35,21 @@ describe('isAuthEventPayload', () => {
 
   it('returns false for an empty object', () => {
     expect(isAuthEventPayload('{}')).toBe(false);
+  });
+});
+
+/**
+ * The provider-id namespace is the kind discriminator that routes the banner CTA (OAuth sign-in vs
+ * the Egress Auth dialog). A mis-classification sends the user to the wrong action.
+ */
+describe('isPredefinedKeyProvider', () => {
+  it('is true for a predefined-<id> provider id', () => {
+    expect(isPredefinedKeyProvider('predefined-abc123')).toBe(true);
+  });
+
+  it('is false for a managed OAuth provider id', () => {
+    expect(isPredefinedKeyProvider('github')).toBe(false);
+    expect(isPredefinedKeyProvider('ado')).toBe(false);
+    expect(isPredefinedKeyProvider('m365')).toBe(false);
   });
 });

--- a/samples/LmStreaming.Sample/ClientApp/src/api/egressAuthApi.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/api/egressAuthApi.ts
@@ -1,0 +1,43 @@
+import type { EgressKeyView, EgressKeyRequest } from '@/types/egressAuth';
+
+/**
+ * Fetches all pre-defined egress keys (masked) from the backend.
+ */
+export async function listEgressKeys(): Promise<EgressKeyView[]> {
+  const response = await fetch('/api/auth/egress-keys');
+  if (!response.ok) {
+    throw new Error(`Failed to fetch egress keys: ${response.statusText}`);
+  }
+  return response.json();
+}
+
+/**
+ * Creates (id null) or updates (id set) an egress key. Surfaces the server's
+ * `error` body on a non-ok response.
+ */
+export async function upsertEgressKey(req: EgressKeyRequest): Promise<EgressKeyView> {
+  const response = await fetch('/api/auth/egress-keys', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(req),
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || `Failed to save egress key: ${response.statusText}`);
+  }
+  return response.json();
+}
+
+/**
+ * Deletes an egress key by id. Surfaces the server's `error` body on a non-ok
+ * response (e.g. 404 for an unknown id).
+ */
+export async function deleteEgressKey(id: string): Promise<void> {
+  const response = await fetch(`/api/auth/egress-keys/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || `Failed to delete egress key: ${response.statusText}`);
+  }
+}

--- a/samples/LmStreaming.Sample/ClientApp/src/api/index.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/api/index.ts
@@ -4,3 +4,4 @@ export * from './wsClient';
 export * from './conversationsApi';
 export * from './chatModesApi';
 export * from './providersApi';
+export * from './egressAuthApi';

--- a/samples/LmStreaming.Sample/ClientApp/src/components/AuthRequiredBanner.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/AuthRequiredBanner.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
 import type { AuthRequiredEvent } from '@/types';
+import { isPredefinedKeyProvider } from '@/types/auth';
+import { openEgressDialog } from '@/composables/useEgressAuth';
 
 /**
- * Banner shown while the backend is HOLDING a sandbox webhook call waiting for an interactive
- * sign-in (deferred auth). One row per pending provider. The sign-in button opens the
- * same-origin landing page (e.g. /auth/github) in a popup; that page drives the OAuth flow.
- * The banner is dismissed by the backend's terminal frame — `auth_completed` (a token landed)
- * or `auth_denied` (the hold timed out / sign-in failed) — both handled in useChat, which
- * removes the provider from the pending set. The ✕ button dismisses locally at any time.
+ * Banner shown while the backend is HOLDING a sandbox webhook call waiting for a credential
+ * (deferred auth). One row per pending provider. For an OAuth provider the "Sign in" button opens
+ * the same-origin landing page (e.g. /auth/github) in a popup; for a pre-defined egress key
+ * (`predefined-<id>`, issue #210) the "Update egress key" button instead opens the Egress Auth
+ * dialog so the user can re-enter the failing credential. Either way the banner is dismissed by the
+ * backend's terminal frame — `auth_completed` (a valid credential landed) or `auth_denied` (the hold
+ * timed out) — both handled in useChat. The ✕ button dismisses locally at any time.
  *
  * Note: the chat WebSocket connects lazily on the first message, so prompts can only arrive
  * once a conversation is active — the backend replays pending prompts to late connections.
@@ -33,12 +36,26 @@ function openSignIn(request: AuthRequiredEvent): void {
     data-testid="auth-required-banner"
     :data-provider-id="request.providerId"
   >
-    <span class="auth-required-text">
+    <span v-if="isPredefinedKeyProvider(request.providerId)" class="auth-required-text">
+      A sandbox egress key needs updating —
+      {{ request.reason || 'a sandbox request is waiting for a valid egress key' }}
+    </span>
+    <span v-else class="auth-required-text">
       Sign in to <strong>{{ request.providerId }}</strong> required —
       {{ request.reason || 'a sandbox request is waiting for your credentials' }}
     </span>
     <span class="auth-required-actions">
       <button
+        v-if="isPredefinedKeyProvider(request.providerId)"
+        type="button"
+        class="auth-signin-btn"
+        data-testid="auth-update-key-button"
+        @click="openEgressDialog()"
+      >
+        Update egress key
+      </button>
+      <button
+        v-else
         type="button"
         class="auth-signin-btn"
         data-testid="auth-signin-button"

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
@@ -5,6 +5,7 @@ import { useChat, getDisplayText } from '@/composables/useChat';
 import { useChatModes } from '@/composables/useChatModes';
 import { useProviders } from '@/composables/useProviders';
 import { useWorkspaces } from '@/composables/useWorkspaces';
+import { egressDialogRequest, closeEgressDialog } from '@/composables/useEgressAuth';
 import { updateConversationMetadata } from '@/api/conversationsApi';
 import type { ChatModeCreateUpdate } from '@/types/chatMode';
 import type { WorkspaceCreate, WorkspaceUpdate } from '@/types/workspace';
@@ -17,6 +18,7 @@ import ProviderSelector from './ProviderSelector.vue';
 import WorkspaceSelector from './WorkspaceSelector.vue';
 import AuthRequiredBanner from './AuthRequiredBanner.vue';
 import MarketplaceModal from './MarketplaceModal.vue';
+import EgressAuthModal from './EgressAuthModal.vue';
 
 const {
   conversations,
@@ -105,6 +107,17 @@ const sidebarCollapsed = ref(false);
 const isSwitchingMode = ref(false);
 const isSwitchingProvider = ref(false);
 const marketplaceModalOpen = ref(false);
+const egressAuthModalOpen = ref(false);
+
+/**
+ * Closes the egress-auth modal, resetting both the header-button flag and any
+ * programmatic open request (openEgressDialog).
+ */
+function handleCloseEgressModal(): void {
+  egressAuthModalOpen.value = false;
+  closeEgressDialog();
+}
+
 const modeSwitchDisabled = computed(
   () => modesLoading.value || chatLoading.value || isSending.value || isSwitchingMode.value
 );
@@ -539,6 +552,14 @@ onBeforeUnmount(() => {
               Marketplaces
             </button>
             <button
+              class="egress-auth-btn"
+              data-testid="egress-auth-button"
+              title="Manage egress auth keys"
+              @click="egressAuthModalOpen = true"
+            >
+              Egress Auth
+            </button>
+            <button
               class="clear-btn"
               data-testid="clear-button"
               @click="clearMessages"
@@ -552,6 +573,11 @@ onBeforeUnmount(() => {
         <MarketplaceModal
           v-if="marketplaceModalOpen"
           @close="marketplaceModalOpen = false"
+        />
+
+        <EgressAuthModal
+          v-if="egressAuthModalOpen || egressDialogRequest.open"
+          @close="handleCloseEgressModal"
         />
 
         <MessageList :display-items="displayItems" :is-loading="chatLoading" />
@@ -672,6 +698,21 @@ onBeforeUnmount(() => {
 
 .marketplace-btn:hover {
   background: #2057bd;
+}
+
+.egress-auth-btn {
+  padding: 8px 16px;
+  background: #6f42c1;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.egress-auth-btn:hover {
+  background: #5a34a0;
 }
 
 .clear-btn {

--- a/samples/LmStreaming.Sample/ClientApp/src/components/EgressAuthModal.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/EgressAuthModal.vue
@@ -1,0 +1,751 @@
+<script setup lang="ts">
+import { computed, onMounted, onBeforeUnmount, ref } from 'vue';
+import type { EgressHeaderPair, EgressKeyKind, EgressKeyRequest, EgressKeyView } from '@/types/egressAuth';
+import { useEgressAuth, egressDialogRequest } from '@/composables/useEgressAuth';
+
+const emit = defineEmits<{ close: [] }>();
+
+const { egressKeys, isLoading, loadEgressKeys, saveEgressKey, removeEgressKey } = useEgressAuth();
+
+// --- Editor state -----------------------------------------------------------
+const editorOpen = ref(false);
+const editingId = ref<string | null>(null);
+const host = ref('');
+const kind = ref<EgressKeyKind>('custom-headers');
+const headerName = ref('Authorization');
+const tokenEndpoint = ref('');
+const clientId = ref('');
+const clientSecret = ref('');
+const refreshToken = ref('');
+const scopesText = ref('');
+const headerRows = ref<EgressHeaderPair[]>([{ name: '', value: '' }]);
+
+const hostError = ref('');
+const serverError = ref('');
+const saving = ref(false);
+
+const isEditing = computed(() => editingId.value !== null);
+const isOAuth = computed(() => kind.value !== 'custom-headers');
+const editorTitle = computed(() => (isEditing.value ? 'Edit egress key' : 'New egress key'));
+
+const KIND_OPTIONS: { value: EgressKeyKind; label: string }[] = [
+  { value: 'custom-headers', label: 'Custom Headers' },
+  { value: 'refresh-token', label: 'OAuth2 Refresh Token' },
+  { value: 'client-credentials', label: 'OAuth2 Client-Credentials' },
+];
+
+function kindLabel(k: EgressKeyKind): string {
+  return KIND_OPTIONS.find((o) => o.value === k)?.label ?? k;
+}
+
+function resetForm(): void {
+  editingId.value = null;
+  host.value = '';
+  kind.value = 'custom-headers';
+  headerName.value = 'Authorization';
+  tokenEndpoint.value = '';
+  clientId.value = '';
+  clientSecret.value = '';
+  refreshToken.value = '';
+  scopesText.value = '';
+  headerRows.value = [{ name: '', value: '' }];
+  hostError.value = '';
+  serverError.value = '';
+}
+
+function startCreate(prefillHost?: string): void {
+  resetForm();
+  if (prefillHost) {
+    host.value = prefillHost;
+  }
+  editorOpen.value = true;
+}
+
+function startEdit(view: EgressKeyView): void {
+  resetForm();
+  editingId.value = view.id;
+  host.value = view.host;
+  kind.value = view.kind;
+  headerName.value = view.headerName || 'Authorization';
+  scopesText.value = view.scopes.join(' ');
+  if (view.kind === 'custom-headers') {
+    // Prefill header NAMES only; values are masked, so leave them blank to keep
+    // the stored secret on update.
+    headerRows.value =
+      view.headerNames.length > 0
+        ? view.headerNames.map((n) => ({ name: n, value: '' }))
+        : [{ name: '', value: '' }];
+  }
+  editorOpen.value = true;
+}
+
+function cancelEditor(): void {
+  editorOpen.value = false;
+  resetForm();
+}
+
+function addHeaderRow(): void {
+  headerRows.value.push({ name: '', value: '' });
+}
+
+function removeHeaderRow(index: number): void {
+  if (headerRows.value.length > 1) {
+    headerRows.value.splice(index, 1);
+  }
+}
+
+function parseScopes(text: string): string[] {
+  return text
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Builds the upsert request. Blank optional fields are OMITTED (not sent as null),
+ * so on update the server preserves the stored value — this is what keeps secrets
+ * (clientSecret / refreshToken / blank custom-header values) intact when left blank.
+ */
+function buildRequest(): EgressKeyRequest {
+  const req: EgressKeyRequest = {
+    id: editingId.value,
+    host: host.value.trim(),
+    kind: kind.value,
+  };
+
+  if (kind.value === 'custom-headers') {
+    req.headers = headerRows.value
+      .filter((r) => r.name.trim().length > 0)
+      .map((r) => ({ name: r.name.trim(), value: r.value }));
+  } else {
+    req.headerName = headerName.value.trim() || 'Authorization';
+    req.scopes = parseScopes(scopesText.value);
+
+    const te = tokenEndpoint.value.trim();
+    if (te) req.tokenEndpoint = te;
+
+    const ci = clientId.value.trim();
+    if (ci) req.clientId = ci;
+
+    if (clientSecret.value.length > 0) req.clientSecret = clientSecret.value;
+
+    if (kind.value === 'refresh-token' && refreshToken.value.length > 0) {
+      req.refreshToken = refreshToken.value;
+    }
+  }
+
+  return req;
+}
+
+async function handleSave(): Promise<void> {
+  hostError.value = '';
+  serverError.value = '';
+
+  if (!host.value.trim()) {
+    hostError.value = 'Host is required';
+    return;
+  }
+
+  saving.value = true;
+  try {
+    await saveEgressKey(buildRequest());
+    editorOpen.value = false;
+    resetForm();
+  } catch (e) {
+    serverError.value = e instanceof Error ? e.message : 'Failed to save egress key';
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function handleDelete(id: string): Promise<void> {
+  serverError.value = '';
+  try {
+    await removeEgressKey(id);
+    // If we were editing the deleted key, drop the editor.
+    if (editingId.value === id) {
+      cancelEditor();
+    }
+  } catch (e) {
+    serverError.value = e instanceof Error ? e.message : 'Failed to delete egress key';
+  }
+}
+
+// --- Modal shell ------------------------------------------------------------
+function handleClose(): void {
+  emit('close');
+}
+
+function handleBackdropClick(event: MouseEvent): void {
+  if (event.target === event.currentTarget) {
+    handleClose();
+  }
+}
+
+function handleKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    handleClose();
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('keydown', handleKeydown);
+  loadEgressKeys();
+  // Honour a programmatic open (openEgressDialog(host)): start in create mode with
+  // the host prefilled.
+  const requestState = egressDialogRequest.value;
+  if (requestState.open) {
+    startCreate(requestState.prefillHost);
+  }
+});
+
+onBeforeUnmount(() => document.removeEventListener('keydown', handleKeydown));
+</script>
+
+<template>
+  <div class="modal-backdrop" data-testid="egress-auth-modal" @click="handleBackdropClick">
+    <div class="modal-container">
+      <div class="modal-header">
+        <h2 class="modal-title">Egress Auth Keys</h2>
+        <button
+          class="close-btn"
+          data-testid="egress-auth-modal-close"
+          title="Close"
+          @click="handleClose"
+        >
+          &times;
+        </button>
+      </div>
+
+      <div class="modal-content">
+        <!-- Existing keys ------------------------------------------------- -->
+        <section class="keys-section">
+          <div class="section-head">
+            <h3 class="section-title">Configured keys</h3>
+            <button
+              type="button"
+              class="btn btn-primary"
+              data-testid="egress-add-button"
+              @click="startCreate()"
+            >
+              + Add key
+            </button>
+          </div>
+
+          <p v-if="isLoading" class="muted">Loading…</p>
+          <p v-else-if="egressKeys.length === 0" class="muted">
+            No egress keys configured yet.
+          </p>
+
+          <ul v-else class="key-list">
+            <li
+              v-for="key in egressKeys"
+              :key="key.id"
+              class="key-item"
+              data-testid="egress-key-item"
+              :data-key-id="key.id"
+            >
+              <div class="key-main">
+                <span class="key-host">{{ key.host }}</span>
+                <span class="kind-badge">{{ kindLabel(key.kind) }}</span>
+              </div>
+              <div class="key-meta">
+                <span v-if="key.headerNames.length" class="meta-line">
+                  Headers: {{ key.headerNames.join(', ') }}
+                </span>
+                <span v-else-if="key.headerName" class="meta-line">
+                  Header: {{ key.headerName }}
+                </span>
+                <span v-if="key.scopes.length" class="meta-line">
+                  Scopes: {{ key.scopes.join(' ') }}
+                </span>
+                <span v-if="key.hasClientSecret" class="indicator">client secret set</span>
+                <span v-if="key.hasRefreshToken" class="indicator">refresh token set</span>
+              </div>
+              <div class="key-actions">
+                <button
+                  type="button"
+                  class="btn btn-secondary btn-sm"
+                  @click="startEdit(key)"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-danger btn-sm"
+                  data-testid="egress-delete-button"
+                  @click="handleDelete(key.id)"
+                >
+                  Delete
+                </button>
+              </div>
+            </li>
+          </ul>
+        </section>
+
+        <!-- Editor -------------------------------------------------------- -->
+        <section v-if="editorOpen" class="editor-section">
+          <h3 class="section-title">{{ editorTitle }}</h3>
+
+          <form class="editor-form" @submit.prevent="handleSave">
+            <div class="form-group">
+              <label class="form-label" for="egress-kind">Kind</label>
+              <select
+                id="egress-kind"
+                v-model="kind"
+                class="form-input"
+                data-testid="egress-kind-select"
+                :disabled="saving"
+              >
+                <option v-for="opt in KIND_OPTIONS" :key="opt.value" :value="opt.value">
+                  {{ opt.label }}
+                </option>
+              </select>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="egress-host">
+                Host <span class="required">*</span>
+              </label>
+              <input
+                id="egress-host"
+                v-model="host"
+                type="text"
+                class="form-input"
+                :class="{ error: hostError }"
+                data-testid="egress-host-input"
+                placeholder="api.example.com"
+                :disabled="saving"
+              />
+              <span v-if="hostError" class="error-message">{{ hostError }}</span>
+            </div>
+
+            <!-- Custom headers -->
+            <template v-if="!isOAuth">
+              <div class="form-group">
+                <label class="form-label">Headers</label>
+                <div
+                  v-for="(row, index) in headerRows"
+                  :key="index"
+                  class="header-row"
+                >
+                  <input
+                    v-model="row.name"
+                    type="text"
+                    class="form-input header-name"
+                    data-testid="egress-header-name-input"
+                    placeholder="Header name (e.g. Authorization)"
+                    :disabled="saving"
+                  />
+                  <input
+                    v-model="row.value"
+                    type="text"
+                    class="form-input header-value"
+                    data-testid="egress-header-value-input"
+                    placeholder="Header value"
+                    :disabled="saving"
+                  />
+                  <button
+                    type="button"
+                    class="btn btn-secondary btn-sm"
+                    :disabled="headerRows.length <= 1 || saving"
+                    @click="removeHeaderRow(index)"
+                  >
+                    &times;
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  class="btn btn-secondary btn-sm add-header-btn"
+                  data-testid="egress-add-header-row"
+                  :disabled="saving"
+                  @click="addHeaderRow"
+                >
+                  + Add header
+                </button>
+                <span v-if="isEditing" class="hint">Leave a value blank to keep the current secret.</span>
+              </div>
+            </template>
+
+            <!-- OAuth kinds -->
+            <template v-else>
+              <div class="form-group">
+                <label class="form-label" for="egress-header-name">Header name</label>
+                <input
+                  id="egress-header-name"
+                  v-model="headerName"
+                  type="text"
+                  class="form-input"
+                  placeholder="Authorization"
+                  :disabled="saving"
+                />
+              </div>
+
+              <div class="form-group">
+                <label class="form-label" for="egress-token-endpoint">Token endpoint</label>
+                <input
+                  id="egress-token-endpoint"
+                  v-model="tokenEndpoint"
+                  type="text"
+                  class="form-input"
+                  placeholder="https://auth.example.com/oauth/token"
+                  :disabled="saving"
+                />
+                <span v-if="isEditing" class="hint">Leave blank to keep current.</span>
+              </div>
+
+              <div class="form-group">
+                <label class="form-label" for="egress-client-id">Client id</label>
+                <input
+                  id="egress-client-id"
+                  v-model="clientId"
+                  type="text"
+                  class="form-input"
+                  placeholder="client id"
+                  :disabled="saving"
+                />
+                <span v-if="isEditing" class="hint">Leave blank to keep current.</span>
+              </div>
+
+              <div class="form-group">
+                <label class="form-label" for="egress-client-secret">Client secret</label>
+                <input
+                  id="egress-client-secret"
+                  v-model="clientSecret"
+                  type="password"
+                  class="form-input"
+                  placeholder="client secret"
+                  autocomplete="off"
+                  :disabled="saving"
+                />
+                <span v-if="isEditing" class="hint">Leave blank to keep current.</span>
+              </div>
+
+              <div v-if="kind === 'refresh-token'" class="form-group">
+                <label class="form-label" for="egress-refresh-token">Refresh token</label>
+                <input
+                  id="egress-refresh-token"
+                  v-model="refreshToken"
+                  type="password"
+                  class="form-input"
+                  placeholder="refresh token"
+                  autocomplete="off"
+                  :disabled="saving"
+                />
+                <span v-if="isEditing" class="hint">Leave blank to keep current.</span>
+              </div>
+
+              <div class="form-group">
+                <label class="form-label" for="egress-scopes">Scopes</label>
+                <input
+                  id="egress-scopes"
+                  v-model="scopesText"
+                  type="text"
+                  class="form-input"
+                  placeholder="space- or comma-separated scopes"
+                  :disabled="saving"
+                />
+              </div>
+            </template>
+
+            <span v-if="serverError" class="error-message" data-testid="egress-error">
+              {{ serverError }}
+            </span>
+
+            <div class="form-actions">
+              <button
+                type="button"
+                class="btn btn-secondary"
+                :disabled="saving"
+                @click="cancelEditor"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                class="btn btn-primary"
+                data-testid="egress-save-button"
+                :disabled="saving"
+              >
+                {{ saving ? 'Saving…' : 'Save' }}
+              </button>
+            </div>
+          </form>
+        </section>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+}
+
+.modal-container {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.2);
+  width: 100%;
+  max-width: 640px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid #eee;
+}
+
+.modal-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #333;
+}
+
+.close-btn {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  font-size: 24px;
+  line-height: 1;
+  color: #666;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+.close-btn:hover {
+  background: #f8f9fa;
+  color: #333;
+}
+
+.modal-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+}
+
+.section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.section-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: #333;
+}
+
+.muted {
+  color: #888;
+  font-size: 14px;
+  margin: 8px 0;
+}
+
+.key-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.key-item {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.key-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.key-host {
+  font-weight: 600;
+  color: #333;
+  word-break: break-all;
+}
+
+.kind-badge {
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #e7f1ff;
+  color: #0b5ed7;
+  white-space: nowrap;
+}
+
+.key-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  font-size: 12px;
+  color: #666;
+}
+
+.indicator {
+  color: #198754;
+}
+
+.key-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.editor-section {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid #eee;
+}
+
+.editor-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 12px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+}
+
+.required {
+  color: #dc3545;
+}
+
+.form-input {
+  padding: 10px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+  font-family: inherit;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: #0d6efd;
+  box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.25);
+}
+
+.form-input.error {
+  border-color: #dc3545;
+}
+
+.header-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.header-name {
+  flex: 1;
+}
+
+.header-value {
+  flex: 1.4;
+}
+
+.add-header-btn {
+  align-self: flex-start;
+}
+
+.hint {
+  font-size: 12px;
+  color: #888;
+}
+
+.error-message {
+  font-size: 12px;
+  color: #dc3545;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding-top: 12px;
+  border-top: 1px solid #eee;
+}
+
+.btn {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s, opacity 0.2s;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-sm {
+  padding: 6px 12px;
+  font-size: 13px;
+}
+
+.btn-primary {
+  background: #0d6efd;
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #0b5ed7;
+}
+
+.btn-secondary {
+  background: #6c757d;
+  color: white;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: #5a6268;
+}
+
+.btn-danger {
+  background: #dc3545;
+  color: white;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: #c82333;
+}
+</style>

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useEgressAuth.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useEgressAuth.ts
@@ -1,0 +1,106 @@
+import { ref } from 'vue';
+import type { EgressKeyView, EgressKeyRequest } from '@/types/egressAuth';
+import {
+  listEgressKeys,
+  upsertEgressKey as apiUpsertEgressKey,
+  deleteEgressKey as apiDeleteEgressKey,
+} from '@/api/egressAuthApi';
+
+// Module-singleton reactive state: every consumer (the modal, the header button,
+// a future auth banner) shares the same key list + loading/error + dialog request.
+const egressKeys = ref<EgressKeyView[]>([]);
+const isLoading = ref(false);
+const error = ref<string | null>(null);
+
+/**
+ * Programmatic open request for the egress-auth dialog. A future auth banner can
+ * call `openEgressDialog(host)` to pop the editor prefilled to a host without
+ * threading props through ChatLayout.
+ */
+export interface EgressDialogRequest {
+  open: boolean;
+  prefillHost?: string;
+}
+
+export const egressDialogRequest = ref<EgressDialogRequest>({ open: false });
+
+/**
+ * Opens the egress-auth dialog. When `prefillHost` is supplied the editor starts in
+ * create mode with the host prefilled.
+ */
+export function openEgressDialog(prefillHost?: string): void {
+  egressDialogRequest.value = { open: true, prefillHost };
+}
+
+/**
+ * Clears the programmatic open request (called when the dialog closes).
+ */
+export function closeEgressDialog(): void {
+  egressDialogRequest.value = { open: false };
+}
+
+/**
+ * Composable exposing the pre-defined egress-key catalog and CRUD actions. State is
+ * module-singleton (see above) so it survives re-mounts of the modal.
+ */
+export function useEgressAuth() {
+  /**
+   * Loads the egress-key catalog (masked). Never throws — surfaces failures via
+   * `error` so the modal can render them.
+   */
+  async function loadEgressKeys(): Promise<void> {
+    isLoading.value = true;
+    error.value = null;
+    try {
+      egressKeys.value = await listEgressKeys();
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load egress keys';
+      console.error('Failed to load egress keys:', e);
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  /**
+   * Creates or updates an egress key, then reloads the catalog. Re-throws so the
+   * caller (the editor) can surface the server validation `error` inline.
+   */
+  async function saveEgressKey(req: EgressKeyRequest): Promise<EgressKeyView> {
+    try {
+      const saved = await apiUpsertEgressKey(req);
+      await loadEgressKeys();
+      return saved;
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to save egress key';
+      console.error('Failed to save egress key:', e);
+      throw e;
+    }
+  }
+
+  /**
+   * Deletes an egress key, then reloads the catalog. Re-throws so the caller can
+   * surface the failure.
+   */
+  async function removeEgressKey(id: string): Promise<void> {
+    try {
+      await apiDeleteEgressKey(id);
+      await loadEgressKeys();
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to delete egress key';
+      console.error('Failed to delete egress key:', e);
+      throw e;
+    }
+  }
+
+  return {
+    egressKeys,
+    isLoading,
+    error,
+    loadEgressKeys,
+    saveEgressKey,
+    removeEgressKey,
+    egressDialogRequest,
+    openEgressDialog,
+    closeEgressDialog,
+  };
+}

--- a/samples/LmStreaming.Sample/ClientApp/src/types/auth.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/types/auth.ts
@@ -28,6 +28,16 @@ export interface AuthDeniedEvent {
 
 export type AuthEvent = AuthRequiredEvent | AuthCompletedEvent | AuthDeniedEvent;
 
+/**
+ * The provider-id namespace IS the kind discriminator: a pre-defined egress key (issue #210) uses a
+ * `predefined-<id>` provider id (see the backend PredefinedKeyRegistry), whereas an OAuth provider is
+ * a bare id like `github`. A failing pre-defined key routes the banner CTA to the Egress Auth dialog
+ * (to re-enter the credential) instead of opening an OAuth sign-in page.
+ */
+export function isPredefinedKeyProvider(providerId: string): boolean {
+  return providerId.startsWith('predefined-');
+}
+
 export function isAuthEventPayload(data: string): boolean {
   return (
     data.includes('"$type":"auth_required"') ||

--- a/samples/LmStreaming.Sample/ClientApp/src/types/egressAuth.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/types/egressAuth.ts
@@ -1,0 +1,52 @@
+/**
+ * Kind of a pre-defined egress auth key. Mirrors the backend `EgressKeyKind`:
+ *  - `custom-headers`      — one or more literal request headers (name/value).
+ *  - `refresh-token`       — OAuth2 refresh-token grant.
+ *  - `client-credentials`  — OAuth2 client-credentials grant.
+ */
+export type EgressKeyKind = 'custom-headers' | 'refresh-token' | 'client-credentials';
+
+/**
+ * A single literal request header for a `custom-headers` key. On UPDATE, a blank
+ * `value` is preserved server-side (the stored secret is kept) — see EgressKeyRequest.
+ */
+export interface EgressHeaderPair {
+  name: string;
+  value: string;
+}
+
+/**
+ * Masked read view returned by `GET /api/auth/egress-keys` (and by upsert). Secret
+ * material is never included — only presence flags (`hasClientSecret` /
+ * `hasRefreshToken`) and header names (`headerNames`, values omitted).
+ */
+export interface EgressKeyView {
+  id: string;
+  host: string;
+  kind: EgressKeyKind;
+  headerName: string;
+  headerNames: string[];
+  hasClientSecret: boolean;
+  hasRefreshToken: boolean;
+  scopes: string[];
+}
+
+/**
+ * Request body for `POST /api/auth/egress-keys`. `id` null = create, set = update.
+ *
+ * On UPDATE, secret fields left blank/empty are PRESERVED server-side (the stored
+ * value is kept): `clientSecret`, `refreshToken`, and any custom header `value`. The
+ * edit form therefore leaves secret inputs blank to keep the current stored secret.
+ */
+export interface EgressKeyRequest {
+  id?: string | null;
+  host: string;
+  kind: EgressKeyKind;
+  headers?: EgressHeaderPair[] | null;
+  headerName?: string | null;
+  tokenEndpoint?: string | null;
+  clientId?: string | null;
+  clientSecret?: string | null;
+  refreshToken?: string | null;
+  scopes?: string[] | null;
+}

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -294,6 +294,16 @@ try
         oauthTokenDir,
         sp.GetRequiredService<ILogger<FileOAuthTokenStore>>()
     ));
+    // Predefined egress keys (issue #210): a runtime-managed registry of custom-header / OAuth
+    // credentials the gateway injects on egress to user-specified hosts (managed via the Egress Auth
+    // dialog / EgressKeysController). Persists under the same gitignored token dir; a dedicated
+    // HttpClient drives the OAuth token-endpoint mint/refresh calls.
+    _ = builder.Services.AddSingleton(sp => new PredefinedKeyRegistry(
+        oauthTokenDir,
+        sp.GetRequiredService<IOAuthTokenStore>(),
+        new HttpClient(),
+        sp.GetRequiredService<ILoggerFactory>()
+    ));
     // Dual-register each provider: the concrete type is what the per-provider controller
     // (AdoAuthController / GitHubAuthController) takes in its ctor, while the IOAuthTokenProvider
     // alias keeps the enumerable-consuming callers (AuthWebhookController, OAuthTokenHydrator)
@@ -352,7 +362,8 @@ try
         // WebSocket request thread, so the 100s default could stall it indefinitely.
         GatewayHttpClient(TimeSpan.FromSeconds(30)),
         authOptions,
-        sp.GetRequiredService<AuthSharedSecret>()
+        sp.GetRequiredService<AuthSharedSecret>(),
+        sp.GetRequiredService<PredefinedKeyRegistry>()
     ));
 
     _ = builder.Services.AddSingleton(sp =>

--- a/src/LmAgentInfra/Auth/AtomicJsonFile.cs
+++ b/src/LmAgentInfra/Auth/AtomicJsonFile.cs
@@ -28,8 +28,31 @@ internal static class AtomicJsonFile
         }
 
         var json = JsonSerializer.Serialize(value, options);
-        var tempFilePath = filePath + ".tmp";
-        await File.WriteAllTextAsync(tempFilePath, json, Encoding.UTF8, ct).ConfigureAwait(false);
-        File.Move(tempFilePath, filePath, overwrite: true);
+
+        // Unique same-directory staging file (not a fixed "<file>.tmp") so concurrent writers / processes
+        // never collide, and delete it if the write or move fails so a secret-bearing partial file is never
+        // left behind on a cancelled/failed write.
+        var tempFilePath = filePath + "." + Path.GetRandomFileName() + ".tmp";
+        try
+        {
+            await File.WriteAllTextAsync(tempFilePath, json, Encoding.UTF8, ct).ConfigureAwait(false);
+            File.Move(tempFilePath, filePath, overwrite: true);
+        }
+        catch
+        {
+            try
+            {
+                if (File.Exists(tempFilePath))
+                {
+                    File.Delete(tempFilePath);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup of the staging file; surface the original failure below.
+            }
+
+            throw;
+        }
     }
 }

--- a/src/LmAgentInfra/Auth/AtomicJsonFile.cs
+++ b/src/LmAgentInfra/Auth/AtomicJsonFile.cs
@@ -1,0 +1,35 @@
+using System.Text;
+using System.Text.Json;
+
+namespace AchieveAi.LmDotnetTools.LmAgentInfra.Auth;
+
+/// <summary>
+/// Shared atomic JSON-file write: serialize + stage to a temp file + <see cref="File.Move(string, string, bool)"/>
+/// over the target, so a concurrent reader never observes a partially-written file. Extracted so both
+/// <see cref="FileOAuthTokenStore"/> and <c>PredefinedKeyRegistry</c> use one implementation of the
+/// tricky part. Callers own their own locking (both hold a per-store gate) and their own reads.
+/// </summary>
+internal static class AtomicJsonFile
+{
+    /// <summary>
+    /// Serializes <paramref name="value"/> to <paramref name="filePath"/> atomically, creating the
+    /// parent directory if needed.
+    /// </summary>
+    public static async Task WriteAsync<T>(
+        string filePath,
+        T value,
+        JsonSerializerOptions options,
+        CancellationToken ct = default)
+    {
+        var dir = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrEmpty(dir))
+        {
+            _ = Directory.CreateDirectory(dir);
+        }
+
+        var json = JsonSerializer.Serialize(value, options);
+        var tempFilePath = filePath + ".tmp";
+        await File.WriteAllTextAsync(tempFilePath, json, Encoding.UTF8, ct).ConfigureAwait(false);
+        File.Move(tempFilePath, filePath, overwrite: true);
+    }
+}

--- a/src/LmAgentInfra/Auth/EgressHostMatcher.cs
+++ b/src/LmAgentInfra/Auth/EgressHostMatcher.cs
@@ -1,0 +1,199 @@
+using System.Text.RegularExpressions;
+
+namespace AchieveAi.LmDotnetTools.LmAgentInfra.Auth;
+
+/// <summary>
+/// Host-pattern matching + header-name/value validation shared by every egress-auth caller: the
+/// OAuth provider host allowlist (<see cref="OAuthProviderHosts"/> delegates its match here), the
+/// predefined-key sandbox network rules (<c>SandboxSessionRegistry.BuildAuthProviders</c>), the
+/// predefined-key webhook host gate (<c>AuthWebhookController</c>), and the predefined-key CRUD
+/// validation (<c>EgressKeysController</c>). One algorithm for all of them so the rule that opens a
+/// host and the webhook check that injects into it can never drift.
+/// </summary>
+/// <remarks>
+/// A user-entered predefined-key host widens a default-deny egress boundary, so
+/// <see cref="ValidateHostPattern"/> is a genuine SSRF trust-boundary check: it rejects bare
+/// wildcards, schemes/ports/paths, loopback, link-local/metadata addresses, and malformed hosts.
+/// </remarks>
+internal static partial class EgressHostMatcher
+{
+    /// <summary>
+    /// Hop-by-hop / framing headers a predefined key must never set: overriding them can break or
+    /// hijack the outbound request. <c>Cookie</c> and <c>Authorization</c> are deliberately allowed.
+    /// </summary>
+    private static readonly HashSet<string> ForbiddenHeaderNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Host",
+        "Content-Length",
+        "Connection",
+        "Transfer-Encoding",
+        "Content-Type",
+    };
+
+    /// <summary>Literal hosts that must never be openable from the sandbox (loopback + cloud metadata).</summary>
+    private static readonly HashSet<string> BlockedLiteralHosts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "localhost",
+        "0.0.0.0",
+        "::1",
+        "[::1]",
+        "169.254.169.254", // cloud instance-metadata endpoint
+        "metadata.google.internal",
+    };
+
+    /// <summary>
+    /// True when <paramref name="destinationHost"/> matches one of the <paramref name="hosts"/>
+    /// patterns — exact (case-insensitive) or a <c>*.</c> wildcard suffix. Fails closed: a null/empty
+    /// destination or host list yields <c>false</c>.
+    /// </summary>
+    public static bool IsAllowed(IReadOnlyList<string>? hosts, string? destinationHost)
+    {
+        if (string.IsNullOrWhiteSpace(destinationHost) || hosts is null)
+        {
+            return false;
+        }
+
+        foreach (var host in hosts)
+        {
+            if (Matches(host, destinationHost))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Exact or <c>*.suffix</c> match of a single pattern against a destination host.</summary>
+    private static bool Matches(string pattern, string destinationHost) =>
+        pattern.StartsWith("*.", StringComparison.Ordinal)
+            ? destinationHost.EndsWith(pattern[1..], StringComparison.OrdinalIgnoreCase)
+            : string.Equals(destinationHost, pattern, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Validates a user-entered host pattern (exact host or <c>*.suffix</c>). Returns <c>null</c> when
+    /// valid, otherwise a UI-safe error message. Rejects bare <c>*</c>, empty/whitespace, an embedded
+    /// scheme/port/path, loopback (<c>localhost</c>/<c>127.x</c>/<c>[::1]</c>), link-local/metadata
+    /// (<c>169.254.169.254</c>), <c>0.0.0.0</c>, a trailing dot, a wildcard covering a bare TLD
+    /// (<c>*.com</c>), and anything that is not a syntactically valid DNS host.
+    /// </summary>
+    public static string? ValidateHostPattern(string? pattern)
+    {
+        if (string.IsNullOrWhiteSpace(pattern))
+        {
+            return "Host is required.";
+        }
+
+        if (pattern != pattern.Trim())
+        {
+            return "Host must not contain leading or trailing whitespace.";
+        }
+
+        if (pattern.Contains("://", StringComparison.Ordinal) || pattern.Contains('/', StringComparison.Ordinal))
+        {
+            return "Host must be a bare hostname — no scheme or path.";
+        }
+
+        if (pattern.Contains(':', StringComparison.Ordinal))
+        {
+            return "Host must not include a port (rules are HTTPS/443 only).";
+        }
+
+        if (pattern == "*")
+        {
+            return "A bare '*' is not allowed — scope the host, e.g. api.example.com or *.example.com.";
+        }
+
+        if (pattern.EndsWith('.'))
+        {
+            return "Host must not end with a dot.";
+        }
+
+        // The concrete host to reason about (strip a single leading "*." wildcard).
+        var isWildcard = pattern.StartsWith("*.", StringComparison.Ordinal);
+        var bareHost = isWildcard ? pattern[2..] : pattern;
+
+        if (bareHost.Length == 0 || bareHost.Contains('*', StringComparison.Ordinal))
+        {
+            return "Wildcards are only allowed as a single leading '*.' label.";
+        }
+
+        if (isWildcard && !bareHost.Contains('.', StringComparison.Ordinal))
+        {
+            return "A wildcard must cover at least two labels, e.g. *.example.com (not *.com).";
+        }
+
+        if (BlockedLiteralHosts.Contains(bareHost) || IsLoopbackOrLinkLocalIp(bareHost))
+        {
+            return "Loopback, link-local, and metadata hosts are not allowed.";
+        }
+
+        if (!HostLabelsRegex().IsMatch(bareHost))
+        {
+            return "Host is not a valid hostname.";
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Validates a header name: RFC 7230 token charset and not a hop-by-hop/framing header. Returns
+    /// <c>null</c> when valid, otherwise a UI-safe error message.
+    /// </summary>
+    public static string? ValidateHeaderName(string? name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return "Header name is required.";
+        }
+
+        if (!HeaderNameRegex().IsMatch(name))
+        {
+            return "Header name contains invalid characters (RFC 7230 token expected).";
+        }
+
+        if (ForbiddenHeaderNames.Contains(name))
+        {
+            return $"Header '{name}' cannot be set (hop-by-hop / framing header).";
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Validates a header value: non-empty and free of CR/LF and other control characters (prevents
+    /// header injection). Returns <c>null</c> when valid, otherwise a UI-safe error message.
+    /// </summary>
+    public static string? ValidateHeaderValue(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return "Header value is required.";
+        }
+
+        foreach (var ch in value)
+        {
+            if (ch is '\r' or '\n' || char.IsControl(ch))
+            {
+                return "Header value must not contain control characters or line breaks.";
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Rejects IPv4 loopback (<c>127.0.0.0/8</c>) and link-local (<c>169.254.0.0/16</c>) literals.</summary>
+    private static bool IsLoopbackOrLinkLocalIp(string host) =>
+        host.StartsWith("127.", StringComparison.Ordinal) || host.StartsWith("169.254.", StringComparison.Ordinal);
+
+    // Syntactically valid DNS host: dot-separated labels of [A-Za-z0-9-], each 1-63 chars, not
+    // starting/ending with a hyphen. Anchored; case-insensitive.
+    [GeneratedRegex(
+        @"^(?=.{1,253}$)([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)(\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex HostLabelsRegex();
+
+    // RFC 7230 token: one or more tchar. tchar = "!#$%&'*+-.^_`|~" / DIGIT / ALPHA.
+    [GeneratedRegex(@"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$", RegexOptions.CultureInvariant)]
+    private static partial Regex HeaderNameRegex();
+}

--- a/src/LmAgentInfra/Auth/FileOAuthTokenStore.cs
+++ b/src/LmAgentInfra/Auth/FileOAuthTokenStore.cs
@@ -88,19 +88,13 @@ public sealed class FileOAuthTokenStore : IOAuthTokenStore
         ArgumentNullException.ThrowIfNull(record);
 
         var filePath = GetFilePath(record.Provider);
-        var json = JsonSerializer.Serialize(record, JsonOptions);
 
         await _gate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            // Ensure the directory still exists (it may have been removed out-of-band).
-            _ = Directory.CreateDirectory(_baseDirectory);
-
-            // Atomic write: stage to a temp file, then move over the target so a reader never
-            // observes a partially written file.
-            var tempFilePath = filePath + ".tmp";
-            await File.WriteAllTextAsync(tempFilePath, json, Encoding.UTF8, ct).ConfigureAwait(false);
-            File.Move(tempFilePath, filePath, overwrite: true);
+            // Atomic write (temp-file + move) via the shared helper so a reader never observes a
+            // partially-written file. The helper re-creates the base dir if it was removed out-of-band.
+            await AtomicJsonFile.WriteAsync(filePath, record, JsonOptions, ct).ConfigureAwait(false);
         }
         finally
         {

--- a/src/LmAgentInfra/Auth/OAuthProviderHosts.cs
+++ b/src/LmAgentInfra/Auth/OAuthProviderHosts.cs
@@ -22,21 +22,36 @@ internal static class OAuthProviderHosts
     /// <summary>
     /// True when <paramref name="destinationHost"/> matches one of the provider's allowed hosts —
     /// exact (case-insensitive) or a <c>*.</c> wildcard suffix match. Fails closed: an unknown
-    /// provider or a missing host is not allowed.
+    /// provider or a missing host is not allowed. Matching is delegated to
+    /// <see cref="EgressHostMatcher.IsAllowed"/> so the OAuth path and the predefined-key path share
+    /// one algorithm.
     /// </summary>
-    public static bool IsAllowed(string providerId, string? destinationHost)
+    public static bool IsAllowed(string providerId, string? destinationHost) =>
+        HostsByProvider.TryGetValue(providerId, out var hosts)
+        && EgressHostMatcher.IsAllowed(hosts, destinationHost);
+
+    /// <summary>
+    /// True when a user-entered predefined-key host <paramref name="pattern"/> would match (or be
+    /// matched by) a managed OAuth provider's host — i.e. it collides with the github/ado/m365 egress
+    /// scope. Predefined-key entries are rejected in that case so a static key can never silently
+    /// shadow (or be shadowed by) a managed OAuth credential on the same host.
+    /// </summary>
+    public static bool CollidesWithManagedHost(string? pattern)
     {
-        if (string.IsNullOrWhiteSpace(destinationHost) || !HostsByProvider.TryGetValue(providerId, out var hosts))
+        if (string.IsNullOrWhiteSpace(pattern))
         {
             return false;
         }
 
-        foreach (var host in hosts)
+        // Strip a single leading "*." so a wildcard entry is compared by its concrete suffix host.
+        var candidate = pattern.StartsWith("*.", StringComparison.Ordinal) ? pattern[2..] : pattern;
+
+        foreach (var hosts in HostsByProvider.Values)
         {
-            var allowed = host.StartsWith("*.", StringComparison.Ordinal)
-                ? destinationHost.EndsWith(host[1..], StringComparison.OrdinalIgnoreCase)
-                : string.Equals(destinationHost, host, StringComparison.OrdinalIgnoreCase);
-            if (allowed)
+            // Collision either way: the entry matches a managed host, or a managed *.wildcard matches
+            // the entry's host.
+            if (EgressHostMatcher.IsAllowed(hosts, candidate)
+                || hosts.Any(h => EgressHostMatcher.IsAllowed([pattern], h)))
             {
                 return true;
             }

--- a/src/LmAgentInfra/Auth/OAuthTokenEndpointClient.cs
+++ b/src/LmAgentInfra/Auth/OAuthTokenEndpointClient.cs
@@ -1,0 +1,68 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace AchieveAi.LmDotnetTools.LmAgentInfra.Auth;
+
+/// <summary>Parsed OAuth2 token-endpoint response — a success token set or an OAuth <c>error</c>.</summary>
+/// <param name="AccessToken">The <c>access_token</c>, or null on error / absent.</param>
+/// <param name="RefreshToken">A rotated <c>refresh_token</c>, or null when the endpoint did not return one.</param>
+/// <param name="ExpiresIn">The <c>expires_in</c> lifetime in seconds, or 0 when absent.</param>
+/// <param name="Error">The OAuth <c>error</c> code (or a synthetic transport error), or null on success.</param>
+internal sealed record OAuthTokenEndpointResponse(string? AccessToken, string? RefreshToken, int ExpiresIn, string? Error);
+
+/// <summary>
+/// Minimal OAuth2 token-endpoint client: form-POSTs a grant to a configurable token endpoint
+/// (<c>Accept: application/json</c>) and parses the standard <c>access_token</c>/<c>refresh_token</c>/
+/// <c>expires_in</c>/<c>error</c> response. Modeled on <c>GitHubOAuthProvider.PostTokenAsync</c> but
+/// standalone and endpoint-agnostic so <c>PredefinedKeyProvider</c> can drive the
+/// <c>refresh_token</c> and <c>client_credentials</c> grants against an arbitrary provider, and so it
+/// is unit-testable against a mock <see cref="HttpMessageHandler"/>.
+/// </summary>
+/// <remarks>SECURITY: never logs the form (it carries the client secret / refresh token) or the response body.</remarks>
+internal sealed class OAuthTokenEndpointClient(HttpClient http)
+{
+    private readonly HttpClient _http = http ?? throw new ArgumentNullException(nameof(http));
+
+    /// <summary>
+    /// POSTs <paramref name="form"/> to <paramref name="tokenEndpoint"/> and parses the token/error
+    /// response. Never throws for a non-success status or an unparseable body — those surface as an
+    /// <see cref="OAuthTokenEndpointResponse.Error"/> so the caller decides whether to deny/invalidate.
+    /// </summary>
+    public async Task<OAuthTokenEndpointResponse> PostAsync(
+        string tokenEndpoint,
+        IReadOnlyDictionary<string, string> form,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tokenEndpoint);
+        ArgumentNullException.ThrowIfNull(form);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, tokenEndpoint)
+        {
+            Content = new FormUrlEncodedContent(form),
+        };
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        using var response = await _http.SendAsync(request, ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return new OAuthTokenEndpointResponse(null, null, 0, "empty_response");
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+            return new OAuthTokenEndpointResponse(
+                root.TryGetProperty("access_token", out var at) ? at.GetString() : null,
+                root.TryGetProperty("refresh_token", out var rt) ? rt.GetString() : null,
+                root.TryGetProperty("expires_in", out var ei) && ei.TryGetInt32(out var seconds) ? seconds : 0,
+                root.TryGetProperty("error", out var er) ? er.GetString() : null);
+        }
+        catch (JsonException)
+        {
+            // Non-JSON body (HTML error page, etc.). Surface as a token-free error; never log the body.
+            return new OAuthTokenEndpointResponse(null, null, 0, "unparseable_response");
+        }
+    }
+}

--- a/src/LmAgentInfra/Auth/OAuthTokenEndpointClient.cs
+++ b/src/LmAgentInfra/Auth/OAuthTokenEndpointClient.cs
@@ -44,25 +44,43 @@ internal sealed class OAuthTokenEndpointClient(HttpClient http)
 
         using var response = await _http.SendAsync(request, ct).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+        // Best-effort parse of the standard OAuth token/error fields (a structured `error` may accompany
+        // either a success or a 4xx credential rejection).
+        string? accessToken = null;
+        string? refreshToken = null;
+        var expiresIn = 0;
+        string? error = null;
         if (string.IsNullOrWhiteSpace(body))
         {
-            return new OAuthTokenEndpointResponse(null, null, 0, "empty_response");
+            error = "empty_response";
+        }
+        else
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(body);
+                var root = doc.RootElement;
+                accessToken = root.TryGetProperty("access_token", out var at) ? at.GetString() : null;
+                refreshToken = root.TryGetProperty("refresh_token", out var rt) ? rt.GetString() : null;
+                expiresIn = root.TryGetProperty("expires_in", out var ei) && ei.TryGetInt32(out var seconds) ? seconds : 0;
+                error = root.TryGetProperty("error", out var er) ? er.GetString() : null;
+            }
+            catch (JsonException)
+            {
+                // Non-JSON body (HTML error page, etc.). Surface as a token-free error; never log the body.
+                error = "unparseable_response";
+            }
         }
 
-        try
+        // A non-success status must NEVER yield a token: return the parsed OAuth `error` when present,
+        // else a normalized `http_<status>` so the caller can tell a transient 429/5xx from a
+        // definitive credential rejection (only the latter invalidates the key).
+        if (!response.IsSuccessStatusCode)
         {
-            using var doc = JsonDocument.Parse(body);
-            var root = doc.RootElement;
-            return new OAuthTokenEndpointResponse(
-                root.TryGetProperty("access_token", out var at) ? at.GetString() : null,
-                root.TryGetProperty("refresh_token", out var rt) ? rt.GetString() : null,
-                root.TryGetProperty("expires_in", out var ei) && ei.TryGetInt32(out var seconds) ? seconds : 0,
-                root.TryGetProperty("error", out var er) ? er.GetString() : null);
+            return new OAuthTokenEndpointResponse(null, null, 0, error ?? $"http_{(int)response.StatusCode}");
         }
-        catch (JsonException)
-        {
-            // Non-JSON body (HTML error page, etc.). Surface as a token-free error; never log the body.
-            return new OAuthTokenEndpointResponse(null, null, 0, "unparseable_response");
-        }
+
+        return new OAuthTokenEndpointResponse(accessToken, refreshToken, expiresIn, error);
     }
 }

--- a/src/LmAgentInfra/Auth/OAuthTokenEndpointClient.cs
+++ b/src/LmAgentInfra/Auth/OAuthTokenEndpointClient.cs
@@ -66,9 +66,12 @@ internal sealed class OAuthTokenEndpointClient(HttpClient http)
                 expiresIn = root.TryGetProperty("expires_in", out var ei) && ei.TryGetInt32(out var seconds) ? seconds : 0;
                 error = root.TryGetProperty("error", out var er) ? er.GetString() : null;
             }
-            catch (JsonException)
+            catch (Exception ex) when (ex is JsonException or InvalidOperationException)
             {
-                // Non-JSON body (HTML error page, etc.). Surface as a token-free error; never log the body.
+                // Non-JSON body (HTML error page) OR valid JSON with unexpected field types (e.g.
+                // {"access_token":{}} makes GetString throw InvalidOperationException). Either way, surface a
+                // fixed token-free error rather than letting it escape the documented result contract; never
+                // log the body.
                 error = "unparseable_response";
             }
         }

--- a/src/LmAgentInfra/Auth/PredefinedKeyEntry.cs
+++ b/src/LmAgentInfra/Auth/PredefinedKeyEntry.cs
@@ -1,0 +1,59 @@
+using System.Text.Json.Serialization;
+
+namespace AchieveAi.LmDotnetTools.LmAgentInfra.Auth;
+
+/// <summary>The credential kind of a predefined egress key.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+internal enum PredefinedKeyKind
+{
+    /// <summary>A list of header name/value pairs injected verbatim (cookie, token, API key, …).</summary>
+    CustomHeaders,
+
+    /// <summary>OAuth2 <c>refresh_token</c> grant: the app mints + auto-refreshes an access token.</summary>
+    RefreshToken,
+
+    /// <summary>OAuth2 <c>client_credentials</c> grant: the app mints + auto-refreshes an access token.</summary>
+    ClientCredentials,
+}
+
+/// <summary>One header name/value pair for a <see cref="PredefinedKeyKind.CustomHeaders"/> entry.</summary>
+internal sealed record PredefinedHeader(string Name, string Value);
+
+/// <summary>
+/// The persisted definition of one predefined egress key. Stored under the gitignored
+/// <c>oauth-tokens/</c> directory (SECRET — the header <see cref="Headers"/> values,
+/// <see cref="ClientSecret"/>, and <see cref="RefreshToken"/> are credential material and are never
+/// logged nor returned by the CRUD API). Kind-specific fields are only meaningful for their kind.
+/// </summary>
+internal sealed record PredefinedKeyEntry
+{
+    /// <summary>Stable id; forms the provider id <c>predefined-{Id}</c> and the sandbox rule/provider ids.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The single destination host (exact or <c>*.suffix</c>) this entry authenticates egress to.</summary>
+    public required string Host { get; init; }
+
+    /// <summary>The credential kind.</summary>
+    public required PredefinedKeyKind Kind { get; init; }
+
+    /// <summary>Header pairs injected verbatim — <see cref="PredefinedKeyKind.CustomHeaders"/> only.</summary>
+    public IReadOnlyList<PredefinedHeader> Headers { get; init; } = [];
+
+    /// <summary>Header the minted <c>Bearer</c> token is injected under (OAuth kinds). Defaults to <c>Authorization</c>.</summary>
+    public string HeaderName { get; init; } = "Authorization";
+
+    /// <summary>OAuth2 token endpoint URL (OAuth kinds).</summary>
+    public string? TokenEndpoint { get; init; }
+
+    /// <summary>OAuth2 client id (OAuth kinds).</summary>
+    public string? ClientId { get; init; }
+
+    /// <summary>OAuth2 client secret (client-credentials always; refresh-token when the provider requires it). SECRET.</summary>
+    public string? ClientSecret { get; init; }
+
+    /// <summary>OAuth2 refresh token (refresh-token kind). SECRET. Rotated values are persisted in the token store, not here.</summary>
+    public string? RefreshToken { get; init; }
+
+    /// <summary>OAuth2 scopes requested when minting (OAuth kinds).</summary>
+    public IReadOnlyList<string> Scopes { get; init; } = [];
+}

--- a/src/LmAgentInfra/Auth/PredefinedKeyProvider.cs
+++ b/src/LmAgentInfra/Auth/PredefinedKeyProvider.cs
@@ -1,0 +1,310 @@
+namespace AchieveAi.LmDotnetTools.LmAgentInfra.Auth;
+
+/// <summary>
+/// An <see cref="IOAuthTokenProvider"/> for ONE predefined egress key. A single instance is kept per
+/// entry id for its whole lifetime (the registry mutates it in place via <see cref="UpdateEntry"/> on
+/// edit) so a held deferred-auth prompt polling <see cref="GetAccessTokenAsync"/> observes an update
+/// the moment the user saves it. Resolves through <c>AuthWebhookController</c> exactly like the OAuth
+/// providers, but the controller reads <see cref="Hosts"/> / <see cref="BuildHeaders"/> /
+/// <see cref="IncludeExpiry"/> off it to inject a custom header list (or a minted <c>Bearer</c> token).
+/// </summary>
+/// <remarks>
+/// <para>Three kinds (<see cref="PredefinedKeyKind"/>):</para>
+/// <list type="bullet">
+/// <item><c>CustomHeaders</c> — no token; <see cref="GetAccessTokenAsync"/> returns a sentinel when the
+/// header list is present (the controller uses <see cref="BuildHeaders"/>), or throws when it is empty
+/// so the deferred prompt fires.</item>
+/// <item><c>RefreshToken</c> / <c>ClientCredentials</c> — mints + auto-refreshes an access token via
+/// <see cref="OAuthTokenEndpointClient"/>, persists it (and any rotated refresh token) through
+/// <see cref="IOAuthTokenStore"/>, and marks itself invalid on a definitive credential rejection.</item>
+/// </list>
+/// <para>SECRET: never logs the header values, client secret, refresh token, or minted access token.</para>
+/// </remarks>
+internal sealed class PredefinedKeyProvider : IOAuthTokenProvider
+{
+    /// <summary>Refresh a token this long before its real expiry (matches the GitHub provider's skew).</summary>
+    private static readonly TimeSpan ExpirySkew = TimeSpan.FromSeconds(120);
+
+    /// <summary>Sentinel expiry for values with no lifetime (custom headers, or an endpoint that omits <c>expires_in</c>).</summary>
+    private static readonly DateTimeOffset NonExpiring = new(9999, 12, 31, 23, 59, 59, TimeSpan.Zero);
+
+    /// <summary>OAuth error codes that mean the credential itself is bad → invalidate + prompt (vs. a transient server error).</summary>
+    private static readonly HashSet<string> CredentialRejectionErrors = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "invalid_grant",
+        "invalid_client",
+        "unauthorized_client",
+        "access_denied",
+        "invalid_scope",
+    };
+
+    private readonly string _id;
+    private readonly IOAuthTokenStore _tokenStore;
+    private readonly OAuthTokenEndpointClient _endpoint;
+    private readonly ILogger _logger;
+    private readonly SemaphoreSlim _refreshGate = new(1, 1);
+
+    private volatile PredefinedKeyEntry _entry;
+    private volatile bool _invalidated;
+    private volatile OAuthStatus _status;
+    private OAuthAccessToken? _cachedToken;
+
+    public PredefinedKeyProvider(
+        PredefinedKeyEntry entry,
+        IOAuthTokenStore tokenStore,
+        OAuthTokenEndpointClient endpoint,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        _id = entry.Id;
+        _entry = entry;
+        _tokenStore = tokenStore ?? throw new ArgumentNullException(nameof(tokenStore));
+        _endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _status = new OAuthStatus(OAuthSignInState.NotStarted, null, entry.Scopes, null, null);
+    }
+
+    /// <inheritdoc />
+    public string ProviderId => $"predefined-{_id}";
+
+    /// <inheritdoc />
+    public OAuthStatus Status => _status;
+
+    /// <summary>The entry as it currently stands (secret-bearing — for the registry's rule building only).</summary>
+    public PredefinedKeyEntry Entry => _entry;
+
+    /// <summary>The single destination host this key authenticates egress to, as a one-element list.</summary>
+    public IReadOnlyList<string> Hosts => [_entry.Host];
+
+    /// <summary>True for the token-minting kinds (their token carries a real expiry the gateway caches on).</summary>
+    public bool IncludeExpiry => _entry.Kind != PredefinedKeyKind.CustomHeaders;
+
+    /// <summary>
+    /// The header(s) to inject: the stored list verbatim for custom-headers, or a single
+    /// <c>Bearer &lt;token&gt;</c> under the configured header name for the OAuth kinds.
+    /// </summary>
+    public IReadOnlyList<KeyValuePair<string, string>> BuildHeaders(OAuthAccessToken? token)
+    {
+        var entry = _entry;
+        if (entry.Kind == PredefinedKeyKind.CustomHeaders)
+        {
+            return [.. entry.Headers.Select(h => new KeyValuePair<string, string>(h.Name, h.Value))];
+        }
+
+        var value = token is null ? string.Empty : $"Bearer {token.Value}";
+        return [new KeyValuePair<string, string>(entry.HeaderName, value)];
+    }
+
+    /// <summary>
+    /// Swaps the entry in place (edit), clears the minted-token cache, and clears the invalidated
+    /// flag so the next <see cref="GetAccessTokenAsync"/> re-mints / re-reads the updated credential.
+    /// </summary>
+    public void UpdateEntry(PredefinedKeyEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        _entry = entry;
+        _invalidated = false;
+        // Reference assignment is atomic; a concurrent in-flight mint under _refreshGate may briefly
+        // re-cache a token from the pre-edit credential, which expires normally — acceptable for a
+        // local-dev sample where edits are rare.
+        _cachedToken = null;
+        _status = new OAuthStatus(OAuthSignInState.NotStarted, null, entry.Scopes, null, null);
+    }
+
+    /// <inheritdoc />
+    public async Task<OAuthAccessToken> GetAccessTokenAsync(
+        IReadOnlyList<string>? scopes = null,
+        CancellationToken ct = default)
+    {
+        var entry = _entry;
+
+        if (entry.Kind == PredefinedKeyKind.CustomHeaders)
+        {
+            if (entry.Headers.Count == 0)
+            {
+                SetStatus(OAuthSignInState.NotStarted, "no headers configured");
+                throw new InvalidOperationException($"predefined key '{_id}' has no headers configured; add them.");
+            }
+
+            SetStatus(OAuthSignInState.SignedIn, null);
+            // Sentinel: the controller injects BuildHeaders() for custom-headers, not this value.
+            return new OAuthAccessToken(string.Empty, NonExpiring);
+        }
+
+        if (_invalidated)
+        {
+            throw new InvalidOperationException($"predefined key '{_id}' is marked invalid; update the credential.");
+        }
+
+        await _refreshGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_invalidated)
+            {
+                throw new InvalidOperationException($"predefined key '{_id}' is marked invalid; update the credential.");
+            }
+
+            _cachedToken ??= await LoadCachedFromStoreAsync(ct).ConfigureAwait(false);
+
+            if (_cachedToken is { } cached && cached.ExpiresAtUtc - ExpirySkew > DateTimeOffset.UtcNow)
+            {
+                return cached;
+            }
+
+            return await MintAsync(entry, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _ = _refreshGate.Release();
+        }
+    }
+
+    /// <summary>Mints (or refreshes) an access token via the token endpoint. Caller holds <see cref="_refreshGate"/>.</summary>
+    private async Task<OAuthAccessToken> MintAsync(PredefinedKeyEntry entry, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(entry.TokenEndpoint))
+        {
+            throw new InvalidOperationException($"predefined key '{_id}' has no token endpoint configured.");
+        }
+
+        // The current refresh token: a rotated value persisted in the store wins over the entry's original.
+        var refreshToken = entry.RefreshToken;
+        if (entry.Kind == PredefinedKeyKind.RefreshToken)
+        {
+            var stored = await _tokenStore.GetAsync(ProviderId, ct).ConfigureAwait(false);
+            if (!string.IsNullOrEmpty(stored?.RefreshToken))
+            {
+                refreshToken = stored.RefreshToken;
+            }
+        }
+
+        var form = new Dictionary<string, string>();
+        if (!string.IsNullOrEmpty(entry.ClientId))
+        {
+            form["client_id"] = entry.ClientId;
+        }
+
+        if (!string.IsNullOrEmpty(entry.ClientSecret))
+        {
+            form["client_secret"] = entry.ClientSecret;
+        }
+
+        if (entry.Scopes.Count > 0)
+        {
+            form["scope"] = string.Join(' ', entry.Scopes);
+        }
+
+        if (entry.Kind == PredefinedKeyKind.RefreshToken)
+        {
+            form["grant_type"] = "refresh_token";
+            form["refresh_token"] = refreshToken ?? string.Empty;
+        }
+        else
+        {
+            form["grant_type"] = "client_credentials";
+        }
+
+        OAuthTokenEndpointResponse resp;
+        try
+        {
+            resp = await _endpoint.PostAsync(entry.TokenEndpoint, form, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Transient transport failure — prompt/retry, but do NOT invalidate (the credential may be fine).
+            SetStatus(OAuthSignInState.Failed, "token_endpoint_unreachable");
+            throw new InvalidOperationException($"predefined key '{_id}': token endpoint unreachable.", ex);
+        }
+
+        if (string.IsNullOrEmpty(resp.AccessToken))
+        {
+            if (IsCredentialRejection(resp.Error))
+            {
+                // Definitive rejection: mark invalid so we prompt for an update instead of re-sending a bad credential.
+                _invalidated = true;
+                SetStatus(OAuthSignInState.Failed, resp.Error);
+                _logger.LogWarning("Predefined key {ProviderId} rejected by token endpoint ({Error}); marked invalid.", ProviderId, resp.Error);
+                throw new InvalidOperationException($"predefined key '{_id}' rejected: {resp.Error}");
+            }
+
+            SetStatus(OAuthSignInState.Failed, resp.Error ?? "mint_failed");
+            throw new InvalidOperationException($"predefined key '{_id}' token mint failed: {resp.Error ?? "no access_token"}");
+        }
+
+        var expiry = resp.ExpiresIn > 0 ? DateTimeOffset.UtcNow.AddSeconds(resp.ExpiresIn) : NonExpiring;
+        var token = new OAuthAccessToken(resp.AccessToken, expiry);
+        _cachedToken = token;
+
+        var persistedRefresh = entry.Kind == PredefinedKeyKind.RefreshToken
+            ? (string.IsNullOrEmpty(resp.RefreshToken) ? refreshToken : resp.RefreshToken)
+            : null;
+        await _tokenStore.SaveAsync(
+            new OAuthTokenRecord(ProviderId, null, persistedRefresh ?? string.Empty, token.Value, expiry, entry.Scopes),
+            ct).ConfigureAwait(false);
+
+        SetStatus(OAuthSignInState.SignedIn, null);
+        _logger.LogInformation("Predefined key {ProviderId} minted an access token (expires {ExpiresAt:o}).", ProviderId, expiry);
+        return token;
+    }
+
+    /// <summary>Best-effort load of a previously-minted, still-valid access token from the store.</summary>
+    private async Task<OAuthAccessToken?> LoadCachedFromStoreAsync(CancellationToken ct)
+    {
+        var record = await _tokenStore.GetAsync(ProviderId, ct).ConfigureAwait(false);
+        if (record?.AccessToken is { Length: > 0 } access && record.AccessTokenExpiresAtUtc is { } expiry)
+        {
+            return new OAuthAccessToken(access, expiry);
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc />
+    public async Task HydrateFromStoreAsync(CancellationToken ct = default)
+    {
+        if (_entry.Kind == PredefinedKeyKind.CustomHeaders)
+        {
+            return;
+        }
+
+        await _refreshGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            _cachedToken = await LoadCachedFromStoreAsync(ct).ConfigureAwait(false);
+            if (_cachedToken is not null)
+            {
+                SetStatus(OAuthSignInState.SignedIn, null);
+            }
+        }
+        finally
+        {
+            _ = _refreshGate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<SignInChallenge> BeginSignInAsync(CancellationToken ct = default) =>
+        throw new NotSupportedException("Predefined egress keys are configured directly, not via an interactive sign-in.");
+
+    /// <inheritdoc />
+    public async Task SignOutAsync(CancellationToken ct = default)
+    {
+        await _refreshGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            _cachedToken = null;
+            await _tokenStore.RemoveAsync(ProviderId, ct).ConfigureAwait(false);
+            SetStatus(OAuthSignInState.NotStarted, null);
+        }
+        finally
+        {
+            _ = _refreshGate.Release();
+        }
+    }
+
+    private static bool IsCredentialRejection(string? error) =>
+        !string.IsNullOrEmpty(error) && CredentialRejectionErrors.Contains(error);
+
+    private void SetStatus(OAuthSignInState state, string? error) =>
+        _status = new OAuthStatus(state, null, _entry.Scopes, _cachedToken?.ExpiresAtUtc, error);
+}

--- a/src/LmAgentInfra/Auth/PredefinedKeyProvider.cs
+++ b/src/LmAgentInfra/Auth/PredefinedKeyProvider.cs
@@ -2,7 +2,7 @@ namespace AchieveAi.LmDotnetTools.LmAgentInfra.Auth;
 
 /// <summary>
 /// An <see cref="IOAuthTokenProvider"/> for ONE predefined egress key. A single instance is kept per
-/// entry id for its whole lifetime (the registry mutates it in place via <see cref="UpdateEntry"/> on
+/// entry id for its whole lifetime (the registry mutates it in place via <see cref="ApplyUpdateAsync"/> on
 /// edit) so a held deferred-auth prompt polling <see cref="GetAccessTokenAsync"/> observes an update
 /// the moment the user saves it. Resolves through <c>AuthWebhookController</c> exactly like the OAuth
 /// providers, but the controller reads <see cref="Hosts"/> / <see cref="BuildHeaders"/> /
@@ -102,18 +102,31 @@ internal sealed class PredefinedKeyProvider : IOAuthTokenProvider
     /// invalidated flag, and DROPS the persisted token record so the next acquisition re-mints with
     /// the new credential instead of reloading the stale access/rotated-refresh token by provider id.
     /// </summary>
-    public async Task UpdateEntry(PredefinedKeyEntry entry, bool credentialChanged, CancellationToken ct = default)
+    public async Task ApplyUpdateAsync(PredefinedKeyEntry entry, bool credentialChanged, Func<Task> persistDefinition)
     {
         ArgumentNullException.ThrowIfNull(entry);
-        await _refreshGate.WaitAsync(ct).ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(persistDefinition);
+
+        // The ENTIRE edit runs under the refresh gate, serialized with any in-flight mint, so no concurrent
+        // GetAccessTokenAsync can interleave and observe (or re-persist) a torn definition/token pair.
+        // CancellationToken.None everywhere past this point: a request cancel must never half-apply the edit
+        // and leave the definition, persisted token, and live provider diverged.
+        await _refreshGate.WaitAsync(CancellationToken.None).ConfigureAwait(false);
         try
         {
+            // 1. Invalidate the stale token FIRST (reliable — a failure throws before anything is published).
+            if (credentialChanged)
+            {
+                await _tokenStore.RemoveAsync(ProviderId, CancellationToken.None).ConfigureAwait(false);
+            }
+
+            // 2. Make the new definition durable while still holding the gate (atomic with the swap below).
+            await persistDefinition().ConfigureAwait(false);
+
+            // 3. Publish the new entry in-memory. A pure host/header edit keeps the still-valid cached token;
+            //    a credential change already dropped it in step 1, so clear the in-memory copy too.
             _entry = entry;
             _invalidated = false;
-            // Only drop the in-memory minted token when the credential changed; a pure host/header edit
-            // keeps the still-valid cached token (re-injected under the new host/header). Invalidating the
-            // PERSISTED token — and its ordering relative to the durable definition write — is the
-            // registry's job (see PredefinedKeyRegistry.UpsertAsync), so a partial failure degrades safely.
             if (credentialChanged)
             {
                 _cachedToken = null;

--- a/src/LmAgentInfra/Auth/PredefinedKeyProvider.cs
+++ b/src/LmAgentInfra/Auth/PredefinedKeyProvider.cs
@@ -102,7 +102,7 @@ internal sealed class PredefinedKeyProvider : IOAuthTokenProvider
     /// invalidated flag, and DROPS the persisted token record so the next acquisition re-mints with
     /// the new credential instead of reloading the stale access/rotated-refresh token by provider id.
     /// </summary>
-    public async Task UpdateEntry(PredefinedKeyEntry entry, CancellationToken ct = default)
+    public async Task UpdateEntry(PredefinedKeyEntry entry, bool credentialChanged, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(entry);
         await _refreshGate.WaitAsync(ct).ConfigureAwait(false);
@@ -110,10 +110,15 @@ internal sealed class PredefinedKeyProvider : IOAuthTokenProvider
         {
             _entry = entry;
             _invalidated = false;
-            _cachedToken = null;
-            // ProviderId is derived from the immutable id, so this drops THIS entry's stale token.
-            await _tokenStore.RemoveAsync(ProviderId, ct).ConfigureAwait(false);
-            _status = new OAuthStatus(OAuthSignInState.NotStarted, null, entry.Scopes, null, null);
+            // Only drop the in-memory minted token when the credential changed; a pure host/header edit
+            // keeps the still-valid cached token (re-injected under the new host/header). Invalidating the
+            // PERSISTED token — and its ordering relative to the durable definition write — is the
+            // registry's job (see PredefinedKeyRegistry.UpsertAsync), so a partial failure degrades safely.
+            if (credentialChanged)
+            {
+                _cachedToken = null;
+                _status = new OAuthStatus(OAuthSignInState.NotStarted, null, entry.Scopes, null, null);
+            }
         }
         finally
         {
@@ -121,34 +126,45 @@ internal sealed class PredefinedKeyProvider : IOAuthTokenProvider
         }
     }
 
+    /// <summary>
+    /// True when the credential material (kind, token endpoint, client id/secret, refresh token, scopes)
+    /// differs — the only case that invalidates a minted/persisted token. A pure host or header-name edit
+    /// preserves the credential and, crucially, the latest ROTATED refresh token in the persisted record.
+    /// </summary>
+    internal static bool CredentialChanged(PredefinedKeyEntry oldEntry, PredefinedKeyEntry newEntry) =>
+        oldEntry.Kind != newEntry.Kind
+        || !string.Equals(oldEntry.TokenEndpoint, newEntry.TokenEndpoint, StringComparison.Ordinal)
+        || !string.Equals(oldEntry.ClientId, newEntry.ClientId, StringComparison.Ordinal)
+        || !string.Equals(oldEntry.ClientSecret, newEntry.ClientSecret, StringComparison.Ordinal)
+        || !string.Equals(oldEntry.RefreshToken, newEntry.RefreshToken, StringComparison.Ordinal)
+        || !oldEntry.Scopes.SequenceEqual(newEntry.Scopes, StringComparer.Ordinal);
+
     /// <inheritdoc />
     public async Task<OAuthAccessToken> GetAccessTokenAsync(
         IReadOnlyList<string>? scopes = null,
         CancellationToken ct = default)
     {
-        var entry = _entry;
-
-        if (entry.Kind == PredefinedKeyKind.CustomHeaders)
-        {
-            if (entry.Headers.Count == 0)
-            {
-                SetStatus(OAuthSignInState.NotStarted, "no headers configured");
-                throw new InvalidOperationException($"predefined key '{_id}' has no headers configured; add them.");
-            }
-
-            SetStatus(OAuthSignInState.SignedIn, null);
-            // Sentinel: the controller injects BuildHeaders() for custom-headers, not this value.
-            return new OAuthAccessToken(string.Empty, NonExpiring);
-        }
-
-        if (_invalidated)
-        {
-            throw new InvalidOperationException($"predefined key '{_id}' is marked invalid; update the credential.");
-        }
-
+        // Everything runs under the gate so a captured entry can never be minted with a credential that
+        // an interleaved UpdateEntry (also gated) has since superseded: the kind/invalidation/credential
+        // decision and the mint all read one locked snapshot.
         await _refreshGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
+            var entry = _entry;
+
+            if (entry.Kind == PredefinedKeyKind.CustomHeaders)
+            {
+                if (entry.Headers.Count == 0)
+                {
+                    SetStatus(OAuthSignInState.NotStarted, "no headers configured");
+                    throw new InvalidOperationException($"predefined key '{_id}' has no headers configured; add them.");
+                }
+
+                SetStatus(OAuthSignInState.SignedIn, null);
+                // Sentinel: the controller injects BuildHeaders() for custom-headers, not this value.
+                return new OAuthAccessToken(string.Empty, NonExpiring);
+            }
+
             if (_invalidated)
             {
                 throw new InvalidOperationException($"predefined key '{_id}' is marked invalid; update the credential.");

--- a/src/LmAgentInfra/Auth/PredefinedKeyProvider.cs
+++ b/src/LmAgentInfra/Auth/PredefinedKeyProvider.cs
@@ -96,19 +96,29 @@ internal sealed class PredefinedKeyProvider : IOAuthTokenProvider
     }
 
     /// <summary>
-    /// Swaps the entry in place (edit), clears the minted-token cache, and clears the invalidated
-    /// flag so the next <see cref="GetAccessTokenAsync"/> re-mints / re-reads the updated credential.
+    /// Swaps the entry in place (edit) and makes the new credential take effect immediately:
+    /// serializes with any in-flight mint through <see cref="_refreshGate"/> (so a mint from the
+    /// PRE-edit credential can't publish a token after the swap), clears the in-memory cache + the
+    /// invalidated flag, and DROPS the persisted token record so the next acquisition re-mints with
+    /// the new credential instead of reloading the stale access/rotated-refresh token by provider id.
     /// </summary>
-    public void UpdateEntry(PredefinedKeyEntry entry)
+    public async Task UpdateEntry(PredefinedKeyEntry entry, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(entry);
-        _entry = entry;
-        _invalidated = false;
-        // Reference assignment is atomic; a concurrent in-flight mint under _refreshGate may briefly
-        // re-cache a token from the pre-edit credential, which expires normally — acceptable for a
-        // local-dev sample where edits are rare.
-        _cachedToken = null;
-        _status = new OAuthStatus(OAuthSignInState.NotStarted, null, entry.Scopes, null, null);
+        await _refreshGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            _entry = entry;
+            _invalidated = false;
+            _cachedToken = null;
+            // ProviderId is derived from the immutable id, so this drops THIS entry's stale token.
+            await _tokenStore.RemoveAsync(ProviderId, ct).ConfigureAwait(false);
+            _status = new OAuthStatus(OAuthSignInState.NotStarted, null, entry.Scopes, null, null);
+        }
+        finally
+        {
+            _ = _refreshGate.Release();
+        }
     }
 
     /// <inheritdoc />

--- a/src/LmAgentInfra/Auth/PredefinedKeyRegistry.cs
+++ b/src/LmAgentInfra/Auth/PredefinedKeyRegistry.cs
@@ -111,16 +111,28 @@ public sealed class PredefinedKeyRegistry
         await _persistGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
+            _ = _providers.TryGetValue(entry.Id, out var existing);
+            var credentialChanged = existing is null || PredefinedKeyProvider.CredentialChanged(existing.Entry, entry);
+
             var candidate = _providers.Values
                 .Select(p => p.Entry)
                 .Where(e => !string.Equals(e.Id, entry.Id, StringComparison.Ordinal))
                 .Append(entry)
                 .ToList();
+
+            // Invalidate the stale minted token BEFORE the new definition is made durable, so a failed
+            // persist can never leave the new definition on disk while the old token stays reloadable under
+            // the unchanged provider id. Cleanup is best-effort (see TryRemovePersistedTokenAsync).
+            if (existing is not null && credentialChanged)
+            {
+                await TryRemovePersistedTokenAsync(entry.Id).ConfigureAwait(false);
+            }
+
             await AtomicJsonFile.WriteAsync(_filePath, candidate, JsonOptions, ct).ConfigureAwait(false);
 
-            if (_providers.TryGetValue(entry.Id, out var existing))
+            if (existing is not null)
             {
-                await existing.UpdateEntry(entry, ct).ConfigureAwait(false);
+                await existing.UpdateEntry(entry, credentialChanged, ct).ConfigureAwait(false);
             }
             else
             {
@@ -155,13 +167,32 @@ public sealed class PredefinedKeyRegistry
             await AtomicJsonFile.WriteAsync(_filePath, candidate, JsonOptions, ct).ConfigureAwait(false);
 
             _ = _providers.TryRemove(id, out _);
-            // Best-effort: drop the persisted minted token so the secret does not linger.
-            await provider.SignOutAsync(ct).ConfigureAwait(false);
+            // Drop the persisted minted token so the secret does not linger — genuinely best-effort so a
+            // cleanup failure/cancellation never fails the (already-committed) deletion or strands the caller.
+            await TryRemovePersistedTokenAsync(id).ConfigureAwait(false);
             return true;
         }
         finally
         {
             _ = _persistGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Best-effort removal of an entry's persisted minted token. Uses a NON-request cancellation token so a
+    /// disconnecting caller cannot strand the cleanup, and never throws — a failure is logged (never the
+    /// secret) and the operation proceeds; a leftover token is harmless (it is re-validated / overwritten on
+    /// the next mint and is not reachable without its now-removed definition).
+    /// </summary>
+    private async Task TryRemovePersistedTokenAsync(string entryId)
+    {
+        try
+        {
+            await _tokenStore.RemoveAsync($"{ProviderIdPrefix}{entryId}", CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Best-effort cleanup of the persisted token for predefined key {Id} failed.", entryId);
         }
     }
 }

--- a/src/LmAgentInfra/Auth/PredefinedKeyRegistry.cs
+++ b/src/LmAgentInfra/Auth/PredefinedKeyRegistry.cs
@@ -99,44 +99,65 @@ public sealed class PredefinedKeyRegistry
     internal PredefinedKeyEntry? Find(string id) =>
         _providers.TryGetValue(id, out var provider) ? provider.Entry : null;
 
-    /// <summary>Creates a new entry or updates an existing one in place (same id), then persists.</summary>
+    /// <summary>
+    /// Creates a new entry or updates an existing one (same id). Persists the candidate set FIRST and
+    /// only publishes the in-memory change when the write succeeds, so a failed/cancelled write never
+    /// leaves memory and disk divergent. The whole mutation is serialized under <see cref="_persistGate"/>.
+    /// </summary>
     internal async Task UpsertAsync(PredefinedKeyEntry entry, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(entry);
 
-        if (_providers.TryGetValue(entry.Id, out var existing))
+        await _persistGate.WaitAsync(ct).ConfigureAwait(false);
+        try
         {
-            existing.UpdateEntry(entry);
-        }
-        else
-        {
-            _providers[entry.Id] = NewProvider(entry);
-        }
+            var candidate = _providers.Values
+                .Select(p => p.Entry)
+                .Where(e => !string.Equals(e.Id, entry.Id, StringComparison.Ordinal))
+                .Append(entry)
+                .ToList();
+            await AtomicJsonFile.WriteAsync(_filePath, candidate, JsonOptions, ct).ConfigureAwait(false);
 
-        await PersistAsync(ct).ConfigureAwait(false);
+            if (_providers.TryGetValue(entry.Id, out var existing))
+            {
+                await existing.UpdateEntry(entry, ct).ConfigureAwait(false);
+            }
+            else
+            {
+                _providers[entry.Id] = NewProvider(entry);
+            }
+        }
+        finally
+        {
+            _ = _persistGate.Release();
+        }
     }
 
-    /// <summary>Removes an entry (and its persisted minted token), then persists. Returns false when the id is unknown.</summary>
+    /// <summary>
+    /// Removes an entry. Persists the candidate (without it) FIRST, then removes it from memory and
+    /// drops its persisted minted token — so a failed write never orphans the on-disk entry. Returns
+    /// false when the id is unknown. Serialized under <see cref="_persistGate"/>.
+    /// </summary>
     internal async Task<bool> RemoveAsync(string id, CancellationToken ct = default)
-    {
-        if (!_providers.TryRemove(id, out var provider))
-        {
-            return false;
-        }
-
-        // Best-effort: drop any minted-token record for this entry so the secret does not linger.
-        await provider.SignOutAsync(ct).ConfigureAwait(false);
-        await PersistAsync(ct).ConfigureAwait(false);
-        return true;
-    }
-
-    /// <summary>Atomically writes the full entry set to disk under the persist gate.</summary>
-    private async Task PersistAsync(CancellationToken ct)
     {
         await _persistGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            await AtomicJsonFile.WriteAsync(_filePath, Entries, JsonOptions, ct).ConfigureAwait(false);
+            if (!_providers.TryGetValue(id, out var provider))
+            {
+                return false;
+            }
+
+            var candidate = _providers.Values
+                .Select(p => p.Entry)
+                .Where(e => !string.Equals(e.Id, id, StringComparison.Ordinal))
+                .ToList();
+            await AtomicJsonFile.WriteAsync(_filePath, candidate, JsonOptions, ct).ConfigureAwait(false);
+
+            _ = _providers.TryRemove(id, out _);
+            // Best-effort: drop the persisted minted token so the secret does not linger.
+            await provider.SignOutAsync(ct).ConfigureAwait(false);
+            return true;
         }
         finally
         {

--- a/src/LmAgentInfra/Auth/PredefinedKeyRegistry.cs
+++ b/src/LmAgentInfra/Auth/PredefinedKeyRegistry.cs
@@ -120,12 +120,14 @@ public sealed class PredefinedKeyRegistry
                 .Append(entry)
                 .ToList();
 
-            // Invalidate the stale minted token BEFORE the new definition is made durable, so a failed
-            // persist can never leave the new definition on disk while the old token stays reloadable under
-            // the unchanged provider id. Cleanup is best-effort (see TryRemovePersistedTokenAsync).
+            // Invalidate the stale minted token BEFORE the new definition is made durable. This is a
+            // RELIABLE (not best-effort) step: if removal fails the whole upsert throws before anything is
+            // persisted or published, so we never leave the new definition live with the old access/rotated
+            // token reloadable under the unchanged provider id. CancellationToken.None so a disconnecting
+            // caller can't strand it mid-invalidation.
             if (existing is not null && credentialChanged)
             {
-                await TryRemovePersistedTokenAsync(entry.Id).ConfigureAwait(false);
+                await _tokenStore.RemoveAsync($"{ProviderIdPrefix}{entry.Id}", CancellationToken.None).ConfigureAwait(false);
             }
 
             await AtomicJsonFile.WriteAsync(_filePath, candidate, JsonOptions, ct).ConfigureAwait(false);

--- a/src/LmAgentInfra/Auth/PredefinedKeyRegistry.cs
+++ b/src/LmAgentInfra/Auth/PredefinedKeyRegistry.cs
@@ -1,0 +1,146 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace AchieveAi.LmDotnetTools.LmAgentInfra.Auth;
+
+/// <summary>
+/// The runtime aggregate for predefined egress keys: one <see cref="PredefinedKeyProvider"/> per
+/// entry, disk persistence of the entry definitions (a single gitignored JSON file), CRUD, and
+/// resolution by provider id. Entries are created at RUNTIME via the CRUD API (not startup config),
+/// so this is the second provider source the webhook consults after the fixed DI-registered OAuth
+/// providers. Minted OAuth tokens ride the shared <see cref="IOAuthTokenStore"/> (keyed by
+/// <c>predefined-&lt;id&gt;</c>); only the entry definitions live in this registry's file.
+/// </summary>
+/// <remarks>SECRET: the persisted file contains credential material — it lives under the gitignored token dir and is never logged.</remarks>
+/// <remarks>
+/// Public only so it can be a constructor dependency of the public <c>AuthWebhookController</c> /
+/// <c>EgressKeysController</c>; its members are internal (all consumers are in this assembly).
+/// </remarks>
+public sealed class PredefinedKeyRegistry
+{
+    /// <summary>Provider-id prefix; <c>ProviderId = "predefined-{entryId}"</c>.</summary>
+    internal const string ProviderIdPrefix = "predefined-";
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    private readonly string _filePath;
+    private readonly IOAuthTokenStore _tokenStore;
+    private readonly OAuthTokenEndpointClient _endpoint;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger<PredefinedKeyRegistry> _logger;
+    private readonly ConcurrentDictionary<string, PredefinedKeyProvider> _providers = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim _persistGate = new(1, 1);
+
+    /// <summary>
+    /// Creates the registry and loads any persisted entries from <c>{baseDirectory}/predefined-keys.json</c>.
+    /// Takes an <see cref="HttpClient"/> (public) and builds the internal token-endpoint client itself so
+    /// the public constructor exposes no internal types.
+    /// </summary>
+    public PredefinedKeyRegistry(
+        string baseDirectory,
+        IOAuthTokenStore tokenStore,
+        HttpClient httpClient,
+        ILoggerFactory loggerFactory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(baseDirectory);
+        _tokenStore = tokenStore ?? throw new ArgumentNullException(nameof(tokenStore));
+        ArgumentNullException.ThrowIfNull(httpClient);
+        _endpoint = new OAuthTokenEndpointClient(httpClient);
+        _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        _logger = loggerFactory.CreateLogger<PredefinedKeyRegistry>();
+        _filePath = Path.Combine(Path.GetFullPath(baseDirectory), "predefined-keys.json");
+        Load();
+    }
+
+    /// <summary>Loads persisted entry definitions at startup (best-effort; a corrupt file logs + starts empty).</summary>
+    private void Load()
+    {
+        if (!File.Exists(_filePath))
+        {
+            return;
+        }
+
+        try
+        {
+            var json = File.ReadAllText(_filePath);
+            var entries = JsonSerializer.Deserialize<List<PredefinedKeyEntry>>(json, JsonOptions) ?? [];
+            foreach (var entry in entries)
+            {
+                _providers[entry.Id] = NewProvider(entry);
+            }
+
+            _logger.LogInformation("Loaded {Count} predefined egress key(s) from {File}.", entries.Count, _filePath);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse predefined egress keys file {File}; starting with none.", _filePath);
+        }
+    }
+
+    private PredefinedKeyProvider NewProvider(PredefinedKeyEntry entry) =>
+        new(entry, _tokenStore, _endpoint, _loggerFactory.CreateLogger<PredefinedKeyProvider>());
+
+    /// <summary>Resolves the provider for a <c>predefined-&lt;id&gt;</c> provider id, or null when not a predefined key.</summary>
+    internal PredefinedKeyProvider? TryResolve(string? providerId)
+    {
+        if (string.IsNullOrEmpty(providerId) || !providerId.StartsWith(ProviderIdPrefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var id = providerId[ProviderIdPrefix.Length..];
+        return _providers.TryGetValue(id, out var provider) ? provider : null;
+    }
+
+    /// <summary>A snapshot of the current entry definitions (for sandbox rule building and the masked CRUD list).</summary>
+    internal IReadOnlyList<PredefinedKeyEntry> Entries => [.. _providers.Values.Select(p => p.Entry)];
+
+    /// <summary>The current entry for <paramref name="id"/>, or null when unknown (for edit-preserves-secret merges).</summary>
+    internal PredefinedKeyEntry? Find(string id) =>
+        _providers.TryGetValue(id, out var provider) ? provider.Entry : null;
+
+    /// <summary>Creates a new entry or updates an existing one in place (same id), then persists.</summary>
+    internal async Task UpsertAsync(PredefinedKeyEntry entry, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        if (_providers.TryGetValue(entry.Id, out var existing))
+        {
+            existing.UpdateEntry(entry);
+        }
+        else
+        {
+            _providers[entry.Id] = NewProvider(entry);
+        }
+
+        await PersistAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Removes an entry (and its persisted minted token), then persists. Returns false when the id is unknown.</summary>
+    internal async Task<bool> RemoveAsync(string id, CancellationToken ct = default)
+    {
+        if (!_providers.TryRemove(id, out var provider))
+        {
+            return false;
+        }
+
+        // Best-effort: drop any minted-token record for this entry so the secret does not linger.
+        await provider.SignOutAsync(ct).ConfigureAwait(false);
+        await PersistAsync(ct).ConfigureAwait(false);
+        return true;
+    }
+
+    /// <summary>Atomically writes the full entry set to disk under the persist gate.</summary>
+    private async Task PersistAsync(CancellationToken ct)
+    {
+        await _persistGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await AtomicJsonFile.WriteAsync(_filePath, Entries, JsonOptions, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _ = _persistGate.Release();
+        }
+    }
+}

--- a/src/LmAgentInfra/Auth/PredefinedKeyRegistry.cs
+++ b/src/LmAgentInfra/Auth/PredefinedKeyRegistry.cs
@@ -108,6 +108,9 @@ public sealed class PredefinedKeyRegistry
     {
         ArgumentNullException.ThrowIfNull(entry);
 
+        // Serialize registry mutations. Only the gate wait observes the request token — once we start
+        // mutating (invalidate token / persist definition / publish) we run to completion uncancellably so
+        // the definition, persisted token, and live provider can never diverge on a mid-operation cancel.
         await _persistGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
@@ -120,24 +123,18 @@ public sealed class PredefinedKeyRegistry
                 .Append(entry)
                 .ToList();
 
-            // Invalidate the stale minted token BEFORE the new definition is made durable. This is a
-            // RELIABLE (not best-effort) step: if removal fails the whole upsert throws before anything is
-            // persisted or published, so we never leave the new definition live with the old access/rotated
-            // token reloadable under the unchanged provider id. CancellationToken.None so a disconnecting
-            // caller can't strand it mid-invalidation.
-            if (existing is not null && credentialChanged)
-            {
-                await _tokenStore.RemoveAsync($"{ProviderIdPrefix}{entry.Id}", CancellationToken.None).ConfigureAwait(false);
-            }
-
-            await AtomicJsonFile.WriteAsync(_filePath, candidate, JsonOptions, ct).ConfigureAwait(false);
+            Task Persist() => AtomicJsonFile.WriteAsync(_filePath, candidate, JsonOptions, CancellationToken.None);
 
             if (existing is not null)
             {
-                await existing.UpdateEntry(entry, credentialChanged, ct).ConfigureAwait(false);
+                // Delegate to the provider so the token invalidation, definition write, and entry swap all
+                // happen atomically under ITS refresh gate — no concurrent mint can interleave, and a
+                // failed token removal aborts before the new definition is written.
+                await existing.ApplyUpdateAsync(entry, credentialChanged, Persist).ConfigureAwait(false);
             }
             else
             {
+                await Persist().ConfigureAwait(false);
                 _providers[entry.Id] = NewProvider(entry);
             }
         }

--- a/src/LmAgentInfra/Controllers/AuthWebhookController.cs
+++ b/src/LmAgentInfra/Controllers/AuthWebhookController.cs
@@ -25,7 +25,8 @@ public sealed class AuthWebhookController(
     IAuthResolutionPolicy authPolicy,
     IAuthWebhookForwarder authWebhookForwarder,
     AuthOptions authOptions,
-    ILogger<AuthWebhookController> logger) : ControllerBase
+    ILogger<AuthWebhookController> logger,
+    PredefinedKeyRegistry? predefinedKeys = null) : ControllerBase
 {
     /// <summary>
     /// Gateway callback: returns an allow decision (with a <c>Bearer</c> Authorization header and the
@@ -62,8 +63,9 @@ public sealed class AuthWebhookController(
 
         // Defense-in-depth: the egress proxy already validates the destination per its rules, but a
         // rules misconfiguration must not turn this endpoint into an open token-minting oracle —
-        // only inject the provider's token toward that provider's own hosts.
-        if (!OAuthProviderHosts.IsAllowed(tokenProvider.ProviderId, body.DestinationHost))
+        // only inject the credential toward that provider's/entry's own hosts. Predefined keys carry
+        // their own (user-entered) host, so they gate on the entry's host, not the managed OAuth list.
+        if (!IsDestinationAllowed(tokenProvider, body.DestinationHost))
         {
             logger.LogWarning(
                 "Auth-webhook deny for provider {ProviderId}: destination host {DestinationHost} is not in the provider's allowlist.",
@@ -78,7 +80,7 @@ public sealed class AuthWebhookController(
         // An await inside a catch block is not protected by the sibling catches of the same try,
         // so running the policy there would let any non-OCE failure escape as a 500, breaking the
         // always-200 allow/deny contract the broad catch below exists to guarantee.
-        bool defer = false;
+        var defer = false;
         try
         {
             var token = await tokenProvider.GetAccessTokenAsync(body.RequiredScopes, ct);
@@ -86,7 +88,7 @@ public sealed class AuthWebhookController(
                 "Auth-webhook allow for provider {ProviderId} (host {DestinationHost}).",
                 tokenProvider.ProviderId,
                 body.DestinationHost);
-            return Ok(AuthWebhookResponse.Allow(tokenProvider.ProviderId, body.DestinationHost, token));
+            return Ok(BuildAllow(tokenProvider, body.DestinationHost, token));
         }
         catch (InvalidOperationException ex)
         {
@@ -146,7 +148,7 @@ public sealed class AuthWebhookController(
                     tokenProvider.ProviderId,
                     body.DestinationHost);
                 await TryNotifyAuthCompletedAsync(capturedTarget, tokenProvider.ProviderId);
-                return Ok(AuthWebhookResponse.Allow(tokenProvider.ProviderId, body.DestinationHost, resolved));
+                return Ok(BuildAllow(tokenProvider, body.DestinationHost, resolved));
             }
 
             logger.LogInformation(
@@ -238,9 +240,32 @@ public sealed class AuthWebhookController(
         }
     }
 
-    /// <summary>Resolves a registered provider by the route id, matching <see cref="IOAuthTokenProvider.ProviderId"/> case-insensitively.</summary>
+    /// <summary>
+    /// Resolves a registered OAuth provider by the route id (case-insensitive), falling back to a
+    /// runtime predefined-key provider (<c>predefined-&lt;id&gt;</c>) from the registry.
+    /// </summary>
     private IOAuthTokenProvider? Resolve(string provider) =>
-        providers.FirstOrDefault(p => string.Equals(p.ProviderId, provider, StringComparison.OrdinalIgnoreCase));
+        providers.FirstOrDefault(p => string.Equals(p.ProviderId, provider, StringComparison.OrdinalIgnoreCase))
+        ?? predefinedKeys?.TryResolve(provider);
+
+    /// <summary>
+    /// The defense-in-depth destination-host gate. Predefined keys gate on their own user-entered
+    /// host(s); managed OAuth providers gate on their compile-time host allowlist.
+    /// </summary>
+    private static bool IsDestinationAllowed(IOAuthTokenProvider provider, string? destinationHost) =>
+        provider is PredefinedKeyProvider pk
+            ? EgressHostMatcher.IsAllowed(pk.Hosts, destinationHost)
+            : OAuthProviderHosts.IsAllowed(provider.ProviderId, destinationHost);
+
+    /// <summary>
+    /// Builds the allow decision: a predefined key injects its custom header list (or a minted
+    /// <c>Bearer</c> token, with the token's real expiry); a managed OAuth provider injects the
+    /// <c>Authorization</c> header as before.
+    /// </summary>
+    private static AuthWebhookResponse BuildAllow(IOAuthTokenProvider provider, string? destinationHost, OAuthAccessToken token) =>
+        provider is PredefinedKeyProvider pk
+            ? AuthWebhookResponse.AllowCustom(pk.BuildHeaders(token), pk.IncludeExpiry ? token.ExpiresAtUtc : null)
+            : AuthWebhookResponse.Allow(provider.ProviderId, destinationHost, token);
 }
 
 /// <summary>
@@ -313,6 +338,21 @@ public sealed record AuthWebhookResponse
         Headers = [["Authorization", BuildAuthorizationHeaderValue(providerId, destinationHost, token)]],
         ExpiresAt = token.ExpiresAtUtc,
     };
+
+    /// <summary>
+    /// Builds an allow decision that injects an explicit list of <c>[name, value]</c> headers (used by
+    /// predefined egress keys: custom headers verbatim, or a single minted <c>Bearer</c> token).
+    /// <paramref name="expiresAt"/> is null for a static value with no lifetime (the gateway then falls
+    /// back to the provider's cache TTL) and the token's real expiry for a minted OAuth token.
+    /// </summary>
+    internal static AuthWebhookResponse AllowCustom(
+        IReadOnlyList<KeyValuePair<string, string>> headers,
+        DateTimeOffset? expiresAt) => new()
+        {
+            Decision = "allow",
+            Headers = [.. headers.Select(h => new[] { h.Key, h.Value })],
+            ExpiresAt = expiresAt,
+        };
 
     /// <summary>
     /// Selects the Authorization scheme for the destination. GitHub's REST API (<c>api.github.com</c>)

--- a/src/LmAgentInfra/Controllers/AuthWebhookController.cs
+++ b/src/LmAgentInfra/Controllers/AuthWebhookController.cs
@@ -195,6 +195,11 @@ public sealed class AuthWebhookController(
                     AuthSigninUrls.BuildReason(providerId),
                     ct);
             }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // The gateway aborted the call — do not swallow it as a forwarder failure.
+                throw;
+            }
             catch (Exception ex)
             {
                 logger.LogWarning(
@@ -216,6 +221,10 @@ public sealed class AuthWebhookController(
             {
                 await authWebhookForwarder.NotifyAuthCompletedAsync(target, body.SessionId, providerId, ct);
             }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 logger.LogWarning(ex, "Auth-webhook forwarder failed on auth-completed for provider {ProviderId}.", providerId);
@@ -232,6 +241,10 @@ public sealed class AuthWebhookController(
             try
             {
                 await authWebhookForwarder.NotifyAuthDeniedAsync(target, body.SessionId, providerId, reason, ct);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {

--- a/src/LmAgentInfra/Controllers/AuthWebhookController.cs
+++ b/src/LmAgentInfra/Controllers/AuthWebhookController.cs
@@ -65,7 +65,7 @@ public sealed class AuthWebhookController(
         // rules misconfiguration must not turn this endpoint into an open token-minting oracle —
         // only inject the credential toward that provider's/entry's own hosts. Predefined keys carry
         // their own (user-entered) host, so they gate on the entry's host, not the managed OAuth list.
-        if (!IsDestinationAllowed(tokenProvider, body.DestinationHost))
+        if (!IsDestinationAllowed(tokenProvider, body.DestinationHost, body.DestinationPort))
         {
             logger.LogWarning(
                 "Auth-webhook deny for provider {ProviderId}: destination host {DestinationHost} is not in the provider's allowlist.",
@@ -262,12 +262,14 @@ public sealed class AuthWebhookController(
         ?? predefinedKeys?.TryResolve(provider);
 
     /// <summary>
-    /// The defense-in-depth destination-host gate. Predefined keys gate on their own user-entered
-    /// host(s); managed OAuth providers gate on their compile-time host allowlist.
+    /// The defense-in-depth destination gate. Predefined keys gate on their own user-entered host(s)
+    /// AND on port 443 — the generated rule is HTTPS/443-only, so a malformed/misbehaving gateway must
+    /// not extract the credential for the same host on another (cleartext) port. Managed OAuth providers
+    /// gate on their compile-time host allowlist.
     /// </summary>
-    private static bool IsDestinationAllowed(IOAuthTokenProvider provider, string? destinationHost) =>
+    private static bool IsDestinationAllowed(IOAuthTokenProvider provider, string? destinationHost, int destinationPort) =>
         provider is PredefinedKeyProvider pk
-            ? EgressHostMatcher.IsAllowed(pk.Hosts, destinationHost)
+            ? destinationPort == 443 && EgressHostMatcher.IsAllowed(pk.Hosts, destinationHost)
             : OAuthProviderHosts.IsAllowed(provider.ProviderId, destinationHost);
 
     /// <summary>

--- a/src/LmAgentInfra/Controllers/EgressKeysController.cs
+++ b/src/LmAgentInfra/Controllers/EgressKeysController.cs
@@ -6,10 +6,16 @@ namespace AchieveAi.LmDotnetTools.LmAgentInfra.Controllers;
 /// <summary>
 /// CRUD for predefined egress keys (issue #210). Entries are created at runtime here and persisted by
 /// the <see cref="PredefinedKeyRegistry"/>; they drive the sandbox <c>auth_providers</c>/<c>network</c>
-/// blocks on the NEXT session create. SECURITY: this endpoint is same-origin/local-UI only and is not
-/// in any sandbox allow-rule (default-deny covers the app's own host); GET never returns secret values
-/// and nothing here logs them.
+/// blocks on the NEXT session create.
 /// </summary>
+/// <remarks>
+/// SECURITY / THREAT MODEL: like the rest of this local-dev sample (the OAuth sign-in controllers, the
+/// workspaces / providers / conversations endpoints — all unauthenticated) this management API assumes a
+/// trusted local user on a localhost-bound host; it is not a hardened, network-exposed service. It is
+/// deliberately NOT reachable from the sandbox: default-deny egress opens no allow-rule for the app's own
+/// host, so a sandboxed agent cannot call it. GET masks all secret values and nothing here logs them.
+/// An enforced management-auth boundary for the sample as a whole is out of scope for #210.
+/// </remarks>
 [ApiController]
 [Route("api/auth/egress-keys")]
 public sealed class EgressKeysController(PredefinedKeyRegistry registry, ILogger<EgressKeysController> logger)
@@ -76,18 +82,23 @@ public sealed class EgressKeysController(PredefinedKeyRegistry registry, ILogger
     private static (PredefinedKeyEntry? entry, string? error) BuildCustomHeadersEntry(
         string id, string host, EgressKeyRequest request, PredefinedKeyEntry? existing)
     {
-        // Preserve existing headers when the edit omits them (e.g. changing only the host).
-        var source = request.Headers is { Count: > 0 }
-            ? [.. request.Headers.Select(h => new PredefinedHeader(h.Name, h.Value))]
-            : existing?.Headers.ToList();
-
-        if (source is null || source.Count == 0)
+        // Edit that omits the header list entirely (e.g. changing only the host) preserves the stored headers.
+        if (request.Headers is not { Count: > 0 })
         {
-            return (null, "At least one header is required.");
+            if (existing is null || existing.Headers.Count == 0)
+            {
+                return (null, "At least one header is required.");
+            }
+
+            return (existing with { Id = id, Host = host }, null);
         }
 
+        // GET masks header values, so the edit form round-trips each header NAME with a blank value.
+        // Per-header preserve: a blank value on an EXISTING header name keeps the stored secret; a
+        // blank value on a NEW header name is an error.
+        var resolved = new List<PredefinedHeader>(request.Headers.Count);
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var header in source)
+        foreach (var header in request.Headers)
         {
             var nameError = EgressHostMatcher.ValidateHeaderName(header.Name);
             if (nameError is not null)
@@ -95,19 +106,29 @@ public sealed class EgressKeysController(PredefinedKeyRegistry registry, ILogger
                 return (null, nameError);
             }
 
-            var valueError = EgressHostMatcher.ValidateHeaderValue(header.Value);
+            if (!seen.Add(header.Name))
+            {
+                return (null, $"Duplicate header '{header.Name}'.");
+            }
+
+            var value = header.Value;
+            if (string.IsNullOrEmpty(value))
+            {
+                var stored = existing?.Headers.FirstOrDefault(
+                    h => string.Equals(h.Name, header.Name, StringComparison.OrdinalIgnoreCase));
+                value = stored?.Value ?? string.Empty;
+            }
+
+            var valueError = EgressHostMatcher.ValidateHeaderValue(value);
             if (valueError is not null)
             {
                 return (null, valueError);
             }
 
-            if (!seen.Add(header.Name))
-            {
-                return (null, $"Duplicate header '{header.Name}'.");
-            }
+            resolved.Add(new PredefinedHeader(header.Name, value));
         }
 
-        return (new PredefinedKeyEntry { Id = id, Host = host, Kind = PredefinedKeyKind.CustomHeaders, Headers = source }, null);
+        return (new PredefinedKeyEntry { Id = id, Host = host, Kind = PredefinedKeyKind.CustomHeaders, Headers = resolved }, null);
     }
 
     private static (PredefinedKeyEntry? entry, string? error) BuildOAuthEntry(

--- a/src/LmAgentInfra/Controllers/EgressKeysController.cs
+++ b/src/LmAgentInfra/Controllers/EgressKeysController.cs
@@ -1,0 +1,232 @@
+using AchieveAi.LmDotnetTools.LmAgentInfra.Auth;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AchieveAi.LmDotnetTools.LmAgentInfra.Controllers;
+
+/// <summary>
+/// CRUD for predefined egress keys (issue #210). Entries are created at runtime here and persisted by
+/// the <see cref="PredefinedKeyRegistry"/>; they drive the sandbox <c>auth_providers</c>/<c>network</c>
+/// blocks on the NEXT session create. SECURITY: this endpoint is same-origin/local-UI only and is not
+/// in any sandbox allow-rule (default-deny covers the app's own host); GET never returns secret values
+/// and nothing here logs them.
+/// </summary>
+[ApiController]
+[Route("api/auth/egress-keys")]
+public sealed class EgressKeysController(PredefinedKeyRegistry registry, ILogger<EgressKeysController> logger)
+    : ControllerBase
+{
+    /// <summary>Lists the configured entries with all secret material masked/omitted.</summary>
+    [HttpGet]
+    public IActionResult List() => Ok(registry.Entries.Select(ToView).ToList());
+
+    /// <summary>Creates a new entry (blank id) or updates an existing one (secrets left blank are preserved).</summary>
+    [HttpPost]
+    public async Task<IActionResult> Upsert([FromBody] EgressKeyRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Host: SSRF-safe pattern + no collision with a managed OAuth provider's egress scope.
+        var hostError = EgressHostMatcher.ValidateHostPattern(request.Host);
+        if (hostError is not null)
+        {
+            return BadRequest(new { error = hostError });
+        }
+
+        if (OAuthProviderHosts.CollidesWithManagedHost(request.Host))
+        {
+            return BadRequest(new { error = "Host collides with a managed OAuth provider (GitHub / Azure DevOps / M365)." });
+        }
+
+        if (!TryParseKind(request.Kind, out var kind))
+        {
+            return BadRequest(new { error = $"Unknown kind '{request.Kind}'. Expected custom-headers, refresh-token, or client-credentials." });
+        }
+
+        var existing = string.IsNullOrEmpty(request.Id) ? null : registry.Find(request.Id);
+        if (!string.IsNullOrEmpty(request.Id) && existing is null)
+        {
+            return NotFound(new { error = $"No egress key with id '{request.Id}'." });
+        }
+
+        var id = existing?.Id ?? Guid.NewGuid().ToString("N");
+
+        var (entry, error) = kind == PredefinedKeyKind.CustomHeaders
+            ? BuildCustomHeadersEntry(id, request.Host, request, existing)
+            : BuildOAuthEntry(id, request.Host, kind, request, existing);
+
+        if (error is not null)
+        {
+            return BadRequest(new { error });
+        }
+
+        await registry.UpsertAsync(entry!, ct).ConfigureAwait(false);
+        logger.LogInformation("Egress key {ProviderId} {Action} (host {Host}, kind {Kind}).",
+            $"{PredefinedKeyRegistry.ProviderIdPrefix}{id}", existing is null ? "created" : "updated", request.Host, request.Kind);
+        return Ok(ToView(entry!));
+    }
+
+    /// <summary>Deletes an entry and its persisted secret. 404 when the id is unknown.</summary>
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(string id, CancellationToken ct = default)
+    {
+        var removed = await registry.RemoveAsync(id, ct).ConfigureAwait(false);
+        return removed ? NoContent() : NotFound();
+    }
+
+    private static (PredefinedKeyEntry? entry, string? error) BuildCustomHeadersEntry(
+        string id, string host, EgressKeyRequest request, PredefinedKeyEntry? existing)
+    {
+        // Preserve existing headers when the edit omits them (e.g. changing only the host).
+        var source = request.Headers is { Count: > 0 }
+            ? [.. request.Headers.Select(h => new PredefinedHeader(h.Name, h.Value))]
+            : existing?.Headers.ToList();
+
+        if (source is null || source.Count == 0)
+        {
+            return (null, "At least one header is required.");
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var header in source)
+        {
+            var nameError = EgressHostMatcher.ValidateHeaderName(header.Name);
+            if (nameError is not null)
+            {
+                return (null, nameError);
+            }
+
+            var valueError = EgressHostMatcher.ValidateHeaderValue(header.Value);
+            if (valueError is not null)
+            {
+                return (null, valueError);
+            }
+
+            if (!seen.Add(header.Name))
+            {
+                return (null, $"Duplicate header '{header.Name}'.");
+            }
+        }
+
+        return (new PredefinedKeyEntry { Id = id, Host = host, Kind = PredefinedKeyKind.CustomHeaders, Headers = source }, null);
+    }
+
+    private static (PredefinedKeyEntry? entry, string? error) BuildOAuthEntry(
+        string id, string host, PredefinedKeyKind kind, EgressKeyRequest request, PredefinedKeyEntry? existing)
+    {
+        var headerName = Coalesce(request.HeaderName, existing?.HeaderName) ?? "Authorization";
+        var headerError = EgressHostMatcher.ValidateHeaderName(headerName);
+        if (headerError is not null)
+        {
+            return (null, headerError);
+        }
+
+        var tokenEndpoint = Coalesce(request.TokenEndpoint, existing?.TokenEndpoint);
+        if (!Uri.TryCreate(tokenEndpoint, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps)
+        {
+            return (null, "Token endpoint must be an absolute https URL.");
+        }
+
+        var clientId = Coalesce(request.ClientId, existing?.ClientId);
+        if (string.IsNullOrWhiteSpace(clientId))
+        {
+            return (null, "Client id is required.");
+        }
+
+        // Secrets: a blank value on an update preserves the stored one.
+        var clientSecret = Coalesce(request.ClientSecret, existing?.ClientSecret);
+        var refreshToken = Coalesce(request.RefreshToken, existing?.RefreshToken);
+
+        if (kind == PredefinedKeyKind.ClientCredentials && string.IsNullOrWhiteSpace(clientSecret))
+        {
+            return (null, "Client secret is required for client-credentials.");
+        }
+
+        if (kind == PredefinedKeyKind.RefreshToken && string.IsNullOrWhiteSpace(refreshToken))
+        {
+            return (null, "Refresh token is required for the refresh-token kind.");
+        }
+
+        var scopes = request.Scopes ?? existing?.Scopes ?? [];
+
+        return (new PredefinedKeyEntry
+        {
+            Id = id,
+            Host = host,
+            Kind = kind,
+            HeaderName = headerName,
+            TokenEndpoint = tokenEndpoint,
+            ClientId = clientId,
+            ClientSecret = clientSecret,
+            RefreshToken = refreshToken,
+            Scopes = scopes,
+        }, null);
+    }
+
+    /// <summary>Maps an internal entry to the masked, secret-free view returned to the UI.</summary>
+    private static EgressKeyView ToView(PredefinedKeyEntry entry) => new(
+        Id: entry.Id,
+        Host: entry.Host,
+        Kind: KindToWire(entry.Kind),
+        HeaderName: entry.HeaderName,
+        HeaderNames: [.. entry.Headers.Select(h => h.Name)],
+        HasClientSecret: !string.IsNullOrEmpty(entry.ClientSecret),
+        HasRefreshToken: !string.IsNullOrEmpty(entry.RefreshToken),
+        Scopes: entry.Scopes);
+
+    private static string? Coalesce(string? preferred, string? fallback) =>
+        string.IsNullOrWhiteSpace(preferred) ? fallback : preferred;
+
+    private static bool TryParseKind(string? wire, out PredefinedKeyKind kind)
+    {
+        switch (wire)
+        {
+            case "custom-headers":
+                kind = PredefinedKeyKind.CustomHeaders;
+                return true;
+            case "refresh-token":
+                kind = PredefinedKeyKind.RefreshToken;
+                return true;
+            case "client-credentials":
+                kind = PredefinedKeyKind.ClientCredentials;
+                return true;
+            default:
+                kind = default;
+                return false;
+        }
+    }
+
+    private static string KindToWire(PredefinedKeyKind kind) => kind switch
+    {
+        PredefinedKeyKind.CustomHeaders => "custom-headers",
+        PredefinedKeyKind.RefreshToken => "refresh-token",
+        PredefinedKeyKind.ClientCredentials => "client-credentials",
+        _ => "custom-headers",
+    };
+}
+
+/// <summary>Create/update request for a predefined egress key. Secret fields left blank on an update preserve the stored value.</summary>
+public sealed record EgressKeyRequest(
+    string? Id,
+    string Host,
+    string Kind,
+    IReadOnlyList<EgressHeaderInput>? Headers,
+    string? HeaderName,
+    string? TokenEndpoint,
+    string? ClientId,
+    string? ClientSecret,
+    string? RefreshToken,
+    IReadOnlyList<string>? Scopes);
+
+/// <summary>One custom header name/value pair from the CRUD request. SECRET: <see cref="Value"/> is credential material.</summary>
+public sealed record EgressHeaderInput(string Name, string Value);
+
+/// <summary>The masked, secret-free view of an egress key returned to the UI.</summary>
+public sealed record EgressKeyView(
+    string Id,
+    string Host,
+    string Kind,
+    string HeaderName,
+    IReadOnlyList<string> HeaderNames,
+    bool HasClientSecret,
+    bool HasRefreshToken,
+    IReadOnlyList<string> Scopes);

--- a/src/LmAgentInfra/Controllers/EgressKeysController.cs
+++ b/src/LmAgentInfra/Controllers/EgressKeysController.cs
@@ -9,12 +9,12 @@ namespace AchieveAi.LmDotnetTools.LmAgentInfra.Controllers;
 /// blocks on the NEXT session create.
 /// </summary>
 /// <remarks>
-/// SECURITY / THREAT MODEL: like the rest of this local-dev sample (the OAuth sign-in controllers, the
-/// workspaces / providers / conversations endpoints — all unauthenticated) this management API assumes a
-/// trusted local user on a localhost-bound host; it is not a hardened, network-exposed service. It is
-/// deliberately NOT reachable from the sandbox: default-deny egress opens no allow-rule for the app's own
-/// host, so a sandboxed agent cannot call it. GET masks all secret values and nothing here logs them.
-/// An enforced management-auth boundary for the sample as a whole is out of scope for #210.
+/// SECURITY / THREAT MODEL: this credential-management API is for a trusted local user of this local-dev
+/// sample (like the OAuth sign-in / workspaces / providers endpoints, which are also unauthenticated). It
+/// is ENFORCED loopback-only in code (<see cref="RejectNonLoopback"/>) so a non-local caller is rejected
+/// even if the app is bound beyond localhost, and it is additionally unreachable from the sandbox
+/// (default-deny egress opens no allow-rule for the app's own host). GET masks all secret values and
+/// nothing here logs them. A full management-auth boundary for the sample as a whole is out of scope for #210.
 /// </remarks>
 [ApiController]
 [Route("api/auth/egress-keys")]
@@ -23,12 +23,25 @@ public sealed class EgressKeysController(PredefinedKeyRegistry registry, ILogger
 {
     /// <summary>Lists the configured entries with all secret material masked/omitted.</summary>
     [HttpGet]
-    public IActionResult List() => Ok(registry.Entries.Select(ToView).ToList());
+    public IActionResult List()
+    {
+        if (RejectNonLoopback() is { } forbidden)
+        {
+            return forbidden;
+        }
+
+        return Ok(registry.Entries.Select(ToView).ToList());
+    }
 
     /// <summary>Creates a new entry (blank id) or updates an existing one (secrets left blank are preserved).</summary>
     [HttpPost]
     public async Task<IActionResult> Upsert([FromBody] EgressKeyRequest request, CancellationToken ct = default)
     {
+        if (RejectNonLoopback() is { } forbidden)
+        {
+            return forbidden;
+        }
+
         ArgumentNullException.ThrowIfNull(request);
 
         // Host: SSRF-safe pattern + no collision with a managed OAuth provider's egress scope.
@@ -75,8 +88,32 @@ public sealed class EgressKeysController(PredefinedKeyRegistry registry, ILogger
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete(string id, CancellationToken ct = default)
     {
+        if (RejectNonLoopback() is { } forbidden)
+        {
+            return forbidden;
+        }
+
         var removed = await registry.RemoveAsync(id, ct).ConfigureAwait(false);
         return removed ? NoContent() : NotFound();
+    }
+
+    /// <summary>
+    /// Enforces the local-only boundary: rejects a caller whose remote address is a real, non-loopback IP
+    /// (returns 403). A null remote address — the in-process TestServer and same-host pipelines — is treated
+    /// as local. Returns null when the caller is allowed.
+    /// </summary>
+    private IActionResult? RejectNonLoopback()
+    {
+        // A null HttpContext/remote (in-process TestServer, direct unit construction) is treated as local;
+        // only a real, non-loopback remote IP is rejected.
+        var remote = HttpContext?.Connection?.RemoteIpAddress;
+        if (remote is not null && !System.Net.IPAddress.IsLoopback(remote))
+        {
+            logger.LogWarning("Rejected non-loopback egress-key management request from {Remote}.", remote);
+            return StatusCode(403, new { error = "Egress-key management is restricted to local (loopback) callers." });
+        }
+
+        return null;
     }
 
     private static (PredefinedKeyEntry? entry, string? error) BuildCustomHeadersEntry(

--- a/src/LmAgentInfra/Controllers/EgressKeysController.cs
+++ b/src/LmAgentInfra/Controllers/EgressKeysController.cs
@@ -98,19 +98,28 @@ public sealed class EgressKeysController(PredefinedKeyRegistry registry, ILogger
     }
 
     /// <summary>
-    /// Enforces the local-only boundary: rejects a caller whose remote address is a real, non-loopback IP
-    /// (returns 403). A null remote address — the in-process TestServer and same-host pipelines — is treated
-    /// as local. Returns null when the caller is allowed.
+    /// Enforces the local-only boundary. Rejects (403) a caller whose remote address is a real, non-loopback
+    /// IP, OR any request that arrived through a proxy (carries a forwarding header) — behind a reverse proxy
+    /// a remote caller can appear to the app as the proxy's loopback address, so the IP check alone is not
+    /// sufficient. A null HttpContext/remote (in-process TestServer, direct unit construction) is treated as
+    /// local. Returns null when the caller is allowed.
     /// </summary>
     private IActionResult? RejectNonLoopback()
     {
-        // A null HttpContext/remote (in-process TestServer, direct unit construction) is treated as local;
-        // only a real, non-loopback remote IP is rejected.
+        var headers = HttpContext?.Request?.Headers;
+        var proxied = headers is not null
+            && (headers.ContainsKey("X-Forwarded-For")
+                || headers.ContainsKey("X-Forwarded-Host")
+                || headers.ContainsKey("Forwarded"));
+
         var remote = HttpContext?.Connection?.RemoteIpAddress;
-        if (remote is not null && !System.Net.IPAddress.IsLoopback(remote))
+        var nonLoopback = remote is not null && !System.Net.IPAddress.IsLoopback(remote);
+
+        if (proxied || nonLoopback)
         {
-            logger.LogWarning("Rejected non-loopback egress-key management request from {Remote}.", remote);
-            return StatusCode(403, new { error = "Egress-key management is restricted to local (loopback) callers." });
+            logger.LogWarning(
+                "Rejected egress-key management request from {Remote} (proxied={Proxied}).", remote, proxied);
+            return StatusCode(403, new { error = "Egress-key management is restricted to direct local (loopback) callers." });
         }
 
         return null;

--- a/src/LmAgentInfra/Sandbox/SandboxSessionRegistry.cs
+++ b/src/LmAgentInfra/Sandbox/SandboxSessionRegistry.cs
@@ -1,8 +1,8 @@
 using System.Collections.Concurrent;
 using System.Text.Json.Serialization;
+using AchieveAi.LmDotnetTools.LmAgentInfra.Auth;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
-using AchieveAi.LmDotnetTools.LmAgentInfra.Auth;
 using AchieveAi.LmDotnetTools.Sandbox;
 
 namespace AchieveAi.LmDotnetTools.LmAgentInfra.Sandbox;
@@ -194,6 +194,7 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
     private readonly HttpClient _httpClient;
     private readonly AuthOptions _authOptions;
     private readonly AuthSharedSecret _sharedSecret;
+    private readonly PredefinedKeyRegistry? _predefinedKeys;
     private readonly SandboxCredential _defaultCredential;
     private bool _disposed;
 
@@ -217,13 +218,17 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
     /// <c>auth_providers</c>/<c>network</c> blocks sent on sandbox creation.</param>
     /// <param name="sharedSecret">Gateway↔webhook shared secret attached to each auth provider.
     /// SECRET — never logged.</param>
+    /// <param name="predefinedKeys">Optional predefined-egress-key registry; when supplied, each
+    /// configured entry contributes a webhook auth-provider + host-scoped allow rule. Null (the
+    /// headless daemon and every test that does not exercise egress keys) emits none — fail-closed.</param>
     public SandboxSessionRegistry(
         SandboxGatewayLifetime gateway,
         SandboxGatewayOptions options,
         ILogger<SandboxSessionRegistry> logger,
         HttpClient httpClient,
         AuthOptions authOptions,
-        AuthSharedSecret sharedSecret
+        AuthSharedSecret sharedSecret,
+        PredefinedKeyRegistry? predefinedKeys = null
     )
     {
         _gateway = gateway ?? throw new ArgumentNullException(nameof(gateway));
@@ -232,6 +237,7 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _authOptions = authOptions ?? throw new ArgumentNullException(nameof(authOptions));
         _sharedSecret = sharedSecret ?? throw new ArgumentNullException(nameof(sharedSecret));
+        _predefinedKeys = predefinedKeys;
         // Non-null default even when no key is configured: contextless paths (liveness/destroy on
         // a session with no side-table entry) always resolve to a credential, never null. An empty
         // AppKey is exactly the keyless AUTH_ENFORCE=off dev path.
@@ -1625,6 +1631,42 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
                     priority: 100
                 )
             );
+        }
+
+        // Predefined egress keys (issue #210): one webhook provider + host-scoped allow rule per
+        // configured entry. Custom-header entries carry no token expiry, so the gateway falls back to
+        // the provider cache TTL — keep it short so an edited/rotated key takes effect promptly; the
+        // token-minting kinds carry the minted token's real expiry regardless.
+        if (_predefinedKeys is not null)
+        {
+            foreach (var entry in _predefinedKeys.Entries)
+            {
+                var id = $"{PredefinedKeyRegistry.ProviderIdPrefix}{entry.Id}";
+                var cacheTtlSeconds = entry.Kind == PredefinedKeyKind.CustomHeaders ? 30 : 300;
+                providers.Add(
+                    new SandboxAuthProvider(
+                        id: id,
+                        type: "webhook",
+                        endpoint: $"{baseUrl}/api/auth/webhook/{id}",
+                        gatewayAuth: _sharedSecret.Value,
+                        cacheTtlSeconds: cacheTtlSeconds,
+                        requiredScopes: []
+                    )
+                );
+                rules.Add(
+                    new SandboxNetworkRule(
+                        id: id,
+                        action: "allow",
+                        hosts: [entry.Host],
+                        ports: [443],
+                        methods: [],
+                        paths: [],
+                        authProvider: id,
+                        requiredScopes: [],
+                        priority: 100
+                    )
+                );
+            }
         }
 
         return providers.Count > 0 ? (providers, rules) : (null, null);

--- a/src/LmAgentInfra/Sandbox/SandboxSessionRegistry.cs
+++ b/src/LmAgentInfra/Sandbox/SandboxSessionRegistry.cs
@@ -1542,6 +1542,14 @@ public sealed class SandboxSessionRegistry : IAsyncDisposable
     internal IReadOnlyList<string> GetAuthProviderIdsForTest() =>
         BuildAuthProviders().Providers?.Select(p => p.Id).ToArray() ?? [];
 
+    /// <summary>
+    /// Test seam: the full <c>auth_providers</c> + <c>network</c> pair the registry would attach, so a
+    /// test can assert the security-sensitive rule shape (host, ports, auth-provider linkage) and the
+    /// webhook endpoint / cache TTL — not just the provider id.
+    /// </summary>
+    internal (IReadOnlyList<SandboxAuthProvider>? Providers, IReadOnlyList<SandboxNetworkRule>? Network) BuildAuthProvidersForTest() =>
+        BuildAuthProviders();
+
     private (IReadOnlyList<SandboxAuthProvider>? Providers, IReadOnlyList<SandboxNetworkRule>? Network) BuildAuthProviders()
     {
         var providers = new List<SandboxAuthProvider>();

--- a/tests/LmStreaming.Sample.E2E.Tests/Scenarios/AuthWebhookControllerTests.cs
+++ b/tests/LmStreaming.Sample.E2E.Tests/Scenarios/AuthWebhookControllerTests.cs
@@ -235,6 +235,13 @@ public sealed class AuthWebhookControllerTests : LoggingTestBase
             {
                 deny.RootElement.GetProperty("decision").GetString().Should().Be("deny");
             }
+
+            // Same host but a non-443 port is denied — a predefined key is HTTPS/443-only, so a
+            // misbehaving gateway cannot extract it over a cleartext port.
+            using (var portDeny = await PostWebhookAsync(client, sharedSecret, providerId, "api.internal.test", port: 8443))
+            {
+                portDeny.RootElement.GetProperty("decision").GetString().Should().Be("deny");
+            }
         }
         finally
         {
@@ -252,7 +259,7 @@ public sealed class AuthWebhookControllerTests : LoggingTestBase
     }
 
     private static async Task<JsonDocument> PostWebhookAsync(
-        HttpClient client, string sharedSecret, string providerId, string destinationHost)
+        HttpClient client, string sharedSecret, string providerId, string destinationHost, int port = 443)
     {
         var body = JsonSerializer.Serialize(new
         {
@@ -261,7 +268,7 @@ public sealed class AuthWebhookControllerTests : LoggingTestBase
             provider_id = providerId,
             rule_id = providerId,
             destination_host = destinationHost,
-            destination_port = 443,
+            destination_port = port,
             method = "GET",
             path = "/",
             required_scopes = Array.Empty<string>(),

--- a/tests/LmStreaming.Sample.E2E.Tests/Scenarios/AuthWebhookControllerTests.cs
+++ b/tests/LmStreaming.Sample.E2E.Tests/Scenarios/AuthWebhookControllerTests.cs
@@ -182,6 +182,101 @@ public sealed class AuthWebhookControllerTests : LoggingTestBase
     }
 
     [Fact]
+    public async Task Predefined_custom_header_key_injected_on_its_host_and_denied_elsewhere()
+    {
+        // End-to-end for issue #210: a custom-header egress key created via the CRUD API is injected
+        // VERBATIM (no Bearer, no expiry) by the predefined webhook route on the entry's own host, and
+        // a request to any OTHER host is denied by the per-entry host gate (anti-oracle guard).
+        LogTestStart();
+        var tokenDir = Path.Combine(Path.GetTempPath(), "lm-egress-key-e2e", Guid.NewGuid().ToString("N"));
+        _ = Directory.CreateDirectory(tokenDir);
+        try
+        {
+            var responder = ScriptedSseResponder.New()
+                .ForRole("noop", _ => true)
+                    .Turn(t => t.Text("ok"))
+                .Build();
+            using var factory = new E2EWebAppFactory(
+                "test",
+                new ScriptedBuilder(responder.AsAnthropicHandler()),
+                new Dictionary<string, string?> { ["Auth:TokenStoreDir"] = tokenDir });
+            using var client = factory.CreateClient();
+            var sharedSecret = factory.Services.GetRequiredService<AuthSharedSecret>().Value;
+
+            var createBody = JsonSerializer.Serialize(new
+            {
+                host = "api.internal.test",
+                kind = "custom-headers",
+                headers = new[] { new { name = "X-Api-Key", value = "secret-123" } },
+            });
+            using var createResponse = await client.PostAsync(
+                "/api/auth/egress-keys",
+                new StringContent(createBody, Encoding.UTF8, "application/json"));
+            createResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            string id;
+            using (var created = JsonDocument.Parse(await createResponse.Content.ReadAsStringAsync()))
+            {
+                id = created.RootElement.GetProperty("id").GetString()!;
+            }
+
+            var providerId = $"predefined-{id}";
+            Logger.LogInformation("Created custom-header egress key {ProviderId} for host api.internal.test", providerId);
+
+            using (var allow = await PostWebhookAsync(client, sharedSecret, providerId, "api.internal.test"))
+            {
+                allow.RootElement.GetProperty("decision").GetString().Should().Be("allow");
+                var pair = allow.RootElement.GetProperty("headers")[0];
+                pair[0].GetString().Should().Be("X-Api-Key");
+                pair[1].GetString().Should().Be("secret-123");
+                allow.RootElement.TryGetProperty("expires_at", out _).Should().BeFalse();
+            }
+
+            using (var deny = await PostWebhookAsync(client, sharedSecret, providerId, "evil.test"))
+            {
+                deny.RootElement.GetProperty("decision").GetString().Should().Be("deny");
+            }
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tokenDir, recursive: true);
+            }
+            catch (IOException)
+            {
+                // Best-effort temp cleanup.
+            }
+        }
+
+        LogTestEnd();
+    }
+
+    private static async Task<JsonDocument> PostWebhookAsync(
+        HttpClient client, string sharedSecret, string providerId, string destinationHost)
+    {
+        var body = JsonSerializer.Serialize(new
+        {
+            session_id = "s-test",
+            app_id = "lmstreaming-sample",
+            provider_id = providerId,
+            rule_id = providerId,
+            destination_host = destinationHost,
+            destination_port = 443,
+            method = "GET",
+            path = "/",
+            required_scopes = Array.Empty<string>(),
+        });
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"/api/auth/webhook/{providerId}")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+        request.Headers.TryAddWithoutValidation("Authorization", sharedSecret);
+        using var response = await client.SendAsync(request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
     public async Task GitHub_git_host_returns_200_allow_with_injected_basic_x_access_token()
     {
         LogTestStart();

--- a/tests/LmStreaming.Sample.Tests/Auth/EgressHostMatcherTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Auth/EgressHostMatcherTests.cs
@@ -1,0 +1,113 @@
+namespace LmStreaming.Sample.Tests.Auth;
+
+/// <summary>
+/// Unit tests for <see cref="EgressHostMatcher"/> — the shared host-pattern match + SSRF host-pattern
+/// validation + header name/value validation used by both the OAuth and predefined-key egress paths,
+/// plus <see cref="OAuthProviderHosts.CollidesWithManagedHost"/>. Pure, ungated (always run in CI).
+/// </summary>
+public sealed class EgressHostMatcherTests
+{
+    [Theory]
+    [InlineData("api.example.com", "api.example.com", true)]      // exact
+    [InlineData("api.example.com", "API.EXAMPLE.COM", true)]      // case-insensitive
+    [InlineData("*.example.com", "sub.example.com", true)]        // wildcard suffix
+    [InlineData("*.example.com", "a.b.example.com", true)]        // multi-label wildcard suffix
+    [InlineData("*.example.com", "example.com", false)]           // wildcard does not match apex
+    [InlineData("*.example.com", "evil-example.com", false)]      // wildcard requires the dot separator
+    [InlineData("api.example.com", "other.example.com", false)]   // exact non-match
+    public void IsAllowed_matches_exact_and_wildcard(string pattern, string host, bool expected) =>
+        EgressHostMatcher.IsAllowed([pattern], host).Should().Be(expected);
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsAllowed_fails_closed_on_empty_destination(string? host) =>
+        EgressHostMatcher.IsAllowed(["api.example.com"], host).Should().BeFalse();
+
+    [Fact]
+    public void IsAllowed_fails_closed_on_empty_host_list() =>
+        EgressHostMatcher.IsAllowed([], "api.example.com").Should().BeFalse();
+
+    [Theory]
+    [InlineData("api.example.com")]
+    [InlineData("*.example.com")]
+    [InlineData("example.com")]
+    [InlineData("a-b.example.co.uk")]
+    public void ValidateHostPattern_accepts_valid_hosts(string pattern) =>
+        EgressHostMatcher.ValidateHostPattern(pattern).Should().BeNull();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("*")]                        // bare wildcard
+    [InlineData("*.com")]                     // wildcard covering a bare TLD
+    [InlineData("*.")]                        // empty wildcard suffix
+    [InlineData("https://example.com")]       // scheme
+    [InlineData("example.com/path")]          // path
+    [InlineData("example.com:443")]           // port
+    [InlineData("example.com.")]              // trailing dot
+    [InlineData(" example.com")]              // leading whitespace
+    [InlineData("exa mple.com")]              // inner space
+    [InlineData("-bad.example.com")]          // label starts with hyphen
+    [InlineData("localhost")]
+    [InlineData("127.0.0.1")]
+    [InlineData("127.9.9.9")]
+    [InlineData("0.0.0.0")]
+    [InlineData("::1")]
+    [InlineData("[::1]")]
+    [InlineData("169.254.169.254")]           // cloud metadata
+    [InlineData("metadata.google.internal")]
+    public void ValidateHostPattern_rejects_invalid_or_dangerous_hosts(string? pattern) =>
+        EgressHostMatcher.ValidateHostPattern(pattern).Should().NotBeNull();
+
+    [Theory]
+    [InlineData("Authorization")]
+    [InlineData("Cookie")]
+    [InlineData("X-API-Key")]
+    [InlineData("x-custom_header")]
+    public void ValidateHeaderName_accepts_valid_names(string name) =>
+        EgressHostMatcher.ValidateHeaderName(name).Should().BeNull();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Has Space")]
+    [InlineData("Bad:Colon")]
+    [InlineData("Bad\nName")]
+    [InlineData("Host")]
+    [InlineData("Content-Length")]
+    [InlineData("Connection")]
+    [InlineData("Transfer-Encoding")]
+    [InlineData("Content-Type")]
+    public void ValidateHeaderName_rejects_invalid_or_forbidden_names(string? name) =>
+        EgressHostMatcher.ValidateHeaderName(name).Should().NotBeNull();
+
+    [Theory]
+    [InlineData("Bearer abc.def")]
+    [InlineData("sessionid=deadbeef; other=1")]
+    public void ValidateHeaderValue_accepts_valid_values(string value) =>
+        EgressHostMatcher.ValidateHeaderValue(value).Should().BeNull();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("has\r\ninjection")]
+    [InlineData("has\nnewline")]
+    public void ValidateHeaderValue_rejects_empty_or_control(string? value) =>
+        EgressHostMatcher.ValidateHeaderValue(value).Should().NotBeNull();
+
+    [Theory]
+    [InlineData("github.com", true)]
+    [InlineData("api.github.com", true)]
+    [InlineData("*.github.com", true)]           // wildcard entry covering a managed host
+    [InlineData("dev.azure.com", true)]
+    [InlineData("sub.dev.azure.com", true)]      // managed *.dev.azure.com covers it
+    [InlineData("myorg.visualstudio.com", true)] // managed *.visualstudio.com covers it
+    [InlineData("graph.microsoft.com", true)]
+    [InlineData("api.example.com", false)]
+    [InlineData("*.example.com", false)]
+    public void CollidesWithManagedHost_flags_managed_overlaps(string pattern, bool expected) =>
+        OAuthProviderHosts.CollidesWithManagedHost(pattern).Should().Be(expected);
+}

--- a/tests/LmStreaming.Sample.Tests/Auth/EgressKeysControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Auth/EgressKeysControllerTests.cs
@@ -1,0 +1,149 @@
+using AchieveAi.LmDotnetTools.LmAgentInfra.Controllers;
+
+namespace LmStreaming.Sample.Tests.Auth;
+
+/// <summary>
+/// Unit tests for <see cref="EgressKeysController"/> — CRUD, host/header validation, managed-host
+/// collision rejection, secret masking on the view, and edit-preserves-secret. Driven directly
+/// against the controller with a temp-dir-backed registry (no HTTP pipeline, no network).
+/// </summary>
+public sealed class EgressKeysControllerTests
+{
+    private sealed class NoopStore : IOAuthTokenStore
+    {
+        public Task<OAuthTokenRecord?> GetAsync(string provider, CancellationToken ct = default) =>
+            Task.FromResult<OAuthTokenRecord?>(null);
+
+        public Task SaveAsync(OAuthTokenRecord record, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task RemoveAsync(string provider, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private static (EgressKeysController controller, PredefinedKeyRegistry registry, DirectoryInfo dir) NewController()
+    {
+        var dir = Directory.CreateTempSubdirectory("egr-ctl");
+        var registry = new PredefinedKeyRegistry(dir.FullName, new NoopStore(), new HttpClient(), NullLoggerFactory.Instance);
+        return (new EgressKeysController(registry, NullLogger<EgressKeysController>.Instance), registry, dir);
+    }
+
+    private static EgressKeyRequest CustomReq(string host, params (string name, string value)[] headers) => new(
+        Id: null, Host: host, Kind: "custom-headers",
+        Headers: [.. headers.Select(h => new EgressHeaderInput(h.name, h.value))],
+        HeaderName: null, TokenEndpoint: null, ClientId: null, ClientSecret: null, RefreshToken: null, Scopes: null);
+
+    [Fact]
+    public async Task Post_creates_custom_headers_entry_and_masks_secrets()
+    {
+        var (controller, _, dir) = NewController();
+        try
+        {
+            var result = await controller.Upsert(CustomReq("api.example.com", ("Cookie", "sid=abc")));
+
+            var view = result.Should().BeOfType<OkObjectResult>().Which.Value.Should().BeOfType<EgressKeyView>().Subject;
+            view.Kind.Should().Be("custom-headers");
+            view.Host.Should().Be("api.example.com");
+            view.HeaderNames.Should().Equal("Cookie");
+            // EgressKeyView exposes no header/secret VALUE fields at all — masking is by shape.
+            typeof(EgressKeyView).GetProperties().Select(p => p.Name)
+                .Should().NotContain(["Headers", "Value", "ClientSecret", "RefreshToken"]);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("*")]
+    [InlineData("github.com")] // collides with a managed OAuth host
+    public async Task Post_rejects_invalid_or_colliding_hosts(string host)
+    {
+        var (controller, _, dir) = NewController();
+        try
+        {
+            (await controller.Upsert(CustomReq(host, ("X-Key", "v")))).Should().BeOfType<BadRequestObjectResult>();
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Post_rejects_forbidden_header_name()
+    {
+        var (controller, _, dir) = NewController();
+        try
+        {
+            (await controller.Upsert(CustomReq("api.example.com", ("Host", "evil")))).Should().BeOfType<BadRequestObjectResult>();
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Post_client_credentials_requires_secret()
+    {
+        var (controller, _, dir) = NewController();
+        try
+        {
+            var req = new EgressKeyRequest(
+                Id: null, Host: "api.example.com", Kind: "client-credentials", Headers: null, HeaderName: null,
+                TokenEndpoint: "https://token.example/oauth", ClientId: "cid", ClientSecret: null, RefreshToken: null, Scopes: null);
+
+            (await controller.Upsert(req)).Should().BeOfType<BadRequestObjectResult>();
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Update_with_blank_secret_preserves_stored_secret()
+    {
+        var (controller, registry, dir) = NewController();
+        try
+        {
+            var create = new EgressKeyRequest(
+                Id: null, Host: "api.example.com", Kind: "client-credentials", Headers: null, HeaderName: null,
+                TokenEndpoint: "https://token.example/oauth", ClientId: "cid", ClientSecret: "the-secret", RefreshToken: null, Scopes: null);
+            var created = (await controller.Upsert(create)).Should().BeOfType<OkObjectResult>().Which.Value
+                .Should().BeOfType<EgressKeyView>().Subject;
+
+            // Edit only the host; leave the secret blank → it must be preserved.
+            var edit = create with { Id = created.Id, Host = "api2.example.com", ClientSecret = null };
+            var updated = (await controller.Upsert(edit)).Should().BeOfType<OkObjectResult>().Which.Value
+                .Should().BeOfType<EgressKeyView>().Subject;
+
+            updated.Host.Should().Be("api2.example.com");
+            updated.HasClientSecret.Should().BeTrue();
+            registry.Find(created.Id)!.ClientSecret.Should().Be("the-secret");
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Delete_removes_entry_and_404s_when_unknown()
+    {
+        var (controller, _, dir) = NewController();
+        try
+        {
+            var created = (await controller.Upsert(CustomReq("api.example.com", ("X-Key", "v")))).Should()
+                .BeOfType<OkObjectResult>().Which.Value.Should().BeOfType<EgressKeyView>().Subject;
+
+            (await controller.Delete(created.Id)).Should().BeOfType<NoContentResult>();
+            (await controller.Delete("missing")).Should().BeOfType<NotFoundResult>();
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Auth/EgressKeysControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Auth/EgressKeysControllerTests.cs
@@ -193,6 +193,29 @@ public sealed class EgressKeysControllerTests
     }
 
     [Fact]
+    public void Proxied_request_with_forwarding_header_is_rejected_403()
+    {
+        var (controller, _, dir) = NewController();
+        try
+        {
+            // The caller appears local (a reverse proxy on loopback) but the forwarding header reveals it was
+            // proxied — the IP check alone would pass, so the forwarding-header check must reject it.
+            var ctx = new DefaultHttpContext();
+            ctx.Connection.RemoteIpAddress = System.Net.IPAddress.Loopback;
+            ctx.Request.Headers["X-Forwarded-For"] = "203.0.113.9";
+            controller.ControllerContext = new Microsoft.AspNetCore.Mvc.ControllerContext { HttpContext = ctx };
+
+            var result = controller.List();
+
+            result.Should().BeOfType<ObjectResult>().Which.StatusCode.Should().Be(403);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Delete_removes_entry_and_404s_when_unknown()
     {
         var (controller, _, dir) = NewController();

--- a/tests/LmStreaming.Sample.Tests/Auth/EgressKeysControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Auth/EgressKeysControllerTests.cs
@@ -130,6 +130,48 @@ public sealed class EgressKeysControllerTests
     }
 
     [Fact]
+    public async Task Update_custom_headers_with_blank_value_preserves_stored_value()
+    {
+        var (controller, registry, dir) = NewController();
+        try
+        {
+            var created = (await controller.Upsert(CustomReq("api.example.com", ("X-Api-Key", "secret-abc"))))
+                .Should().BeOfType<OkObjectResult>().Which.Value.Should().BeOfType<EgressKeyView>().Subject;
+
+            // GET masks header values, so an edit re-sends the header NAME with a blank value. Changing
+            // only the host must preserve the stored value, not wipe/reject it.
+            var edit = new EgressKeyRequest(
+                Id: created.Id, Host: "api2.example.com", Kind: "custom-headers",
+                Headers: [new EgressHeaderInput("X-Api-Key", "")],
+                HeaderName: null, TokenEndpoint: null, ClientId: null, ClientSecret: null, RefreshToken: null, Scopes: null);
+            var updated = (await controller.Upsert(edit)).Should().BeOfType<OkObjectResult>().Which.Value
+                .Should().BeOfType<EgressKeyView>().Subject;
+
+            updated.Host.Should().Be("api2.example.com");
+            registry.Find(created.Id)!.Headers.Single().Value.Should().Be("secret-abc");
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Post_rejects_blank_value_for_a_new_header()
+    {
+        var (controller, _, dir) = NewController();
+        try
+        {
+            // No existing entry to preserve from → a blank value on a fresh header is an error.
+            (await controller.Upsert(CustomReq("api.example.com", ("X-New", "")))).Should().BeOfType<BadRequestObjectResult>();
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Delete_removes_entry_and_404s_when_unknown()
     {
         var (controller, _, dir) = NewController();

--- a/tests/LmStreaming.Sample.Tests/Auth/EgressKeysControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Auth/EgressKeysControllerTests.cs
@@ -1,4 +1,5 @@
 using AchieveAi.LmDotnetTools.LmAgentInfra.Controllers;
+using Microsoft.AspNetCore.Http;
 
 namespace LmStreaming.Sample.Tests.Auth;
 
@@ -164,6 +165,26 @@ public sealed class EgressKeysControllerTests
         {
             // No existing entry to preserve from → a blank value on a fresh header is an error.
             (await controller.Upsert(CustomReq("api.example.com", ("X-New", "")))).Should().BeOfType<BadRequestObjectResult>();
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Non_loopback_caller_is_rejected_403()
+    {
+        var (controller, _, dir) = NewController();
+        try
+        {
+            var ctx = new DefaultHttpContext();
+            ctx.Connection.RemoteIpAddress = System.Net.IPAddress.Parse("203.0.113.7"); // a real, non-loopback IP
+            controller.ControllerContext = new Microsoft.AspNetCore.Mvc.ControllerContext { HttpContext = ctx };
+
+            var result = await controller.Upsert(CustomReq("api.example.com", ("X-Key", "v")));
+
+            result.Should().BeOfType<ObjectResult>().Which.StatusCode.Should().Be(403);
         }
         finally
         {

--- a/tests/LmStreaming.Sample.Tests/Auth/OAuthTokenEndpointClientTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Auth/OAuthTokenEndpointClientTests.cs
@@ -104,6 +104,19 @@ public sealed class OAuthTokenEndpointClientTests
     }
 
     [Fact]
+    public async Task PostAsync_handles_unexpected_json_field_types()
+    {
+        // Valid JSON but access_token is an object → GetString throws InvalidOperationException, which
+        // must be normalized rather than escaping the documented result contract.
+        var (client, _) = NewClient("{\"access_token\":{}}");
+
+        var result = await client.PostAsync("https://token.example/oauth/token", RefreshForm());
+
+        result.AccessToken.Should().BeNull();
+        result.Error.Should().Be("unparseable_response");
+    }
+
+    [Fact]
     public async Task PostAsync_surfaces_oauth_error_on_4xx()
     {
         var (client, _) = NewClient(new HttpResponseMessage(System.Net.HttpStatusCode.BadRequest)

--- a/tests/LmStreaming.Sample.Tests/Auth/OAuthTokenEndpointClientTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Auth/OAuthTokenEndpointClientTests.cs
@@ -1,0 +1,90 @@
+namespace LmStreaming.Sample.Tests.Auth;
+
+/// <summary>
+/// Unit tests for <see cref="OAuthTokenEndpointClient"/> — the endpoint-agnostic token-endpoint
+/// POST/parse helper used by the predefined-key refresh_token / client_credentials grants. Driven
+/// against an in-memory <see cref="HttpMessageHandler"/> (no network). SECURITY: assertions never
+/// print the form or token values.
+/// </summary>
+public sealed class OAuthTokenEndpointClientTests
+{
+    private sealed class CannedHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        public string? LastBody { get; private set; }
+        public Uri? LastUri { get; private set; }
+        public bool SawJsonAccept { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastUri = request.RequestUri;
+            LastBody = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+            SawJsonAccept = request.Headers.Accept.Any(a => a.MediaType == "application/json");
+            return response;
+        }
+    }
+
+    private static (OAuthTokenEndpointClient client, CannedHandler handler) NewClient(string body) =>
+        NewClient(new HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new StringContent(body) });
+
+    private static (OAuthTokenEndpointClient client, CannedHandler handler) NewClient(HttpResponseMessage response)
+    {
+        var handler = new CannedHandler(response);
+        return (new OAuthTokenEndpointClient(new HttpClient(handler)), handler);
+    }
+
+    private static Dictionary<string, string> RefreshForm() => new()
+    {
+        ["grant_type"] = "refresh_token",
+        ["client_id"] = "cid",
+        ["refresh_token"] = "rt-secret",
+    };
+
+    [Fact]
+    public async Task PostAsync_parses_success_token_and_posts_json_form()
+    {
+        var (client, handler) = NewClient("{\"access_token\":\"AT\",\"refresh_token\":\"RT2\",\"expires_in\":3600}");
+
+        var result = await client.PostAsync("https://token.example/oauth/token", RefreshForm());
+
+        result.AccessToken.Should().Be("AT");
+        result.RefreshToken.Should().Be("RT2");
+        result.ExpiresIn.Should().Be(3600);
+        result.Error.Should().BeNull();
+        handler.LastUri.Should().Be(new Uri("https://token.example/oauth/token"));
+        handler.SawJsonAccept.Should().BeTrue();
+        handler.LastBody.Should().Contain("grant_type=refresh_token");
+    }
+
+    [Fact]
+    public async Task PostAsync_surfaces_oauth_error()
+    {
+        var (client, _) = NewClient("{\"error\":\"invalid_grant\"}");
+
+        var result = await client.PostAsync("https://token.example/oauth/token", RefreshForm());
+
+        result.AccessToken.Should().BeNull();
+        result.Error.Should().Be("invalid_grant");
+    }
+
+    [Fact]
+    public async Task PostAsync_handles_empty_body()
+    {
+        var (client, _) = NewClient(string.Empty);
+
+        var result = await client.PostAsync("https://token.example/oauth/token", RefreshForm());
+
+        result.AccessToken.Should().BeNull();
+        result.Error.Should().Be("empty_response");
+    }
+
+    [Fact]
+    public async Task PostAsync_handles_unparseable_body()
+    {
+        var (client, _) = NewClient("<html>gateway error</html>");
+
+        var result = await client.PostAsync("https://token.example/oauth/token", RefreshForm());
+
+        result.AccessToken.Should().BeNull();
+        result.Error.Should().Be("unparseable_response");
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Auth/OAuthTokenEndpointClientTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Auth/OAuthTokenEndpointClientTests.cs
@@ -87,4 +87,33 @@ public sealed class OAuthTokenEndpointClientTests
         result.AccessToken.Should().BeNull();
         result.Error.Should().Be("unparseable_response");
     }
+
+    [Fact]
+    public async Task PostAsync_rejects_token_from_non_success_status()
+    {
+        // A 503 (transient) with a token-shaped body must NOT be accepted as a credential.
+        var (client, _) = NewClient(new HttpResponseMessage(System.Net.HttpStatusCode.ServiceUnavailable)
+        {
+            Content = new StringContent("{\"access_token\":\"should-be-ignored\"}"),
+        });
+
+        var result = await client.PostAsync("https://token.example/oauth/token", RefreshForm());
+
+        result.AccessToken.Should().BeNull();
+        result.Error.Should().Be("http_503");
+    }
+
+    [Fact]
+    public async Task PostAsync_surfaces_oauth_error_on_4xx()
+    {
+        var (client, _) = NewClient(new HttpResponseMessage(System.Net.HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent("{\"error\":\"invalid_grant\"}"),
+        });
+
+        var result = await client.PostAsync("https://token.example/oauth/token", RefreshForm());
+
+        result.AccessToken.Should().BeNull();
+        result.Error.Should().Be("invalid_grant");
+    }
 }

--- a/tests/LmStreaming.Sample.Tests/Auth/PredefinedKeyProviderTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Auth/PredefinedKeyProviderTests.cs
@@ -159,6 +159,27 @@ public sealed class PredefinedKeyProviderTests
     }
 
     [Fact]
+    public async Task ApplyUpdate_when_persist_fails_invalidates_token_but_leaves_the_old_entry()
+    {
+        // Deliberate, consistent degradation on the (narrow) persist-failure window of a credential-change
+        // edit: the stale token is invalidated first (step 1), then the definition write fails, so the
+        // in-memory entry is NOT swapped (step 3 never runs). State stays consistent with the pre-edit
+        // definition — the next acquisition re-mints from the OLD entry credential (safe), and the caller
+        // sees the failure — rather than the unsafe alternative of a stale token under a new definition.
+        var (provider, store, _) = NewProvider(RefreshEntry(), () => "{\"access_token\":\"AT\",\"expires_in\":3600}");
+        _ = await provider.GetAccessTokenAsync();
+        (await store.GetAsync("predefined-r1")).Should().NotBeNull();
+
+        var newEntry = RefreshEntry() with { RefreshToken = "new-rt" };
+        await FluentActions
+            .Awaiting(() => provider.ApplyUpdateAsync(newEntry, credentialChanged: true, () => throw new IOException("persist failed")))
+            .Should().ThrowAsync<IOException>();
+
+        provider.Entry.RefreshToken.Should().Be("rt0");           // entry NOT swapped
+        (await store.GetAsync("predefined-r1")).Should().BeNull(); // token invalidated (step 1)
+    }
+
+    [Fact]
     public async Task Update_preserving_credential_keeps_the_cached_token()
     {
         var (provider, _, handler) = NewProvider(RefreshEntry(), () => "{\"access_token\":\"AT\",\"expires_in\":3600}");

--- a/tests/LmStreaming.Sample.Tests/Auth/PredefinedKeyProviderTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Auth/PredefinedKeyProviderTests.cs
@@ -1,0 +1,160 @@
+namespace LmStreaming.Sample.Tests.Auth;
+
+/// <summary>
+/// Unit tests for <see cref="PredefinedKeyProvider"/> — the per-entry egress credential provider.
+/// Covers the three kinds (custom-headers verbatim, refresh-token / client-credentials mint + cache +
+/// persist), credential-rejection invalidation + recovery via <c>UpdateEntry</c>. Token-endpoint calls
+/// hit an in-memory handler (no network). SECRET: no token/secret values are logged by the assertions.
+/// </summary>
+public sealed class PredefinedKeyProviderTests
+{
+    private sealed class MemoryTokenStore : IOAuthTokenStore
+    {
+        private readonly Dictionary<string, OAuthTokenRecord> _map = new(StringComparer.Ordinal);
+
+        public Task<OAuthTokenRecord?> GetAsync(string provider, CancellationToken ct = default) =>
+            Task.FromResult(_map.TryGetValue(provider, out var r) ? r : null);
+
+        public Task SaveAsync(OAuthTokenRecord record, CancellationToken ct = default)
+        {
+            _map[record.Provider] = record;
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAsync(string provider, CancellationToken ct = default)
+        {
+            _ = _map.Remove(provider);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ScriptHandler(Func<string> respond) : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+        public List<string> Bodies { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls++;
+            Bodies.Add(request.Content is null ? string.Empty : await request.Content.ReadAsStringAsync(cancellationToken));
+            return new HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new StringContent(respond()) };
+        }
+    }
+
+    private static (PredefinedKeyProvider provider, MemoryTokenStore store, ScriptHandler handler) NewProvider(
+        PredefinedKeyEntry entry, Func<string> respond)
+    {
+        var store = new MemoryTokenStore();
+        var handler = new ScriptHandler(respond);
+        var endpoint = new OAuthTokenEndpointClient(new HttpClient(handler));
+        return (new PredefinedKeyProvider(entry, store, endpoint, NullLogger.Instance), store, handler);
+    }
+
+    private static PredefinedKeyEntry CustomEntry(params (string name, string value)[] headers) => new()
+    {
+        Id = "c1",
+        Host = "api.example.com",
+        Kind = PredefinedKeyKind.CustomHeaders,
+        Headers = [.. headers.Select(h => new PredefinedHeader(h.name, h.value))],
+    };
+
+    private static PredefinedKeyEntry RefreshEntry() => new()
+    {
+        Id = "r1",
+        Host = "api.example.com",
+        Kind = PredefinedKeyKind.RefreshToken,
+        HeaderName = "Authorization",
+        TokenEndpoint = "https://token.example/oauth/token",
+        ClientId = "cid",
+        ClientSecret = "csec",
+        RefreshToken = "rt0",
+        Scopes = ["read"],
+    };
+
+    private static PredefinedKeyEntry ClientCredentialsEntry() => new()
+    {
+        Id = "cc1",
+        Host = "api.example.com",
+        Kind = PredefinedKeyKind.ClientCredentials,
+        HeaderName = "Authorization",
+        TokenEndpoint = "https://token.example/oauth/token",
+        ClientId = "cid",
+        ClientSecret = "csec",
+        Scopes = ["read"],
+    };
+
+    [Fact]
+    public async Task Custom_headers_returns_list_verbatim_without_hitting_endpoint()
+    {
+        var (provider, _, handler) = NewProvider(CustomEntry(("Cookie", "sid=abc"), ("X-API-Key", "k")), () => "{}");
+
+        var token = await provider.GetAccessTokenAsync();
+        var headers = provider.BuildHeaders(token);
+
+        headers.Select(h => (h.Key, h.Value)).Should().Equal(("Cookie", "sid=abc"), ("X-API-Key", "k"));
+        provider.IncludeExpiry.Should().BeFalse();
+        handler.Calls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Custom_headers_with_no_headers_throws()
+    {
+        var entry = new PredefinedKeyEntry { Id = "c", Host = "api.example.com", Kind = PredefinedKeyKind.CustomHeaders, Headers = [] };
+        var (provider, _, _) = NewProvider(entry, () => "{}");
+
+        await FluentActions.Awaiting(() => provider.GetAccessTokenAsync()).Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task Refresh_token_mints_bearer_persists_and_caches()
+    {
+        var (provider, store, handler) = NewProvider(RefreshEntry(), () => "{\"access_token\":\"AT\",\"expires_in\":3600}");
+
+        var token = await provider.GetAccessTokenAsync();
+
+        token.Value.Should().Be("AT");
+        provider.IncludeExpiry.Should().BeTrue();
+        provider.BuildHeaders(token).Select(h => (h.Key, h.Value)).Should().Equal(("Authorization", "Bearer AT"));
+        handler.Bodies[0].Should().Contain("grant_type=refresh_token").And.Contain("refresh_token=rt0");
+        (await store.GetAsync("predefined-r1"))!.AccessToken.Should().Be("AT");
+
+        // A second call is served from cache (token still fresh) — no second POST.
+        _ = await provider.GetAccessTokenAsync();
+        handler.Calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Client_credentials_mints_with_client_credentials_grant()
+    {
+        var (provider, _, handler) = NewProvider(ClientCredentialsEntry(), () => "{\"access_token\":\"CC\",\"expires_in\":60}");
+
+        var token = await provider.GetAccessTokenAsync();
+
+        token.Value.Should().Be("CC");
+        handler.Bodies[0].Should().Contain("grant_type=client_credentials").And.Contain("client_secret=csec");
+    }
+
+    [Fact]
+    public async Task Credential_rejection_marks_invalid_until_updated()
+    {
+        var fail = true;
+        var (provider, _, handler) = NewProvider(
+            RefreshEntry(),
+            () => fail ? "{\"error\":\"invalid_grant\"}" : "{\"access_token\":\"AT2\",\"expires_in\":60}");
+
+        // First mint is rejected → throws + marks invalid.
+        await FluentActions.Awaiting(() => provider.GetAccessTokenAsync()).Should().ThrowAsync<InvalidOperationException>();
+        handler.Calls.Should().Be(1);
+
+        // While invalid it short-circuits — no further endpoint calls.
+        await FluentActions.Awaiting(() => provider.GetAccessTokenAsync()).Should().ThrowAsync<InvalidOperationException>();
+        handler.Calls.Should().Be(1);
+
+        // Updating the entry (user re-enters the credential) clears the invalid flag → mint retried.
+        fail = false;
+        provider.UpdateEntry(RefreshEntry());
+        var token = await provider.GetAccessTokenAsync();
+        token.Value.Should().Be("AT2");
+        handler.Calls.Should().Be(2);
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Auth/PredefinedKeyProviderTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Auth/PredefinedKeyProviderTests.cs
@@ -152,9 +152,24 @@ public sealed class PredefinedKeyProviderTests
 
         // Updating the entry (user re-enters the credential) clears the invalid flag → mint retried.
         fail = false;
-        await provider.UpdateEntry(RefreshEntry());
+        await provider.UpdateEntry(RefreshEntry(), credentialChanged: true);
         var token = await provider.GetAccessTokenAsync();
         token.Value.Should().Be("AT2");
         handler.Calls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Update_preserving_credential_keeps_the_cached_token()
+    {
+        var (provider, _, handler) = NewProvider(RefreshEntry(), () => "{\"access_token\":\"AT\",\"expires_in\":3600}");
+        _ = await provider.GetAccessTokenAsync();
+
+        // A host-only edit (credentialChanged: false) keeps the still-valid cached token → no re-mint.
+        // (The credential-change re-mint path — where the registry removes the persisted token — is
+        // covered by PredefinedKeyRegistryTests.Update_changing_credential_invalidates_the_persisted_token.)
+        await provider.UpdateEntry(RefreshEntry() with { Host = "api2.example.com" }, credentialChanged: false);
+
+        _ = await provider.GetAccessTokenAsync();
+        handler.Calls.Should().Be(1);
     }
 }

--- a/tests/LmStreaming.Sample.Tests/Auth/PredefinedKeyProviderTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Auth/PredefinedKeyProviderTests.cs
@@ -152,7 +152,7 @@ public sealed class PredefinedKeyProviderTests
 
         // Updating the entry (user re-enters the credential) clears the invalid flag → mint retried.
         fail = false;
-        await provider.UpdateEntry(RefreshEntry(), credentialChanged: true);
+        await provider.ApplyUpdateAsync(RefreshEntry(), credentialChanged: true, () => Task.CompletedTask);
         var token = await provider.GetAccessTokenAsync();
         token.Value.Should().Be("AT2");
         handler.Calls.Should().Be(2);
@@ -167,7 +167,7 @@ public sealed class PredefinedKeyProviderTests
         // A host-only edit (credentialChanged: false) keeps the still-valid cached token → no re-mint.
         // (The credential-change re-mint path — where the registry removes the persisted token — is
         // covered by PredefinedKeyRegistryTests.Update_changing_credential_invalidates_the_persisted_token.)
-        await provider.UpdateEntry(RefreshEntry() with { Host = "api2.example.com" }, credentialChanged: false);
+        await provider.ApplyUpdateAsync(RefreshEntry() with { Host = "api2.example.com" }, credentialChanged: false, () => Task.CompletedTask);
 
         _ = await provider.GetAccessTokenAsync();
         handler.Calls.Should().Be(1);

--- a/tests/LmStreaming.Sample.Tests/Auth/PredefinedKeyProviderTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Auth/PredefinedKeyProviderTests.cs
@@ -152,7 +152,7 @@ public sealed class PredefinedKeyProviderTests
 
         // Updating the entry (user re-enters the credential) clears the invalid flag → mint retried.
         fail = false;
-        provider.UpdateEntry(RefreshEntry());
+        await provider.UpdateEntry(RefreshEntry());
         var token = await provider.GetAccessTokenAsync();
         token.Value.Should().Be("AT2");
         handler.Calls.Should().Be(2);

--- a/tests/LmStreaming.Sample.Tests/Auth/PredefinedKeyRegistryTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Auth/PredefinedKeyRegistryTests.cs
@@ -1,0 +1,110 @@
+namespace LmStreaming.Sample.Tests.Auth;
+
+/// <summary>
+/// Unit tests for <see cref="PredefinedKeyRegistry"/> — runtime CRUD, disk persistence (reload), and
+/// provider resolution. Uses a temp directory and a no-op token store (no network).
+/// </summary>
+public sealed class PredefinedKeyRegistryTests
+{
+    private sealed class NoopStore : IOAuthTokenStore
+    {
+        public Task<OAuthTokenRecord?> GetAsync(string provider, CancellationToken ct = default) =>
+            Task.FromResult<OAuthTokenRecord?>(null);
+
+        public Task SaveAsync(OAuthTokenRecord record, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task RemoveAsync(string provider, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private static PredefinedKeyRegistry NewRegistry(string dir) =>
+        new(dir, new NoopStore(), new HttpClient(), NullLoggerFactory.Instance);
+
+    private static PredefinedKeyEntry Custom(string id, string host = "api.example.com") => new()
+    {
+        Id = id,
+        Host = host,
+        Kind = PredefinedKeyKind.CustomHeaders,
+        Headers = [new PredefinedHeader("X-Key", "v")],
+    };
+
+    [Fact]
+    public async Task Upsert_creates_resolves_and_persists_across_reload()
+    {
+        var dir = Directory.CreateTempSubdirectory("egr-reg");
+        try
+        {
+            var registry = NewRegistry(dir.FullName);
+            await registry.UpsertAsync(Custom("e1"));
+
+            registry.TryResolve("predefined-e1").Should().NotBeNull();
+            registry.Entries.Should().ContainSingle(e => e.Id == "e1");
+
+            // A fresh registry over the same dir reloads the persisted entry.
+            NewRegistry(dir.FullName).Entries.Should().ContainSingle(e => e.Id == "e1");
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Update_keeps_the_same_provider_instance()
+    {
+        var dir = Directory.CreateTempSubdirectory("egr-reg");
+        try
+        {
+            var registry = NewRegistry(dir.FullName);
+            await registry.UpsertAsync(Custom("e1", "a.example.com"));
+            var first = registry.TryResolve("predefined-e1");
+
+            await registry.UpsertAsync(Custom("e1", "b.example.com"));
+            var second = registry.TryResolve("predefined-e1");
+
+            second.Should().BeSameAs(first); // updated in place, not replaced
+            registry.Entries.Single().Host.Should().Be("b.example.com");
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Remove_deletes_and_persists()
+    {
+        var dir = Directory.CreateTempSubdirectory("egr-reg");
+        try
+        {
+            var registry = NewRegistry(dir.FullName);
+            await registry.UpsertAsync(Custom("e1"));
+
+            (await registry.RemoveAsync("e1")).Should().BeTrue();
+            registry.TryResolve("predefined-e1").Should().BeNull();
+            NewRegistry(dir.FullName).Entries.Should().BeEmpty();
+
+            (await registry.RemoveAsync("missing")).Should().BeFalse();
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryResolve_ignores_non_predefined_ids()
+    {
+        var dir = Directory.CreateTempSubdirectory("egr-reg");
+        try
+        {
+            var registry = NewRegistry(dir.FullName);
+            registry.TryResolve("github").Should().BeNull();
+            registry.TryResolve(null).Should().BeNull();
+            registry.TryResolve("predefined-unknown").Should().BeNull();
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Auth/PredefinedKeyRegistryTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Auth/PredefinedKeyRegistryTests.cs
@@ -212,19 +212,21 @@ public sealed class PredefinedKeyRegistryTests
     }
 
     [Fact]
-    public async Task Token_cleanup_failure_does_not_fail_upsert_or_remove()
+    public async Task Credential_change_aborts_when_token_invalidation_fails_but_delete_stays_best_effort()
     {
         var dir = Directory.CreateTempSubdirectory("egr-reg");
         try
         {
             var store = new InMemoryStore { ThrowOnRemove = true };
             var registry = NewRegistry(dir.FullName, store);
-            await registry.UpsertAsync(Refresh("e1"));
+            await registry.UpsertAsync(Refresh("e1")); // create: no existing entry → no token invalidation
 
-            // A credential-change upsert and a delete both trigger best-effort token cleanup that throws
-            // internally — neither must surface the failure to the caller.
+            // A credential-change upsert must FAIL (reliably) if the stale token can't be invalidated,
+            // rather than commit the new definition while the old token stays reloadable.
             await FluentActions.Awaiting(() => registry.UpsertAsync(Refresh("e1", refreshToken: "x")))
-                .Should().NotThrowAsync();
+                .Should().ThrowAsync<IOException>();
+
+            // Delete cleanup stays best-effort — a token-store failure does not fail the delete.
             (await registry.RemoveAsync("e1")).Should().BeTrue();
         }
         finally

--- a/tests/LmStreaming.Sample.Tests/Auth/PredefinedKeyRegistryTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Auth/PredefinedKeyRegistryTests.cs
@@ -16,8 +16,35 @@ public sealed class PredefinedKeyRegistryTests
         public Task RemoveAsync(string provider, CancellationToken ct = default) => Task.CompletedTask;
     }
 
-    private static PredefinedKeyRegistry NewRegistry(string dir) =>
-        new(dir, new NoopStore(), new HttpClient(), NullLoggerFactory.Instance);
+    private sealed class InMemoryStore : IOAuthTokenStore
+    {
+        private readonly Dictionary<string, OAuthTokenRecord> _map = new(StringComparer.Ordinal);
+
+        public bool ThrowOnRemove { get; init; }
+
+        public Task<OAuthTokenRecord?> GetAsync(string provider, CancellationToken ct = default) =>
+            Task.FromResult(_map.TryGetValue(provider, out var r) ? r : null);
+
+        public Task SaveAsync(OAuthTokenRecord record, CancellationToken ct = default)
+        {
+            _map[record.Provider] = record;
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAsync(string provider, CancellationToken ct = default)
+        {
+            if (ThrowOnRemove)
+            {
+                throw new IOException("simulated token-store cleanup failure");
+            }
+
+            _ = _map.Remove(provider);
+            return Task.CompletedTask;
+        }
+    }
+
+    private static PredefinedKeyRegistry NewRegistry(string dir, IOAuthTokenStore? store = null) =>
+        new(dir, store ?? new NoopStore(), new HttpClient(), NullLoggerFactory.Instance);
 
     private static PredefinedKeyEntry Custom(string id, string host = "api.example.com") => new()
     {
@@ -26,6 +53,19 @@ public sealed class PredefinedKeyRegistryTests
         Kind = PredefinedKeyKind.CustomHeaders,
         Headers = [new PredefinedHeader("X-Key", "v")],
     };
+
+    private static PredefinedKeyEntry Refresh(string id, string host = "api.example.com", string refreshToken = "rt0") => new()
+    {
+        Id = id,
+        Host = host,
+        Kind = PredefinedKeyKind.RefreshToken,
+        TokenEndpoint = "https://token.example/oauth/token",
+        ClientId = "cid",
+        RefreshToken = refreshToken,
+    };
+
+    private static OAuthTokenRecord Minted(string providerId) =>
+        new(providerId, null, "rotated-rt", "at", DateTimeOffset.UtcNow.AddHours(1), []);
 
     [Fact]
     public async Task Upsert_creates_resolves_and_persists_across_reload()
@@ -101,6 +141,91 @@ public sealed class PredefinedKeyRegistryTests
             registry.TryResolve("github").Should().BeNull();
             registry.TryResolve(null).Should().BeNull();
             registry.TryResolve("predefined-unknown").Should().BeNull();
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Update_changing_credential_invalidates_the_persisted_token()
+    {
+        var dir = Directory.CreateTempSubdirectory("egr-reg");
+        try
+        {
+            var store = new InMemoryStore();
+            var registry = NewRegistry(dir.FullName, store);
+            await registry.UpsertAsync(Refresh("e1"));
+            await store.SaveAsync(Minted("predefined-e1"));
+
+            await registry.UpsertAsync(Refresh("e1", refreshToken: "new-rt")); // credential change
+
+            (await store.GetAsync("predefined-e1")).Should().BeNull();
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Update_preserving_credential_retains_the_persisted_rotated_token()
+    {
+        var dir = Directory.CreateTempSubdirectory("egr-reg");
+        try
+        {
+            var store = new InMemoryStore();
+            var registry = NewRegistry(dir.FullName, store);
+            await registry.UpsertAsync(Refresh("e1"));
+            await store.SaveAsync(Minted("predefined-e1"));
+
+            await registry.UpsertAsync(Refresh("e1", host: "api2.example.com")); // host-only edit
+
+            (await store.GetAsync("predefined-e1")).Should().NotBeNull();
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Remove_cleans_up_the_persisted_token()
+    {
+        var dir = Directory.CreateTempSubdirectory("egr-reg");
+        try
+        {
+            var store = new InMemoryStore();
+            var registry = NewRegistry(dir.FullName, store);
+            await registry.UpsertAsync(Refresh("e1"));
+            await store.SaveAsync(Minted("predefined-e1"));
+
+            (await registry.RemoveAsync("e1")).Should().BeTrue();
+
+            (await store.GetAsync("predefined-e1")).Should().BeNull();
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Token_cleanup_failure_does_not_fail_upsert_or_remove()
+    {
+        var dir = Directory.CreateTempSubdirectory("egr-reg");
+        try
+        {
+            var store = new InMemoryStore { ThrowOnRemove = true };
+            var registry = NewRegistry(dir.FullName, store);
+            await registry.UpsertAsync(Refresh("e1"));
+
+            // A credential-change upsert and a delete both trigger best-effort token cleanup that throws
+            // internally — neither must surface the failure to the caller.
+            await FluentActions.Awaiting(() => registry.UpsertAsync(Refresh("e1", refreshToken: "x")))
+                .Should().NotThrowAsync();
+            (await registry.RemoveAsync("e1")).Should().BeTrue();
         }
         finally
         {

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryBuildAuthProvidersTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryBuildAuthProvidersTests.cs
@@ -109,8 +109,22 @@ public class SandboxSessionRegistryBuildAuthProvidersTests
 
             await using var registry = CreateRegistry(new AuthOptions(), keys);
 
-            // No OAuth providers configured, so the ONLY emitted provider is the predefined entry's.
-            registry.GetAuthProviderIdsForTest().Should().ContainSingle().Which.Should().Be("predefined-e1");
+            var (providers, network) = registry.BuildAuthProvidersForTest();
+
+            // Exactly one webhook auth-provider, pointing at this entry's predefined route.
+            var provider = providers.Should().ContainSingle().Subject;
+            provider.Id.Should().Be("predefined-e1");
+            provider.Type.Should().Be("webhook");
+            provider.Endpoint.Should().EndWith("/api/auth/webhook/predefined-e1");
+            provider.CacheTtlSeconds.Should().Be(30); // custom-headers: short TTL for prompt rotation
+
+            // Exactly one allow rule, host-scoped to the entry's host on 443, linked to the provider.
+            var rule = network.Should().ContainSingle().Subject;
+            rule.Id.Should().Be("predefined-e1");
+            rule.Action.Should().Be("allow");
+            rule.Hosts.Should().Equal("api.internal.example.com");
+            rule.Ports.Should().Equal(443);
+            rule.AuthProvider.Should().Be("predefined-e1");
         }
         finally
         {

--- a/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryBuildAuthProvidersTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/SandboxSessionRegistryBuildAuthProvidersTests.cs
@@ -92,7 +92,52 @@ public class SandboxSessionRegistryBuildAuthProvidersTests
         registry.GetAuthProviderIdsForTest().Should().BeEmpty();
     }
 
-    private static SandboxSessionRegistry CreateRegistry(AuthOptions auth)
+    [Fact]
+    public async Task Predefined_key_entry_emits_its_own_webhook_provider()
+    {
+        var dir = Directory.CreateTempSubdirectory("egr-bap");
+        try
+        {
+            var keys = new PredefinedKeyRegistry(dir.FullName, new NoopTokenStore(), new HttpClient(), NullLoggerFactory.Instance);
+            await keys.UpsertAsync(new PredefinedKeyEntry
+            {
+                Id = "e1",
+                Host = "api.internal.example.com",
+                Kind = PredefinedKeyKind.CustomHeaders,
+                Headers = [new PredefinedHeader("X-Key", "v")],
+            });
+
+            await using var registry = CreateRegistry(new AuthOptions(), keys);
+
+            // No OAuth providers configured, so the ONLY emitted provider is the predefined entry's.
+            registry.GetAuthProviderIdsForTest().Should().ContainSingle().Which.Should().Be("predefined-e1");
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task No_predefined_registry_emits_no_predefined_providers()
+    {
+        // Fail-closed: the headless daemon (and any caller) that passes no registry gets no keys.
+        await using var registry = CreateRegistry(new AuthOptions(), predefinedKeys: null);
+
+        registry.GetAuthProviderIdsForTest().Should().BeEmpty();
+    }
+
+    private sealed class NoopTokenStore : IOAuthTokenStore
+    {
+        public Task<OAuthTokenRecord?> GetAsync(string provider, CancellationToken ct = default) =>
+            Task.FromResult<OAuthTokenRecord?>(null);
+
+        public Task SaveAsync(OAuthTokenRecord record, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task RemoveAsync(string provider, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private static SandboxSessionRegistry CreateRegistry(AuthOptions auth, PredefinedKeyRegistry? predefinedKeys = null)
     {
         static HttpResponseMessage Unused(HttpRequestMessage _) => new(HttpStatusCode.OK);
 
@@ -107,7 +152,8 @@ public class SandboxSessionRegistryBuildAuthProvidersTests
             NullLogger<SandboxSessionRegistry>.Instance,
             new HttpClient(new StubHandler(Unused)),
             auth,
-            new AuthSharedSecret(auth));
+            new AuthSharedSecret(auth),
+            predefinedKeys);
     }
 
     private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler


### PR DESCRIPTION
## Summary

Adds **pre-defined egress keys** (#210): per-entry credentials the sandbox gateway injects on
outbound requests to a user-specified host, alongside the existing OAuth webhook. Three credential
kinds:

- **Custom Headers + Value** — a *list* of `{ headerName, value }` pairs injected verbatim (a session
  cookie, an `Authorization` token, an API key, any custom header(s)).
- **OAuth2 Refresh Token** — the app runs `grant_type=refresh_token` and injects `Bearer <access>`, auto-refreshing.
- **OAuth2 Client-Credentials** — the app runs `grant_type=client_credentials`, injects `Bearer <access>`, auto-refreshing.

Managed at runtime via a new **Egress Auth** dialog + REST CRUD (`api/auth/egress-keys`), so a user
can authenticate sandbox egress to *any* service with a credential they already hold — no interactive
sign-in, no code change.

## Design

Reuses the existing egress-auth machinery rather than duplicating it:
- One `PredefinedKeyProvider : IOAuthTokenProvider` (kind switch); the webhook's `Resolve` falls back
  to a runtime `PredefinedKeyRegistry`, with a polymorphic host-gate + `AllowCustom` header builder.
- `SandboxSessionRegistry.BuildAuthProviders` emits a `webhook` auth-provider + host-scoped port-443
  `allow` rule per entry (a new **optional** registry param → `null` = fail-closed, zero churn to the
  ~30 existing callers and the daemon).
- A missing / mint-invalidated key re-prompts through the **existing deferred-auth hold + banner**;
  the banner routes `predefined-<id>` providers to the Egress Auth dialog (the provider-id prefix is
  the discriminator — no new WS-frame field). Updating the entry resolves the held call automatically.
- `OAuthTokenEndpointClient` (refresh/client-credentials grants) is new; `GitHubOAuthProvider` is left
  untouched. `FileOAuthTokenStore` shares a small `AtomicJsonFile` helper with the registry.

Scope was trimmed after an over-engineering + class-design review: no one-impl interface, no separate
store type, no config-seeding, no `/invalidate` endpoint.

## Security

- Secrets persist under the gitignored `oauth-tokens/predefined-keys.json` (minted tokens keyed
  `predefined-<id>`); **never logged**, GET returns masked values only, DELETE removes them.
- Default-deny egress preserved: each entry opens **only its own host**, HTTPS/**443 only**. Host
  patterns are SSRF-validated (rejects `*`, loopback, `169.254.169.254`, scheme/port/path, and
  managed-OAuth-host collisions); the same matcher builds the rule and gates the webhook.
- Header names must be RFC 7230 tokens and may not be hop-by-hop/framing headers (`Cookie` allowed).
- The webhook injects a key's headers **only** when the destination host matches that entry (anti-oracle).
- The headless CodeReviewDaemon fails closed (no keys, no prompt).

## Testing

- Backend: **758** unit tests + **8** over-HTTP webhook E2E (incl. create-key → inject-verbatim →
  host-mismatch-deny), 0 failures.
- Frontend: **492** Vitest passing, `vue-tsc` clean.
- Daemon build green (fail-closed via the optional param).

## Out of scope

Detecting a **post-egress** 401/403 (a static key the *target* rejects) needs a gateway change —
filed as **achieveai/SandboxedOstoolsMcpServer#143**. This PR scopes the re-prompt to
missing / mint-invalid only.

Docs: `samples/LmStreaming.Sample/AuthProviderGuide.md` gains a "Pre-defined egress keys" section.

Closes #210
