### PR TITLE
fix(daemon): stop empty-review spam from GitHub reply guidance

### DIFF
--- a/samples/CodeReviewDaemon.Sample/Prompts/daemon-prompts.yaml
+++ b/samples/CodeReviewDaemon.Sample/Prompts/daemon-prompts.yaml
@@ -75,15 +75,21 @@ review:
          Never post multiple reviews, never one review per finding, and NEVER submit an EMPTY review (no comments
          AND no meaningful body). If you have nothing new to post, post NOTHING at all.
        - FORBIDDEN — never create standalone review comments with POST .../pulls/{{ pr_number }}/comments (the
-         one-call-per-finding endpoint). GitHub wraps EVERY standalone review comment in its OWN empty-bodied
-         review, so that endpoint turns N findings into N empty reviews — the exact spam we are eliminating. The
-         ONLY write that carries findings is the single POST .../pulls/{{ pr_number }}/reviews above.
+         one-call-per-finding endpoint) and never reply with POST .../pulls/{{ pr_number }}/comments/{comment_id}/replies.
+         GitHub wraps EVERY write to either review-comment endpoint in its OWN submitted, empty-bodied review, so a
+         standalone comment OR a thread reply each turns into one empty review — the exact spam we are eliminating.
+         The ONLY write that carries findings is the single POST .../pulls/{{ pr_number }}/reviews above.
        - Do NOT use the code-reviewer:post-pr-review skill to POST on GitHub: it posts findings one-at-a-time via
          POST .../pulls/{{ pr_number }}/comments and produces exactly those empty reviews. Assemble all findings
          into the one batched POST /reviews call above and make it yourself.
-       To answer an OPEN review thread, reply IN-THREAD — the replies endpoint below ADDS to an existing thread
-       and does NOT create a new review, so it is fine (it is not the forbidden standalone-comment endpoint):
-         POST /repos/{{ gh_owner }}/{{ gh_repo }}/pulls/{{ pr_number }}/comments/{comment_id}/replies  body {"body":"<reply>"}
+       To ANSWER an OPEN review thread (a prior finding you are replying to), do NOT use the /replies endpoint —
+       it makes an empty review (see above). Instead fold your answer into the SAME single batched POST /reviews:
+       add a comments[] entry anchored to that thread's file+line whose body opens by naming the thread it answers
+       (e.g. "Re: <finding> —"). A PR-CONVERSATION issue comment (a question in the PR's main conversation, not on a
+       code line — its id is an issue-comment id, not a review-comment id, so it CANNOT be answered on any review
+       endpoint) is answered EITHER by a line in the POST /reviews summary body OR by ONE wrapper-free comment:
+         POST /repos/{{ gh_owner }}/{{ gh_repo }}/issues/{{ pr_number }}/comments  body {"body":"<answer>"}
+       That issues endpoint is a PR-conversation comment, not a review, so it never creates an empty review.
        {{ end ~}}
        On a re-review, the review input includes a "## Already posted on this PR" section: the existing
        discussion FROM ALL AUTHORS (other bots, humans, and you), grouped into threads (a finding + its replies)

--- a/samples/CodeReviewDaemon.Sample/Prompts/daemon-prompts.yaml
+++ b/samples/CodeReviewDaemon.Sample/Prompts/daemon-prompts.yaml
@@ -82,12 +82,20 @@ review:
        - Do NOT use the code-reviewer:post-pr-review skill to POST on GitHub: it posts findings one-at-a-time via
          POST .../pulls/{{ pr_number }}/comments and produces exactly those empty reviews. Assemble all findings
          into the one batched POST /reviews call above and make it yourself.
