### PR TITLE
Sub-agent conversations as colored center-pane tabs

### DIFF
--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ChatLayout.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ChatLayout.test.ts
@@ -133,6 +133,8 @@ vi.mock('@/composables/useChat', async () => {
       markStreamIdle: sharedMocks.markStreamIdle,
       markStreamLoading: sharedMocks.markStreamLoading,
       getResultForToolCall: vi.fn(() => null),
+      // Hoisted useSubAgentPanel(() => chatThreadId.value) reads this; useConversationTabs watches it.
+      threadId: ref('thread-1'),
     }),
   };
 });
@@ -180,6 +182,7 @@ vi.mock('@/composables/useSubAgentPanel', async () => {
       focusedAgentId: ref<string | null>(null),
       focusedDisplayItems: ref([]),
       isFocusedStreaming: ref(false),
+      error: ref<string | null>(null),
       startPolling: vi.fn(),
       stopPolling: vi.fn(),
       refreshChildren: vi.fn(async () => {}),

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ConversationTabs.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/ConversationTabs.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ConversationTabs from '@/components/ConversationTabs.vue';
+import type { ConversationTab } from '@/composables/useConversationTabs';
+
+const TABS: ConversationTab[] = [
+  { id: 'main', label: 'main', kind: 'main', color: null },
+  { id: 'a1', label: 'Researcher', kind: 'subagent', color: '#2563eb', status: 'running' },
+  { id: 'a2', label: 'Planner', kind: 'subagent', color: '#0d9488', status: 'completed' },
+];
+
+describe('ConversationTabs', () => {
+  it('renders one tab per entry with labels and tab ids', () => {
+    const wrapper = mount(ConversationTabs, { props: { tabs: TABS, activeTabId: 'main' } });
+    const tabs = wrapper.findAll('[data-testid="conversation-tab"]');
+    expect(tabs).toHaveLength(3);
+    expect(tabs.map((t) => t.attributes('data-tab-id'))).toEqual(['main', 'a1', 'a2']);
+    expect(tabs[1].text()).toContain('Researcher');
+  });
+
+  it('marks the active tab and reflects it in aria-selected', () => {
+    const wrapper = mount(ConversationTabs, { props: { tabs: TABS, activeTabId: 'a1' } });
+    const active = wrapper.get('[data-tab-id="a1"]');
+    expect(active.classes()).toContain('active');
+    expect(active.attributes('aria-selected')).toBe('true');
+    expect(wrapper.get('[data-tab-id="main"]').attributes('aria-selected')).toBe('false');
+  });
+
+  it('applies the assigned hue to the color dot', () => {
+    const wrapper = mount(ConversationTabs, { props: { tabs: TABS, activeTabId: 'main' } });
+    const dot = wrapper.get('[data-tab-id="a1"] .conversation-tab__dot');
+    // jsdom normalizes the hex to rgb.
+    expect(dot.attributes('style')).toContain('background');
+  });
+
+  it('emits select with the tab id on click', async () => {
+    const wrapper = mount(ConversationTabs, { props: { tabs: TABS, activeTabId: 'main' } });
+    await wrapper.get('[data-tab-id="a2"]').trigger('click');
+    expect(wrapper.emitted('select')).toEqual([['a2']]);
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/SubAgentListPanel.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/SubAgentListPanel.test.ts
@@ -1,33 +1,11 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { nextTick } from 'vue';
 import SubAgentListPanel from '@/components/SubAgentListPanel.vue';
 import type { SubAgentSummary } from '@/api/subAgentsApi';
 
-// The panel is presentation-only: it drives the (separately tested) useSubAgentPanel composable and
-// renders its reactive surface. We mock the composable so the component test is deterministic — no
-// real fetch/WebSocket — and expose the returned api so a test can mutate its refs.
-const panelState = vi.hoisted(() => ({ api: null as any }));
-
-vi.mock('@/composables/useSubAgentPanel', async () => {
-  const { ref } = await import('vue');
-  const api = {
-    children: ref([]),
-    focusedAgentId: ref<string | null>(null),
-    focusedDisplayItems: ref([]),
-    isFocusedStreaming: ref(false),
-    error: ref<string | null>(null),
-    startPolling: vi.fn(),
-    stopPolling: vi.fn(),
-    refreshChildren: vi.fn(),
-    focusChild: vi.fn(),
-    unfocusChild: vi.fn(),
-    sendToFocusedChild: vi.fn(),
-    getResultForToolCall: vi.fn(() => null),
-  };
-  panelState.api = api;
-  return { useSubAgentPanel: () => api };
-});
+// The panel is now a stateless LAUNCHER: it takes the shared `children` + `activeTabId` as props and
+// emits `select(agentId)`. It no longer owns a composable, transcript, input, or error banner (those
+// moved to ChatLayout / SubAgentTranscript).
 
 function summary(agentId: string, overrides: Partial<SubAgentSummary> = {}): SubAgentSummary {
   return {
@@ -42,67 +20,24 @@ function summary(agentId: string, overrides: Partial<SubAgentSummary> = {}): Sub
   };
 }
 
-// Stub the heavy child components so the panel test asserts wiring, not their internals.
-const MessageListStub = {
-  props: ['displayItems', 'isLoading'],
-  template:
-    '<div data-testid="stub-message-list" :data-count="displayItems.length" :data-loading="String(isLoading)"></div>',
-};
-const ChatInputStub = {
-  props: ['disabled', 'streaming'],
-  emits: ['send', 'cancel'],
-  template:
-    '<div data-testid="stub-chat-input" :data-streaming="String(streaming)">' +
-    '<button data-testid="stub-send" @click="$emit(\'send\', \'hello child\')">send</button></div>',
-};
-
-function mountPanel(parentThreadId: string | null = 'parent-1') {
-  return mount(SubAgentListPanel, {
-    props: { parentThreadId },
-    global: {
-      stubs: { MessageList: MessageListStub, ChatInput: ChatInputStub },
-    },
-  });
+function mountPanel(children: SubAgentSummary[] = [], activeTabId = 'main') {
+  return mount(SubAgentListPanel, { props: { children, activeTabId } });
 }
 
-beforeEach(() => {
-  const api = panelState.api;
-  api.children.value = [];
-  api.focusedAgentId.value = null;
-  api.focusedDisplayItems.value = [];
-  api.isFocusedStreaming.value = false;
-  api.error.value = null;
-  api.startPolling.mockClear();
-  api.stopPolling.mockClear();
-  api.focusChild.mockClear();
-  api.unfocusChild.mockClear();
-  api.sendToFocusedChild.mockClear();
-});
-
-describe('SubAgentListPanel', () => {
-  it('starts polling for sub-agents on mount', () => {
-    mountPanel();
-    expect(panelState.api.startPolling).toHaveBeenCalledTimes(1);
-  });
-
+describe('SubAgentListPanel (launcher)', () => {
   it('is collapsed by default: shows the toggle with the child count, panel hidden', () => {
-    panelState.api.children.value = [summary('a1'), summary('a2')];
-    const wrapper = mountPanel();
-
+    const wrapper = mountPanel([summary('a1'), summary('a2')]);
     const toggle = wrapper.get('[data-testid="subagent-panel-toggle"]');
     expect(toggle.text()).toContain('Sub-agents (2)');
     expect(wrapper.find('[data-testid="subagent-panel"]').exists()).toBe(false);
   });
 
   it('expands to show the list of children on toggle', async () => {
-    panelState.api.children.value = [summary('a1'), summary('a2', { name: null, template: 'planner' })];
-    const wrapper = mountPanel();
+    const wrapper = mountPanel([summary('a1'), summary('a2', { name: null, template: 'planner' })]);
 
     await wrapper.get('[data-testid="subagent-panel-toggle"]').trigger('click');
 
     expect(wrapper.find('[data-testid="subagent-panel"]').exists()).toBe(true);
-    expect(wrapper.find('[data-testid="subagent-list"]').exists()).toBe(true);
-
     const items = wrapper.findAll('[data-testid="subagent-item"]');
     expect(items).toHaveLength(2);
     expect(items[0].attributes('data-agent-id')).toBe('a1');
@@ -112,95 +47,26 @@ describe('SubAgentListPanel', () => {
     expect(items[1].text()).toContain('planner');
   });
 
-  it('clicking a row focus button calls focusChild with the agent id', async () => {
-    panelState.api.children.value = [summary('a1')];
-    const wrapper = mountPanel();
+  it('shows an empty state when there are no children', async () => {
+    const wrapper = mountPanel([]);
+    await wrapper.get('[data-testid="subagent-panel-toggle"]').trigger('click');
+    expect(wrapper.get('[data-testid="subagent-list"]').text()).toContain('No sub-agents yet.');
+  });
+
+  it('clicking a row emits select with the agent id', async () => {
+    const wrapper = mountPanel([summary('a1')]);
     await wrapper.get('[data-testid="subagent-panel-toggle"]').trigger('click');
 
     await wrapper.get('[data-testid="subagent-focus-button"]').trigger('click');
-    expect(panelState.api.focusChild).toHaveBeenCalledWith('a1');
+    expect(wrapper.emitted('select')).toEqual([['a1']]);
   });
 
-  it('renders the transcript and a send-only input when a child is focused', async () => {
-    panelState.api.children.value = [summary('a1')];
-    panelState.api.focusedDisplayItems.value = [{ type: 'user-message' }, { type: 'assistant-message' }];
-    panelState.api.isFocusedStreaming.value = true;
-    const wrapper = mountPanel();
+  it('highlights the row matching the active tab', async () => {
+    const wrapper = mountPanel([summary('a1'), summary('a2')], 'a2');
     await wrapper.get('[data-testid="subagent-panel-toggle"]').trigger('click');
 
-    // Focus a child (simulate the composable setting focusedAgentId).
-    panelState.api.focusedAgentId.value = 'a1';
-    await nextTick();
-
-    expect(wrapper.find('[data-testid="subagent-unfocus-button"]').exists()).toBe(true);
-
-    const transcript = wrapper.get('[data-testid="subagent-transcript"]');
-    const list = transcript.get('[data-testid="stub-message-list"]');
-    expect(list.attributes('data-count')).toBe('2');
-    expect(list.attributes('data-loading')).toBe('true');
-
-    // The input is send-only: ChatInput is not put into streaming mode, so it never shows Stop.
-    const input = wrapper.get('[data-testid="subagent-input"]');
-    expect(input.get('[data-testid="stub-chat-input"]').attributes('data-streaming')).toBe('false');
-    expect(wrapper.find('[data-testid="stop-button"]').exists()).toBe(false);
-    // The focused row is highlighted.
-    expect(wrapper.get('[data-testid="subagent-item"]').classes()).toContain('focused');
-  });
-
-  it('@send from the focused input forwards text to sendToFocusedChild', async () => {
-    panelState.api.children.value = [summary('a1')];
-    const wrapper = mountPanel();
-    await wrapper.get('[data-testid="subagent-panel-toggle"]').trigger('click');
-    panelState.api.focusedAgentId.value = 'a1';
-    await nextTick();
-
-    await wrapper.get('[data-testid="subagent-input"] [data-testid="stub-send"]').trigger('click');
-    expect(panelState.api.sendToFocusedChild).toHaveBeenCalledWith('hello child');
-  });
-
-  it('the unfocus button calls unfocusChild', async () => {
-    panelState.api.children.value = [summary('a1')];
-    const wrapper = mountPanel();
-    await wrapper.get('[data-testid="subagent-panel-toggle"]').trigger('click');
-    panelState.api.focusedAgentId.value = 'a1';
-    await nextTick();
-
-    await wrapper.get('[data-testid="subagent-unfocus-button"]').trigger('click');
-    expect(panelState.api.unfocusChild).toHaveBeenCalledTimes(1);
-  });
-
-  it('never renders a Stop control (the child panel is send-only)', async () => {
-    panelState.api.children.value = [summary('a1')];
-    const wrapper = mountPanel();
-    await wrapper.get('[data-testid="subagent-panel-toggle"]').trigger('click');
-    panelState.api.focusedAgentId.value = 'a1';
-    await nextTick();
-
-    expect(wrapper.html()).not.toContain('data-testid="stop-button"');
-  });
-
-  it('surfaces the composable error when present', async () => {
-    const wrapper = mountPanel();
-    await wrapper.get('[data-testid="subagent-panel-toggle"]').trigger('click');
-    expect(wrapper.find('[data-testid="subagent-error"]').exists()).toBe(false);
-
-    panelState.api.error.value = 'Failed to list sub-agents: boom';
-    await nextTick();
-
-    const banner = wrapper.get('[data-testid="subagent-error"]');
-    expect(banner.text()).toContain('Failed to list sub-agents: boom');
-  });
-
-  it('surfaces a relay_failed stream error in the banner (FINDING C)', async () => {
-    const wrapper = mountPanel();
-    await wrapper.get('[data-testid="subagent-panel-toggle"]').trigger('click');
-    expect(wrapper.find('[data-testid="subagent-error"]').exists()).toBe(false);
-
-    // The composable copies a relay_failed stream error into its public `error` ref.
-    panelState.api.error.value = "Failed to relay the message to sub-agent 'a1'. Please retry.";
-    await nextTick();
-
-    const banner = wrapper.get('[data-testid="subagent-error"]');
-    expect(banner.text()).toContain('Failed to relay the message');
+    const items = wrapper.findAll('[data-testid="subagent-item"]');
+    expect(items[0].classes()).not.toContain('focused');
+    expect(items[1].classes()).toContain('focused');
   });
 });

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/SubAgentTranscript.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/SubAgentTranscript.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { inject } from 'vue';
+import { mount } from '@vue/test-utils';
+import SubAgentTranscript from '@/components/SubAgentTranscript.vue';
+import { GET_RESULT_FOR_TOOL_CALL } from '@/composables/useToolResult';
+import type { ToolCallResultMessage } from '@/types';
+
+// Stub MessageList so we assert wiring; it also injects the child tool-result resolver to prove the
+// subtree provide points at the child (not the parent chat).
+const MessageListStub = {
+  props: ['displayItems', 'isLoading'],
+  setup() {
+    const resolver = inject<(id: string | null | undefined) => ToolCallResultMessage | null>(
+      GET_RESULT_FOR_TOOL_CALL,
+      () => null
+    );
+    const resolved = resolver('tc-1');
+    return { marker: resolved ? resolved.result : 'none' };
+  },
+  template:
+    '<div data-testid="stub-ml" :data-count="displayItems.length" :data-loading="String(isLoading)" :data-marker="marker"></div>',
+};
+
+const ChatInputStub = {
+  props: ['disabled', 'streaming'],
+  emits: ['send', 'cancel'],
+  template:
+    '<div data-testid="stub-input" :data-disabled="String(disabled)" :data-streaming="String(streaming)">' +
+    '<button data-testid="stub-send" @click="$emit(\'send\', \'hi child\')">send</button></div>',
+};
+
+function mountView(props: Partial<Record<string, unknown>> = {}) {
+  return mount(SubAgentTranscript, {
+    props: {
+      activeAgentId: 'a1',
+      focusedAgentId: 'a1',
+      displayItems: [{ type: 'user-message' }, { type: 'assistant-message' }],
+      isStreaming: true,
+      error: null,
+      getResultForToolCall: vi.fn(() => null),
+      ...props,
+    } as never,
+    global: { stubs: { MessageList: MessageListStub, ChatInput: ChatInputStub } },
+  });
+}
+
+describe('SubAgentTranscript', () => {
+  it('renders the transcript MessageList with the display items and streaming state', () => {
+    const wrapper = mountView();
+    const ml = wrapper.get('[data-testid="subagent-transcript"] [data-testid="stub-ml"]');
+    expect(ml.attributes('data-count')).toBe('2');
+    expect(ml.attributes('data-loading')).toBe('true');
+  });
+
+  it('provides the CHILD tool-result resolver to its subtree (not the parent chat)', () => {
+    const childResolver = (id: string | null | undefined): ToolCallResultMessage | null =>
+      id === 'tc-1' ? ({ result: 'CHILD-RESULT' } as ToolCallResultMessage) : null;
+    const wrapper = mountView({ getResultForToolCall: childResolver });
+    expect(wrapper.get('[data-testid="stub-ml"]').attributes('data-marker')).toBe('CHILD-RESULT');
+  });
+
+  it('surfaces a relay_failed stream error in the banner (FINDING C, relocated from the panel)', () => {
+    const wrapper = mountView({ error: "Failed to relay the message to sub-agent 'a1'. Please retry." });
+    const banner = wrapper.get('[data-testid="subagent-error"]');
+    expect(banner.text()).toContain('Failed to relay the message');
+  });
+
+  it('has no error banner when there is no error', () => {
+    const wrapper = mountView({ error: null });
+    expect(wrapper.find('[data-testid="subagent-error"]').exists()).toBe(false);
+  });
+
+  it('input is send-only (never streaming, so never a Stop control)', () => {
+    const wrapper = mountView();
+    expect(wrapper.get('[data-testid="stub-input"]').attributes('data-streaming')).toBe('false');
+  });
+
+  it('disables the input until the live connection for this tab is attached', () => {
+    // focus not yet on this tab -> disabled
+    const notReady = mountView({ focusedAgentId: null });
+    expect(notReady.get('[data-testid="stub-input"]').attributes('data-disabled')).toBe('true');
+    // focused on this exact tab -> enabled
+    const ready = mountView({ focusedAgentId: 'a1' });
+    expect(ready.get('[data-testid="stub-input"]').attributes('data-disabled')).toBe('false');
+  });
+
+  it('forwards @send text to the parent', async () => {
+    const wrapper = mountView();
+    await wrapper.get('[data-testid="stub-send"]').trigger('click');
+    expect(wrapper.emitted('send')).toEqual([['hi child']]);
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useConversationTabs.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/composables/useConversationTabs.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ref, computed, effectScope, nextTick } from 'vue';
+import { useConversationTabs, MAIN_TAB_ID } from '@/composables/useConversationTabs';
+import { AGENT_HUES } from '@/utils/agentColors';
+import type { SubAgentSummary } from '@/api/subAgentsApi';
+
+function child(agentId: string, over: Partial<SubAgentSummary> = {}): SubAgentSummary {
+  return {
+    agentId,
+    name: `Agent ${agentId}`,
+    template: 'research',
+    task: 'work',
+    status: 'running',
+    threadId: `subagent-${agentId}`,
+    lastActivityUtc: null,
+    ...over,
+  };
+}
+
+/** Run the composable inside an effect scope so its watchers are created (and disposable). */
+function harness(initialChildren: SubAgentSummary[] = [], parentThreadId: string | null = 'parent-1') {
+  const children = ref<SubAgentSummary[]>(initialChildren);
+  const focusedAgentId = ref<string | null>(null);
+  const parent = ref<string | null>(parentThreadId);
+  const focusChild = vi.fn(async (id: string) => {
+    focusedAgentId.value = id;
+  });
+  const unfocusChild = vi.fn(async () => {
+    focusedAgentId.value = null;
+  });
+  const scope = effectScope();
+  const api = scope.run(() =>
+    useConversationTabs({
+      children,
+      focusedAgentId,
+      focusChild,
+      unfocusChild,
+      getParentThreadId: () => parent.value,
+    })
+  )!;
+  return { api, children, focusedAgentId, parent, focusChild, unfocusChild, scope };
+}
+
+describe('useConversationTabs', () => {
+  it('always shows a main tab first, then one tab per child with name||template labels', () => {
+    const { api } = harness([child('a1'), child('a2', { name: null, template: 'planner' })]);
+    const tabs = api.tabs.value;
+    expect(tabs.map((t) => t.id)).toEqual([MAIN_TAB_ID, 'a1', 'a2']);
+    expect(tabs[0]).toMatchObject({ kind: 'main', label: 'main', color: null });
+    expect(tabs[1]).toMatchObject({ kind: 'subagent', label: 'Agent a1' });
+    // name falls back to template when null
+    expect(tabs[2].label).toBe('planner');
+  });
+
+  it('assigns colors in discovery order and keeps them stable as the list mutates', async () => {
+    const { api, children } = harness([child('a1'), child('a2')]);
+    expect(api.getAgentColor('a1')).toBe(AGENT_HUES[0]);
+    expect(api.getAgentColor('a2')).toBe(AGENT_HUES[1]);
+
+    // a1 drops out, a3 appears: a2 keeps its hue, a3 gets the next index (not a1's freed slot).
+    children.value = [child('a2'), child('a3')];
+    await nextTick();
+    expect(api.getAgentColor('a2')).toBe(AGENT_HUES[1]);
+    expect(api.getAgentColor('a3')).toBe(AGENT_HUES[2]);
+    expect(api.getAgentColor('unknown')).toBeNull();
+  });
+
+  it('getAgentColor is reactive: a computed re-evaluates when the color is assigned on a later poll', async () => {
+    // Models an inline pill: it renders BEFORE the child appears in the polled list, so its color
+    // resolves to null first and must reactively pick up the hue once the child is discovered.
+    const { api, children, scope } = harness([]);
+    const pillColor = scope.run(() => computed(() => api.getAgentColor('late-agent')))!;
+    expect(pillColor.value).toBeNull();
+
+    children.value = [child('late-agent')];
+    await nextTick();
+    expect(pillColor.value).toBe(AGENT_HUES[0]);
+  });
+
+  it('selectTab(main) unfocuses; selectTab(agent) focuses that child', async () => {
+    const { api, focusChild, unfocusChild } = harness([child('a1')]);
+    await api.selectTab('a1');
+    expect(focusChild).toHaveBeenCalledWith('a1');
+    expect(api.activeTabId.value).toBe('a1');
+
+    await api.selectTab(MAIN_TAB_ID);
+    expect(unfocusChild).toHaveBeenCalledTimes(1);
+    expect(api.activeTabId.value).toBe(MAIN_TAB_ID);
+  });
+
+  it('is a no-op when selecting the already-active tab', async () => {
+    const { api, focusChild } = harness([child('a1')]);
+    await api.selectTab(MAIN_TAB_ID);
+    expect(focusChild).not.toHaveBeenCalled();
+  });
+
+  it('snaps back to main when the parent conversation changes', async () => {
+    const { api, parent } = harness([child('a1')]);
+    await api.selectTab('a1');
+    expect(api.activeTabId.value).toBe('a1');
+
+    parent.value = 'parent-2';
+    await nextTick();
+    expect(api.activeTabId.value).toBe(MAIN_TAB_ID);
+  });
+
+  it('snaps back to main and unfocuses when the active sub-agent leaves the list', async () => {
+    const { api, children, unfocusChild } = harness([child('a1')]);
+    await api.selectTab('a1');
+    unfocusChild.mockClear();
+
+    children.value = [child('a2')];
+    await nextTick();
+    expect(api.activeTabId.value).toBe(MAIN_TAB_ID);
+    expect(unfocusChild).toHaveBeenCalled();
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/utils/agentColors.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/utils/agentColors.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { AGENT_HUES, MAIN_TAB_COLOR, hueForIndex, resolveAgentIdFromCall } from '@/utils/agentColors';
+
+describe('agentColors palette', () => {
+  it('exposes a non-empty palette of distinct hues', () => {
+    expect(AGENT_HUES.length).toBeGreaterThan(1);
+    expect(new Set(AGENT_HUES).size).toBe(AGENT_HUES.length);
+  });
+
+  it('does not reuse the app reserved accent/error colors', () => {
+    expect(AGENT_HUES).not.toContain('#007bff');
+    expect(AGENT_HUES).not.toContain('#dc3545');
+    expect(MAIN_TAB_COLOR).not.toBe('#007bff');
+  });
+
+  it('assigns hues by discovery index and wraps around the palette', () => {
+    expect(hueForIndex(0)).toBe(AGENT_HUES[0]);
+    expect(hueForIndex(1)).toBe(AGENT_HUES[1]);
+    // Wrap: index N returns hue 0 again.
+    expect(hueForIndex(AGENT_HUES.length)).toBe(AGENT_HUES[0]);
+    expect(hueForIndex(AGENT_HUES.length + 2)).toBe(AGENT_HUES[2]);
+  });
+});
+
+describe('resolveAgentIdFromCall (exact-agentId only)', () => {
+  it('reads agent_id from call args (sendmessage/checkagent)', () => {
+    expect(resolveAgentIdFromCall({ agent_id: 'a-42' }, null)).toBe('a-42');
+    expect(resolveAgentIdFromCall({ agentId: 'a-7' }, null)).toBe('a-7');
+  });
+
+  it('reads agent_id from a background spawn result JSON when args lack it', () => {
+    const spawnResult = JSON.stringify({ agent_id: 'spawned-9', name: null, template: 'research', status: 'spawned' });
+    expect(resolveAgentIdFromCall({ subagent_type: 'research', prompt: 'go' }, spawnResult)).toBe('spawned-9');
+  });
+
+  it('prefers args agent_id over the result', () => {
+    const result = JSON.stringify({ agent_id: 'from-result' });
+    expect(resolveAgentIdFromCall({ agent_id: 'from-args' }, result)).toBe('from-args');
+  });
+
+  it('returns null when no exact id is available (synchronous spawn answer text, or template-only args)', () => {
+    expect(resolveAgentIdFromCall({ subagent_type: 'research', prompt: 'go' }, 'The answer is 42.')).toBeNull();
+    expect(resolveAgentIdFromCall({ subagent_type: 'research' }, null)).toBeNull();
+    expect(resolveAgentIdFromCall(null, null)).toBeNull();
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ChatLayout.vue
@@ -14,6 +14,11 @@ import MessageList from './MessageList.vue';
 import PendingMessageQueue from './PendingMessageQueue.vue';
 import ChatInput from './ChatInput.vue';
 import SubAgentListPanel from './SubAgentListPanel.vue';
+import ConversationTabs from './ConversationTabs.vue';
+import SubAgentTranscript from './SubAgentTranscript.vue';
+import { useSubAgentPanel } from '@/composables/useSubAgentPanel';
+import { useConversationTabs } from '@/composables/useConversationTabs';
+import { GET_AGENT_COLOR } from '@/utils/agentColors';
 import ModeSelector from './ModeSelector.vue';
 import ProviderSelector from './ProviderSelector.vue';
 import WorkspaceSelector from './WorkspaceSelector.vue';
@@ -103,8 +108,40 @@ async function handleCancel(): Promise<void> {
   await cancelStream();
 }
 
-// Provide getResultForToolCall to child components
+// Sub-agent panel state is hoisted HERE (it used to live inside SubAgentListPanel) so the center-pane
+// tabs and the right-side launcher share ONE instance/poller/socket. The tab selector/router drives
+// which conversation the center pane shows.
+const {
+  children: subAgentChildren,
+  focusedAgentId,
+  focusedDisplayItems,
+  isFocusedStreaming,
+  error: subAgentError,
+  startPolling: startSubAgentPolling,
+  focusChild,
+  unfocusChild,
+  sendToFocusedChild,
+  getResultForToolCall: getSubAgentResultForToolCall,
+} = useSubAgentPanel(() => chatThreadId.value);
+
+const { activeTabId, tabs, selectTab, getAgentColor } = useConversationTabs({
+  children: subAgentChildren,
+  focusedAgentId,
+  focusChild,
+  unfocusChild,
+  getParentThreadId: () => chatThreadId.value,
+});
+
+function handleSubAgentSend(text: string): void {
+  sendToFocusedChild(text);
+}
+
+// Provide getResultForToolCall to the MAIN view's pills. The sub-agent view (SubAgentTranscript)
+// shadows this with the child's own resolver for its subtree.
 provide('getResultForToolCall', getResultForToolCall);
+// Provide agentId → color so ToolPill (agent family) and NotificationPill (completion) can tint a
+// sub-agent's inline calls to match its tab.
+provide(GET_AGENT_COLOR, getAgentColor);
 
 const sidebarCollapsed = ref(false);
 const isSwitchingMode = ref(false);
@@ -468,6 +505,8 @@ function checkMobile(): void {
 onMounted(() => {
   checkMobile();
   window.addEventListener('resize', checkMobile);
+  // Poll the active conversation's sub-agents so tabs/launcher populate as children spawn.
+  startSubAgentPolling();
 });
 
 onBeforeUnmount(() => {
@@ -598,41 +637,68 @@ onBeforeUnmount(() => {
           @close="fileBrowserModalOpen = false"
         />
 
-        <MessageList :display-items="displayItems" :is-loading="chatLoading" />
+        <ConversationTabs
+          v-if="tabs.length > 1"
+          :tabs="tabs"
+          :active-tab-id="activeTabId"
+          @select="selectTab"
+        />
 
-        <AuthRequiredBanner :requests="pendingAuthRequests" @dismiss="dismissAuthRequest" />
+        <!-- MAIN conversation view: stays mounted (v-show) so its scroll/stream/pill state survives
+             tab detours. Its banners, usage, pending queue and input are main-only by construction. -->
+        <div v-show="activeTabId === 'main'" class="tab-view" data-testid="main-view">
+          <MessageList :display-items="displayItems" :is-loading="chatLoading" />
 
-        <div v-if="error" class="error-banner" data-testid="error-banner">
-          {{ error }}
+          <AuthRequiredBanner :requests="pendingAuthRequests" @dismiss="dismissAuthRequest" />
+
+          <div v-if="error" class="error-banner" data-testid="error-banner">
+            {{ error }}
+          </div>
+
+          <div v-if="cumulativeUsage.totalTokens > 0" class="usage-banner" data-testid="usage-banner">
+            Total: {{ cumulativeUsage.totalTokens }} |
+            In: {{ cumulativeUsage.uncachedInputTokens }} |
+            Out: {{ cumulativeUsage.completionTokens }}
+            <template v-if="cumulativeUsage.cachedTokens > 0">
+              | Cached: {{ cumulativeUsage.cachedTokens }}
+            </template>
+            <template v-if="cumulativeUsage.cacheCreationTokens > 0">
+              | Cache created: {{ cumulativeUsage.cacheCreationTokens }}
+            </template>
+          </div>
+
+          <PendingMessageQueue :pending-messages="pendingMessages" />
+
+          <ChatInput
+            :disabled="isSending && !chatLoading"
+            :streaming="chatLoading"
+            @send="handleSend"
+            @cancel="handleCancel"
+          />
         </div>
 
-        <div v-if="cumulativeUsage.totalTokens > 0" class="usage-banner" data-testid="usage-banner">
-          Total: {{ cumulativeUsage.totalTokens }} |
-          In: {{ cumulativeUsage.uncachedInputTokens }} |
-          Out: {{ cumulativeUsage.completionTokens }}
-          <template v-if="cumulativeUsage.cachedTokens > 0">
-            | Cached: {{ cumulativeUsage.cachedTokens }}
-          </template>
-          <template v-if="cumulativeUsage.cacheCreationTokens > 0">
-            | Cache created: {{ cumulativeUsage.cacheCreationTokens }}
-          </template>
-        </div>
-
-        <PendingMessageQueue :pending-messages="pendingMessages" />
-
-        <ChatInput
-          :disabled="isSending && !chatLoading"
-          :streaming="chatLoading"
-          @send="handleSend"
-          @cancel="handleCancel"
+        <!-- SUB-AGENT view: mounted only while a sub-agent tab is active; its own error banner + input
+             (routed to the focused child) + child-scoped tool-result provide live inside it. -->
+        <SubAgentTranscript
+          v-if="activeTabId !== 'main'"
+          :active-agent-id="activeTabId"
+          :focused-agent-id="focusedAgentId"
+          :display-items="focusedDisplayItems"
+          :is-streaming="isFocusedStreaming"
+          :error="subAgentError"
+          :get-result-for-tool-call="getSubAgentResultForToolCall"
+          @send="handleSubAgentSend"
         />
       </div>
     </main>
 
-    <!-- Bind the sub-agent panel to the ACTIVE chat thread (useChat's threadId), not the
-         sidebar's currentThreadId: a freshly-started chat runs on useChat's thread before it is
-         ever selected/persisted in the sidebar, and the panel must track where sub-agents spawn. -->
-    <SubAgentListPanel :parent-thread-id="chatThreadId" />
+    <!-- Right-side launcher: shares ChatLayout's hoisted sub-agent state (the panel no longer owns a
+         composable). Clicking a row activates that sub-agent's center-pane tab via selectTab. -->
+    <SubAgentListPanel
+      :children="subAgentChildren"
+      :active-tab-id="activeTabId"
+      @select="selectTab"
+    />
   </div>
 </template>
 
@@ -658,6 +724,15 @@ onBeforeUnmount(() => {
   margin: 0 auto;
   width: 100%;
   background: #fff;
+}
+
+/* A single tab's content column (main or sub-agent view): grows to fill, letting its MessageList
+   scroll and its ChatInput pin to the bottom, exactly as the pre-tabs layout did. */
+.tab-view {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .chat-header {

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ConversationTabs.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ConversationTabs.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import type { ConversationTab } from '@/composables/useConversationTabs';
+import { MAIN_TAB_COLOR } from '@/utils/agentColors';
+
+/**
+ * Presentational tab strip for the center conversation pane: a `main` tab plus one per sub-agent, each
+ * tinted with its assigned color. Emits `select` — all state lives in the parent (`useConversationTabs`).
+ */
+const props = defineProps<{
+  tabs: ConversationTab[];
+  activeTabId: string;
+}>();
+
+const emit = defineEmits<{ select: [tabId: string] }>();
+
+function hueFor(tab: ConversationTab): string {
+  return tab.color ?? MAIN_TAB_COLOR;
+}
+
+function tabStyle(tab: ConversationTab): Record<string, string> {
+  const hue = hueFor(tab);
+  const active = tab.id === props.activeTabId;
+  return {
+    borderBottomColor: active ? hue : 'transparent',
+    background: active ? `color-mix(in srgb, ${hue} 12%, white)` : 'transparent',
+    color: active ? hue : '#555',
+  };
+}
+</script>
+
+<template>
+  <div class="conversation-tabs" data-testid="conversation-tabs" role="tablist">
+    <button
+      v-for="tab in tabs"
+      :key="tab.id"
+      type="button"
+      class="conversation-tab"
+      :class="{ active: tab.id === activeTabId }"
+      role="tab"
+      :aria-selected="tab.id === activeTabId"
+      data-testid="conversation-tab"
+      :data-tab-id="tab.id"
+      :title="tab.status ? `${tab.label} · ${tab.status}` : tab.label"
+      :style="tabStyle(tab)"
+      @click="emit('select', tab.id)"
+    >
+      <span class="conversation-tab__dot" :style="{ background: hueFor(tab) }" aria-hidden="true" />
+      <span class="conversation-tab__label">{{ tab.label }}</span>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.conversation-tabs {
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+  padding: 0 12px;
+  border-bottom: 1px solid #e0e0e0;
+  background: #fff;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+}
+
+.conversation-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  max-width: 200px;
+  padding: 8px 12px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  color: #555;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.conversation-tab:hover:not(.active) {
+  background: #f5f5f5;
+}
+
+.conversation-tab.active {
+  font-weight: 600;
+}
+
+.conversation-tab__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.conversation-tab__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/samples/LmStreaming.Sample/ClientApp/src/components/NotificationPill.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/NotificationPill.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed, ref, toRef } from 'vue';
+import { computed, inject, ref, toRef } from 'vue';
 import type { NotificationDisplayData } from '@/types';
+import { GET_AGENT_COLOR, type AgentColorLookup } from '@/utils/agentColors';
 
 /**
  * Presentational pill for an out-of-band notification (async sub-agent completion, sandbox
@@ -56,6 +57,13 @@ function toggle(): void {
     expanded.value = !expanded.value;
   }
 }
+
+// Tint a sub-agent-completion pill with the completing agent's color (its `source_tool_call_id` is the
+// exact agentId) so it matches that agent's tab. Other notification kinds are unchanged.
+const getAgentColor = inject<AgentColorLookup>(GET_AGENT_COLOR, () => null);
+const agentColor = computed<string | null>(() =>
+  data.value.notifyKind === 'subagent-completion' ? getAgentColor(data.value.sourceToolCallId) : null
+);
 </script>
 
 <template>
@@ -63,6 +71,7 @@ function toggle(): void {
     class="notification-pill"
     data-testid="notification-pill"
     :data-notify-kind="data.notifyKind"
+    :style="agentColor ? { borderLeftColor: agentColor, borderLeftWidth: '3px' } : undefined"
   >
     <div
       class="notification-header"

--- a/samples/LmStreaming.Sample/ClientApp/src/components/SubAgentListPanel.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/SubAgentListPanel.vue
@@ -1,51 +1,30 @@
 <script setup lang="ts">
-import { ref, onMounted, provide } from 'vue';
-import { useSubAgentPanel } from '@/composables/useSubAgentPanel';
-import MessageList from './MessageList.vue';
-import ChatInput from './ChatInput.vue';
+import { ref } from 'vue';
+import type { SubAgentSummary } from '@/api/subAgentsApi';
 
+/**
+ * Compact right-side LAUNCHER for a conversation's sub-agents. Stateless/presentational: it renders the
+ * shared `children` list (owned by ChatLayout's `useSubAgentPanel`) and emits `select(agentId)` to
+ * activate that sub-agent's center-pane tab. The transcript + reply input now live in the center tab
+ * (`SubAgentTranscript`), not here.
+ */
 const props = defineProps<{
-  parentThreadId: string | null;
+  children: SubAgentSummary[];
+  /** The active center tab (`'main'` or an agentId) — highlights the matching row. */
+  activeTabId: string;
 }>();
 
-const {
-  children,
-  focusedAgentId,
-  focusedDisplayItems,
-  isFocusedStreaming,
-  error,
-  startPolling,
-  focusChild,
-  unfocusChild,
-  sendToFocusedChild,
-  getResultForToolCall,
-} = useSubAgentPanel(() => props.parentThreadId);
-
-// Nested tool pills inside the focused transcript must resolve against the CHILD's tool results, not
-// the parent chat's. provide/inject is component-subtree scoped, so this overrides ChatLayout's
-// provide('getResultForToolCall', …) ONLY for the MessageList rendered inside this panel.
-provide('getResultForToolCall', getResultForToolCall);
+const emit = defineEmits<{ select: [agentId: string] }>();
 
 const expanded = ref(false);
-
 function toggle(): void {
   expanded.value = !expanded.value;
-}
-
-function handleSend(text: string): void {
-  sendToFocusedChild(text);
 }
 
 function truncate(text: string, max: number): string {
   if (!text) return '';
   return text.length <= max ? text : text.slice(0, max) + '...';
 }
-
-onMounted(() => {
-  startPolling();
-});
-// Teardown (stopPolling + unfocusChild) is handled by the composable's onScopeDispose when this
-// component unmounts, so no explicit onBeforeUnmount hook is needed here.
 </script>
 
 <template>
@@ -56,57 +35,31 @@ onMounted(() => {
       :title="expanded ? 'Collapse sub-agents' : 'Expand sub-agents'"
       @click="toggle"
     >
-      Sub-agents ({{ children.length }})
+      Sub-agents ({{ props.children.length }})
       <span class="subagent-toggle-caret">{{ expanded ? '▸' : '◂' }}</span>
     </button>
 
     <div v-if="expanded" class="subagent-panel" data-testid="subagent-panel">
-      <div v-if="error" class="subagent-error" data-testid="subagent-error" role="alert">
-        {{ error }}
-      </div>
       <ul class="subagent-list" data-testid="subagent-list">
-        <li v-if="children.length === 0" class="subagent-empty">
-          No sub-agents yet.
-        </li>
+        <li v-if="props.children.length === 0" class="subagent-empty">No sub-agents yet.</li>
         <li
-          v-for="child in children"
+          v-for="child in props.children"
           :key="child.agentId"
-          :class="['subagent-item', { focused: child.agentId === focusedAgentId }]"
+          :class="['subagent-item', { focused: child.agentId === props.activeTabId }]"
           data-testid="subagent-item"
           :data-agent-id="child.agentId"
         >
-          <div class="subagent-info">
+          <button
+            class="subagent-row"
+            data-testid="subagent-focus-button"
+            @click="emit('select', child.agentId)"
+          >
             <div class="subagent-name">{{ child.name || child.template }}</div>
             <div class="subagent-task">{{ truncate(child.task, 60) }}</div>
             <div class="subagent-status">{{ child.status }}</div>
-          </div>
-          <button
-            class="subagent-focus-btn"
-            data-testid="subagent-focus-button"
-            @click="focusChild(child.agentId)"
-          >
-            View
           </button>
         </li>
       </ul>
-
-      <div v-if="focusedAgentId" class="subagent-focused">
-        <button
-          class="subagent-back-btn"
-          data-testid="subagent-unfocus-button"
-          @click="unfocusChild"
-        >
-          &larr; Back to list
-        </button>
-
-        <div class="subagent-transcript" data-testid="subagent-transcript">
-          <MessageList :display-items="focusedDisplayItems" :is-loading="isFocusedStreaming" />
-        </div>
-
-        <div class="subagent-input" data-testid="subagent-input">
-          <ChatInput :streaming="false" @send="handleSend" />
-        </div>
-      </div>
     </div>
   </aside>
 </template>
@@ -146,8 +99,8 @@ onMounted(() => {
 }
 
 .subagent-panel {
-  width: 340px;
-  min-width: 340px;
+  width: 300px;
+  min-width: 300px;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -159,8 +112,7 @@ onMounted(() => {
   padding: 0;
   margin: 0;
   overflow-y: auto;
-  max-height: 40%;
-  border-bottom: 1px solid #e0e0e0;
+  flex: 1;
 }
 
 .subagent-empty {
@@ -170,31 +122,31 @@ onMounted(() => {
   font-size: 13px;
 }
 
-.subagent-error {
-  padding: 10px 14px;
-  background: #fdecea;
-  color: #b3261e;
-  font-size: 12px;
-  border-bottom: 1px solid #f5c6cb;
-}
-
 .subagent-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 10px 14px;
   border-bottom: 1px solid #e0e0e0;
 }
 
 .subagent-item.focused {
   background: #d4e5f7;
   border-left: 3px solid #007bff;
+}
+
+.subagent-row {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 10px 14px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.subagent-item.focused .subagent-row {
   padding-left: 11px;
 }
 
-.subagent-info {
-  flex: 1;
-  min-width: 0;
+.subagent-row:hover {
+  background: #eef2f7;
 }
 
 .subagent-name {
@@ -216,50 +168,5 @@ onMounted(() => {
   font-size: 11px;
   color: #adb5bd;
   text-transform: capitalize;
-}
-
-.subagent-focus-btn {
-  flex-shrink: 0;
-  padding: 6px 12px;
-  background: #007bff;
-  color: white;
-  border: none;
-  border-radius: 6px;
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-}
-
-.subagent-focus-btn:hover {
-  background: #0056b3;
-}
-
-.subagent-focused {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-}
-
-.subagent-back-btn {
-  align-self: flex-start;
-  margin: 8px 14px;
-  padding: 6px 12px;
-  background: transparent;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  font-size: 12px;
-  color: #666;
-  cursor: pointer;
-}
-
-.subagent-back-btn:hover {
-  background: #e9ecef;
-}
-
-.subagent-transcript {
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
 }
 </style>

--- a/samples/LmStreaming.Sample/ClientApp/src/components/SubAgentTranscript.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/SubAgentTranscript.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { provide } from 'vue';
+import type { DisplayItem, ToolCallResultMessage } from '@/types';
+import { GET_RESULT_FOR_TOOL_CALL } from '@/composables/useToolResult';
+import MessageList from './MessageList.vue';
+import ChatInput from './ChatInput.vue';
+
+/**
+ * The center-pane view for the active sub-agent tab. Relocates the transcript + reply input + error
+ * banner that used to live inside `SubAgentListPanel`, driven by the shared `useSubAgentPanel` surface
+ * passed in as props. Streams live only for the active tab (connect-on-activate).
+ */
+const props = defineProps<{
+  /** The sub-agent tab currently active (the focus target); also the MessageList remount key. */
+  activeAgentId: string;
+  /** The sub-agent whose live stream is actually attached (null until focus completes). */
+  focusedAgentId: string | null;
+  displayItems: DisplayItem[];
+  isStreaming: boolean;
+  error: string | null;
+  /** Child-scoped tool-result resolver (this sub-agent's results, not the parent chat's). */
+  getResultForToolCall: (toolCallId: string | null | undefined) => ToolCallResultMessage | null;
+}>();
+
+const emit = defineEmits<{ send: [text: string] }>();
+
+// Shadow ChatLayout's provide for THIS subtree so nested tool pills resolve against the child's
+// results — identical to the override SubAgentListPanel used to do. The resolver reads live state at
+// call time, so a stable identity provided once stays correct across focus changes.
+provide(GET_RESULT_FOR_TOOL_CALL, props.getResultForToolCall);
+</script>
+
+<template>
+  <div class="subagent-view" data-testid="subagent-view">
+    <div v-if="error" class="subagent-view__error" data-testid="subagent-error" role="alert">
+      {{ error }}
+    </div>
+    <div class="subagent-view__transcript" data-testid="subagent-transcript">
+      <MessageList :key="activeAgentId" :display-items="displayItems" :is-loading="isStreaming" />
+    </div>
+    <!-- Send-only: never streaming (so no Stop button) — a reply resumes a completed child. Disabled
+         until the live connection for this exact tab is attached, so a send can't drop on a dead socket. -->
+    <ChatInput
+      :streaming="false"
+      :disabled="focusedAgentId !== activeAgentId"
+      @send="emit('send', $event)"
+    />
+  </div>
+</template>
+
+<style scoped>
+.subagent-view {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.subagent-view__error {
+  padding: 10px 16px;
+  background: #fdecea;
+  color: #b3261e;
+  font-size: 13px;
+  border-bottom: 1px solid #f5c6cb;
+}
+
+.subagent-view__transcript {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+</style>

--- a/samples/LmStreaming.Sample/ClientApp/src/components/ToolPill.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/ToolPill.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, inject, ref } from 'vue';
 import type { Component } from 'vue';
 import type { ToolCall } from '@/types';
 import type { ToolCallState } from '@/utils/toolTypes';
 import { resolveRenderer, deriveToolPillState } from '@/utils';
 import { useToolResult } from '@/composables/useToolResult';
+import { GET_AGENT_COLOR, resolveAgentIdFromCall, type AgentColorLookup } from '@/utils/agentColors';
 import CodeBlockRich from '@/components/tools/CodeBlockRich.vue';
 import DiffRich from '@/components/tools/DiffRich.vue';
 import TerminalRich from '@/components/tools/TerminalRich.vue';
@@ -42,6 +43,16 @@ const summary = computed(() => {
 
 /** EXACT raw result string — the frozen `.tool-call-result` contract (never pretty-printed). */
 const rawResult = computed(() => resultMsg.value?.result ?? '');
+
+// Tint a sub-agent CALL pill (Agent / SendMessage / CheckAgent) with the target sub-agent's assigned
+// color so it visually links to that agent's tab. Exact-agentId only — a call we can't resolve to a
+// known agent stays uncolored (unchanged appearance). Purely additive style; testids are untouched.
+const getAgentColor = inject<AgentColorLookup>(GET_AGENT_COLOR, () => null);
+const agentColor = computed<string | null>(() => {
+  if (renderer.value.family !== 'agent') return null;
+  const agentId = resolveAgentIdFromCall(view.value.parsedArgs, rawResult.value);
+  return agentId ? getAgentColor(agentId) : null;
+});
 
 const argEntries = computed(() =>
   view.value.parsedArgs ? Object.entries(view.value.parsedArgs) : []
@@ -89,7 +100,8 @@ async function copyResult() {
 <template>
   <div
     class="tool-pill"
-    :class="[`f-${renderer.family}`, `st-${view.state}`]"
+    :class="[`f-${renderer.family}`, `st-${view.state}`, { 'has-agent-color': agentColor }]"
+    :style="agentColor ? { borderLeftColor: agentColor, borderLeftWidth: '3px' } : undefined"
     data-testid="tool-call-pill"
     :data-tool-name="toolCall.function_name || undefined"
   >

--- a/samples/LmStreaming.Sample/ClientApp/src/composables/useConversationTabs.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/composables/useConversationTabs.ts
@@ -1,0 +1,118 @@
+import { computed, reactive, ref, watch, type ComputedRef, type Ref } from 'vue';
+import type { SubAgentSummary, SubAgentStatus } from '@/api/subAgentsApi';
+import { hueForIndex, type AgentColorLookup } from '@/utils/agentColors';
+
+/** The id of the always-present top-level tab. */
+export const MAIN_TAB_ID = 'main';
+
+/** One entry in the center-pane tab strip: the `main` conversation or a sub-agent. */
+export interface ConversationTab {
+  /** `'main'` for the top-level agent, else the sub-agent's `agentId`. */
+  id: string;
+  /** Display label: `'main'`, or the sub-agent's `name || template`. */
+  label: string;
+  kind: 'main' | 'subagent';
+  /** Assigned hue for a sub-agent, or null for the neutral `main` tab. */
+  color: string | null;
+  status?: SubAgentStatus;
+}
+
+/**
+ * The slice of {@link useSubAgentPanel}'s surface this router needs. Passed IN (never re-instantiated
+ * here) so `useConversationTabs` stays a pure selector/router over the already-created composable —
+ * re-instantiating would spin up a second poller/socket.
+ */
+export interface ConversationTabsDeps {
+  children: Ref<SubAgentSummary[]>;
+  focusedAgentId: Ref<string | null>;
+  focusChild: (agentId: string) => Promise<void> | void;
+  unfocusChild: () => Promise<void> | void;
+  /** Resolves the active parent conversation's thread id (to reset the active tab on switch). */
+  getParentThreadId: () => string | null;
+}
+
+/**
+ * Owns "which conversation is shown in the center pane, and how selecting/coloring it works." It holds
+ * ONLY the tab-selection state (`activeTabId`) and the discovery-order color map; message state,
+ * sockets, polling and send side-effects stay in `useChat` / `useSubAgentPanel` / `ChatLayout`.
+ *
+ * Connection model = connect-on-activate: selecting a sub-agent tab focuses that child (one live
+ * stream at a time), selecting `main` unfocuses. `focusChild` already tears down any prior focus, so
+ * A→B switching is correct without extra teardown here.
+ */
+export function useConversationTabs(deps: ConversationTabsDeps) {
+  const { children, focusedAgentId, focusChild, unfocusChild, getParentThreadId } = deps;
+
+  const activeTabId = ref<string>(MAIN_TAB_ID);
+
+  // agentId → hue, assigned once per agent in the order it is first DISCOVERED and kept stable for the
+  // session (so an agent's color never shifts as the polled list mutates). Assigned in a watch (a
+  // side-effect), never inside the `tabs` computed getter. REACTIVE so a color assigned on a later poll
+  // reactively reaches BOTH the tabs and the inline call pills (ToolPill / NotificationPill inject
+  // getAgentColor) whose render may precede the child's first appearance in the list.
+  const colorByAgent = reactive<Record<string, string>>({});
+  let nextColorIndex = 0;
+
+  function assignColors(list: readonly SubAgentSummary[]): void {
+    for (const child of list) {
+      if (!(child.agentId in colorByAgent)) {
+        colorByAgent[child.agentId] = hueForIndex(nextColorIndex);
+        nextColorIndex += 1;
+      }
+    }
+  }
+
+  const getAgentColor: AgentColorLookup = (agentId) => (agentId ? colorByAgent[agentId] ?? null : null);
+
+  // Assign colors as children are discovered. `immediate` so any children already present at setup are
+  // colored before the first render reads `tabs`.
+  watch(children, (list) => assignColors(list), { immediate: true });
+
+  // Keep the active tab valid: snap back to `main` when the parent conversation changes (before the
+  // child list clears, avoiding a stale-agent flash), or when the active sub-agent leaves the list.
+  watch(getParentThreadId, () => {
+    if (activeTabId.value !== MAIN_TAB_ID) {
+      activeTabId.value = MAIN_TAB_ID;
+    }
+  });
+  watch(children, (list) => {
+    if (activeTabId.value !== MAIN_TAB_ID && !list.some((c) => c.agentId === activeTabId.value)) {
+      activeTabId.value = MAIN_TAB_ID;
+      void unfocusChild();
+    }
+  });
+
+  const tabs: ComputedRef<ConversationTab[]> = computed(() => {
+    const list: ConversationTab[] = [
+      { id: MAIN_TAB_ID, label: 'main', kind: 'main', color: null },
+    ];
+    for (const child of children.value) {
+      list.push({
+        id: child.agentId,
+        label: child.name || child.template,
+        kind: 'subagent',
+        color: getAgentColor(child.agentId),
+        status: child.status,
+      });
+    }
+    return list;
+  });
+
+  /**
+   * Switch the center pane to a tab. `main` unfocuses the active child; a sub-agent tab focuses it
+   * (connect-on-activate). Sets `activeTabId` first so the view swaps immediately while `focusChild`'s
+   * async history/stream load resolves under the (empty → populated) transcript.
+   */
+  async function selectTab(id: string): Promise<void> {
+    if (id === activeTabId.value) return;
+    if (id === MAIN_TAB_ID) {
+      activeTabId.value = MAIN_TAB_ID;
+      await unfocusChild();
+      return;
+    }
+    activeTabId.value = id;
+    await focusChild(id);
+  }
+
+  return { activeTabId, tabs, selectTab, getAgentColor, focusedAgentId };
+}

--- a/samples/LmStreaming.Sample/ClientApp/src/utils/agentColors.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/utils/agentColors.ts
@@ -1,0 +1,74 @@
+/**
+ * Deterministic, client-side color assignment for sub-agents (#tabbed-subagents).
+ *
+ * NO Vue imports — a pure `.ts` module (mirrors `components/tools/registry.ts`) so it is cheap to
+ * unit-test. Colors are assigned by DISCOVERY ORDER (1st sub-agent → hue 0, 2nd → hue 1, …), never by
+ * an LLM, and used to tint a sub-agent's tab and its inline calls in the conversation.
+ */
+
+/**
+ * The rotating palette: distinct, AA-readable-on-white hues. Deliberately avoids the app's reserved
+ * accent `#007bff` and error `#dc3545` so agent colors never read as "link" or "error". The pale tab
+ * background is derived from a hue in CSS via `color-mix`, so only the base hue is stored here.
+ */
+export const AGENT_HUES: readonly string[] = [
+  '#2563eb', // blue
+  '#0d9488', // teal
+  '#7c3aed', // violet
+  '#b45309', // amber
+  '#be123c', // rose
+  '#15803d', // green
+  '#0891b2', // cyan
+  '#a21caf', // magenta
+];
+
+/** Fixed neutral color for the top-level `main` tab — NOT part of the rotating palette. */
+export const MAIN_TAB_COLOR = '#334155'; // slate
+
+/** provide/inject key for the agentId → color resolver (mirrors GET_RESULT_FOR_TOOL_CALL). */
+export const GET_AGENT_COLOR = 'getAgentColor';
+
+/** Resolver injected into descendant pills: agentId → hue, or null when unknown/unassigned. */
+export type AgentColorLookup = (agentId: string | null | undefined) => string | null;
+
+/** The hue for a 0-based discovery index, wrapping around the palette. */
+export function hueForIndex(index: number): string {
+  return AGENT_HUES[index % AGENT_HUES.length];
+}
+
+function firstStringField(obj: Record<string, unknown> | null, keys: readonly string[]): string | null {
+  if (!obj) return null;
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return null;
+}
+
+/**
+ * Extract an EXACT sub-agent id from a sub-agent tool call so its inline pill can be colored to match
+ * that agent's tab. Reliable sources only (no template/name guessing, which would mis-color two
+ * siblings spawned from the same template):
+ *   - `agent_id` in the call args (`sendmessage` / `checkagent`), or
+ *   - `agent_id` in the tool result JSON (a background `Agent` spawn returns `{ agent_id, … }`).
+ * Returns null when no exact id is present (e.g. a synchronous spawn whose result is the final answer
+ * text) — the caller then renders the pill uncolored, unchanged from today.
+ */
+export function resolveAgentIdFromCall(
+  parsedArgs: Record<string, unknown> | null,
+  resultText: string | null | undefined
+): string | null {
+  const fromArgs = firstStringField(parsedArgs, ['agent_id', 'agentId']);
+  if (fromArgs) return fromArgs;
+  if (resultText) {
+    try {
+      const parsed = JSON.parse(resultText) as unknown;
+      if (parsed && typeof parsed === 'object') {
+        return firstStringField(parsed as Record<string, unknown>, ['agent_id', 'agentId']);
+      }
+    } catch {
+      /* result is not JSON (e.g. a synchronous spawn's answer text) — no exact id available */
+    }
+  }
+  return null;
+}

--- a/samples/LmStreaming.Sample/PromptExamples.md
+++ b/samples/LmStreaming.Sample/PromptExamples.md
@@ -147,6 +147,55 @@ Expected behavior:
 
 ---
 
+## Sub-Agent Tabs (center-pane, colored)
+
+Drive the **center-pane tab strip**: a sub-agent conversation opens as a tab next to `main`, each
+sub-agent is assigned a stable color (in discovery order — 1st sub-agent → hue 0, 2nd → hue 1, …) that
+tints **both its tab and its inline `Agent`/`SendMessage` call pills** in the parent conversation.
+Selecting a tab swaps the center pane to that child's transcript; `main` returns to the parent.
+
+Requires `test` / `test-anthropic` mode and **General Assistant** (Agent + calculate wired). Prefer
+`run_in_background: true` so each spawn returns a receipt immediately (its `agent_id` lets the pill
+resolve its color exactly) and the child's transcript persists as the tab's replay source.
+
+**Authoring tip:** build these nested-chain prompts with `JSON.stringify` rather than hand-escaping —
+`playwright-scripts/subagent-tabs.mjs` constructs the exact prompt below programmatically, so the
+inner-quote escaping (`\"`) and literal `<|instruction_start|>` tags are correct by construction.
+
+### Two sub-agents → two distinct colored tabs (validated)
+
+One parent turn spawns **two** background sub-agents (`alpha` = a researcher that replies with text;
+`beta` = a general-purpose worker that runs `calculate` then replies). Two colored tabs (`alpha`,
+`beta`) appear alongside `main`; both inline `Agent` pills are tinted to match their tab.
+
+<|instruction_start|>{"instruction_chain":[{"id":"spawn-two","id_message":"Spawn two background workers","messages":[{"tool_call":[{"name":"Agent","args":{"subagent_type":"researcher","name":"alpha","run_in_background":true,"prompt":"<|instruction_start|>{\"instruction_chain\":[{\"id\":\"a1\",\"messages\":[{\"text\":\"Alpha reporting: I found three fresh AI papers today.\"}]}]}<|instruction_end|>"}},{"name":"Agent","args":{"subagent_type":"general-purpose","name":"beta","run_in_background":true,"prompt":"<|instruction_start|>{\"instruction_chain\":[{\"id\":\"b1\",\"messages\":[{\"tool_call\":[{\"name\":\"calculate\",\"args\":{\"a\":40,\"operation\":\"add\",\"b\":2}}]}]},{\"id\":\"b2\",\"messages\":[{\"text\":\"Beta reporting: 40 + 2 = 42.\"}]}]}<|instruction_end|>"}}]}]},{"id":"parent-done","id_message":"Wrap up","messages":[{"text":"Spawned alpha and beta in the background."}]}]}<|instruction_end|>
+
+Expected UI:
+1. Within ~3s (the sub-agent poll) a `main` tab plus an `alpha` and a `beta` tab appear; the two
+   sub-agent tab dots have **different** colors.
+2. In the parent conversation, each `Agent` tool-call pill has a colored **left border** matching its
+   tab (background spawns resolve the exact `agent_id` from the receipt). The two
+   `Sub-agent completed ← Agent …` notification pills are tinted the same way.
+3. Click `alpha` → the center pane shows alpha's transcript ("Alpha reporting: …"); click `beta` →
+   beta's transcript (its `calculate 40 add 2 = 42` pill + "Beta reporting: 40 + 2 = 42."); click
+   `main` → back to the parent conversation.
+
+Known cosmetic quirk (pre-existing, not tab-specific): a sub-agent's own *user* message renders the
+raw nested `<|instruction_start|>…` chain (the parent hides it as "Test instruction sent"; the
+sub-agent transcript does not).
+
+### Richer per-tab transcript (reasoning + multiple tools + text)
+
+A single background sub-agent whose nested chain reasons, calls two tools, then summarizes — so its
+tab holds a substantial transcript (a MetadataPill with a thinking row + two tool pills, then text).
+
+<|instruction_start|>{"instruction_chain":[{"id":"spawn-analyst","id_message":"Spawn a background analyst","messages":[{"tool_call":[{"name":"Agent","args":{"subagent_type":"general-purpose","name":"analyst","run_in_background":true,"prompt":"<|instruction_start|>{\"instruction_chain\":[{\"id\":\"r1\",\"reasoning\":{\"length\":30},\"messages\":[{\"tool_call\":[{\"name\":\"get_weather\",\"args\":{\"location\":\"Tokyo\"}}]}]},{\"id\":\"r2\",\"messages\":[{\"tool_call\":[{\"name\":\"calculate\",\"args\":{\"a\":18,\"operation\":\"multiply\",\"b\":2}}]}]},{\"id\":\"r3\",\"messages\":[{\"text\":\"Analyst: Tokyo checked, 18x2=36. Analysis complete.\"}]}]}<|instruction_end|>"}}]}]},{"id":"analyst-ack","id_message":"Wrap up","messages":[{"text":"Analyst spawned in the background."}]}]}<|instruction_end|>
+
+The browser-observable slice of the two-tab scenario is locked in CI by
+`tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/SubAgentTabsTests.cs`.
+
+---
+
 ## Wait / Trigger (Park-and-Wake)
 
 Requires `test` or `test-anthropic` mode. The `Wait` / `CancelWait` / `ListWaits` tools are wired into

--- a/samples/LmStreaming.Sample/playwright-scripts/subagent-tabs.mjs
+++ b/samples/LmStreaming.Sample/playwright-scripts/subagent-tabs.mjs
@@ -1,0 +1,148 @@
+// subagent-tabs.mjs — single-call Playwright smoke check for sub-agent CENTER-PANE TABS.
+// Runs the WHOLE flow in ONE call and returns structured JSON:
+//
+//   browser_run_code_unsafe({ filename: "samples/LmStreaming.Sample/playwright-scripts/subagent-tabs.mjs" })
+//
+// Returns { pass, failures, steps }. Assert only DETERMINISTIC, browser-observable state.
+//
+// A parent BACKGROUND-spawns two named sub-agents (alpha, beta) via the Agent tool; each nested chain
+// (built with JSON.stringify so the escaping rule is handled automatically — inner tags stay literal,
+// inner quotes get escaped) drives that child and persists its transcript. The feature under test:
+//   1. a `main` tab plus one colored tab per sub-agent appears in the center tab strip (via the poll)
+//   2. the two sub-agent tabs get DISTINCT assigned colors (dots differ)
+//   3. selecting a tab switches the center pane to that child's persisted transcript
+//   4. the parent's inline Agent-call pills are tinted (colored left border) to match their tab
+//   5. selecting `main` returns to the parent conversation (sub-agent view unmounts)
+//
+// Prompt format = PromptExamples.md → "Sub-Agent Delegation" + "Multiple sub-agents → colored tabs".
+// Uses the MOCK provider `test-anthropic`. BASE: this repo's .env sets ASPNETCORE_URLS=:5055 (default
+// sample port is :5000) — adjust if yours differs.
+async (page) => {
+  const BASE = 'http://localhost:5055';
+  const PROVIDER = 'test-anthropic';
+  const SHOT_DIR = 'B:/sources/LmDotnetTools/.worktrees/WT3/.logs/manual';
+
+  // Build the parent prompt programmatically so the nested-chain escaping is correct by construction.
+  const innerAlpha = JSON.stringify({
+    instruction_chain: [
+      { id: 'a1', messages: [{ text: 'Alpha reporting: I found three fresh AI papers today.' }] },
+    ],
+  });
+  const innerBeta = JSON.stringify({
+    instruction_chain: [
+      { id: 'b1', messages: [{ tool_call: [{ name: 'calculate', args: { a: 40, operation: 'add', b: 2 } }] }] },
+      { id: 'b2', messages: [{ text: 'Beta reporting: 40 + 2 = 42.' }] },
+    ],
+  });
+  const parent = {
+    instruction_chain: [
+      {
+        id: 'spawn-two',
+        id_message: 'Spawn two background workers',
+        messages: [
+          {
+            tool_call: [
+              { name: 'Agent', args: { subagent_type: 'researcher', name: 'alpha', run_in_background: true, prompt: `<|instruction_start|>${innerAlpha}<|instruction_end|>` } },
+              { name: 'Agent', args: { subagent_type: 'general-purpose', name: 'beta', run_in_background: true, prompt: `<|instruction_start|>${innerBeta}<|instruction_end|>` } },
+            ],
+          },
+        ],
+      },
+      { id: 'parent-done', id_message: 'Wrap up', messages: [{ text: 'Spawned alpha and beta in the background.' }] },
+    ],
+  };
+  const PROMPT = `<|instruction_start|>${JSON.stringify(parent)}<|instruction_end|>`;
+
+  const steps = [];
+  const record = (name, pass, detail) => steps.push({ name, pass, detail });
+  const tid = (id) => page.locator(`[data-testid="${id}"]`);
+  const shot = (name) => page.screenshot({ path: `${SHOT_DIR}/${name}.png` }).catch(() => {});
+  const waitIdle = async () => {
+    await tid('stop-button').waitFor({ state: 'hidden', timeout: 90000 });
+    await tid('send-button').waitFor({ state: 'visible', timeout: 90000 });
+  };
+  const send = async (text) => {
+    await tid('chat-input-textarea').fill(text);
+    await tid('send-button').click();
+  };
+  const subTabs = () => page.locator('[data-testid="conversation-tab"]:not([data-tab-id="main"])');
+  // computed dot color for a sub-agent tab, keyed by label text
+  const dotColorByLabel = (label) =>
+    page.evaluate((lbl) => {
+      const tabs = [...document.querySelectorAll('[data-testid="conversation-tab"]')];
+      const tab = tabs.find((t) => t.textContent.trim().includes(lbl));
+      const dot = tab?.querySelector('.conversation-tab__dot');
+      return dot ? getComputedStyle(dot).backgroundColor : null;
+    }, label);
+
+  try {
+    await page.goto(BASE);
+    await tid('chat-input-textarea').waitFor({ timeout: 20000 });
+
+    // Fresh chat on the mock provider (General Assistant is the default mode → Agent + calculate wired).
+    // Clear first so this box is isolated from any prior/concurrent conversation content on this dev host.
+    await page.getByRole('button', { name: '+ New Chat' }).click();
+    await tid('clear-button').click().catch(() => {});
+    await tid('provider-selector-button').click();
+    await tid(`provider-option-${PROVIDER}`).click();
+
+    // 1. Spawn two background sub-agents; wait for the run to settle.
+    await send(PROMPT);
+    await waitIdle();
+
+    // 2. Two sub-agent tabs appear (poll every 3s) alongside `main`.
+    await subTabs().nth(1).waitFor({ state: 'attached', timeout: 20000 });
+    const labels = (await subTabs().allInnerTexts()).map((t) => t.trim());
+    record('two sub-agent tabs appear (alpha, beta)',
+      labels.length === 2 && labels.some((l) => l.includes('alpha')) && labels.some((l) => l.includes('beta')),
+      { labels });
+    await shot('01-tabs-on-main');
+
+    // 3. The two tabs get DISTINCT assigned colors.
+    const [alphaDot, betaDot] = [await dotColorByLabel('alpha'), await dotColorByLabel('beta')];
+    record('sub-agent tabs have distinct colors', !!alphaDot && !!betaDot && alphaDot !== betaDot, { alphaDot, betaDot });
+
+    // 4. The two sub-agent tab colors each appear as an inline Agent-call pill border in the parent
+    //    conversation — proving the inline calls are tinted to MATCH their tabs. (Robust to any stale
+    //    uncolored Agent pills from unrelated conversation content on a shared dev host.)
+    const pillBorders = await page.evaluate(() =>
+      [...document.querySelectorAll('[data-testid="main-view"] [data-testid="tool-call-pill"][data-tool-name="Agent"]')]
+        .map((p) => getComputedStyle(p).borderLeftColor));
+    record('inline Agent pills tinted to match tabs',
+      pillBorders.includes(alphaDot) && pillBorders.includes(betaDot),
+      { pillBorders, alphaDot, betaDot });
+
+    // 5. Selecting the alpha tab shows alpha's persisted transcript (exact match so the sub-agent's
+    //    raw user-prompt <p> — which also contains this phrase — doesn't create a strict-mode clash).
+    await subTabs().filter({ hasText: 'alpha' }).first().click();
+    await tid('subagent-view').waitFor({ state: 'visible', timeout: 10000 });
+    await tid('subagent-transcript')
+      .getByText('Alpha reporting: I found three fresh AI papers today.', { exact: true })
+      .first()
+      .waitFor({ timeout: 20000 });
+    record('alpha tab shows alpha transcript', true);
+    await shot('02-alpha-tab');
+
+    // 6. Selecting the beta tab swaps to beta's transcript (calculate → text).
+    await subTabs().filter({ hasText: 'beta' }).first().click();
+    await tid('subagent-transcript')
+      .getByText('Beta reporting: 40 + 2 = 42.', { exact: true })
+      .first()
+      .waitFor({ timeout: 20000 });
+    record('beta tab shows beta transcript', true);
+    await shot('03-beta-tab');
+
+    // 7. Back to main: the parent conversation is shown; the sub-agent view unmounts.
+    await page.locator('[data-testid="conversation-tab"][data-tab-id="main"]').click();
+    await tid('main-view').waitFor({ state: 'visible', timeout: 10000 });
+    const subViewCount = await tid('subagent-view').count();
+    record('main tab returns to parent (sub-agent view unmounts)', subViewCount === 0, { subViewCount });
+    await shot('04-back-to-main');
+  } catch (e) {
+    record('exception', false, String((e && e.stack) || e));
+    await shot('99-error');
+  }
+
+  const failures = steps.filter((s) => !s.pass).map((s) => s.name);
+  return { pass: failures.length === 0, failures, steps };
+}

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Infrastructure/UiHelpers.cs
@@ -182,6 +182,30 @@ public static class UiHelpers
         await page.SendButton().ClickAsync();
     }
 
+    /// <summary>The center-pane conversation tab strip (rendered only when ≥1 sub-agent exists).</summary>
+    public static ILocator ConversationTabs(this IPage page)
+    {
+        return page.GetByTestId("conversation-tabs");
+    }
+
+    /// <summary>A single conversation tab — pass the tab id (<c>main</c> or an agentId via <c>data-tab-id</c>).</summary>
+    public static ILocator ConversationTab(this IPage page, string tabId)
+    {
+        return page.Locator($"[data-testid=\"conversation-tab\"][data-tab-id=\"{tabId}\"]");
+    }
+
+    /// <summary>All sub-agent tabs (every conversation tab except the always-present <c>main</c> tab).</summary>
+    public static ILocator SubAgentTabs(this IPage page)
+    {
+        return page.Locator("[data-testid=\"conversation-tab\"]:not([data-tab-id=\"main\"])");
+    }
+
+    /// <summary>The center-pane sub-agent view (mounted only while a sub-agent tab is active).</summary>
+    public static ILocator SubAgentView(this IPage page)
+    {
+        return page.GetByTestId("subagent-view");
+    }
+
     /// <summary>Header button that opens the marketplace browser modal.</summary>
     public static ILocator MarketplaceButton(this IPage page)
     {

--- a/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/SubAgentTabsTests.cs
+++ b/tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/SubAgentTabsTests.cs
@@ -1,0 +1,176 @@
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.LmTestUtils.TestMode;
+using FluentAssertions;
+using LmStreaming.Sample.Browser.E2E.Tests.Infrastructure;
+
+namespace LmStreaming.Sample.Browser.E2E.Tests.Scenarios;
+
+/// <summary>
+/// Center-pane sub-agent TABS (#tabbed-subagents). A parent spawns a background sub-agent; once the
+/// 3s poll surfaces it, a colored tab appears in the center tab strip, and selecting it switches the
+/// center pane to that sub-agent's persisted transcript (the main view stays mounted underneath).
+/// </summary>
+/// <remarks>
+/// This deliberately exercises only the DETERMINISTIC path the focus feature relies on — viewing a
+/// COMPLETED child: the tab is driven by the <c>ListSubAgents</c> poll, and its transcript loads from
+/// the persisted child thread over REST (both proven deterministic by the API-level
+/// <c>SubAgentFocusFlowTests</c>). It does NOT race a live focus against a still-running child; that
+/// raciness is why the composable/router logic is otherwise covered by vitest.
+/// </remarks>
+[Collection(PlaywrightCollection.Name)]
+public sealed class SubAgentTabsTests
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public SubAgentTabsTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Theory]
+    [InlineData("test")]
+    [InlineData("test-anthropic")]
+    public async Task Sub_agent_gets_a_center_tab_that_shows_its_transcript(string providerMode)
+    {
+        const string ResearcherMarker = "You are the research sub-agent";
+        const string ResearcherAnswer = "Found three fresh AI papers today.";
+
+        var responder = ScriptedSseResponder
+            .New()
+            .ForRole("researcher", ctx => ctx.SystemPromptContains(ResearcherMarker))
+            .Turn(t => t.Text(ResearcherAnswer))
+            .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
+            // Background spawn: the Agent call returns a receipt immediately and the child runs
+            // out-of-band, persisting its transcript under subagent-{agentId} (the tab replay source).
+            .Turn(t => t.ToolCall(
+                "Agent",
+                new { subagent_type = "researcher", prompt = "Find AI papers", run_in_background = true }))
+            .Turn(t => t.Text("Kicked off the researcher in the background."))
+            .Build();
+
+        await using var session = await _fixture.OpenAsync(
+            providerMode,
+            responder.HandlerFor(providerMode),
+            subAgentFactory: (_, providerAgentFactory) =>
+                new SubAgentOptions
+                {
+                    Templates = new Dictionary<string, SubAgentTemplate>
+                    {
+                        ["researcher"] = new SubAgentTemplate
+                        {
+                            Name = "Researcher",
+                            SystemPrompt = ResearcherMarker,
+                            AgentFactory = providerAgentFactory,
+                            MaxTurnsPerRun = 5,
+                        },
+                    },
+                    MaxConcurrentSubAgents = 5,
+                }
+        );
+        var page = session.Page;
+
+        await page.SendMessageAsync("research AI papers for me");
+        await page.WaitForStreamIdleAsync(timeoutMs: 30_000);
+
+        // The poll (every 3s) surfaces the spawned child as a sub-agent tab alongside the `main` tab.
+        await page.SubAgentTabs().WaitForCountAtLeastAsync(1, timeoutMs: 20_000);
+        (await page.ConversationTabs().IsVisibleAsync()).Should().BeTrue("the tab strip appears once a sub-agent exists");
+        await page.ConversationTab("main").WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Attached });
+        await page.SubAgentTabs().First.WaitForTextContainsAsync("research", timeoutMs: 20_000);
+
+        // Selecting the sub-agent tab switches the center pane to that child's persisted transcript.
+        await page.SubAgentTabs().First.ClickAsync();
+        await page.SubAgentView().WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible });
+        await page.GetByTestId("subagent-transcript").WaitForTextContainsAsync(ResearcherAnswer, timeoutMs: 20_000);
+
+        // Selecting `main` returns to the parent conversation; the sub-agent view unmounts.
+        await page.ConversationTab("main").ClickAsync();
+        await page.GetByTestId("main-view").WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible });
+        (await page.SubAgentView().CountAsync()).Should().Be(0, "the sub-agent view unmounts when main is active");
+
+        await session.SaveSuccessScreenshotAsync($"SubAgentTabs.Sub_agent_gets_a_center_tab_{providerMode}");
+    }
+
+    /// <summary>
+    /// Two sub-agents each get their OWN center tab with a DISTINCT assigned color, and that color also
+    /// tints the sub-agent's inline <c>Agent</c> call pill in the parent conversation. Switching tabs
+    /// swaps the center pane to the matching child's transcript. Mirrors the validated manual run
+    /// <c>playwright-scripts/subagent-tabs.mjs</c>.
+    /// </summary>
+    [Theory]
+    [InlineData("test")]
+    [InlineData("test-anthropic")]
+    public async Task Two_sub_agents_get_distinct_colored_tabs(string providerMode)
+    {
+        const string AlphaMarker = "You are the ALPHA research sub-agent";
+        const string BetaMarker = "You are the BETA math sub-agent";
+        const string AlphaAnswer = "Alpha reporting: I found three fresh AI papers today.";
+        const string BetaAnswer = "Beta reporting: the answer is 42.";
+
+        // Two background spawns in successive parent turns (each returns a receipt immediately, so the
+        // parent loop advances), then a wrap-up. Each child is scripted by its distinct system-prompt role.
+        var responder = ScriptedSseResponder
+            .New()
+            .ForRole("alpha", ctx => ctx.SystemPromptContains(AlphaMarker))
+            .Turn(t => t.Text(AlphaAnswer))
+            .ForRole("beta", ctx => ctx.SystemPromptContains(BetaMarker))
+            .Turn(t => t.Text(BetaAnswer))
+            .ForRole("parent", ctx => ctx.SystemPromptContains("helpful assistant"))
+            .Turn(t => t.ToolCall("Agent", new { subagent_type = "alpha", name = "alpha", run_in_background = true, prompt = "go alpha" }))
+            .Turn(t => t.ToolCall("Agent", new { subagent_type = "beta", name = "beta", run_in_background = true, prompt = "go beta" }))
+            .Turn(t => t.Text("Spawned alpha and beta in the background."))
+            .Build();
+
+        await using var session = await _fixture.OpenAsync(
+            providerMode,
+            responder.HandlerFor(providerMode),
+            subAgentFactory: (_, providerAgentFactory) =>
+                new SubAgentOptions
+                {
+                    Templates = new Dictionary<string, SubAgentTemplate>
+                    {
+                        ["alpha"] = new SubAgentTemplate { Name = "alpha", SystemPrompt = AlphaMarker, AgentFactory = providerAgentFactory, MaxTurnsPerRun = 5 },
+                        ["beta"] = new SubAgentTemplate { Name = "beta", SystemPrompt = BetaMarker, AgentFactory = providerAgentFactory, MaxTurnsPerRun = 5 },
+                    },
+                    MaxConcurrentSubAgents = 5,
+                }
+        );
+        var page = session.Page;
+
+        await page.SendMessageAsync("spawn two background workers");
+        await page.WaitForStreamIdleAsync(timeoutMs: 30_000);
+
+        // Two sub-agent tabs (alpha, beta) appear alongside main.
+        await page.SubAgentTabs().WaitForCountAtLeastAsync(2, timeoutMs: 20_000);
+        var labels = (await page.SubAgentTabs().AllInnerTextsAsync()).Select(l => l.Trim()).ToList();
+        labels.Should().HaveCount(2);
+        labels.Should().Contain(l => l.Contains("alpha"));
+        labels.Should().Contain(l => l.Contains("beta"));
+
+        // Each tab dot gets a DISTINCT assigned color.
+        var dotColors = await page.EvaluateAsync<string[]>(
+            "() => Array.from(document.querySelectorAll(\"[data-testid='conversation-tab']:not([data-tab-id='main']) .conversation-tab__dot\")).map(d => getComputedStyle(d).backgroundColor)");
+        dotColors.Should().HaveCount(2);
+        dotColors.Distinct().Should().HaveCount(2, "each sub-agent tab gets a distinct color");
+
+        // Each tab color also tints its inline Agent call pill in the parent conversation.
+        var pillBorders = await page.EvaluateAsync<string[]>(
+            "() => Array.from(document.querySelectorAll(\"[data-testid='main-view'] [data-testid='tool-call-pill'][data-tool-name='Agent']\")).map(p => getComputedStyle(p).borderLeftColor)");
+        foreach (var color in dotColors)
+        {
+            pillBorders.Should().Contain(color, "the sub-agent's inline Agent pill is tinted to match its tab");
+        }
+
+        // Selecting each tab swaps the center pane to that child's transcript.
+        await page.SubAgentTabs().Filter(new LocatorFilterOptions { HasText = "alpha" }).First.ClickAsync();
+        await page.SubAgentView().WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible });
+        await page.GetByTestId("subagent-transcript").GetByText(AlphaAnswer, new LocatorGetByTextOptions { Exact = true })
+            .First.WaitForAsync(new LocatorWaitForOptions { Timeout = 20_000 });
+
+        await page.SubAgentTabs().Filter(new LocatorFilterOptions { HasText = "beta" }).First.ClickAsync();
+        await page.GetByTestId("subagent-transcript").GetByText(BetaAnswer, new LocatorGetByTextOptions { Exact = true })
+            .First.WaitForAsync(new LocatorWaitForOptions { Timeout = 20_000 });
+
+        await session.SaveSuccessScreenshotAsync($"SubAgentTabs.Two_sub_agents_distinct_colors_{providerMode}");
+    }
+}


### PR DESCRIPTION
## Summary

Sub-agent conversations now open as **tabs in the center conversation pane** of `LmStreaming.Sample`,
each with a deterministic color used on its tab and its inline calls. The right-side panel is kept as
a compact launcher, per-tab reply is preserved, and the main chat behaves exactly as before.
**Frontend-only — no backend/API changes.**

## What changed

- **Center tab strip** (`ConversationTabs.vue`): a `main` tab plus one tab per sub-agent
  (label `name || template`); clicking switches the center pane. Hidden when there are no sub-agents.
- **Colors** (`agentColors.ts`): client-only, assigned in discovery order, applied to the tab and to
  the sub-agent's inline calls — the Agent-family `ToolPill` and the completion `NotificationPill` —
  resolved by **exact `agent_id`** and made reactive so a color assigned on a later poll still appears.
- **`useConversationTabs.ts`**: a pure selector/router that *receives* the `useChat` / `useSubAgentPanel`
  surfaces (owns only `activeTabId` + the color map), routing tab selection to `focusChild`/`unfocusChild`.
- **Right panel -> launcher** (`SubAgentListPanel.vue`): stateless list that activates the center tab.
- **Sub-agent view** (`SubAgentTranscript.vue`): relocates the transcript + reply input + error banner
  into the center, with a child-scoped tool-result `provide`.
- **`ChatLayout.vue`**: hoists `useSubAgentPanel`, keeps the main view mounted (`v-show`) so its
  scroll/stream/pill state survives tab switches, and mounts the sub-agent view on demand (`v-if`).

## Testing

- **641 vitest** green (new: `agentColors`, `useConversationTabs`, `ConversationTabs`,
  `SubAgentTranscript`; updated launcher + relocated sub-agent error assertion; a reactivity guard).
- `vue-tsc` type-check clean; production build clean; Husky `format-verify` hook passed.
- **Browser E2E**: new `SubAgentTabsTests` (single-spawn tab + two-sub-agent distinct colors, x2 mock
  providers) and the 6 existing sub-agent scenarios — all green.
- **Manual headed Playwright** run (`playwright-scripts/subagent-tabs.mjs`): 6/6 checks (two colored
  tabs, inline pills matching the tabs, per-tab transcript switching).

## Notes

- Branch is based on the current worktree HEAD (a few commits behind `main`) but has **zero file
  overlap** with the newer `main` commits, so it merges cleanly.
- Known pre-existing cosmetic gap (not introduced here): a sub-agent's own *user* message renders the
  raw `<|instruction_start|>...` chain in its transcript (the main view hides it). Can be a follow-up.

## Related Issues

Fixes #220