-       To ANSWER an OPEN review thread (a prior finding you are replying to), do NOT use the /replies endpoint —
-       it makes an empty review (see above). Instead fold your answer into the SAME single batched POST /reviews:
-       add a comments[] entry anchored to that thread's file+line whose body opens by naming the thread it answers
-       (e.g. "Re: <finding> —"). A PR-CONVERSATION issue comment (a question in the PR's main conversation, not on a
-       code line — its id is an issue-comment id, not a review-comment id, so it CANNOT be answered on any review
-       endpoint) is answered EITHER by a line in the POST /reviews summary body OR by ONE wrapper-free comment:
+       comments[] carries NEW findings on lines in THIS PR's diff ONLY — it CANNOT reply in-thread and must NOT be
+       used to answer a prior thread. The batched POST /reviews comments[] array has NO in_reply_to field, so an
+       entry placed at an old thread's file+line does NOT continue that thread — GitHub opens a brand-new top-level
+       thread there (a "Re:" prefix is just text), the original stays open, and if that old line is no longer in the
+       diff the whole review 422s and NOTHING posts. There is no REST way to reply inside an existing thread without
+       an empty-review wrapper, so do not try to fake one.
+       To ANSWER an OPEN review thread (a prior finding you are replying to), do NOT use the /replies endpoint (it
+       makes an empty review, see above) and do NOT anchor a comments[] entry to that thread. Put your answer in the
+       POST /reviews SUMMARY BODY instead — one line per thread, naming the thread it answers (e.g. "Re: <finding> —
+       fixed in <sha>"). That body ships inside the same single non-empty review (which also carries your new
+       comments[] findings), so it costs no extra review and creates no empty one. A PR-CONVERSATION issue comment (a
+       question in the PR's main conversation, not on a code line — its id is an issue-comment id, not a
+       review-comment id, so it CANNOT be answered on any review endpoint) is answered EITHER by a line in that same
+       summary body OR by ONE wrapper-free comment:
          POST /repos/{{ gh_owner }}/{{ gh_repo }}/issues/{{ pr_number }}/comments  body {"body":"<answer>"}
        That issues endpoint is a PR-conversation comment, not a review, so it never creates an empty review.
        {{ end ~}}

--- a/tests/CodeReviewDaemon.Sample.Tests/Scenarios/DaemonAgentFactoryTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Scenarios/DaemonAgentFactoryTests.cs
@@ -216,6 +216,24 @@ public sealed class DaemonAgentFactoryTests
     }
 
     [Fact]
+    public void ReviewProfile_Prompt_RoutesGithubThreadAnswers_WithoutTheEmptyReviewSpammingRepliesEndpoint()
+    {
+        // Regression (empty-review spam, live #224): the old guidance told the agent that replying via
+        // POST /pulls/{pr}/comments/{comment_id}/replies "does NOT create a new review, so it is fine" — that
+        // is FALSE. GitHub wraps EACH reply in its own submitted, empty-bodied COMMENTED review (proven on #224:
+        // six replies → six empty reviews). The corrected GitHub guidance must (a) drop that false claim, (b)
+        // fold an answer to an open review thread into the SAME single batched POST /reviews as an inline
+        // comment (never the /replies endpoint), and (c) answer a PR-CONVERSATION issue comment via the
+        // wrapper-free POST /issues/{pr}/comments. Rendered with should_post=true and is_ado unset (a GitHub run).
+        var prompt = DaemonAgentFactory.CreateReviewProfile(
+            new Dictionary<string, object> { ["bot_name"] = "Revobot", ["should_post"] = true }).SystemPrompt;
+
+        prompt.Should().NotContain("does NOT create a new review"); // the false "replies are safe" claim is gone
+        prompt.Should().MatchRegex("(?is)replies.{0,200}empty"); // the /replies endpoint is now called out as empty-review spam
+        prompt.Should().Contain("issues/"); // PR-conversation answers route through the wrapper-free issue-comments endpoint
+    }
+
+    [Fact]
     public void ReviewProfile_Prompt_GroundsViaReadByPathAndAvoidsRootGlob()
     {
         // The gateway's Glob/Grep cannot enumerate the repo root reliably, so the reviewer must ground via

--- a/tests/CodeReviewDaemon.Sample.Tests/Scenarios/DaemonAgentFactoryTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Scenarios/DaemonAgentFactoryTests.cs
@@ -221,16 +221,36 @@ public sealed class DaemonAgentFactoryTests
         // Regression (empty-review spam, live #224): the old guidance told the agent that replying via
         // POST /pulls/{pr}/comments/{comment_id}/replies "does NOT create a new review, so it is fine" — that
         // is FALSE. GitHub wraps EACH reply in its own submitted, empty-bodied COMMENTED review (proven on #224:
-        // six replies → six empty reviews). The corrected GitHub guidance must (a) drop that false claim, (b)
-        // fold an answer to an open review thread into the SAME single batched POST /reviews as an inline
-        // comment (never the /replies endpoint), and (c) answer a PR-CONVERSATION issue comment via the
-        // wrapper-free POST /issues/{pr}/comments. Rendered with should_post=true and is_ado unset (a GitHub run).
+        // six replies → six empty reviews). The corrected GitHub guidance must (a) drop that false claim and (b)
+        // call out the /replies endpoint as empty-review spam. Rendered with should_post=true and is_ado unset.
         var prompt = DaemonAgentFactory.CreateReviewProfile(
             new Dictionary<string, object> { ["bot_name"] = "Revobot", ["should_post"] = true }).SystemPrompt;
 
         prompt.Should().NotContain("does NOT create a new review"); // the false "replies are safe" claim is gone
         prompt.Should().MatchRegex("(?is)replies.{0,200}empty"); // the /replies endpoint is now called out as empty-review spam
         prompt.Should().Contain("issues/"); // PR-conversation answers route through the wrapper-free issue-comments endpoint
+    }
+
+    [Fact]
+    public void ReviewProfile_Prompt_DoesNotClaimBatchedCommentsCanReplyInThread()
+    {
+        // Regression (PR #226 Must, comment 3651558773): the first #224 fix replaced the /replies endpoint with
+        // "fold your answer into the SAME single batched POST /reviews: add a comments[] entry anchored to that
+        // thread's file+line". That is ALSO wrong — the batched comments[] array has NO in_reply_to field, so an
+        // entry at the old path/line opens a NEW top-level thread (GitHubReviewCommentPublisher.ThreadIdOf groups
+        // it under its own id), leaving the original thread active; and an outdated original line 422s the whole
+        // batch. There is no REST way to reply in-thread without an empty-review wrapper, so the prompt must NOT
+        // claim comments[] answers/continues an existing thread. A prior-thread answer must route to the review
+        // SUMMARY BODY or the wrapper-free POST /issues/{pr}/comments; comments[] carries NEW in-diff findings only.
+        var prompt = DaemonAgentFactory.CreateReviewProfile(
+            new Dictionary<string, object> { ["bot_name"] = "Revobot", ["should_post"] = true }).SystemPrompt;
+
+        // The flawed "anchor a comments[] reply to the old thread's line" instruction must be gone.
+        prompt.Should().NotContain("anchored to that thread's file+line");
+        // The prompt must state comments[] cannot reply in-thread (no in_reply_to on the batched endpoint).
+        prompt.Should().MatchRegex("(?is)comments\\[\\].{0,160}(cannot|can't|does not|do not|no in_reply_to).{0,160}(thread|reply)");
+        // A prior-thread answer routes to the summary body or the wrapper-free issues endpoint, not a fake reply.
+        prompt.Should().MatchRegex("(?is)(summary body|issues/)");
     }
 
     [Fact]

--- a/tests/CodeReviewDaemon.Sample.Tests/Scenarios/GitHubReviewCommentPublisherTests.cs
+++ b/tests/CodeReviewDaemon.Sample.Tests/Scenarios/GitHubReviewCommentPublisherTests.cs
@@ -104,6 +104,32 @@ public sealed class GitHubReviewCommentPublisherTests : LoggingTestBase
     }
 
     [Fact]
+    public async Task PostReviewComment_never_uses_the_empty_review_spawning_review_comment_endpoints()
+    {
+        // API-level contract (regression, live #224): GitHub wraps EVERY write to a review-comment endpoint —
+        // standalone POST /pulls/{pr}/comments AND POST /pulls/{pr}/comments/{id}/replies — in its own submitted,
+        // empty-bodied COMMENTED review (six #224 replies produced six empty reviews). The host publisher must
+        // therefore post ONLY through the wrapper-free issue-comments endpoint. Prompt-text assertions cannot
+        // catch a regression here; this pins the actual HTTP the publisher emits.
+        var handler = new FakeHttpMessageHandler().OnJson(
+            HttpMethod.Post, "/issues/7/comments", """{"id":777}""", HttpStatusCode.Created);
+
+        await Publisher(handler).PostReviewCommentAsync(Target, Key, "## Review\nfinding", CancellationToken.None);
+
+        var post = handler.Requests.Should().ContainSingle(r => r.Method == HttpMethod.Post).Subject;
+        post.Uri.ToString().Should().Be(
+            "https://api.github.com/repos/acme/widgets/issues/7/comments",
+            "the only wrapper-free write is the issue-comments endpoint");
+        handler.Requests.Should().NotContain(
+            r => r.Uri.ToString().Contains("/replies", StringComparison.Ordinal),
+            "POST .../comments/{id}/replies wraps each reply in its own empty review — the #224 spam");
+        handler.Requests.Should().NotContain(
+            r => r.Uri.ToString().Contains("/pulls/", StringComparison.Ordinal)
+                && r.Uri.ToString().Contains("/comments", StringComparison.Ordinal),
+            "standalone POST /pulls/{pr}/comments also wraps each write in an empty review");
+    }
+
+    [Fact]
     public async Task ListExisting_returns_inline_findings_and_review_summaries()
     {
         var comments = JsonSerializer.Serialize(new object[]


### PR DESCRIPTION
## What

Fixes false GitHub reply guidance in the CodeReviewDaemon prompt that recreated the empty-review spam this pipeline is meant to eliminate — the last review comment on the now-merged #224.

## The bug

`daemon-prompts.yaml` told the review agent that answering an open thread via `POST /pulls/{pr}/comments/{comment_id}/replies` *"does NOT create a new review, so it is fine."* That is false.

GitHub wraps **every** write to a review-comment endpoint — both standalone `POST /pulls/{pr}/comments` **and** the `/comments/{id}/replies` endpoint — in its own submitted, empty-bodied `COMMENTED` review. On #224 the six in-thread replies produced **six empty reviews**, correlated 1:1 by `pull_request_review_id` — the exact spam the surrounding guardrail forbids.

Second defect on the same guidance: the replies endpoint **cannot** answer a PR-conversation issue comment, because those ids are issue-comment ids, not review-comment ids.

There is no GitHub endpoint that posts a true threaded reply without a review wrapper: the batched `POST /pulls/{pr}/reviews` accepts only `path/line/side/body` (no `in_reply_to`), and the only wrapper-free write on a PR is `POST /issues/{pr}/comments`.

## The fix

- **`daemon-prompts.yaml`** — drop the false "replies are safe" claim; add `/comments/{id}/replies` to the FORBIDDEN list beside standalone `/comments`; route an answer to an open review thread into the **same single batched `POST /reviews`** (an inline `comments[]` entry anchored to the thread's file+line), and route a PR-conversation issue-comment answer to the wrapper-free `POST /issues/{pr}/comments` (or the review summary body).
- **API-level contract test** (`GitHubReviewCommentPublisherTests`) — asserts the host publisher's write surface targets `/issues/{pr}/comments` only and **never** `/replies` or standalone `/pulls/{pr}/comments`. This is the finding's explicit requirement: prompt-text assertions cannot catch this regression, so the invariant is pinned at the HTTP level.
- **Prompt-model test** (`DaemonAgentFactoryTests`) — the rendered GitHub guidance no longer contains the false claim, flags `/replies` as empty-review spam, and routes issue-comment answers through the issues endpoint.

## Testing

- TDD RED→GREEN: the prompt-model test failed on the false guidance before the fix, passes after.
- Full `CodeReviewDaemon.Sample.Tests`: **613 passed** (was 611 + 2 new).
- `dotnet format whitespace` clean; husky format-verify passed on commit.

Addresses the outstanding `Must` finding from #224 (review comment 3651349038).
