### PR TITLE
feat(sample): serve every Copilot model through both the Anthropic and OpenAI APIs

### DIFF
--- a/docs/superpowers/plans/2026-07-27-copilot-proxy-bidirectional-api.md
+++ b/docs/superpowers/plans/2026-07-27-copilot-proxy-bidirectional-api.md
@@ -1,6 +1,6 @@
 # Copilot Proxy Bidirectional API Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> Steps use checkbox (`- [ ]`) syntax so progress can be tracked task-by-task.
 
 **Goal:** Let Claude Code, Codex CLI, and opencode each drive *any* GitHub Copilot model through `samples/CopilotAnthropicProxy.Sample`, regardless of which API dialect the client speaks.
 
@@ -29,7 +29,7 @@
 
 ## Deviations from the spec
 
-Two places where this plan intentionally does something other than what the spec's prose says. Both were reasoned out against the existing test suite; a reviewer should check the reasoning rather than the prose.
+Two places where this plan intentionally does something other than what the spec's prose says. Both were reasoned out against the existing test suite; the reasoning is recorded below, and it — not the spec's prose — is what these deviations rest on.
 
 ### D1 — `COPILOT_ANTHROPIC_MODEL` keeps its discovery short-circuit
 
@@ -53,9 +53,33 @@ Consequences, given a default of `claude-opus-4.8` (`/v1/messages` + `/chat/comp
 
 ---
 
-## Findings from the client wire-protocol research
+## Final decisions, recorded after implementation
 
-A background research agent mined the installed Claude Code 2.1.220 bundle, upstream Codex/opencode source, and the official specs. Items that change this plan are folded into the tasks below; recorded here so a reviewer knows they were considered rather than missed.
+The tasks below are kept as they were written and executed; these two points record where the shipped code deliberately ends up somewhere else. They are appended rather than edited into the task text so the history stays readable.
+
+### F1 — the default port stays `8787`
+
+Task 5 moves the default listen port from `8787` to `8788`, on the reasoning that the sample should be able to run beside an existing proxy on the old port. That was reversed before merge: `8787` is the port every existing client config, shell alias and note already points at, and changing it silently breaks all of them to buy a convenience nobody asked for. Anyone who genuinely needs two proxies at once sets `COPILOT_ANTHROPIC_PORT`, which has always existed.
+
+Shipped state: `ProxyConfig.FromEnvironment` falls back to `8787`, the sample README documents `8787` throughout, and `HostGuardTests`'s local `Port` constant — which was always `8787` — needs no exception. Every `8788` in Task 5's steps and in the client-configuration snippets below should be read as `8787`.
+
+### F2 — `COPILOT_ANTHROPIC_MODEL_ENDPOINTS` supplements D1
+
+D1's consequence — a pinned catalog entry carries no endpoint metadata, and "no metadata" routes as Anthropic-Messages-capable — turns out to have a sharper edge than D1 admits: pinning a Responses-ONLY model makes the translated route unreachable, so `COPILOT_ANTHROPIC_MODEL=gpt-5.3-codex` cannot be driven from Claude Code at all.
+
+Running discovery in pinned mode is still not an option, for exactly the reason D1 gives. Instead the operator can now supply the metadata discovery would have found:
+
+```bash
+export COPILOT_ANTHROPIC_MODEL=gpt-5.3-codex
+export COPILOT_ANTHROPIC_MODEL_ENDPOINTS=/responses
+```
+
+Unset, nothing changes: the pinned entry stays endpoint-free and behaves exactly as D1 describes. Absent metadata is deliberately not read as "serves everything" — inventing capabilities would make the proxy claim things nobody verified.
+
+---
+
+
+A background research pass mined the installed Claude Code 2.1.220 bundle, upstream Codex/opencode source, and the official specs. Items that change this plan are folded into the tasks below; the rest are recorded here as considered-and-set-aside rather than missed.
 
 **Folded in as requirements:**
 
@@ -3322,7 +3346,7 @@ Reuse the file's existing proxy-hosting helper for `PostProxyAsync`; add `PickRe
 dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj
 dotnet test tests/CopilotLive.Tests/CopilotLive.Tests.csproj
 ```
-Expected: the first passes; the second passes or skips cleanly when no Copilot credentials are present. If a live test fails, that is a real finding — fix the code, not the assertion.
+Expected: the first passes; the second passes or skips cleanly when no Copilot credentials are present. A live failure is evidence about the real backend, so the assertion describes something the code no longer does — the code is what needs to change.
 
 - [ ] **Step 4: Verify the whole solution still builds**
 

--- a/docs/superpowers/plans/2026-07-27-copilot-proxy-bidirectional-api.md
+++ b/docs/superpowers/plans/2026-07-27-copilot-proxy-bidirectional-api.md
@@ -1,0 +1,3353 @@
+# Copilot Proxy Bidirectional API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Claude Code, Codex CLI, and opencode each drive *any* GitHub Copilot model through `samples/CopilotAnthropicProxy.Sample`, regardless of which API dialect the client speaks.
+
+**Architecture:** The proxy already forwards Anthropic Messages traffic to Copilot byte-for-byte. Copilot's `/models` catalog says which transport each model actually serves (`/v1/messages`, `/chat/completions`, `/responses`). We widen the catalog to carry that metadata, add two new inbound routes (`/v1/chat/completions`, `/v1/responses`) that are also byte-for-byte passthroughs, and write exactly one real translator for the single quadrant Copilot cannot serve directly: **Anthropic Messages in → OpenAI Responses out**, for Responses-only GPT models. Translation is direct wire-to-wire JSON — it does not go through LmCore's `IMessage` types.
+
+**Tech Stack:** .NET 9, `Microsoft.NET.Sdk.Web` minimal APIs, `System.Text.Json` (`JsonNode` / `JsonDocument`), xUnit 2.9.3, FluentAssertions 7.1.0, `Microsoft.AspNetCore.Mvc.Testing` 9.0.0.
+
+## Global Constraints
+
+- **This is a sample, not production infrastructure.** Copied verbatim from the spec's purpose statement (the user's words): *"we just want to use this proxy to make claude, codex, open-code etc to work on top of all the models exposed through copilot backend APIs"*. When a choice is between "more correct in the abstract" and "fewer moving parts", pick fewer moving parts and write the limitation down.
+- **No changes to anything under `src/`.** The spec puts provider changes out of scope. The only `src/` types this plan *reads* are `CopilotModelsResponse` and `CopilotHttpClientFactory`, both already referenced by the sample.
+- **No hard-coded model ids anywhere in `samples/CopilotAnthropicProxy.Sample/`.** The live catalog gains and loses models (`claude-opus-5`, `gpt-5.6-*` appeared after the test fixture was captured). Everything is derived from `GET /models` at startup. Test fixtures may name ids; production code may not.
+- **Types in `samples/CopilotAnthropicProxy.Sample/` live in the global namespace.** `Program.cs` uses top-level statements with no `namespace` declaration, and the test project references `ProxyModelResolver` / `ProxyGuard` with no `using`. New files must follow suit — no `namespace` line.
+- **The sample does not expose internals to the test project.** There is no `InternalsVisibleTo` for `CopilotAnthropicProxy.Sample` anywhere in the repo (verified). `ProxyConfig` and `ProxyHttp` are `internal` and therefore *not* unit-testable; `ProxyModelResolver` and `ProxyGuard` are `public` and are. **Every new type this plan adds must be `public`** or it cannot be tested. Do not add `InternalsVisibleTo` — making the new types public is the smaller change.
+- **`EnforceCodeStyleInBuild=true`** in the sample csproj: IDE analyzer diagnostics are build errors. In particular `IDE0370` fires on a null-forgiving `!` the compiler can prove is redundant. Prefer `is` patterns over `!`.
+- **`dotnet format whitespace --verify-no-changes` gates every commit** via `.husky/pre-commit` → `.husky/task-runner.json`. If a commit is rejected for formatting, run `dotnet format whitespace LmDotnetTools.sln` and re-stage. Do **not** use `--no-verify`.
+- **Never fabricate SSE frames.** `ProxyHttp.CopyBodyAsync` already encodes this rule for mid-stream failures. The translator inherits it: if the upstream stream ends without a terminal event, emit nothing further and let the client observe the truncation. An empty *result* is fine (zero content blocks); an invented *frame* is not.
+- **Commit message style:** conventional commits (`feat:`, `fix:`, `test:`, `docs:`). **Never** add `Co-Authored-By` or any AI/Claude signature — this is a standing user instruction.
+- **Every task ends green.** The gate for all tasks is:
+  ```bash
+  dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj
+  ```
+  Tasks 1–9 must never leave that suite red between commits.
+
+---
+
+## Deviations from the spec
+
+Two places where this plan intentionally does something other than what the spec's prose says. Both were reasoned out against the existing test suite; a reviewer should check the reasoning rather than the prose.
+
+### D1 — `COPILOT_ANTHROPIC_MODEL` keeps its discovery short-circuit
+
+The spec says pinning should be "demoted to a fallback". This plan keeps the current behavior: when the env var is set, `ResolveAsync` returns immediately without calling `GET /models`.
+
+Why: `tests/CopilotAnthropicProxy.Tests/PassthroughTests.cs`'s `Idle_timeout_before_first_byte_returns_504_api_error` uses an upstream handler that answers *every* request with `await Task.Delay(Timeout.Infinite, ct)`. If the override ran discovery, startup would block on the 30-second `modelCts` in `Program.cs:139-160` and then fail the boot (`return 1`). It would also directly break `ModelResolverTests.ResolveAsync_returns_override_without_calling_upstream` (`:81`), whose handler throws if called.
+
+Consequence: in pinned mode the catalog holds one entry with an empty vendor and an empty endpoint list. Empty endpoints means "no metadata", which `ModelRouter` treats as Anthropic-Messages-capable — i.e. exactly today's behavior. This preserves spec success criterion 4 ("nothing that works today breaks"). The env var is opt-in and unset by default, so the multi-model routing the user actually wants is the default path.
+
+### D2 — an unrecognized model id still falls back to the catalog default
+
+The spec's routing table could be read as "unknown model → 404". This plan keeps `ModelDiscoveryPassthroughTests.Unrecognized_model_falls_back_to_the_discovered_default` (`:114`) green: `SelectOutboundModel` resolves an unknown id to the catalog default, and the *dialect* check then runs against the **resolved** model. A 404 happens only when the resolved model genuinely cannot serve the requested dialect.
+
+Consequences, given a default of `claude-opus-4.8` (`/v1/messages` + `/chat/completions`):
+
+| Route | Unknown id resolves to | Outcome |
+|---|---|---|
+| `/v1/messages` | default opus | passthrough (existing test stays green) |
+| `/v1/chat/completions` | default opus | passthrough — opus advertises `/chat/completions` |
+| `/v1/responses` | default opus | **404**, naming the models that do serve `/responses` |
+
+---
+
+## Findings from the client wire-protocol research
+
+A background research agent mined the installed Claude Code 2.1.220 bundle, upstream Codex/opencode source, and the official specs. Items that change this plan are folded into the tasks below; recorded here so a reviewer knows they were considered rather than missed.
+
+**Folded in as requirements:**
+
+1. **Claude Code's first request against any new model is a validation probe with `max_tokens: 1`** (`querySource:"model_validation"`, single `"Hi"` text block, `maxRetries:0`). The OpenAI Responses API rejects `max_output_tokens` below 16. Without a floor, *every* GPT model would be rejected by Claude Code before the user ever gets a turn. → **Task 6 clamps the outbound floor to 16.**
+2. That probe (and any truncated generation) can legitimately produce **zero content blocks**. The Anthropic envelope must still be well-formed. → **Task 7 and Task 8 both pin an empty-content case**, and neither fabricates a placeholder text block.
+3. **Claude Code always sends `system` as an array of `{type:"text", text}` blocks**, never a bare string. → **Task 6 treats the array form as the primary case** and still accepts the string form.
+4. **Haiku-tier side traffic shares the base URL.** `ANTHROPIC_SMALL_FAST_MODEL` / `ANTHROPIC_DEFAULT_HAIKU_MODEL` resolve against the same `ANTHROPIC_BASE_URL`, so conversation-title generation, auto-mode classification and summarization arrive as `claude-3-5-haiku-*`. Under a plain default-fallback those all bill against the default **opus** model. → **Task 3 adds family-aware fallback.**
+5. **Codex always sends `store:false` and resends full history each turn**, and Responses' default for `store` is `true`. The translated path is likewise stateless (Claude Code resends full history). → **Task 6 sets `store:false`.**
+
+**Safe by construction — pinned with a test, no code needed:**
+
+6. Claude Code puts betas in the request **body** as `betas:[...]` (≈29 of them) as well as in the `anthropic-beta` header, and `cache_control` carries `ttl` / `scope:"global"` sub-fields. The translator builds a fresh Responses body from an explicit allowlist of fields, so both are dropped by construction. (On the passthrough path they already ride through untouched, which is today's live-proven behavior.) → asserted in Task 6.
+7. Claude Code sends server tools such as `{type:"web_search_20250305", name:"web_search", max_uses:8}`, which Copilot rejects with `400 "The use of the web search tool is not supported."`. These blocks have no `input_schema`, and Task 6 maps only tools that have one — so they are dropped before they can 400 the request. → asserted in Task 6.
+8. `metadata.user_id` is always present. The translator never reads it, and nothing deserializes into a strict DTO, so it is ignored. No action.
+
+**Considered and deliberately rejected — see Known Limitations (Task 10):**
+
+9. **Re-minting tool ids to `toolu_[A-Za-z0-9_]+`.** Claude Code matches that regex when explaining tool-pairing failures, and Responses emits `call_…` / `fc_…`. The *functional* round-trip already works (we hand back whatever id we were given, and map it back verbatim), so the only gain is nicer text in a rare error path — while a lossy id sanitize would risk breaking the round-trip outright. Not worth it in a sample.
+10. **`stop_sequences` emulation.** Anthropic supports it; Responses has no equivalent parameter. Emulating it means truncating the output stream at a token boundary that can straddle SSE chunks. Claude Code only uses it for auto-mode classification, which targets the haiku tier — an Anthropic model, i.e. the passthrough path, where `stop_sequences` rides through untouched. Documented, not implemented.
+11. **Encrypted-reasoning continuity across tool loops.** Preserving GPT reasoning across turns needs `include:["reasoning.encrypted_content"]` plus smuggling the blob through Anthropic's `thinking.signature` field and back. Real work, real risk, and a sample does not need it. Reasoning summaries are surfaced as `thinking` blocks for display only.
+12. **A local `count_tokens` estimate for non-Anthropic models.** Claude Code degrades gracefully (it logs `countTokens API call failed` and falls back to a local estimate), so the existing Anthropic-only behavior stands unchanged.
+
+---
+
+## File Structure
+
+**Created**
+
+| File | Responsibility |
+|---|---|
+| `samples/CopilotAnthropicProxy.Sample/Translation/ModelRoute.cs` | `ProxyDialect`, `ProxyRouteKind`, `ModelRoute`, `ModelRouter` — pure routing decision. No I/O. |
+| `samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs` | Anthropic Messages request JSON → Responses request JSON. Pure function. |
+| `samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicJson.cs` | Non-streaming Responses response JSON → Anthropic Message JSON. Pure function. |
+| `samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicSse.cs` | Streaming Responses SSE → Anthropic SSE. Stateful per request; no I/O. |
+| `tests/CopilotAnthropicProxy.Tests/ModelRouteTests.cs` | Unit tests for `ModelRouter`. |
+| `tests/CopilotAnthropicProxy.Tests/OpenAiDialectTests.cs` | Integration tests for the two new passthrough routes. |
+| `tests/CopilotAnthropicProxy.Tests/AnthropicToResponsesRequestTests.cs` | Unit tests for the request translator. |
+| `tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicJsonTests.cs` | Unit tests for the non-streaming response translator. |
+| `tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicSseTests.cs` | Unit tests for the SSE state machine. |
+| `tests/CopilotAnthropicProxy.Tests/TranslatedMessagesTests.cs` | Integration tests for `/v1/messages` → `/responses`. |
+
+**Modified**
+
+| File | Change |
+|---|---|
+| `samples/CopilotAnthropicProxy.Sample/Program.cs` | Catalog reshape, family-aware fallback, new routes, dialect-shaped errors, models union, default port, translated branch. |
+| `samples/CopilotAnthropicProxy.Sample/README.md` | New endpoints, per-client configuration, port, known limitations. |
+| `tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs` | Retarget the catalog pins onto `ParseServableModels`. |
+| `tests/CopilotAnthropicProxy.Tests/ModelDiscoveryPassthroughTests.cs` | Widened `/v1/models` expectations. |
+| `tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs` | Live smoke for the new routes. |
+
+Everything in `Translation/` is a pure function or a pure state machine: no `HttpContext`, no `HttpClient`, no logging. That is what makes them unit-testable given the no-`InternalsVisibleTo` constraint, and it keeps `Program.cs` as the only file that knows about ASP.NET.
+
+---
+
+## Task 1: Catalog carries vendor and endpoints
+
+**Files:**
+- Modify: `samples/CopilotAnthropicProxy.Sample/Program.cs:401` (`ProxyModelCatalog`), `:412-444` (`ResolveAsync`), `:502-532` (`ParseMessagesCapableModelIds`), `:539-555` (`SelectOutboundModel`)
+- Test: `tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs`
+
+**Interfaces:**
+- Consumes: `CopilotModelsResponse.MessagesEndpoint` (`"/v1/messages"`), `.ResponsesEndpoint` (`"/responses"`), `.EnumerateModelEntries(JsonElement)`, `.HasSupportedEndpoints(JsonElement)`, `.SupportsEndpoint(JsonElement, string)`, `.GetString(JsonElement, string)` — all `public static` on `AchieveAi.LmDotnetTools.GithubCopilotProvider.Models.CopilotModelsResponse`.
+- Produces:
+  - `public sealed record ProxyModelInfo(string Id, string Vendor, IReadOnlyList<string> Endpoints)` with `bool Supports(string endpoint)` and `bool IsAnthropic { get; }`
+  - `public sealed record ProxyModelCatalog(string Default, IReadOnlyList<ProxyModelInfo> Models)` with `IReadOnlyList<string> Available { get; }` and `ProxyModelInfo? Find(string? id)`
+  - `public const string ProxyModelResolver.ChatCompletionsEndpoint = "/chat/completions"`
+  - `public static IReadOnlyList<ProxyModelInfo> ProxyModelResolver.ParseServableModels(string json)`
+  - `ProxyModelResolver.SelectOutboundModel(string?, ProxyModelCatalog)` keeps its signature.
+
+**Background — why the record is reshaped.** `ProxyModelCatalog` currently carries `IReadOnlyList<string> Available`: ids only. Every routing decision in this plan needs to know *which endpoints a model serves*, and the token-field rewrite needs to know *the vendor*. Ids alone cannot answer either. `Available` survives as a computed property so logging and tests keep working.
+
+**Background — the two filtering rules.**
+1. *Endpoint rule:* keep a model if it advertises at least one endpoint this proxy can forward to. The live catalog has ~19 entries advertising **no** endpoints at all, including `text-embedding-*`. Those must stay out — an embedding model must never appear as a chat model.
+2. *Vendor rule:* drop `Google` (Gemini is excluded by user decision, 2026-07-27) and `Microsoft` (`mai-code-1-flash-picker` is a Copilot-internal router, not a chat model). This is a **denylist, not an allowlist**, deliberately: several test fixtures inline `/models` JSON with no `vendor` field at all, and an allowlist would silently drop every one of them. The endpoint list is the real capability signal; vendor only vetoes.
+
+**Background — the fallback is per response, not per entry.** If *no* entry in the whole response carries `supported_endpoints`, the response is an older/alternative `/models` shape and we keep every id rather than concluding that nothing is servable. This behavior is pinned by `ModelResolverTests.cs:68` and `:122`; preserve it exactly. Entries produced by that fallback get an empty endpoint list, which downstream means "no metadata" and is treated as Anthropic-Messages-capable.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the two `ParseMessagesCapableModelIds` tests in `tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs` (around `:52` and `:68`) with these, and add the third:
+
+```csharp
+[Fact]
+public void ParseServableModels_keeps_models_with_a_reachable_endpoint_and_a_servable_vendor()
+{
+    const string json = """
+    {"data":[
+      {"id":"claude-opus-4.8","vendor":"Anthropic","supported_endpoints":["/v1/messages","/chat/completions"]},
+      {"id":"gpt-5.3-codex","vendor":"OpenAI","supported_endpoints":["/responses","ws:/responses"]},
+      {"id":"gemini-3.5-flash","vendor":"Google","supported_endpoints":["/chat/completions"]},
+      {"id":"mai-code-1-flash-picker","vendor":"Microsoft","supported_endpoints":["/responses"]},
+      {"id":"text-embedding-3-small","vendor":"Azure OpenAI","supported_endpoints":[]}
+    ]}
+    """;
+
+    var models = ProxyModelResolver.ParseServableModels(json);
+
+    models.Select(m => m.Id).Should().Equal("claude-opus-4.8", "gpt-5.3-codex");
+    models[0].Vendor.Should().Be("Anthropic");
+    models[0].Supports(CopilotModelsResponse.MessagesEndpoint).Should().BeTrue();
+    models[0].Supports(CopilotModelsResponse.ResponsesEndpoint).Should().BeFalse();
+    models[0].IsAnthropic.Should().BeTrue();
+    models[1].Supports(CopilotModelsResponse.ResponsesEndpoint).Should().BeTrue();
+    models[1].IsAnthropic.Should().BeFalse();
+}
+
+[Fact]
+public void ParseServableModels_falls_back_to_every_id_when_no_entry_has_endpoint_metadata()
+{
+    const string json = """
+    {"data":[{"id":"claude-opus-4.8"},{"id":"claude-sonnet-4.5"}]}
+    """;
+
+    var models = ProxyModelResolver.ParseServableModels(json);
+
+    models.Select(m => m.Id).Should().Equal("claude-opus-4.8", "claude-sonnet-4.5");
+    models.Should().OnlyContain(m => m.Endpoints.Count == 0, "no-metadata entries carry no endpoints");
+}
+
+[Fact]
+public void Catalog_find_is_case_insensitive_and_returns_null_for_unknown_ids()
+{
+    var catalog = new ProxyModelCatalog(
+        "claude-opus-4.8",
+        [new ProxyModelInfo("claude-opus-4.8", "Anthropic", [CopilotModelsResponse.MessagesEndpoint])]
+    );
+
+    catalog.Find("CLAUDE-OPUS-4.8")!.Id.Should().Be("claude-opus-4.8");
+    catalog.Find("nope").Should().BeNull();
+    catalog.Find(null).Should().BeNull();
+    catalog.Available.Should().Equal("claude-opus-4.8");
+}
+```
+
+Add `using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;` to the file's usings if it is not already there.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --filter "FullyQualifiedName~ModelResolverTests"
+```
+Expected: compile errors — `ParseServableModels` and `ProxyModelInfo` do not exist.
+
+- [ ] **Step 3: Add the two records**
+
+Replace `Program.cs:401` (`public sealed record ProxyModelCatalog(string Default, IReadOnlyList<string> Available);`) with:
+
+```csharp
+/// <summary>
+///     One servable Copilot model: its id, its vendor, and the transports it advertises.
+///     An EMPTY <paramref name="Endpoints"/> list means "no metadata" — either the model came from a
+///     <c>/models</c> response that carried no <c>supported_endpoints</c> at all, or the catalog was
+///     pinned via <c>COPILOT_ANTHROPIC_MODEL</c>. Callers treat that as Anthropic-Messages-capable,
+///     which is exactly how the proxy behaved before endpoint metadata existed.
+/// </summary>
+public sealed record ProxyModelInfo(string Id, string Vendor, IReadOnlyList<string> Endpoints)
+{
+    /// <summary>True when this model advertises <paramref name="endpoint"/> (case-insensitive).</summary>
+    public bool Supports(string endpoint) => Endpoints.Contains(endpoint, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    ///     True for Anthropic models. Falls back to the id when the vendor is unknown, so a pinned
+    ///     Claude model is still recognised as Anthropic and keeps its <c>max_tokens</c> spelling.
+    /// </summary>
+    public bool IsAnthropic =>
+        Vendor.Equals("Anthropic", StringComparison.OrdinalIgnoreCase)
+        || (Vendor.Length == 0 && Id.Contains("claude", StringComparison.OrdinalIgnoreCase));
+}
+
+/// <summary>The models this proxy will serve, plus the id used when a request names an unknown model.</summary>
+public sealed record ProxyModelCatalog(string Default, IReadOnlyList<ProxyModelInfo> Models)
+{
+    /// <summary>
+    ///     Every available model id, in upstream order. Computed rather than cached so a
+    ///     <c>with</c>-expression cannot leave it stale; only startup logging and tests read it.
+    /// </summary>
+    public IReadOnlyList<string> Available => Models.Select(m => m.Id).ToArray();
+
+    /// <summary>Case-insensitive lookup. Null when the id is absent, blank, or null.</summary>
+    public ProxyModelInfo? Find(string? id) =>
+        string.IsNullOrWhiteSpace(id)
+            ? null
+            : Models.FirstOrDefault(m => string.Equals(m.Id, id, StringComparison.OrdinalIgnoreCase));
+}
+```
+
+- [ ] **Step 4: Replace `ParseMessagesCapableModelIds` with `ParseServableModels`**
+
+Delete `Program.cs:502-532` and put this in its place, inside `ProxyModelResolver`:
+
+```csharp
+/// <summary><c>POST /chat/completions</c> — the OpenAI Chat Completions transport.</summary>
+public const string ChatCompletionsEndpoint = "/chat/completions";
+
+/// <summary>The transports this proxy knows how to forward to.</summary>
+private static readonly string[] ReachableEndpoints =
+[
+    CopilotModelsResponse.MessagesEndpoint,
+    ChatCompletionsEndpoint,
+    CopilotModelsResponse.ResponsesEndpoint,
+];
+
+/// <summary>
+///     Vendors this proxy refuses to serve. A DENYLIST, not an allowlist: several <c>/models</c>
+///     shapes omit <c>vendor</c> entirely, and an allowlist would silently drop all of them. The
+///     advertised endpoint list is the real capability signal; vendor only vetoes.
+///     Google is excluded by user decision (2026-07-27); Microsoft's <c>mai-code-*</c> is a
+///     Copilot-internal router rather than a chat model.
+/// </summary>
+private static readonly string[] ExcludedVendors = ["Google", "Microsoft"];
+
+/// <summary>
+///     Parses a Copilot <c>/models</c> response into the models this proxy will serve, preserving
+///     upstream order.
+///
+///     A model is kept when it advertises at least one endpoint in <see cref="ReachableEndpoints"/>
+///     and its vendor is not in <see cref="ExcludedVendors"/>. Entries advertising NO endpoints are
+///     dropped — that set includes <c>text-embedding-*</c>, which must never surface as a chat model.
+///
+///     The no-metadata fallback is deliberately per RESPONSE, not per entry: only when NOT ONE entry
+///     carries <c>supported_endpoints</c> do we conclude the response uses an older shape and keep
+///     every id. Otherwise a partially-annotated response would resurrect the embedding models.
+/// </summary>
+public static IReadOnlyList<ProxyModelInfo> ParseServableModels(string json)
+{
+    using var doc = JsonDocument.Parse(json);
+    var entries = CopilotModelsResponse.EnumerateModelEntries(doc.RootElement).ToList();
+
+    if (!entries.Any(CopilotModelsResponse.HasSupportedEndpoints))
+    {
+        return ParseModelIds(json).Select(id => new ProxyModelInfo(id, string.Empty, [])).ToArray();
+    }
+
+    var models = new List<ProxyModelInfo>();
+    foreach (var item in entries)
+    {
+        var id = CopilotModelsResponse.GetString(item, "id");
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            continue;
+        }
+
+        var vendor = CopilotModelsResponse.GetString(item, "vendor") ?? string.Empty;
+        if (ExcludedVendors.Contains(vendor, StringComparer.OrdinalIgnoreCase))
+        {
+            continue;
+        }
+
+        var endpoints = ReachableEndpoints.Where(e => CopilotModelsResponse.SupportsEndpoint(item, e)).ToArray();
+        if (endpoints.Length == 0)
+        {
+            continue;
+        }
+
+        models.Add(new ProxyModelInfo(id, vendor, endpoints));
+    }
+
+    return models;
+}
+```
+
+- [ ] **Step 5: Update `ResolveAsync` and `SelectOutboundModel`**
+
+In `ResolveAsync` (`Program.cs:412-444`), replace the override short-circuit and the discovery tail:
+
+```csharp
+if (!string.IsNullOrWhiteSpace(modelOverride))
+{
+    var pinned = modelOverride.Trim();
+
+    // DEVIATION D1: pinning still short-circuits discovery. Vendor and endpoints are unknown, and an
+    // empty endpoint list means "no metadata", which routes as Anthropic Messages — today's behavior.
+    return new ProxyModelCatalog(pinned, [new ProxyModelInfo(pinned, string.Empty, [])]);
+}
+
+using var response = await client.GetAsync("/models", cancellationToken).ConfigureAwait(false);
+_ = response.EnsureSuccessStatusCode();
+var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+var models = ParseServableModels(json);
+
+// The default is the fallback for the Anthropic surface, so it must be able to serve /v1/messages.
+// A chat-completions-only model named "opus" is servable, but it cannot be the default.
+var claudeIds = models
+    .Where(m => m.Endpoints.Count == 0 || m.Supports(CopilotModelsResponse.MessagesEndpoint))
+    .Select(m => m.Id)
+    .Where(id => id.Contains("claude", StringComparison.OrdinalIgnoreCase))
+    .ToList();
+
+var opus = PickHighestVersionOpusId(claudeIds);
+if (opus is null)
+{
+    throw new InvalidOperationException(
+        "No Claude Opus model is available on this Copilot account. Messages-capable Claude models: "
+            + (claudeIds.Count == 0 ? "(none)" : string.Join(", ", claudeIds))
+    );
+}
+
+return new ProxyModelCatalog(opus, models);
+```
+
+Keep whatever exception type and message the existing code throws if it differs — `ModelResolverTests.cs:142` and `:172` assert on the message containing the discovered claude ids.
+
+Then replace `SelectOutboundModel` (`Program.cs:539-555`):
+
+```csharp
+/// <summary>
+///     Maps the model a client asked for onto a model this proxy serves. Unknown ids fall back to the
+///     catalog default (DEVIATION D2) — the dialect check downstream runs against the RESOLVED model.
+/// </summary>
+public static string SelectOutboundModel(string? incomingModel, ProxyModelCatalog catalog)
+{
+    ArgumentNullException.ThrowIfNull(catalog);
+    return catalog.Find(incomingModel)?.Id ?? catalog.Default;
+}
+```
+
+- [ ] **Step 6: Fix the remaining compile breaks and stale expectations**
+
+`Program.cs:139-160` logs `catalog.Available` — unchanged, still compiles. `BuildModelsStub(catalog.Available)` at `:220` will not: change the call site to `ProxyHttp.BuildModelsStub(catalog.Models)` and the parameter to `IReadOnlyList<ProxyModelInfo> models`, projecting `m.Id` where the body currently uses `model`. Task 5 reshapes the body properly; this step only keeps it compiling.
+
+In `ModelResolverTests.cs`, update:
+
+| Location | Change |
+|---|---|
+| `:100` `ResolveAsync_picks_the_opus_claude_id_from_models` | `gpt-4o` in that fixture advertises `/chat/completions` with no `vendor`, so it is now servable. Expect `Available` to equal `"gpt-4o", "claude-sonnet-4.5", "claude-opus-4.8"` in upstream order. `Default` is unchanged. |
+| `:160` `ResolveAsync_excludes_messages_incapable_models_from_the_opus_search_even_if_named_opus` | Still passes unchanged — `claude-opus-chat-only` is servable but not messages-capable, so it stays out of the opus search. |
+| `:215` real-fixture test | Rename to `ParseServableModels_matches_the_real_captured_copilot_response` and expect exactly these 13 ids in fixture order: `claude-opus-4.6`, `claude-opus-4.7`, `claude-opus-4.8`, `claude-sonnet-4.6`, `claude-sonnet-5`, `gpt-5.3-codex`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4`, `gpt-5.5`, `gpt-5-mini`, `claude-sonnet-4.5`, `claude-haiku-4.5`. |
+| `:268`, `:276` | `new ProxyModelCatalog("claude-opus-4.8", ["claude-sonnet-4.5", "claude-opus-4.8"])` → `new ProxyModelCatalog("claude-opus-4.8", [new ProxyModelInfo("claude-sonnet-4.5", "Anthropic", [CopilotModelsResponse.MessagesEndpoint]), new ProxyModelInfo("claude-opus-4.8", "Anthropic", [CopilotModelsResponse.MessagesEndpoint])])` |
+
+In `ModelDiscoveryPassthroughTests.cs`:
+
+| Location | Change |
+|---|---|
+| `:49` | Expect the same 13-id list as above. |
+| `:88` | The inline discovery JSON's `gpt-5.4` advertises `/responses`, so `/v1/models` now lists all three. Expect `"claude-opus-4.8"`, `"claude-sonnet-4.5"`, `"gpt-5.4"`, and update the assertion's reason string — the old one said gpt-5.4 was excluded for lacking `/v1/messages`, which is no longer why we filter. |
+
+- [ ] **Step 7: Run the full suite**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj
+```
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add samples/CopilotAnthropicProxy.Sample/Program.cs tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs tests/CopilotAnthropicProxy.Tests/ModelDiscoveryPassthroughTests.cs
+git commit -m "feat(proxy): catalog carries vendor and advertised endpoints"
+```
+
+---
+
+## Task 2: The routing decision
+
+**Files:**
+- Create: `samples/CopilotAnthropicProxy.Sample/Translation/ModelRoute.cs`
+- Test: `tests/CopilotAnthropicProxy.Tests/ModelRouteTests.cs`
+
+**Interfaces:**
+- Consumes: `ProxyModelInfo`, `ProxyModelCatalog` (Task 1); `ProxyModelResolver.ChatCompletionsEndpoint` (Task 1); `CopilotModelsResponse.MessagesEndpoint` / `.ResponsesEndpoint`.
+- Produces:
+  - `public enum ProxyDialect { AnthropicMessages, ChatCompletions, Responses }`
+  - `public enum ProxyRouteKind { Passthrough, TranslateAnthropicToResponses }`
+  - `public sealed record ModelRoute(ProxyRouteKind Kind, string UpstreamPath, ProxyModelInfo Model)`
+  - `public static class ModelRouter` with constants `MessagesPath`, `CountTokensPath`, `ChatCompletionsPath`, `ResponsesPath`; `static ModelRoute? Resolve(ProxyDialect, ProxyModelInfo)`; `static IReadOnlyList<string> Servable(ProxyDialect, ProxyModelCatalog)`.
+
+This is the whole routing table in one pure function. `Resolve` returning `null` is the 404 signal; `Servable` exists so the 404 body can name what the client *could* have asked for.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/CopilotAnthropicProxy.Tests/ModelRouteTests.cs`:
+
+```csharp
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+public class ModelRouteTests
+{
+    private static ProxyModelInfo Dual =>
+        new("claude-opus-4.8", "Anthropic", [CopilotModelsResponse.MessagesEndpoint, ProxyModelResolver.ChatCompletionsEndpoint]);
+
+    private static ProxyModelInfo ResponsesOnly =>
+        new("gpt-5.3-codex", "OpenAI", [CopilotModelsResponse.ResponsesEndpoint]);
+
+    private static ProxyModelInfo ResponsesAndChat =>
+        new("gpt-5.4", "OpenAI", [CopilotModelsResponse.ResponsesEndpoint, ProxyModelResolver.ChatCompletionsEndpoint]);
+
+    private static ProxyModelInfo NoMetadata => new("pinned-model", "", []);
+
+    [Fact]
+    public void Anthropic_dialect_passes_through_for_a_messages_capable_model()
+    {
+        var route = ModelRouter.Resolve(ProxyDialect.AnthropicMessages, Dual);
+
+        route.Should().NotBeNull();
+        route!.Kind.Should().Be(ProxyRouteKind.Passthrough);
+        route.UpstreamPath.Should().Be("/v1/messages");
+    }
+
+    [Fact]
+    public void Anthropic_dialect_translates_for_a_responses_only_model()
+    {
+        var route = ModelRouter.Resolve(ProxyDialect.AnthropicMessages, ResponsesOnly);
+
+        route.Should().NotBeNull();
+        route!.Kind.Should().Be(ProxyRouteKind.TranslateAnthropicToResponses);
+        route.UpstreamPath.Should().Be("/responses");
+    }
+
+    [Fact]
+    public void Anthropic_dialect_prefers_passthrough_when_a_model_serves_both()
+    {
+        // gpt-5.4 advertises /responses AND /chat/completions but NOT /v1/messages, so it translates.
+        ModelRouter.Resolve(ProxyDialect.AnthropicMessages, ResponsesAndChat)!
+            .Kind.Should().Be(ProxyRouteKind.TranslateAnthropicToResponses);
+    }
+
+    [Fact]
+    public void A_model_with_no_endpoint_metadata_is_treated_as_anthropic_capable()
+    {
+        var route = ModelRouter.Resolve(ProxyDialect.AnthropicMessages, NoMetadata);
+
+        route.Should().NotBeNull();
+        route!.Kind.Should().Be(ProxyRouteKind.Passthrough);
+    }
+
+    [Fact]
+    public void Chat_completions_dialect_passes_through_only_for_models_that_advertise_it()
+    {
+        ModelRouter.Resolve(ProxyDialect.ChatCompletions, Dual)!.UpstreamPath.Should().Be("/chat/completions");
+        ModelRouter.Resolve(ProxyDialect.ChatCompletions, ResponsesOnly).Should().BeNull();
+    }
+
+    [Fact]
+    public void Responses_dialect_passes_through_only_for_models_that_advertise_it()
+    {
+        ModelRouter.Resolve(ProxyDialect.Responses, ResponsesOnly)!.UpstreamPath.Should().Be("/responses");
+        ModelRouter.Resolve(ProxyDialect.Responses, Dual).Should().BeNull();
+    }
+
+    [Fact]
+    public void A_pinned_model_cannot_serve_the_responses_dialect()
+    {
+        // Pinned mode has no endpoint metadata, so we cannot claim Responses support.
+        ModelRouter.Resolve(ProxyDialect.Responses, NoMetadata).Should().BeNull();
+    }
+
+    [Fact]
+    public void Servable_lists_the_ids_that_can_serve_a_dialect()
+    {
+        var catalog = new ProxyModelCatalog("claude-opus-4.8", [Dual, ResponsesOnly, ResponsesAndChat]);
+
+        ModelRouter.Servable(ProxyDialect.Responses, catalog).Should().Equal("gpt-5.3-codex", "gpt-5.4");
+        ModelRouter.Servable(ProxyDialect.ChatCompletions, catalog).Should().Equal("claude-opus-4.8", "gpt-5.4");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --filter "FullyQualifiedName~ModelRouteTests"
+```
+Expected: compile errors — `ModelRouter`, `ModelRoute`, `ProxyDialect` do not exist.
+
+- [ ] **Step 3: Create the router**
+
+Create `samples/CopilotAnthropicProxy.Sample/Translation/ModelRoute.cs` (no `namespace` line — global namespace, per Global Constraints):
+
+```csharp
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+
+/// <summary>The API dialect a request arrived in.</summary>
+public enum ProxyDialect
+{
+    /// <summary>Anthropic Messages — Claude Code.</summary>
+    AnthropicMessages,
+
+    /// <summary>OpenAI Chat Completions — opencode and most OpenAI SDKs.</summary>
+    ChatCompletions,
+
+    /// <summary>OpenAI Responses — Codex CLI.</summary>
+    Responses,
+}
+
+/// <summary>How a request must be served.</summary>
+public enum ProxyRouteKind
+{
+    /// <summary>Forward the body to Copilot essentially unchanged.</summary>
+    Passthrough,
+
+    /// <summary>Rewrite an Anthropic Messages request into an OpenAI Responses request, and the reply back.</summary>
+    TranslateAnthropicToResponses,
+}
+
+/// <summary>The resolved upstream target for one request.</summary>
+public sealed record ModelRoute(ProxyRouteKind Kind, string UpstreamPath, ProxyModelInfo Model);
+
+/// <summary>
+///     The routing table. Copilot serves three transports and every model advertises which of them it
+///     honors, so the only question is whether the client's dialect matches one the model accepts.
+///     Exactly one mismatch is worth translating: Anthropic Messages in, for a model that only speaks
+///     Responses. Everything else either passes through or 404s.
+/// </summary>
+public static class ModelRouter
+{
+    /// <summary>Copilot's Anthropic Messages path.</summary>
+    public const string MessagesPath = CopilotModelsResponse.MessagesEndpoint;
+
+    /// <summary>Copilot's Anthropic token-counting path.</summary>
+    public const string CountTokensPath = "/v1/messages/count_tokens";
+
+    /// <summary>Copilot's OpenAI Chat Completions path.</summary>
+    public const string ChatCompletionsPath = ProxyModelResolver.ChatCompletionsEndpoint;
+
+    /// <summary>Copilot's OpenAI Responses path.</summary>
+    public const string ResponsesPath = CopilotModelsResponse.ResponsesEndpoint;
+
+    /// <summary>
+    ///     Resolves how to serve <paramref name="model"/> for an inbound <paramref name="dialect"/>.
+    ///     Returns null when the model cannot serve that dialect at all; the caller answers 404.
+    ///
+    ///     A model with NO endpoint metadata (pinned via COPILOT_ANTHROPIC_MODEL, or discovered from a
+    ///     legacy /models shape) is treated as Anthropic-Messages-capable and nothing else, which is
+    ///     precisely how this proxy behaved before endpoint metadata existed.
+    /// </summary>
+    public static ModelRoute? Resolve(ProxyDialect dialect, ProxyModelInfo model)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+        var noMetadata = model.Endpoints.Count == 0;
+
+        return dialect switch
+        {
+            ProxyDialect.AnthropicMessages when noMetadata || model.Supports(MessagesPath) => new ModelRoute(
+                ProxyRouteKind.Passthrough,
+                MessagesPath,
+                model
+            ),
+            ProxyDialect.AnthropicMessages when model.Supports(ResponsesPath) => new ModelRoute(
+                ProxyRouteKind.TranslateAnthropicToResponses,
+                ResponsesPath,
+                model
+            ),
+            ProxyDialect.ChatCompletions when noMetadata || model.Supports(ChatCompletionsPath) => new ModelRoute(
+                ProxyRouteKind.Passthrough,
+                ChatCompletionsPath,
+                model
+            ),
+            ProxyDialect.Responses when model.Supports(ResponsesPath) => new ModelRoute(
+                ProxyRouteKind.Passthrough,
+                ResponsesPath,
+                model
+            ),
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    ///     The ids that can serve <paramref name="dialect"/>, in catalog order. Used to make a 404 body
+    ///     actionable — telling a client its model is unavailable is only useful alongside the list of
+    ///     models that are.
+    /// </summary>
+    public static IReadOnlyList<string> Servable(ProxyDialect dialect, ProxyModelCatalog catalog)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        return catalog.Models.Where(m => Resolve(dialect, m) is not null).Select(m => m.Id).ToArray();
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --filter "FullyQualifiedName~ModelRouteTests"
+```
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add samples/CopilotAnthropicProxy.Sample/Translation/ModelRoute.cs tests/CopilotAnthropicProxy.Tests/ModelRouteTests.cs
+git commit -m "feat(proxy): add the dialect-to-endpoint routing table"
+```
+
+---
+
+## Task 3: Family-aware fallback for unknown model ids
+
+**Files:**
+- Modify: `samples/CopilotAnthropicProxy.Sample/Program.cs` (`ProxyModelResolver.SelectOutboundModel`)
+- Test: `tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs`
+
+**Interfaces:**
+- Consumes: `ProxyModelCatalog.Find`, `ProxyModelCatalog.Models` (Task 1).
+- Produces: no new signatures — `SelectOutboundModel(string?, ProxyModelCatalog)` changes behavior only.
+
+**Background.** Claude Code does not send only your chosen model to `ANTHROPIC_BASE_URL`. Conversation-title generation, auto-mode classification, and summarization all resolve through `ANTHROPIC_SMALL_FAST_MODEL` → `ANTHROPIC_DEFAULT_HAIKU_MODEL` → a built-in default, and every one of them hits *this* proxy with an id like `claude-3-5-haiku-20241022`. That id is not in Copilot's catalog (Copilot has `claude-haiku-4.5`). With a plain default-fallback, every title generation would be billed against the default **opus** model. There is no separate base URL to point them at, so the proxy has to do the mapping.
+
+The fix generalises: before falling back to the default, look for a catalog model in the same *family*. Three families, checked longest-first so `sonnet` cannot shadow anything.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs`:
+
+```csharp
+private static ProxyModelCatalog FamilyCatalog =>
+    new(
+        "claude-opus-4.8",
+        [
+            new ProxyModelInfo("claude-opus-4.8", "Anthropic", [CopilotModelsResponse.MessagesEndpoint]),
+            new ProxyModelInfo("claude-sonnet-4.5", "Anthropic", [CopilotModelsResponse.MessagesEndpoint]),
+            new ProxyModelInfo("claude-haiku-4.5", "Anthropic", [CopilotModelsResponse.MessagesEndpoint]),
+        ]
+    );
+
+[Theory]
+[InlineData("claude-3-5-haiku-20241022", "claude-haiku-4.5")]
+[InlineData("claude-haiku-4-5-20251001", "claude-haiku-4.5")]
+[InlineData("claude-sonnet-4-20250514", "claude-sonnet-4.5")]
+[InlineData("claude-3-opus-20240229", "claude-opus-4.8")]
+public void SelectOutboundModel_maps_an_unknown_id_onto_its_own_family(string incoming, string expected)
+{
+    ProxyModelResolver.SelectOutboundModel(incoming, FamilyCatalog).Should().Be(expected);
+}
+
+[Fact]
+public void SelectOutboundModel_falls_back_to_the_default_when_no_family_matches()
+{
+    ProxyModelResolver.SelectOutboundModel("some-unknown-model", FamilyCatalog).Should().Be("claude-opus-4.8");
+}
+
+[Fact]
+public void SelectOutboundModel_still_prefers_an_exact_match_over_a_family_match()
+{
+    ProxyModelResolver.SelectOutboundModel("claude-haiku-4.5", FamilyCatalog).Should().Be("claude-haiku-4.5");
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --filter "FullyQualifiedName~SelectOutboundModel"
+```
+Expected: FAIL — the haiku and sonnet cases return `claude-opus-4.8`.
+
+- [ ] **Step 3: Implement family-aware fallback**
+
+Replace `SelectOutboundModel` in `ProxyModelResolver`:
+
+```csharp
+/// <summary>
+///     Model families, longest name first so a shorter name cannot shadow a longer one.
+///     Used to route side traffic that names a model this account does not have — Claude Code sends
+///     conversation-title, classification and summarisation calls as <c>claude-3-5-haiku-*</c> to the
+///     SAME base URL, and without this they would all bill against the default opus model.
+/// </summary>
+private static readonly string[] ModelFamilies = ["sonnet", "haiku", "opus"];
+
+/// <summary>
+///     Maps the model a client asked for onto a model this proxy serves:
+///     exact match (case-insensitive) → same-family match → catalog default.
+///     The dialect check downstream runs against the RESOLVED model (DEVIATION D2).
+/// </summary>
+public static string SelectOutboundModel(string? incomingModel, ProxyModelCatalog catalog)
+{
+    ArgumentNullException.ThrowIfNull(catalog);
+
+    if (catalog.Find(incomingModel) is { } exact)
+    {
+        return exact.Id;
+    }
+
+    if (!string.IsNullOrWhiteSpace(incomingModel))
+    {
+        var family = ModelFamilies.FirstOrDefault(f => incomingModel.Contains(f, StringComparison.OrdinalIgnoreCase));
+        if (family is not null)
+        {
+            var sameFamily = catalog.Models.FirstOrDefault(m =>
+                m.Id.Contains(family, StringComparison.OrdinalIgnoreCase)
+            );
+            if (sameFamily is not null)
+            {
+                return sameFamily.Id;
+            }
+        }
+    }
+
+    return catalog.Default;
+}
+```
+
+- [ ] **Step 4: Run the full suite**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj
+```
+Expected: PASS. Note `ModelDiscoveryPassthroughTests.Unrecognized_model_falls_back_to_the_discovered_default` (`:114`) — check the id it sends. If it contains `sonnet`/`haiku`/`opus` and the discovery fixture has a matching model, the family rule now applies; change the test's model to a genuinely family-less id such as `"some-unknown-model"` and keep the assertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add samples/CopilotAnthropicProxy.Sample/Program.cs tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs tests/CopilotAnthropicProxy.Tests/ModelDiscoveryPassthroughTests.cs
+git commit -m "feat(proxy): map unknown model ids onto their own family before defaulting"
+```
+
+---
+
+## Task 4: OpenAI-dialect passthrough routes
+
+**Files:**
+- Modify: `samples/CopilotAnthropicProxy.Sample/Program.cs:201-234` (routes), `:595-636` (`TryRewriteModel`), `:644-829` (`ForwardAsync`), `:1054-1065` (error writers)
+- Test: `tests/CopilotAnthropicProxy.Tests/OpenAiDialectTests.cs`
+
+**Interfaces:**
+- Consumes: `ModelRouter.Resolve` / `.Servable`, `ProxyDialect`, `ProxyRouteKind` (Task 2); `ProxyModelInfo.IsAnthropic` (Task 1).
+- Produces:
+  - `ProxyModelResolver.TryRewriteModel(byte[] body, string model, out byte[] rewritten, out string? incomingModel, bool renameMaxTokens = false)` — the new optional parameter defaults to false, so the six existing call sites in `ModelRewriteTests.cs` still compile.
+  - `ProxyHttp.ForwardAsync(HttpContext, ProxyModelCatalog, TimeSpan idleTimeout, TimeSpan keepAliveInterval, ProxyDialect dialect, bool isCountTokens = false)`
+  - `ProxyHttp.WriteOpenAiErrorAsync(HttpContext, int status, string type, string message)`
+  - `ProxyHttp.WriteErrorAsync(HttpContext, ProxyDialect, int status, string type, string message)`
+
+**Background — why the token-field rename exists.** Live-probed on 2026-07-27 (`tests/CopilotLive.Tests/CopilotChatCompletionsProbeTests.cs`, 4/4 passing): Claude models accept `max_tokens` on `/chat/completions`, but GPT models return `400 "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."` on the *same* endpoint. It is per-model, not per-endpoint. opencode's `@ai-sdk/openai-compatible` path still emits the deprecated `max_tokens`, so a naive passthrough to a GPT model 400s. This is a one-field rewrite riding inside the body rewrite that already happens.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/CopilotAnthropicProxy.Tests/OpenAiDialectTests.cs`:
+
+```csharp
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+public class OpenAiDialectTests
+{
+    private const string DiscoveryJson = """
+    {"data":[
+      {"id":"claude-opus-4.8","vendor":"Anthropic","supported_endpoints":["/v1/messages","/chat/completions"]},
+      {"id":"gpt-5.4","vendor":"OpenAI","supported_endpoints":["/responses","/chat/completions"]},
+      {"id":"gpt-5.3-codex","vendor":"OpenAI","supported_endpoints":["/responses"]}
+    ]}
+    """;
+
+    /// <summary>
+    ///     Builds a factory whose upstream answers startup discovery from <see cref="DiscoveryJson"/>
+    ///     and hands every other request to <paramref name="onProxied"/>, recording the path it hit.
+    /// </summary>
+    private static ProxyWebAppFactory Factory(
+        Func<HttpRequestMessage, string, Task<HttpResponseMessage>> onProxied
+    ) =>
+        new(
+            async (request, _) =>
+            {
+                var path = request.RequestUri!.AbsolutePath;
+                if (request.Method == HttpMethod.Get && path.EndsWith("/models", StringComparison.Ordinal))
+                {
+                    return TestUpstream.Json(DiscoveryJson);
+                }
+
+                return await onProxied(request, path);
+            },
+            model: null
+        );
+
+    [Fact]
+    public async Task Chat_completions_forwards_to_the_upstream_chat_completions_path()
+    {
+        string? seenPath = null;
+        await using var factory = Factory(
+            (_, path) =>
+            {
+                seenPath = path;
+                return Task.FromResult(TestUpstream.Json("""{"id":"x","choices":[]}"""));
+            }
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/chat/completions",
+            new { model = "claude-opus-4.8", messages = Array.Empty<object>() }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        seenPath.Should().Be("/chat/completions");
+    }
+
+    [Fact]
+    public async Task Chat_completions_renames_max_tokens_for_a_non_anthropic_model()
+    {
+        string? body = null;
+        await using var factory = Factory(
+            async (request, _) =>
+            {
+                body = await request.Content!.ReadAsStringAsync();
+                return TestUpstream.Json("""{"id":"x","choices":[]}""");
+            }
+        );
+        using var client = factory.CreateClient();
+
+        _ = await client.PostAsJsonAsync(
+            "/v1/chat/completions",
+            new
+            {
+                model = "gpt-5.4",
+                max_tokens = 256,
+                messages = Array.Empty<object>(),
+            }
+        );
+
+        using var sent = JsonDocument.Parse(body!);
+        sent.RootElement.TryGetProperty("max_tokens", out _).Should().BeFalse();
+        sent.RootElement.GetProperty("max_completion_tokens").GetInt32().Should().Be(256);
+    }
+
+    [Fact]
+    public async Task Chat_completions_keeps_max_tokens_for_an_anthropic_model()
+    {
+        string? body = null;
+        await using var factory = Factory(
+            async (request, _) =>
+            {
+                body = await request.Content!.ReadAsStringAsync();
+                return TestUpstream.Json("""{"id":"x","choices":[]}""");
+            }
+        );
+        using var client = factory.CreateClient();
+
+        _ = await client.PostAsJsonAsync(
+            "/v1/chat/completions",
+            new
+            {
+                model = "claude-opus-4.8",
+                max_tokens = 256,
+                messages = Array.Empty<object>(),
+            }
+        );
+
+        using var sent = JsonDocument.Parse(body!);
+        sent.RootElement.GetProperty("max_tokens").GetInt32().Should().Be(256);
+        sent.RootElement.TryGetProperty("max_completion_tokens", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Responses_forwards_to_the_upstream_responses_path()
+    {
+        string? seenPath = null;
+        await using var factory = Factory(
+            (_, path) =>
+            {
+                seenPath = path;
+                return Task.FromResult(TestUpstream.Json("""{"id":"resp_1","output":[]}"""));
+            }
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/responses",
+            new { model = "gpt-5.3-codex", input = Array.Empty<object>() }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        seenPath.Should().Be("/responses");
+    }
+
+    [Fact]
+    public async Task Responses_returns_an_openai_shaped_404_for_a_model_that_cannot_serve_it()
+    {
+        await using var factory = Factory((_, _) => throw new InvalidOperationException("must not be forwarded"));
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/responses",
+            new { model = "claude-opus-4.8", input = Array.Empty<object>() }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var message = error.RootElement.GetProperty("error").GetProperty("message").GetString();
+        message.Should().Contain("claude-opus-4.8");
+        message.Should().Contain("gpt-5.4").And.Contain("gpt-5.3-codex", "the 404 must name what IS servable");
+    }
+
+    [Fact]
+    public async Task The_unprefixed_twins_are_bound_too()
+    {
+        await using var factory = Factory(
+            (_, _) => Task.FromResult(TestUpstream.Json("""{"id":"x","choices":[]}"""))
+        );
+        using var client = factory.CreateClient();
+
+        var chat = await client.PostAsJsonAsync(
+            "/chat/completions",
+            new { model = "claude-opus-4.8", messages = Array.Empty<object>() }
+        );
+        var responses = await client.PostAsJsonAsync(
+            "/responses",
+            new { model = "gpt-5.3-codex", input = Array.Empty<object>() }
+        );
+
+        chat.StatusCode.Should().Be(HttpStatusCode.OK);
+        responses.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --filter "FullyQualifiedName~OpenAiDialectTests"
+```
+Expected: FAIL — the new paths hit `MapFallback` and return the Anthropic 404.
+
+- [ ] **Step 3: Add the OpenAI error writer**
+
+In `ProxyHttp`, next to `WriteAnthropicErrorAsync` (`Program.cs:1054-1065`):
+
+```csharp
+/// <summary>
+///     Writes an OpenAI-shaped error envelope. No-op once the response has started — a half-written
+///     body must not be capped with an error object.
+/// </summary>
+public static async Task WriteOpenAiErrorAsync(HttpContext ctx, int status, string type, string message)
+{
+    if (ctx.Response.HasStarted)
+    {
+        return;
+    }
+
+    ctx.Response.StatusCode = status;
+    ctx.Response.ContentType = "application/json";
+
+    var payload = JsonSerializer.SerializeToUtf8Bytes(
+        new
+        {
+            error = new
+            {
+                message,
+                type,
+                param = (string?)null,
+                code = (string?)null,
+            },
+        }
+    );
+
+    await ctx.Response.Body.WriteAsync(payload, ctx.RequestAborted).ConfigureAwait(false);
+}
+
+/// <summary>Writes an error in the envelope shape the INBOUND dialect expects.</summary>
+public static Task WriteErrorAsync(HttpContext ctx, ProxyDialect dialect, int status, string type, string message) =>
+    dialect == ProxyDialect.AnthropicMessages
+        ? WriteAnthropicErrorAsync(ctx, status, type, message)
+        : WriteOpenAiErrorAsync(ctx, status, type, message);
+```
+
+- [ ] **Step 4: Teach `TryRewriteModel` the token-field rename**
+
+Add the optional parameter and the rename to `ProxyModelResolver.TryRewriteModel` (`Program.cs:595-636`). Signature:
+
+```csharp
+public static bool TryRewriteModel(
+    byte[] body,
+    string model,
+    out byte[] rewritten,
+    out string? incomingModel,
+    bool renameMaxTokens = false
+)
+```
+
+and, inside the existing `JsonNode` block, just before the body is re-serialised (after `obj.Remove("context_management")`):
+
+```csharp
+// GPT models on Copilot reject `max_tokens` on /chat/completions and demand
+// `max_completion_tokens` — live-confirmed 2026-07-27. Claude models accept `max_tokens` on the
+// same endpoint, so this is keyed on the model, not the route. Clone before removing: a JsonNode
+// cannot be re-parented while it still belongs to the object.
+if (renameMaxTokens && obj["max_tokens"] is { } maxTokens)
+{
+    var value = maxTokens.DeepClone();
+    _ = obj.Remove("max_tokens");
+    if (!obj.ContainsKey("max_completion_tokens"))
+    {
+        obj["max_completion_tokens"] = value;
+    }
+}
+```
+
+- [ ] **Step 5: Make `ForwardAsync` dialect-aware**
+
+In `ProxyHttp.ForwardAsync` (`Program.cs:644-829`):
+
+1. Add `ProxyDialect dialect` as a parameter before the existing `bool isCountTokens` (give `isCountTokens` a default of `false`).
+2. After the outbound model is selected, resolve the route and reject a dialect mismatch:
+
+```csharp
+var outboundModel = ProxyModelResolver.SelectOutboundModel(ProxyModelResolver.PeekModel(inboundBody), catalog);
+
+// A model resolved via the default/family fallback may not be in the catalog at all (pinned mode);
+// treat it as metadata-free, which routes as Anthropic Messages.
+var modelInfo = catalog.Find(outboundModel) ?? new ProxyModelInfo(outboundModel, string.Empty, []);
+var route = ModelRouter.Resolve(dialect, modelInfo);
+
+if (route is null)
+{
+    var alternatives = ModelRouter.Servable(dialect, catalog);
+    await WriteErrorAsync(
+            ctx,
+            dialect,
+            StatusCodes.Status404NotFound,
+            "not_found_error",
+            $"Model '{outboundModel}' is not available on this endpoint. "
+                + $"Models that are: {(alternatives.Count == 0 ? "(none)" : string.Join(", ", alternatives))}."
+        )
+        .ConfigureAwait(false);
+    return;
+}
+```
+
+3. Replace the hard-coded upstream path at `:705`:
+
+```csharp
+var upstreamPath = isCountTokens ? ModelRouter.CountTokensPath : route.UpstreamPath;
+```
+
+4. Pass the rename flag into the body rewrite:
+
+```csharp
+var renameMaxTokens = dialect == ProxyDialect.ChatCompletions && !modelInfo.IsAnthropic;
+if (!ProxyModelResolver.TryRewriteModel(inboundBody, outboundModel, out var outboundBody, out _, renameMaxTokens))
+```
+
+5. Replace every pre-send `WriteAnthropicErrorAsync(ctx, …)` call in `ForwardAsync` — the 400 on rewrite failure, and the 504/401/502 catch blocks — with `WriteErrorAsync(ctx, dialect, …)`, keeping the existing status codes and messages. Also update the `CopyBodyAsync` callback at `:813`:
+
+```csharp
+(c, status, message) => WriteErrorAsync(c, dialect, status, "api_error", message),
+```
+
+> Leave `ProxyRouteKind.TranslateAnthropicToResponses` unhandled for now — it cannot occur yet, because Task 2's router only returns it for a model that advertises `/responses` and *not* `/v1/messages`, and nothing routes those to `/v1/messages` until Task 9. Task 9 adds the branch. If you want a belt-and-braces guard in the meantime, treat a non-`Passthrough` kind exactly like `route is null`.
+
+- [ ] **Step 6: Register the routes**
+
+In `Program.cs:201-234`, update the two existing `MapPost` calls to pass `ProxyDialect.AnthropicMessages`, then add:
+
+```csharp
+// Each POST also binds its un-prefixed twin. Base-URL conventions differ per client: Claude Code
+// appends /v1/messages to a bare host, the AI SDK appends only /messages to a ".../v1" base, and
+// Codex joins "{base}/responses". Binding both forms removes a whole class of misconfiguration.
+foreach (var path in new[] { "/v1/messages", "/messages" })
+{
+    _ = app.MapPost(
+        path,
+        ctx =>
+            ProxyHttp.ForwardAsync(
+                ctx,
+                catalog,
+                config.IdleTimeout,
+                config.KeepAliveInterval,
+                ProxyDialect.AnthropicMessages
+            )
+    );
+    _ = app.MapPost(
+        $"{path}/count_tokens",
+        ctx =>
+            ProxyHttp.ForwardAsync(
+                ctx,
+                catalog,
+                config.IdleTimeout,
+                config.KeepAliveInterval,
+                ProxyDialect.AnthropicMessages,
+                isCountTokens: true
+            )
+    );
+}
+
+foreach (var path in new[] { "/v1/chat/completions", "/chat/completions" })
+{
+    _ = app.MapPost(
+        path,
+        ctx =>
+            ProxyHttp.ForwardAsync(
+                ctx,
+                catalog,
+                config.IdleTimeout,
+                config.KeepAliveInterval,
+                ProxyDialect.ChatCompletions
+            )
+    );
+}
+
+foreach (var path in new[] { "/v1/responses", "/responses" })
+{
+    _ = app.MapPost(
+        path,
+        ctx => ProxyHttp.ForwardAsync(ctx, catalog, config.IdleTimeout, config.KeepAliveInterval, ProxyDialect.Responses)
+    );
+}
+```
+
+Delete the two original `MapPost("/v1/messages", …)` / `MapPost("/v1/messages/count_tokens", …)` lines — the first loop replaces them.
+
+- [ ] **Step 7: Run the full suite**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj
+```
+Expected: PASS. `PassthroughTests`, `EndpointBehaviorTests`, and `HeaderAllowlistTests` must all stay green — they exercise `/v1/messages`, whose behavior is unchanged.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add samples/CopilotAnthropicProxy.Sample/Program.cs tests/CopilotAnthropicProxy.Tests/OpenAiDialectTests.cs
+git commit -m "feat(proxy): serve /chat/completions and /responses as passthrough routes"
+```
+
+---
+
+## Task 5: Models union shape and default port
+
+**Files:**
+- Modify: `samples/CopilotAnthropicProxy.Sample/Program.cs:258` (port), `:1071-1092` (`BuildModelsStub`); `samples/CopilotAnthropicProxy.Sample/README.md`
+- Test: `tests/CopilotAnthropicProxy.Tests/EndpointBehaviorTests.cs`, `tests/CopilotAnthropicProxy.Tests/ModelDiscoveryPassthroughTests.cs`
+
+**Interfaces:**
+- Consumes: `ProxyModelInfo` (Task 1).
+- Produces: `ProxyHttp.BuildModelsStub(IReadOnlyList<ProxyModelInfo> models)` — same name, new parameter type (already changed to compile in Task 1 Step 6; this task fixes the body).
+
+**Background — one body, both shapes.** Anthropic clients read `data[].type == "model"` and `display_name`; OpenAI clients read `object == "list"` and `data[].object == "model"` with `owned_by` and a numeric `created`. The two shapes do not conflict, so a single body carrying every field satisfies both and we never have to branch on who is asking.
+
+The research agent found that Claude Code effectively never calls this endpoint (its models-list cache is hard-disabled and gateway discovery is triple-gated), opencode takes its model list from `models.dev` or `opencode.json`, and Codex decodes a third shape (`{models:[…]}`). So this endpoint is a convenience, not a critical path — which is exactly why it gets the cheap union treatment and nothing more.
+
+**Background — the port.** Default moves `8787` → `8788` so the sample can run beside an existing proxy on the old port. `HostGuardTests.cs` declares its own `private const int Port = 8787;` and passes it explicitly, so it is unaffected. `ProxyConfig` is `internal` and cannot be unit-tested (see Global Constraints); verify this change by reading the constant and the README.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/CopilotAnthropicProxy.Tests/ModelDiscoveryPassthroughTests.cs`:
+
+```csharp
+[Fact]
+public async Task Models_endpoint_serves_a_body_both_dialects_can_read()
+{
+    await using var factory = DiscoveryFactory(_ => TestUpstream.Json("{}"));
+    using var client = factory.CreateClient();
+
+    using var doc = JsonDocument.Parse(await client.GetStringAsync("/v1/models"));
+    var root = doc.RootElement;
+
+    root.GetProperty("object").GetString().Should().Be("list", "OpenAI clients key off this");
+    root.GetProperty("has_more").GetBoolean().Should().BeFalse();
+
+    var first = root.GetProperty("data")[0];
+    first.GetProperty("type").GetString().Should().Be("model", "Anthropic clients key off this");
+    first.GetProperty("object").GetString().Should().Be("model", "OpenAI clients key off this");
+    first.GetProperty("id").GetString().Should().NotBeNullOrWhiteSpace();
+    first.GetProperty("display_name").GetString().Should().NotBeNullOrWhiteSpace();
+    first.GetProperty("owned_by").GetString().Should().NotBeNullOrWhiteSpace();
+    first.GetProperty("created").GetInt64().Should().BeGreaterThan(0);
+    first.GetProperty("created_at").GetString().Should().NotBeNullOrWhiteSpace();
+}
+```
+
+Use whatever the file's existing `DiscoveryFactory` helper signature is — the file already defines one that answers startup `GET /models`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --filter "FullyQualifiedName~Models_endpoint_serves_a_body"
+```
+Expected: FAIL — `object` and `owned_by` are missing.
+
+- [ ] **Step 3: Rewrite `BuildModelsStub`**
+
+Replace the body at `Program.cs:1071-1092`:
+
+```csharp
+/// <summary>
+///     Builds a model list that BOTH dialects can parse. Anthropic clients read
+///     <c>data[].type == "model"</c> and <c>display_name</c>; OpenAI clients read
+///     <c>object == "list"</c>, <c>data[].object == "model"</c> and <c>owned_by</c>. The two shapes do
+///     not conflict, so one body carrying every field serves both and we never branch on the caller.
+///
+///     <c>created</c> is a fixed epoch — Copilot's /models does not report a creation time, and the
+///     field exists only because OpenAI SDKs deserialise into a struct that requires it.
+/// </summary>
+public static string BuildModelsStub(IReadOnlyList<ProxyModelInfo> models)
+{
+    ArgumentNullException.ThrowIfNull(models);
+
+    const long CreatedEpochSeconds = 1735689600L; // 2025-01-01T00:00:00Z
+    const string CreatedIso = "2025-01-01T00:00:00Z";
+
+    var data = models
+        .Select(m => new
+        {
+            type = "model",
+            @object = "model",
+            id = m.Id,
+            display_name = m.Id,
+            owned_by = string.IsNullOrEmpty(m.Vendor) ? "copilot" : m.Vendor,
+            created = CreatedEpochSeconds,
+            created_at = CreatedIso,
+        })
+        .ToArray();
+
+    return JsonSerializer.Serialize(
+        new
+        {
+            @object = "list",
+            data,
+            has_more = false,
+            first_id = models.Count == 0 ? null : models[0].Id,
+            last_id = models.Count == 0 ? null : models[^1].Id,
+        }
+    );
+}
+```
+
+- [ ] **Step 4: Change the default port**
+
+At `Program.cs:258`, change the fallback in `ProxyConfig.FromEnvironment` from `8787` to `8788`:
+
+```csharp
+Port = ParseInt(Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_PORT"), 8788),
+```
+
+Then update every `8787` in `samples/CopilotAnthropicProxy.Sample/README.md` to `8788` (there are 7). Leave `tests/CopilotAnthropicProxy.Tests/HostGuardTests.cs` alone — its `Port` constant is local and deliberate.
+
+```bash
+grep -rn "8787" samples/CopilotAnthropicProxy.Sample/
+```
+Expected after editing: no hits.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj
+```
+Expected: PASS. `EndpointBehaviorTests.Models_stub_advertises_the_resolved_model` stays green — the union only *adds* fields, and pinned mode still yields exactly one entry whose `id` is `ProxyWebAppFactory.ConfiguredModel`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add samples/CopilotAnthropicProxy.Sample/Program.cs samples/CopilotAnthropicProxy.Sample/README.md tests/CopilotAnthropicProxy.Tests/ModelDiscoveryPassthroughTests.cs
+git commit -m "feat(proxy): serve a dual-dialect model list and default to port 8788"
+```
+
+**P0 is complete here.** Claude Code → Claude, opencode → Claude, opencode → dual-endpoint GPT, and Codex → any GPT all work. What remains is the one quadrant Copilot cannot serve directly.
+
+---
+
+## Task 6: Anthropic request → Responses request
+
+**Files:**
+- Create: `samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs`
+- Test: `tests/CopilotAnthropicProxy.Tests/AnthropicToResponsesRequestTests.cs`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks — this is a pure JSON→JSON function.
+- Produces:
+  - `public static class AnthropicToResponsesRequest`
+  - `public static string Translate(string anthropicJson)`
+  - `public static JsonObject Translate(JsonObject source)`
+  - `public const int MinimumOutputTokens = 16`
+
+**Background — the allowlist is the security model.** The translator does not copy the inbound body and patch it; it builds a new object and copies only fields it understands. That is what makes items 6 and 7 from the research findings safe *by construction*: body-level `betas`, `cache_control` with `ttl`/`scope` sub-fields, `metadata.user_id`, and server tools like `web_search_20250305` are all simply never read, so none of them can reach Copilot and 400 the request.
+
+**Background — the `max_output_tokens` floor.** Claude Code's very first request against a model it has not seen is a validation probe with `max_tokens: 1`. The Responses API rejects `max_output_tokens` below 16. Without the floor, every Responses-only GPT model would be rejected by Claude Code before the user ever got a turn — the feature would appear completely broken. The floor raises 1 to 16; the probe then succeeds, possibly producing zero content, which Task 7 and Task 8 handle.
+
+**Background — mapping table.**
+
+| Anthropic | Responses | Note |
+|---|---|---|
+| `model` | `model` | already rewritten to the outbound id by the caller |
+| `stream` | `stream` | defaults to `false` |
+| `system` (array of text blocks, or string) | `instructions` | flattened, blocks joined with a blank line |
+| `max_tokens` | `max_output_tokens` | clamped to ≥ 16 |
+| `temperature`, `top_p` | same | copied when present |
+| `messages[].content` text | `input[]` message item, `input_text` / `output_text` | role decides the part type |
+| `messages[].content` image | `input_image` with a data URL | base64 or URL source |
+| `messages[].content` `tool_use` | top-level `function_call` item | `input` object → `arguments` JSON **string** |
+| `messages[].content` `tool_result` | top-level `function_call_output` item | text flattened |
+| `thinking` / `redacted_thinking` | — | dropped; see Known Limitations |
+| `tools[]` with `input_schema` | `tools[]` `{type:"function", …}` | `input_schema` → `parameters` |
+| `tools[]` without `input_schema` | — | dropped (server tools Copilot rejects) |
+| `tool_choice` | `tool_choice` | `any` → `required`; `tool` → `{type:"function",name}` |
+| — | `store: false` | always; the proxy is stateless and full history is resent each turn |
+| `stop_sequences`, `betas`, `cache_control`, `metadata` | — | dropped |
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/CopilotAnthropicProxy.Tests/AnthropicToResponsesRequestTests.cs`:
+
+```csharp
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+public class AnthropicToResponsesRequestTests
+{
+    private static JsonElement TranslateToElement(string anthropicJson) =>
+        JsonDocument.Parse(AnthropicToResponsesRequest.Translate(anthropicJson)).RootElement.Clone();
+
+    [Fact]
+    public void Translates_a_plain_text_turn()
+    {
+        var result = TranslateToElement(
+            """
+            {"model":"gpt-5.3-codex","max_tokens":1024,"stream":true,
+             "messages":[{"role":"user","content":"Hello"}]}
+            """
+        );
+
+        result.GetProperty("model").GetString().Should().Be("gpt-5.3-codex");
+        result.GetProperty("max_output_tokens").GetInt32().Should().Be(1024);
+        result.GetProperty("stream").GetBoolean().Should().BeTrue();
+        result.GetProperty("store").GetBoolean().Should().BeFalse();
+
+        var item = result.GetProperty("input")[0];
+        item.GetProperty("type").GetString().Should().Be("message");
+        item.GetProperty("role").GetString().Should().Be("user");
+        item.GetProperty("content")[0].GetProperty("type").GetString().Should().Be("input_text");
+        item.GetProperty("content")[0].GetProperty("text").GetString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public void Clamps_the_model_validation_probe_to_the_minimum_output_tokens()
+    {
+        // Claude Code's first request against any new model is `max_tokens: 1`. The Responses API
+        // rejects max_output_tokens < 16, so without this clamp EVERY GPT model is rejected on sight.
+        var result = TranslateToElement(
+            """
+            {"model":"gpt-5.3-codex","max_tokens":1,
+             "messages":[{"role":"user","content":[{"type":"text","text":"Hi"}]}]}
+            """
+        );
+
+        result.GetProperty("max_output_tokens").GetInt32().Should().Be(AnthropicToResponsesRequest.MinimumOutputTokens);
+    }
+
+    [Fact]
+    public void Flattens_a_system_block_array_into_instructions()
+    {
+        // Claude Code ALWAYS sends `system` as an array of text blocks, never a bare string.
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,
+             "system":[{"type":"text","text":"You are terse.","cache_control":{"type":"ephemeral","ttl":"1h"}},
+                       {"type":"text","text":"Answer in English."}],
+             "messages":[{"role":"user","content":"Hi"}]}
+            """
+        );
+
+        result.GetProperty("instructions").GetString().Should().Be("You are terse.\n\nAnswer in English.");
+    }
+
+    [Fact]
+    public void Accepts_the_legacy_bare_string_system_prompt()
+    {
+        var result = TranslateToElement(
+            """{"model":"m","max_tokens":100,"system":"Be brief.","messages":[{"role":"user","content":"Hi"}]}"""
+        );
+
+        result.GetProperty("instructions").GetString().Should().Be("Be brief.");
+    }
+
+    [Fact]
+    public void Turns_tool_use_and_tool_result_into_top_level_items()
+    {
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"messages":[
+              {"role":"user","content":"weather?"},
+              {"role":"assistant","content":[
+                 {"type":"text","text":"checking"},
+                 {"type":"tool_use","id":"call_1","name":"get_weather","input":{"city":"Paris"}}]},
+              {"role":"user","content":[
+                 {"type":"tool_result","tool_use_id":"call_1","content":[{"type":"text","text":"18C"}]}]}
+            ]}
+            """
+        );
+
+        var input = result.GetProperty("input");
+        input.GetArrayLength().Should().Be(4);
+
+        input[1].GetProperty("type").GetString().Should().Be("message");
+        input[1].GetProperty("content")[0].GetProperty("type").GetString().Should().Be("output_text");
+
+        input[2].GetProperty("type").GetString().Should().Be("function_call");
+        input[2].GetProperty("call_id").GetString().Should().Be("call_1");
+        input[2].GetProperty("name").GetString().Should().Be("get_weather");
+        input[2].GetProperty("arguments").GetString().Should().Be("""{"city":"Paris"}""");
+
+        input[3].GetProperty("type").GetString().Should().Be("function_call_output");
+        input[3].GetProperty("call_id").GetString().Should().Be("call_1");
+        input[3].GetProperty("output").GetString().Should().Be("18C");
+    }
+
+    [Fact]
+    public void Maps_function_tools_and_drops_server_tools()
+    {
+        // web_search_20250305 has no input_schema. Copilot answers
+        // 400 "The use of the web search tool is not supported." if it is forwarded.
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"messages":[{"role":"user","content":"hi"}],
+             "tools":[
+               {"name":"get_weather","description":"Weather.","input_schema":{"type":"object","properties":{}}},
+               {"type":"web_search_20250305","name":"web_search","max_uses":8}],
+             "tool_choice":{"type":"any"}}
+            """
+        );
+
+        var tools = result.GetProperty("tools");
+        tools.GetArrayLength().Should().Be(1);
+        tools[0].GetProperty("type").GetString().Should().Be("function");
+        tools[0].GetProperty("name").GetString().Should().Be("get_weather");
+        tools[0].GetProperty("parameters").GetProperty("type").GetString().Should().Be("object");
+
+        result.GetProperty("tool_choice").GetString().Should().Be("required");
+    }
+
+    [Fact]
+    public void Drops_fields_the_responses_api_would_reject()
+    {
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"betas":["context-management-2025-06-27"],
+             "stop_sequences":["</severity>"],"metadata":{"user_id":"abc"},
+             "messages":[{"role":"user","content":[
+               {"type":"thinking","thinking":"hmm","signature":"sig"},
+               {"type":"text","text":"Hi","cache_control":{"type":"ephemeral","scope":"global"}}]}]}
+            """
+        );
+
+        result.TryGetProperty("betas", out _).Should().BeFalse();
+        result.TryGetProperty("stop_sequences", out _).Should().BeFalse();
+        result.TryGetProperty("metadata", out _).Should().BeFalse();
+
+        var content = result.GetProperty("input")[0].GetProperty("content");
+        content.GetArrayLength().Should().Be(1, "thinking blocks are not replayed");
+        content[0].GetProperty("text").GetString().Should().Be("Hi");
+        content[0].TryGetProperty("cache_control", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Maps_a_base64_image_block_to_a_data_url()
+    {
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"messages":[{"role":"user","content":[
+              {"type":"image","source":{"type":"base64","media_type":"image/png","data":"AAAA"}}]}]}
+            """
+        );
+
+        var part = result.GetProperty("input")[0].GetProperty("content")[0];
+        part.GetProperty("type").GetString().Should().Be("input_image");
+        part.GetProperty("image_url").GetString().Should().Be("data:image/png;base64,AAAA");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --filter "FullyQualifiedName~AnthropicToResponsesRequestTests"
+```
+Expected: compile error — `AnthropicToResponsesRequest` does not exist.
+
+- [ ] **Step 3: Write the translator**
+
+Create `samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs`:
+
+```csharp
+using System.Text.Json.Nodes;
+
+/// <summary>
+///     Rewrites an Anthropic Messages request into an OpenAI Responses request.
+///
+///     Builds a NEW object from an explicit allowlist rather than patching the inbound body. That is
+///     deliberate: Claude Code sends a great deal that Copilot's Responses endpoint rejects outright —
+///     body-level <c>betas</c> (~29 of them), <c>cache_control</c> with <c>ttl</c>/<c>scope</c>
+///     sub-fields, <c>metadata.user_id</c>, and server tools such as <c>web_search_20250305</c>. An
+///     allowlist drops all of it by construction; a patch-in-place would have to chase each one.
+/// </summary>
+public static class AnthropicToResponsesRequest
+{
+    /// <summary>
+    ///     The smallest <c>max_output_tokens</c> the Responses API accepts.
+    ///
+    ///     Claude Code's FIRST request against a model it has not used is a validation probe with
+    ///     <c>max_tokens: 1</c> and <c>maxRetries: 0</c>. Passed through literally it is a 400, and
+    ///     Claude Code concludes the model is unusable — so every GPT model would appear broken before
+    ///     the user ever got a turn. Clamping up costs nothing: the probe only checks that a
+    ///     well-formed response comes back.
+    /// </summary>
+    public const int MinimumOutputTokens = 16;
+
+    /// <summary>Translates an Anthropic request body. Throws <see cref="ArgumentException"/> if it is not a JSON object.</summary>
+    public static string Translate(string anthropicJson)
+    {
+        ArgumentNullException.ThrowIfNull(anthropicJson);
+
+        return JsonNode.Parse(anthropicJson) is JsonObject source
+            ? Translate(source).ToJsonString()
+            : throw new ArgumentException("An Anthropic request body must be a JSON object.", nameof(anthropicJson));
+    }
+
+    /// <summary>Translates a parsed Anthropic request body.</summary>
+    public static JsonObject Translate(JsonObject source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        var target = new JsonObject
+        {
+            ["model"] = source["model"]?.DeepClone(),
+            ["stream"] = (source["stream"] ?? JsonValue.Create(false)).DeepClone(),
+
+            // The proxy holds no server-side state and the client resends full history every turn,
+            // so opt out of the Responses store (whose default is true).
+            ["store"] = false,
+            ["input"] = BuildInput(source["messages"] as JsonArray),
+        };
+
+        var instructions = FlattenText(source["system"]);
+        if (instructions.Length > 0)
+        {
+            target["instructions"] = instructions;
+        }
+
+        // Anthropic requires max_tokens; Responses treats max_output_tokens as optional. Omit rather
+        // than invent a cap when the client did not send one.
+        if (source["max_tokens"]?.GetValue<int>() is { } maxTokens)
+        {
+            target["max_output_tokens"] = Math.Max(maxTokens, MinimumOutputTokens);
+        }
+
+        foreach (var passthrough in new[] { "temperature", "top_p" })
+        {
+            if (source[passthrough] is { } value)
+            {
+                target[passthrough] = value.DeepClone();
+            }
+        }
+
+        if (BuildTools(source["tools"] as JsonArray) is { Count: > 0 } tools)
+        {
+            target["tools"] = tools;
+        }
+
+        if (BuildToolChoice(source["tool_choice"]) is { } toolChoice)
+        {
+            target["tool_choice"] = toolChoice;
+        }
+
+        return target;
+    }
+
+    /// <summary>
+    ///     Flattens an Anthropic text value into a plain string. Accepts a bare string, a single block,
+    ///     or an array of blocks; non-text blocks are ignored. Claude Code always sends the array form
+    ///     for <c>system</c>, but the string form is legal and older clients use it.
+    /// </summary>
+    private static string FlattenText(JsonNode? value)
+    {
+        switch (value)
+        {
+            case JsonValue scalar when scalar.TryGetValue<string>(out var text):
+                return text;
+            case JsonObject block:
+                return block["type"]?.GetValue<string>() == "text" ? block["text"]?.GetValue<string>() ?? "" : "";
+            case JsonArray blocks:
+                var parts = blocks
+                    .OfType<JsonObject>()
+                    .Where(b => b["type"]?.GetValue<string>() == "text")
+                    .Select(b => b["text"]?.GetValue<string>() ?? "")
+                    .Where(t => t.Length > 0);
+                return string.Join("\n\n", parts);
+            default:
+                return "";
+        }
+    }
+
+    /// <summary>
+    ///     Turns Anthropic's messages into a Responses <c>input</c> array.
+    ///
+    ///     The shapes differ structurally: Anthropic nests tool calls and tool results INSIDE message
+    ///     content, while Responses makes them top-level items. So a message's text and image blocks
+    ///     accumulate into one message item, and any tool block flushes that item and appends its own.
+    ///     Order is preserved throughout — Responses pairs a function_call with its output by
+    ///     <c>call_id</c>, but a sane ordering keeps transcripts readable and matches what Codex sends.
+    /// </summary>
+    private static JsonArray BuildInput(JsonArray? messages)
+    {
+        var input = new JsonArray();
+        if (messages is null)
+        {
+            return input;
+        }
+
+        foreach (var message in messages.OfType<JsonObject>())
+        {
+            var role = message["role"]?.GetValue<string>() ?? "user";
+            var textPartType = role == "assistant" ? "output_text" : "input_text";
+            JsonArray? pending = null;
+
+            void Flush()
+            {
+                if (pending is { Count: > 0 })
+                {
+                    input.Add(
+                        new JsonObject
+                        {
+                            ["type"] = "message",
+                            ["role"] = role,
+                            ["content"] = pending,
+                        }
+                    );
+                }
+
+                pending = null;
+            }
+
+            JsonArray Pending() => pending ??= [];
+
+            switch (message["content"])
+            {
+                case JsonValue scalar when scalar.TryGetValue<string>(out var text):
+                    Pending().Add(new JsonObject { ["type"] = textPartType, ["text"] = text });
+                    break;
+
+                case JsonArray blocks:
+                    foreach (var block in blocks.OfType<JsonObject>())
+                    {
+                        switch (block["type"]?.GetValue<string>())
+                        {
+                            case "text":
+                                Pending()
+                                    .Add(
+                                        new JsonObject
+                                        {
+                                            ["type"] = textPartType,
+                                            ["text"] = block["text"]?.GetValue<string>() ?? "",
+                                        }
+                                    );
+                                break;
+
+                            case "image" when ToImageUrl(block["source"] as JsonObject) is { } imageUrl:
+                                Pending().Add(new JsonObject { ["type"] = "input_image", ["image_url"] = imageUrl });
+                                break;
+
+                            case "tool_use":
+                                Flush();
+                                input.Add(
+                                    new JsonObject
+                                    {
+                                        ["type"] = "function_call",
+                                        ["call_id"] = block["id"]?.GetValue<string>() ?? "",
+                                        ["name"] = block["name"]?.GetValue<string>() ?? "",
+                                        // Anthropic sends a JSON object; Responses wants a JSON STRING.
+                                        ["arguments"] = (block["input"] ?? new JsonObject()).ToJsonString(),
+                                    }
+                                );
+                                break;
+
+                            case "tool_result":
+                                Flush();
+                                input.Add(
+                                    new JsonObject
+                                    {
+                                        ["type"] = "function_call_output",
+                                        ["call_id"] = block["tool_use_id"]?.GetValue<string>() ?? "",
+                                        ["output"] = FlattenText(block["content"]),
+                                    }
+                                );
+                                break;
+
+                            // "thinking" / "redacted_thinking" are dropped: replaying them needs
+                            // reasoning.encrypted_content round-tripping, which this sample does not do.
+                            // Anything else is unknown and equally not forwarded.
+                        }
+                    }
+
+                    break;
+            }
+
+            Flush();
+        }
+
+        return input;
+    }
+
+    /// <summary>Builds a data URL (or passes a plain URL through) for an Anthropic image source.</summary>
+    private static string? ToImageUrl(JsonObject? imageSource)
+    {
+        if (imageSource is null)
+        {
+            return null;
+        }
+
+        return imageSource["type"]?.GetValue<string>() switch
+        {
+            "url" => imageSource["url"]?.GetValue<string>(),
+            "base64" =>
+                $"data:{imageSource["media_type"]?.GetValue<string>() ?? "image/png"};base64,{imageSource["data"]?.GetValue<string>() ?? ""}",
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    ///     Maps Anthropic tools onto Responses function tools. ONLY entries carrying an
+    ///     <c>input_schema</c> are mapped — that filter is what silently drops Claude Code's server
+    ///     tools (<c>web_search_20250305</c>, <c>advisor_20260301</c>), which Copilot rejects with
+    ///     400 "The use of the web search tool is not supported."
+    /// </summary>
+    private static JsonArray BuildTools(JsonArray? tools)
+    {
+        var mapped = new JsonArray();
+        if (tools is null)
+        {
+            return mapped;
+        }
+
+        foreach (var tool in tools.OfType<JsonObject>())
+        {
+            if (tool["input_schema"] is not { } schema)
+            {
+                continue;
+            }
+
+            var mappedTool = new JsonObject
+            {
+                ["type"] = "function",
+                ["name"] = tool["name"]?.GetValue<string>() ?? "",
+                ["parameters"] = schema.DeepClone(),
+            };
+
+            if (tool["description"]?.GetValue<string>() is { Length: > 0 } description)
+            {
+                mappedTool["description"] = description;
+            }
+
+            mapped.Add(mappedTool);
+        }
+
+        return mapped;
+    }
+
+    /// <summary>Maps Anthropic's tool_choice onto the Responses spelling.</summary>
+    private static JsonNode? BuildToolChoice(JsonNode? toolChoice)
+    {
+        if (toolChoice is not JsonObject choice)
+        {
+            return null;
+        }
+
+        return choice["type"]?.GetValue<string>() switch
+        {
+            "auto" => JsonValue.Create("auto"),
+            "none" => JsonValue.Create("none"),
+            "any" => JsonValue.Create("required"),
+            "tool" => new JsonObject { ["type"] = "function", ["name"] = choice["name"]?.GetValue<string>() ?? "" },
+            _ => null,
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --filter "FullyQualifiedName~AnthropicToResponsesRequestTests"
+```
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs tests/CopilotAnthropicProxy.Tests/AnthropicToResponsesRequestTests.cs
+git commit -m "feat(proxy): translate Anthropic Messages requests into Responses requests"
+```
+
+---
+
+## Task 7: Responses response → Anthropic Message (non-streaming)
+
+**Files:**
+- Create: `samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicJson.cs`
+- Test: `tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicJsonTests.cs`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `public static class ResponsesToAnthropicJson`
+  - `public static string Translate(string responsesJson, string fallbackModel)`
+  - `public static string DeriveStopReason(JsonObject response)` — also used by Task 8, so both agree on the rule.
+
+**Background — `stop_reason`.** Anthropic clients branch on it, so getting it wrong changes client behavior. The rule, in order:
+
+1. `response.output` contains any `function_call` item → `tool_use`
+2. `response.incomplete_details.reason == "max_output_tokens"` → `max_tokens`
+3. otherwise → `end_turn`
+
+Caveat carried from the spec: `incomplete_details` is not parsed anywhere under `src/OpenAiResponsesProvider`, so its exact live shape is unconfirmed. Any unrecognised shape falls through to `end_turn` — an honest default. Task 10's live smoke test is what confirms it.
+
+**Background — zero content is a valid answer.** The `max_tokens: 1` probe (clamped to 16) against a reasoning model can finish having emitted only reasoning, leaving `output` with no text and no function calls. The translator must then produce `content: []`, not a fabricated empty text block. Anthropic's own API does exactly this.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicJsonTests.cs`:
+
+```csharp
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+public class ResponsesToAnthropicJsonTests
+{
+    private static JsonElement Translate(string responsesJson) =>
+        JsonDocument.Parse(ResponsesToAnthropicJson.Translate(responsesJson, "fallback-model")).RootElement.Clone();
+
+    [Fact]
+    public void Translates_a_text_response()
+    {
+        var result = Translate(
+            """
+            {"id":"resp_1","model":"gpt-5.3-codex",
+             "output":[{"type":"message","role":"assistant",
+                        "content":[{"type":"output_text","text":"Hello there"}]}],
+             "usage":{"input_tokens":12,"output_tokens":3}}
+            """
+        );
+
+        result.GetProperty("id").GetString().Should().Be("resp_1");
+        result.GetProperty("type").GetString().Should().Be("message");
+        result.GetProperty("role").GetString().Should().Be("assistant");
+        result.GetProperty("model").GetString().Should().Be("gpt-5.3-codex");
+        result.GetProperty("stop_reason").GetString().Should().Be("end_turn");
+        result.GetProperty("stop_sequence").ValueKind.Should().Be(JsonValueKind.Null);
+        result.GetProperty("usage").GetProperty("input_tokens").GetInt32().Should().Be(12);
+        result.GetProperty("usage").GetProperty("output_tokens").GetInt32().Should().Be(3);
+
+        var content = result.GetProperty("content");
+        content.GetArrayLength().Should().Be(1);
+        content[0].GetProperty("type").GetString().Should().Be("text");
+        content[0].GetProperty("text").GetString().Should().Be("Hello there");
+    }
+
+    [Fact]
+    public void Translates_a_function_call_into_a_tool_use_block()
+    {
+        var result = Translate(
+            """
+            {"id":"resp_2","model":"m",
+             "output":[{"type":"function_call","call_id":"call_9","name":"get_weather",
+                        "arguments":"{\"city\":\"Paris\"}"}],
+             "usage":{"input_tokens":1,"output_tokens":1}}
+            """
+        );
+
+        result.GetProperty("stop_reason").GetString().Should().Be("tool_use");
+
+        var block = result.GetProperty("content")[0];
+        block.GetProperty("type").GetString().Should().Be("tool_use");
+        block.GetProperty("id").GetString().Should().Be("call_9");
+        block.GetProperty("name").GetString().Should().Be("get_weather");
+        block.GetProperty("input").GetProperty("city").GetString().Should().Be("Paris");
+    }
+
+    [Fact]
+    public void Surfaces_a_reasoning_summary_as_a_thinking_block()
+    {
+        var result = Translate(
+            """
+            {"id":"r","model":"m",
+             "output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"weighing options"}]},
+                       {"type":"message","content":[{"type":"output_text","text":"Done"}]}],
+             "usage":{"input_tokens":1,"output_tokens":1}}
+            """
+        );
+
+        var content = result.GetProperty("content");
+        content[0].GetProperty("type").GetString().Should().Be("thinking");
+        content[0].GetProperty("thinking").GetString().Should().Be("weighing options");
+        content[1].GetProperty("type").GetString().Should().Be("text");
+    }
+
+    [Fact]
+    public void Reports_max_tokens_when_the_response_was_truncated()
+    {
+        var result = Translate(
+            """
+            {"id":"r","model":"m","incomplete_details":{"reason":"max_output_tokens"},
+             "output":[{"type":"message","content":[{"type":"output_text","text":"partial"}]}],
+             "usage":{"input_tokens":1,"output_tokens":16}}
+            """
+        );
+
+        result.GetProperty("stop_reason").GetString().Should().Be("max_tokens");
+    }
+
+    [Fact]
+    public void An_empty_output_yields_an_empty_content_array_not_a_placeholder_block()
+    {
+        // This is what Claude Code's `max_tokens: 1` model-validation probe can produce against a
+        // reasoning model. The envelope must be well-formed; the content must NOT be invented.
+        var result = Translate("""{"id":"r","model":"m","output":[],"usage":{"input_tokens":1,"output_tokens":0}}""");
+
+        result.GetProperty("content").GetArrayLength().Should().Be(0);
+        result.GetProperty("stop_reason").GetString().Should().Be("end_turn");
+        result.GetProperty("type").GetString().Should().Be("message");
+    }
+
+    [Fact]
+    public void Falls_back_to_the_supplied_model_when_the_response_omits_one()
+    {
+        var result = Translate("""{"id":"r","output":[]}""");
+
+        result.GetProperty("model").GetString().Should().Be("fallback-model");
+        result.GetProperty("usage").GetProperty("input_tokens").GetInt32().Should().Be(0);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --filter "FullyQualifiedName~ResponsesToAnthropicJsonTests"
+```
+Expected: compile error — `ResponsesToAnthropicJson` does not exist.
+
+- [ ] **Step 3: Write the translator**
+
+Create `samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicJson.cs`:
+
+```csharp
+using System.Text.Json.Nodes;
+
+/// <summary>
+///     Rewrites a non-streaming OpenAI Responses reply into an Anthropic Message.
+///     <see cref="ResponsesToAnthropicSse"/> does the same job for streaming replies and shares
+///     <see cref="DeriveStopReason"/> so the two cannot drift apart.
+/// </summary>
+public static class ResponsesToAnthropicJson
+{
+    /// <summary>
+    ///     Translates a Responses reply body. <paramref name="fallbackModel"/> is reported when the
+    ///     reply omits <c>model</c>.
+    /// </summary>
+    public static string Translate(string responsesJson, string fallbackModel)
+    {
+        ArgumentNullException.ThrowIfNull(responsesJson);
+
+        if (JsonNode.Parse(responsesJson) is not JsonObject response)
+        {
+            throw new ArgumentException("A Responses reply must be a JSON object.", nameof(responsesJson));
+        }
+
+        var usage = response["usage"] as JsonObject;
+
+        var message = new JsonObject
+        {
+            ["id"] = response["id"]?.GetValue<string>() ?? "msg_proxy",
+            ["type"] = "message",
+            ["role"] = "assistant",
+            ["model"] = response["model"]?.GetValue<string>() ?? fallbackModel,
+            ["content"] = BuildContent(response["output"] as JsonArray),
+            ["stop_reason"] = DeriveStopReason(response),
+            ["stop_sequence"] = null,
+            ["usage"] = new JsonObject
+            {
+                ["input_tokens"] = usage?["input_tokens"]?.GetValue<int>() ?? 0,
+                ["output_tokens"] = usage?["output_tokens"]?.GetValue<int>() ?? 0,
+            },
+        };
+
+        return message.ToJsonString();
+    }
+
+    /// <summary>
+    ///     Derives Anthropic's <c>stop_reason</c> from a Responses reply, in priority order:
+    ///     a function call outranks truncation, truncation outranks a normal finish.
+    ///
+    ///     Any unrecognised <c>incomplete_details</c> shape falls through to <c>end_turn</c>. That
+    ///     field is not modelled anywhere under src/OpenAiResponsesProvider, so its live shape is
+    ///     confirmed by the live smoke test rather than by a fixture.
+    /// </summary>
+    public static string DeriveStopReason(JsonObject response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+
+        if (
+            response["output"] is JsonArray output
+            && output.OfType<JsonObject>().Any(item => item["type"]?.GetValue<string>() == "function_call")
+        )
+        {
+            return "tool_use";
+        }
+
+        if ((response["incomplete_details"] as JsonObject)?["reason"]?.GetValue<string>() == "max_output_tokens")
+        {
+            return "max_tokens";
+        }
+
+        return "end_turn";
+    }
+
+    /// <summary>
+    ///     Maps Responses output items onto Anthropic content blocks, in order. An empty result is a
+    ///     legitimate answer — a truncated or reasoning-only turn genuinely produced no content — so
+    ///     nothing is invented to fill the gap.
+    /// </summary>
+    private static JsonArray BuildContent(JsonArray? output)
+    {
+        var content = new JsonArray();
+        if (output is null)
+        {
+            return content;
+        }
+
+        foreach (var item in output.OfType<JsonObject>())
+        {
+            switch (item["type"]?.GetValue<string>())
+            {
+                case "message":
+                    foreach (var part in (item["content"] as JsonArray ?? []).OfType<JsonObject>())
+                    {
+                        if (part["type"]?.GetValue<string>() == "output_text")
+                        {
+                            content.Add(
+                                new JsonObject { ["type"] = "text", ["text"] = part["text"]?.GetValue<string>() ?? "" }
+                            );
+                        }
+                    }
+
+                    break;
+
+                case "reasoning":
+                    // Display only. The encrypted payload that would make reasoning replayable across
+                    // turns is not carried — see the README's Known limitations.
+                    var summary = string.Join(
+                        "\n\n",
+                        (item["summary"] as JsonArray ?? [])
+                            .OfType<JsonObject>()
+                            .Select(s => s["text"]?.GetValue<string>() ?? "")
+                            .Where(t => t.Length > 0)
+                    );
+
+                    if (summary.Length > 0)
+                    {
+                        content.Add(new JsonObject { ["type"] = "thinking", ["thinking"] = summary });
+                    }
+
+                    break;
+
+                case "function_call":
+                    content.Add(
+                        new JsonObject
+                        {
+                            ["type"] = "tool_use",
+                            ["id"] = item["call_id"]?.GetValue<string>() ?? "",
+                            ["name"] = item["name"]?.GetValue<string>() ?? "",
+                            ["input"] = ParseArguments(item["arguments"]?.GetValue<string>()),
+                        }
+                    );
+                    break;
+            }
+        }
+
+        return content;
+    }
+
+    /// <summary>
+    ///     Parses a function call's arguments, which Responses sends as a JSON STRING while Anthropic
+    ///     expects an object. Malformed or empty arguments become an empty object rather than an error:
+    ///     a client can recover from a tool call with no arguments, but not from a broken envelope.
+    /// </summary>
+    private static JsonNode ParseArguments(string? arguments)
+    {
+        if (string.IsNullOrWhiteSpace(arguments))
+        {
+            return new JsonObject();
+        }
+
+        try
+        {
+            return JsonNode.Parse(arguments) as JsonObject ?? new JsonObject();
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return new JsonObject();
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --filter "FullyQualifiedName~ResponsesToAnthropicJsonTests"
+```
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicJson.cs tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicJsonTests.cs
+git commit -m "feat(proxy): translate non-streaming Responses replies into Anthropic messages"
+```
+
+---
+
+## Task 8: Responses SSE → Anthropic SSE
+
+**Files:**
+- Create: `samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicSse.cs`
+- Test: `tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicSseTests.cs`
+
+**Interfaces:**
+- Consumes: `ResponsesToAnthropicJson.DeriveStopReason(JsonObject)` (Task 7).
+- Produces:
+  - `public sealed class ResponsesToAnthropicSse`
+  - `public ResponsesToAnthropicSse(string messageId, string model)`
+  - `public IReadOnlyList<string> Next(string responsesEventJson)` — returns complete `event: …\ndata: …\n\n` frames, possibly empty.
+
+**Background — the two stream shapes.** Anthropic's stream is a block cursor: `message_start`, then for each content block `content_block_start` → deltas → `content_block_stop` at a monotonically increasing `index`, then `message_delta` carrying `stop_reason` and cumulative usage, then `message_stop`. Responses emits `response.*` events keyed by `output_index` / `content_index`. Because Responses works through its output items in order, tracking a single open block is enough — no index bookkeeping across interleaved blocks is needed.
+
+**Background — why there is no `Finish()`.** Under the "never fabricate SSE frames" rule, if the upstream stream ends without `response.completed` or `response.incomplete`, we emit nothing further and let the client see the truncation. Claude Code detects exactly this (`Stream completed without receiving message_start event` / `…but no content blocks completed`) and falls back to a non-streaming retry. Synthesising a clean terminator would convert an upstream failure into a silently empty successful answer — the worst outcome of the three. So the class is `Next()` only; the caller stops writing when the upstream stops.
+
+**Background — usage.** Responses does not report input tokens until the terminal event, so `message_start` reports zeros and `message_delta` carries the real figures. Emitting `input_tokens` in `message_delta` as well as `output_tokens` is what keeps client-side cost accounting correct.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicSseTests.cs`:
+
+```csharp
+using FluentAssertions;
+using Xunit;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+public class ResponsesToAnthropicSseTests
+{
+    /// <summary>Feeds a scripted Responses stream and returns the concatenated Anthropic SSE output.</summary>
+    private static string Run(params string[] events)
+    {
+        var translator = new ResponsesToAnthropicSse("msg_test", "gpt-5.3-codex");
+        return string.Concat(events.SelectMany(translator.Next));
+    }
+
+    [Fact]
+    public void Emits_a_well_formed_text_stream()
+    {
+        var output = Run(
+            """{"type":"response.created","response":{"id":"resp_1","model":"gpt-5.3-codex"}}""",
+            """{"type":"response.content_part.added","part":{"type":"output_text","text":""}}""",
+            """{"type":"response.output_text.delta","delta":"Hel"}""",
+            """{"type":"response.output_text.delta","delta":"lo"}""",
+            """{"type":"response.content_part.done"}""",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":9,"output_tokens":2}}}"""
+        );
+
+        output.Should().Contain("event: message_start");
+        output.Should().Contain("\"id\":\"resp_1\"");
+        output.Should().Contain("event: content_block_start");
+        output.Should().Contain("\"index\":0");
+        output.Should().Contain("\"type\":\"text_delta\",\"text\":\"Hel\"");
+        output.Should().Contain("\"type\":\"text_delta\",\"text\":\"lo\"");
+        output.Should().Contain("event: content_block_stop");
+        output.Should().Contain("\"stop_reason\":\"end_turn\"");
+        output.Should().Contain("\"input_tokens\":9");
+        output.Should().Contain("\"output_tokens\":2");
+        output.Should().EndWith("\n\n");
+        output.Should().Contain("event: message_stop");
+    }
+
+    [Fact]
+    public void Streams_a_tool_call_as_an_input_json_delta_block()
+    {
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_1","name":"get_weather"}}""",
+            """{"type":"response.function_call_arguments.delta","delta":"{\"city\":"}""",
+            """{"type":"response.function_call_arguments.delta","delta":"\"Paris\"}"}""",
+            """{"type":"response.output_item.done"}""",
+            """{"type":"response.completed","response":{"output":[{"type":"function_call"}],"usage":{"input_tokens":1,"output_tokens":5}}}"""
+        );
+
+        output.Should().Contain("\"type\":\"tool_use\"");
+        output.Should().Contain("\"id\":\"call_1\"");
+        output.Should().Contain("\"name\":\"get_weather\"");
+        output.Should().Contain("\"type\":\"input_json_delta\"");
+        output.Should().Contain("\"stop_reason\":\"tool_use\"");
+    }
+
+    [Fact]
+    public void Streams_a_reasoning_summary_as_a_thinking_block()
+    {
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.reasoning_summary_part.added"}""",
+            """{"type":"response.reasoning_summary_text.delta","delta":"thinking..."}""",
+            """{"type":"response.reasoning_summary_part.done"}""",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":1,"output_tokens":1}}}"""
+        );
+
+        output.Should().Contain("\"type\":\"thinking\"");
+        output.Should().Contain("\"type\":\"thinking_delta\"");
+    }
+
+    [Fact]
+    public void Closes_an_open_block_before_terminating()
+    {
+        // Upstream ends the response without closing its content part — the block must still be closed
+        // before message_delta, or the Anthropic stream is malformed.
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.content_part.added","part":{"type":"output_text"}}""",
+            """{"type":"response.output_text.delta","delta":"hi"}""",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":1,"output_tokens":1}}}"""
+        );
+
+        output.IndexOf("content_block_stop", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(output.IndexOf("message_delta", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void A_response_with_no_content_still_produces_a_well_formed_envelope()
+    {
+        // Claude Code's `max_tokens: 1` validation probe. Zero content blocks, but message_start and
+        // message_stop MUST both be present or the model is judged unusable.
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":3,"output_tokens":0}}}"""
+        );
+
+        output.Should().Contain("event: message_start");
+        output.Should().Contain("event: message_delta");
+        output.Should().Contain("event: message_stop");
+        output.Should().NotContain("content_block_start", "no content is honest; a fabricated block is not");
+    }
+
+    [Fact]
+    public void Reports_max_tokens_for_an_incomplete_response()
+    {
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.incomplete","response":{"output":[],"incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":1,"output_tokens":16}}}"""
+        );
+
+        output.Should().Contain("\"stop_reason\":\"max_tokens\"");
+        output.Should().Contain("event: message_stop");
+    }
+
+    [Fact]
+    public void A_truncated_stream_is_not_capped_with_a_fabricated_terminator()
+    {
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.content_part.added","part":{"type":"output_text"}}""",
+            """{"type":"response.output_text.delta","delta":"partial"}"""
+        );
+
+        output.Should().Contain("event: message_start");
+        output.Should().NotContain("message_stop", "the upstream never terminated; inventing one hides the failure");
+    }
+
+    [Fact]
+    public void Ignores_unknown_and_malformed_events()
+    {
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.some_future_event","data":{}}""",
+            "not json at all",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":1,"output_tokens":1}}}"""
+        );
+
+        output.Should().Contain("event: message_stop");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --filter "FullyQualifiedName~ResponsesToAnthropicSseTests"
+```
+Expected: compile error — `ResponsesToAnthropicSse` does not exist.
+
+- [ ] **Step 3: Write the state machine**
+
+Create `samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicSse.cs`:
+
+```csharp
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+/// <summary>
+///     Rewrites an OpenAI Responses SSE stream into an Anthropic Messages SSE stream, one upstream
+///     event at a time.
+///
+///     Anthropic's stream is a block cursor — message_start, then per content block a
+///     content_block_start / deltas / content_block_stop triple at a monotonically increasing index,
+///     then message_delta with the stop reason and usage, then message_stop. Responses emits its
+///     output items in order, so tracking ONE open block is sufficient.
+///
+///     There is deliberately no Finish(): if the upstream stream ends without a terminal event this
+///     class emits nothing more, leaving the client to observe the truncation. Capping a failed stream
+///     with a synthetic message_stop would turn an upstream error into a silently empty success.
+/// </summary>
+public sealed class ResponsesToAnthropicSse
+{
+    private readonly string _fallbackMessageId;
+    private readonly string _fallbackModel;
+
+    private bool _started;
+    private bool _finished;
+    private int _nextIndex;
+    private bool _blockOpen;
+
+    /// <summary>
+    ///     <paramref name="messageId"/> and <paramref name="model"/> are used when the upstream stream
+    ///     does not announce its own — Anthropic requires both in message_start.
+    /// </summary>
+    public ResponsesToAnthropicSse(string messageId, string model)
+    {
+        _fallbackMessageId = messageId;
+        _fallbackModel = model;
+    }
+
+    /// <summary>
+    ///     Feeds one Responses SSE <c>data:</c> payload and returns the Anthropic frames it produces
+    ///     (often none). Unparseable or unrecognised payloads produce no frames rather than an error —
+    ///     a stream must not die because the upstream added an event type we have not seen.
+    /// </summary>
+    public IReadOnlyList<string> Next(string responsesEventJson)
+    {
+        if (_finished || string.IsNullOrWhiteSpace(responsesEventJson))
+        {
+            return [];
+        }
+
+        JsonObject? evt;
+        try
+        {
+            evt = JsonNode.Parse(responsesEventJson) as JsonObject;
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+
+        if (evt?["type"]?.GetValue<string>() is not { } type)
+        {
+            return [];
+        }
+
+        var frames = new List<string>();
+        var response = evt["response"] as JsonObject;
+
+        switch (type)
+        {
+            case "response.created":
+                Start(frames, response);
+                break;
+
+            case "response.content_part.added" when evt["part"]?["type"]?.GetValue<string>() == "output_text":
+                Start(frames, response);
+                OpenBlock(frames, new JsonObject { ["type"] = "text", ["text"] = "" });
+                break;
+
+            case "response.output_text.delta":
+                Start(frames, response);
+                if (!_blockOpen)
+                {
+                    OpenBlock(frames, new JsonObject { ["type"] = "text", ["text"] = "" });
+                }
+
+                Delta(frames, "text_delta", "text", evt["delta"]?.GetValue<string>() ?? "");
+                break;
+
+            case "response.reasoning_summary_part.added":
+                Start(frames, response);
+                OpenBlock(frames, new JsonObject { ["type"] = "thinking", ["thinking"] = "" });
+                break;
+
+            case "response.reasoning_summary_text.delta":
+                Start(frames, response);
+                if (!_blockOpen)
+                {
+                    OpenBlock(frames, new JsonObject { ["type"] = "thinking", ["thinking"] = "" });
+                }
+
+                Delta(frames, "thinking_delta", "thinking", evt["delta"]?.GetValue<string>() ?? "");
+                break;
+
+            case "response.output_item.added" when evt["item"]?["type"]?.GetValue<string>() == "function_call":
+                Start(frames, response);
+                OpenBlock(
+                    frames,
+                    new JsonObject
+                    {
+                        ["type"] = "tool_use",
+                        ["id"] = evt["item"]?["call_id"]?.GetValue<string>() ?? "",
+                        ["name"] = evt["item"]?["name"]?.GetValue<string>() ?? "",
+                        ["input"] = new JsonObject(),
+                    }
+                );
+                break;
+
+            case "response.function_call_arguments.delta":
+                Start(frames, response);
+                Delta(frames, "input_json_delta", "partial_json", evt["delta"]?.GetValue<string>() ?? "");
+                break;
+
+            case "response.content_part.done":
+            case "response.output_item.done":
+            case "response.reasoning_summary_part.done":
+                CloseBlock(frames);
+                break;
+
+            case "response.completed":
+            case "response.incomplete":
+                Start(frames, response);
+                CloseBlock(frames);
+                Terminate(frames, response);
+                break;
+        }
+
+        return frames;
+    }
+
+    /// <summary>Emits message_start once, taking the id and model from the upstream response if it offered them.</summary>
+    private void Start(List<string> frames, JsonObject? response)
+    {
+        if (_started)
+        {
+            return;
+        }
+
+        _started = true;
+
+        var message = new JsonObject
+        {
+            ["id"] = response?["id"]?.GetValue<string>() ?? _fallbackMessageId,
+            ["type"] = "message",
+            ["role"] = "assistant",
+            ["model"] = response?["model"]?.GetValue<string>() ?? _fallbackModel,
+            ["content"] = new JsonArray(),
+            ["stop_reason"] = null,
+            ["stop_sequence"] = null,
+
+            // Responses does not report token counts until its terminal event; the real figures
+            // arrive in message_delta.
+            ["usage"] = new JsonObject { ["input_tokens"] = 0, ["output_tokens"] = 0 },
+        };
+
+        frames.Add(Frame("message_start", new JsonObject { ["type"] = "message_start", ["message"] = message }));
+    }
+
+    private void OpenBlock(List<string> frames, JsonObject contentBlock)
+    {
+        CloseBlock(frames);
+        _blockOpen = true;
+
+        frames.Add(
+            Frame(
+                "content_block_start",
+                new JsonObject
+                {
+                    ["type"] = "content_block_start",
+                    ["index"] = _nextIndex,
+                    ["content_block"] = contentBlock,
+                }
+            )
+        );
+    }
+
+    private void Delta(List<string> frames, string deltaType, string field, string value)
+    {
+        if (!_blockOpen || value.Length == 0)
+        {
+            return;
+        }
+
+        frames.Add(
+            Frame(
+                "content_block_delta",
+                new JsonObject
+                {
+                    ["type"] = "content_block_delta",
+                    ["index"] = _nextIndex,
+                    ["delta"] = new JsonObject { ["type"] = deltaType, [field] = value },
+                }
+            )
+        );
+    }
+
+    private void CloseBlock(List<string> frames)
+    {
+        if (!_blockOpen)
+        {
+            return;
+        }
+
+        frames.Add(Frame("content_block_stop", new JsonObject { ["type"] = "content_block_stop", ["index"] = _nextIndex }));
+        _blockOpen = false;
+        _nextIndex++;
+    }
+
+    private void Terminate(List<string> frames, JsonObject? response)
+    {
+        _finished = true;
+
+        var usage = response?["usage"] as JsonObject;
+
+        frames.Add(
+            Frame(
+                "message_delta",
+                new JsonObject
+                {
+                    ["type"] = "message_delta",
+                    ["delta"] = new JsonObject
+                    {
+                        ["stop_reason"] = response is null ? "end_turn" : ResponsesToAnthropicJson.DeriveStopReason(response),
+                        ["stop_sequence"] = null,
+                    },
+                    ["usage"] = new JsonObject
+                    {
+                        ["input_tokens"] = usage?["input_tokens"]?.GetValue<int>() ?? 0,
+                        ["output_tokens"] = usage?["output_tokens"]?.GetValue<int>() ?? 0,
+                    },
+                }
+            )
+        );
+
+        frames.Add(Frame("message_stop", new JsonObject { ["type"] = "message_stop" }));
+    }
+
+    private static string Frame(string eventName, JsonObject payload) =>
+        $"event: {eventName}\ndata: {payload.ToJsonString()}\n\n";
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --filter "FullyQualifiedName~ResponsesToAnthropicSseTests"
+```
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicSse.cs tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicSseTests.cs
+git commit -m "feat(proxy): translate Responses SSE into Anthropic SSE"
+```
+
+---
+
+## Task 9: Wire the translated branch into `/v1/messages`
+
+**Files:**
+- Modify: `samples/CopilotAnthropicProxy.Sample/Program.cs` (`ProxyHttp`)
+- Test: `tests/CopilotAnthropicProxy.Tests/TranslatedMessagesTests.cs`
+
+**Interfaces:**
+- Consumes: `ProxyRouteKind.TranslateAnthropicToResponses`, `ModelRoute` (Task 2); `AnthropicToResponsesRequest.Translate(string)` (Task 6); `ResponsesToAnthropicJson.Translate(string, string)` (Task 7); `ResponsesToAnthropicSse` (Task 8); the existing `ProxyHttp.ApplyRequestHeaderAllowlist`, `WriteAnthropicErrorAsync`.
+- Produces: no new public surface — a private `ProxyHttp.TranslateAnthropicToResponsesAsync`.
+
+**Background — the cancellation obligation.** The translated path does **not** go through `ProxyHttp.CopyBodyAsync`, so it does not inherit the two behaviors that file's comments spend most of their length on:
+
+1. **Idle timeout reset per read.** `ForwardAsync` builds a `CancellationTokenSource` linked with `ctx.RequestAborted` and calls `CancelAfter(idleTimeout)` before *every* read, so the clock measures the gap between bytes rather than total request duration. A long generation must not be killed for being long.
+2. **Keep-alive pings.** When `keepAliveInterval > TimeSpan.Zero`, a read that takes longer than the interval emits an SSE comment/ping so intermediaries do not drop an idle-looking connection.
+
+Both must be re-implemented here. Losing them turns a slow model into a 504.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/CopilotAnthropicProxy.Tests/TranslatedMessagesTests.cs`:
+
+```csharp
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+public class TranslatedMessagesTests
+{
+    private const string DiscoveryJson = """
+    {"data":[
+      {"id":"claude-opus-4.8","vendor":"Anthropic","supported_endpoints":["/v1/messages","/chat/completions"]},
+      {"id":"gpt-5.3-codex","vendor":"OpenAI","supported_endpoints":["/responses"]}
+    ]}
+    """;
+
+    private static ProxyWebAppFactory Factory(Func<HttpRequestMessage, string, Task<HttpResponseMessage>> onProxied) =>
+        new(
+            async (request, _) =>
+            {
+                var path = request.RequestUri!.AbsolutePath;
+                if (request.Method == HttpMethod.Get && path.EndsWith("/models", StringComparison.Ordinal))
+                {
+                    return TestUpstream.Json(DiscoveryJson);
+                }
+
+                return await onProxied(request, path);
+            },
+            model: null
+        );
+
+    [Fact]
+    public async Task A_responses_only_model_is_reached_via_the_responses_endpoint()
+    {
+        string? path = null;
+        string? body = null;
+
+        await using var factory = Factory(
+            async (request, seen) =>
+            {
+                path = seen;
+                body = await request.Content!.ReadAsStringAsync();
+                return TestUpstream.Json(
+                    """
+                    {"id":"resp_1","model":"gpt-5.3-codex",
+                     "output":[{"type":"message","content":[{"type":"output_text","text":"Hi there"}]}],
+                     "usage":{"input_tokens":4,"output_tokens":2}}
+                    """
+                );
+            }
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            new
+            {
+                model = "gpt-5.3-codex",
+                max_tokens = 1024,
+                messages = new[] { new { role = "user", content = "Hello" } },
+            }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        path.Should().Be("/responses");
+
+        using var sent = JsonDocument.Parse(body!);
+        sent.RootElement.GetProperty("max_output_tokens").GetInt32().Should().Be(1024);
+        sent.RootElement.GetProperty("store").GetBoolean().Should().BeFalse();
+
+        using var received = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        received.RootElement.GetProperty("type").GetString().Should().Be("message");
+        received.RootElement.GetProperty("content")[0].GetProperty("text").GetString().Should().Be("Hi there");
+    }
+
+    [Fact]
+    public async Task A_streaming_request_is_translated_frame_by_frame()
+    {
+        await using var factory = Factory(
+            (_, _) =>
+                Task.FromResult(
+                    TestUpstream.Sse(
+                        string.Concat(
+                            """
+                            event: response.created
+                            data: {"type":"response.created","response":{"id":"resp_2","model":"gpt-5.3-codex"}}
+
+
+                            """.ReplaceLineEndings("\n"),
+                            """
+                            event: response.output_text.delta
+                            data: {"type":"response.output_text.delta","delta":"Hello"}
+
+
+                            """.ReplaceLineEndings("\n"),
+                            """
+                            event: response.completed
+                            data: {"type":"response.completed","response":{"output":[],"usage":{"input_tokens":4,"output_tokens":1}}}
+
+
+                            """.ReplaceLineEndings("\n")
+                        )
+                    )
+                )
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            new
+            {
+                model = "gpt-5.3-codex",
+                max_tokens = 1024,
+                stream = true,
+                messages = new[] { new { role = "user", content = "Hello" } },
+            }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("text/event-stream");
+
+        var stream = await response.Content.ReadAsStringAsync();
+        stream.Should().Contain("event: message_start");
+        stream.Should().Contain("\"type\":\"text_delta\",\"text\":\"Hello\"");
+        stream.Should().Contain("event: message_stop");
+        stream.Should().NotContain("response.created", "upstream frames must not leak through");
+    }
+
+    [Fact]
+    public async Task The_model_validation_probe_returns_a_well_formed_empty_message()
+    {
+        // Claude Code's first request against any new model: max_tokens 1, one text block, no retries.
+        string? body = null;
+
+        await using var factory = Factory(
+            async (request, _) =>
+            {
+                body = await request.Content!.ReadAsStringAsync();
+                return TestUpstream.Json(
+                    """{"id":"resp_3","model":"gpt-5.3-codex","output":[],"usage":{"input_tokens":3,"output_tokens":0}}"""
+                );
+            }
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            new
+            {
+                model = "gpt-5.3-codex",
+                max_tokens = 1,
+                messages = new[]
+                {
+                    new { role = "user", content = new[] { new { type = "text", text = "Hi" } } },
+                },
+            }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var sent = JsonDocument.Parse(body!);
+        sent.RootElement.GetProperty("max_output_tokens")
+            .GetInt32()
+            .Should()
+            .Be(16, "Responses rejects max_output_tokens below 16 and Claude Code would reject the model");
+
+        using var received = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        received.RootElement.GetProperty("type").GetString().Should().Be("message");
+        received.RootElement.GetProperty("content").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task An_upstream_error_is_reported_in_the_anthropic_error_shape()
+    {
+        await using var factory = Factory(
+            (_, _) =>
+                Task.FromResult(
+                    TestUpstream.Json("""{"error":{"message":"model is overloaded"}}""", HttpStatusCode.ServiceUnavailable)
+                )
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            new
+            {
+                model = "gpt-5.3-codex",
+                max_tokens = 100,
+                messages = new[] { new { role = "user", content = "Hi" } },
+            }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        error.RootElement.GetProperty("type").GetString().Should().Be("error");
+        error.RootElement.GetProperty("error").GetProperty("message").GetString().Should().Contain("overloaded");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --filter "FullyQualifiedName~TranslatedMessagesTests"
+```
+Expected: FAIL with 404 — `ForwardAsync` still rejects a non-`Passthrough` route.
+
+- [ ] **Step 3: Branch in `ForwardAsync`**
+
+In `ProxyHttp.ForwardAsync`, immediately after the route is resolved and before the body is rewritten:
+
+```csharp
+if (route.Kind == ProxyRouteKind.TranslateAnthropicToResponses)
+{
+    await TranslateAnthropicToResponsesAsync(ctx, http, inboundBody, outboundModel, idleTimeout, keepAliveInterval, logger)
+        .ConfigureAwait(false);
+    return;
+}
+```
+
+Use whatever local name `ForwardAsync` already gives the `HttpClient` it resolved from DI, and pass the same `ILogger` it already holds.
+
+- [ ] **Step 4: Implement the translated path**
+
+Add to `ProxyHttp`:
+
+```csharp
+/// <summary>
+///     Serves an Anthropic Messages request from a model that only speaks OpenAI Responses.
+///
+///     This path does NOT go through <see cref="CopyBodyAsync"/>, so it re-implements that method's
+///     two cancellation behaviors itself: the idle timeout is reset before EVERY read (so the clock
+///     measures the gap between bytes, not the total request duration), and a slow read emits a
+///     keep-alive ping. Losing either turns a slow generation into a 504.
+/// </summary>
+private static async Task TranslateAnthropicToResponsesAsync(
+    HttpContext ctx,
+    HttpClient http,
+    byte[] inboundBody,
+    string outboundModel,
+    TimeSpan idleTimeout,
+    TimeSpan keepAliveInterval,
+    ILogger logger
+)
+{
+    string translatedBody;
+    bool isStreaming;
+
+    try
+    {
+        var source = JsonNode.Parse(inboundBody) as JsonObject;
+        if (source is null)
+        {
+            await WriteAnthropicErrorAsync(
+                    ctx,
+                    StatusCodes.Status400BadRequest,
+                    "invalid_request_error",
+                    "Request body must be a JSON object."
+                )
+                .ConfigureAwait(false);
+            return;
+        }
+
+        source["model"] = outboundModel;
+        isStreaming = source["stream"]?.GetValue<bool>() ?? false;
+        translatedBody = AnthropicToResponsesRequest.Translate(source).ToJsonString();
+    }
+    catch (Exception ex) when (ex is JsonException or ArgumentException or InvalidOperationException)
+    {
+        logger.LogWarning(ex, "Could not translate an Anthropic request for {Model}", outboundModel);
+        await WriteAnthropicErrorAsync(
+                ctx,
+                StatusCodes.Status400BadRequest,
+                "invalid_request_error",
+                "Request body could not be translated to the Responses API."
+            )
+            .ConfigureAwait(false);
+        return;
+    }
+
+    using var request = new HttpRequestMessage(HttpMethod.Post, ModelRouter.ResponsesPath)
+    {
+        Content = new StringContent(translatedBody, Encoding.UTF8, "application/json"),
+    };
+    ApplyRequestHeaderAllowlist(ctx.Request.Headers, request);
+
+    using var idleCts = new CancellationTokenSource();
+    using var linked = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted, idleCts.Token);
+    idleCts.CancelAfter(idleTimeout);
+
+    HttpResponseMessage upstream;
+    try
+    {
+        upstream = await http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, linked.Token)
+            .ConfigureAwait(false);
+    }
+    catch (OperationCanceledException) when (!ctx.RequestAborted.IsCancellationRequested)
+    {
+        await WriteAnthropicErrorAsync(
+                ctx,
+                StatusCodes.Status504GatewayTimeout,
+                "api_error",
+                "Upstream did not respond before the idle timeout."
+            )
+            .ConfigureAwait(false);
+        return;
+    }
+    catch (HttpRequestException ex)
+    {
+        logger.LogWarning(ex, "Upstream request to {Path} failed", ModelRouter.ResponsesPath);
+        await WriteAnthropicErrorAsync(ctx, StatusCodes.Status502BadGateway, "api_error", "Upstream request failed.")
+            .ConfigureAwait(false);
+        return;
+    }
+
+    using (upstream)
+    {
+        if (!upstream.IsSuccessStatusCode)
+        {
+            var errorBody = await upstream.Content.ReadAsStringAsync(ctx.RequestAborted).ConfigureAwait(false);
+            await WriteAnthropicErrorAsync(ctx, (int)upstream.StatusCode, "api_error", ExtractErrorMessage(errorBody))
+                .ConfigureAwait(false);
+            return;
+        }
+
+        if (!isStreaming)
+        {
+            var json = await upstream.Content.ReadAsStringAsync(ctx.RequestAborted).ConfigureAwait(false);
+            ctx.Response.StatusCode = StatusCodes.Status200OK;
+            ctx.Response.ContentType = "application/json";
+            await ctx.Response.WriteAsync(ResponsesToAnthropicJson.Translate(json, outboundModel), ctx.RequestAborted)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        ctx.Response.StatusCode = StatusCodes.Status200OK;
+        ctx.Response.ContentType = "text/event-stream";
+        ctx.Response.Headers.CacheControl = "no-cache";
+        ctx.Response.Headers["X-Accel-Buffering"] = "no";
+        ctx.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
+
+        var translator = new ResponsesToAnthropicSse($"msg_{Guid.NewGuid():N}", outboundModel);
+
+        await using var upstreamStream = await upstream
+            .Content.ReadAsStreamAsync(linked.Token)
+            .ConfigureAwait(false);
+        using var reader = new StreamReader(upstreamStream, Encoding.UTF8);
+
+        while (true)
+        {
+            // Reset per read: the idle timeout measures the gap between bytes, never total duration.
+            idleCts.CancelAfter(idleTimeout);
+
+            string? line;
+            try
+            {
+                line = await ReadLineWithKeepAliveAsync(ctx, reader, keepAliveInterval, linked.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (ctx.RequestAborted.IsCancellationRequested)
+            {
+                return; // The client hung up. Nothing to report to anyone.
+            }
+            catch (Exception ex) when (ex is OperationCanceledException or IOException or HttpRequestException)
+            {
+                // Mid-stream failure. The response has already started, so no error envelope can be
+                // written and no terminator may be fabricated — stop and let the client see truncation.
+                logger.LogWarning(ex, "Translated stream from {Model} failed mid-flight", outboundModel);
+                return;
+            }
+
+            if (line is null)
+            {
+                return;
+            }
+
+            if (!line.StartsWith("data:", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var payload = line[5..].Trim();
+            if (payload.Length == 0 || payload == "[DONE]")
+            {
+                continue;
+            }
+
+            foreach (var frame in translator.Next(payload))
+            {
+                await ctx.Response.WriteAsync(frame, ctx.RequestAborted).ConfigureAwait(false);
+            }
+
+            await ctx.Response.Body.FlushAsync(ctx.RequestAborted).ConfigureAwait(false);
+        }
+    }
+}
+
+/// <summary>
+///     Reads one line, emitting an Anthropic <c>ping</c> event whenever the wait exceeds
+///     <paramref name="keepAliveInterval"/> so intermediaries do not drop a connection that merely
+///     looks idle. A non-positive interval disables pings.
+/// </summary>
+private static async Task<string?> ReadLineWithKeepAliveAsync(
+    HttpContext ctx,
+    StreamReader reader,
+    TimeSpan keepAliveInterval,
+    CancellationToken cancellationToken
+)
+{
+    var readTask = reader.ReadLineAsync(cancellationToken).AsTask();
+    if (keepAliveInterval <= TimeSpan.Zero)
+    {
+        return await readTask.ConfigureAwait(false);
+    }
+
+    while (true)
+    {
+        using var delayCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var delay = Task.Delay(keepAliveInterval, delayCts.Token);
+
+        if (await Task.WhenAny(readTask, delay).ConfigureAwait(false) == readTask)
+        {
+            await delayCts.CancelAsync().ConfigureAwait(false);
+            return await readTask.ConfigureAwait(false);
+        }
+
+        await ctx.Response.WriteAsync("event: ping\ndata: {\"type\":\"ping\"}\n\n", cancellationToken)
+            .ConfigureAwait(false);
+        await ctx.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+}
+
+/// <summary>Pulls a human-readable message out of an OpenAI-shaped error body, falling back to the raw text.</summary>
+private static string ExtractErrorMessage(string body)
+{
+    try
+    {
+        if (JsonNode.Parse(body) is JsonObject obj && obj["error"]?["message"]?.GetValue<string>() is { } message)
+        {
+            return message;
+        }
+    }
+    catch (JsonException)
+    {
+        // Not JSON — fall through and return what we got.
+    }
+
+    return string.IsNullOrWhiteSpace(body) ? "Upstream request failed." : body;
+}
+```
+
+No new `using` directives are needed: `Program.cs:6-9` already imports `System.Text`, `System.Text.Json` and `System.Text.Json.Nodes`, and `IHttpResponseBodyFeature` is already used at `Program.cs:804`. Note `ApplyRequestHeaderAllowlist` takes an `IHeaderDictionary`, not an `HttpContext` — `Program.cs:1014`.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj
+```
+Expected: PASS, including all pre-existing tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add samples/CopilotAnthropicProxy.Sample/Program.cs tests/CopilotAnthropicProxy.Tests/TranslatedMessagesTests.cs
+git commit -m "feat(proxy): serve Responses-only models through the Anthropic Messages endpoint"
+```
+
+**P1 is complete here.** All four client/model quadrants work.
+
+---
+
+## Task 10: Documentation and live smoke tests
+
+**Files:**
+- Modify: `samples/CopilotAnthropicProxy.Sample/README.md`
+- Modify: `tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs`
+
+**Interfaces:**
+- Consumes: everything above. Adds no new production code.
+
+**Background.** `tests/CopilotLive.Tests/` is outside `LmDotnetTools.sln`, so CI never runs it — these tests hit the real Copilot backend and are run by hand. They exist to confirm the parts a fixture cannot prove, above all the live shape of `incomplete_details` (Task 7's documented caveat). Follow the existing file's conventions: `[SkippableFact]`, `Skip.IfNot(_fixture.Available, _fixture.SkipReason)`, and `_output.WriteLine` for the raw payload so a failure is diagnosable from the log alone.
+
+- [ ] **Step 1: Update the README**
+
+Add to `samples/CopilotAnthropicProxy.Sample/README.md`:
+
+```markdown
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/v1/messages`, `/messages` | Anthropic Messages. Passthrough for Claude models; translated to `/responses` for Responses-only GPT models. |
+| `POST` | `/v1/messages/count_tokens`, `/messages/count_tokens` | Anthropic token counting. Claude models only. |
+| `POST` | `/v1/chat/completions`, `/chat/completions` | OpenAI Chat Completions. Passthrough. |
+| `POST` | `/v1/responses`, `/responses` | OpenAI Responses. Passthrough. |
+| `GET` | `/v1/models` | Model list in a body both dialects can parse. |
+| `GET` | `/health` | Liveness. |
+| `ALL` | `/mcp`, `/mcp/readonly` | Unchanged MCP passthrough. |
+
+Every `POST` binds both the `/v1`-prefixed and un-prefixed form, because clients disagree about where
+the prefix belongs: Claude Code appends `/v1/messages` to a bare host, the Vercel AI SDK appends only
+`/messages` to a `…/v1` base, and Codex joins `{base}/responses`.
+
+## Configuring each client
+
+```bash
+# Claude Code — any model in the catalog, Claude or GPT
+export ANTHROPIC_BASE_URL=http://127.0.0.1:8788
+export ANTHROPIC_MODEL=gpt-5.3-codex
+
+# Codex CLI — ~/.codex/config.toml
+# base_url = "http://127.0.0.1:8788/v1"
+
+# opencode — OpenAI-compatible provider
+# baseURL: "http://127.0.0.1:8788/v1"
+```
+
+## Which models are served
+
+Discovered from Copilot's `/models` at startup — nothing is hard-coded. A model is served when it
+advertises at least one of `/v1/messages`, `/chat/completions` or `/responses`, and its vendor is
+neither Google nor Microsoft. Models advertising no endpoints (including `text-embedding-*`) are
+excluded so an embedding model can never surface as a chat model.
+
+Requests naming an unknown model are mapped onto the same family when one exists
+(`claude-3-5-haiku-*` → `claude-haiku-4.5`) and otherwise onto the catalog default. That matters
+because Claude Code sends conversation-title, classification and summarisation traffic to this same
+base URL under haiku model ids; without family mapping, every one of them would bill against Opus.
+
+## Known limitations
+
+These affect **only** the translated route — Anthropic Messages in, for a model that speaks only the
+Responses API. Every passthrough route is byte-for-byte and has none of them.
+
+- **`stop_sequences` is dropped.** The Responses API has no equivalent parameter, and emulating one
+  means truncating a stream at a boundary that can straddle SSE chunks. Claude Code uses it only for
+  auto-mode classification, which targets the haiku tier — an Anthropic model, hence passthrough.
+- **Reasoning does not carry across turns.** Reasoning summaries are surfaced as `thinking` blocks for
+  display; the encrypted payload that would let a GPT model resume its own reasoning through a tool
+  loop is not round-tripped. Answers stay correct; the model re-derives its reasoning each turn.
+- **Tool ids are passed through verbatim.** Responses mints `call_…`; Anthropic conventionally uses
+  `toolu_…`. The round-trip works because the id we hand out is the id we accept back, but Claude Code
+  cannot pattern-match these ids when explaining a tool-pairing failure, so that one error message is
+  less specific than usual.
+- **`count_tokens` serves Claude models only.** Clients degrade gracefully — Claude Code logs
+  `countTokens API call failed` and falls back to a local estimate, which drives only the `/context`
+  bar and the auto-compact threshold.
+- **Prompt caching, batch and files APIs are not proxied.**
+```
+
+Also confirm the port is `8788` everywhere in the file (Task 5 changed it).
+
+- [ ] **Step 2: Add the live smoke tests**
+
+Append to `tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs`, following the file's existing fixture and skip conventions:
+
+```csharp
+/// <summary>
+///     THE GATE for the translated route: drive a Responses-only model through the ANTHROPIC endpoint
+///     and require a well-formed Anthropic stream back. This is the one quadrant that is real
+///     translation rather than passthrough.
+/// </summary>
+[SkippableFact]
+public async Task Anthropic_endpoint_streams_a_responses_only_model()
+{
+    Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+    var model = await PickResponsesOnlyModelAsync(cts.Token);
+    _output.WriteLine($"model: {model}");
+
+    var body = await PostProxyAsync(
+        "/v1/messages",
+        new
+        {
+            model,
+            max_tokens = 128,
+            stream = true,
+            messages = new[] { new { role = "user", content = "Reply with the single word: ok" } },
+        },
+        cts.Token
+    );
+
+    _output.WriteLine(body);
+
+    body.Should().Contain("event: message_start");
+    body.Should().Contain("content_block_delta");
+    body.Should().Contain("event: message_stop");
+    body.Should().NotContain("response.created", "upstream Responses frames must not leak through");
+}
+
+/// <summary>
+///     Confirms Claude Code's model-validation probe survives translation. It sends max_tokens: 1 with
+///     maxRetries: 0 as the FIRST request against any new model; a 400 here makes the model look
+///     unusable before the user ever gets a turn.
+/// </summary>
+[SkippableFact]
+public async Task Anthropic_endpoint_survives_the_max_tokens_one_validation_probe()
+{
+    Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+    var model = await PickResponsesOnlyModelAsync(cts.Token);
+
+    var body = await PostProxyAsync(
+        "/v1/messages",
+        new
+        {
+            model,
+            max_tokens = 1,
+            messages = new[]
+            {
+                new { role = "user", content = new[] { new { type = "text", text = "Hi" } } },
+            },
+        },
+        cts.Token
+    );
+
+    _output.WriteLine(body);
+
+    using var doc = JsonDocument.Parse(body);
+    doc.RootElement.GetProperty("type").GetString().Should().Be("message");
+    doc.RootElement.GetProperty("role").GetString().Should().Be("assistant");
+    doc.RootElement.TryGetProperty("stop_reason", out _).Should().BeTrue();
+
+    // Confirms Task 7's documented caveat: the live shape of incomplete_details is unverified, so
+    // record what came back rather than asserting a reason we have never observed.
+    _output.WriteLine($"OBSERVED stop_reason: {doc.RootElement.GetProperty("stop_reason").GetString()}");
+}
+
+/// <summary>Codex's quadrant: a Responses request must reach Copilot unchanged.</summary>
+[SkippableFact]
+public async Task Responses_endpoint_passes_through()
+{
+    Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+    var model = await PickResponsesOnlyModelAsync(cts.Token);
+
+    var body = await PostProxyAsync(
+        "/v1/responses",
+        new
+        {
+            model,
+            store = false,
+            input = new[]
+            {
+                new
+                {
+                    type = "message",
+                    role = "user",
+                    content = new[] { new { type = "input_text", text = "Reply with: ok" } },
+                },
+            },
+        },
+        cts.Token
+    );
+
+    _output.WriteLine(body);
+    body.Should().Contain("\"output\"");
+}
+```
+
+Reuse the file's existing proxy-hosting helper for `PostProxyAsync`; add `PickResponsesOnlyModelAsync` modelled on `CopilotChatCompletionsProbeTests.PickByEndpointAsync`, reading the live catalog rather than guessing an id from its name — guessing by name is what made an earlier probe pick a Responses-only model when it wanted a dual-endpoint one.
+
+- [ ] **Step 3: Run the unit suite, then the live suite by hand**
+
+```bash
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj
+dotnet test tests/CopilotLive.Tests/CopilotLive.Tests.csproj
+```
+Expected: the first passes; the second passes or skips cleanly when no Copilot credentials are present. If a live test fails, that is a real finding — fix the code, not the assertion.
+
+- [ ] **Step 4: Verify the whole solution still builds**
+
+```bash
+dotnet build LmDotnetTools.sln
+```
+Expected: no errors, no new warnings. `EnforceCodeStyleInBuild=true` means IDE diagnostics are errors — `IDE0370` on an unnecessary `!` is the usual culprit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add samples/CopilotAnthropicProxy.Sample/README.md tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs
+git commit -m "docs(proxy): document the bidirectional surface and add live smoke tests"
+```
+
+---
+
+## Verification checklist
+
+Against the spec's success criteria:
+
+| # | Criterion | Verified by |
+|---|---|---|
+| 1 | opencode drives Claude and dual-endpoint GPT models | `OpenAiDialectTests` (Task 4) |
+| 2 | Codex CLI drives any GPT model | `OpenAiDialectTests.Responses_forwards_to_the_upstream_responses_path` (Task 4), `Responses_endpoint_passes_through` (Task 10) |
+| 3 | Claude Code drives Responses-only GPT models | `TranslatedMessagesTests` (Task 9), `Anthropic_endpoint_streams_a_responses_only_model` (Task 10) |
+| 4 | Nothing that works today breaks | The whole pre-existing suite stays green at every commit; deviations D1 and D2 are the two places that took explicit care |
+| 5 | No hard-coded model ids | `grep -rn "claude-\|gpt-" samples/CopilotAnthropicProxy.Sample/ --include=*.cs` returns only comments |

--- a/docs/superpowers/plans/2026-07-27-copilot-proxy-bidirectional-api.md
+++ b/docs/superpowers/plans/2026-07-27-copilot-proxy-bidirectional-api.md
@@ -2433,7 +2433,7 @@ public sealed class ResponsesToAnthropicSse
                 Start(frames, response);
                 break;
 
-            case "response.content_part.added" when evt["part"]?["type"]?.GetValue<string>() == "output_text":
+            case "response.content_part.added" when (evt["part"] as JsonObject)?["type"]?.GetValue<string>() == "output_text":
                 Start(frames, response);
                 OpenBlock(frames, new JsonObject { ["type"] = "text", ["text"] = "" });
                 break;
@@ -2463,7 +2463,7 @@ public sealed class ResponsesToAnthropicSse
                 Delta(frames, "thinking_delta", "thinking", evt["delta"]?.GetValue<string>() ?? "");
                 break;
 
-            case "response.output_item.added" when evt["item"]?["type"]?.GetValue<string>() == "function_call":
+            case "response.output_item.added" when (evt["item"] as JsonObject)?["type"]?.GetValue<string>() == "function_call":
                 Start(frames, response);
                 OpenBlock(
                     frames,

--- a/docs/superpowers/specs/2026-07-27-copilot-proxy-bidirectional-api-design.md
+++ b/docs/superpowers/specs/2026-07-27-copilot-proxy-bidirectional-api-design.md
@@ -1,0 +1,301 @@
+# Bidirectional API proxy for Copilot models
+
+Date: 2026-07-27
+Status: **approved design** (approved 2026-07-27 from device "Kay9")
+Component: `samples/CopilotAnthropicProxy.Sample`
+
+## Purpose
+
+> "we just want to use this proxy to make claude, codex, open-code etc to work on top of all the
+> models exposed through copilot backend APIs" — the user, verbatim
+
+Point Claude Code, Codex CLI, and opencode at this proxy and let each drive any Copilot model,
+regardless of which API dialect the client speaks. GitHub Copilot is the only backend.
+
+This is a **sample**, not production infrastructure. Where a choice exists between a general
+mechanism and the smallest thing that demonstrably works, take the smaller one.
+
+### Success criteria
+
+1. `opencode` (OpenAI Chat Completions) completes a streaming tool-calling turn against a Claude
+   model and against `gpt-5.4`.
+2. Codex CLI (OpenAI Responses) completes a streaming tool-calling turn against any GPT model.
+3. Claude Code (Anthropic Messages) completes a streaming tool-calling turn against a
+   Responses-only GPT model (`gpt-5.5`, `gpt-5.3-codex`, `gpt-5.6-*`).
+4. Claude Code → Claude keeps its **exact** current byte-level behavior. No regression.
+
+## Live-verified facts
+
+Established by `tests/CopilotLive.Tests/CopilotChatCompletionsProbeTests.cs` (4/4 green, raw HTTP
+against the real backend, outside the solution so CI never runs it). Full evidence in
+`scratchpad/conversation_memories/copilot-bidirectional-api-proxy/07-live-verification.md`.
+
+1. **Claude is servable over Copilot's `/chat/completions`** — 200 OK with streaming, fragmented
+   `tool_calls`, `finish_reason: "tool_calls"`, and usage. `max_tokens` is accepted.
+2. **`gpt-5.4` is servable over `/chat/completions`, but rejects `max_tokens`** with
+   `400 invalid_request_body` — *"Use 'max_completion_tokens' instead."* Claude accepts
+   `max_tokens` on the same endpoint, so this is **per-model, not per-endpoint**.
+3. **Responses-only models reject `/chat/completions`** with
+   `400 unsupported_api_for_model`.
+4. **`finish_reason` and usage are present on the wire** for both passthrough dialects.
+5. The live catalog holds 40 models and already differs from our captured fixture
+   (`claude-opus-5`, `claude-sonnet-5`, `gpt-5.6-{luna,sol,terra}` are new; `claude-sonnet-4.5` is
+   gone). ~19 entries advertise **no** endpoints at all, including `text-embedding-*`.
+
+Fact 1 is the load-bearing one: it removes an entire translation layer that the earlier draft
+assumed was mandatory.
+
+## Routing
+
+| Client (dialect) | Target model | Copilot endpoint | Work |
+|---|---|---|---|
+| Claude Code (Anthropic) | Claude | `/v1/messages` | passthrough — **unchanged today** |
+| Claude Code (Anthropic) | GPT | `/responses` | **TRANSLATE** |
+| opencode (Chat Completions) | Claude | `/chat/completions` | passthrough |
+| opencode (Chat Completions) | `gpt-5.4`, `gpt-5-mini` | `/chat/completions` | passthrough + token-field rewrite |
+| opencode (Chat Completions) | Responses-only GPT | — | 404 naming the servable alternatives |
+| Codex CLI (Responses) | GPT | `/responses` | passthrough |
+| Codex CLI (Responses) | Claude | — | deferred (see Out of scope) |
+
+**Exactly one** direction needs real translation.
+
+## Architecture: direct wire-to-wire translation
+
+Translate Anthropic request JSON straight to Responses request JSON, and Responses SSE straight to
+Anthropic SSE. **No LmCore `IMessage` middle, no `IAgent` reuse on the translated path.**
+
+### Why not the unified LmCore middle
+
+The earlier draft routed everything through LmCore's message model so that adding a dialect would
+be "+1 reader +1 writer". That trade only pays off across many translation pairs. Live evidence
+reduced the count to one, and the middle carries four defects verified against source:
+
+| # | Defect | Evidence |
+|---|---|---|
+| 1 | Images are silently dropped on every Responses route | `src/OpenAiResponsesProvider/Agents/MessageMapper.cs:252-255` — bare `default: break;`, no `ImageMessage` case, and `input_image` appears nowhere in the provider |
+| 2 | The two providers speak opposite `IMessage` dialects | `AnthropicAgent.cs:262-284` emits updates only (`ToolsCallMessage` branch is an empty body; the `TextMessage` yield is commented out) while `OpenAiResponsesAgent.cs:313,349` emits finalized `ToolsCallMessage` only |
+| 3 | LmCore carries no termination reason | zero matches for `StopReason\|FinishReason\|stop_reason\|finish_reason` — so Anthropic `stop_reason` could not be derived |
+| 4 | Responses agent defaults to WebSocket with shared mutable turn state | `CopilotResponsesAgentFactory.cs:41` defaults to `Transport.WebSocket`; `CopilotResponsesWebSocketClient.cs:42,45` holds a `SemaphoreSlim` turn gate and a mutable `_previousResponseId` on a shared client |
+
+Wire-to-wire avoids all four rather than fixing them, and it **preserves** information the middle
+would destroy: `finish_reason` and `incomplete_details` are right there on the Responses wire, so
+Anthropic's `stop_reason` is derivable (defect 3 disappears rather than being worked around).
+
+Rejected alternative recorded so it is not re-litigated: the unified middle would require changing
+shared provider code that other consumers depend on, to serve one sample.
+
+## HTTP surface
+
+Inbound paths do not collide, so all dialects share **one base URL** — one value for the user to
+configure in each client.
+
+| Route | Behavior |
+|---|---|
+| `POST /v1/messages` | Claude → passthrough to `/v1/messages`; GPT → translate to `/responses` |
+| `POST /v1/messages/count_tokens` | unchanged (Claude only; 400 for GPT — Responses has no equivalent) |
+| `POST /v1/chat/completions` | passthrough to `/chat/completions` + token-field rewrite |
+| `POST /v1/responses` | passthrough to `/responses` |
+| `GET /v1/models` | union-shaped catalog (below) |
+| `GET /health` | unchanged |
+| `/mcp` | unchanged |
+
+Each `POST` also binds its un-prefixed twin (`/chat/completions`, `/responses`) so a base URL with
+or without `/v1` works. Both bindings call the same handler.
+
+### The one real collision: `GET /v1/models`
+
+Anthropic and OpenAI both define `GET /v1/models` with different body shapes. Emit a **union**
+object per entry and let each client read the fields it knows:
+
+```json
+{
+  "object": "list",
+  "has_more": false,
+  "data": [
+    {
+      "id": "gpt-5.5",
+      "type": "model",
+      "object": "model",
+      "display_name": "GPT-5.5",
+      "owned_by": "OpenAI",
+      "created": 1735689600,
+      "created_at": "2025-01-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+Extra fields are ignored by both clients; every real client keys off `id`. `BuildModelsStub` grows
+this shape.
+
+### Catalog
+
+Replace `ParseMessagesCapableModelIds`' `/v1/messages`-only filter with: **include a model if it
+advertises at least one endpoint this proxy can reach** (`/v1/messages`, `/chat/completions`, or
+`/responses`), and its vendor is Anthropic, OpenAI, or Azure OpenAI.
+
+- Models advertising **no** endpoints stay excluded. This matters: it is what keeps
+  `text-embedding-*` from being offered as a chat model.
+- Keep the fallback **per response, not per entry** (`Program.cs:502-514`): fall back to id-only
+  parsing when *no* entry in the whole response carries `supported_endpoints`. Pinned by
+  `ModelResolverTests.cs:68,122`. Since live responses do carry the metadata, the fallback stays
+  dormant and the no-endpoint entries are correctly dropped.
+- The catalog is fetched at startup and is the single source of truth for routing. **No hard-coded
+  model ids** — the live-vs-fixture drift proves any static list is already stale.
+- Gemini is excluded by user decision (2026-07-27), even though `/chat/completions` would reach it.
+
+`COPILOT_ANTHROPIC_MODEL` demotes from an unconditional rewrite to a **fallback**: used only when
+the client sends no model, or one absent from the catalog. Default port becomes **8788** (8787 is
+occupied by a running proxy instance).
+
+### Token-field rewrite
+
+On `/chat/completions` only: if the resolved model's catalog `vendor` is `Anthropic`, keep
+`max_tokens`; otherwise rename it to `max_completion_tokens`. Deterministic, offline-testable, and
+it rides inside `ProxyModelResolver.TryRewriteModel`, which already parses and rewrites the body.
+
+## Components
+
+New, under `samples/CopilotAnthropicProxy.Sample/Translation/`:
+
+| File | Responsibility | Depends on |
+|---|---|---|
+| `ModelRoute.cs` | model id → (backend endpoint, passthrough vs. translate, vendor) | catalog |
+| `AnthropicToResponsesRequest.cs` | Anthropic request JSON → Responses request JSON. Pure function, no I/O | — |
+| `ResponsesToAnthropicSse.cs` | Responses SSE event stream → Anthropic SSE event stream. Owns the block state machine | — |
+| `ResponsesToAnthropicJson.cs` | non-streaming Responses response → Anthropic `Message` JSON | — |
+
+Each is independently testable from string in / string out. `ModelRoute` is the only one that
+touches configuration.
+
+`Program.cs` changes: register the new routes, swap the catalog filter, demote pinning, extend
+`BuildModelsStub`, add the token rewrite, and branch `/v1/messages` on `ModelRoute`.
+
+### Request mapping — Anthropic → Responses
+
+| Anthropic | Responses |
+|---|---|
+| `model` | `model` |
+| `system` (string or block array) | flattened to text, sent as `instructions` (`ResponseCreateRequest.cs:18`; matches how `MessageMapper.cs:63` already folds system text) |
+| `messages[]` | `input[]` items |
+| content `text` | `{type:"input_text"}` (user) / `{type:"output_text"}` (assistant) |
+| content `image` (base64 or url) | `{type:"input_image", image_url:"data:<media_type>;base64,<data>"}` |
+| content `tool_use` | `{type:"function_call", call_id, name, arguments}` |
+| content `tool_result` | `{type:"function_call_output", call_id, output}` |
+| content `thinking` | dropped — see Limitations |
+| `tools[].input_schema` | `tools[].parameters` (`{type:"function", name, description, parameters}`) |
+| `tool_choice` `auto`/`any`/`tool`/`none` | `auto`/`required`/`{type:"function",name}`/`none` |
+| `max_tokens` (required by Anthropic) | `max_output_tokens` (`ResponseCreateRequest.cs:34`) |
+| `temperature`, `top_p`, `stream` | identical |
+| `stop_sequences` | dropped — no Responses equivalent; see Limitations |
+
+The sample emits this JSON directly rather than through `ResponseCreateRequest`, because the
+provider's `ContentItem` has no image representation.
+
+### SSE mapping — Responses → Anthropic
+
+Event names taken from `src/OpenAiResponsesProvider/Models/ResponseEventTypes.cs`.
+
+| Responses event | Anthropic output |
+|---|---|
+| `response.created` | `message_start` |
+| `response.output_item.added` (message) | `content_block_start` `{type:"text"}` |
+| `response.output_text.delta` | `content_block_delta` `{type:"text_delta"}` |
+| `response.reasoning_summary_text.delta` | `content_block_delta` `{type:"thinking_delta"}` |
+| `response.output_item.added` (`function_call`) | `content_block_start` `{type:"tool_use", id, name}` |
+| `response.function_call_arguments.delta` | `content_block_delta` `{type:"input_json_delta"}` |
+| `response.output_item.done` | `content_block_stop` |
+| `response.completed` | `message_delta` (`stop_reason` + cumulative usage), then `message_stop` |
+| `response.failed` | terminal SSE `error` event |
+
+The writer owns Anthropic's block discipline: a monotonically increasing `index` per block, open
+lazily on the first delta of a kind, close on kind change or stream end, and never leave a block
+open at `message_stop`.
+
+**`stop_reason` derivation** (from the wire, which is why the middle was dropped):
+
+| Condition on `response.completed` | `stop_reason` |
+|---|---|
+| any output item is a `function_call` | `tool_use` |
+| `incomplete_details.reason == "max_output_tokens"` | `max_tokens` |
+| otherwise | `end_turn` |
+
+Caveat: `incomplete_details` is **not** parsed anywhere in `src/OpenAiResponsesProvider`, so unlike
+the event names above it is not grounded in our code — it comes from the Responses API contract.
+P1 must confirm its exact shape against a live truncated response before relying on it. Until
+confirmed, an unrecognized terminal shape falls back to `end_turn`, which is the safe default: a
+wrong `max_tokens` would make a client believe output was truncated when it was not.
+
+Anthropic requires `usage` in `message_delta` to be **cumulative**; the Responses `usage` object on
+`response.completed` is already a total, so it maps directly.
+
+## Error handling
+
+Errors are shaped in the **inbound** dialect: Anthropic `{type:"error",error:{type,message}}` via
+the existing `WriteAnthropicErrorAsync`, or OpenAI `{error:{message,type,param,code}}`.
+
+| Condition | Status |
+|---|---|
+| Unknown model | 404 |
+| Model not servable on the requested dialect | 404, message naming servable alternatives |
+| Token acquisition failure | 401 |
+| Upstream transport failure | 502 |
+| Idle timeout | 504 |
+| Client abort | no body; cancellation propagates |
+
+Once response headers are committed the status can no longer change, so a mid-stream failure emits
+a terminal SSE `error` event (Anthropic) or an error chunk followed by `[DONE]` (OpenAI).
+
+The translated path does not flow through `ProxyHttp.ForwardAsync`, so it must **re-apply**
+keep-alive and the reset-per-read idle-timeout CTS itself. This is a known trap: those behaviors
+live in `ForwardAsync` today and would otherwise be silently lost on the new branch.
+
+## Testing
+
+1. **Request-mapper unit tests** (pure JSON → JSON): tools, `tool_choice` in all four forms,
+   images, system-as-string and system-as-blocks, a multi-turn `tool_use`/`tool_result` loop,
+   `max_tokens` → `max_output_tokens`.
+2. **SSE-writer unit tests**: scripted Responses event sequences → exact expected Anthropic event
+   and JSON assertions. Covers interleaved text/tool blocks, index monotonicity, all three
+   `stop_reason` branches, and mid-stream `response.failed`.
+3. **Integration tests** through the existing `ProxyWebAppFactory` + fake upstream — one per route.
+   Reuse `GatedStream` to prove incremental flush and `CancellationObservingStream` to prove
+   cancellation propagates.
+4. **Live smoke** in `CopilotLive.Tests` beside the existing probe: one real turn per client shape.
+   Opt-in, outside the solution, never in CI.
+
+Tiers 1 and 2 carry the weight — a protocol translator's bugs are almost all in field mapping and
+stream framing, and both tiers run offline in milliseconds.
+
+## Delivery
+
+**P0 — passthrough and catalog. No translation code.**
+New `/v1/chat/completions` and `/v1/responses` routes, catalog filter widened, models union,
+token-field rewrite, pinning demoted, port 8788. Delivers success criteria 1 and 2, and preserves
+4. Low risk: it adds routes beside the existing one and reuses `ForwardAsync` wholesale.
+
+**P1 — the translator.** `AnthropicToResponsesRequest` + `ResponsesToAnthropicJson` (non-streaming
+first, easier to assert), then `ResponsesToAnthropicSse`. Delivers success criterion 3.
+
+**P2 — docs and live smoke.** README base-URL forms per client, the security note, limitations.
+
+Each phase is independently shippable and independently tested, per the user's "make sure each step
+is well tested before taking bet."
+
+## Limitations (documented, not solved)
+
+- **Thinking signatures do not round-trip.** Anthropic `thinking` blocks carry a `signature` with
+  no Responses equivalent, so a signed thinking block from a prior turn cannot be replayed to a GPT
+  model. Inbound `thinking` blocks are dropped on the translated path. Responses reasoning summaries
+  *are* surfaced outbound as `thinking_delta`, without a signature.
+- **`stop_sequences` is dropped** on the translated path; the Responses API has no equivalent.
+- **`count_tokens` is Claude-only** and returns 400 for GPT models.
+- **Gemini is out of scope** by user decision, though `/chat/completions` would reach it.
+
+## Out of scope
+
+- Inbound `/responses` → Claude models (Codex CLI driving Claude). Deferred, and cheap when wanted:
+  it is a Responses ↔ Chat Completions mapping between two OpenAI-family dialects, and Claude is
+  live-proven on `/chat/completions`.
+- Prompt caching, batch, and files APIs.
+- Any change to `src/` providers. This work is confined to the sample plus its tests.

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -602,13 +602,45 @@ public static class ProxyModelResolver
     }
 
     /// <summary>
-    ///     Maps the model a client asked for onto a model this proxy serves. Unknown ids fall back to the
-    ///     catalog default (DEVIATION D2) — the dialect check downstream runs against the RESOLVED model.
+    ///     Model families, longest name first so a shorter name cannot shadow a longer one.
+    ///     Used to route side traffic that names a model this account does not have — Claude Code sends
+    ///     conversation-title, classification and summarisation calls as <c>claude-3-5-haiku-*</c> to the
+    ///     SAME base URL, and without this they would all bill against the default opus model.
+    /// </summary>
+    private static readonly string[] ModelFamilies = ["sonnet", "haiku", "opus"];
+
+    /// <summary>
+    ///     Maps the model a client asked for onto a model this proxy serves:
+    ///     exact match (case-insensitive) → same-family match → catalog default.
+    ///     The dialect check downstream runs against the RESOLVED model (DEVIATION D2).
     /// </summary>
     public static string SelectOutboundModel(string? incomingModel, ProxyModelCatalog catalog)
     {
         ArgumentNullException.ThrowIfNull(catalog);
-        return catalog.Find(incomingModel)?.Id ?? catalog.Default;
+
+        if (catalog.Find(incomingModel) is { } exact)
+        {
+            return exact.Id;
+        }
+
+        if (!string.IsNullOrWhiteSpace(incomingModel))
+        {
+            var family = ModelFamilies.FirstOrDefault(f =>
+                incomingModel.Contains(f, StringComparison.OrdinalIgnoreCase)
+            );
+            if (family is not null)
+            {
+                var sameFamily = catalog.Models.FirstOrDefault(m =>
+                    m.Id.Contains(family, StringComparison.OrdinalIgnoreCase)
+                );
+                if (sameFamily is not null)
+                {
+                    return sameFamily.Id;
+                }
+            }
+        }
+
+        return catalog.Default;
     }
 
     /// <summary>Peeks at the JSON body's <c>model</c> field without mutating it. Null on any parse failure.</summary>

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -755,8 +755,17 @@ public static class ProxyModelResolver
     ///     tools this proxy has never seen instead of forwarding them into a 400. Live-probed
     ///     2026-07-28 — <c>image_generation</c>, <c>local_shell</c>, <c>code_interpreter</c> and
     ///     <c>mcp</c> each fail with <c>"The requested tool &lt;type&gt; is not supported."</c>
-    ///     <c>web_search</c> is currently accepted upstream but is dropped anyway: it is hosted, and
-    ///     the translated Anthropic route already drops its counterpart <c>web_search_20250305</c>.
+    ///
+    ///     Keep this list curated by hand. It is meant to stay narrow, so it deliberately does not
+    ///     widen on its own when Copilot starts accepting a new hosted type: admitting one is a
+    ///     decision, not a consequence.
+    ///
+    ///     <c>web_search</c> and <c>web_search_preview</c> are the two types Copilot accepts that get
+    ///     dropped anyway. Both are hosted, and the translated Anthropic route already drops their
+    ///     counterpart <c>web_search_20250305</c>. The planned direction (agreed, not scheduled) is to
+    ///     stop treating web search as a server tool at all: the proxy would expose it as a client tool
+    ///     it implements itself, servicing the call against Copilot's MCP server. That makes it an
+    ///     ordinary <c>function</c> and removes the exemption rather than widening this list.
     /// </remarks>
     private static readonly HashSet<string> ClientDefinedToolTypes = new(StringComparer.Ordinal)
     {

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -206,16 +206,58 @@ app.MapGet(
     () => Results.Content(ProxyHttp.BuildModelsStub(catalog.Models), "application/json", Encoding.UTF8)
 );
 
-// POST /v1/messages and /v1/messages/count_tokens — the forward path.
-app.MapPost(
-    "/v1/messages",
-    ctx => ProxyHttp.ForwardAsync(ctx, catalog, config.IdleTimeout, config.KeepAliveInterval, isCountTokens: false)
-);
+// Each POST also binds its un-prefixed twin. Base-URL conventions differ per client: Claude Code
+// appends /v1/messages to a bare host, the AI SDK appends only /messages to a ".../v1" base, and
+// Codex joins "{base}/responses". Binding both forms removes a whole class of misconfiguration.
+foreach (var path in new[] { "/v1/messages", "/messages" })
+{
+    _ = app.MapPost(
+        path,
+        ctx =>
+            ProxyHttp.ForwardAsync(
+                ctx,
+                catalog,
+                config.IdleTimeout,
+                config.KeepAliveInterval,
+                ProxyDialect.AnthropicMessages
+            )
+    );
+    _ = app.MapPost(
+        $"{path}/count_tokens",
+        ctx =>
+            ProxyHttp.ForwardAsync(
+                ctx,
+                catalog,
+                config.IdleTimeout,
+                config.KeepAliveInterval,
+                ProxyDialect.AnthropicMessages,
+                isCountTokens: true
+            )
+    );
+}
 
-app.MapPost(
-    "/v1/messages/count_tokens",
-    ctx => ProxyHttp.ForwardAsync(ctx, catalog, config.IdleTimeout, config.KeepAliveInterval, isCountTokens: true)
-);
+foreach (var path in new[] { "/v1/chat/completions", "/chat/completions" })
+{
+    _ = app.MapPost(
+        path,
+        ctx =>
+            ProxyHttp.ForwardAsync(
+                ctx,
+                catalog,
+                config.IdleTimeout,
+                config.KeepAliveInterval,
+                ProxyDialect.ChatCompletions
+            )
+    );
+}
+
+foreach (var path in new[] { "/v1/responses", "/responses" })
+{
+    _ = app.MapPost(
+        path,
+        ctx => ProxyHttp.ForwardAsync(ctx, catalog, config.IdleTimeout, config.KeepAliveInterval, ProxyDialect.Responses)
+    );
+}
 
 // /mcp and /mcp/readonly — transparent MCP (Streamable HTTP) proxy. Every HTTP method is routed
 // here (not just GET/POST/DELETE) so an unsupported method gets ProxyMcp's own MCP/JSON-RPC-shaped
@@ -682,7 +724,13 @@ public static class ProxyModelResolver
     ///     blocks, and every other unknown field are preserved verbatim.
     /// </summary>
     /// <returns>True on success; false when the body is missing, not JSON, or not a JSON object.</returns>
-    public static bool TryRewriteModel(byte[] body, string model, out byte[] rewritten, out string? incomingModel)
+    public static bool TryRewriteModel(
+        byte[] body,
+        string model,
+        out byte[] rewritten,
+        out string? incomingModel,
+        bool renameMaxTokens = false
+    )
     {
         ArgumentNullException.ThrowIfNull(body);
         ArgumentNullException.ThrowIfNull(model);
@@ -721,6 +769,21 @@ public static class ProxyModelResolver
 
         obj["model"] = model;
         _ = obj.Remove("context_management");
+
+        // GPT models on Copilot reject `max_tokens` on /chat/completions and demand
+        // `max_completion_tokens` — live-confirmed 2026-07-27. Claude models accept `max_tokens` on the
+        // same endpoint, so this is keyed on the model, not the route. Clone before removing: a JsonNode
+        // cannot be re-parented while it still belongs to the object.
+        if (renameMaxTokens && obj["max_tokens"] is { } maxTokens)
+        {
+            var clonedMaxTokens = maxTokens.DeepClone();
+            _ = obj.Remove("max_tokens");
+            if (!obj.ContainsKey("max_completion_tokens"))
+            {
+                obj["max_completion_tokens"] = clonedMaxTokens;
+            }
+        }
+
         rewritten = JsonSerializer.SerializeToUtf8Bytes(obj);
         return true;
     }
@@ -752,13 +815,14 @@ internal static class ProxyHttp
         "Content-Type",
     };
 
-    /// <summary>Forwards POST /v1/messages (and count_tokens) to Copilot and streams the response back.</summary>
+    /// <summary>Forwards a request to Copilot in the given dialect and streams the response back.</summary>
     public static async Task ForwardAsync(
         HttpContext ctx,
         ProxyModelCatalog catalog,
         TimeSpan idleTimeout,
         TimeSpan keepAliveInterval,
-        bool isCountTokens
+        ProxyDialect dialect,
+        bool isCountTokens = false
     )
     {
         var services = ctx.RequestServices;
@@ -775,15 +839,47 @@ internal static class ProxyHttp
         }
 
         // 2) Pass the requested model through unchanged when it's one of the available ids; otherwise fall
-        //    back to the catalog's default. Then rewrite the body (raw JSON). Parse failure -> 400 (do NOT
-        //    call upstream).
+        //    back to the catalog's default. Resolve the route for this dialect and reject a mismatch.
         var outboundModel = ProxyModelResolver.SelectOutboundModel(ProxyModelResolver.PeekModel(inboundBody), catalog);
+
+        // A model resolved via the default/family fallback may not be in the catalog at all (pinned mode);
+        // treat it as metadata-free, which routes as Anthropic Messages.
+        var modelInfo = catalog.Find(outboundModel) ?? new ProxyModelInfo(outboundModel, string.Empty, []);
+        var route = ModelRouter.Resolve(dialect, modelInfo);
+
+        // TranslateAnthropicToResponses is not implemented yet (Task 9 wires the translator into
+        // /v1/messages) — treat it exactly like a routing miss rather than forwarding an untranslated
+        // Anthropic body to the Responses endpoint.
+        if (route is null || route.Kind != ProxyRouteKind.Passthrough)
+        {
+            var alternatives = ModelRouter.Servable(dialect, catalog);
+            await WriteErrorAsync(
+                    ctx,
+                    dialect,
+                    StatusCodes.Status404NotFound,
+                    "not_found_error",
+                    $"Model '{outboundModel}' is not available on this endpoint. "
+                        + $"Models that are: {(alternatives.Count == 0 ? "(none)" : string.Join(", ", alternatives))}."
+                )
+                .ConfigureAwait(false);
+            return;
+        }
+
+        // 3) Rewrite the body (raw JSON). Parse failure -> 400 (do NOT call upstream).
+        var renameMaxTokens = dialect == ProxyDialect.ChatCompletions && !modelInfo.IsAnthropic;
         if (
-            !ProxyModelResolver.TryRewriteModel(inboundBody, outboundModel, out var outboundBody, out var incomingModel)
+            !ProxyModelResolver.TryRewriteModel(
+                inboundBody,
+                outboundModel,
+                out var outboundBody,
+                out var incomingModel,
+                renameMaxTokens
+            )
         )
         {
-            await WriteAnthropicErrorAsync(
+            await WriteErrorAsync(
                 ctx,
+                dialect,
                 StatusCodes.Status400BadRequest,
                 "invalid_request_error",
                 "Request body must be a non-empty JSON object."
@@ -791,8 +887,8 @@ internal static class ProxyHttp
             return;
         }
 
-        // 3) Build a fresh upstream request with the positive request-header allowlist.
-        var upstreamPath = isCountTokens ? "/v1/messages/count_tokens" : "/v1/messages";
+        // 4) Build a fresh upstream request with the positive request-header allowlist.
+        var upstreamPath = isCountTokens ? ModelRouter.CountTokensPath : route.UpstreamPath;
         using var upstreamRequest = new HttpRequestMessage(HttpMethod.Post, upstreamPath)
         {
             Content = new ByteArrayContent(outboundBody),
@@ -800,12 +896,12 @@ internal static class ProxyHttp
         upstreamRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
         ApplyRequestHeaderAllowlist(ctx.Request.Headers, upstreamRequest);
 
-        // 4) Per-request deadlines: link client-abort + a reset-per-read idle timeout.
+        // 5) Per-request deadlines: link client-abort + a reset-per-read idle timeout.
         using var idleCts = new CancellationTokenSource();
         idleCts.CancelAfter(idleTimeout);
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted, idleCts.Token);
 
-        // 5) Send and read response headers (status + headers lock at first byte).
+        // 6) Send and read response headers (status + headers lock at first byte).
         HttpResponseMessage upstream;
         try
         {
@@ -821,8 +917,9 @@ internal static class ProxyHttp
         }
         catch (OperationCanceledException) when (idleCts.IsCancellationRequested)
         {
-            await WriteAnthropicErrorAsync(
+            await WriteErrorAsync(
                 ctx,
+                dialect,
                 StatusCodes.Status504GatewayTimeout,
                 "api_error",
                 "Timed out waiting for the upstream Copilot API to respond."
@@ -833,8 +930,9 @@ internal static class ProxyHttp
         {
             // Token acquisition failure surfaces from CopilotHeadersHandler before the first byte.
             logger.LogError("Copilot token acquisition failed: {Reason}", ex.Message);
-            await WriteAnthropicErrorAsync(
+            await WriteErrorAsync(
                 ctx,
+                dialect,
                 StatusCodes.Status401Unauthorized,
                 "authentication_error",
                 "Failed to acquire a GitHub Copilot token. Re-authenticate with the GitHub Copilot CLI or "
@@ -845,8 +943,9 @@ internal static class ProxyHttp
         catch (HttpRequestException ex)
         {
             logger.LogError("Upstream connection failed: {Reason}", ex.Message);
-            await WriteAnthropicErrorAsync(
+            await WriteErrorAsync(
                 ctx,
+                dialect,
                 StatusCodes.Status502BadGateway,
                 "api_error",
                 "Failed to reach the upstream Copilot API."
@@ -900,7 +999,7 @@ internal static class ProxyHttp
                 idleCts,
                 linked,
                 logger,
-                (c, status, message) => WriteAnthropicErrorAsync(c, status, "api_error", message),
+                (c, status, message) => WriteErrorAsync(c, dialect, status, "api_error", message),
                 isSse,
                 keepAliveInterval
             );
@@ -1153,6 +1252,42 @@ internal static class ProxyHttp
         var payload = JsonSerializer.SerializeToUtf8Bytes(new { type = "error", error = new { type, message } });
         await ctx.Response.Body.WriteAsync(payload, ctx.RequestAborted);
     }
+
+    /// <summary>
+    ///     Writes an OpenAI-shaped error envelope. No-op once the response has started — a half-written
+    ///     body must not be capped with an error object.
+    /// </summary>
+    public static async Task WriteOpenAiErrorAsync(HttpContext ctx, int status, string type, string message)
+    {
+        if (ctx.Response.HasStarted)
+        {
+            return;
+        }
+
+        ctx.Response.StatusCode = status;
+        ctx.Response.ContentType = "application/json";
+
+        var payload = JsonSerializer.SerializeToUtf8Bytes(
+            new
+            {
+                error = new
+                {
+                    message,
+                    type,
+                    param = (string?)null,
+                    code = (string?)null,
+                },
+            }
+        );
+
+        await ctx.Response.Body.WriteAsync(payload, ctx.RequestAborted).ConfigureAwait(false);
+    }
+
+    /// <summary>Writes an error in the envelope shape the INBOUND dialect expects.</summary>
+    public static Task WriteErrorAsync(HttpContext ctx, ProxyDialect dialect, int status, string type, string message) =>
+        dialect == ProxyDialect.AnthropicMessages
+            ? WriteAnthropicErrorAsync(ctx, status, type, message)
+            : WriteOpenAiErrorAsync(ctx, status, type, message);
 
     /// <summary>
     ///     Builds the Anthropic-shaped GET /v1/models response listing every available model.

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -847,10 +847,7 @@ internal static class ProxyHttp
         var modelInfo = catalog.Find(outboundModel) ?? new ProxyModelInfo(outboundModel, string.Empty, []);
         var route = ModelRouter.Resolve(dialect, modelInfo);
 
-        // TranslateAnthropicToResponses is not implemented yet (Task 9 wires the translator into
-        // /v1/messages) — treat it exactly like a routing miss rather than forwarding an untranslated
-        // Anthropic body to the Responses endpoint.
-        if (route is null || route.Kind != ProxyRouteKind.Passthrough)
+        if (route is null)
         {
             var alternatives = ModelRouter.Servable(dialect, catalog);
             await WriteErrorAsync(
@@ -860,6 +857,27 @@ internal static class ProxyHttp
                     "not_found_error",
                     $"Model '{outboundModel}' is not available on this endpoint. "
                         + $"Models that are: {(alternatives.Count == 0 ? "(none)" : string.Join(", ", alternatives))}."
+                )
+                .ConfigureAwait(false);
+            return;
+        }
+
+        // TranslateAnthropicToResponses is not implemented yet (Task 9 wires the translator into
+        // /v1/messages). ModelRouter.Servable would list this model as "available" for this dialect
+        // (Resolve returns a non-null route for it), so reusing the generic "not available … Models
+        // that are: …" message above would be actively misleading — it would name the very model that
+        // was just rejected as one of the alternatives. This gets its own honest text instead, and the
+        // whole branch disappears cleanly once Task 9 wires the translator in.
+        if (route.Kind != ProxyRouteKind.Passthrough)
+        {
+            await WriteErrorAsync(
+                    ctx,
+                    dialect,
+                    StatusCodes.Status404NotFound,
+                    "not_found_error",
+                    $"Model '{outboundModel}' can only be reached via OpenAI Responses on this Copilot "
+                        + "account, and translating Anthropic Messages requests to Responses is not "
+                        + "implemented yet."
                 )
                 .ConfigureAwait(false);
             return;

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -862,22 +862,33 @@ internal static class ProxyHttp
             return;
         }
 
-        // TranslateAnthropicToResponses is not implemented yet (Task 9 wires the translator into
-        // /v1/messages). ModelRouter.Servable would list this model as "available" for this dialect
-        // (Resolve returns a non-null route for it), so reusing the generic "not available … Models
-        // that are: …" message above would be actively misleading — it would name the very model that
-        // was just rejected as one of the alternatives. This gets its own honest text instead, and the
-        // whole branch disappears cleanly once Task 9 wires the translator in.
-        if (route.Kind != ProxyRouteKind.Passthrough)
+        if (route.Kind == ProxyRouteKind.TranslateAnthropicToResponses)
         {
-            await WriteErrorAsync(
+            // count_tokens has no Responses counterpart. Translating it would answer a token-count
+            // request by running a full (billed) generation, and the only alternative — inventing a
+            // count — is a fabricated answer. An honest 404 is the whole option set; Claude Code
+            // already falls back to a local estimate when count_tokens is unavailable.
+            if (isCountTokens)
+            {
+                await WriteAnthropicErrorAsync(
+                        ctx,
+                        StatusCodes.Status404NotFound,
+                        "not_found_error",
+                        $"Model '{outboundModel}' is served by translating to OpenAI Responses, which has no "
+                            + "token-counting endpoint."
+                    )
+                    .ConfigureAwait(false);
+                return;
+            }
+
+            await TranslateAnthropicToResponsesAsync(
                     ctx,
-                    dialect,
-                    StatusCodes.Status404NotFound,
-                    "not_found_error",
-                    $"Model '{outboundModel}' can only be reached via OpenAI Responses on this Copilot "
-                        + "account, and translating Anthropic Messages requests to Responses is not "
-                        + "implemented yet."
+                    httpClient,
+                    inboundBody,
+                    outboundModel,
+                    idleTimeout,
+                    keepAliveInterval,
+                    logger
                 )
                 .ConfigureAwait(false);
             return;
@@ -1209,6 +1220,493 @@ internal static class ProxyHttp
             await ctx.Response.Body.FlushAsync(linkedToken).ConfigureAwait(false);
         }
     }
+
+    /// <summary>
+    ///     An Anthropic <c>ping</c> event. Anthropic's own stream emits these during long generations, so
+    ///     every Messages client already tolerates them. The raw passthrough uses an SSE comment instead
+    ///     because it must not alter the byte stream; this path is reframing events anyway, so a real
+    ///     (contentless) event is the honest shape.
+    /// </summary>
+    private const string AnthropicPingFrame = "event: ping\ndata: {\"type\":\"ping\"}\n\n";
+
+    /// <summary>
+    ///     Serves an Anthropic Messages request from a model this Copilot account exposes only through
+    ///     OpenAI Responses: the request is translated on the way out and the reply on the way back.
+    ///
+    ///     Bytes are reframed rather than copied, so this path cannot use <see cref="CopyBodyAsync" />
+    ///     and re-implements its two obligations itself. The idle deadline is reset before EVERY upstream
+    ///     read, so it measures the gap between upstream lines and never the total request duration — a
+    ///     long generation must not be killed for being long — and a silent upstream is covered by
+    ///     downstream pings so an intermediary does not drop the connection mid-generation.
+    /// </summary>
+    private static async Task TranslateAnthropicToResponsesAsync(
+        HttpContext ctx,
+        HttpClient httpClient,
+        byte[] inboundBody,
+        string outboundModel,
+        TimeSpan idleTimeout,
+        TimeSpan keepAliveInterval,
+        ILogger logger
+    )
+    {
+        string translatedBody;
+        bool wantsStream;
+        try
+        {
+            if (JsonNode.Parse(inboundBody) is not JsonObject source)
+            {
+                // Defensive only: this route was chosen by reading `model` out of the body, so the body
+                // has already parsed as a JSON object once.
+                await WriteAnthropicErrorAsync(
+                    ctx,
+                    StatusCodes.Status400BadRequest,
+                    "invalid_request_error",
+                    "Request body must be a non-empty JSON object."
+                );
+                return;
+            }
+
+            source["model"] = outboundModel;
+            wantsStream = source["stream"] is JsonValue flag && flag.TryGetValue<bool>(out var asked) && asked;
+            translatedBody = AnthropicToResponsesRequest.Translate(source).ToJsonString();
+        }
+        catch (Exception ex) when (ex is JsonException or ArgumentException or InvalidOperationException)
+        {
+            // A field carrying an unexpected JSON kind (max_tokens as a string, say) is the client's
+            // error, so this is a 400 — and Copilot never sees a request we could not translate.
+            logger.LogWarning(
+                "Could not translate an Anthropic request for {Model}: {Reason}",
+                outboundModel,
+                ex.Message
+            );
+            await WriteAnthropicErrorAsync(
+                ctx,
+                StatusCodes.Status400BadRequest,
+                "invalid_request_error",
+                "Request body could not be translated to the OpenAI Responses API."
+            );
+            return;
+        }
+
+        using var upstreamRequest = new HttpRequestMessage(HttpMethod.Post, ModelRouter.ResponsesPath)
+        {
+            Content = new StringContent(translatedBody, Encoding.UTF8, "application/json"),
+        };
+        ApplyRequestHeaderAllowlist(ctx.Request.Headers, upstreamRequest);
+
+        using var idleCts = new CancellationTokenSource();
+        idleCts.CancelAfter(idleTimeout);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted, idleCts.Token);
+
+        HttpResponseMessage upstream;
+        try
+        {
+            upstream = await httpClient.SendAsync(
+                upstreamRequest,
+                HttpCompletionOption.ResponseHeadersRead,
+                linked.Token
+            );
+        }
+        catch (OperationCanceledException) when (ctx.RequestAborted.IsCancellationRequested)
+        {
+            return; // Client disconnected before we connected; nothing to write.
+        }
+        catch (OperationCanceledException) when (idleCts.IsCancellationRequested)
+        {
+            await WriteAnthropicErrorAsync(
+                ctx,
+                StatusCodes.Status504GatewayTimeout,
+                "api_error",
+                "Timed out waiting for the upstream Copilot API to respond."
+            );
+            return;
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Token acquisition failure surfaces from CopilotHeadersHandler before the first byte.
+            logger.LogError("Copilot token acquisition failed: {Reason}", ex.Message);
+            await WriteAnthropicErrorAsync(
+                ctx,
+                StatusCodes.Status401Unauthorized,
+                "authentication_error",
+                "Failed to acquire a GitHub Copilot token. Re-authenticate with the GitHub Copilot CLI or "
+                    + "`gh auth login`, or set GITHUB_COPILOT_TOKEN / GH_TOKEN."
+            );
+            return;
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogError("Upstream connection failed: {Reason}", ex.Message);
+            await WriteAnthropicErrorAsync(
+                ctx,
+                StatusCodes.Status502BadGateway,
+                "api_error",
+                "Failed to reach the upstream Copilot API."
+            );
+            return;
+        }
+
+        using (upstream)
+        {
+            logger.LogInformation(
+                "{Method} {Path} model {ResolvedModel} stream={Stream} upstream={Status} (Anthropic -> Responses)",
+                ctx.Request.Method,
+                ModelRouter.ResponsesPath,
+                outboundModel,
+                wantsStream,
+                (int)upstream.StatusCode
+            );
+
+            if (!upstream.IsSuccessStatusCode)
+            {
+                // The upstream status is preserved: a 429 or 503 must stay one so the client's own
+                // retry logic still works. Only the envelope is reshaped.
+                var errorBody = await upstream.Content.ReadAsStringAsync(ctx.RequestAborted);
+                await WriteAnthropicErrorAsync(
+                    ctx,
+                    (int)upstream.StatusCode,
+                    "api_error",
+                    ExtractErrorMessage(errorBody)
+                );
+                return;
+            }
+
+            if (!wantsStream)
+            {
+                await TranslateBufferedReplyAsync(ctx, upstream, outboundModel, logger);
+                return;
+            }
+
+            var isSse = string.Equals(
+                upstream.Content.Headers.ContentType?.MediaType,
+                "text/event-stream",
+                StringComparison.OrdinalIgnoreCase
+            );
+            if (!isSse)
+            {
+                // Relaying a non-SSE body down an SSE-shaped path would translate to zero frames, i.e.
+                // an empty 200 that looks like a successful empty turn. Fail loudly instead.
+                logger.LogWarning(
+                    "Upstream answered a streaming request for {Model} with {ContentType}; refusing to relay it as SSE.",
+                    outboundModel,
+                    upstream.Content.Headers.ContentType?.MediaType ?? "(no content type)"
+                );
+                await WriteAnthropicErrorAsync(
+                    ctx,
+                    StatusCodes.Status502BadGateway,
+                    "api_error",
+                    "The upstream Copilot API answered a streaming request with a non-streaming reply."
+                );
+                return;
+            }
+
+            await TranslateStreamedReplyAsync(
+                ctx,
+                upstream,
+                outboundModel,
+                idleTimeout,
+                idleCts,
+                linked,
+                keepAliveInterval,
+                logger
+            );
+        }
+    }
+
+    /// <summary>
+    ///     Translates a buffered Responses reply into an Anthropic Message. A reply this proxy cannot
+    ///     read answers 400 rather than leaking a 500 — the contract
+    ///     <see cref="ResponsesToAnthropicJson.Translate" /> documents its <see cref="ArgumentException" />
+    ///     for.
+    /// </summary>
+    private static async Task TranslateBufferedReplyAsync(
+        HttpContext ctx,
+        HttpResponseMessage upstream,
+        string outboundModel,
+        ILogger logger
+    )
+    {
+        var responsesJson = await upstream.Content.ReadAsStringAsync(ctx.RequestAborted);
+
+        string anthropicJson;
+        try
+        {
+            anthropicJson = ResponsesToAnthropicJson.Translate(responsesJson, outboundModel);
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogWarning(
+                "Could not translate the Responses reply for {Model}: {Reason}",
+                outboundModel,
+                ex.Message
+            );
+            await WriteAnthropicErrorAsync(
+                ctx,
+                StatusCodes.Status400BadRequest,
+                "invalid_request_error",
+                "The upstream Copilot reply could not be translated into an Anthropic message."
+            );
+            return;
+        }
+
+        ctx.Response.StatusCode = StatusCodes.Status200OK;
+        ctx.Response.ContentType = "application/json";
+        await ctx.Response.WriteAsync(anthropicJson, ctx.RequestAborted);
+    }
+
+    /// <summary>
+    ///     Relays a Responses SSE stream as an Anthropic Messages SSE stream, one upstream line at a
+    ///     time. Nothing is ever appended when the upstream ends early: a truncated stream is exactly
+    ///     what a dropped upstream looks like, and capping it with a synthetic <c>message_stop</c> would
+    ///     turn a failure into a silently empty success.
+    /// </summary>
+    private static async Task TranslateStreamedReplyAsync(
+        HttpContext ctx,
+        HttpResponseMessage upstream,
+        string outboundModel,
+        TimeSpan idleTimeout,
+        CancellationTokenSource idleCts,
+        CancellationTokenSource linked,
+        TimeSpan keepAliveInterval,
+        ILogger logger
+    )
+    {
+        Stream upstreamStream;
+        try
+        {
+            upstreamStream = await upstream.Content.ReadAsStreamAsync(linked.Token);
+        }
+        catch (OperationCanceledException) when (ctx.RequestAborted.IsCancellationRequested)
+        {
+            return;
+        }
+
+        ctx.Response.StatusCode = StatusCodes.Status200OK;
+        ctx.Response.ContentType = "text/event-stream";
+        ctx.Response.Headers["X-Accel-Buffering"] = "no";
+        ctx.Response.Headers.CacheControl = "no-cache";
+        ctx.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
+
+        var translator = new ResponsesToAnthropicSse($"msg_{Guid.NewGuid():N}", outboundModel);
+        var reportedSilentDrop = false;
+
+        await using (upstreamStream.ConfigureAwait(false))
+        {
+            using var reader = new StreamReader(upstreamStream, Encoding.UTF8);
+            while (true)
+            {
+                // Reset BEFORE each read: the deadline measures the gap between upstream lines, never the
+                // total request duration.
+                idleCts.CancelAfter(idleTimeout);
+
+                string? line;
+                try
+                {
+                    line = await ReadLineWithKeepAliveAsync(ctx, reader, keepAliveInterval, linked.Token);
+                }
+                catch (OperationCanceledException) when (ctx.RequestAborted.IsCancellationRequested)
+                {
+                    logger.LogDebug("Client disconnected mid-translated-stream; ending relay.");
+                    return;
+                }
+                catch (OperationCanceledException) when (idleCts.IsCancellationRequested)
+                {
+                    logger.LogWarning(
+                        "Upstream idle timeout after {IdleSeconds:0}s with no data; ending translated relay.",
+                        idleTimeout.TotalSeconds
+                    );
+                    if (!ctx.Response.HasStarted)
+                    {
+                        await WriteAnthropicErrorAsync(
+                            ctx,
+                            StatusCodes.Status504GatewayTimeout,
+                            "api_error",
+                            "The upstream Copilot stream produced no data before the idle timeout."
+                        );
+                    }
+
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning("Mid-stream translated upstream failure: {Reason}", ex.Message);
+                    if (!ctx.Response.HasStarted)
+                    {
+                        await WriteAnthropicErrorAsync(
+                            ctx,
+                            StatusCodes.Status502BadGateway,
+                            "api_error",
+                            "The upstream Copilot stream failed before any data was received."
+                        );
+                    }
+
+                    return;
+                }
+
+                if (line is null)
+                {
+                    return; // Upstream EOF.
+                }
+
+                // Only the payload matters: the translator dispatches on the JSON `type`, and the
+                // upstream `event:` line merely repeats it. Blank separators fall out here too.
+                if (!line.StartsWith("data:", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                // The [DONE] sentinel is not JSON and produces no frames, like any other event this
+                // translator does not surface.
+                var frames = translator.Next(line[5..].Trim());
+                if (frames.Count == 0)
+                {
+                    reportedSilentDrop = ReportSilentlyDroppedEvent(logger, outboundModel, line, reportedSilentDrop);
+                    continue;
+                }
+
+                try
+                {
+                    foreach (var frame in frames)
+                    {
+                        await ctx.Response.WriteAsync(frame, linked.Token);
+                    }
+
+                    await ctx.Response.Body.FlushAsync(linked.Token);
+                }
+                catch (OperationCanceledException)
+                    when (ctx.RequestAborted.IsCancellationRequested || idleCts.IsCancellationRequested)
+                {
+                    logger.LogDebug(
+                        "Downstream write cancelled ({Reason}); ending translated relay.",
+                        ctx.RequestAborted.IsCancellationRequested ? "client disconnect" : "idle timeout"
+                    );
+                    return;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Awaits the next upstream SSE line, emitting a downstream Anthropic <c>ping</c> every
+    ///     <paramref name="keepAliveInterval" /> while the upstream stays silent. The ping timer never
+    ///     restarts the read and never resets the upstream idle deadline, so a genuinely dead upstream
+    ///     still fails at the idle timeout.
+    /// </summary>
+    private static async Task<string?> ReadLineWithKeepAliveAsync(
+        HttpContext ctx,
+        StreamReader reader,
+        TimeSpan keepAliveInterval,
+        CancellationToken linkedToken
+    )
+    {
+        if (keepAliveInterval <= TimeSpan.Zero)
+        {
+            return await reader.ReadLineAsync(linkedToken);
+        }
+
+        var readTask = reader.ReadLineAsync(linkedToken).AsTask();
+        while (true)
+        {
+            using var keepAliveCts = new CancellationTokenSource();
+            var completed = await Task.WhenAny(readTask, Task.Delay(keepAliveInterval, keepAliveCts.Token))
+                .ConfigureAwait(false);
+            keepAliveCts.Cancel(); // Stop the loser's timer (a no-op if it already finished).
+
+            if (completed == readTask)
+            {
+                return await readTask; // Observe the line / propagate any read exception.
+            }
+
+            await ctx.Response.WriteAsync(AnthropicPingFrame, linkedToken);
+            await ctx.Response.Body.FlushAsync(linkedToken);
+        }
+    }
+
+    /// <summary>
+    ///     Reports, at most once per stream, an upstream event that translated to nothing AND whose
+    ///     absence a user would notice: a tool call whose arguments were dropped, and an upstream
+    ///     failure, which reaches the client as an unexplained truncation. Neither justifies inventing a
+    ///     frame, but both are otherwise completely invisible. This is the only layer with a logger in
+    ///     scope — the translators deliberately take no logging dependency. Returns the new
+    ///     "already reported" state.
+    /// </summary>
+    private static bool ReportSilentlyDroppedEvent(ILogger logger, string model, string line, bool alreadyReported)
+    {
+        if (alreadyReported)
+        {
+            return true;
+        }
+
+        string reason;
+        if (line.Contains("response.function_call_arguments.delta", StringComparison.Ordinal))
+        {
+            reason =
+                "a tool call's arguments were dropped because no tool_use block was open — "
+                + "response.output_item.added was missing, unreadable, or spelled differently than expected";
+        }
+        else if (line.Contains("response.failed", StringComparison.Ordinal))
+        {
+            reason =
+                "the upstream reported a failure, which reaches the client as a truncated stream rather "
+                + "than a fabricated error frame";
+        }
+        else
+        {
+            return false;
+        }
+
+        logger.LogWarning("Translated stream for {Model}: {Reason}.", model, reason);
+        return true;
+    }
+
+    /// <summary>
+    ///     Pulls a human-readable message out of an upstream error body. Every read is kind-safe:
+    ///     <c>{"error":"boom"}</c> indexed as an object throws <see cref="InvalidOperationException" />,
+    ///     which would turn a clean relayed 503 into an unhandled 500. An unrecognised body falls back to
+    ///     its own (capped) text rather than a generic placeholder, because the raw text is what makes an
+    ///     unfamiliar upstream failure diagnosable.
+    /// </summary>
+    private static string ExtractErrorMessage(string body)
+    {
+        const int MaxRawLength = 500;
+
+        try
+        {
+            if (JsonNode.Parse(body) is JsonObject obj)
+            {
+                if (ScalarText((obj["error"] as JsonObject)?["message"]) is { } nested)
+                {
+                    return nested;
+                }
+
+                if (ScalarText(obj["error"]) is { } plain)
+                {
+                    return plain;
+                }
+
+                if (ScalarText(obj["message"]) is { } top)
+                {
+                    return top;
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            // Not JSON at all (an HTML error page from an intermediary, say) — fall through to the text.
+        }
+
+        var trimmed = body.Trim();
+        if (trimmed.Length == 0)
+        {
+            return "The upstream Copilot API returned an error with no body.";
+        }
+
+        return trimmed.Length <= MaxRawLength ? trimmed : trimmed[..MaxRawLength];
+    }
+
+    /// <summary>Reads a JSON string, or null if <paramref name="node" /> is absent or carries another kind.</summary>
+    private static string? ScalarText(JsonNode? node) =>
+        node is JsonValue scalar && scalar.TryGetValue<string>(out var text) ? text : null;
 
     /// <summary>
     ///     Copies the positive request-header allowlist: only <c>anthropic-version</c> is forwarded (a

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -18,16 +18,38 @@ using ILogger = Microsoft.Extensions.Logging.ILogger;
 // =============================================================================
 // CopilotAnthropicProxy.Sample
 //
-// A thin, loopback-only reverse proxy that accepts the Anthropic Messages API
-// and forwards it to GitHub Copilot. It rewrites the JSON `model` field to a
-// configured Copilot Claude (Opus) id, strips the `context_management` field and the
-// `anthropic-beta` header (both unsupported by Copilot's backend), attaches Copilot
-// auth/headers via the proven GithubCopilotProvider transport, and streams the SSE
-// response back as raw bytes.
+// A loopback-only reverse proxy in front of GitHub Copilot that speaks BOTH
+// dialects: Anthropic Messages (/v1/messages and its /count_tokens twin) and
+// OpenAI (/v1/chat/completions, /v1/responses). Every POST also binds its
+// un-prefixed form, because clients disagree about where the /v1 belongs.
+// GET /v1/models answers in a body both dialects can parse; GET /health is liveness.
+//
+// The servable catalog is DISCOVERED at startup, never hard-coded — see
+// ProxyModelResolver.ParseServableModels. A model is kept when it advertises at
+// least one of /v1/messages, /chat/completions or /responses AND its vendor is not
+// denied (Google, Microsoft). Entries advertising no endpoints at all are dropped,
+// which is where text-embedding-* lives, so an embedding model can never surface as
+// a chat model. The default is the highest-version Claude opus among the
+// Messages-capable ids; it catches only requests naming a model this account does
+// not have, and then only after family mapping (see ModelFamilies).
+//
+// Routing is the inbound dialect against what the named model advertises
+// (ModelRouter.Resolve). Three of the four combinations are byte-for-byte
+// passthrough. ONE is real translation — Anthropic Messages in, for a model that
+// speaks only Responses — where the request, the non-streaming reply and the SSE
+// stream are each rewritten (see Translation/). A dialect the model cannot serve
+// 404s rather than being guessed at.
+//
+// On the passthrough paths the body's `model` is rewritten to the resolved id and
+// the top-level `context_management` field is stripped; on the translated path the
+// outbound body is built from scratch, so it cannot carry either. `anthropic-beta`
+// is dropped on both (Copilot 400s the whole request over one unrecognised value).
+// Copilot auth/headers come from the proven GithubCopilotProvider transport, and
+// responses stream back without buffering.
 // It also exposes Copilot's MCP server (Streamable HTTP transport) as a transparent
 // byte-level proxy on /mcp and /mcp/readonly, with Copilot auth attached the same way.
 //
-// Point Claude Code (or any Anthropic-Messages client) at it via ANTHROPIC_BASE_URL.
+// Point Claude Code, Codex CLI or opencode at it via that client's base-URL setting.
 // SECURITY: binds to loopback only and attaches the developer's Copilot credentials
 // outbound; never expose it on 0.0.0.0 or through a tunnel. See README.md.
 // =============================================================================
@@ -135,7 +157,8 @@ catch (Exception ex) when (ex is InvalidOperationException or OperationCanceledE
 }
 
 // 2) Resolve the outbound model catalog (env wins and pins a single model; else discover every
-//    /v1/messages-capable Copilot model and pick the `opus` Claude id as the default; else fail fast).
+//    servable Copilot model — any of /v1/messages, /chat/completions, /responses, minus the vendor
+//    denylist — and pick the highest-version `opus` Claude id as the default; else fail fast).
 ProxyModelCatalog catalog;
 try
 {
@@ -478,9 +501,14 @@ public static class ProxyModelResolver
 {
     /// <summary>
     ///     Resolves the model catalog: <c>COPILOT_ANTHROPIC_MODEL</c> override wins and pins a single model
-    ///     (no discovery, no passthrough); otherwise queries <c>GET /models</c>, filters to the ids that
-    ///     support <c>/v1/messages</c>, and picks the <c>opus</c> Claude id as the default. Throws when no
-    ///     override is set and no opus Claude id is available (caller fails fast).
+    ///     (no discovery, no passthrough); otherwise queries <c>GET /models</c> and keeps everything
+    ///     <see cref="ParseServableModels"/> considers servable — advertising any of <c>/v1/messages</c>,
+    ///     <c>/chat/completions</c> or <c>/responses</c>, vendor not denied.
+    ///
+    ///     The DEFAULT is drawn from a narrower set than the catalog. It is the fallback for the Anthropic
+    ///     surface, so it is picked from the Messages-capable ids only, and among those it is the
+    ///     highest-version <c>opus</c> Claude id. Throws when no override is set and there is no such id
+    ///     (caller fails fast) — a catalog full of Responses-only models is not enough on its own.
     /// </summary>
     public static async Task<ProxyModelCatalog> ResolveAsync(
         HttpClient client,

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -745,11 +745,33 @@ public static class ProxyModelResolver
     }
 
     /// <summary>
+    ///     Tool types Copilot's <c>/responses</c> accepts. Both are client-defined: <c>function</c>
+    ///     (JSON-schema arguments) and <c>custom</c> (freeform text, which is how current Codex sends
+    ///     <c>apply_patch</c>). Every other type is a hosted tool executed on the server.
+    /// </summary>
+    /// <remarks>
+    ///     An allowlist rather than a denylist, for the same reason
+    ///     <c>AnthropicToResponsesRequest.BuildTools</c> keys off <c>input_schema</c>: it drops hosted
+    ///     tools this proxy has never seen instead of forwarding them into a 400. Live-probed
+    ///     2026-07-28 — <c>image_generation</c>, <c>local_shell</c>, <c>code_interpreter</c> and
+    ///     <c>mcp</c> each fail with <c>"The requested tool &lt;type&gt; is not supported."</c>
+    ///     <c>web_search</c> is currently accepted upstream but is dropped anyway: it is hosted, and
+    ///     the translated Anthropic route already drops its counterpart <c>web_search_20250305</c>.
+    /// </remarks>
+    private static readonly HashSet<string> ClientDefinedToolTypes = new(StringComparer.Ordinal)
+    {
+        "function",
+        "custom",
+    };
+
+    /// <summary>
     ///     Raw <see cref="JsonNode"/> rewrite of the request body: sets/injects <c>model</c> and strips
     ///     the top-level <c>context_management</c> field (Copilot's backend rejects it outright with
     ///     <c>"context_management: Extra inputs are not permitted"</c>, so it can never be forwarded).
-    ///     Never deserializes to a typed DTO, so <c>cache_control</c>, <c>thinking</c>, <c>system</c>
-    ///     blocks, and every other unknown field are preserved verbatim.
+    ///     With <paramref name="stripHostedTools"/> it also filters <c>tools</c> down to
+    ///     <see cref="ClientDefinedToolTypes"/>. Never deserializes to a typed DTO, so
+    ///     <c>cache_control</c>, <c>thinking</c>, <c>system</c> blocks, and every other unknown field
+    ///     are preserved verbatim.
     /// </summary>
     /// <returns>True on success; false when the body is missing, not JSON, or not a JSON object.</returns>
     public static bool TryRewriteModel(
@@ -757,7 +779,8 @@ public static class ProxyModelResolver
         string model,
         out byte[] rewritten,
         out string? incomingModel,
-        bool renameMaxTokens = false
+        bool renameMaxTokens = false,
+        bool stripHostedTools = false
     )
     {
         ArgumentNullException.ThrowIfNull(body);
@@ -809,6 +832,40 @@ public static class ProxyModelResolver
             if (!obj.ContainsKey("max_completion_tokens"))
             {
                 obj["max_completion_tokens"] = clonedMaxTokens;
+            }
+        }
+
+        // Codex CLI advertises the hosted `image_generation` tool on every request and offers no way
+        // to turn it off (`-c tools.image_generation=false` has no effect), so without this filter
+        // Copilot 400s the request and Codex cannot use the proxy at all.
+        if (stripHostedTools && obj["tools"] is JsonArray tools)
+        {
+            var kept = new JsonArray();
+            foreach (var tool in tools)
+            {
+                if (
+                    tool is JsonObject toolObject
+                    && toolObject["type"] is JsonValue toolType
+                    && toolType.TryGetValue<string>(out var type)
+                    && ClientDefinedToolTypes.Contains(type)
+                )
+                {
+                    kept.Add(tool.DeepClone());
+                }
+            }
+
+            // Only touch the body when something was actually dropped: a request that carries no
+            // hosted tools must forward byte-for-byte.
+            if (kept.Count != tools.Count)
+            {
+                if (kept.Count == 0)
+                {
+                    _ = obj.Remove("tools");
+                }
+                else
+                {
+                    obj["tools"] = kept;
+                }
             }
         }
 
@@ -924,13 +981,15 @@ internal static class ProxyHttp
 
         // 3) Rewrite the body (raw JSON). Parse failure -> 400 (do NOT call upstream).
         var renameMaxTokens = dialect == ProxyDialect.ChatCompletions && !modelInfo.IsAnthropic;
+        var stripHostedTools = dialect == ProxyDialect.Responses;
         if (
             !ProxyModelResolver.TryRewriteModel(
                 inboundBody,
                 outboundModel,
                 out var outboundBody,
                 out var incomingModel,
-                renameMaxTokens
+                renameMaxTokens,
+                stripHostedTools
             )
         )
         {

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -94,8 +94,9 @@ builder.WebHost.ConfigureKestrel(options =>
     options.Listen(IPAddress.IPv6Loopback, config.Port);
     // Local dev proxy on a trusted loopback socket. The forward path buffers and JsonNode-rewrites the
     // whole body in memory, so the cap matches Anthropic's own ~32 MB request limit rather than being
-    // arbitrarily large; Kestrel rejects an over-limit body mid-read, before full allocation.
-    options.Limits.MaxRequestBodySize = 32L * 1024 * 1024; // 32 MB (matches the Anthropic API request limit)
+    // arbitrarily large; Kestrel rejects an over-limit body mid-read, before full allocation. The same
+    // ceiling is applied to every buffered read inside the proxy (see ProxyHttp.ReadCappedAsync).
+    options.Limits.MaxRequestBodySize = config.MaxBodyBytes;
 });
 
 // --- Dependency injection ----------------------------------------------------
@@ -167,7 +168,8 @@ try
         app.Services.GetRequiredService<HttpClient>(),
         config.ModelOverride,
         logger,
-        modelCts.Token
+        modelCts.Token,
+        config.ModelEndpointsOverride
     );
 }
 catch (Exception ex) when (ex is InvalidOperationException or HttpRequestException or OperationCanceledException)
@@ -194,7 +196,10 @@ logger.LogInformation(
 );
 
 // --- Pipeline ----------------------------------------------------------------
-// Host/loopback/cross-site guard runs FIRST.
+// Host/loopback/cross-site guard runs FIRST. Its rejection is shaped for the dialect the caller was
+// speaking: an OpenAI SDK cannot parse Anthropic's top-level {type, error} envelope, so a rejected
+// /chat/completions or /responses request would otherwise surface as an unparseable body rather than
+// as the 403 it is.
 app.Use(
     async (ctx, next) =>
     {
@@ -208,8 +213,9 @@ app.Use(
             )
         )
         {
-            await ProxyHttp.WriteAnthropicErrorAsync(
+            await ProxyHttp.WriteErrorAsync(
                 ctx,
+                ProxyHttp.DialectForPath(ctx.Request.Path),
                 StatusCodes.Status403Forbidden,
                 "permission_error",
                 "This proxy only accepts loopback requests from a same-origin client."
@@ -242,6 +248,7 @@ foreach (var path in new[] { "/v1/messages", "/messages" })
                 catalog,
                 config.IdleTimeout,
                 config.KeepAliveInterval,
+                config.MaxBodyBytes,
                 ProxyDialect.AnthropicMessages
             )
     );
@@ -253,6 +260,7 @@ foreach (var path in new[] { "/v1/messages", "/messages" })
                 catalog,
                 config.IdleTimeout,
                 config.KeepAliveInterval,
+                config.MaxBodyBytes,
                 ProxyDialect.AnthropicMessages,
                 isCountTokens: true
             )
@@ -269,6 +277,7 @@ foreach (var path in new[] { "/v1/chat/completions", "/chat/completions" })
                 catalog,
                 config.IdleTimeout,
                 config.KeepAliveInterval,
+                config.MaxBodyBytes,
                 ProxyDialect.ChatCompletions
             )
     );
@@ -278,7 +287,15 @@ foreach (var path in new[] { "/v1/responses", "/responses" })
 {
     _ = app.MapPost(
         path,
-        ctx => ProxyHttp.ForwardAsync(ctx, catalog, config.IdleTimeout, config.KeepAliveInterval, ProxyDialect.Responses)
+        ctx =>
+            ProxyHttp.ForwardAsync(
+                ctx,
+                catalog,
+                config.IdleTimeout,
+                config.KeepAliveInterval,
+                config.MaxBodyBytes,
+                ProxyDialect.Responses
+            )
     );
 }
 
@@ -309,6 +326,9 @@ return 0;
 /// <summary>Immutable proxy configuration sourced from environment variables.</summary>
 internal sealed record ProxyConfig
 {
+    /// <summary>Matches the Anthropic API's own ~32 MB request limit.</summary>
+    public const long DefaultMaxBodyBytes = 32L * 1024 * 1024;
+
     public required int Port { get; init; }
     public required string BaseUrl { get; init; }
     public required TimeSpan IdleTimeout { get; init; }
@@ -316,11 +336,24 @@ internal sealed record ProxyConfig
     public required bool EnableDeviceFlow { get; init; }
     public required string? ModelOverride { get; init; }
 
+    /// <summary>
+    ///     Endpoints the pinned <see cref="ModelOverride"/> serves, when the operator states them.
+    ///     Empty means "unstated" — see ProxyModelResolver.ResolveAsync.
+    /// </summary>
+    public required IReadOnlyList<string> ModelEndpointsOverride { get; init; }
+
+    /// <summary>
+    ///     Ceiling on any single buffered body, inbound or upstream. The forward and translate paths
+    ///     both hold a whole body in memory to rewrite it, so this is what stops one oversized reply
+    ///     from turning into several large-object-heap allocations.
+    /// </summary>
+    public required long MaxBodyBytes { get; init; }
+
     public static ProxyConfig FromEnvironment()
     {
         return new ProxyConfig
         {
-            Port = ParseInt(Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_PORT"), 8788),
+            Port = ParseInt(Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_PORT"), 8787),
             BaseUrl =
                 NullIfBlank(Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_BASE_URL"))
                 ?? CopilotOptions.DefaultBaseUrl,
@@ -332,13 +365,30 @@ internal sealed record ProxyConfig
             ),
             EnableDeviceFlow = ParseBool(Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_ENABLE_DEVICE_FLOW")),
             ModelOverride = NullIfBlank(Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_MODEL")),
+            ModelEndpointsOverride = ParseList(
+                Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_MODEL_ENDPOINTS")
+            ),
+            MaxBodyBytes = ParseLong(
+                Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_MAX_BODY_BYTES"),
+                DefaultMaxBodyBytes
+            ),
         };
     }
 
     private static string? NullIfBlank(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
+    private static IReadOnlyList<string> ParseList(string? value) =>
+        NullIfBlank(value) is not { } list
+            ? []
+            : [.. list.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
+
     private static int ParseInt(string? value, int fallback) =>
         int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) && parsed > 0
+            ? parsed
+            : fallback;
+
+    private static long ParseLong(string? value, long fallback) =>
+        long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) && parsed > 0
             ? parsed
             : fallback;
 
@@ -505,6 +555,12 @@ public static class ProxyModelResolver
     ///     <see cref="ParseServableModels"/> considers servable — advertising any of <c>/v1/messages</c>,
     ///     <c>/chat/completions</c> or <c>/responses</c>, vendor not denied.
     ///
+    ///     <paramref name="pinnedEndpoints"/> states what the pinned id serves. It exists because pinning
+    ///     skips discovery, so nothing else can know: without it a pinned Responses-only model has no
+    ///     endpoint metadata, and <c>ModelRouter</c> reads "no metadata" as Messages-capable — which makes
+    ///     the Anthropic-to-Responses translation route unreachable for exactly the models it was built
+    ///     for. Empty keeps the historical behaviour.
+    ///
     ///     The DEFAULT is drawn from a narrower set than the catalog. It is the fallback for the Anthropic
     ///     surface, so it is picked from the Messages-capable ids only, and among those it is the
     ///     highest-version <c>opus</c> Claude id. Throws when no override is set and there is no such id
@@ -514,7 +570,8 @@ public static class ProxyModelResolver
         HttpClient client,
         string? modelOverride,
         ILogger logger,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        IReadOnlyList<string>? pinnedEndpoints = null
     )
     {
         ArgumentNullException.ThrowIfNull(client);
@@ -523,10 +580,21 @@ public static class ProxyModelResolver
         {
             var pinned = modelOverride.Trim();
 
-            // DEVIATION D1: pinning still short-circuits discovery. Vendor and endpoints are unknown, and an
-            // empty endpoint list means "no metadata", which routes as Anthropic Messages and Chat Completions,
-            // but not Responses — we cannot claim Responses support we have not seen advertised.
-            return new ProxyModelCatalog(pinned, [new ProxyModelInfo(pinned, string.Empty, [])]);
+            // DEVIATION D1: pinning still short-circuits discovery — see the plan's D1 note. Vendor stays
+            // unknown; endpoints are whatever the operator stated. An empty list still means "no metadata",
+            // which routes as Anthropic Messages and Chat Completions but not Responses: we do not claim
+            // Responses support nobody advertised.
+            IReadOnlyList<string> endpoints = pinnedEndpoints ?? [];
+            if (endpoints.Count > 0)
+            {
+                logger.LogInformation(
+                    "Model {Model} is pinned with the endpoints {Endpoints}; discovery is skipped.",
+                    pinned,
+                    string.Join(", ", endpoints)
+                );
+            }
+
+            return new ProxyModelCatalog(pinned, [new ProxyModelInfo(pinned, string.Empty, endpoints)]);
         }
 
         using var response = await client.GetAsync("/models", cancellationToken).ConfigureAwait(false);
@@ -875,12 +943,56 @@ public static class ProxyModelResolver
                 {
                     obj["tools"] = kept;
                 }
+
+                // A tool_choice that outlived its tool is not a smaller problem than the hosted tool
+                // was: Responses rejects a choice with no tools at all, and a named choice pointing at
+                // a tool that was just filtered out is a 400 for a tool the client never sent.
+                DropOrphanedToolChoice(obj, kept);
             }
         }
 
         rewritten = JsonSerializer.SerializeToUtf8Bytes(obj);
         return true;
     }
+
+    /// <summary>
+    ///     Removes <c>tool_choice</c> when the tools that survived hosted-tool filtering can no longer
+    ///     satisfy it. A bare "auto"/"none"/"required" string is kept whenever any tool survived; it is
+    ///     dropped only when the tools key itself went away.
+    /// </summary>
+    private static void DropOrphanedToolChoice(JsonObject obj, JsonArray kept)
+    {
+        if (obj["tool_choice"] is not { } choice)
+        {
+            return;
+        }
+
+        if (kept.Count == 0)
+        {
+            _ = obj.Remove("tool_choice");
+            return;
+        }
+
+        // The object form names one tool: {"type":"function","name":"shell"}. Anything else — a hosted
+        // tool type such as {"type":"image_generation"}, or a shape we do not recognise — cannot be
+        // checked against what survived, so it goes with the tools it referred to.
+        if (choice is not JsonObject named)
+        {
+            return;
+        }
+
+        var name = ScalarString(named["name"]);
+        var survives = name is not null && kept.OfType<JsonObject>().Any(tool => ScalarString(tool["name"]) == name);
+
+        if (!survives)
+        {
+            _ = obj.Remove("tool_choice");
+        }
+    }
+
+    /// <summary>Reads a JSON string, or null when the node is absent or carries another kind.</summary>
+    private static string? ScalarString(JsonNode? node) =>
+        node is JsonValue scalar && scalar.TryGetValue<string>(out var text) ? text : null;
 }
 
 // =============================================================================
@@ -892,22 +1004,60 @@ internal static class ProxyHttp
 {
     private const int BufferSize = 8192;
 
-    // Hop-by-hop / framing / content-coding headers that must NOT be copied from the upstream response.
-    // Content-Type is copied separately from the content headers.
-    private static readonly HashSet<string> ExcludedResponseHeaders = new(StringComparer.OrdinalIgnoreCase)
+    // Positive allowlist for upstream response headers. A negative list forwards by default, so every
+    // header a provider or an intermediary invents — Set-Cookie, tracing identifiers, whatever the next
+    // gateway adds — reaches the client until someone remembers to deny it. This list is instead the
+    // complete set the client is known to need: retry pacing, rate-limit accounting, the request id that
+    // makes a provider-side incident traceable, and the one MCP protocol header below.
+    // Content-Type is applied separately from the content headers.
+    private static readonly HashSet<string> AllowedResponseHeaders = new(StringComparer.OrdinalIgnoreCase)
     {
-        "Content-Length",
-        "Transfer-Encoding",
-        "Connection",
-        "Keep-Alive",
-        "Upgrade",
-        "TE",
-        "Trailer",
-        "Proxy-Authenticate",
-        "Proxy-Authorization",
-        "Content-Encoding",
-        "Content-Type",
+        "Retry-After",
+        "request-id",
+        "x-request-id",
+        "ETag",
+        "Cache-Control",
+        "Vary",
+        "openai-processing-ms",
+        "openai-version",
+        "openai-model",
+        // MCP Streamable HTTP: the server assigns the session id on InitializeResult and the client
+        // MUST echo it on every later request. Withholding it does not merely lose a diagnostic — it
+        // ends the session before it starts, so this is protocol payload rather than provider noise.
+        "Mcp-Session-Id",
     };
+
+    // Rate-limit families are open-ended (Anthropic alone ships requests/tokens/input-tokens/
+    // output-tokens variants and adds more), so they are matched by prefix rather than enumerated.
+    private static readonly string[] AllowedResponseHeaderPrefixes =
+    [
+        "anthropic-ratelimit-",
+        "x-ratelimit-",
+        "ratelimit-",
+    ];
+
+    /// <summary>
+    ///     The dialect a path speaks, for code that runs before routing (the loopback guard) and so
+    ///     cannot be told by the endpoint which dialect it is serving. Anything unrecognised is
+    ///     Anthropic: that is the proxy's primary surface and the shape its fallback 404 already uses.
+    /// </summary>
+    public static ProxyDialect DialectForPath(PathString path)
+    {
+        var value = path.Value ?? string.Empty;
+
+        if (HasSegment(value, "/chat/completions"))
+        {
+            return ProxyDialect.ChatCompletions;
+        }
+
+        return HasSegment(value, "/responses") ? ProxyDialect.Responses : ProxyDialect.AnthropicMessages;
+
+        // Matches the route family in both bound forms — "/v1/responses" and "/responses" — without
+        // matching a longer path that merely starts the same way.
+        static bool HasSegment(string path, string segment) =>
+            path.Equals(segment, StringComparison.OrdinalIgnoreCase)
+            || path.Equals("/v1" + segment, StringComparison.OrdinalIgnoreCase);
+    }
 
     /// <summary>Forwards a request to Copilot in the given dialect and streams the response back.</summary>
     public static async Task ForwardAsync(
@@ -915,6 +1065,7 @@ internal static class ProxyHttp
         ProxyModelCatalog catalog,
         TimeSpan idleTimeout,
         TimeSpan keepAliveInterval,
+        long maxBodyBytes,
         ProxyDialect dialect,
         bool isCountTokens = false
     )
@@ -982,6 +1133,7 @@ internal static class ProxyHttp
                     outboundModel,
                     idleTimeout,
                     keepAliveInterval,
+                    maxBodyBytes,
                     logger
                 )
                 .ConfigureAwait(false);
@@ -1345,6 +1497,7 @@ internal static class ProxyHttp
         string outboundModel,
         TimeSpan idleTimeout,
         TimeSpan keepAliveInterval,
+        long maxBodyBytes,
         ILogger logger
     )
     {
@@ -1465,6 +1618,7 @@ internal static class ProxyHttp
                     upstream,
                     outboundModel,
                     idleTimeout,
+                    maxBodyBytes,
                     idleCts,
                     linked,
                     logger
@@ -1478,7 +1632,7 @@ internal static class ProxyHttp
                     ctx,
                     (int)upstream.StatusCode,
                     "api_error",
-                    ExtractErrorMessage(errorBody)
+                    ExtractErrorMessage(errorBody, logger)
                 );
                 return;
             }
@@ -1490,6 +1644,7 @@ internal static class ProxyHttp
                     upstream,
                     outboundModel,
                     idleTimeout,
+                    maxBodyBytes,
                     idleCts,
                     linked,
                     logger
@@ -1534,13 +1689,19 @@ internal static class ProxyHttp
     }
 
     /// <summary>
-    ///     Reads a complete upstream body under the linked (client-abort + idle) token. Because the send
-    ///     used <see cref="HttpCompletionOption.ResponseHeadersRead" /> this read still pulls from the
+    ///     Reads a complete upstream body under the linked (client-abort + idle) token, bounded by
+    ///     <paramref name="maxBodyBytes" />. Because the send used
+    ///     <see cref="HttpCompletionOption.ResponseHeadersRead" /> this read still pulls from the
     ///     socket, and the proxy's <see cref="HttpClient" /> deliberately carries no timeout — so without
     ///     the idle token nothing at all would end a reply that stops arriving half-way through. The
     ///     deadline is re-armed here so it measures the wait for the BODY rather than counting whatever
     ///     the headers already spent. It does span the whole body read: a buffered reply arrives as one
     ///     payload, so there are no inter-chunk gaps to measure at this layer.
+    ///
+    ///     The cap matters because an idle timeout does not bound SIZE: an upstream that keeps sending
+    ///     never goes idle, so a runaway or hostile reply would be buffered whole, in a single
+    ///     large-object-heap allocation per concurrent request. The inbound direction is already bounded
+    ///     by Kestrel's <c>MaxRequestBodySize</c>, set from the same configured limit.
     /// </summary>
     /// <returns>
     ///     The body, or <c>null</c> once the failure has already been answered (or the client has gone).
@@ -1551,6 +1712,7 @@ internal static class ProxyHttp
         HttpResponseMessage upstream,
         string outboundModel,
         TimeSpan idleTimeout,
+        long maxBodyBytes,
         CancellationTokenSource idleCts,
         CancellationTokenSource linked,
         ILogger logger
@@ -1560,7 +1722,24 @@ internal static class ProxyHttp
 
         try
         {
-            return await upstream.Content.ReadAsStringAsync(linked.Token);
+            var body = await ReadCappedStringAsync(upstream.Content, maxBodyBytes, linked.Token);
+            if (body is not null)
+            {
+                return body;
+            }
+
+            logger.LogError(
+                "Upstream reply for {Model} exceeded the {MaxBodyBytes}-byte relay cap and was not buffered.",
+                outboundModel,
+                maxBodyBytes
+            );
+            await WriteAnthropicErrorAsync(
+                ctx,
+                StatusCodes.Status502BadGateway,
+                "api_error",
+                "The upstream Copilot reply was larger than this proxy will buffer."
+            );
+            return null;
         }
         catch (OperationCanceledException) when (ctx.RequestAborted.IsCancellationRequested)
         {
@@ -1601,8 +1780,52 @@ internal static class ProxyHttp
     }
 
     /// <summary>
+    ///     Buffers an upstream body as UTF-8 text, or returns <c>null</c> the moment it would exceed
+    ///     <paramref name="maxBytes" />. A declared <c>Content-Length</c> short-circuits the read
+    ///     entirely; a chunked reply is measured as it arrives, so nothing over the cap is ever held.
+    /// </summary>
+    private static async Task<string?> ReadCappedStringAsync(
+        HttpContent content,
+        long maxBytes,
+        CancellationToken token
+    )
+    {
+        if (content.Headers.ContentLength is { } declared && declared > maxBytes)
+        {
+            return null;
+        }
+
+        var stream = await content.ReadAsStreamAsync(token).ConfigureAwait(false);
+        await using (stream.ConfigureAwait(false))
+        {
+            using var buffer = new MemoryStream();
+            var chunk = new byte[BufferSize];
+
+            while (true)
+            {
+                var read = await stream.ReadAsync(chunk, token).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                if (buffer.Length + read > maxBytes)
+                {
+                    return null;
+                }
+
+                buffer.Write(chunk, 0, read);
+            }
+
+            // GetBuffer avoids the second full-size copy ToArray would make of a reply that can already
+            // be megabytes; the decode below is the only other full-size representation.
+            return Encoding.UTF8.GetString(buffer.GetBuffer(), 0, (int)buffer.Length);
+        }
+    }
+
+    /// <summary>
     ///     Translates a buffered Responses reply into an Anthropic Message. A reply this proxy cannot
-    ///     read answers 400 rather than leaking a 500 — the contract
+    ///     read answers 502 rather than leaking a 500 — the contract
     ///     <see cref="ResponsesToAnthropicJson.Translate" /> documents its <see cref="ArgumentException" />
     ///     for.
     /// </summary>
@@ -1611,6 +1834,7 @@ internal static class ProxyHttp
         HttpResponseMessage upstream,
         string outboundModel,
         TimeSpan idleTimeout,
+        long maxBodyBytes,
         CancellationTokenSource idleCts,
         CancellationTokenSource linked,
         ILogger logger
@@ -1621,6 +1845,7 @@ internal static class ProxyHttp
             upstream,
             outboundModel,
             idleTimeout,
+            maxBodyBytes,
             idleCts,
             linked,
             logger
@@ -1637,15 +1862,20 @@ internal static class ProxyHttp
         }
         catch (ArgumentException ex)
         {
-            logger.LogWarning(
-                "Could not translate the Responses reply for {Model}: {Reason}",
-                outboundModel,
-                ex.Message
+            // 502, not 400. The client's request was accepted, forwarded, and answered with 2xx; what
+            // failed is the upstream's reply. Reporting that as invalid_request_error tells the client
+            // to fix a request that was never wrong, and hides a real upstream regression behind a
+            // client-side error class. The exception object is logged rather than only its message, so
+            // a translator defect keeps its type and stack trace.
+            logger.LogError(
+                ex,
+                "Could not translate the Responses reply for {Model} into an Anthropic message.",
+                outboundModel
             );
             await WriteAnthropicErrorAsync(
                 ctx,
-                StatusCodes.Status400BadRequest,
-                "invalid_request_error",
+                StatusCodes.Status502BadGateway,
+                "api_error",
                 "The upstream Copilot reply could not be translated into an Anthropic message."
             );
             return;
@@ -1682,6 +1912,39 @@ internal static class ProxyHttp
         {
             return;
         }
+        catch (OperationCanceledException) when (idleCts.IsCancellationRequested)
+        {
+            // The linked token cancels for two reasons and only one of them was handled above, so an
+            // idle timeout during acquisition escaped as an unhandled OperationCanceledException — a
+            // bare 500 with no Anthropic envelope, on the exact path whose 504 contract is documented.
+            logger.LogWarning(
+                "Upstream idle timeout after {IdleSeconds:0}s while opening the stream for {Model}.",
+                idleTimeout.TotalSeconds,
+                outboundModel
+            );
+            await WriteAnthropicErrorAsync(
+                ctx,
+                StatusCodes.Status504GatewayTimeout,
+                "api_error",
+                "The upstream Copilot stream produced no data before the idle timeout."
+            );
+            return;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or IOException)
+        {
+            logger.LogError(
+                "Upstream connection dropped while opening the stream for {Model}: {Reason}",
+                outboundModel,
+                ex.Message
+            );
+            await WriteAnthropicErrorAsync(
+                ctx,
+                StatusCodes.Status502BadGateway,
+                "api_error",
+                "The upstream Copilot API dropped the connection before its stream began."
+            );
+            return;
+        }
 
         ctx.Response.StatusCode = StatusCodes.Status200OK;
         ctx.Response.ContentType = "text/event-stream";
@@ -1697,6 +1960,54 @@ internal static class ProxyHttp
             // leaveOpen: the enclosing `await using` owns the stream. Double disposal is harmless, but
             // saying so beats leaving a reader that looks like it owns something it does not.
             using var reader = new StreamReader(upstreamStream, Encoding.UTF8, leaveOpen: true);
+
+            // SSE allows one event to span several `data:` lines, which the receiver joins with "\n" at
+            // the blank line that terminates the event. Feeding each line to the translator on its own —
+            // which this loop used to do — turns any such event into several fragments that individually
+            // fail to parse as JSON, and the translator's "unparseable payloads produce no frames"
+            // contract then drops the whole event silently. Copilot sends single-line events today;
+            // nothing in the protocol promises it always will.
+            var pending = new StringBuilder();
+
+            // Emits one reassembled event. Returns false when the relay should stop.
+            async Task<bool> DispatchAsync(string payload)
+            {
+                // The [DONE] sentinel is not JSON and produces no frames, like any other event this
+                // translator does not surface.
+                var frames = translator.Next(payload.Trim());
+                if (frames.Count == 0)
+                {
+                    reportedSilentDrop = ReportSilentlyDroppedEvent(
+                        logger,
+                        outboundModel,
+                        payload,
+                        reportedSilentDrop
+                    );
+                    return true;
+                }
+
+                try
+                {
+                    foreach (var frame in frames)
+                    {
+                        await ctx.Response.WriteAsync(frame, linked.Token);
+                    }
+
+                    await ctx.Response.Body.FlushAsync(linked.Token);
+                }
+                catch (OperationCanceledException)
+                    when (ctx.RequestAborted.IsCancellationRequested || idleCts.IsCancellationRequested)
+                {
+                    logger.LogDebug(
+                        "Downstream write cancelled ({Reason}); ending translated relay.",
+                        ctx.RequestAborted.IsCancellationRequested ? "client disconnect" : "idle timeout"
+                    );
+                    return false;
+                }
+
+                return true;
+            }
+
             while (true)
             {
                 // Reset BEFORE each read: the deadline measures the gap between upstream lines, never the
@@ -1731,17 +2042,22 @@ internal static class ProxyHttp
 
                     return;
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is IOException or HttpRequestException or ObjectDisposedException)
                 {
+                    // Narrowed to transport faults, and logging the exception OBJECT: a catch-all here
+                    // swallowed programming defects — a NullReferenceException in the translator became
+                    // an "upstream stream failed" line with no type and no stack trace, and the relay
+                    // ended looking like an ordinary truncation.
+                    //
                     // The upstream read and the downstream keep-alive write share this one call, so the
                     // failing side is not knowable here — saying "upstream" would blame Copilot for a
                     // client that hung up. The envelope below is upstream-only regardless: a keep-alive
                     // write can only fail after it has started the response, which this guard excludes.
                     logger.LogWarning(
+                        ex,
                         "Translated relay for {Model} failed mid-stream, on either the upstream read or the "
-                            + "downstream keep-alive write: {Reason}",
-                        outboundModel,
-                        ex.Message
+                            + "downstream keep-alive write.",
+                        outboundModel
                     );
                     if (!ctx.Response.HasStarted)
                     {
@@ -1758,43 +2074,52 @@ internal static class ProxyHttp
 
                 if (line is null)
                 {
-                    return; // Upstream EOF.
+                    // Upstream EOF. An event whose terminating blank line never arrived is still an
+                    // event the upstream sent, so it is dispatched rather than discarded.
+                    if (pending.Length > 0)
+                    {
+                        _ = await DispatchAsync(pending.ToString());
+                    }
+
+                    return;
                 }
 
-                // Only the payload matters: the translator dispatches on the JSON `type`, and the
-                // upstream `event:` line merely repeats it. Blank separators fall out here too.
+                // The blank line terminates the event and is the only place a payload is dispatched.
+                if (line.Length == 0)
+                {
+                    if (pending.Length > 0)
+                    {
+                        var payload = pending.ToString();
+                        _ = pending.Clear();
+                        if (!await DispatchAsync(payload))
+                        {
+                            return;
+                        }
+                    }
+
+                    continue;
+                }
+
+                // Only `data:` matters: the translator dispatches on the JSON `type`, and the upstream
+                // `event:` line merely repeats it. Comments and other fields fall out here.
                 if (!line.StartsWith("data:", StringComparison.Ordinal))
                 {
                     continue;
                 }
 
-                // The [DONE] sentinel is not JSON and produces no frames, like any other event this
-                // translator does not surface.
-                var frames = translator.Next(line[5..].Trim());
-                if (frames.Count == 0)
+                // SSE strips exactly ONE optional space after the colon; any further whitespace is data.
+                var value = line[5..];
+                if (value.StartsWith(' '))
                 {
-                    reportedSilentDrop = ReportSilentlyDroppedEvent(logger, outboundModel, line, reportedSilentDrop);
-                    continue;
+                    value = value[1..];
                 }
 
-                try
+                if (pending.Length > 0)
                 {
-                    foreach (var frame in frames)
-                    {
-                        await ctx.Response.WriteAsync(frame, linked.Token);
-                    }
+                    _ = pending.Append('\n');
+                }
 
-                    await ctx.Response.Body.FlushAsync(linked.Token);
-                }
-                catch (OperationCanceledException)
-                    when (ctx.RequestAborted.IsCancellationRequested || idleCts.IsCancellationRequested)
-                {
-                    logger.LogDebug(
-                        "Downstream write cancelled ({Reason}); ending translated relay.",
-                        ctx.RequestAborted.IsCancellationRequested ? "client disconnect" : "idle timeout"
-                    );
-                    return;
-                }
+                _ = pending.Append(value);
             }
         }
     }
@@ -1837,13 +2162,15 @@ internal static class ProxyHttp
 
     /// <summary>
     ///     Reports, at most once per stream, an upstream event that translated to nothing AND whose
-    ///     absence a user would notice: a tool call whose arguments were dropped, and an upstream
-    ///     failure, which reaches the client as an unexplained truncation. Neither justifies inventing a
-    ///     frame, but both are otherwise completely invisible. This is the only layer with a logger in
-    ///     scope — the translators deliberately take no logging dependency. Returns the new
-    ///     "already reported" state.
+    ///     absence a user would notice. An upstream FAILURE is no longer one of those cases — it now
+    ///     produces a real Anthropic <c>error</c> frame — so what is left is the two ways an event can
+    ///     vanish without anyone deciding it should: a tool call's arguments that carried nothing
+    ///     readable, and a payload that is not a JSON object at all. Neither justifies inventing a frame,
+    ///     but both are otherwise completely invisible. This is the only layer with a logger in scope —
+    ///     the translators deliberately take no logging dependency. Returns the new "already reported"
+    ///     state.
     /// </summary>
-    private static bool ReportSilentlyDroppedEvent(ILogger logger, string model, string line, bool alreadyReported)
+    private static bool ReportSilentlyDroppedEvent(ILogger logger, string model, string payload, bool alreadyReported)
     {
         if (alreadyReported)
         {
@@ -1851,17 +2178,17 @@ internal static class ProxyHttp
         }
 
         string reason;
-        if (line.Contains("response.function_call_arguments.delta", StringComparison.Ordinal))
+        if (payload.Contains("response.function_call_arguments.delta", StringComparison.Ordinal))
         {
             reason =
-                "a tool call's arguments were dropped because no tool_use block was open — "
-                + "response.output_item.added was missing, unreadable, or spelled differently than expected";
+                "a tool call's arguments produced no output — the delta was absent, empty, or carried a "
+                + "JSON kind other than string";
         }
-        else if (line.Contains("response.failed", StringComparison.Ordinal))
+        else if (!IsReadableEventPayload(payload))
         {
             reason =
-                "the upstream reported a failure, which reaches the client as a truncated stream rather "
-                + "than a fabricated error frame";
+                "an upstream event could not be read as a JSON object and was dropped; a truncated or "
+                + "mis-framed SSE event is the usual cause";
         }
         else
         {
@@ -1873,16 +2200,51 @@ internal static class ProxyHttp
     }
 
     /// <summary>
+    ///     True when a zero-frame payload is one the translator legitimately chose not to surface,
+    ///     rather than one it could not read. The empty payload and the <c>[DONE]</c> sentinel are both
+    ///     expected and are not JSON.
+    /// </summary>
+    private static bool IsReadableEventPayload(string payload)
+    {
+        var trimmed = payload.Trim();
+        if (trimmed.Length == 0 || trimmed == "[DONE]")
+        {
+            return true;
+        }
+
+        try
+        {
+            return JsonNode.Parse(trimmed) is JsonObject;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     ///     Pulls a human-readable message out of an upstream error body. Every read is kind-safe:
     ///     <c>{"error":"boom"}</c> indexed as an object throws <see cref="InvalidOperationException" />,
-    ///     which would turn a clean relayed 503 into an unhandled 500. An unrecognised body falls back to
-    ///     its own text rather than a generic placeholder, because the raw text is what makes an
-    ///     unfamiliar upstream failure diagnosable. Every shape is capped: an upstream that echoes the
-    ///     whole request back inside <c>error.message</c> must not turn one bad call into a megabyte of
-    ///     client-visible noise.
+    ///     which would turn a clean relayed 503 into an unhandled 500.
+    ///
+    ///     Only a message the upstream deliberately PUT in a message field is relayed, and only capped.
+    ///     A body with no such field used to be relayed as its own raw text, which is the shape most
+    ///     likely to carry something the client should not see — an intermediary's HTML error page with
+    ///     internal hostnames, a stack trace, a proxy's echo of the request. That text is now logged
+    ///     (truncated) for the operator, who is the person who can act on it, and the client gets a
+    ///     fixed sentence plus the status code it already has.
+    ///
+    ///     The cap is not redaction and is not claimed to be: <c>error.message</c> can still echo
+    ///     request content back. This proxy binds to loopback only and serves one local user, who is the
+    ///     same person whose prompt it would be echoing — so relaying the provider's own diagnosis is
+    ///     worth more than withholding it. A multi-tenant deployment would have to replace this with a
+    ///     fixed message per status code.
     /// </summary>
-    private static string ExtractErrorMessage(string body)
+    private static string ExtractErrorMessage(string body, ILogger logger)
     {
+        const string opaque =
+            "The upstream Copilot API returned an error. See the proxy log for the response body.";
+
         try
         {
             if (JsonNode.Parse(body) is JsonObject obj)
@@ -1905,7 +2267,7 @@ internal static class ProxyHttp
         }
         catch (JsonException)
         {
-            // Not JSON at all (an HTML error page from an intermediary, say) — fall through to the text.
+            // Not JSON at all (an HTML error page from an intermediary, say) — fall through.
         }
 
         var trimmed = body.Trim();
@@ -1914,7 +2276,12 @@ internal static class ProxyHttp
             return "The upstream Copilot API returned an error with no body.";
         }
 
-        return CapErrorText(trimmed);
+        logger.LogWarning(
+            "Upstream error body carried no recognised message field; first {Length} characters: {Body}",
+            Math.Min(trimmed.Length, MaxRelayedErrorLength),
+            CapErrorText(trimmed)
+        );
+        return opaque;
     }
 
     /// <summary>Caps upstream-authored text at <see cref="MaxRelayedErrorLength" /> characters.</summary>
@@ -1952,12 +2319,15 @@ internal static class ProxyHttp
         }
     }
 
-    /// <summary>Copies upstream response headers verbatim except hop-by-hop/framing/content-coding.</summary>
+    /// <summary>
+    ///     Copies the upstream response headers the client is known to need, and nothing else. See
+    ///     <see cref="AllowedResponseHeaders" /> for why this is an allowlist rather than a denylist.
+    /// </summary>
     public static void CopyResponseHeaders(HttpResponseMessage upstream, HttpResponse response)
     {
         foreach (var header in upstream.Headers)
         {
-            if (!ExcludedResponseHeaders.Contains(header.Key))
+            if (IsRelayableResponseHeader(header.Key))
             {
                 response.Headers[header.Key] = header.Value.ToArray();
             }
@@ -1965,12 +2335,16 @@ internal static class ProxyHttp
 
         foreach (var header in upstream.Content.Headers)
         {
-            if (!ExcludedResponseHeaders.Contains(header.Key))
+            if (IsRelayableResponseHeader(header.Key))
             {
                 response.Headers[header.Key] = header.Value.ToArray();
             }
         }
     }
+
+    private static bool IsRelayableResponseHeader(string name) =>
+        AllowedResponseHeaders.Contains(name)
+        || AllowedResponseHeaderPrefixes.Any(prefix => name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>Writes an Anthropic-shaped error envelope (when the response has not started).</summary>
     public static async Task WriteAnthropicErrorAsync(HttpContext ctx, int status, string type, string message)
@@ -2027,6 +2401,13 @@ internal static class ProxyHttp
     ///     <c>data[].type == "model"</c> and <c>display_name</c>; OpenAI clients read
     ///     <c>object == "list"</c>, <c>data[].object == "model"</c> and <c>owned_by</c>. The two shapes do
     ///     not conflict, so one body carrying every field serves both and we never branch on the caller.
+    ///
+    ///     This assumes the caller ignores fields it does not know, which is what both official SDKs and
+    ///     every client this proxy targets do — and what the APIs themselves rely on to add fields
+    ///     without a version bump. A consumer that validates against a CLOSED schema would reject the
+    ///     union, and that is the documented limit of this endpoint: serving such a client would need a
+    ///     per-dialect view, which is only worth building once one is actually in scope. Nothing else in
+    ///     this proxy shares the assumption — every other route relays the upstream body untouched.
     ///
     ///     <c>created</c> is a fixed epoch — Copilot's /models does not report a creation time, and the
     ///     field exists only because OpenAI SDKs deserialise into a struct that requires it.

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -297,7 +297,7 @@ internal sealed record ProxyConfig
     {
         return new ProxyConfig
         {
-            Port = ParseInt(Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_PORT"), 8787),
+            Port = ParseInt(Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_PORT"), 8788),
             BaseUrl =
                 NullIfBlank(Environment.GetEnvironmentVariable("COPILOT_ANTHROPIC_BASE_URL"))
                 ?? CopilotOptions.DefaultBaseUrl,
@@ -1308,28 +1308,42 @@ internal static class ProxyHttp
             : WriteOpenAiErrorAsync(ctx, status, type, message);
 
     /// <summary>
-    ///     Builds the Anthropic-shaped GET /v1/models response listing every available model.
-    ///     <paramref name="models"/> must be non-empty (the catalog always resolves at least one).
+    ///     Builds a model list that BOTH dialects can parse. Anthropic clients read
+    ///     <c>data[].type == "model"</c> and <c>display_name</c>; OpenAI clients read
+    ///     <c>object == "list"</c>, <c>data[].object == "model"</c> and <c>owned_by</c>. The two shapes do
+    ///     not conflict, so one body carrying every field serves both and we never branch on the caller.
+    ///
+    ///     <c>created</c> is a fixed epoch — Copilot's /models does not report a creation time, and the
+    ///     field exists only because OpenAI SDKs deserialise into a struct that requires it.
     /// </summary>
     public static string BuildModelsStub(IReadOnlyList<ProxyModelInfo> models)
     {
+        ArgumentNullException.ThrowIfNull(models);
+
+        const long CreatedEpochSeconds = 1735689600L; // 2025-01-01T00:00:00Z
+        const string CreatedIso = "2025-01-01T00:00:00Z";
+
         var data = models
-            .Select(model => new
+            .Select(m => new
             {
                 type = "model",
-                id = model.Id,
-                display_name = model.Id,
-                created_at = "2025-01-01T00:00:00Z",
+                @object = "model",
+                id = m.Id,
+                display_name = m.Id,
+                owned_by = string.IsNullOrEmpty(m.Vendor) ? "copilot" : m.Vendor,
+                created = CreatedEpochSeconds,
+                created_at = CreatedIso,
             })
             .ToArray();
 
         return JsonSerializer.Serialize(
             new
             {
+                @object = "list",
                 data,
                 has_more = false,
-                first_id = models[0].Id,
-                last_id = models[^1].Id,
+                first_id = models.Count == 0 ? null : models[0].Id,
+                last_id = models.Count == 0 ? null : models[^1].Id,
             }
         );
     }

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -454,7 +454,8 @@ public static class ProxyModelResolver
             var pinned = modelOverride.Trim();
 
             // DEVIATION D1: pinning still short-circuits discovery. Vendor and endpoints are unknown, and an
-            // empty endpoint list means "no metadata", which routes as Anthropic Messages — today's behavior.
+            // empty endpoint list means "no metadata", which routes as Anthropic Messages and Chat Completions,
+            // but not Responses — we cannot claim Responses support we have not seen advertised.
             return new ProxyModelCatalog(pinned, [new ProxyModelInfo(pinned, string.Empty, [])]);
         }
 

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -203,7 +203,7 @@ app.MapGet("/health", () => Results.Ok(new { status = "healthy", model = catalog
 // GET /v1/models — Anthropic-shaped list of every available (/v1/messages-capable) model.
 app.MapGet(
     "/v1/models",
-    () => Results.Content(ProxyHttp.BuildModelsStub(catalog.Available), "application/json", Encoding.UTF8)
+    () => Results.Content(ProxyHttp.BuildModelsStub(catalog.Models), "application/json", Encoding.UTF8)
 );
 
 // POST /v1/messages and /v1/messages/count_tokens — the forward path.
@@ -395,10 +395,41 @@ public static class ProxyGuard
 // =============================================================================
 
 /// <summary>
-///     The resolved outbound model set: <see cref="Default"/> is used when a request's model is missing or
-///     unrecognized; <see cref="Available"/> lists every model the proxy will pass through unchanged.
+///     One servable Copilot model: its id, its vendor, and the transports it advertises.
+///     An EMPTY <paramref name="Endpoints"/> list means "no metadata" — either the model came from a
+///     <c>/models</c> response that carried no <c>supported_endpoints</c> at all, or the catalog was
+///     pinned via <c>COPILOT_ANTHROPIC_MODEL</c>. Callers treat that as Anthropic-Messages-capable,
+///     which is exactly how the proxy behaved before endpoint metadata existed.
 /// </summary>
-public sealed record ProxyModelCatalog(string Default, IReadOnlyList<string> Available);
+public sealed record ProxyModelInfo(string Id, string Vendor, IReadOnlyList<string> Endpoints)
+{
+    /// <summary>True when this model advertises <paramref name="endpoint"/> (case-insensitive).</summary>
+    public bool Supports(string endpoint) => Endpoints.Contains(endpoint, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    ///     True for Anthropic models. Falls back to the id when the vendor is unknown, so a pinned
+    ///     Claude model is still recognised as Anthropic and keeps its <c>max_tokens</c> spelling.
+    /// </summary>
+    public bool IsAnthropic =>
+        Vendor.Equals("Anthropic", StringComparison.OrdinalIgnoreCase)
+        || (Vendor.Length == 0 && Id.Contains("claude", StringComparison.OrdinalIgnoreCase));
+}
+
+/// <summary>The models this proxy will serve, plus the id used when a request names an unknown model.</summary>
+public sealed record ProxyModelCatalog(string Default, IReadOnlyList<ProxyModelInfo> Models)
+{
+    /// <summary>
+    ///     Every available model id, in upstream order. Computed rather than cached so a
+    ///     <c>with</c>-expression cannot leave it stale; only startup logging and tests read it.
+    /// </summary>
+    public IReadOnlyList<string> Available => [.. Models.Select(m => m.Id)];
+
+    /// <summary>Case-insensitive lookup. Null when the id is absent, blank, or null.</summary>
+    public ProxyModelInfo? Find(string? id) =>
+        string.IsNullOrWhiteSpace(id)
+            ? null
+            : Models.FirstOrDefault(m => string.Equals(m.Id, id, StringComparison.OrdinalIgnoreCase));
+}
 
 /// <summary>Resolves the outbound Copilot model catalog and rewrites the inbound request's model field.</summary>
 public static class ProxyModelResolver
@@ -421,26 +452,36 @@ public static class ProxyModelResolver
         if (!string.IsNullOrWhiteSpace(modelOverride))
         {
             var pinned = modelOverride.Trim();
-            return new ProxyModelCatalog(pinned, [pinned]);
+
+            // DEVIATION D1: pinning still short-circuits discovery. Vendor and endpoints are unknown, and an
+            // empty endpoint list means "no metadata", which routes as Anthropic Messages — today's behavior.
+            return new ProxyModelCatalog(pinned, [new ProxyModelInfo(pinned, string.Empty, [])]);
         }
 
-        using var response = await client.GetAsync("/models", cancellationToken);
+        using var response = await client.GetAsync("/models", cancellationToken).ConfigureAwait(false);
         _ = response.EnsureSuccessStatusCode();
-        var json = await response.Content.ReadAsStringAsync(cancellationToken);
-        var availableIds = ParseMessagesCapableModelIds(json);
+        var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
-        var claudeIds = availableIds.Where(id => id.Contains("claude", StringComparison.OrdinalIgnoreCase)).ToList();
+        var models = ParseServableModels(json);
+
+        // The default is the fallback for the Anthropic surface, so it must be able to serve /v1/messages.
+        // A chat-completions-only model named "opus" is servable, but it cannot be the default.
+        var claudeIds = models
+            .Where(m => m.Endpoints.Count == 0 || m.Supports(CopilotModelsResponse.MessagesEndpoint))
+            .Select(m => m.Id)
+            .Where(id => id.Contains("claude", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
         var opus = PickHighestVersionOpusId(claudeIds);
-        if (opus is not null)
+        if (opus is null)
         {
-            return new ProxyModelCatalog(opus, availableIds);
+            throw new InvalidOperationException(
+                "No Claude Opus model is available on this Copilot account. Messages-capable Claude models: "
+                    + (claudeIds.Count == 0 ? "(none)" : string.Join(", ", claudeIds))
+            );
         }
 
-        throw new InvalidOperationException(
-            "No Copilot 'opus' Claude model was found. Available Claude models: "
-                + (claudeIds.Count > 0 ? string.Join(", ", claudeIds) : "(none)")
-                + ". Set COPILOT_ANTHROPIC_MODEL to the exact id you want."
-        );
+        return new ProxyModelCatalog(opus, models);
     }
 
     /// <summary>
@@ -491,29 +532,49 @@ public static class ProxyModelResolver
         return ids;
     }
 
+    /// <summary><c>POST /chat/completions</c> — the OpenAI Chat Completions transport.</summary>
+    public const string ChatCompletionsEndpoint = "/chat/completions";
+
+    /// <summary>The transports this proxy knows how to forward to.</summary>
+    private static readonly string[] ReachableEndpoints =
+    [
+        CopilotModelsResponse.MessagesEndpoint,
+        ChatCompletionsEndpoint,
+        CopilotModelsResponse.ResponsesEndpoint,
+    ];
+
     /// <summary>
-    ///     Extracts ids for models whose <c>supported_endpoints</c> includes <c>/v1/messages</c> — the only
-    ///     ones this Anthropic-Messages-shaped proxy can forward to. Copilot also serves GPT/Gemini models
-    ///     that only support <c>/responses</c> or <c>/chat/completions</c>; those are excluded. If no entry
-    ///     in the response carries <c>supported_endpoints</c> metadata at all (an older or alternative
-    ///     Copilot-compatible <c>/models</c> shape), falls back to <see cref="ParseModelIds"/> — id-only,
-    ///     no endpoint filtering — rather than treating every model as unsupported and failing startup.
+    ///     Vendors this proxy refuses to serve. A DENYLIST, not an allowlist: several <c>/models</c>
+    ///     shapes omit <c>vendor</c> entirely, and an allowlist would silently drop all of them. The
+    ///     advertised endpoint list is the real capability signal; vendor only vetoes.
+    ///     Google is excluded by user decision (2026-07-27); Microsoft's <c>mai-code-*</c> is a
+    ///     Copilot-internal router rather than a chat model.
     /// </summary>
-    public static IReadOnlyList<string> ParseMessagesCapableModelIds(string json)
+    private static readonly string[] ExcludedVendors = ["Google", "Microsoft"];
+
+    /// <summary>
+    ///     Parses a Copilot <c>/models</c> response into the models this proxy will serve, preserving
+    ///     upstream order.
+    ///
+    ///     A model is kept when it advertises at least one endpoint in <see cref="ReachableEndpoints"/>
+    ///     and its vendor is not in <see cref="ExcludedVendors"/>. Entries advertising NO endpoints are
+    ///     dropped — that set includes <c>text-embedding-*</c>, which must never surface as a chat model.
+    ///
+    ///     The no-metadata fallback is deliberately per RESPONSE, not per entry: only when NOT ONE entry
+    ///     carries <c>supported_endpoints</c> do we conclude the response uses an older shape and keep
+    ///     every id. Otherwise a partially-annotated response would resurrect the embedding models.
+    /// </summary>
+    public static IReadOnlyList<ProxyModelInfo> ParseServableModels(string json)
     {
         using var doc = JsonDocument.Parse(json);
         var entries = CopilotModelsResponse.EnumerateModelEntries(doc.RootElement).ToList();
 
-        // The fallback is per RESPONSE, not per entry: if NO entry carries supported_endpoints metadata
-        // at all (an older/alternative Copilot-compatible /models shape), fall back to id-only rather
-        // than treating every model as unsupported and failing startup. If ANY entry declares it, filter
-        // the whole response to the /v1/messages-capable ids.
         if (!entries.Any(CopilotModelsResponse.HasSupportedEndpoints))
         {
-            return ParseModelIds(json);
+            return [.. ParseModelIds(json).Select(id => new ProxyModelInfo(id, string.Empty, []))];
         }
 
-        var ids = new List<string>();
+        var models = new List<ProxyModelInfo>();
         foreach (var item in entries)
         {
             var id = CopilotModelsResponse.GetString(item, "id");
@@ -522,36 +583,32 @@ public static class ProxyModelResolver
                 continue;
             }
 
-            if (CopilotModelsResponse.SupportsEndpoint(item, CopilotModelsResponse.MessagesEndpoint))
+            var vendor = CopilotModelsResponse.GetString(item, "vendor") ?? string.Empty;
+            if (ExcludedVendors.Contains(vendor, StringComparer.OrdinalIgnoreCase))
             {
-                ids.Add(id);
+                continue;
             }
+
+            var endpoints = ReachableEndpoints.Where(e => CopilotModelsResponse.SupportsEndpoint(item, e)).ToArray();
+            if (endpoints.Length == 0)
+            {
+                continue;
+            }
+
+            models.Add(new ProxyModelInfo(id, vendor, endpoints));
         }
 
-        return ids;
+        return models;
     }
 
     /// <summary>
-    ///     Picks the outbound model for a single request: <paramref name="incomingModel"/> passes through
-    ///     unchanged (normalized to the catalog's exact casing) when it matches one of
-    ///     <paramref name="catalog"/>'s available ids; otherwise falls back to the catalog's default.
+    ///     Maps the model a client asked for onto a model this proxy serves. Unknown ids fall back to the
+    ///     catalog default (DEVIATION D2) — the dialect check downstream runs against the RESOLVED model.
     /// </summary>
     public static string SelectOutboundModel(string? incomingModel, ProxyModelCatalog catalog)
     {
         ArgumentNullException.ThrowIfNull(catalog);
-
-        if (!string.IsNullOrWhiteSpace(incomingModel))
-        {
-            var match = catalog.Available.FirstOrDefault(id =>
-                string.Equals(id, incomingModel, StringComparison.OrdinalIgnoreCase)
-            );
-            if (match is not null)
-            {
-                return match;
-            }
-        }
-
-        return catalog.Default;
+        return catalog.Find(incomingModel)?.Id ?? catalog.Default;
     }
 
     /// <summary>Peeks at the JSON body's <c>model</c> field without mutating it. Null on any parse failure.</summary>
@@ -1068,14 +1125,14 @@ internal static class ProxyHttp
     ///     Builds the Anthropic-shaped GET /v1/models response listing every available model.
     ///     <paramref name="models"/> must be non-empty (the catalog always resolves at least one).
     /// </summary>
-    public static string BuildModelsStub(IReadOnlyList<string> models)
+    public static string BuildModelsStub(IReadOnlyList<ProxyModelInfo> models)
     {
         var data = models
             .Select(model => new
             {
                 type = "model",
-                id = model,
-                display_name = model,
+                id = model.Id,
+                display_name = model.Id,
                 created_at = "2025-01-01T00:00:00Z",
             })
             .ToArray();
@@ -1085,8 +1142,8 @@ internal static class ProxyHttp
             {
                 data,
                 has_more = false,
-                first_id = models[0],
-                last_id = models[^1],
+                first_id = models[0].Id,
+                last_id = models[^1].Id,
             }
         );
     }

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -200,7 +200,7 @@ app.Use(
 
 app.MapGet("/health", () => Results.Ok(new { status = "healthy", model = catalog.Default }));
 
-// GET /v1/models — Anthropic-shaped list of every available (/v1/messages-capable) model.
+// GET /v1/models — dual-dialect union list of every available (servable) model.
 app.MapGet(
     "/v1/models",
     () => Results.Content(ProxyHttp.BuildModelsStub(catalog.Models), "application/json", Encoding.UTF8)

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -1229,6 +1229,9 @@ internal static class ProxyHttp
     /// </summary>
     private const string AnthropicPingFrame = "event: ping\ndata: {\"type\":\"ping\"}\n\n";
 
+    /// <summary>How much upstream-authored error text is relayed to the client, in characters.</summary>
+    private const int MaxRelayedErrorLength = 500;
+
     /// <summary>
     ///     Serves an Anthropic Messages request from a model this Copilot account exposes only through
     ///     OpenAI Responses: the request is translated on the way out and the reply on the way back.
@@ -1361,7 +1364,20 @@ internal static class ProxyHttp
             {
                 // The upstream status is preserved: a 429 or 503 must stay one so the client's own
                 // retry logic still works. Only the envelope is reshaped.
-                var errorBody = await upstream.Content.ReadAsStringAsync(ctx.RequestAborted);
+                var errorBody = await ReadUpstreamBodyAsync(
+                    ctx,
+                    upstream,
+                    outboundModel,
+                    idleTimeout,
+                    idleCts,
+                    linked,
+                    logger
+                );
+                if (errorBody is null)
+                {
+                    return; // Already answered as a 504/502, or the client left.
+                }
+
                 await WriteAnthropicErrorAsync(
                     ctx,
                     (int)upstream.StatusCode,
@@ -1373,7 +1389,15 @@ internal static class ProxyHttp
 
             if (!wantsStream)
             {
-                await TranslateBufferedReplyAsync(ctx, upstream, outboundModel, logger);
+                await TranslateBufferedReplyAsync(
+                    ctx,
+                    upstream,
+                    outboundModel,
+                    idleTimeout,
+                    idleCts,
+                    linked,
+                    logger
+                );
                 return;
             }
 
@@ -1414,6 +1438,73 @@ internal static class ProxyHttp
     }
 
     /// <summary>
+    ///     Reads a complete upstream body under the linked (client-abort + idle) token. Because the send
+    ///     used <see cref="HttpCompletionOption.ResponseHeadersRead" /> this read still pulls from the
+    ///     socket, and the proxy's <see cref="HttpClient" /> deliberately carries no timeout — so without
+    ///     the idle token nothing at all would end a reply that stops arriving half-way through. The
+    ///     deadline is re-armed here so it measures the wait for the BODY rather than counting whatever
+    ///     the headers already spent. It does span the whole body read: a buffered reply arrives as one
+    ///     payload, so there are no inter-chunk gaps to measure at this layer.
+    /// </summary>
+    /// <returns>
+    ///     The body, or <c>null</c> once the failure has already been answered (or the client has gone).
+    ///     <c>null</c> is unambiguous — a successful read of an empty body yields <c>""</c>.
+    /// </returns>
+    private static async Task<string?> ReadUpstreamBodyAsync(
+        HttpContext ctx,
+        HttpResponseMessage upstream,
+        string outboundModel,
+        TimeSpan idleTimeout,
+        CancellationTokenSource idleCts,
+        CancellationTokenSource linked,
+        ILogger logger
+    )
+    {
+        idleCts.CancelAfter(idleTimeout);
+
+        try
+        {
+            return await upstream.Content.ReadAsStringAsync(linked.Token);
+        }
+        catch (OperationCanceledException) when (ctx.RequestAborted.IsCancellationRequested)
+        {
+            return null;
+        }
+        catch (OperationCanceledException) when (idleCts.IsCancellationRequested)
+        {
+            logger.LogWarning(
+                "Upstream idle timeout after {IdleSeconds:0}s while reading the reply for {Model}.",
+                idleTimeout.TotalSeconds,
+                outboundModel
+            );
+            await WriteAnthropicErrorAsync(
+                ctx,
+                StatusCodes.Status504GatewayTimeout,
+                "api_error",
+                "The upstream Copilot API stopped sending its reply before the idle timeout."
+            );
+            return null;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or IOException)
+        {
+            // A body that dies part-way is an upstream fault, and gets the same 502 the raw path's relay
+            // produces. Letting it escape would surface as a bare 500 with no Anthropic envelope at all.
+            logger.LogError(
+                "Upstream connection dropped while reading the reply for {Model}: {Reason}",
+                outboundModel,
+                ex.Message
+            );
+            await WriteAnthropicErrorAsync(
+                ctx,
+                StatusCodes.Status502BadGateway,
+                "api_error",
+                "The upstream Copilot API dropped the connection before its reply was complete."
+            );
+            return null;
+        }
+    }
+
+    /// <summary>
     ///     Translates a buffered Responses reply into an Anthropic Message. A reply this proxy cannot
     ///     read answers 400 rather than leaking a 500 — the contract
     ///     <see cref="ResponsesToAnthropicJson.Translate" /> documents its <see cref="ArgumentException" />
@@ -1423,10 +1514,25 @@ internal static class ProxyHttp
         HttpContext ctx,
         HttpResponseMessage upstream,
         string outboundModel,
+        TimeSpan idleTimeout,
+        CancellationTokenSource idleCts,
+        CancellationTokenSource linked,
         ILogger logger
     )
     {
-        var responsesJson = await upstream.Content.ReadAsStringAsync(ctx.RequestAborted);
+        var responsesJson = await ReadUpstreamBodyAsync(
+            ctx,
+            upstream,
+            outboundModel,
+            idleTimeout,
+            idleCts,
+            linked,
+            logger
+        );
+        if (responsesJson is null)
+        {
+            return; // Already answered as a 504/502, or the client left.
+        }
 
         string anthropicJson;
         try
@@ -1492,7 +1598,9 @@ internal static class ProxyHttp
 
         await using (upstreamStream.ConfigureAwait(false))
         {
-            using var reader = new StreamReader(upstreamStream, Encoding.UTF8);
+            // leaveOpen: the enclosing `await using` owns the stream. Double disposal is harmless, but
+            // saying so beats leaving a reader that looks like it owns something it does not.
+            using var reader = new StreamReader(upstreamStream, Encoding.UTF8, leaveOpen: true);
             while (true)
             {
                 // Reset BEFORE each read: the deadline measures the gap between upstream lines, never the
@@ -1529,7 +1637,16 @@ internal static class ProxyHttp
                 }
                 catch (Exception ex)
                 {
-                    logger.LogWarning("Mid-stream translated upstream failure: {Reason}", ex.Message);
+                    // The upstream read and the downstream keep-alive write share this one call, so the
+                    // failing side is not knowable here — saying "upstream" would blame Copilot for a
+                    // client that hung up. The envelope below is upstream-only regardless: a keep-alive
+                    // write can only fail after it has started the response, which this guard excludes.
+                    logger.LogWarning(
+                        "Translated relay for {Model} failed mid-stream, on either the upstream read or the "
+                            + "downstream keep-alive write: {Reason}",
+                        outboundModel,
+                        ex.Message
+                    );
                     if (!ctx.Response.HasStarted)
                     {
                         await WriteAnthropicErrorAsync(
@@ -1663,30 +1780,30 @@ internal static class ProxyHttp
     ///     Pulls a human-readable message out of an upstream error body. Every read is kind-safe:
     ///     <c>{"error":"boom"}</c> indexed as an object throws <see cref="InvalidOperationException" />,
     ///     which would turn a clean relayed 503 into an unhandled 500. An unrecognised body falls back to
-    ///     its own (capped) text rather than a generic placeholder, because the raw text is what makes an
-    ///     unfamiliar upstream failure diagnosable.
+    ///     its own text rather than a generic placeholder, because the raw text is what makes an
+    ///     unfamiliar upstream failure diagnosable. Every shape is capped: an upstream that echoes the
+    ///     whole request back inside <c>error.message</c> must not turn one bad call into a megabyte of
+    ///     client-visible noise.
     /// </summary>
     private static string ExtractErrorMessage(string body)
     {
-        const int MaxRawLength = 500;
-
         try
         {
             if (JsonNode.Parse(body) is JsonObject obj)
             {
                 if (ScalarText((obj["error"] as JsonObject)?["message"]) is { } nested)
                 {
-                    return nested;
+                    return CapErrorText(nested);
                 }
 
                 if (ScalarText(obj["error"]) is { } plain)
                 {
-                    return plain;
+                    return CapErrorText(plain);
                 }
 
                 if (ScalarText(obj["message"]) is { } top)
                 {
-                    return top;
+                    return CapErrorText(top);
                 }
             }
         }
@@ -1701,8 +1818,12 @@ internal static class ProxyHttp
             return "The upstream Copilot API returned an error with no body.";
         }
 
-        return trimmed.Length <= MaxRawLength ? trimmed : trimmed[..MaxRawLength];
+        return CapErrorText(trimmed);
     }
+
+    /// <summary>Caps upstream-authored text at <see cref="MaxRelayedErrorLength" /> characters.</summary>
+    private static string CapErrorText(string text) =>
+        text.Length <= MaxRelayedErrorLength ? text : text[..MaxRelayedErrorLength];
 
     /// <summary>Reads a JSON string, or null if <paramref name="node" /> is absent or carries another kind.</summary>
     private static string? ScalarText(JsonNode? node) =>

--- a/samples/CopilotAnthropicProxy.Sample/README.md
+++ b/samples/CopilotAnthropicProxy.Sample/README.md
@@ -321,6 +321,12 @@ Copilot's backend rejects three things its clients routinely send. All are strip
   route, which already drops its counterpart `web_search_20250305`. Requests carrying no hosted
   tools are forwarded byte-for-byte.
 
+  Dropping those two is a decision rather than an oversight, and so is the fact that the allowlist
+  does not widen on its own — it is meant to be curated by hand. The planned direction for web
+  search (agreed, not scheduled) is to stop treating it as a server tool at all: the proxy would
+  expose it as a client tool it implements itself and service the call against Copilot's MCP server,
+  which turns it into an ordinary `function` and removes the exemption instead of widening the list.
+
 The translated route avoids the first two by construction: it builds a new Responses body from an
 explicit allowlist rather than patching the inbound one, so `betas`, `cache_control`, `metadata` and
 server tools are dropped without needing to be enumerated.

--- a/samples/CopilotAnthropicProxy.Sample/README.md
+++ b/samples/CopilotAnthropicProxy.Sample/README.md
@@ -128,21 +128,35 @@ Responses API. Every passthrough route is byte-for-byte and has none of them.
 
 **Reasoning**
 
-- **`thinking` blocks are best-effort, and reasoning never carries across turns.** Copilot emits
-  reasoning summaries *only* when one is explicitly asked for, so the translated request always sends
-  `reasoning: {"summary": "auto"}` — without it no summary events arrive and no `thinking` block can
-  ever be emitted. Asking is safe everywhere: all nine `/responses` models this account serves accept
-  the field. Getting a summary back is another matter. Copilot gives each model a default reasoning
-  `effort`, and the models it defaults to `"none"` produced no summary on any probe — they cannot
-  summarise a turn they never reasoned through. Among the models defaulting to `"medium"` it varies
-  **per turn, not per model**: two sweeps of the same nine models with the same prompt produced
-  summaries from a different single model each time. Treat a `thinking` block as something you may
-  get, not something a given model will reliably give you. The proxy does not send an `effort` of its
-  own, because choosing one would change how hard every model thinks and what every request costs.
-  Separately, the encrypted payload that would let a GPT model resume its own reasoning through a tool
-  loop is not round-tripped, so answers stay correct but the model re-derives its reasoning each turn.
-  The `thinking` blocks that do get emitted carry **no `signature`** — Anthropic clients that verify
-  one will reject them.
+- **Turn extended thinking on if you want `thinking` blocks.** Copilot emits reasoning summaries
+  only when asked, so the translated request always sends `reasoning: {"summary": "auto"}` — without
+  it no summary events arrive and no `thinking` block can ever be emitted. Every served `/responses`
+  model accepts that field, but on its own it is unreliable: Copilot gives each model a default
+  reasoning `effort`, and a model defaulting to `"none"` never reasons, so there is nothing to
+  summarise. Even among models defaulting to `"medium"`, whether a summary arrives varies **per turn,
+  not per model**.
+
+  What makes it dependable is enabling extended thinking on the client. When a request carries
+  `thinking: {"type": "enabled", "budget_tokens": N}`, the proxy maps that budget onto the
+  Responses `effort` the model actually needs:
+
+  | `budget_tokens` | `effort` |
+  |---|---|
+  | `< 8192` | `low` |
+  | `< 24576` | `medium` |
+  | `>= 24576` | `high` |
+  | absent | `medium` |
+
+  Every served model accepts all three efforts. Measured over four runs against the four models that
+  default to `effort: "none"` — models that can *never* produce a `thinking` block otherwise — three
+  of them returned one on every run and the fourth on two of four. So enabling thinking moves this
+  from impossible to usual, but a `thinking` block is still not contractually guaranteed on any given
+  turn. **No `effort` is sent when the client did not enable thinking**, so a turn the user never
+  asked to think about costs exactly what it costs today.
+- **Reasoning still does not carry across turns.** The encrypted payload that would let a GPT model
+  resume its own reasoning through a tool loop is not round-tripped, so answers stay correct but the
+  model re-derives its reasoning each turn. The `thinking` blocks that are emitted also carry **no
+  `signature`** — Anthropic clients that verify one will reject them.
 
 **Response content**
 
@@ -299,8 +313,8 @@ tools are dropped without needing to be enumerated.
 real Copilot backend and are run by hand; they cover the things a fixture cannot prove — the live
 spelling of every Responses SSE event the stream translator switches on, the shape of
 `incomplete_details` on a truncated reply, whether every served model accepts the reasoning field and
-which of them produce summaries from it, and whether a cached prefix is counted inside the reported
-`input_tokens`.
+every mapped `effort`, whether enabling extended thinking rescues the models that default to
+`effort: "none"`, and whether a cached prefix is counted inside the reported `input_tokens`.
 
 ```bash
 dotnet test tests/CopilotLive.Tests/CopilotLive.Tests.csproj

--- a/samples/CopilotAnthropicProxy.Sample/README.md
+++ b/samples/CopilotAnthropicProxy.Sample/README.md
@@ -1,38 +1,38 @@
 # CopilotAnthropicProxy.Sample
 
-A thin, **loopback-only** reverse proxy that speaks the **Anthropic Messages API** on the inbound
-side and forwards every request to **GitHub Copilot** on the outbound side. It lets a developer who
-has a GitHub Copilot entitlement (but no Anthropic API key) drive **Claude Code** — or the in-house
-`AnthropicClient` — on a Copilot-hosted Claude model by pointing `ANTHROPIC_BASE_URL` at this proxy.
+A thin, **loopback-only** reverse proxy that puts every model in your **GitHub Copilot** catalog
+behind whichever API dialect your coding agent already speaks. It accepts the **Anthropic Messages
+API** *and* the **OpenAI Chat Completions / Responses APIs** on the inbound side, and forwards to
+Copilot on the outbound side. A developer with a Copilot entitlement (but no Anthropic or OpenAI
+key) can point **Claude Code**, **Codex CLI** or **opencode** at it and drive any model Copilot
+exposes.
 
-What it does, end to end:
-
-1. Accepts `POST /v1/messages` (streaming and non-streaming), `POST /v1/messages/count_tokens`, and
-   `GET /v1/models`.
-2. Rewrites the JSON `model` field of the request body: if it names a model the proxy knows about
-   (see "Choosing the model" below), it passes through unchanged; otherwise it's rewritten to the
-   resolved default Copilot Claude (Opus) id. The top-level `context_management` field is stripped
-   (Copilot's backend rejects it outright — see "Known request incompatibilities" below). Everything
-   else — `system` blocks, `cache_control`, `thinking`, `tools`, and unknown fields — is preserved
-   verbatim (raw `JsonNode` swap, never a typed DTO).
-3. Drops the inbound `anthropic-beta` header entirely — it is never forwarded (see "Known request
-   incompatibilities" below).
-4. Attaches Copilot auth + tracking headers using the proven `GithubCopilotProvider` transport
-   (`CopilotHttpClientFactory` / `CopilotHeadersHandler` / the CLI credential token provider).
-5. Streams the upstream Server-Sent-Events response straight back to the client as **raw bytes**
-   (no parsing, no buffering, incremental flush) and passes status codes and rate-limit headers
-   through unchanged. If the upstream stream fails mid-flight the proxy does **not** fabricate any
-   terminal frames: it returns a `502` when nothing has been sent yet, otherwise it stops and closes
-   the (now incomplete) stream — the client detects the truncation from the missing `message_stop`,
-   exactly as it would if the upstream connection had dropped directly.
-6. Also transparently exposes Copilot's **MCP server** on `/mcp` and `/mcp/readonly` — see
-   "Exposing Copilot's MCP server" below.
+Most of that is byte-for-byte passthrough. The one place real work happens is **Anthropic Messages
+in, for a model that only speaks the Responses API** — Claude Code asking for `gpt-5.3-codex`. There
+the proxy translates the request, the reply, and the SSE stream between the two shapes. See
+"Known limitations" for what that translation cannot carry.
 
 > [!WARNING]
 > **Local development only.** This proxy has **no inbound authentication** but attaches **your**
 > Copilot credentials to every outbound call. It binds to loopback (`127.0.0.1` / `[::1]`) only and
 > rejects non-loopback remote addresses, foreign `Host` headers, and cross-site requests. **Never**
 > bind it to `0.0.0.0`, put it behind a public reverse proxy, or expose it through a tunnel.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/v1/messages`, `/messages` | Anthropic Messages. Passthrough for Claude models; translated to `/responses` for Responses-only GPT models. |
+| `POST` | `/v1/messages/count_tokens`, `/messages/count_tokens` | Anthropic token counting. Claude models only. |
+| `POST` | `/v1/chat/completions`, `/chat/completions` | OpenAI Chat Completions. Passthrough. |
+| `POST` | `/v1/responses`, `/responses` | OpenAI Responses. Passthrough. |
+| `GET` | `/v1/models` | Model list in a body both dialects can parse. |
+| `GET` | `/health` | Liveness. |
+| `ALL` | `/mcp`, `/mcp/readonly` | Unchanged MCP passthrough. |
+
+Every `POST` binds both the `/v1`-prefixed and un-prefixed form, because clients disagree about where
+the prefix belongs: Claude Code appends `/v1/messages` to a bare host, the Vercel AI SDK appends only
+`/messages` to a `…/v1` base, and Codex joins `{base}/responses`.
 
 ## Prerequisites
 
@@ -53,46 +53,26 @@ On startup the proxy logs the resolved default model, how many models are availa
 address, e.g.:
 
 ```
-CopilotAnthropicProxy listening on http://127.0.0.1:8788 -> https://api.enterprise.githubcopilot.com (default model: <resolved-opus-id>, 7 available)
+CopilotAnthropicProxy listening on http://127.0.0.1:8788 -> https://api.enterprise.githubcopilot.com (default model: <resolved-opus-id>, 17 available; idle 180s, keep-alive 15s)
 ```
 
-### Choosing the model
-
-The proxy resolves an outbound **model catalog** (a default id plus the full set of available ids)
-at startup in one of two modes:
-
-1. **Pinned** — `COPILOT_ANTHROPIC_MODEL` is set. The catalog is just that one id (both default and
-   only available entry); Copilot's `/models` endpoint is never queried, and **every** request is
-   rewritten to it regardless of what `model` the client sent — this matches the proxy's original
-   single-model behavior.
-2. **Discovered** — `COPILOT_ANTHROPIC_MODEL` is unset. The proxy queries Copilot `GET /models` and
-   keeps every model whose `supported_endpoints` includes `/v1/messages` (the only ones this
-   Anthropic-Messages-shaped proxy can forward to — Copilot's GPT/Gemini models are excluded). The
-   default is the Claude id containing `opus`; if none is found, the proxy **fails fast** and logs
-   the available Claude ids so you can set `COPILOT_ANTHROPIC_MODEL` explicitly. Copilot can expose
-   multiple concurrent `opus` ids at once (e.g. `claude-opus-4.6`, `claude-opus-4.7`,
-   `claude-opus-4.8`); the proxy picks the one with the numerically highest version suffix — not
-   just the first one Copilot happens to list — so the default always tracks the newest opus model.
-   In this mode, a request whose `model` field exactly matches (case-insensitively) one of the
-   discovered ids is forwarded **unchanged** (normalized to the catalog's casing); anything else
-   falls back to the default.
-
-`GET /v1/models` on the proxy returns a dual-dialect union list of every id in the catalog (one entry
-in pinned mode, every discovered `/v1/messages`-capable id in discovered mode).
-
-## Point a client at the proxy
-
-There are **two** valid base-URL forms depending on how the client builds the request URL.
-
-### Claude Code / Anthropic SDK-style clients
-
-These append `/v1/messages` to the base URL, so use the **bare host** (no `/v1`):
+## Configuring each client
 
 ```bash
-ANTHROPIC_BASE_URL=http://127.0.0.1:8788 \
-ANTHROPIC_API_KEY=dummy \
-claude
+# Claude Code — any model in the catalog, Claude or GPT
+export ANTHROPIC_BASE_URL=http://127.0.0.1:8788
+export ANTHROPIC_MODEL=gpt-5.3-codex
+
+# Codex CLI — ~/.codex/config.toml
+# base_url = "http://127.0.0.1:8788/v1"
+
+# opencode — OpenAI-compatible provider
+# baseURL: "http://127.0.0.1:8788/v1"
 ```
+
+`ANTHROPIC_API_KEY` (or `OPENAI_API_KEY`) is required by these clients but ignored by the proxy: the
+inbound `x-api-key` / `Authorization` headers are **not** forwarded, and Copilot auth is attached
+outbound.
 
 ### `samples/LmStreaming.Sample` (in-house `AnthropicClient`)
 
@@ -106,10 +86,94 @@ ANTHROPIC_MODEL=any-model-id-the-proxy-will-rewrite \
 dotnet run --project samples/LmStreaming.Sample
 ```
 
-`ANTHROPIC_API_KEY` is required by clients but ignored by the proxy (the inbound `x-api-key` /
-`Authorization` are **not** forwarded; Copilot auth is attached outbound). The `ANTHROPIC_MODEL`
-value is honored when `COPILOT_ANTHROPIC_MODEL` is unset and it matches one of the models the proxy
-discovered from Copilot (see "Choosing the model"); otherwise it's rewritten to the resolved default.
+## Which models are served
+
+Discovered from Copilot's `/models` at startup — nothing is hard-coded. A model is served when it
+advertises at least one of `/v1/messages`, `/chat/completions` or `/responses`, and its vendor is
+neither Google nor Microsoft. Models advertising no endpoints (including `text-embedding-*`) are
+excluded so an embedding model can never surface as a chat model.
+
+Requests naming an unknown model are mapped onto the same family when one exists
+(`claude-3-5-haiku-*` → `claude-haiku-4.5`) and otherwise onto the catalog default. That matters
+because Claude Code sends conversation-title, classification and summarisation traffic to this same
+base URL under haiku model ids; without family mapping, every one of them would bill against Opus.
+
+`GET /v1/models` returns a dual-dialect union list of every id in the catalog.
+
+> [!NOTE]
+> Setting `COPILOT_ANTHROPIC_MODEL` **pins** every request to that one id and skips discovery
+> entirely. A pinned catalog carries no endpoint metadata, so the pinned model is treated as an
+> Anthropic Messages passthrough — **the translated route is unreachable in pinned mode**. Leave the
+> variable unset to drive GPT models through `/v1/messages`.
+
+## Known limitations
+
+These affect **only** the translated route — Anthropic Messages in, for a model that speaks only the
+Responses API. Every passthrough route is byte-for-byte and has none of them.
+
+**Request fields**
+
+- **`stop_sequences` is dropped.** The Responses API has no equivalent parameter, and emulating one
+  means truncating a stream at a boundary that can straddle SSE chunks. Claude Code uses it only for
+  auto-mode classification, which targets the haiku tier — an Anthropic model, hence passthrough.
+- **`max_tokens` is raised to 16 when smaller.** Claude Code's first request against a new model is a
+  validation probe with `max_tokens: 1`, which the Responses API rejects outright; passed through
+  literally, every GPT model would look broken before you got a turn.
+- **`temperature` and `top_p` are passed through.** Verified live rather than assumed — OpenAI
+  documents its own reasoning models as rejecting a non-default `temperature`, but Copilot accepts
+  both and honours them.
+
+**Reasoning**
+
+- **`thinking` blocks are never produced, and reasoning does not carry across turns.** The translated
+  request sends no `reasoning` field, and Copilot emits reasoning summaries *only* when one is
+  explicitly asked for — so no summary events arrive and no `thinking` block is ever emitted. The
+  encrypted payload that would let a GPT model resume its own reasoning through a tool loop is not
+  round-tripped either. Answers stay correct; the model re-derives its reasoning each turn, and you
+  simply do not see it. (Should a future request start asking for summaries, the `thinking` blocks
+  the translators would then emit carry **no `signature`** — Anthropic clients that verify one will
+  reject them.)
+
+**Response content**
+
+- **Only `output_text` message parts survive.** Any other part type in a `message` item is dropped,
+  including `refusal`. A turn that consists solely of a refusal therefore arrives as `content: []`
+  with `stop_reason: "end_turn"` — indistinguishable from a genuinely empty turn, and the refusal
+  text is lost.
+- **Tool ids are passed through verbatim.** Responses mints `call_…`; Anthropic conventionally uses
+  `toolu_…`. The round-trip works because the id we hand out is the id we accept back, but Claude
+  Code cannot pattern-match these ids when explaining a tool-pairing failure, so that one error
+  message is less specific than usual.
+- **Cached input tokens are reported as fresh ones.** Copilot returns the cached prefix as
+  `input_tokens_details.cached_tokens` *inside* the total `input_tokens`, and the Anthropic usage
+  shape the proxy emits has only `input_tokens` / `output_tokens` — no
+  `cache_read_input_tokens` field to put it in. Any client costing a session from these numbers will
+  over-report whenever Copilot serves a cached prefix.
+
+**Streaming**
+
+- **A multi-line `data:` event would be silently dropped.** SSE permits an event to span several
+  `data:` lines; the stream translator reads one line at a time and does not reassemble them. Not
+  observed in practice — every live Copilot Responses stream measured so far uses exactly one
+  `data:` line per event — but a change upstream would lose those events with no error.
+- **A mid-stream upstream failure looks like a dropped connection.** The proxy never fabricates
+  terminal frames, so an upstream `response.failed` and a severed socket both end as a stream with no
+  `message_stop`. The reason is logged proxy-side; the client sees only the truncation.
+- **An early keep-alive forfeits the error envelope.** If the keep-alive interval elapses before the
+  first upstream frame arrives, the ping starts the response body — after which a subsequent upstream
+  error can no longer be reported as a clean `502` JSON envelope. This is deliberate parity with the
+  raw passthrough route, which has always behaved this way.
+- **The idle timeout measures the gap between upstream *lines*, not bytes.** An upstream dribbling a
+  single enormous line for longer than `COPILOT_ANTHROPIC_IDLE_TIMEOUT_SECONDS` is treated as idle
+  even though bytes are still moving.
+
+**Endpoints**
+
+- **`count_tokens` serves Claude models only.** For a Responses-only model the proxy answers `404`
+  with an Anthropic `not_found_error` rather than running a billed generation or inventing a number.
+  Clients degrade gracefully — Claude Code logs `countTokens API call failed` and falls back to a
+  local estimate, which drives only the `/context` bar and the auto-compact threshold.
+- **Prompt caching, batch and files APIs are not proxied.**
 
 ## Exposing Copilot's MCP server
 
@@ -138,12 +202,14 @@ proxy attaches its own Copilot bearer token instead, via the same `CopilotHeader
 proxy, no inbound auth is required to reach `/mcp*`; it's covered by the same loopback +
 host/cross-site guard described in the warning above.
 
-### Troubleshooting the base URL
+## Troubleshooting the base URL
 
 | Symptom (request that reaches the proxy) | Cause | Fix |
 | --- | --- | --- |
 | `404` on `POST /messages` | You used the bare host with a client that appends only `/messages`. | Add `/v1`: `…:8788/v1`. |
 | `404` on `POST /v1/v1/messages` | You added `/v1` for a client that already appends `/v1/messages`. | Drop `/v1`: use `…:8788`. |
+| `404 not_found_error` on `count_tokens` | The model is served by translation to Responses, which has no token-counting endpoint. | Expected; the client falls back to a local estimate. |
+| A GPT model answers as Claude | `COPILOT_ANTHROPIC_MODEL` is pinned, so every request is rewritten to it. | Unset it to use the discovered catalog. |
 | `403 permission_error` | Non-loopback `Host`, cross-site request, or a non-loopback `Origin`. | Use `127.0.0.1`/`localhost`; don't proxy from a browser page on another origin. |
 | `401 authentication_error` | The proxy could not acquire a Copilot token on the request. | Re-authenticate (`gh auth login` / Copilot CLI) or set `GITHUB_COPILOT_TOKEN`. |
 
@@ -151,11 +217,11 @@ host/cross-site guard described in the warning above.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `COPILOT_ANTHROPIC_MODEL` | (discovered from `/models`) | Pins every request to this single Copilot model id and skips discovery entirely. Unset to discover the full `/v1/messages`-capable catalog instead (see "Choosing the model"). |
+| `COPILOT_ANTHROPIC_MODEL` | (discovered from `/models`) | Pins every request to this single Copilot model id and skips discovery entirely. Leave unset to serve the full catalog — see the note under "Which models are served". |
 | `COPILOT_ANTHROPIC_PORT` | `8788` | Loopback listen port. |
 | `COPILOT_ANTHROPIC_BASE_URL` | `https://api.enterprise.githubcopilot.com` | Copilot host root (for non-enterprise hosts). |
 | `COPILOT_ANTHROPIC_IDLE_TIMEOUT_SECONDS` | `180` | Per-request idle timeout, reset after each streamed upstream read. The total exchange has no deadline, so long generations are not cut off; this only fires when the upstream produces *nothing* for the whole window. |
-| `COPILOT_ANTHROPIC_KEEPALIVE_SECONDS` | `15` | While an SSE upstream is silent, emit a downstream SSE keep-alive comment (`:` line) this often so the client's own read timeout does not fire mid-generation. Keep-alives don't reset the idle timeout above. Set `0` to disable. |
+| `COPILOT_ANTHROPIC_KEEPALIVE_SECONDS` | `15` | While an SSE upstream is silent, emit a downstream SSE keep-alive this often so the client's own read timeout does not fire mid-generation. Keep-alives don't reset the idle timeout above. Set `0` to disable. |
 | `COPILOT_ANTHROPIC_ENABLE_DEVICE_FLOW` | `false` | When truthy, allow an interactive GitHub device-flow login at startup (composite provider). Off by default — the request path never blocks on device flow. |
 
 ## Logs
@@ -173,8 +239,10 @@ The proxy logs through Serilog to two sinks:
 
 `samples/LmStreaming.Sample` in `anthropic` mode can enable the Anthropic server-side
 `AnthropicWebSearchTool`. The GitHub Copilot backend **rejects** that tool shape with HTTP 400
-(`"The use of the web search tool is not supported."`). This proxy does **not** special-case it — the
-rejection passes straight through as an upstream 400.
+(`"The use of the web search tool is not supported."`). On the passthrough route this rejection
+passes straight through as an upstream 400; on the translated route the tool is dropped before the
+request is sent (only tools carrying an `input_schema` are mapped), so the request succeeds without
+web search.
 
 To validate against the proxy, run a flow that does **not** enable web search. The clean way to do
 that in `LmStreaming.Sample` is to select (or define) a chat **mode with an empty `EnabledTools`
@@ -194,18 +262,34 @@ Copilot's backend rejects two things Claude Code routinely sends. Both are strip
   (`"context_management: Extra inputs are not permitted"`) if this top-level field is present. It is
   removed from the JSON body (alongside the `model` rewrite) before forwarding.
 
+The translated route avoids both by construction: it builds a new Responses body from an explicit
+allowlist rather than patching the inbound one, so `betas`, `cache_control`, `metadata` and server
+tools are dropped without needing to be enumerated.
+
 ## Non-goals (intentionally not implemented)
 
-- **No response-body rewriting.** The response body and the SSE `message_start` event carry whatever
-  model id was actually sent upstream (the passed-through id, or the resolved default when the
-  request's model wasn't recognized) — never rewritten back to the client's requested id. This is
-  accepted for raw-passthrough fidelity.
+- **No response-body rewriting on the passthrough routes.** The response body and the SSE
+  `message_start` event carry whatever model id was actually sent upstream — never rewritten back to
+  the client's requested id. This is accepted for raw-passthrough fidelity.
 - **No 200K → 1M context fallback / model routing.** Context-length errors pass through unchanged.
 - **No refresh-on-401 / token invalidation.** A request-path token failure maps to a local
   `authentication_error`; re-authenticate out of band.
-- **No synthetic `count_tokens` estimator.** `count_tokens` is best-effort pass-through; an
-  unsupported upstream (404/405) is normalized to an Anthropic `not_found_error`.
+- **No synthetic `count_tokens` estimator.** `count_tokens` is best-effort pass-through for Claude
+  models; an unsupported upstream (404/405) is normalized to an Anthropic `not_found_error`.
 - **No inbound auth, TLS, or CORS** beyond the loopback + host/cross-site guard.
 - **No MCP session bookkeeping or resumability logic.** The proxy relays `Mcp-Session-Id` and
   `Last-Event-ID` verbatim but never inspects, persists, or validates them — session lifecycle is
   entirely between the client and Copilot.
+
+## Live smoke tests
+
+`tests/CopilotLive.Tests/` is outside `LmDotnetTools.sln`, so CI never runs it. Those tests hit the
+real Copilot backend and are run by hand; they cover the things a fixture cannot prove — the live
+spelling of every Responses SSE event the stream translator switches on, the shape of
+`incomplete_details` on a truncated reply, and whether reasoning summaries arrive unrequested.
+
+```bash
+dotnet test tests/CopilotLive.Tests/CopilotLive.Tests.csproj
+```
+
+They skip cleanly with an explanatory message when no Copilot credential is present.

--- a/samples/CopilotAnthropicProxy.Sample/README.md
+++ b/samples/CopilotAnthropicProxy.Sample/README.md
@@ -120,19 +120,29 @@ Responses API. Every passthrough route is byte-for-byte and has none of them.
   validation probe with `max_tokens: 1`, which the Responses API rejects outright; passed through
   literally, every GPT model would look broken before you got a turn.
 - **`temperature` and `top_p` are passed through.** Verified live rather than assumed — OpenAI
-  documents its own reasoning models as rejecting a non-default `temperature`, but Copilot accepts
-  both and honours them.
+  documents its own reasoning models as rejecting a non-default `temperature`. Copilot instead
+  accepted `0.7` / `0.5` and echoed both values back unchanged, rather than clamping them to the
+  defaults it reports when neither is sent. That was measured on one Responses-only model, not swept
+  across the catalog, so treat it as "not universally rejected" rather than a guarantee for every
+  model.
 
 **Reasoning**
 
-- **`thinking` blocks are never produced, and reasoning does not carry across turns.** The translated
-  request sends no `reasoning` field, and Copilot emits reasoning summaries *only* when one is
-  explicitly asked for — so no summary events arrive and no `thinking` block is ever emitted. The
-  encrypted payload that would let a GPT model resume its own reasoning through a tool loop is not
-  round-tripped either. Answers stay correct; the model re-derives its reasoning each turn, and you
-  simply do not see it. (Should a future request start asking for summaries, the `thinking` blocks
-  the translators would then emit carry **no `signature`** — Anthropic clients that verify one will
-  reject them.)
+- **`thinking` blocks are best-effort, and reasoning never carries across turns.** Copilot emits
+  reasoning summaries *only* when one is explicitly asked for, so the translated request always sends
+  `reasoning: {"summary": "auto"}` — without it no summary events arrive and no `thinking` block can
+  ever be emitted. Asking is safe everywhere: all nine `/responses` models this account serves accept
+  the field. Getting a summary back is another matter. Copilot gives each model a default reasoning
+  `effort`, and the models it defaults to `"none"` produced no summary on any probe — they cannot
+  summarise a turn they never reasoned through. Among the models defaulting to `"medium"` it varies
+  **per turn, not per model**: two sweeps of the same nine models with the same prompt produced
+  summaries from a different single model each time. Treat a `thinking` block as something you may
+  get, not something a given model will reliably give you. The proxy does not send an `effort` of its
+  own, because choosing one would change how hard every model thinks and what every request costs.
+  Separately, the encrypted payload that would let a GPT model resume its own reasoning through a tool
+  loop is not round-tripped, so answers stay correct but the model re-derives its reasoning each turn.
+  The `thinking` blocks that do get emitted carry **no `signature`** — Anthropic clients that verify
+  one will reject them.
 
 **Response content**
 
@@ -148,7 +158,9 @@ Responses API. Every passthrough route is byte-for-byte and has none of them.
   `input_tokens_details.cached_tokens` *inside* the total `input_tokens`, and the Anthropic usage
   shape the proxy emits has only `input_tokens` / `output_tokens` — no
   `cache_read_input_tokens` field to put it in. Any client costing a session from these numbers will
-  over-report whenever Copilot serves a cached prefix.
+  over-report whenever Copilot serves a cached prefix. Measured by sending one long prefix twice:
+  `input_tokens` read 6010 both times while `cached_tokens` went 0 → 5888, so 98% of the second
+  call's reported input was billed to the client at the uncached rate.
 
 **Streaming**
 
@@ -286,7 +298,9 @@ tools are dropped without needing to be enumerated.
 `tests/CopilotLive.Tests/` is outside `LmDotnetTools.sln`, so CI never runs it. Those tests hit the
 real Copilot backend and are run by hand; they cover the things a fixture cannot prove — the live
 spelling of every Responses SSE event the stream translator switches on, the shape of
-`incomplete_details` on a truncated reply, and whether reasoning summaries arrive unrequested.
+`incomplete_details` on a truncated reply, whether every served model accepts the reasoning field and
+which of them produce summaries from it, and whether a cached prefix is counted inside the reported
+`input_tokens`.
 
 ```bash
 dotnet test tests/CopilotLive.Tests/CopilotLive.Tests.csproj

--- a/samples/CopilotAnthropicProxy.Sample/README.md
+++ b/samples/CopilotAnthropicProxy.Sample/README.md
@@ -77,7 +77,7 @@ at startup in one of two modes:
    discovered ids is forwarded **unchanged** (normalized to the catalog's casing); anything else
    falls back to the default.
 
-`GET /v1/models` on the proxy returns an Anthropic-shaped list of every id in the catalog (one entry
+`GET /v1/models` on the proxy returns a dual-dialect union list of every id in the catalog (one entry
 in pinned mode, every discovered `/v1/messages`-capable id in discovered mode).
 
 ## Point a client at the proxy

--- a/samples/CopilotAnthropicProxy.Sample/README.md
+++ b/samples/CopilotAnthropicProxy.Sample/README.md
@@ -293,8 +293,8 @@ list**: `ModeToolFilter.FilterBuiltInTools` returns `null` for an empty tool set
 
 ## Known request incompatibilities (stripped before forwarding)
 
-Copilot's backend rejects two things Claude Code routinely sends. Both are stripped unconditionally
-— the client never sees a 400 for either:
+Copilot's backend rejects three things its clients routinely send. All are stripped unconditionally
+— the client never sees a 400 for any of them:
 
 - **`anthropic-beta` header.** Copilot's backend rejects the *entire* request if even one value in a
   comma-separated `anthropic-beta` header is one it doesn't recognize (`"unsupported beta header(s):
@@ -303,13 +303,35 @@ Copilot's backend rejects two things Claude Code routinely sends. Both are strip
 - **`context_management` body field.** Copilot's backend rejects the request outright
   (`"context_management: Extra inputs are not permitted"`) if this top-level field is present. It is
   removed from the JSON body (alongside the `model` rewrite) before forwarding.
+- **Hosted tools on `/responses`.** Copilot supports only *client-defined* tools. Anything else is
+  rejected with `"The requested tool <type> is not supported."` — live-probed 2026-07-28:
 
-The translated route avoids both by construction: it builds a new Responses body from an explicit
-allowlist rather than patching the inbound one, so `betas`, `cache_control`, `metadata` and server
-tools are dropped without needing to be enumerated.
+  | tool type | Copilot |
+  | --- | --- |
+  | `function`, `custom` | accepted — forwarded |
+  | `web_search`, `web_search_preview` | accepted, but **still stripped** (see below) |
+  | `image_generation`, `local_shell`, `code_interpreter`, `mcp` | **400** |
+
+  This matters because Codex CLI advertises `image_generation` on *every* request and offers no way
+  to disable it (`-c tools.image_generation=false` has no effect), so without this filter Codex
+  cannot use the proxy at all. The `tools` array is filtered to `function` and `custom`; if nothing
+  survives, the key is removed. It is an allowlist rather than a denylist so that hosted tools this
+  proxy has never seen are dropped instead of forwarded into the same 400 — which is also why
+  `web_search` goes even though Copilot currently accepts it, matching the translated Anthropic
+  route, which already drops its counterpart `web_search_20250305`. Requests carrying no hosted
+  tools are forwarded byte-for-byte.
+
+The translated route avoids the first two by construction: it builds a new Responses body from an
+explicit allowlist rather than patching the inbound one, so `betas`, `cache_control`, `metadata` and
+server tools are dropped without needing to be enumerated.
 
 ## Non-goals (intentionally not implemented)
 
+- **No Codex-shaped model discovery.** Codex CLI logs `failed to refresh available models: missing
+  field 'models'` at startup: it expects `{"models":[…]}` from `GET /models`, while `GET /v1/models`
+  serves the standard OpenAI `{"object":"list","data":[…]}` that opencode and the OpenAI SDKs
+  require. The two shapes conflict on one path, and the failure is non-fatal — Codex falls back to
+  the configured `-c model=…` and runs normally, including tool calls.
 - **No response-body rewriting on the passthrough routes.** The response body and the SSE
   `message_start` event carry whatever model id was actually sent upstream — never rewritten back to
   the client's requested id. This is accepted for raw-passthrough fidelity.

--- a/samples/CopilotAnthropicProxy.Sample/README.md
+++ b/samples/CopilotAnthropicProxy.Sample/README.md
@@ -205,7 +205,17 @@ Responses API. Every passthrough route is byte-for-byte and has none of them.
   with an Anthropic `not_found_error` rather than running a billed generation or inventing a number.
   Clients degrade gracefully — Claude Code logs `countTokens API call failed` and falls back to a
   local estimate, which drives only the `/context` bar and the auto-compact threshold.
-- **Prompt caching, batch and files APIs are not proxied.**
+- **Prompt caching does not survive translation.** `cache_control` is dropped by construction, because
+  the translated request is built from an explicit allowlist rather than patched — see *Known request
+  incompatibilities* below. The passthrough routes forward it untouched.
+
+**Not route-specific**
+
+These are the exception to the scoping note above: they are proxy-wide gaps, and the passthrough routes
+do **not** escape them.
+
+- **The batch and files APIs are not proxied at all.** No route binds them in either dialect, so they
+  answer the fallback `404` for every model — passthrough included.
 
 ## Exposing Copilot's MCP server
 

--- a/samples/CopilotAnthropicProxy.Sample/README.md
+++ b/samples/CopilotAnthropicProxy.Sample/README.md
@@ -53,21 +53,21 @@ On startup the proxy logs the resolved default model, how many models are availa
 address, e.g.:
 
 ```
-CopilotAnthropicProxy listening on http://127.0.0.1:8788 -> https://api.enterprise.githubcopilot.com (default model: <resolved-opus-id>, 17 available; idle 180s, keep-alive 15s)
+CopilotAnthropicProxy listening on http://127.0.0.1:8787 -> https://api.enterprise.githubcopilot.com (default model: <resolved-opus-id>, 17 available; idle 180s, keep-alive 15s)
 ```
 
 ## Configuring each client
 
 ```bash
 # Claude Code — any model in the catalog, Claude or GPT
-export ANTHROPIC_BASE_URL=http://127.0.0.1:8788
+export ANTHROPIC_BASE_URL=http://127.0.0.1:8787
 export ANTHROPIC_MODEL=gpt-5.3-codex
 
 # Codex CLI — ~/.codex/config.toml
-# base_url = "http://127.0.0.1:8788/v1"
+# base_url = "http://127.0.0.1:8787/v1"
 
 # opencode — OpenAI-compatible provider
-# baseURL: "http://127.0.0.1:8788/v1"
+# baseURL: "http://127.0.0.1:8787/v1"
 ```
 
 `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY`) is required by these clients but ignored by the proxy: the
@@ -81,7 +81,7 @@ The in-house `AnthropicClient` appends `/messages` to the configured base URL, s
 ```bash
 LM_PROVIDER_MODE=anthropic \
 ANTHROPIC_API_KEY=dummy \
-ANTHROPIC_BASE_URL=http://127.0.0.1:8788/v1 \
+ANTHROPIC_BASE_URL=http://127.0.0.1:8787/v1 \
 ANTHROPIC_MODEL=any-model-id-the-proxy-will-rewrite \
 dotnet run --project samples/LmStreaming.Sample
 ```
@@ -102,9 +102,17 @@ base URL under haiku model ids; without family mapping, every one of them would 
 
 > [!NOTE]
 > Setting `COPILOT_ANTHROPIC_MODEL` **pins** every request to that one id and skips discovery
-> entirely. A pinned catalog carries no endpoint metadata, so the pinned model is treated as an
-> Anthropic Messages passthrough — **the translated route is unreachable in pinned mode**. Leave the
-> variable unset to drive GPT models through `/v1/messages`.
+> entirely. A pinned catalog carries no endpoint metadata, so by default the pinned model is treated
+> as an Anthropic Messages passthrough and the translated route stays unreachable. To pin a
+> Responses-only model, declare what discovery would have found:
+>
+> ```bash
+> export COPILOT_ANTHROPIC_MODEL=gpt-5.3-codex
+> export COPILOT_ANTHROPIC_MODEL_ENDPOINTS=/responses
+> ```
+>
+> Leave both unset to serve the whole discovered catalog, which is the usual way to drive GPT models
+> through `/v1/messages`.
 
 ## Known limitations
 
@@ -227,7 +235,7 @@ transport) on:
 
 This is a **byte-level reverse proxy**, not an MCP-aware reimplementation: there's no JSON-RPC
 parsing and no proxy-side session bookkeeping. Point any MCP Streamable-HTTP client at
-`http://127.0.0.1:8788/mcp` (or `/mcp/readonly`) exactly as you would point it at
+`http://127.0.0.1:8787/mcp` (or `/mcp/readonly`) exactly as you would point it at
 `https://api.enterprise.githubcopilot.com/mcp` (or `/mcp/readonly`) directly — request/response
 bodies, status codes, and headers are relayed verbatim, including SSE responses (same raw-byte
 streaming as `/v1/messages`).
@@ -248,8 +256,8 @@ host/cross-site guard described in the warning above.
 
 | Symptom (request that reaches the proxy) | Cause | Fix |
 | --- | --- | --- |
-| `404` on `POST /messages` | You used the bare host with a client that appends only `/messages`. | Add `/v1`: `…:8788/v1`. |
-| `404` on `POST /v1/v1/messages` | You added `/v1` for a client that already appends `/v1/messages`. | Drop `/v1`: use `…:8788`. |
+| `404` on `POST /messages` | You used the bare host with a client that appends only `/messages`. | Add `/v1`: `…:8787/v1`. |
+| `404` on `POST /v1/v1/messages` | You added `/v1` for a client that already appends `/v1/messages`. | Drop `/v1`: use `…:8787`. |
 | `404 not_found_error` on `count_tokens` | The model is served by translation to Responses, which has no token-counting endpoint. | Expected; the client falls back to a local estimate. |
 | A GPT model answers as Claude | `COPILOT_ANTHROPIC_MODEL` is pinned, so every request is rewritten to it. | Unset it to use the discovered catalog. |
 | `403 permission_error` | Non-loopback `Host`, cross-site request, or a non-loopback `Origin`. | Use `127.0.0.1`/`localhost`; don't proxy from a browser page on another origin. |
@@ -260,8 +268,10 @@ host/cross-site guard described in the warning above.
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `COPILOT_ANTHROPIC_MODEL` | (discovered from `/models`) | Pins every request to this single Copilot model id and skips discovery entirely. Leave unset to serve the full catalog — see the note under "Which models are served". |
-| `COPILOT_ANTHROPIC_PORT` | `8788` | Loopback listen port. |
+| `COPILOT_ANTHROPIC_MODEL_ENDPOINTS` | (none) | Comma-separated endpoints the pinned model serves, e.g. `/responses`. Only read alongside `COPILOT_ANTHROPIC_MODEL`, where it supplies the capability metadata discovery would have found; without it a pinned model routes as an Anthropic Messages passthrough. |
+| `COPILOT_ANTHROPIC_PORT` | `8787` | Loopback listen port. |
 | `COPILOT_ANTHROPIC_BASE_URL` | `https://api.enterprise.githubcopilot.com` | Copilot host root (for non-enterprise hosts). |
+| `COPILOT_ANTHROPIC_MAX_BODY_BYTES` | `33554432` (32 MiB) | Cap on both the inbound request body and any upstream reply the proxy has to buffer whole in order to translate it. A reply over the cap is refused as `502` rather than read into memory. Streamed relays are unaffected — they are never buffered. |
 | `COPILOT_ANTHROPIC_IDLE_TIMEOUT_SECONDS` | `180` | Per-request idle timeout, reset after each streamed upstream read. The total exchange has no deadline, so long generations are not cut off; this only fires when the upstream produces *nothing* for the whole window. |
 | `COPILOT_ANTHROPIC_KEEPALIVE_SECONDS` | `15` | While an SSE upstream is silent, emit a downstream SSE keep-alive this often so the client's own read timeout does not fire mid-generation. Keep-alives don't reset the idle timeout above. Set `0` to disable. |
 | `COPILOT_ANTHROPIC_ENABLE_DEVICE_FLOW` | `false` | When truthy, allow an interactive GitHub device-flow login at startup (composite provider). Off by default — the request path never blocks on device flow. |

--- a/samples/CopilotAnthropicProxy.Sample/README.md
+++ b/samples/CopilotAnthropicProxy.Sample/README.md
@@ -147,12 +147,18 @@ Responses API. Every passthrough route is byte-for-byte and has none of them.
   | `>= 24576` | `high` |
   | absent | `medium` |
 
-  Every served model accepts all three efforts. Measured over four runs against the four models that
-  default to `effort: "none"` — models that can *never* produce a `thinking` block otherwise — three
-  of them returned one on every run and the fourth on two of four. So enabling thinking moves this
-  from impossible to usual, but a `thinking` block is still not contractually guaranteed on any given
-  turn. **No `effort` is sent when the client did not enable thinking**, so a turn the user never
-  asked to think about costs exactly what it costs today.
+  Every served model accepts all three efforts. Measured over five runs against the four models that
+  default to `effort: "none"` — models that can *never* produce a `thinking` block otherwise — two runs
+  had all four produce one. On the other three at least one model stayed silent, and it was not always
+  the same one: `gpt-5.4` on two of them and `gpt-5.4-nano` on the third. So enabling thinking moves
+  this from impossible to usual, for no model in particular.
+
+  Even at the largest budgets a `thinking` block is not guaranteed on every turn. Probed over ten runs
+  at `budget_tokens: 32768`, `gpt-5.4` returned a complete, correct answer with no `thinking` block on
+  two of them. A larger budget improves the odds; it does not make thinking contractual.
+
+  **No `effort` is sent when the client did not enable thinking**, so a turn the user never asked to
+  think about costs exactly what it costs today.
 - **Reasoning still does not carry across turns.** The encrypted payload that would let a GPT model
   resume its own reasoning through a tool loop is not round-tripped, so answers stay correct but the
   model re-derives its reasoning each turn. The `thinking` blocks that are emitted also carry **no

--- a/samples/CopilotAnthropicProxy.Sample/README.md
+++ b/samples/CopilotAnthropicProxy.Sample/README.md
@@ -53,7 +53,7 @@ On startup the proxy logs the resolved default model, how many models are availa
 address, e.g.:
 
 ```
-CopilotAnthropicProxy listening on http://127.0.0.1:8787 -> https://api.enterprise.githubcopilot.com (default model: <resolved-opus-id>, 7 available)
+CopilotAnthropicProxy listening on http://127.0.0.1:8788 -> https://api.enterprise.githubcopilot.com (default model: <resolved-opus-id>, 7 available)
 ```
 
 ### Choosing the model
@@ -89,7 +89,7 @@ There are **two** valid base-URL forms depending on how the client builds the re
 These append `/v1/messages` to the base URL, so use the **bare host** (no `/v1`):
 
 ```bash
-ANTHROPIC_BASE_URL=http://127.0.0.1:8787 \
+ANTHROPIC_BASE_URL=http://127.0.0.1:8788 \
 ANTHROPIC_API_KEY=dummy \
 claude
 ```
@@ -101,7 +101,7 @@ The in-house `AnthropicClient` appends `/messages` to the configured base URL, s
 ```bash
 LM_PROVIDER_MODE=anthropic \
 ANTHROPIC_API_KEY=dummy \
-ANTHROPIC_BASE_URL=http://127.0.0.1:8787/v1 \
+ANTHROPIC_BASE_URL=http://127.0.0.1:8788/v1 \
 ANTHROPIC_MODEL=any-model-id-the-proxy-will-rewrite \
 dotnet run --project samples/LmStreaming.Sample
 ```
@@ -121,7 +121,7 @@ transport) on:
 
 This is a **byte-level reverse proxy**, not an MCP-aware reimplementation: there's no JSON-RPC
 parsing and no proxy-side session bookkeeping. Point any MCP Streamable-HTTP client at
-`http://127.0.0.1:8787/mcp` (or `/mcp/readonly`) exactly as you would point it at
+`http://127.0.0.1:8788/mcp` (or `/mcp/readonly`) exactly as you would point it at
 `https://api.enterprise.githubcopilot.com/mcp` (or `/mcp/readonly`) directly — request/response
 bodies, status codes, and headers are relayed verbatim, including SSE responses (same raw-byte
 streaming as `/v1/messages`).
@@ -142,8 +142,8 @@ host/cross-site guard described in the warning above.
 
 | Symptom (request that reaches the proxy) | Cause | Fix |
 | --- | --- | --- |
-| `404` on `POST /messages` | You used the bare host with a client that appends only `/messages`. | Add `/v1`: `…:8787/v1`. |
-| `404` on `POST /v1/v1/messages` | You added `/v1` for a client that already appends `/v1/messages`. | Drop `/v1`: use `…:8787`. |
+| `404` on `POST /messages` | You used the bare host with a client that appends only `/messages`. | Add `/v1`: `…:8788/v1`. |
+| `404` on `POST /v1/v1/messages` | You added `/v1` for a client that already appends `/v1/messages`. | Drop `/v1`: use `…:8788`. |
 | `403 permission_error` | Non-loopback `Host`, cross-site request, or a non-loopback `Origin`. | Use `127.0.0.1`/`localhost`; don't proxy from a browser page on another origin. |
 | `401 authentication_error` | The proxy could not acquire a Copilot token on the request. | Re-authenticate (`gh auth login` / Copilot CLI) or set `GITHUB_COPILOT_TOKEN`. |
 
@@ -152,7 +152,7 @@ host/cross-site guard described in the warning above.
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `COPILOT_ANTHROPIC_MODEL` | (discovered from `/models`) | Pins every request to this single Copilot model id and skips discovery entirely. Unset to discover the full `/v1/messages`-capable catalog instead (see "Choosing the model"). |
-| `COPILOT_ANTHROPIC_PORT` | `8787` | Loopback listen port. |
+| `COPILOT_ANTHROPIC_PORT` | `8788` | Loopback listen port. |
 | `COPILOT_ANTHROPIC_BASE_URL` | `https://api.enterprise.githubcopilot.com` | Copilot host root (for non-enterprise hosts). |
 | `COPILOT_ANTHROPIC_IDLE_TIMEOUT_SECONDS` | `180` | Per-request idle timeout, reset after each streamed upstream read. The total exchange has no deadline, so long generations are not cut off; this only fires when the upstream produces *nothing* for the whole window. |
 | `COPILOT_ANTHROPIC_KEEPALIVE_SECONDS` | `15` | While an SSE upstream is silent, emit a downstream SSE keep-alive comment (`:` line) this often so the client's own read timeout does not fire mid-generation. Keep-alives don't reset the idle timeout above. Set `0` to disable. |

--- a/samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs
@@ -61,6 +61,12 @@ public static class AnthropicToResponsesRequest
             target["max_output_tokens"] = Math.Max(maxTokens, MinimumOutputTokens);
         }
 
+        // Copilot accepts both on a Responses-only model, so they are copied rather than dropped.
+        // Probed live on 2026-07-27 because OpenAI documents its own reasoning models as REJECTING a
+        // non-default temperature, which would have made this a 400 on every request that set one:
+        // POST /responses {model: gpt-5.4-nano, temperature: 0.7, top_p: 0.5} answered 200 and echoed
+        // "temperature": 0.7, "top_p": 0.5 — the values were honoured, not clamped back to the
+        // defaults (1 and 0.98) that the same endpoint reports when neither field is sent.
         foreach (var passthrough in new[] { "temperature", "top_p" })
         {
             if (source[passthrough] is { } value)

--- a/samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs
@@ -75,6 +75,26 @@ public static class AnthropicToResponsesRequest
             }
         }
 
+        // Ask for reasoning summaries on every translated request. Without this the Responses stream
+        // carries no reasoning_summary events at all, so ResponsesToAnthropicStream has nothing to turn
+        // into a thinking block and a GPT model driven from Claude Code never appears to think.
+        //
+        // Sent unconditionally, and only after probing whether that is safe. On 2026-07-27 all nine
+        // /responses models this account serves answered 200 to {"summary":"auto"} with no effort field,
+        // on both the streaming and non-streaming path; each echoed it back normalised to
+        // "summary":"detailed" alongside a per-model default effort. So no served model rejects it.
+        //
+        // It is not uniformly PRODUCTIVE, though, and not even deterministically so. Across two sweeps
+        // of the same nine models with the same prompt, the models Copilot defaults to "effort":"none"
+        // emitted no summary events either time, while the ones defaulting to "medium" varied run to
+        // run — a different single model produced summaries in each sweep. So a summary is a per-turn
+        // possibility, not a per-model property, and no caller should depend on getting one.
+        //
+        // Sending an effort of our own would likely make this reliable, but it would also change how
+        // hard every model thinks and what every request costs — a decision this translation layer
+        // should not make silently on the caller's behalf.
+        target["reasoning"] = new JsonObject { ["summary"] = "auto" };
+
         // tool_choice is only considered when a non-empty tools array actually made it into the
         // request — the Responses API rejects tool_choice when tools is absent, and BuildToolChoice
         // additionally checks a "tool" choice's name against what survived BuildTools' filter.

--- a/samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs
@@ -1,0 +1,297 @@
+using System.Text.Json.Nodes;
+
+/// <summary>
+///     Rewrites an Anthropic Messages request into an OpenAI Responses request.
+///
+///     Builds a NEW object from an explicit allowlist rather than patching the inbound body. That is
+///     deliberate: Claude Code sends a great deal that Copilot's Responses endpoint rejects outright —
+///     body-level <c>betas</c> (~29 of them), <c>cache_control</c> with <c>ttl</c>/<c>scope</c>
+///     sub-fields, <c>metadata.user_id</c>, and server tools such as <c>web_search_20250305</c>. An
+///     allowlist drops all of it by construction; a patch-in-place would have to chase each one.
+/// </summary>
+public static class AnthropicToResponsesRequest
+{
+    /// <summary>
+    ///     The smallest <c>max_output_tokens</c> the Responses API accepts.
+    ///
+    ///     Claude Code's FIRST request against a model it has not used is a validation probe with
+    ///     <c>max_tokens: 1</c> and <c>maxRetries: 0</c>. Passed through literally it is a 400, and
+    ///     Claude Code concludes the model is unusable — so every GPT model would appear broken before
+    ///     the user ever got a turn. Clamping up costs nothing: the probe only checks that a
+    ///     well-formed response comes back.
+    /// </summary>
+    public const int MinimumOutputTokens = 16;
+
+    /// <summary>Translates an Anthropic request body. Throws <see cref="ArgumentException"/> if it is not a JSON object.</summary>
+    public static string Translate(string anthropicJson)
+    {
+        ArgumentNullException.ThrowIfNull(anthropicJson);
+
+        return JsonNode.Parse(anthropicJson) is JsonObject source
+            ? Translate(source).ToJsonString()
+            : throw new ArgumentException("An Anthropic request body must be a JSON object.", nameof(anthropicJson));
+    }
+
+    /// <summary>Translates a parsed Anthropic request body.</summary>
+    public static JsonObject Translate(JsonObject source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        var target = new JsonObject
+        {
+            ["model"] = source["model"]?.DeepClone(),
+            ["stream"] = (source["stream"] ?? JsonValue.Create(false)).DeepClone(),
+
+            // The proxy holds no server-side state and the client resends full history every turn,
+            // so opt out of the Responses store (whose default is true).
+            ["store"] = false,
+            ["input"] = BuildInput(source["messages"] as JsonArray),
+        };
+
+        var instructions = FlattenText(source["system"]);
+        if (instructions.Length > 0)
+        {
+            target["instructions"] = instructions;
+        }
+
+        // Anthropic requires max_tokens; Responses treats max_output_tokens as optional. Omit rather
+        // than invent a cap when the client did not send one.
+        if (source["max_tokens"]?.GetValue<int>() is { } maxTokens)
+        {
+            target["max_output_tokens"] = Math.Max(maxTokens, MinimumOutputTokens);
+        }
+
+        foreach (var passthrough in new[] { "temperature", "top_p" })
+        {
+            if (source[passthrough] is { } value)
+            {
+                target[passthrough] = value.DeepClone();
+            }
+        }
+
+        if (BuildTools(source["tools"] as JsonArray) is { Count: > 0 } tools)
+        {
+            target["tools"] = tools;
+        }
+
+        if (BuildToolChoice(source["tool_choice"]) is { } toolChoice)
+        {
+            target["tool_choice"] = toolChoice;
+        }
+
+        return target;
+    }
+
+    /// <summary>
+    ///     Flattens an Anthropic text value into a plain string. Accepts a bare string, a single block,
+    ///     or an array of blocks; non-text blocks are ignored. Claude Code always sends the array form
+    ///     for <c>system</c>, but the string form is legal and older clients use it.
+    /// </summary>
+    private static string FlattenText(JsonNode? value)
+    {
+        switch (value)
+        {
+            case JsonValue scalar when scalar.TryGetValue<string>(out var text):
+                return text;
+            case JsonObject block:
+                return block["type"]?.GetValue<string>() == "text" ? block["text"]?.GetValue<string>() ?? "" : "";
+            case JsonArray blocks:
+                var parts = blocks
+                    .OfType<JsonObject>()
+                    .Where(b => b["type"]?.GetValue<string>() == "text")
+                    .Select(b => b["text"]?.GetValue<string>() ?? "")
+                    .Where(t => t.Length > 0);
+                return string.Join("\n\n", parts);
+            default:
+                return "";
+        }
+    }
+
+    /// <summary>
+    ///     Turns Anthropic's messages into a Responses <c>input</c> array.
+    ///
+    ///     The shapes differ structurally: Anthropic nests tool calls and tool results INSIDE message
+    ///     content, while Responses makes them top-level items. So a message's text and image blocks
+    ///     accumulate into one message item, and any tool block flushes that item and appends its own.
+    ///     Order is preserved throughout — Responses pairs a function_call with its output by
+    ///     <c>call_id</c>, but a sane ordering keeps transcripts readable and matches what Codex sends.
+    /// </summary>
+    private static JsonArray BuildInput(JsonArray? messages)
+    {
+        var input = new JsonArray();
+        if (messages is null)
+        {
+            return input;
+        }
+
+        foreach (var message in messages.OfType<JsonObject>())
+        {
+            var role = message["role"]?.GetValue<string>() ?? "user";
+            var textPartType = role == "assistant" ? "output_text" : "input_text";
+            JsonArray? pending = null;
+
+            void Flush()
+            {
+                if (pending is { Count: > 0 })
+                {
+                    input.Add(
+                        new JsonObject
+                        {
+                            ["type"] = "message",
+                            ["role"] = role,
+                            ["content"] = pending,
+                        }
+                    );
+                }
+
+                pending = null;
+            }
+
+            JsonArray Pending() => pending ??= [];
+
+            switch (message["content"])
+            {
+                case JsonValue scalar when scalar.TryGetValue<string>(out var text):
+                    Pending().Add(new JsonObject { ["type"] = textPartType, ["text"] = text });
+                    break;
+
+                case JsonArray blocks:
+                    foreach (var block in blocks.OfType<JsonObject>())
+                    {
+                        switch (block["type"]?.GetValue<string>())
+                        {
+                            // "thinking" / "redacted_thinking" are dropped: replaying them needs
+                            // reasoning.encrypted_content round-tripping, which this sample does not do.
+                            // Anything else is unknown and equally not forwarded.
+                            default:
+                                break;
+
+                            case "text":
+                                Pending()
+                                    .Add(
+                                        new JsonObject
+                                        {
+                                            ["type"] = textPartType,
+                                            ["text"] = block["text"]?.GetValue<string>() ?? "",
+                                        }
+                                    );
+                                break;
+
+                            case "image" when ToImageUrl(block["source"] as JsonObject) is { } imageUrl:
+                                Pending().Add(new JsonObject { ["type"] = "input_image", ["image_url"] = imageUrl });
+                                break;
+
+                            case "tool_use":
+                                Flush();
+                                input.Add(
+                                    new JsonObject
+                                    {
+                                        ["type"] = "function_call",
+                                        ["call_id"] = block["id"]?.GetValue<string>() ?? "",
+                                        ["name"] = block["name"]?.GetValue<string>() ?? "",
+                                        // Anthropic sends a JSON object; Responses wants a JSON STRING.
+                                        ["arguments"] = (block["input"] ?? new JsonObject()).ToJsonString(),
+                                    }
+                                );
+                                break;
+
+                            case "tool_result":
+                                Flush();
+                                input.Add(
+                                    new JsonObject
+                                    {
+                                        ["type"] = "function_call_output",
+                                        ["call_id"] = block["tool_use_id"]?.GetValue<string>() ?? "",
+                                        ["output"] = FlattenText(block["content"]),
+                                    }
+                                );
+                                break;
+                        }
+                    }
+
+                    break;
+
+                default:
+                    break;
+            }
+
+            Flush();
+        }
+
+        return input;
+    }
+
+    /// <summary>Builds a data URL (or passes a plain URL through) for an Anthropic image source.</summary>
+    private static string? ToImageUrl(JsonObject? imageSource)
+    {
+        if (imageSource is null)
+        {
+            return null;
+        }
+
+        return imageSource["type"]?.GetValue<string>() switch
+        {
+            "url" => imageSource["url"]?.GetValue<string>(),
+            "base64" =>
+                $"data:{imageSource["media_type"]?.GetValue<string>() ?? "image/png"};base64,{imageSource["data"]?.GetValue<string>() ?? ""}",
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    ///     Maps Anthropic tools onto Responses function tools. ONLY entries carrying an
+    ///     <c>input_schema</c> are mapped — that filter is what silently drops Claude Code's server
+    ///     tools (<c>web_search_20250305</c>, <c>advisor_20260301</c>), which Copilot rejects with
+    ///     400 "The use of the web search tool is not supported."
+    /// </summary>
+    private static JsonArray BuildTools(JsonArray? tools)
+    {
+        var mapped = new JsonArray();
+        if (tools is null)
+        {
+            return mapped;
+        }
+
+        foreach (var tool in tools.OfType<JsonObject>())
+        {
+            if (tool["input_schema"] is not { } schema)
+            {
+                continue;
+            }
+
+            var mappedTool = new JsonObject
+            {
+                ["type"] = "function",
+                ["name"] = tool["name"]?.GetValue<string>() ?? "",
+                ["parameters"] = schema.DeepClone(),
+            };
+
+            if (tool["description"]?.GetValue<string>() is { Length: > 0 } description)
+            {
+                mappedTool["description"] = description;
+            }
+
+            mapped.Add(mappedTool);
+        }
+
+        return mapped;
+    }
+
+    /// <summary>Maps Anthropic's tool_choice onto the Responses spelling.</summary>
+    private static JsonNode? BuildToolChoice(JsonNode? toolChoice)
+    {
+        if (toolChoice is not JsonObject choice)
+        {
+            return null;
+        }
+
+        return choice["type"]?.GetValue<string>() switch
+        {
+            "auto" => JsonValue.Create("auto"),
+            "none" => JsonValue.Create("none"),
+            "any" => JsonValue.Create("required"),
+            "tool" => new JsonObject { ["type"] = "function", ["name"] = choice["name"]?.GetValue<string>() ?? "" },
+            _ => null,
+        };
+    }
+}

--- a/samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs
@@ -84,16 +84,14 @@ public static class AnthropicToResponsesRequest
         // on both the streaming and non-streaming path; each echoed it back normalised to
         // "summary":"detailed" alongside a per-model default effort. So no served model rejects it.
         //
-        // It is not uniformly PRODUCTIVE, though, and not even deterministically so. Across two sweeps
-        // of the same nine models with the same prompt, the models Copilot defaults to "effort":"none"
-        // emitted no summary events either time, while the ones defaulting to "medium" varied run to
-        // run — a different single model produced summaries in each sweep. So a summary is a per-turn
-        // possibility, not a per-model property, and no caller should depend on getting one.
-        //
-        // Sending an effort of our own would likely make this reliable, but it would also change how
-        // hard every model thinks and what every request costs — a decision this translation layer
-        // should not make silently on the caller's behalf.
-        target["reasoning"] = new JsonObject { ["summary"] = "auto" };
+        // It is not uniformly PRODUCTIVE on its own, though, and not even deterministically so. Across
+        // two sweeps of the same nine models with the same prompt, the models Copilot defaults to
+        // "effort":"none" emitted no summary events either time, while the ones defaulting to "medium"
+        // varied run to run — a different single model produced summaries in each sweep. An effort is
+        // what moves a summary from impossible to usual (still not guaranteed on any one turn), and
+        // BuildReasoning takes that from the client rather than imposing one, so a turn the user never
+        // asked to think about costs exactly what it costs today.
+        target["reasoning"] = BuildReasoning(source["thinking"]);
 
         // tool_choice is only considered when a non-empty tools array actually made it into the
         // request — the Responses API rejects tool_choice when tools is absent, and BuildToolChoice
@@ -110,6 +108,52 @@ public static class AnthropicToResponsesRequest
         }
 
         return target;
+    }
+
+    /// <summary>
+    ///     Builds the Responses <c>reasoning</c> field from Anthropic's top-level <c>thinking</c>.
+    ///
+    ///     <c>summary: "auto"</c> is unconditional — without it Copilot sends no reasoning summary
+    ///     events at all, so no <c>thinking</c> block can ever be produced. Every served model accepts
+    ///     it; none rejects it.
+    ///
+    ///     <c>effort</c> is NOT unconditional, and is never invented. Copilot gives each model a default
+    ///     effort and several default to <c>"none"</c>, which means the turn does not reason and there
+    ///     is nothing to summarise — so summaries alone are unreliable. The fix is to ask for effort,
+    ///     but choosing a global one would change how hard every model thinks and what every request
+    ///     costs. Anthropic clients already say how hard to think: extended thinking arrives as
+    ///     <c>thinking: {"type":"enabled","budget_tokens":N}</c>. So the client's own budget is mapped
+    ///     onto the coarse effort Responses accepts, and a request that never enabled thinking gets no
+    ///     <c>effort</c> — today's behaviour and today's cost, exactly.
+    /// </summary>
+    private static JsonObject BuildReasoning(JsonNode? thinking)
+    {
+        var reasoning = new JsonObject { ["summary"] = "auto" };
+
+        if (
+            thinking is not JsonObject request
+            || request["type"] is not JsonValue kind
+            || !kind.TryGetValue<string>(out var type)
+            || type != "enabled"
+        )
+        {
+            return reasoning;
+        }
+
+        // The thresholds separate the tiers Claude Code itself sends, which sit near 4k, 10k and 32k
+        // tokens — each lands in a different bucket with room to spare, so they are not arbitrary.
+        // An enabled request with no budget means "think", and medium is the neutral reading of that.
+        reasoning["effort"] =
+            request["budget_tokens"] is JsonValue budget && budget.TryGetValue<int>(out var budgetTokens)
+                ? budgetTokens switch
+                {
+                    < 8192 => "low",
+                    < 24576 => "medium",
+                    _ => "high",
+                }
+                : "medium";
+
+        return reasoning;
     }
 
     /// <summary>

--- a/samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs
@@ -110,10 +110,30 @@ public static class AnthropicToResponsesRequest
             {
                 target["tool_choice"] = toolChoice;
             }
+
+            // Anthropic carries this INSIDE tool_choice and defaults it to false; Responses carries it
+            // at the top level and defaults it to true. Dropping it would let a client that
+            // deliberately serialises tool execution receive several tool calls in one turn and break
+            // its tool loop. Only an explicit true is translated — sending parallel_tool_calls: true
+            // for every other request would be inventing an instruction the client never gave.
+            if (DisablesParallelToolUse(source["tool_choice"]))
+            {
+                target["parallel_tool_calls"] = false;
+            }
         }
 
         return target;
     }
+
+    /// <summary>
+    ///     True when the client set Anthropic's <c>tool_choice.disable_parallel_tool_use</c>. The flag
+    ///     is meaningless without tools, so this is only consulted once tools survived the filter.
+    /// </summary>
+    private static bool DisablesParallelToolUse(JsonNode? toolChoice) =>
+        toolChoice is JsonObject choice
+        && choice["disable_parallel_tool_use"] is JsonValue flag
+        && flag.TryGetValue<bool>(out var disabled)
+        && disabled;
 
     /// <summary>
     ///     Builds the Responses <c>reasoning</c> field from Anthropic's top-level <c>thinking</c>.
@@ -128,8 +148,15 @@ public static class AnthropicToResponsesRequest
     ///     but choosing a global one would change how hard every model thinks and what every request
     ///     costs. Anthropic clients already say how hard to think: extended thinking arrives as
     ///     <c>thinking: {"type":"enabled","budget_tokens":N}</c>. So the client's own budget is mapped
-    ///     onto the coarse effort Responses accepts, and a request that never enabled thinking gets no
+    ///     onto the coarse effort Responses accepts, and a request that never mentioned thinking gets no
     ///     <c>effort</c> — today's behaviour and today's cost, exactly.
+    ///
+    ///     <c>thinking: {"type":"disabled"}</c> is NOT "never mentioned". The client explicitly asked
+    ///     not to reason, and several served models default to a non-<c>none</c> effort, so omitting the
+    ///     field would bill the caller for reasoning it just turned off. That maps to Responses'
+    ///     <c>effort: "none"</c>, which is a documented value of the enum. A model that cannot honour it
+    ///     answers 400, and that 400 is relayed to the client — visibly refusing is the point; silently
+    ///     reasoning anyway is what this branch exists to prevent.
     /// </summary>
     private static JsonObject BuildReasoning(JsonNode? thinking)
     {
@@ -139,8 +166,18 @@ public static class AnthropicToResponsesRequest
             thinking is not JsonObject request
             || request["type"] is not JsonValue kind
             || !kind.TryGetValue<string>(out var type)
-            || type != "enabled"
         )
+        {
+            return reasoning;
+        }
+
+        if (type == "disabled")
+        {
+            reasoning["effort"] = "none";
+            return reasoning;
+        }
+
+        if (type != "enabled")
         {
             return reasoning;
         }

--- a/samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs
@@ -84,6 +84,11 @@ public static class AnthropicToResponsesRequest
         // on both the streaming and non-streaming path; each echoed it back normalised to
         // "summary":"detailed" alongside a per-model default effort. So no served model rejects it.
         //
+        // That is a dated observation, and the thing that keeps it true is the live probe
+        // Every_responses_model_accepts_a_reasoning_field: it re-sweeps the served /responses catalog
+        // and names any model that refuses. If Copilot ever ships one that does, that probe fails rather
+        // than this comment quietly going stale.
+        //
         // It is not uniformly PRODUCTIVE on its own, though, and not even deterministically so. Across
         // two sweeps of the same nine models with the same prompt, the models Copilot defaults to
         // "effort":"none" emitted no summary events either time, while the ones defaulting to "medium"

--- a/samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/AnthropicToResponsesRequest.cs
@@ -69,14 +69,18 @@ public static class AnthropicToResponsesRequest
             }
         }
 
-        if (BuildTools(source["tools"] as JsonArray) is { Count: > 0 } tools)
+        // tool_choice is only considered when a non-empty tools array actually made it into the
+        // request — the Responses API rejects tool_choice when tools is absent, and BuildToolChoice
+        // additionally checks a "tool" choice's name against what survived BuildTools' filter.
+        var tools = BuildTools(source["tools"] as JsonArray);
+        if (tools is { Count: > 0 })
         {
             target["tools"] = tools;
-        }
 
-        if (BuildToolChoice(source["tool_choice"]) is { } toolChoice)
-        {
-            target["tool_choice"] = toolChoice;
+            if (BuildToolChoice(source["tool_choice"], tools) is { } toolChoice)
+            {
+                target["tool_choice"] = toolChoice;
+            }
         }
 
         return target;
@@ -277,8 +281,13 @@ public static class AnthropicToResponsesRequest
         return mapped;
     }
 
-    /// <summary>Maps Anthropic's tool_choice onto the Responses spelling.</summary>
-    private static JsonNode? BuildToolChoice(JsonNode? toolChoice)
+    /// <summary>
+    ///     Maps Anthropic's tool_choice onto the Responses spelling. <paramref name="tools"/> is the
+    ///     already-filtered array BuildTools produced — a "tool" choice naming an entry that filter
+    ///     dropped (a server tool, e.g. web_search) resolves to null rather than pointing Responses at
+    ///     a tool that no longer exists in the request.
+    /// </summary>
+    private static JsonNode? BuildToolChoice(JsonNode? toolChoice, JsonArray tools)
     {
         if (toolChoice is not JsonObject choice)
         {
@@ -290,8 +299,22 @@ public static class AnthropicToResponsesRequest
             "auto" => JsonValue.Create("auto"),
             "none" => JsonValue.Create("none"),
             "any" => JsonValue.Create("required"),
-            "tool" => new JsonObject { ["type"] = "function", ["name"] = choice["name"]?.GetValue<string>() ?? "" },
+            "tool" => NamedToolChoice(choice["name"]?.GetValue<string>(), tools),
             _ => null,
         };
+    }
+
+    /// <summary>
+    ///     Builds the Responses <c>{"type":"function","name":...}</c> choice shape, but only when
+    ///     <paramref name="name"/> is one of the function tools that survived BuildTools' filter.
+    /// </summary>
+    private static JsonObject? NamedToolChoice(string? name, JsonArray tools)
+    {
+        if (string.IsNullOrEmpty(name) || !tools.OfType<JsonObject>().Any(t => t["name"]?.GetValue<string>() == name))
+        {
+            return null;
+        }
+
+        return new JsonObject { ["type"] = "function", ["name"] = name };
     }
 }

--- a/samples/CopilotAnthropicProxy.Sample/Translation/ModelRoute.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/ModelRoute.cs
@@ -1,0 +1,98 @@
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+
+/// <summary>The API dialect a request arrived in.</summary>
+public enum ProxyDialect
+{
+    /// <summary>Anthropic Messages — Claude Code.</summary>
+    AnthropicMessages,
+
+    /// <summary>OpenAI Chat Completions — opencode and most OpenAI SDKs.</summary>
+    ChatCompletions,
+
+    /// <summary>OpenAI Responses — Codex CLI.</summary>
+    Responses,
+}
+
+/// <summary>How a request must be served.</summary>
+public enum ProxyRouteKind
+{
+    /// <summary>Forward the body to Copilot essentially unchanged.</summary>
+    Passthrough,
+
+    /// <summary>Rewrite an Anthropic Messages request into an OpenAI Responses request, and the reply back.</summary>
+    TranslateAnthropicToResponses,
+}
+
+/// <summary>The resolved upstream target for one request.</summary>
+public sealed record ModelRoute(ProxyRouteKind Kind, string UpstreamPath, ProxyModelInfo Model);
+
+/// <summary>
+///     The routing table. Copilot serves three transports and every model advertises which of them it
+///     honors, so the only question is whether the client's dialect matches one the model accepts.
+///     Exactly one mismatch is worth translating: Anthropic Messages in, for a model that only speaks
+///     Responses. Everything else either passes through or 404s.
+/// </summary>
+public static class ModelRouter
+{
+    /// <summary>Copilot's Anthropic Messages path.</summary>
+    public const string MessagesPath = CopilotModelsResponse.MessagesEndpoint;
+
+    /// <summary>Copilot's Anthropic token-counting path.</summary>
+    public const string CountTokensPath = "/v1/messages/count_tokens";
+
+    /// <summary>Copilot's OpenAI Chat Completions path.</summary>
+    public const string ChatCompletionsPath = ProxyModelResolver.ChatCompletionsEndpoint;
+
+    /// <summary>Copilot's OpenAI Responses path.</summary>
+    public const string ResponsesPath = CopilotModelsResponse.ResponsesEndpoint;
+
+    /// <summary>
+    ///     Resolves how to serve <paramref name="model"/> for an inbound <paramref name="dialect"/>.
+    ///     Returns null when the model cannot serve that dialect at all; the caller answers 404.
+    ///
+    ///     A model with NO endpoint metadata (pinned via COPILOT_ANTHROPIC_MODEL, or discovered from a
+    ///     legacy /models shape) is treated as Anthropic-Messages-capable and nothing else, which is
+    ///     precisely how this proxy behaved before endpoint metadata existed.
+    /// </summary>
+    public static ModelRoute? Resolve(ProxyDialect dialect, ProxyModelInfo model)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+        var noMetadata = model.Endpoints.Count == 0;
+
+        return dialect switch
+        {
+            ProxyDialect.AnthropicMessages when noMetadata || model.Supports(MessagesPath) => new ModelRoute(
+                ProxyRouteKind.Passthrough,
+                MessagesPath,
+                model
+            ),
+            ProxyDialect.AnthropicMessages when model.Supports(ResponsesPath) => new ModelRoute(
+                ProxyRouteKind.TranslateAnthropicToResponses,
+                ResponsesPath,
+                model
+            ),
+            ProxyDialect.ChatCompletions when noMetadata || model.Supports(ChatCompletionsPath) => new ModelRoute(
+                ProxyRouteKind.Passthrough,
+                ChatCompletionsPath,
+                model
+            ),
+            ProxyDialect.Responses when model.Supports(ResponsesPath) => new ModelRoute(
+                ProxyRouteKind.Passthrough,
+                ResponsesPath,
+                model
+            ),
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    ///     The ids that can serve <paramref name="dialect"/>, in catalog order. Used to make a 404 body
+    ///     actionable — telling a client its model is unavailable is only useful alongside the list of
+    ///     models that are.
+    /// </summary>
+    public static IReadOnlyList<string> Servable(ProxyDialect dialect, ProxyModelCatalog catalog)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        return [.. catalog.Models.Where(m => Resolve(dialect, m) is not null).Select(m => m.Id)];
+    }
+}

--- a/samples/CopilotAnthropicProxy.Sample/Translation/ModelRoute.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/ModelRoute.cs
@@ -19,7 +19,7 @@ public enum ProxyRouteKind
     /// <summary>Forward the body to Copilot essentially unchanged.</summary>
     Passthrough,
 
-    /// <summary>Rewrite an Anthropic Messages request into an OpenAI Responses request, and the reply back.</summary>
+    /// <summary>Rewrite an Anthropic Messages request into an OpenAI Responses request, and translate the reply back.</summary>
     TranslateAnthropicToResponses,
 }
 
@@ -51,8 +51,8 @@ public static class ModelRouter
     ///     Returns null when the model cannot serve that dialect at all; the caller answers 404.
     ///
     ///     A model with NO endpoint metadata (pinned via COPILOT_ANTHROPIC_MODEL, or discovered from a
-    ///     legacy /models shape) is treated as Anthropic-Messages-capable and nothing else, which is
-    ///     precisely how this proxy behaved before endpoint metadata existed.
+    ///     legacy /models shape) is treated as capable of Anthropic Messages and Chat Completions, but
+    ///     not Responses — we cannot claim Responses support we have not seen advertised.
     /// </summary>
     public static ModelRoute? Resolve(ProxyDialect dialect, ProxyModelInfo model)
     {

--- a/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicJson.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicJson.cs
@@ -68,7 +68,10 @@ public static class ResponsesToAnthropicJson
     ///
     ///     Any unrecognised <c>incomplete_details</c> shape falls through to <c>end_turn</c>. That
     ///     field is not modelled anywhere under src/OpenAiResponsesProvider, so its live shape is
-    ///     confirmed by the live smoke test rather than by a fixture.
+    ///     confirmed by the live smoke test rather than by a fixture. Reads are kind-safe rather than
+    ///     throwing: unlike <see cref="Translate"/>, this method is called directly by
+    ///     <c>ResponsesToAnthropicSse</c> outside any try/catch, so a field present with an unexpected
+    ///     JSON kind (e.g. <c>"type": 123</c>) must fall through to <c>end_turn</c> rather than throw.
     /// </summary>
     public static string DeriveStopReason(JsonObject response)
     {
@@ -76,19 +79,23 @@ public static class ResponsesToAnthropicJson
 
         if (
             response["output"] is JsonArray output
-            && output.OfType<JsonObject>().Any(item => item["type"]?.GetValue<string>() == "function_call")
+            && output.OfType<JsonObject>().Any(item => IsStringValue(item["type"], "function_call"))
         )
         {
             return "tool_use";
         }
 
-        if ((response["incomplete_details"] as JsonObject)?["reason"]?.GetValue<string>() == "max_output_tokens")
+        if (IsStringValue((response["incomplete_details"] as JsonObject)?["reason"], "max_output_tokens"))
         {
             return "max_tokens";
         }
 
         return "end_turn";
     }
+
+    /// <summary>True when <paramref name="node"/> is a JSON string equal to <paramref name="value"/>.</summary>
+    private static bool IsStringValue(JsonNode? node, string value) =>
+        node is JsonValue scalar && scalar.TryGetValue<string>(out var text) && text == value;
 
     /// <summary>
     ///     Maps Responses output items onto Anthropic content blocks, in order. An empty result is a
@@ -107,8 +114,8 @@ public static class ResponsesToAnthropicJson
         {
             switch (item["type"]?.GetValue<string>())
             {
-                // Other Responses item types (web_search_call, code_interpreter_call, mcp_call, ...)
-                // are not surfaced by this sample proxy; skip them rather than fail the whole reply.
+                // IDE0010 requires an explicit arm here. Other Responses item types (web_search_call,
+                // code_interpreter_call, mcp_call, ...) are intentionally not surfaced by this sample.
                 default:
                     break;
 
@@ -174,11 +181,16 @@ public static class ResponsesToAnthropicJson
 
         try
         {
-            return JsonNode.Parse(arguments) as JsonObject ?? [];
+            if (JsonNode.Parse(arguments) is JsonObject parsed)
+            {
+                return parsed;
+            }
         }
         catch (JsonException)
         {
-            return new JsonObject();
+            // Malformed JSON falls through to the empty-object default below.
         }
+
+        return new JsonObject();
     }
 }

--- a/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicJson.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicJson.cs
@@ -70,8 +70,9 @@ public static class ResponsesToAnthropicJson
     ///     field is not modelled anywhere under src/OpenAiResponsesProvider, so its live shape is
     ///     confirmed by the live smoke test rather than by a fixture. Reads are kind-safe rather than
     ///     throwing: unlike <see cref="Translate"/>, this method is called directly by
-    ///     <c>ResponsesToAnthropicSse</c> outside any try/catch, so a field present with an unexpected
-    ///     JSON kind (e.g. <c>"type": 123</c>) must fall through to <c>end_turn</c> rather than throw.
+    ///     <see cref="ResponsesToAnthropicSse"/> outside any try/catch, so a field present with an
+    ///     unexpected JSON kind (e.g. <c>"type": 123</c>) must fall through to <c>end_turn</c> rather
+    ///     than throw.
     /// </summary>
     public static string DeriveStopReason(JsonObject response)
     {

--- a/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicJson.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicJson.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Nodes;
 
 /// <summary>
 ///     Rewrites a non-streaming OpenAI Responses reply into an Anthropic Message.
-///     <c>ResponsesToAnthropicSse</c> does the same job for streaming replies and shares
+///     <see cref="ResponsesToAnthropicSse"/> does the same job for streaming replies and shares
 ///     <see cref="DeriveStopReason"/> so the two cannot drift apart.
 /// </summary>
 public static class ResponsesToAnthropicJson

--- a/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicJson.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicJson.cs
@@ -1,10 +1,13 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
 /// <summary>
 ///     Rewrites a non-streaming OpenAI Responses reply into an Anthropic Message.
 ///     <see cref="ResponsesToAnthropicSse"/> does the same job for streaming replies and shares
-///     <see cref="DeriveStopReason"/> and <see cref="TokenCount"/> so the two cannot drift apart.
+///     <see cref="DescribeLifecycleFailure"/>, <see cref="DeriveStopReason"/>,
+///     <see cref="DescribeUpstreamFailure"/>, <see cref="TryParseArguments"/> and
+///     <see cref="TokenCount"/> so the two cannot drift apart.
 /// </summary>
 public static class ResponsesToAnthropicJson
 {
@@ -13,13 +16,16 @@ public static class ResponsesToAnthropicJson
     ///     reply omits <c>model</c>.
     /// </summary>
     /// <exception cref="ArgumentException">
-    ///     <paramref name="responsesJson"/> is not well-formed JSON, is not a JSON object, or its
-    ///     fields carry a type this translator does not expect (e.g. <c>id</c> present but not a
-    ///     string, or <c>output</c> present but not an array). Copilot is a live upstream, not a
-    ///     fixture, so a malformed or unexpected reply must surface as this one documented type rather
-    ///     than leaking the underlying <see cref="JsonException"/> or
-    ///     <see cref="InvalidOperationException"/>. The client's request was accepted and well formed,
-    ///     so the caller answers 502 <c>api_error</c> — the failure is upstream, not the client's.
+    ///     <paramref name="responsesJson"/> is not well-formed JSON, is not a JSON object, declares a
+    ///     lifecycle state that is not a finished turn (see <see cref="DescribeLifecycleFailure"/>), or
+    ///     carries a field whose JSON kind this translator does not expect — at the top level
+    ///     (<c>id</c> present but not a string, <c>output</c> present but not an array) or anywhere
+    ///     inside <c>output</c> (a non-object item, a non-array <c>content</c>, a recognised content
+    ///     part missing its payload). Copilot is a live upstream, not a fixture, so a malformed or
+    ///     unexpected reply must surface as this one documented type rather than leaking the underlying
+    ///     <see cref="JsonException"/> or <see cref="InvalidOperationException"/>. The client's request
+    ///     was accepted and well formed, so the caller answers 502 <c>api_error</c> — the failure is
+    ///     upstream, not the client's.
     /// </exception>
     public static string Translate(string responsesJson, string fallbackModel)
     {
@@ -33,12 +39,57 @@ public static class ResponsesToAnthropicJson
                 throw new ArgumentException("A Responses reply must be a JSON object.", nameof(responsesJson));
             }
 
+            // Before anything is read out of the body: a reply that declares its own failure must never
+            // be reshaped into a successful Anthropic turn, however well formed the rest of it is.
+            if (DescribeLifecycleFailure(response) is { } failure)
+            {
+                throw new InvalidOperationException(failure);
+            }
+
             return BuildMessage(response, fallbackModel).ToJsonString();
         }
         catch (Exception ex) when (ex is JsonException or InvalidOperationException)
         {
             throw new ArgumentException("The Responses reply is malformed.", nameof(responsesJson), ex);
         }
+    }
+
+    /// <summary>
+    ///     Describes why a Responses body does not represent a finished, successful turn, or null when
+    ///     it does. Shared with <see cref="ResponsesToAnthropicSse"/> so a buffered and a streamed reply
+    ///     cannot disagree about whether the upstream succeeded.
+    ///
+    ///     The Responses <c>status</c> enum has exactly six members: <c>completed</c>, <c>incomplete</c>,
+    ///     <c>failed</c>, <c>cancelled</c>, <c>in_progress</c> and <c>queued</c>. Only the first two are
+    ///     finished turns this proxy can present as an Anthropic message — <c>incomplete</c> included,
+    ///     because <see cref="DeriveStopReason"/> reports it as <c>max_tokens</c> or <c>refusal</c>.
+    ///     <c>failed</c> and <c>cancelled</c> are reported as upstream failures; the two non-terminal
+    ///     states, and any status a future spec adds, are reported as an unfinished turn. An absent
+    ///     <c>status</c> stays legitimate: it is optional on the wire and its absence asserts nothing.
+    ///
+    ///     A non-null top-level <c>error</c> is treated as a failure on its own. The spec leaves it null
+    ///     unless the response failed, so its presence contradicts any status claiming success — and
+    ///     believing the status over the error is precisely how an HTTP-2xx failure became an empty
+    ///     successful turn.
+    /// </summary>
+    public static string? DescribeLifecycleFailure(JsonObject response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+
+        var error = response["error"];
+        var status = response["status"];
+
+        if (IsStringValue(status, "failed") || IsStringValue(status, "cancelled") || error is not null)
+        {
+            return DescribeUpstreamFailure(error as JsonObject);
+        }
+
+        if (status is null || IsStringValue(status, "completed") || IsStringValue(status, "incomplete"))
+        {
+            return null;
+        }
+
+        return "The upstream Copilot reply did not report a finished turn.";
     }
 
     /// <summary>Builds the Anthropic Message envelope for an already-parsed Responses reply.</summary>
@@ -78,13 +129,20 @@ public static class ResponsesToAnthropicJson
         };
 
     /// <summary>
-    ///     Derives Anthropic's <c>stop_reason</c> from a Responses reply, in priority order:
-    ///     classifier intervention outranks everything, then a function call, then truncation, then a
-    ///     normal finish.
+    ///     Derives Anthropic's <c>stop_reason</c> from a Responses reply, in priority order: a refusal —
+    ///     whether reported as a classifier intervention or as official refusal output — outranks
+    ///     everything, then a function call, then truncation, then a normal finish.
     ///
-    ///     <c>content_filter</c> is checked first on purpose. A filtered turn can still carry the
-    ///     partial output the model produced before the classifier fired, including a half-formed
-    ///     function call; reporting that as <c>tool_use</c> would invite the client to execute it.
+    ///     Refusals are checked first on purpose. A refused turn can still carry the partial output the
+    ///     model produced before it declined, including a half-formed function call; reporting that as
+    ///     <c>tool_use</c> would invite the client to execute it. Anthropic documents its own
+    ///     <c>refusal</c> stop reason the same way: treat any partial output as incomplete.
+    ///
+    ///     The two representations are genuinely distinct. <c>incomplete_details.reason ==
+    ///     "content_filter"</c> accompanies status <c>incomplete</c> — the turn was cut short. An
+    ///     official <c>refusal</c> content part accompanies status <c>completed</c> — the model
+    ///     answered, and its answer was a refusal. Either one must reach the client as
+    ///     <c>stop_reason: "refusal"</c>.
     ///
     ///     Any unrecognised <c>incomplete_details</c> shape falls through to <c>end_turn</c>. That
     ///     field is not modelled anywhere under src/OpenAiResponsesProvider, so its live shape is
@@ -102,7 +160,7 @@ public static class ResponsesToAnthropicJson
 
         // The Responses spec defines exactly two reasons: max_output_tokens and content_filter.
         // Anthropic exposes "refusal" for the latter — a classifier stopped the turn, it did not end.
-        if (IsStringValue(incompleteReason, "content_filter"))
+        if (IsStringValue(incompleteReason, "content_filter") || CarriesRefusalOutput(response))
         {
             return "refusal";
         }
@@ -122,6 +180,40 @@ public static class ResponsesToAnthropicJson
 
         return "end_turn";
     }
+
+    /// <summary>
+    ///     True when any message item carries an official <c>refusal</c> content part. Kind-safe for the
+    ///     same reason <see cref="DeriveStopReason"/> is: the streamed path calls it outside a try/catch.
+    /// </summary>
+    private static bool CarriesRefusalOutput(JsonObject response) =>
+        response["output"] is JsonArray output
+        && output
+            .OfType<JsonObject>()
+            .Where(item => IsStringValue(item["type"], "message"))
+            .SelectMany(item => (item["content"] as JsonArray ?? []).OfType<JsonObject>())
+            .Any(part => IsStringValue(part["type"], "refusal"));
+
+    /// <summary>
+    ///     Describes an upstream failure without relaying its text. A provider's error message can echo
+    ///     the prompt, tool arguments, or account details back at whoever is listening, so only the
+    ///     machine-readable <c>code</c> is passed through, and only when it looks like a code rather
+    ///     than a sentence. Shared with <see cref="ResponsesToAnthropicSse"/> so a buffered failure and
+    ///     a streamed one are described identically.
+    /// </summary>
+    public static string DescribeUpstreamFailure(JsonObject? error)
+    {
+        const string fallback = "The upstream Copilot API reported a failure.";
+
+        return Text(error?["code"]) is { } code && IsErrorCode(code) ? $"{fallback} Upstream code: {code}." : fallback;
+    }
+
+    /// <summary>
+    ///     True for a short token-shaped identifier such as <c>server_error</c> or
+    ///     <c>rate_limit_exceeded</c>. Anything longer or containing whitespace or punctuation is
+    ///     treated as free text and withheld.
+    /// </summary>
+    private static bool IsErrorCode(string code) =>
+        code.Length is > 0 and <= 64 && code.All(c => char.IsAsciiLetterOrDigit(c) || c is '_' or '-' or '.');
 
     /// <summary>
     ///     Reads a Responses token count. Shared with <see cref="ResponsesToAnthropicSse"/> so a
@@ -157,13 +249,23 @@ public static class ResponsesToAnthropicJson
     }
 
     /// <summary>True when <paramref name="node"/> is a JSON string equal to <paramref name="value"/>.</summary>
-    private static bool IsStringValue(JsonNode? node, string value) =>
-        node is JsonValue scalar && scalar.TryGetValue<string>(out var text) && text == value;
+    private static bool IsStringValue(JsonNode? node, string value) => Text(node) == value;
+
+    /// <summary>Reads a JSON string, or null when <paramref name="node"/> is absent or another kind.</summary>
+    private static string? Text(JsonNode? node) =>
+        node is JsonValue scalar && scalar.TryGetValue<string>(out var text) ? text : null;
 
     /// <summary>
     ///     Maps Responses output items onto Anthropic content blocks, in order. An empty result is a
     ///     legitimate answer — a truncated or reasoning-only turn genuinely produced no content — so
     ///     nothing is invented to fill the gap.
+    ///
+    ///     Every element of <c>output</c>, and every part of a recognised item's payload, is validated
+    ///     rather than filtered. Skipping a corrupt element would report an unreadable upstream reply as
+    ///     a successful turn that happened to say less — the same defect the <c>output</c> container
+    ///     check above removes, one level deeper. Item and part TYPES this sample does not surface are a
+    ///     different matter and are still skipped: the Responses catalogue grows, and an unknown type is
+    ///     an upstream that is newer than this proxy, not an upstream that is broken.
     /// </summary>
     private static JsonArray BuildContent(JsonArray? output)
     {
@@ -173,9 +275,9 @@ public static class ResponsesToAnthropicJson
             return content;
         }
 
-        foreach (var item in output.OfType<JsonObject>())
+        foreach (var item in RequireObjects(output, "output item"))
         {
-            switch (item["type"]?.GetValue<string>())
+            switch (RequireString(item["type"], "output item's type"))
             {
                 // IDE0010 requires an explicit arm here. Other Responses item types (web_search_call,
                 // code_interpreter_call, mcp_call, ...) are intentionally not surfaced by this sample.
@@ -183,34 +285,11 @@ public static class ResponsesToAnthropicJson
                     break;
 
                 case "message":
-                    foreach (var part in (item["content"] as JsonArray ?? []).OfType<JsonObject>())
-                    {
-                        if (part["type"]?.GetValue<string>() == "output_text")
-                        {
-                            content.Add(
-                                new JsonObject { ["type"] = "text", ["text"] = part["text"]?.GetValue<string>() ?? "" }
-                            );
-                        }
-                    }
-
+                    AppendMessageContent(content, item);
                     break;
 
                 case "reasoning":
-                    // Display only. The encrypted payload that would make reasoning replayable across
-                    // turns is not carried — see the README's Known limitations.
-                    var summary = string.Join(
-                        "\n\n",
-                        (item["summary"] as JsonArray ?? [])
-                            .OfType<JsonObject>()
-                            .Select(s => s["text"]?.GetValue<string>() ?? "")
-                            .Where(t => t.Length > 0)
-                    );
-
-                    if (summary.Length > 0)
-                    {
-                        content.Add(new JsonObject { ["type"] = "thinking", ["thinking"] = summary });
-                    }
-
+                    AppendReasoningSummary(content, item);
                     break;
 
                 case "function_call":
@@ -218,8 +297,8 @@ public static class ResponsesToAnthropicJson
                         new JsonObject
                         {
                             ["type"] = "tool_use",
-                            ["id"] = item["call_id"]?.GetValue<string>() ?? "",
-                            ["name"] = item["name"]?.GetValue<string>() ?? "",
+                            ["id"] = RequireString(item["call_id"], "function call's call_id"),
+                            ["name"] = RequireString(item["name"], "function call's name"),
                             ["input"] = ParseArguments(item["arguments"]),
                         }
                     );
@@ -229,6 +308,98 @@ public static class ResponsesToAnthropicJson
 
         return content;
     }
+
+    /// <summary>
+    ///     Appends the Anthropic blocks for one <c>message</c> output item.
+    ///
+    ///     A <c>refusal</c> part becomes a text block. Anthropic has no refusal content block — it
+    ///     reports a decline through <c>stop_reason: "refusal"</c> (which
+    ///     <see cref="DeriveStopReason"/> derives from this same part) and documents that a client must
+    ///     not depend on refusal text being present. Dropping the model's own wording entirely would
+    ///     leave the user with an unexplained empty turn, so it is carried as text; the stop reason, not
+    ///     the block type, is what a client is told to branch on.
+    /// </summary>
+    private static void AppendMessageContent(JsonArray content, JsonObject item)
+    {
+        foreach (var part in RequireObjects(RequireArray(item["content"], "message item's content"), "content part"))
+        {
+            switch (RequireString(part["type"], "content part's type"))
+            {
+                default:
+                    break;
+
+                case "output_text":
+                    content.Add(
+                        new JsonObject
+                        {
+                            ["type"] = "text",
+                            ["text"] = RequireString(part["text"], "output_text part's text"),
+                        }
+                    );
+                    break;
+
+                case "refusal":
+                    content.Add(
+                        new JsonObject
+                        {
+                            ["type"] = "text",
+                            ["text"] = RequireString(part["refusal"], "refusal part's refusal"),
+                        }
+                    );
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Appends the Anthropic thinking block for one <c>reasoning</c> output item. Display only: the
+    ///     encrypted payload that would make reasoning replayable across turns is not carried — see the
+    ///     README's Known limitations.
+    /// </summary>
+    private static void AppendReasoningSummary(JsonArray content, JsonObject item)
+    {
+        var summary = string.Join(
+            "\n\n",
+            RequireObjects(RequireArray(item["summary"], "reasoning item's summary"), "summary part")
+                .Select(part => part["text"] is null ? "" : RequireString(part["text"], "summary part's text"))
+                .Where(text => text.Length > 0)
+        );
+
+        if (summary.Length > 0)
+        {
+            content.Add(new JsonObject { ["type"] = "thinking", ["thinking"] = summary });
+        }
+    }
+
+    /// <summary>
+    ///     Returns <paramref name="node"/> as an array. Absent is legitimate — an item that carries no
+    ///     parts — but present-and-not-an-array is malformed for the same reason a non-array
+    ///     <c>output</c> is.
+    /// </summary>
+    private static JsonArray RequireArray(JsonNode? node, string what) =>
+        node switch
+        {
+            null => [],
+            JsonArray array => array,
+            _ => throw new InvalidOperationException($"A Responses reply's {what} must be an array."),
+        };
+
+    /// <summary>
+    ///     Enumerates <paramref name="items"/>, failing on the first element that is not a JSON object.
+    ///     <c>OfType&lt;JsonObject&gt;()</c> here would silently drop the corrupt element instead.
+    /// </summary>
+    private static IEnumerable<JsonObject> RequireObjects(JsonArray items, string what)
+    {
+        foreach (var item in items)
+        {
+            yield return item as JsonObject
+                ?? throw new InvalidOperationException($"Every {what} in a Responses reply must be a JSON object.");
+        }
+    }
+
+    /// <summary>Reads a field that a recognised item or part is required to carry as a string.</summary>
+    private static string RequireString(JsonNode? node, string what) =>
+        Text(node) ?? throw new InvalidOperationException($"A Responses reply's {what} must be a string.");
 
     /// <summary>
     ///     Parses a function call's arguments, which Responses sends as a JSON STRING while Anthropic
@@ -247,26 +418,39 @@ public static class ResponsesToAnthropicJson
     /// </exception>
     private static JsonNode ParseArguments(JsonNode? arguments)
     {
-        if (
-            arguments is not JsonValue value
-            || !value.TryGetValue<string>(out var text)
-            || string.IsNullOrWhiteSpace(text)
-        )
+        if (arguments is not JsonValue value || !value.TryGetValue<string>(out var text))
         {
-            throw new InvalidOperationException("A function call's arguments must be a non-empty JSON string.");
+            throw new InvalidOperationException("A function call's arguments must be a JSON string.");
         }
 
-        JsonNode? parsed;
+        return TryParseArguments(text, out var parsed)
+            ? parsed
+            : throw new InvalidOperationException("A function call's arguments must be a non-empty JSON object.");
+    }
+
+    /// <summary>
+    ///     Reads a Responses function-call argument STRING as the JSON object Anthropic's
+    ///     <c>tool_use.input</c> requires. Shared with <see cref="ResponsesToAnthropicSse"/>, which
+    ///     applies it to the argument text it reassembled from the stream, so the same argument string
+    ///     cannot be accepted streamed and rejected buffered.
+    /// </summary>
+    public static bool TryParseArguments(string? arguments, [NotNullWhen(true)] out JsonObject? parsed)
+    {
+        parsed = null;
+        if (string.IsNullOrWhiteSpace(arguments))
+        {
+            return false;
+        }
+
         try
         {
-            parsed = JsonNode.Parse(text);
+            parsed = JsonNode.Parse(arguments) as JsonObject;
         }
-        catch (JsonException ex)
+        catch (JsonException)
         {
-            throw new InvalidOperationException("A function call's arguments must be well-formed JSON.", ex);
+            return false;
         }
 
-        return parsed as JsonObject
-            ?? throw new InvalidOperationException("A function call's arguments must be a JSON object.");
+        return parsed is not null;
     }
 }

--- a/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicJson.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicJson.cs
@@ -1,0 +1,184 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+/// <summary>
+///     Rewrites a non-streaming OpenAI Responses reply into an Anthropic Message.
+///     <c>ResponsesToAnthropicSse</c> does the same job for streaming replies and shares
+///     <see cref="DeriveStopReason"/> so the two cannot drift apart.
+/// </summary>
+public static class ResponsesToAnthropicJson
+{
+    /// <summary>
+    ///     Translates a Responses reply body. <paramref name="fallbackModel"/> is reported when the
+    ///     reply omits <c>model</c>.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    ///     <paramref name="responsesJson"/> is not well-formed JSON, is not a JSON object, or its
+    ///     fields carry a type this translator does not expect (e.g. <c>id</c> present but not a
+    ///     string). Copilot is a live upstream, not a fixture, so a malformed or unexpected reply must
+    ///     surface as this one documented type rather than leaking the underlying
+    ///     <see cref="JsonException"/> or <see cref="InvalidOperationException"/> — callers (Task 9's
+    ///     endpoint) branch on that to answer 400 instead of 500.
+    /// </exception>
+    public static string Translate(string responsesJson, string fallbackModel)
+    {
+        ArgumentNullException.ThrowIfNull(responsesJson);
+        ArgumentNullException.ThrowIfNull(fallbackModel);
+
+        try
+        {
+            if (JsonNode.Parse(responsesJson) is not JsonObject response)
+            {
+                throw new ArgumentException("A Responses reply must be a JSON object.", nameof(responsesJson));
+            }
+
+            return BuildMessage(response, fallbackModel).ToJsonString();
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException)
+        {
+            throw new ArgumentException("The Responses reply is malformed.", nameof(responsesJson), ex);
+        }
+    }
+
+    /// <summary>Builds the Anthropic Message envelope for an already-parsed Responses reply.</summary>
+    private static JsonObject BuildMessage(JsonObject response, string fallbackModel)
+    {
+        var usage = response["usage"] as JsonObject;
+
+        return new JsonObject
+        {
+            ["id"] = response["id"]?.GetValue<string>() ?? "msg_proxy",
+            ["type"] = "message",
+            ["role"] = "assistant",
+            ["model"] = response["model"]?.GetValue<string>() ?? fallbackModel,
+            ["content"] = BuildContent(response["output"] as JsonArray),
+            ["stop_reason"] = DeriveStopReason(response),
+            ["stop_sequence"] = null,
+            ["usage"] = new JsonObject
+            {
+                ["input_tokens"] = usage?["input_tokens"]?.GetValue<int>() ?? 0,
+                ["output_tokens"] = usage?["output_tokens"]?.GetValue<int>() ?? 0,
+            },
+        };
+    }
+
+    /// <summary>
+    ///     Derives Anthropic's <c>stop_reason</c> from a Responses reply, in priority order:
+    ///     a function call outranks truncation, truncation outranks a normal finish.
+    ///
+    ///     Any unrecognised <c>incomplete_details</c> shape falls through to <c>end_turn</c>. That
+    ///     field is not modelled anywhere under src/OpenAiResponsesProvider, so its live shape is
+    ///     confirmed by the live smoke test rather than by a fixture.
+    /// </summary>
+    public static string DeriveStopReason(JsonObject response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+
+        if (
+            response["output"] is JsonArray output
+            && output.OfType<JsonObject>().Any(item => item["type"]?.GetValue<string>() == "function_call")
+        )
+        {
+            return "tool_use";
+        }
+
+        if ((response["incomplete_details"] as JsonObject)?["reason"]?.GetValue<string>() == "max_output_tokens")
+        {
+            return "max_tokens";
+        }
+
+        return "end_turn";
+    }
+
+    /// <summary>
+    ///     Maps Responses output items onto Anthropic content blocks, in order. An empty result is a
+    ///     legitimate answer — a truncated or reasoning-only turn genuinely produced no content — so
+    ///     nothing is invented to fill the gap.
+    /// </summary>
+    private static JsonArray BuildContent(JsonArray? output)
+    {
+        var content = new JsonArray();
+        if (output is null)
+        {
+            return content;
+        }
+
+        foreach (var item in output.OfType<JsonObject>())
+        {
+            switch (item["type"]?.GetValue<string>())
+            {
+                // Other Responses item types (web_search_call, code_interpreter_call, mcp_call, ...)
+                // are not surfaced by this sample proxy; skip them rather than fail the whole reply.
+                default:
+                    break;
+
+                case "message":
+                    foreach (var part in (item["content"] as JsonArray ?? []).OfType<JsonObject>())
+                    {
+                        if (part["type"]?.GetValue<string>() == "output_text")
+                        {
+                            content.Add(
+                                new JsonObject { ["type"] = "text", ["text"] = part["text"]?.GetValue<string>() ?? "" }
+                            );
+                        }
+                    }
+
+                    break;
+
+                case "reasoning":
+                    // Display only. The encrypted payload that would make reasoning replayable across
+                    // turns is not carried — see the README's Known limitations.
+                    var summary = string.Join(
+                        "\n\n",
+                        (item["summary"] as JsonArray ?? [])
+                            .OfType<JsonObject>()
+                            .Select(s => s["text"]?.GetValue<string>() ?? "")
+                            .Where(t => t.Length > 0)
+                    );
+
+                    if (summary.Length > 0)
+                    {
+                        content.Add(new JsonObject { ["type"] = "thinking", ["thinking"] = summary });
+                    }
+
+                    break;
+
+                case "function_call":
+                    content.Add(
+                        new JsonObject
+                        {
+                            ["type"] = "tool_use",
+                            ["id"] = item["call_id"]?.GetValue<string>() ?? "",
+                            ["name"] = item["name"]?.GetValue<string>() ?? "",
+                            ["input"] = ParseArguments(item["arguments"]?.GetValue<string>()),
+                        }
+                    );
+                    break;
+            }
+        }
+
+        return content;
+    }
+
+    /// <summary>
+    ///     Parses a function call's arguments, which Responses sends as a JSON STRING while Anthropic
+    ///     expects an object. Malformed or empty arguments become an empty object rather than an error:
+    ///     a client can recover from a tool call with no arguments, but not from a broken envelope.
+    /// </summary>
+    private static JsonNode ParseArguments(string? arguments)
+    {
+        if (string.IsNullOrWhiteSpace(arguments))
+        {
+            return new JsonObject();
+        }
+
+        try
+        {
+            return JsonNode.Parse(arguments) as JsonObject ?? [];
+        }
+        catch (JsonException)
+        {
+            return new JsonObject();
+        }
+    }
+}

--- a/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicJson.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicJson.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Nodes;
 /// <summary>
 ///     Rewrites a non-streaming OpenAI Responses reply into an Anthropic Message.
 ///     <see cref="ResponsesToAnthropicSse"/> does the same job for streaming replies and shares
-///     <see cref="DeriveStopReason"/> so the two cannot drift apart.
+///     <see cref="DeriveStopReason"/> and <see cref="TokenCount"/> so the two cannot drift apart.
 /// </summary>
 public static class ResponsesToAnthropicJson
 {
@@ -15,10 +15,11 @@ public static class ResponsesToAnthropicJson
     /// <exception cref="ArgumentException">
     ///     <paramref name="responsesJson"/> is not well-formed JSON, is not a JSON object, or its
     ///     fields carry a type this translator does not expect (e.g. <c>id</c> present but not a
-    ///     string). Copilot is a live upstream, not a fixture, so a malformed or unexpected reply must
-    ///     surface as this one documented type rather than leaking the underlying
-    ///     <see cref="JsonException"/> or <see cref="InvalidOperationException"/> — callers (Task 9's
-    ///     endpoint) branch on that to answer 400 instead of 500.
+    ///     string, or <c>output</c> present but not an array). Copilot is a live upstream, not a
+    ///     fixture, so a malformed or unexpected reply must surface as this one documented type rather
+    ///     than leaking the underlying <see cref="JsonException"/> or
+    ///     <see cref="InvalidOperationException"/>. The client's request was accepted and well formed,
+    ///     so the caller answers 502 <c>api_error</c> — the failure is upstream, not the client's.
     /// </exception>
     public static string Translate(string responsesJson, string fallbackModel)
     {
@@ -51,20 +52,39 @@ public static class ResponsesToAnthropicJson
             ["type"] = "message",
             ["role"] = "assistant",
             ["model"] = response["model"]?.GetValue<string>() ?? fallbackModel,
-            ["content"] = BuildContent(response["output"] as JsonArray),
+            ["content"] = BuildContent(RequireOutput(response)),
             ["stop_reason"] = DeriveStopReason(response),
             ["stop_sequence"] = null,
             ["usage"] = new JsonObject
             {
-                ["input_tokens"] = usage?["input_tokens"]?.GetValue<int>() ?? 0,
-                ["output_tokens"] = usage?["output_tokens"]?.GetValue<int>() ?? 0,
+                ["input_tokens"] = TokenCount(usage?["input_tokens"]),
+                ["output_tokens"] = TokenCount(usage?["output_tokens"]),
             },
         };
     }
 
     /// <summary>
+    ///     Returns the reply's <c>output</c> array. An absent <c>output</c> is a legitimate shape (a
+    ///     reply that produced nothing), but an <c>output</c> that is present and is not an array is a
+    ///     malformed reply: silently reading it as "absent" would turn an invalid upstream response
+    ///     into a successful, empty Anthropic message and hide the failure from the client.
+    /// </summary>
+    private static JsonArray? RequireOutput(JsonObject response) =>
+        response["output"] switch
+        {
+            null => null,
+            JsonArray output => output,
+            _ => throw new InvalidOperationException("A Responses reply's output must be an array."),
+        };
+
+    /// <summary>
     ///     Derives Anthropic's <c>stop_reason</c> from a Responses reply, in priority order:
-    ///     a function call outranks truncation, truncation outranks a normal finish.
+    ///     classifier intervention outranks everything, then a function call, then truncation, then a
+    ///     normal finish.
+    ///
+    ///     <c>content_filter</c> is checked first on purpose. A filtered turn can still carry the
+    ///     partial output the model produced before the classifier fired, including a half-formed
+    ///     function call; reporting that as <c>tool_use</c> would invite the client to execute it.
     ///
     ///     Any unrecognised <c>incomplete_details</c> shape falls through to <c>end_turn</c>. That
     ///     field is not modelled anywhere under src/OpenAiResponsesProvider, so its live shape is
@@ -78,6 +98,15 @@ public static class ResponsesToAnthropicJson
     {
         ArgumentNullException.ThrowIfNull(response);
 
+        var incompleteReason = (response["incomplete_details"] as JsonObject)?["reason"];
+
+        // The Responses spec defines exactly two reasons: max_output_tokens and content_filter.
+        // Anthropic exposes "refusal" for the latter — a classifier stopped the turn, it did not end.
+        if (IsStringValue(incompleteReason, "content_filter"))
+        {
+            return "refusal";
+        }
+
         if (
             response["output"] is JsonArray output
             && output.OfType<JsonObject>().Any(item => IsStringValue(item["type"], "function_call"))
@@ -86,12 +115,45 @@ public static class ResponsesToAnthropicJson
             return "tool_use";
         }
 
-        if (IsStringValue((response["incomplete_details"] as JsonObject)?["reason"], "max_output_tokens"))
+        if (IsStringValue(incompleteReason, "max_output_tokens"))
         {
             return "max_tokens";
         }
 
         return "end_turn";
+    }
+
+    /// <summary>
+    ///     Reads a Responses token count. Shared with <see cref="ResponsesToAnthropicSse"/> so a
+    ///     buffered and a streamed reply cannot report the same upstream figure differently.
+    ///
+    ///     Copilot has been observed sending these as JSON numbers that do not fit <c>int</c> and as
+    ///     whole numbers written in floating-point form. Anything unreadable degrades to 0 rather than
+    ///     failing the reply: a wrong cost figure is recoverable, a broken envelope is not.
+    /// </summary>
+    public static long TokenCount(JsonNode? node)
+    {
+        if (node is not JsonValue value)
+        {
+            return 0;
+        }
+
+        if (value.TryGetValue<long>(out var exact))
+        {
+            return exact;
+        }
+
+        if (!value.TryGetValue<double>(out var approximate) || double.IsNaN(approximate))
+        {
+            return 0;
+        }
+
+        return approximate switch
+        {
+            <= long.MinValue => long.MinValue,
+            >= long.MaxValue => long.MaxValue,
+            _ => (long)Math.Round(approximate),
+        };
     }
 
     /// <summary>True when <paramref name="node"/> is a JSON string equal to <paramref name="value"/>.</summary>
@@ -158,7 +220,7 @@ public static class ResponsesToAnthropicJson
                             ["type"] = "tool_use",
                             ["id"] = item["call_id"]?.GetValue<string>() ?? "",
                             ["name"] = item["name"]?.GetValue<string>() ?? "",
-                            ["input"] = ParseArguments(item["arguments"]?.GetValue<string>()),
+                            ["input"] = ParseArguments(item["arguments"]),
                         }
                     );
                     break;
@@ -170,28 +232,41 @@ public static class ResponsesToAnthropicJson
 
     /// <summary>
     ///     Parses a function call's arguments, which Responses sends as a JSON STRING while Anthropic
-    ///     expects an object. Malformed or empty arguments become an empty object rather than an error:
-    ///     a client can recover from a tool call with no arguments, but not from a broken envelope.
+    ///     expects an object.
+    ///
+    ///     Arguments that are missing, empty, not valid JSON, or not a JSON object fail the
+    ///     translation. Substituting <c>{}</c> would hand the client a well-formed <c>tool_use</c>
+    ///     whose input silently lost every argument the model chose — a shell command without its
+    ///     command, a delete without its filter — and the client has no way to tell that apart from a
+    ///     genuinely parameterless call. An explicit <c>"{}"</c> from the upstream still parses and is
+    ///     still honoured; only a call whose arguments we could not read is rejected.
     /// </summary>
-    private static JsonNode ParseArguments(string? arguments)
+    /// <exception cref="InvalidOperationException">
+    ///     The arguments are absent or cannot be read as a JSON object. <see cref="Translate"/> wraps
+    ///     this into the <see cref="ArgumentException"/> it documents.
+    /// </exception>
+    private static JsonNode ParseArguments(JsonNode? arguments)
     {
-        if (string.IsNullOrWhiteSpace(arguments))
+        if (
+            arguments is not JsonValue value
+            || !value.TryGetValue<string>(out var text)
+            || string.IsNullOrWhiteSpace(text)
+        )
         {
-            return new JsonObject();
+            throw new InvalidOperationException("A function call's arguments must be a non-empty JSON string.");
         }
 
+        JsonNode? parsed;
         try
         {
-            if (JsonNode.Parse(arguments) is JsonObject parsed)
-            {
-                return parsed;
-            }
+            parsed = JsonNode.Parse(text);
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
-            // Malformed JSON falls through to the empty-object default below.
+            throw new InvalidOperationException("A function call's arguments must be well-formed JSON.", ex);
         }
 
-        return new JsonObject();
+        return parsed as JsonObject
+            ?? throw new InvalidOperationException("A function call's arguments must be a JSON object.");
     }
 }

--- a/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicSse.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicSse.cs
@@ -22,7 +22,15 @@ public sealed class ResponsesToAnthropicSse
     private bool _started;
     private bool _finished;
     private int _nextIndex;
-    private bool _blockOpen;
+
+    /// <summary>
+    ///     The <c>content_block.type</c> of the block currently open ("text" / "thinking" /
+    ///     "tool_use"), or null when none is. The KIND matters, not just the fact of a block being
+    ///     open: a delta must never be written into a block of a different type, which is malformed
+    ///     rather than merely degraded. The upstream is not trusted to close its own blocks — the
+    ///     auto-open fallbacks below exist precisely because it sometimes does not.
+    /// </summary>
+    private string? _openKind;
 
     /// <summary>
     ///     <paramref name="messageId"/> and <paramref name="model"/> are used when the upstream stream
@@ -85,12 +93,12 @@ public sealed class ResponsesToAnthropicSse
 
             case "response.output_text.delta":
                 Start(frames, response);
-                if (!_blockOpen)
+                if (_openKind != "text")
                 {
                     OpenBlock(frames, new JsonObject { ["type"] = "text", ["text"] = "" });
                 }
 
-                Delta(frames, "text_delta", "text", Text(evt["delta"]) ?? "");
+                Delta(frames, "text", "text_delta", "text", Text(evt["delta"]) ?? "");
                 break;
 
             case "response.reasoning_summary_part.added":
@@ -100,12 +108,12 @@ public sealed class ResponsesToAnthropicSse
 
             case "response.reasoning_summary_text.delta":
                 Start(frames, response);
-                if (!_blockOpen)
+                if (_openKind != "thinking")
                 {
                     OpenBlock(frames, new JsonObject { ["type"] = "thinking", ["thinking"] = "" });
                 }
 
-                Delta(frames, "thinking_delta", "thinking", Text(evt["delta"]) ?? "");
+                Delta(frames, "thinking", "thinking_delta", "thinking", Text(evt["delta"]) ?? "");
                 break;
 
             case "response.output_item.added" when Text(item?["type"]) == "function_call":
@@ -122,12 +130,13 @@ public sealed class ResponsesToAnthropicSse
                 );
                 break;
 
-            // No block is opened here if one is not already open: unlike a text delta, a tool_use
-            // block cannot be invented after the fact — its id and name only ever arrive on
-            // response.output_item.added.
+            // No block is opened here: unlike a text delta, a tool_use block cannot be invented after
+            // the fact — its id and name only ever arrive on response.output_item.added. If that event
+            // was missing or unreadable, the arguments are dropped rather than written into whatever
+            // block happens to be open, which is what requiring the "tool_use" kind enforces.
             case "response.function_call_arguments.delta":
                 Start(frames, response);
-                Delta(frames, "input_json_delta", "partial_json", Text(evt["delta"]) ?? "");
+                Delta(frames, "tool_use", "input_json_delta", "partial_json", Text(evt["delta"]) ?? "");
                 break;
 
             case "response.content_part.done":
@@ -175,10 +184,14 @@ public sealed class ResponsesToAnthropicSse
         frames.Add(Frame("message_start", new JsonObject { ["type"] = "message_start", ["message"] = message }));
     }
 
+    /// <summary>
+    ///     Closes any block still open and starts a new one at the next index. The kind is taken from
+    ///     the block itself, so <see cref="_openKind"/> cannot drift from what was announced.
+    /// </summary>
     private void OpenBlock(List<string> frames, JsonObject contentBlock)
     {
         CloseBlock(frames);
-        _blockOpen = true;
+        _openKind = Text(contentBlock["type"]);
 
         frames.Add(
             Frame(
@@ -193,9 +206,15 @@ public sealed class ResponsesToAnthropicSse
         );
     }
 
-    private void Delta(List<string> frames, string deltaType, string field, string value)
+    /// <summary>
+    ///     Appends a delta to the open block, but only when that block is of
+    ///     <paramref name="requiredKind"/>. A tool call's arguments spliced into rendered assistant
+    ///     text, or a text delta at the index of a thinking block, is worse than a dropped delta:
+    ///     a client validating delta type against the block it opened rejects the whole stream.
+    /// </summary>
+    private void Delta(List<string> frames, string requiredKind, string deltaType, string field, string value)
     {
-        if (!_blockOpen || value.Length == 0)
+        if (_openKind != requiredKind || value.Length == 0)
         {
             return;
         }
@@ -215,7 +234,7 @@ public sealed class ResponsesToAnthropicSse
 
     private void CloseBlock(List<string> frames)
     {
-        if (!_blockOpen)
+        if (_openKind is null)
         {
             return;
         }
@@ -223,7 +242,7 @@ public sealed class ResponsesToAnthropicSse
         frames.Add(
             Frame("content_block_stop", new JsonObject { ["type"] = "content_block_stop", ["index"] = _nextIndex })
         );
-        _blockOpen = false;
+        _openKind = null;
         _nextIndex++;
     }
 
@@ -267,9 +286,37 @@ public sealed class ResponsesToAnthropicSse
     private static string? Text(JsonNode? node) =>
         node is JsonValue scalar && scalar.TryGetValue<string>(out var text) ? text : null;
 
-    /// <summary>Reads a token count, defaulting to 0 when it is absent or not a JSON integer.</summary>
-    private static int TokenCount(JsonNode? node) =>
-        node is JsonValue scalar && scalar.TryGetValue<int>(out var count) ? count : 0;
+    /// <summary>
+    ///     Reads a token count, falling back to 0 only when it is absent or not a number at all.
+    ///     Reporting 0 for a figure the upstream DID send is a worse lie than an approximate one — it
+    ///     silently zeroes a client's cost accounting — so a whole number written in floating-point
+    ///     form (<c>9.0</c>) is rounded rather than rejected, and a value too large for
+    ///     <see cref="long"/> saturates. JSON cannot express NaN or Infinity, so the cast is total.
+    /// </summary>
+    private static long TokenCount(JsonNode? node)
+    {
+        if (node is not JsonValue scalar)
+        {
+            return 0;
+        }
+
+        if (scalar.TryGetValue<long>(out var count))
+        {
+            return count;
+        }
+
+        if (!scalar.TryGetValue<double>(out var approximate))
+        {
+            return 0;
+        }
+
+        return approximate switch
+        {
+            >= long.MaxValue => long.MaxValue,
+            <= long.MinValue => long.MinValue,
+            _ => (long)Math.Round(approximate),
+        };
+    }
 
     private static string Frame(string eventName, JsonObject payload) =>
         $"event: {eventName}\ndata: {payload.ToJsonString()}\n\n";

--- a/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicSse.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicSse.cs
@@ -12,7 +12,9 @@ using System.Text.Json.Nodes;
 ///
 ///     There is deliberately no Finish(): if the upstream stream ends without a terminal event this
 ///     class emits nothing more, leaving the client to observe the truncation. Capping a failed stream
-///     with a synthetic message_stop would turn an upstream error into a silently empty success.
+///     with a synthetic message_stop would turn an upstream error into a silently empty success. A
+///     failure the upstream DOES report — an <c>error</c> or <c>response.failed</c> event — is the
+///     opposite case and is translated into Anthropic's terminal <c>error</c> event.
 /// </summary>
 public sealed class ResponsesToAnthropicSse
 {
@@ -132,10 +134,19 @@ public sealed class ResponsesToAnthropicSse
 
             // No block is opened here: unlike a text delta, a tool_use block cannot be invented after
             // the fact — its id and name only ever arrive on response.output_item.added. If that event
-            // was missing or unreadable, the arguments are dropped rather than written into whatever
-            // block happens to be open, which is what requiring the "tool_use" kind enforces.
+            // was missing or unreadable there is nowhere to put these arguments, and writing them into
+            // whatever block happens to be open would splice tool-call JSON into rendered assistant
+            // text. Dropping them silently is equally wrong: the client would be handed a tool call
+            // with no arguments, or none at all, and no way to know arguments existed. So the stream
+            // fails visibly instead.
             case "response.function_call_arguments.delta":
                 Start(frames, response);
+                if (_openKind != "tool_use" && Text(evt["delta"]) is { Length: > 0 })
+                {
+                    Fail(frames, "The upstream sent tool call arguments for a tool call it never announced.");
+                    break;
+                }
+
                 Delta(frames, "tool_use", "input_json_delta", "partial_json", Text(evt["delta"]) ?? "");
                 break;
 
@@ -150,6 +161,18 @@ public sealed class ResponsesToAnthropicSse
                 Start(frames, response);
                 CloseBlock(frames);
                 Terminate(frames, response);
+                break;
+
+            // The two ways a Responses stream reports failure. "error" is a top-level semantic event
+            // carrying {code, message, param}; "response.failed" carries the same under response.error.
+            // Both used to land in the silent default arm, so the client saw an unexplained truncation
+            // and could not tell a failure from a dropped connection.
+            case "error":
+                Fail(frames, DescribeUpstreamFailure(evt));
+                break;
+
+            case "response.failed":
+                Fail(frames, DescribeUpstreamFailure(response?["error"] as JsonObject));
                 break;
         }
 
@@ -278,6 +301,54 @@ public sealed class ResponsesToAnthropicSse
     }
 
     /// <summary>
+    ///     Ends the stream with Anthropic's terminal <c>error</c> event. No message_delta and no
+    ///     message_stop follow: the turn did not complete, and claiming it did is exactly the silent
+    ///     failure this arm exists to remove. Any open block is closed first so the client's block
+    ///     cursor is not left dangling.
+    /// </summary>
+    private void Fail(List<string> frames, string message)
+    {
+        CloseBlock(frames);
+        _finished = true;
+
+        frames.Add(
+            Frame(
+                "error",
+                new JsonObject
+                {
+                    ["type"] = "error",
+                    ["error"] = new JsonObject { ["type"] = "api_error", ["message"] = message },
+                }
+            )
+        );
+    }
+
+    /// <summary>
+    ///     Describes an upstream failure without relaying its text. A provider's error message can
+    ///     echo the prompt, tool arguments, or account details back at whoever is listening, so only
+    ///     the machine-readable <c>code</c> is passed through, and only when it looks like a code
+    ///     rather than a sentence.
+    /// </summary>
+    private static string DescribeUpstreamFailure(JsonObject? error)
+    {
+        const string fallback = "The upstream Copilot stream failed.";
+        if (Text(error?["code"]) is not { } code || !IsErrorCode(code))
+        {
+            return fallback;
+        }
+
+        return $"{fallback} Upstream code: {code}.";
+    }
+
+    /// <summary>
+    ///     True for a short token-shaped identifier such as <c>server_error</c> or
+    ///     <c>rate_limit_exceeded</c>. Anything longer or containing whitespace or punctuation is
+    ///     treated as free text and withheld.
+    /// </summary>
+    private static bool IsErrorCode(string code) =>
+        code.Length is > 0 and <= 64 && code.All(c => char.IsAsciiLetterOrDigit(c) || c is '_' or '-' or '.');
+
+    /// <summary>
     ///     Reads a JSON string, or null if <paramref name="node"/> is absent or carries another kind.
     ///     Every read of a live upstream frame goes through this rather than <c>GetValue&lt;string&gt;()</c>:
     ///     the reads happen outside the parse try/catch, and an <see cref="InvalidOperationException"/>
@@ -287,36 +358,10 @@ public sealed class ResponsesToAnthropicSse
         node is JsonValue scalar && scalar.TryGetValue<string>(out var text) ? text : null;
 
     /// <summary>
-    ///     Reads a token count, falling back to 0 only when it is absent or not a number at all.
-    ///     Reporting 0 for a figure the upstream DID send is a worse lie than an approximate one — it
-    ///     silently zeroes a client's cost accounting — so a whole number written in floating-point
-    ///     form (<c>9.0</c>) is rounded rather than rejected, and a value too large for
-    ///     <see cref="long"/> saturates. JSON cannot express NaN or Infinity, so the cast is total.
+    ///     Reads a token count through the same policy the buffered translator uses, so a streamed and
+    ///     a buffered reply cannot report the same upstream figure differently.
     /// </summary>
-    private static long TokenCount(JsonNode? node)
-    {
-        if (node is not JsonValue scalar)
-        {
-            return 0;
-        }
-
-        if (scalar.TryGetValue<long>(out var count))
-        {
-            return count;
-        }
-
-        if (!scalar.TryGetValue<double>(out var approximate))
-        {
-            return 0;
-        }
-
-        return approximate switch
-        {
-            >= long.MaxValue => long.MaxValue,
-            <= long.MinValue => long.MinValue,
-            _ => (long)Math.Round(approximate),
-        };
-    }
+    private static long TokenCount(JsonNode? node) => ResponsesToAnthropicJson.TokenCount(node);
 
     private static string Frame(string eventName, JsonObject payload) =>
         $"event: {eventName}\ndata: {payload.ToJsonString()}\n\n";

--- a/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicSse.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicSse.cs
@@ -1,0 +1,276 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+/// <summary>
+///     Rewrites an OpenAI Responses SSE stream into an Anthropic Messages SSE stream, one upstream
+///     event at a time.
+///
+///     Anthropic's stream is a block cursor — message_start, then per content block a
+///     content_block_start / deltas / content_block_stop triple at a monotonically increasing index,
+///     then message_delta with the stop reason and usage, then message_stop. Responses emits its
+///     output items in order, so tracking ONE open block is sufficient.
+///
+///     There is deliberately no Finish(): if the upstream stream ends without a terminal event this
+///     class emits nothing more, leaving the client to observe the truncation. Capping a failed stream
+///     with a synthetic message_stop would turn an upstream error into a silently empty success.
+/// </summary>
+public sealed class ResponsesToAnthropicSse
+{
+    private readonly string _fallbackMessageId;
+    private readonly string _fallbackModel;
+
+    private bool _started;
+    private bool _finished;
+    private int _nextIndex;
+    private bool _blockOpen;
+
+    /// <summary>
+    ///     <paramref name="messageId"/> and <paramref name="model"/> are used when the upstream stream
+    ///     does not announce its own — Anthropic requires both in message_start.
+    /// </summary>
+    public ResponsesToAnthropicSse(string messageId, string model)
+    {
+        _fallbackMessageId = messageId;
+        _fallbackModel = model;
+    }
+
+    /// <summary>
+    ///     Feeds one Responses SSE <c>data:</c> payload and returns the Anthropic frames it produces
+    ///     (often none). Unparseable or unrecognised payloads produce no frames rather than an error —
+    ///     a stream must not die because the upstream added an event type we have not seen.
+    /// </summary>
+    public IReadOnlyList<string> Next(string responsesEventJson)
+    {
+        if (_finished || string.IsNullOrWhiteSpace(responsesEventJson))
+        {
+            return [];
+        }
+
+        JsonObject? evt;
+        try
+        {
+            evt = JsonNode.Parse(responsesEventJson) as JsonObject;
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+
+        if (evt is null || Text(evt["type"]) is not { } type)
+        {
+            return [];
+        }
+
+        var frames = new List<string>();
+        var response = evt["response"] as JsonObject;
+        var item = evt["item"] as JsonObject;
+
+        switch (type)
+        {
+            // IDE0010 requires an explicit arm here. Every other response.* event — the *.done
+            // twins of the deltas below, response.in_progress, response.output_item.added for item
+            // types this sample does not surface — is deliberately silent.
+            default:
+                break;
+
+            case "response.created":
+                Start(frames, response);
+                break;
+
+            case "response.content_part.added"
+                when Text((evt["part"] as JsonObject)?["type"]) == "output_text":
+                Start(frames, response);
+                OpenBlock(frames, new JsonObject { ["type"] = "text", ["text"] = "" });
+                break;
+
+            case "response.output_text.delta":
+                Start(frames, response);
+                if (!_blockOpen)
+                {
+                    OpenBlock(frames, new JsonObject { ["type"] = "text", ["text"] = "" });
+                }
+
+                Delta(frames, "text_delta", "text", Text(evt["delta"]) ?? "");
+                break;
+
+            case "response.reasoning_summary_part.added":
+                Start(frames, response);
+                OpenBlock(frames, new JsonObject { ["type"] = "thinking", ["thinking"] = "" });
+                break;
+
+            case "response.reasoning_summary_text.delta":
+                Start(frames, response);
+                if (!_blockOpen)
+                {
+                    OpenBlock(frames, new JsonObject { ["type"] = "thinking", ["thinking"] = "" });
+                }
+
+                Delta(frames, "thinking_delta", "thinking", Text(evt["delta"]) ?? "");
+                break;
+
+            case "response.output_item.added" when Text(item?["type"]) == "function_call":
+                Start(frames, response);
+                OpenBlock(
+                    frames,
+                    new JsonObject
+                    {
+                        ["type"] = "tool_use",
+                        ["id"] = Text(item?["call_id"]) ?? "",
+                        ["name"] = Text(item?["name"]) ?? "",
+                        ["input"] = new JsonObject(),
+                    }
+                );
+                break;
+
+            // No block is opened here if one is not already open: unlike a text delta, a tool_use
+            // block cannot be invented after the fact — its id and name only ever arrive on
+            // response.output_item.added.
+            case "response.function_call_arguments.delta":
+                Start(frames, response);
+                Delta(frames, "input_json_delta", "partial_json", Text(evt["delta"]) ?? "");
+                break;
+
+            case "response.content_part.done":
+            case "response.output_item.done":
+            case "response.reasoning_summary_part.done":
+                CloseBlock(frames);
+                break;
+
+            case "response.completed":
+            case "response.incomplete":
+                Start(frames, response);
+                CloseBlock(frames);
+                Terminate(frames, response);
+                break;
+        }
+
+        return frames;
+    }
+
+    /// <summary>Emits message_start once, taking the id and model from the upstream response if it offered them.</summary>
+    private void Start(List<string> frames, JsonObject? response)
+    {
+        if (_started)
+        {
+            return;
+        }
+
+        _started = true;
+
+        var message = new JsonObject
+        {
+            ["id"] = Text(response?["id"]) ?? _fallbackMessageId,
+            ["type"] = "message",
+            ["role"] = "assistant",
+            ["model"] = Text(response?["model"]) ?? _fallbackModel,
+            ["content"] = new JsonArray(),
+            ["stop_reason"] = null,
+            ["stop_sequence"] = null,
+
+            // Responses does not report token counts until its terminal event; the real figures
+            // arrive in message_delta.
+            ["usage"] = new JsonObject { ["input_tokens"] = 0, ["output_tokens"] = 0 },
+        };
+
+        frames.Add(Frame("message_start", new JsonObject { ["type"] = "message_start", ["message"] = message }));
+    }
+
+    private void OpenBlock(List<string> frames, JsonObject contentBlock)
+    {
+        CloseBlock(frames);
+        _blockOpen = true;
+
+        frames.Add(
+            Frame(
+                "content_block_start",
+                new JsonObject
+                {
+                    ["type"] = "content_block_start",
+                    ["index"] = _nextIndex,
+                    ["content_block"] = contentBlock,
+                }
+            )
+        );
+    }
+
+    private void Delta(List<string> frames, string deltaType, string field, string value)
+    {
+        if (!_blockOpen || value.Length == 0)
+        {
+            return;
+        }
+
+        frames.Add(
+            Frame(
+                "content_block_delta",
+                new JsonObject
+                {
+                    ["type"] = "content_block_delta",
+                    ["index"] = _nextIndex,
+                    ["delta"] = new JsonObject { ["type"] = deltaType, [field] = value },
+                }
+            )
+        );
+    }
+
+    private void CloseBlock(List<string> frames)
+    {
+        if (!_blockOpen)
+        {
+            return;
+        }
+
+        frames.Add(
+            Frame("content_block_stop", new JsonObject { ["type"] = "content_block_stop", ["index"] = _nextIndex })
+        );
+        _blockOpen = false;
+        _nextIndex++;
+    }
+
+    private void Terminate(List<string> frames, JsonObject? response)
+    {
+        _finished = true;
+
+        var usage = response?["usage"] as JsonObject;
+
+        frames.Add(
+            Frame(
+                "message_delta",
+                new JsonObject
+                {
+                    ["type"] = "message_delta",
+                    ["delta"] = new JsonObject
+                    {
+                        ["stop_reason"] = response is null
+                            ? "end_turn"
+                            : ResponsesToAnthropicJson.DeriveStopReason(response),
+                        ["stop_sequence"] = null,
+                    },
+                    ["usage"] = new JsonObject
+                    {
+                        ["input_tokens"] = TokenCount(usage?["input_tokens"]),
+                        ["output_tokens"] = TokenCount(usage?["output_tokens"]),
+                    },
+                }
+            )
+        );
+
+        frames.Add(Frame("message_stop", new JsonObject { ["type"] = "message_stop" }));
+    }
+
+    /// <summary>
+    ///     Reads a JSON string, or null if <paramref name="node"/> is absent or carries another kind.
+    ///     Every read of a live upstream frame goes through this rather than <c>GetValue&lt;string&gt;()</c>:
+    ///     the reads happen outside the parse try/catch, and an <see cref="InvalidOperationException"/>
+    ///     escaping mid-stream would reach the client as an unexplained truncation with no error frame.
+    /// </summary>
+    private static string? Text(JsonNode? node) =>
+        node is JsonValue scalar && scalar.TryGetValue<string>(out var text) ? text : null;
+
+    /// <summary>Reads a token count, defaulting to 0 when it is absent or not a JSON integer.</summary>
+    private static int TokenCount(JsonNode? node) =>
+        node is JsonValue scalar && scalar.TryGetValue<int>(out var count) ? count : 0;
+
+    private static string Frame(string eventName, JsonObject payload) =>
+        $"event: {eventName}\ndata: {payload.ToJsonString()}\n\n";
+}

--- a/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicSse.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Translation/ResponsesToAnthropicSse.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -13,13 +14,23 @@ using System.Text.Json.Nodes;
 ///     There is deliberately no Finish(): if the upstream stream ends without a terminal event this
 ///     class emits nothing more, leaving the client to observe the truncation. Capping a failed stream
 ///     with a synthetic message_stop would turn an upstream error into a silently empty success. A
-///     failure the upstream DOES report — an <c>error</c> or <c>response.failed</c> event — is the
-///     opposite case and is translated into Anthropic's terminal <c>error</c> event.
+///     failure the upstream DOES report — an <c>error</c> or <c>response.failed</c> event, a terminal
+///     event whose response declares a failed lifecycle, or a tool call whose arguments could not be
+///     reassembled — is the opposite case and is translated into Anthropic's terminal <c>error</c>
+///     event.
 /// </summary>
 public sealed class ResponsesToAnthropicSse
 {
     private readonly string _fallbackMessageId;
     private readonly string _fallbackModel;
+
+    /// <summary>
+    ///     The argument text reassembled so far for the open <c>tool_use</c> block, exactly as it was
+    ///     forwarded to the client in <c>input_json_delta</c> frames. Anthropic's client concatenates
+    ///     those fragments and parses the result, so this is the client's view of the call — which is
+    ///     what has to be proven complete before the block is allowed to close.
+    /// </summary>
+    private readonly StringBuilder _toolArguments = new();
 
     private bool _started;
     private bool _finished;
@@ -33,6 +44,18 @@ public sealed class ResponsesToAnthropicSse
     ///     auto-open fallbacks below exist precisely because it sometimes does not.
     /// </summary>
     private string? _openKind;
+
+    /// <summary>How many deltas have been written into the open block. Reset when the block closes.</summary>
+    private int _openBlockDeltas;
+
+    /// <summary>
+    ///     Set once the upstream has reported an official refusal, through a <c>refusal</c> content
+    ///     part or a <c>response.refusal.*</c> event. The terminal event's response usually carries the
+    ///     same refusal part and <see cref="ResponsesToAnthropicJson.DeriveStopReason"/> would find it,
+    ///     but Copilot has been observed sending lean terminal payloads, and a refusal reported as
+    ///     <c>end_turn</c> is a safety decline presented to the user as a normal answer.
+    /// </summary>
+    private bool _sawRefusal;
 
     /// <summary>
     ///     <paramref name="messageId"/> and <paramref name="model"/> are used when the upstream stream
@@ -74,6 +97,7 @@ public sealed class ResponsesToAnthropicSse
         var frames = new List<string>();
         var response = evt["response"] as JsonObject;
         var item = evt["item"] as JsonObject;
+        var partType = Text((evt["part"] as JsonObject)?["type"]);
 
         switch (type)
         {
@@ -87,9 +111,11 @@ public sealed class ResponsesToAnthropicSse
                 Start(frames, response);
                 break;
 
-            case "response.content_part.added"
-                when Text((evt["part"] as JsonObject)?["type"]) == "output_text":
+            // A refusal part opens a text block, for the same reason the buffered translator emits one:
+            // Anthropic has no refusal content block and reports the decline through stop_reason.
+            case "response.content_part.added" when partType is "output_text" or "refusal":
                 Start(frames, response);
+                _sawRefusal |= partType == "refusal";
                 OpenBlock(frames, new JsonObject { ["type"] = "text", ["text"] = "" });
                 break;
 
@@ -101,6 +127,36 @@ public sealed class ResponsesToAnthropicSse
                 }
 
                 Delta(frames, "text", "text_delta", "text", Text(evt["delta"]) ?? "");
+                break;
+
+            // ResponseRefusalDeltaEvent carries its fragment under "delta", exactly like output text.
+            case "response.refusal.delta":
+                Start(frames, response);
+                _sawRefusal = true;
+                if (_openKind != "text")
+                {
+                    OpenBlock(frames, new JsonObject { ["type"] = "text", ["text"] = "" });
+                }
+
+                Delta(frames, "text", "text_delta", "text", Text(evt["delta"]) ?? "");
+                break;
+
+            // ResponseRefusalDoneEvent carries the COMPLETE refusal under "refusal", not "delta". It is
+            // the only carrier when the upstream sent no refusal deltas at all, so it is adopted then;
+            // once deltas have been forwarded, re-sending the whole text would duplicate it.
+            case "response.refusal.done":
+                Start(frames, response);
+                _sawRefusal = true;
+                if (_openKind != "text")
+                {
+                    OpenBlock(frames, new JsonObject { ["type"] = "text", ["text"] = "" });
+                }
+
+                if (_openBlockDeltas == 0)
+                {
+                    Delta(frames, "text", "text_delta", "text", Text(evt["refusal"]) ?? "");
+                }
+
                 break;
 
             case "response.reasoning_summary_part.added":
@@ -118,15 +174,31 @@ public sealed class ResponsesToAnthropicSse
                 Delta(frames, "thinking", "thinking_delta", "thinking", Text(evt["delta"]) ?? "");
                 break;
 
+            // A tool call the client can neither correlate nor dispatch is not a tool call. call_id is
+            // what the client echoes back in tool_result and name is what it dispatches on, and the
+            // only other event carrying either is output_item.done — so an announcement missing one
+            // fails the stream rather than opening a block that can never be honoured.
             case "response.output_item.added" when Text(item?["type"]) == "function_call":
                 Start(frames, response);
+                if (Text(item?["call_id"]) is not { Length: > 0 } callId)
+                {
+                    Fail(frames, "The upstream announced a tool call with no readable call id.");
+                    break;
+                }
+
+                if (Text(item?["name"]) is not { Length: > 0 } toolName)
+                {
+                    Fail(frames, "The upstream announced a tool call with no readable name.");
+                    break;
+                }
+
                 OpenBlock(
                     frames,
                     new JsonObject
                     {
                         ["type"] = "tool_use",
-                        ["id"] = Text(item?["call_id"]) ?? "",
-                        ["name"] = Text(item?["name"]) ?? "",
+                        ["id"] = callId,
+                        ["name"] = toolName,
                         ["input"] = new JsonObject(),
                     }
                 );
@@ -138,28 +210,79 @@ public sealed class ResponsesToAnthropicSse
             // whatever block happens to be open would splice tool-call JSON into rendered assistant
             // text. Dropping them silently is equally wrong: the client would be handed a tool call
             // with no arguments, or none at all, and no way to know arguments existed. So the stream
-            // fails visibly instead.
+            // fails visibly instead — and for the same reason, a fragment that cannot be READ ends the
+            // stream too. Ignoring it leaves the client concatenating a hole in the middle of the
+            // argument JSON, which either fails to parse or, worse, parses into a different call.
             case "response.function_call_arguments.delta":
                 Start(frames, response);
-                if (_openKind != "tool_use" && Text(evt["delta"]) is { Length: > 0 })
+                if (_openKind != "tool_use")
                 {
                     Fail(frames, "The upstream sent tool call arguments for a tool call it never announced.");
                     break;
                 }
 
-                Delta(frames, "tool_use", "input_json_delta", "partial_json", Text(evt["delta"]) ?? "");
+                if (Text(evt["delta"]) is not { } fragment)
+                {
+                    Fail(frames, "The upstream sent a tool call argument fragment that could not be read.");
+                    break;
+                }
+
+                _toolArguments.Append(fragment);
+                Delta(frames, "tool_use", "input_json_delta", "partial_json", fragment);
+                break;
+
+            // ResponseFunctionCallArgumentsDoneEvent carries the COMPLETE argument string. It is
+            // authoritative: it is what the model actually chose, and it is the only carrier when the
+            // deltas never arrived or could not be read.
+            case "response.function_call_arguments.done":
+                Start(frames, response);
+                if (_openKind != "tool_use")
+                {
+                    Fail(frames, "The upstream completed tool call arguments for a tool call it never announced.");
+                    break;
+                }
+
+                AdoptCompleteArguments(frames, evt["arguments"]);
                 break;
 
             case "response.content_part.done":
-            case "response.output_item.done":
+                _sawRefusal |= partType == "refusal";
+                CloseBlock(frames);
+                break;
+
             case "response.reasoning_summary_part.done":
+                CloseBlock(frames);
+                break;
+
+            // The completed item carries the final function_call, including its arguments — the last
+            // chance to reconcile what the client was streamed against what the model actually chose.
+            case "response.output_item.done":
+                if (_openKind == "tool_use" && !AdoptCompleteArguments(frames, item?["arguments"]))
+                {
+                    break;
+                }
+
                 CloseBlock(frames);
                 break;
 
             case "response.completed":
             case "response.incomplete":
                 Start(frames, response);
-                CloseBlock(frames);
+
+                // A terminal event whose own response declares a failed or unfinished lifecycle is the
+                // streamed twin of the buffered check, answered the same way rather than dressed up as
+                // a completed turn.
+                if (response is not null && ResponsesToAnthropicJson.DescribeLifecycleFailure(response) is { } broken)
+                {
+                    Fail(frames, broken);
+                    break;
+                }
+
+                if (!CloseBlock(frames))
+                {
+                    break;
+                }
+
                 Terminate(frames, response);
                 break;
 
@@ -168,11 +291,11 @@ public sealed class ResponsesToAnthropicSse
             // Both used to land in the silent default arm, so the client saw an unexplained truncation
             // and could not tell a failure from a dropped connection.
             case "error":
-                Fail(frames, DescribeUpstreamFailure(evt));
+                Fail(frames, ResponsesToAnthropicJson.DescribeUpstreamFailure(evt));
                 break;
 
             case "response.failed":
-                Fail(frames, DescribeUpstreamFailure(response?["error"] as JsonObject));
+                Fail(frames, ResponsesToAnthropicJson.DescribeUpstreamFailure(response?["error"] as JsonObject));
                 break;
         }
 
@@ -182,7 +305,7 @@ public sealed class ResponsesToAnthropicSse
     /// <summary>Emits message_start once, taking the id and model from the upstream response if it offered them.</summary>
     private void Start(List<string> frames, JsonObject? response)
     {
-        if (_started)
+        if (_started || _finished)
         {
             return;
         }
@@ -209,11 +332,16 @@ public sealed class ResponsesToAnthropicSse
 
     /// <summary>
     ///     Closes any block still open and starts a new one at the next index. The kind is taken from
-    ///     the block itself, so <see cref="_openKind"/> cannot drift from what was announced.
+    ///     the block itself, so <see cref="_openKind"/> cannot drift from what was announced. Nothing is
+    ///     opened when closing the previous block failed — the stream is already ending.
     /// </summary>
     private void OpenBlock(List<string> frames, JsonObject contentBlock)
     {
-        CloseBlock(frames);
+        if (!CloseBlock(frames))
+        {
+            return;
+        }
+
         _openKind = Text(contentBlock["type"]);
 
         frames.Add(
@@ -242,6 +370,8 @@ public sealed class ResponsesToAnthropicSse
             return;
         }
 
+        _openBlockDeltas++;
+
         frames.Add(
             Frame(
                 "content_block_delta",
@@ -255,7 +385,79 @@ public sealed class ResponsesToAnthropicSse
         );
     }
 
-    private void CloseBlock(List<string> frames)
+    /// <summary>
+    ///     Reconciles the authoritative complete argument string an upstream <c>*.done</c> event carries
+    ///     against the fragments already forwarded to the client, and returns false when the stream was
+    ///     failed instead.
+    ///
+    ///     Three cases. Absent: the event did not offer one, so the fragments remain the only source and
+    ///     <see cref="CloseBlock"/> validates them. Nothing forwarded yet: the complete string IS the
+    ///     call — ignoring it is how a lost delta could still produce a tool call announced to the
+    ///     client with <c>input: {}</c>. Already forwarded and different: the client has been streamed
+    ///     a call the model did not make and no later frame can retract it, so the stream fails.
+    /// </summary>
+    private bool AdoptCompleteArguments(List<string> frames, JsonNode? arguments)
+    {
+        if (arguments is null)
+        {
+            return true;
+        }
+
+        if (Text(arguments) is not { } complete)
+        {
+            Fail(frames, "The upstream reported completed tool call arguments that could not be read.");
+            return false;
+        }
+
+        if (_toolArguments.Length == 0)
+        {
+            _toolArguments.Append(complete);
+            Delta(frames, "tool_use", "input_json_delta", "partial_json", complete);
+            return true;
+        }
+
+        if (!string.Equals(_toolArguments.ToString(), complete, StringComparison.Ordinal))
+        {
+            Fail(frames, "The upstream's completed tool call arguments do not match the fragments it streamed.");
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    ///     Closes the open block, and returns false when the stream was failed instead of closed.
+    ///
+    ///     A <c>tool_use</c> block may only close once the argument text streamed to the client reads
+    ///     back as the JSON object Anthropic's <c>tool_use.input</c> requires — through the SAME check
+    ///     the buffered translator applies, so one argument string cannot be accepted streamed and
+    ///     rejected buffered. Closing it otherwise hands the client an executable call whose input
+    ///     silently lost every argument the model chose, which it cannot tell apart from a
+    ///     parameterless call.
+    /// </summary>
+    private bool CloseBlock(List<string> frames)
+    {
+        if (_openKind is null)
+        {
+            return true;
+        }
+
+        if (_openKind == "tool_use" && !ResponsesToAnthropicJson.TryParseArguments(_toolArguments.ToString(), out _))
+        {
+            Fail(frames, "The upstream completed a tool call whose arguments could not be reassembled.");
+            return false;
+        }
+
+        EmitBlockStop(frames);
+        return true;
+    }
+
+    /// <summary>
+    ///     Emits content_block_stop unconditionally and resets the per-block state. Used by
+    ///     <see cref="CloseBlock"/> once its checks pass, and by <see cref="Fail"/>, which must not
+    ///     re-run those checks: the stream is already ending in an error frame.
+    /// </summary>
+    private void EmitBlockStop(List<string> frames)
     {
         if (_openKind is null)
         {
@@ -266,6 +468,8 @@ public sealed class ResponsesToAnthropicSse
             Frame("content_block_stop", new JsonObject { ["type"] = "content_block_stop", ["index"] = _nextIndex })
         );
         _openKind = null;
+        _openBlockDeltas = 0;
+        _toolArguments.Clear();
         _nextIndex++;
     }
 
@@ -281,13 +485,7 @@ public sealed class ResponsesToAnthropicSse
                 new JsonObject
                 {
                     ["type"] = "message_delta",
-                    ["delta"] = new JsonObject
-                    {
-                        ["stop_reason"] = response is null
-                            ? "end_turn"
-                            : ResponsesToAnthropicJson.DeriveStopReason(response),
-                        ["stop_sequence"] = null,
-                    },
+                    ["delta"] = new JsonObject { ["stop_reason"] = StopReason(response), ["stop_sequence"] = null },
                     ["usage"] = new JsonObject
                     {
                         ["input_tokens"] = TokenCount(usage?["input_tokens"]),
@@ -301,6 +499,22 @@ public sealed class ResponsesToAnthropicSse
     }
 
     /// <summary>
+    ///     The stop reason for the terminal message_delta. A refusal seen ON THE STREAM outranks the
+    ///     terminal payload: that payload is what the buffered translator would read and the two must
+    ///     not disagree, but a lean terminal payload that omits the refusal part must not downgrade a
+    ///     decline this translator already watched arrive.
+    /// </summary>
+    private string StopReason(JsonObject? response)
+    {
+        if (_sawRefusal)
+        {
+            return "refusal";
+        }
+
+        return response is null ? "end_turn" : ResponsesToAnthropicJson.DeriveStopReason(response);
+    }
+
+    /// <summary>
     ///     Ends the stream with Anthropic's terminal <c>error</c> event. No message_delta and no
     ///     message_stop follow: the turn did not complete, and claiming it did is exactly the silent
     ///     failure this arm exists to remove. Any open block is closed first so the client's block
@@ -308,7 +522,7 @@ public sealed class ResponsesToAnthropicSse
     /// </summary>
     private void Fail(List<string> frames, string message)
     {
-        CloseBlock(frames);
+        EmitBlockStop(frames);
         _finished = true;
 
         frames.Add(
@@ -322,31 +536,6 @@ public sealed class ResponsesToAnthropicSse
             )
         );
     }
-
-    /// <summary>
-    ///     Describes an upstream failure without relaying its text. A provider's error message can
-    ///     echo the prompt, tool arguments, or account details back at whoever is listening, so only
-    ///     the machine-readable <c>code</c> is passed through, and only when it looks like a code
-    ///     rather than a sentence.
-    /// </summary>
-    private static string DescribeUpstreamFailure(JsonObject? error)
-    {
-        const string fallback = "The upstream Copilot stream failed.";
-        if (Text(error?["code"]) is not { } code || !IsErrorCode(code))
-        {
-            return fallback;
-        }
-
-        return $"{fallback} Upstream code: {code}.";
-    }
-
-    /// <summary>
-    ///     True for a short token-shaped identifier such as <c>server_error</c> or
-    ///     <c>rate_limit_exceeded</c>. Anything longer or containing whitespace or punctuation is
-    ///     treated as free text and withheld.
-    /// </summary>
-    private static bool IsErrorCode(string code) =>
-        code.Length is > 0 and <= 64 && code.All(c => char.IsAsciiLetterOrDigit(c) || c is '_' or '-' or '.');
 
     /// <summary>
     ///     Reads a JSON string, or null if <paramref name="node"/> is absent or carries another kind.

--- a/tests/CopilotAnthropicProxy.Tests/AnthropicToResponsesRequestTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/AnthropicToResponsesRequestTests.cs
@@ -1,0 +1,167 @@
+using System.Text.Json;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+public class AnthropicToResponsesRequestTests
+{
+    private static JsonElement TranslateToElement(string anthropicJson) =>
+        JsonDocument.Parse(AnthropicToResponsesRequest.Translate(anthropicJson)).RootElement.Clone();
+
+    [Fact]
+    public void Translates_a_plain_text_turn()
+    {
+        var result = TranslateToElement(
+            """
+            {"model":"gpt-5.3-codex","max_tokens":1024,"stream":true,
+             "messages":[{"role":"user","content":"Hello"}]}
+            """
+        );
+
+        result.GetProperty("model").GetString().Should().Be("gpt-5.3-codex");
+        result.GetProperty("max_output_tokens").GetInt32().Should().Be(1024);
+        result.GetProperty("stream").GetBoolean().Should().BeTrue();
+        result.GetProperty("store").GetBoolean().Should().BeFalse();
+
+        var item = result.GetProperty("input")[0];
+        item.GetProperty("type").GetString().Should().Be("message");
+        item.GetProperty("role").GetString().Should().Be("user");
+        item.GetProperty("content")[0].GetProperty("type").GetString().Should().Be("input_text");
+        item.GetProperty("content")[0].GetProperty("text").GetString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public void Clamps_the_model_validation_probe_to_the_minimum_output_tokens()
+    {
+        // Claude Code's first request against any new model is `max_tokens: 1`. The Responses API
+        // rejects max_output_tokens < 16, so without this clamp EVERY GPT model is rejected on sight.
+        var result = TranslateToElement(
+            """
+            {"model":"gpt-5.3-codex","max_tokens":1,
+             "messages":[{"role":"user","content":[{"type":"text","text":"Hi"}]}]}
+            """
+        );
+
+        result.GetProperty("max_output_tokens").GetInt32().Should().Be(AnthropicToResponsesRequest.MinimumOutputTokens);
+    }
+
+    [Fact]
+    public void Flattens_a_system_block_array_into_instructions()
+    {
+        // Claude Code ALWAYS sends `system` as an array of text blocks, never a bare string.
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,
+             "system":[{"type":"text","text":"You are terse.","cache_control":{"type":"ephemeral","ttl":"1h"}},
+                       {"type":"text","text":"Answer in English."}],
+             "messages":[{"role":"user","content":"Hi"}]}
+            """
+        );
+
+        result.GetProperty("instructions").GetString().Should().Be("You are terse.\n\nAnswer in English.");
+    }
+
+    [Fact]
+    public void Accepts_the_legacy_bare_string_system_prompt()
+    {
+        var result = TranslateToElement(
+            """{"model":"m","max_tokens":100,"system":"Be brief.","messages":[{"role":"user","content":"Hi"}]}"""
+        );
+
+        result.GetProperty("instructions").GetString().Should().Be("Be brief.");
+    }
+
+    [Fact]
+    public void Turns_tool_use_and_tool_result_into_top_level_items()
+    {
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"messages":[
+              {"role":"user","content":"weather?"},
+              {"role":"assistant","content":[
+                 {"type":"text","text":"checking"},
+                 {"type":"tool_use","id":"call_1","name":"get_weather","input":{"city":"Paris"}}]},
+              {"role":"user","content":[
+                 {"type":"tool_result","tool_use_id":"call_1","content":[{"type":"text","text":"18C"}]}]}
+            ]}
+            """
+        );
+
+        var input = result.GetProperty("input");
+        input.GetArrayLength().Should().Be(4);
+
+        input[1].GetProperty("type").GetString().Should().Be("message");
+        input[1].GetProperty("content")[0].GetProperty("type").GetString().Should().Be("output_text");
+
+        input[2].GetProperty("type").GetString().Should().Be("function_call");
+        input[2].GetProperty("call_id").GetString().Should().Be("call_1");
+        input[2].GetProperty("name").GetString().Should().Be("get_weather");
+        input[2].GetProperty("arguments").GetString().Should().Be("""{"city":"Paris"}""");
+
+        input[3].GetProperty("type").GetString().Should().Be("function_call_output");
+        input[3].GetProperty("call_id").GetString().Should().Be("call_1");
+        input[3].GetProperty("output").GetString().Should().Be("18C");
+    }
+
+    [Fact]
+    public void Maps_function_tools_and_drops_server_tools()
+    {
+        // web_search_20250305 has no input_schema. Copilot answers
+        // 400 "The use of the web search tool is not supported." if it is forwarded.
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"messages":[{"role":"user","content":"hi"}],
+             "tools":[
+               {"name":"get_weather","description":"Weather.","input_schema":{"type":"object","properties":{}}},
+               {"type":"web_search_20250305","name":"web_search","max_uses":8}],
+             "tool_choice":{"type":"any"}}
+            """
+        );
+
+        var tools = result.GetProperty("tools");
+        tools.GetArrayLength().Should().Be(1);
+        tools[0].GetProperty("type").GetString().Should().Be("function");
+        tools[0].GetProperty("name").GetString().Should().Be("get_weather");
+        tools[0].GetProperty("parameters").GetProperty("type").GetString().Should().Be("object");
+
+        result.GetProperty("tool_choice").GetString().Should().Be("required");
+    }
+
+    [Fact]
+    public void Drops_fields_the_responses_api_would_reject()
+    {
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"betas":["context-management-2025-06-27"],
+             "stop_sequences":["</severity>"],"metadata":{"user_id":"abc"},
+             "messages":[{"role":"user","content":[
+               {"type":"thinking","thinking":"hmm","signature":"sig"},
+               {"type":"text","text":"Hi","cache_control":{"type":"ephemeral","scope":"global"}}]}]}
+            """
+        );
+
+        result.TryGetProperty("betas", out _).Should().BeFalse();
+        result.TryGetProperty("stop_sequences", out _).Should().BeFalse();
+        result.TryGetProperty("metadata", out _).Should().BeFalse();
+
+        var content = result.GetProperty("input")[0].GetProperty("content");
+        content.GetArrayLength().Should().Be(1, "thinking blocks are not replayed");
+        content[0].GetProperty("text").GetString().Should().Be("Hi");
+        content[0].TryGetProperty("cache_control", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Maps_a_base64_image_block_to_a_data_url()
+    {
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"messages":[{"role":"user","content":[
+              {"type":"image","source":{"type":"base64","media_type":"image/png","data":"AAAA"}}]}]}
+            """
+        );
+
+        var part = result.GetProperty("input")[0].GetProperty("content")[0];
+        part.GetProperty("type").GetString().Should().Be("input_image");
+        part.GetProperty("image_url").GetString().Should().Be("data:image/png;base64,AAAA");
+    }
+}

--- a/tests/CopilotAnthropicProxy.Tests/AnthropicToResponsesRequestTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/AnthropicToResponsesRequestTests.cs
@@ -259,7 +259,78 @@ public class AnthropicToResponsesRequestTests
         reasoning
             .TryGetProperty("effort", out _)
             .Should()
-            .BeFalse("choosing an effort would change how much every model thinks, and how much it costs");
+            .BeFalse("a request that never enabled thinking must cost exactly what it costs today");
+    }
+
+    [Theory]
+    [InlineData(1024, "low")]
+    [InlineData(4096, "low")] // Claude Code's lowest tier
+    [InlineData(8191, "low")]
+    [InlineData(8192, "medium")] // boundary: the low/medium threshold is exclusive below
+    [InlineData(10240, "medium")] // Claude Code's middle tier
+    [InlineData(24575, "medium")]
+    [InlineData(24576, "high")] // boundary: the medium/high threshold is inclusive above
+    [InlineData(32768, "high")] // Claude Code's top tier
+    public void Maps_the_thinking_budget_onto_a_reasoning_effort(int budgetTokens, string expected)
+    {
+        var result = TranslateToElement(
+            $$"""
+            {"model":"m","max_tokens":100,"thinking":{"type":"enabled","budget_tokens":{{budgetTokens}}},
+             "messages":[{"role":"user","content":"Hi"}]}
+            """
+        );
+
+        var reasoning = result.GetProperty("reasoning");
+        reasoning.GetProperty("effort").GetString().Should().Be(expected);
+        reasoning.GetProperty("summary").GetString().Should().Be("auto", "summaries are asked for either way");
+    }
+
+    [Fact]
+    public void Treats_enabled_thinking_with_no_budget_as_medium_effort()
+    {
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"thinking":{"type":"enabled"},
+             "messages":[{"role":"user","content":"Hi"}]}
+            """
+        );
+
+        result.GetProperty("reasoning").GetProperty("effort").GetString().Should().Be("medium");
+    }
+
+    [Theory]
+    [InlineData("""{"type":"disabled"}""")]
+    [InlineData("""{"type":"enabled_but_not_really"}""")]
+    [InlineData("""{"budget_tokens":32768}""")] // a budget without type:enabled is not a request to think
+    [InlineData("""{"type":null}""")]
+    [InlineData("\"enabled\"")] // a bare string where an object belongs must not throw
+    [InlineData("null")]
+    public void Sends_no_effort_unless_thinking_is_explicitly_enabled(string thinking)
+    {
+        var result = TranslateToElement(
+            $$"""
+            {"model":"m","max_tokens":100,"thinking":{{thinking}},
+             "messages":[{"role":"user","content":"Hi"}]}
+            """
+        );
+
+        var reasoning = result.GetProperty("reasoning");
+        reasoning.TryGetProperty("effort", out _).Should().BeFalse();
+        reasoning.GetProperty("summary").GetString().Should().Be("auto");
+    }
+
+    [Fact]
+    public void Does_not_forward_the_thinking_field_itself()
+    {
+        // Responses has no top-level `thinking`; it is consumed into `reasoning` and must not leak.
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"thinking":{"type":"enabled","budget_tokens":10240},
+             "messages":[{"role":"user","content":"Hi"}]}
+            """
+        );
+
+        result.TryGetProperty("thinking", out _).Should().BeFalse();
     }
 
     [Fact]

--- a/tests/CopilotAnthropicProxy.Tests/AnthropicToResponsesRequestTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/AnthropicToResponsesRequestTests.cs
@@ -245,6 +245,51 @@ public class AnthropicToResponsesRequestTests
     }
 
     [Fact]
+    public void Always_asks_for_reasoning_summaries()
+    {
+        // Without this field the Responses stream carries no reasoning_summary events, so the
+        // translated route can never produce a thinking block. It is sent on every request — no
+        // opt-in, no model sniffing — which is why it is asserted on the plainest possible body.
+        var result = TranslateToElement(
+            """{"model":"m","max_tokens":100,"messages":[{"role":"user","content":"Hi"}]}"""
+        );
+
+        var reasoning = result.GetProperty("reasoning");
+        reasoning.GetProperty("summary").GetString().Should().Be("auto");
+        reasoning
+            .TryGetProperty("effort", out _)
+            .Should()
+            .BeFalse("choosing an effort would change how much every model thinks, and how much it costs");
+    }
+
+    [Fact]
+    public void Passes_temperature_and_top_p_through()
+    {
+        // Probed live before being allowed through: OpenAI documents its own reasoning models as
+        // rejecting a non-default temperature, which would have made this a 400 on every such request.
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"temperature":0.7,"top_p":0.5,
+             "messages":[{"role":"user","content":"Hi"}]}
+            """
+        );
+
+        result.GetProperty("temperature").GetDouble().Should().Be(0.7);
+        result.GetProperty("top_p").GetDouble().Should().Be(0.5);
+    }
+
+    [Fact]
+    public void Omits_temperature_and_top_p_when_the_client_sent_neither()
+    {
+        var result = TranslateToElement(
+            """{"model":"m","max_tokens":100,"messages":[{"role":"user","content":"Hi"}]}"""
+        );
+
+        result.TryGetProperty("temperature", out _).Should().BeFalse();
+        result.TryGetProperty("top_p", out _).Should().BeFalse();
+    }
+
+    [Fact]
     public void Maps_a_base64_image_block_to_a_data_url()
     {
         var result = TranslateToElement(

--- a/tests/CopilotAnthropicProxy.Tests/AnthropicToResponsesRequestTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/AnthropicToResponsesRequestTests.cs
@@ -299,7 +299,6 @@ public class AnthropicToResponsesRequestTests
     }
 
     [Theory]
-    [InlineData("""{"type":"disabled"}""")]
     [InlineData("""{"type":"enabled_but_not_really"}""")]
     [InlineData("""{"budget_tokens":32768}""")] // a budget without type:enabled is not a request to think
     [InlineData("""{"type":null}""")]
@@ -317,6 +316,75 @@ public class AnthropicToResponsesRequestTests
         var reasoning = result.GetProperty("reasoning");
         reasoning.TryGetProperty("effort", out _).Should().BeFalse();
         reasoning.GetProperty("summary").GetString().Should().Be("auto");
+    }
+
+    [Fact]
+    public void Maps_explicitly_disabled_thinking_onto_effort_none()
+    {
+        // "disabled" is not "never mentioned": several Copilot models default to a non-none effort, so
+        // omitting the field bills the caller for reasoning the client just turned off.
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"thinking":{"type":"disabled"},
+             "messages":[{"role":"user","content":"Hi"}]}
+            """
+        );
+
+        var reasoning = result.GetProperty("reasoning");
+        reasoning.GetProperty("effort").GetString().Should().Be("none");
+        reasoning.GetProperty("summary").GetString().Should().Be("auto");
+    }
+
+    [Fact]
+    public void Propagates_disable_parallel_tool_use_as_parallel_tool_calls_false()
+    {
+        // Anthropic defaults this to false and carries it inside tool_choice; Responses defaults the
+        // top-level flag to TRUE. Dropping it lets a client that serialises its tool loop receive
+        // several tool calls in one turn.
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"messages":[{"role":"user","content":"hi"}],
+             "tools":[{"name":"get_weather","input_schema":{"type":"object"}}],
+             "tool_choice":{"type":"auto","disable_parallel_tool_use":true}}
+            """
+        );
+
+        result.GetProperty("parallel_tool_calls").GetBoolean().Should().BeFalse();
+        result.GetProperty("tool_choice").GetString().Should().Be("auto");
+    }
+
+    [Theory]
+    [InlineData("""{"type":"auto","disable_parallel_tool_use":false}""")]
+    [InlineData("""{"type":"auto"}""")]
+    [InlineData("""{"type":"auto","disable_parallel_tool_use":"true"}""")] // wrong kind must not throw
+    public void Never_invents_parallel_tool_calls_the_client_did_not_ask_for(string toolChoice)
+    {
+        // Sending parallel_tool_calls: true for every other request would be an instruction the client
+        // never gave, so only an explicit `true` is translated.
+        var result = TranslateToElement(
+            $$"""
+            {"model":"m","max_tokens":100,"messages":[{"role":"user","content":"hi"}],
+             "tools":[{"name":"get_weather","input_schema":{"type":"object"} }],
+             "tool_choice":{{toolChoice}} }
+            """
+        );
+
+        result.TryGetProperty("parallel_tool_calls", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Omits_parallel_tool_calls_when_no_tools_survive_filtering()
+    {
+        // The flag is meaningless without tools, and Responses rejects it alongside an absent `tools`.
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"messages":[{"role":"user","content":"hi"}],
+             "tools":[{"type":"web_search_20250305","name":"web_search","max_uses":8}],
+             "tool_choice":{"type":"any","disable_parallel_tool_use":true}}
+            """
+        );
+
+        result.TryGetProperty("parallel_tool_calls", out _).Should().BeFalse();
     }
 
     [Fact]

--- a/tests/CopilotAnthropicProxy.Tests/AnthropicToResponsesRequestTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/AnthropicToResponsesRequestTests.cs
@@ -45,6 +45,30 @@ public class AnthropicToResponsesRequestTests
         result.GetProperty("max_output_tokens").GetInt32().Should().Be(AnthropicToResponsesRequest.MinimumOutputTokens);
     }
 
+    [Theory]
+    [InlineData(1, 16)]
+    [InlineData(15, 16)]
+    [InlineData(16, 16)]
+    [InlineData(17, 17)]
+    public void Clamps_max_tokens_at_the_minimum_output_tokens_boundary(int maxTokens, int expected)
+    {
+        var result = TranslateToElement(
+            $$"""{"model":"m","max_tokens":{{maxTokens}},"messages":[{"role":"user","content":"Hi"}]}"""
+        );
+
+        result.GetProperty("max_output_tokens").GetInt32().Should().Be(expected);
+    }
+
+    [Fact]
+    public void Defaults_stream_to_false_when_absent()
+    {
+        var result = TranslateToElement(
+            """{"model":"m","max_tokens":100,"messages":[{"role":"user","content":"Hi"}]}"""
+        );
+
+        result.GetProperty("stream").GetBoolean().Should().BeFalse();
+    }
+
     [Fact]
     public void Flattens_a_system_block_array_into_instructions()
     {
@@ -125,6 +149,76 @@ public class AnthropicToResponsesRequestTests
         tools[0].GetProperty("parameters").GetProperty("type").GetString().Should().Be("object");
 
         result.GetProperty("tool_choice").GetString().Should().Be("required");
+    }
+
+    [Theory]
+    [InlineData("auto", "auto")]
+    [InlineData("none", "none")]
+    public void Maps_tool_choice_auto_and_none(string anthropicType, string expected)
+    {
+        var result = TranslateToElement(
+            $$$"""
+            {"model":"m","max_tokens":100,"messages":[{"role":"user","content":"hi"}],
+             "tools":[{"name":"get_weather","input_schema":{"type":"object"}}],
+             "tool_choice":{"type":"{{{anthropicType}}}"}}
+            """
+        );
+
+        result.GetProperty("tool_choice").GetString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void Maps_tool_choice_naming_a_specific_tool()
+    {
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"messages":[{"role":"user","content":"hi"}],
+             "tools":[{"name":"get_weather","input_schema":{"type":"object"}}],
+             "tool_choice":{"type":"tool","name":"get_weather"}}
+            """
+        );
+
+        var toolChoice = result.GetProperty("tool_choice");
+        toolChoice.GetProperty("type").GetString().Should().Be("function");
+        toolChoice.GetProperty("name").GetString().Should().Be("get_weather");
+    }
+
+    [Fact]
+    public void Omits_tool_choice_when_no_function_tools_survive_filtering()
+    {
+        // Every tool here is a server tool (no input_schema), so BuildTools produces an empty array.
+        // Emitting `tool_choice` alongside an absent `tools` is a Responses 400 ("'tool_choice' is
+        // only allowed when 'tools' are specified") — a legal Anthropic request must not become that.
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"messages":[{"role":"user","content":"hi"}],
+             "tools":[{"type":"web_search_20250305","name":"web_search","max_uses":8}],
+             "tool_choice":{"type":"any"}}
+            """
+        );
+
+        result.TryGetProperty("tools", out _).Should().BeFalse();
+        result.TryGetProperty("tool_choice", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Omits_tool_choice_naming_a_tool_that_filtering_dropped()
+    {
+        // tool_choice names the server tool that BuildTools' input_schema filter removed from `tools`.
+        // Forwarding {"type":"function","name":"web_search"} would point Responses at a tool that no
+        // longer exists in the request, so the safer behavior is to omit tool_choice entirely.
+        var result = TranslateToElement(
+            """
+            {"model":"m","max_tokens":100,"messages":[{"role":"user","content":"hi"}],
+             "tools":[
+               {"name":"get_weather","input_schema":{"type":"object"}},
+               {"type":"web_search_20250305","name":"web_search","max_uses":8}],
+             "tool_choice":{"type":"tool","name":"web_search"}}
+            """
+        );
+
+        result.GetProperty("tools").GetArrayLength().Should().Be(1, "only get_weather survives the filter");
+        result.TryGetProperty("tool_choice", out _).Should().BeFalse();
     }
 
     [Fact]

--- a/tests/CopilotAnthropicProxy.Tests/EndpointBehaviorTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/EndpointBehaviorTests.cs
@@ -106,10 +106,15 @@ public sealed class EndpointBehaviorTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var node = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        node["object"]!.GetValue<string>().Should().Be("list");
         node["has_more"]!.GetValue<bool>().Should().BeFalse();
         var first = node["data"]!.AsArray()[0]!;
         first["type"]!.GetValue<string>().Should().Be("model");
+        first["object"]!.GetValue<string>().Should().Be("model");
         first["id"]!.GetValue<string>().Should().Be(ProxyWebAppFactory.ConfiguredModel);
+        // Pinned mode carries no vendor metadata, so owned_by falls back to the proxy's own label.
+        first["owned_by"]!.GetValue<string>().Should().Be("copilot");
+        first["created"]!.GetValue<long>().Should().BeGreaterThan(0);
     }
 
     [Fact]

--- a/tests/CopilotAnthropicProxy.Tests/HostGuardTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/HostGuardTests.cs
@@ -111,4 +111,52 @@ public sealed class HostGuardTests
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
+
+    [Theory]
+    [InlineData("/v1/chat/completions")]
+    [InlineData("/chat/completions")]
+    [InlineData("/v1/responses")]
+    [InlineData("/responses")]
+    public async Task An_openai_caller_is_refused_in_the_openai_error_shape(string path)
+    {
+        // The guard used to answer every route in Anthropic's envelope. An OpenAI SDK deserialises
+        // `error` into its own type and reads `error.type` / `error.code`; handed
+        // {"type":"error","error":{...}} it raises a DESERIALISATION failure instead of the 403 it knows
+        // how to report, so the operator sees a parse error rather than "this proxy refused you".
+        await using var factory = new ProxyWebAppFactory((req, ct) => Task.FromResult(TestUpstream.Json("{}")));
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, path);
+        request.Headers.TryAddWithoutValidation("Sec-Fetch-Site", "cross-site");
+
+        using var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        var node = System.Text.Json.Nodes.JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        node["error"]!["message"]!.GetValue<string>().Should().NotBeNullOrEmpty();
+        node["error"]!["type"]!.GetValue<string>().Should().Be("permission_error");
+        node["type"].Should().BeNull("the Anthropic envelope's top-level discriminator has no place here");
+    }
+
+    [Theory]
+    [InlineData("/v1/messages")]
+    [InlineData("/messages")]
+    [InlineData("/v1/models")]
+    public async Task An_anthropic_caller_is_refused_in_the_anthropic_error_shape(string path)
+    {
+        await using var factory = new ProxyWebAppFactory((req, ct) => Task.FromResult(TestUpstream.Json("{}")));
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, path);
+        request.Headers.TryAddWithoutValidation("Sec-Fetch-Site", "cross-site");
+
+        using var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        var node = System.Text.Json.Nodes.JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        node["type"]!.GetValue<string>().Should().Be("error");
+        node["error"]!["type"]!.GetValue<string>().Should().Be("permission_error");
+    }
 }

--- a/tests/CopilotAnthropicProxy.Tests/ModelDiscoveryPassthroughTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ModelDiscoveryPassthroughTests.cs
@@ -6,9 +6,9 @@ using FluentAssertions;
 namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
 
 /// <summary>
-///     End-to-end coverage for the no-override discovery path: GET /v1/models lists every
-///     /v1/messages-capable Copilot model, and POST /v1/messages passes a recognized model through
-///     unchanged instead of always rewriting to the default.
+///     End-to-end coverage for the no-override discovery path: GET /v1/models lists every servable
+///     Copilot model, and POST /v1/messages passes a recognized model through unchanged instead of
+///     always rewriting to the default.
 /// </summary>
 public sealed class ModelDiscoveryPassthroughTests
 {
@@ -22,8 +22,9 @@ public sealed class ModelDiscoveryPassthroughTests
 
     /// <summary>
     ///     A real (sanitized) <c>GET /models</c> response body captured from
-    ///     <c>api.enterprise.githubcopilot.com</c> — 34 models, of which 7 support <c>/v1/messages</c>,
-    ///     including three concurrent <c>claude-opus-*</c> versions (4.6, 4.7, 4.8).
+    ///     <c>api.enterprise.githubcopilot.com</c> — 34 models, of which 13 are servable (advertise a
+    ///     reachable endpoint and a non-excluded vendor), including three concurrent <c>claude-opus-*</c>
+    ///     versions (4.6, 4.7, 4.8).
     /// </summary>
     private static string RealModelsResponseJson =>
         File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "copilot-models-real-response.json"));
@@ -46,7 +47,7 @@ public sealed class ModelDiscoveryPassthroughTests
     }
 
     [Fact]
-    public async Task Models_endpoint_lists_the_real_captured_copilot_response_messages_capable_models()
+    public async Task Models_endpoint_lists_the_real_captured_copilot_response_servable_models()
     {
         await using var factory = new ProxyWebAppFactory(
             (req, ct) =>
@@ -69,6 +70,12 @@ public sealed class ModelDiscoveryPassthroughTests
                 "claude-opus-4.8",
                 "claude-sonnet-4.6",
                 "claude-sonnet-5",
+                "gpt-5.3-codex",
+                "gpt-5.4-mini",
+                "gpt-5.4-nano",
+                "gpt-5.4",
+                "gpt-5.5",
+                "gpt-5-mini",
                 "claude-sonnet-4.5",
                 "claude-haiku-4.5"
             );
@@ -85,7 +92,11 @@ public sealed class ModelDiscoveryPassthroughTests
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var node = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
         var ids = node["data"]!.AsArray().Select(m => m!["id"]!.GetValue<string>());
-        ids.Should().BeEquivalentTo(["claude-opus-4.8", "claude-sonnet-4.5"], "gpt-5.4 does not support /v1/messages");
+        ids.Should()
+            .BeEquivalentTo(
+                ["claude-opus-4.8", "claude-sonnet-4.5", "gpt-5.4"],
+                "gpt-5.4 advertises /responses, which this proxy can also forward to"
+            );
     }
 
     [Fact]

--- a/tests/CopilotAnthropicProxy.Tests/ModelDiscoveryPassthroughTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ModelDiscoveryPassthroughTests.cs
@@ -83,7 +83,7 @@ public sealed class ModelDiscoveryPassthroughTests
     }
 
     [Fact]
-    public async Task Models_endpoint_lists_only_messages_capable_models_when_discovering()
+    public async Task Models_endpoint_lists_only_servable_models_when_discovering()
     {
         await using var factory = DiscoveryFactory((req, ct) => Task.FromResult(TestUpstream.Json("{}")));
         using var client = factory.CreateClient();

--- a/tests/CopilotAnthropicProxy.Tests/ModelDiscoveryPassthroughTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ModelDiscoveryPassthroughTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using FluentAssertions;
 
@@ -141,6 +142,28 @@ public sealed class ModelDiscoveryPassthroughTests
 
         response.IsSuccessStatusCode.Should().BeTrue();
         JsonNode.Parse(forwardedBody!)!["model"]!.GetValue<string>().Should().Be("claude-opus-4.8");
+    }
+
+    [Fact]
+    public async Task Models_endpoint_serves_a_body_both_dialects_can_read()
+    {
+        await using var factory = DiscoveryFactory((req, ct) => Task.FromResult(TestUpstream.Json("{}")));
+        using var client = factory.CreateClient();
+
+        using var doc = JsonDocument.Parse(await client.GetStringAsync("/v1/models"));
+        var root = doc.RootElement;
+
+        root.GetProperty("object").GetString().Should().Be("list", "OpenAI clients key off this");
+        root.GetProperty("has_more").GetBoolean().Should().BeFalse();
+
+        var first = root.GetProperty("data")[0];
+        first.GetProperty("type").GetString().Should().Be("model", "Anthropic clients key off this");
+        first.GetProperty("object").GetString().Should().Be("model", "OpenAI clients key off this");
+        first.GetProperty("id").GetString().Should().NotBeNullOrWhiteSpace();
+        first.GetProperty("display_name").GetString().Should().NotBeNullOrWhiteSpace();
+        first.GetProperty("owned_by").GetString().Should().NotBeNullOrWhiteSpace();
+        first.GetProperty("created").GetInt64().Should().BeGreaterThan(0);
+        first.GetProperty("created_at").GetString().Should().NotBeNullOrWhiteSpace();
     }
 
     [Fact]

--- a/tests/CopilotAnthropicProxy.Tests/ModelDiscoveryPassthroughTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ModelDiscoveryPassthroughTests.cs
@@ -161,9 +161,37 @@ public sealed class ModelDiscoveryPassthroughTests
         first.GetProperty("object").GetString().Should().Be("model", "OpenAI clients key off this");
         first.GetProperty("id").GetString().Should().NotBeNullOrWhiteSpace();
         first.GetProperty("display_name").GetString().Should().NotBeNullOrWhiteSpace();
-        first.GetProperty("owned_by").GetString().Should().NotBeNullOrWhiteSpace();
+        first
+            .GetProperty("owned_by")
+            .GetString()
+            .Should()
+            .Be("copilot", "DiscoveryJson entries carry no \"vendor\" key, so owned_by falls back");
         first.GetProperty("created").GetInt64().Should().BeGreaterThan(0);
         first.GetProperty("created_at").GetString().Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Models_endpoint_passes_a_populated_vendor_through_as_owned_by()
+    {
+        await using var factory = new ProxyWebAppFactory(
+            (req, ct) =>
+                req.Method == HttpMethod.Get && req.RequestUri!.AbsolutePath == "/models"
+                    ? Task.FromResult(TestUpstream.Json(RealModelsResponseJson))
+                    : Task.FromResult(TestUpstream.Json("{}")),
+            model: null
+        );
+        using var client = factory.CreateClient();
+
+        using var doc = JsonDocument.Parse(await client.GetStringAsync("/v1/models"));
+        var first = doc.RootElement.GetProperty("data")[0];
+
+        // The real fixture's first servable entry is claude-opus-4.6 with "vendor":"Anthropic".
+        first.GetProperty("id").GetString().Should().Be("claude-opus-4.6");
+        first
+            .GetProperty("owned_by")
+            .GetString()
+            .Should()
+            .Be("Anthropic", "a populated vendor should pass through unchanged, not fall back to \"copilot\"");
     }
 
     [Fact]

--- a/tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs
@@ -327,6 +327,38 @@ public sealed class ModelResolverTests
         ProxyModelResolver.SelectOutboundModel("claude-sonnet-4.5", catalog).Should().Be("claude-sonnet-4.5");
     }
 
+    private static ProxyModelCatalog FamilyCatalog =>
+        new(
+            "claude-opus-4.8",
+            [
+                new ProxyModelInfo("claude-opus-4.8", "Anthropic", [CopilotModelsResponse.MessagesEndpoint]),
+                new ProxyModelInfo("claude-sonnet-4.5", "Anthropic", [CopilotModelsResponse.MessagesEndpoint]),
+                new ProxyModelInfo("claude-haiku-4.5", "Anthropic", [CopilotModelsResponse.MessagesEndpoint]),
+            ]
+        );
+
+    [Theory]
+    [InlineData("claude-3-5-haiku-20241022", "claude-haiku-4.5")]
+    [InlineData("claude-haiku-4-5-20251001", "claude-haiku-4.5")]
+    [InlineData("claude-sonnet-4-20250514", "claude-sonnet-4.5")]
+    [InlineData("claude-3-opus-20240229", "claude-opus-4.8")]
+    public void SelectOutboundModel_maps_an_unknown_id_onto_its_own_family(string incoming, string expected)
+    {
+        ProxyModelResolver.SelectOutboundModel(incoming, FamilyCatalog).Should().Be(expected);
+    }
+
+    [Fact]
+    public void SelectOutboundModel_falls_back_to_the_default_when_no_family_matches()
+    {
+        ProxyModelResolver.SelectOutboundModel("some-unknown-model", FamilyCatalog).Should().Be("claude-opus-4.8");
+    }
+
+    [Fact]
+    public void SelectOutboundModel_still_prefers_an_exact_match_over_a_family_match()
+    {
+        ProxyModelResolver.SelectOutboundModel("claude-haiku-4.5", FamilyCatalog).Should().Be("claude-haiku-4.5");
+    }
+
     [Fact]
     public void PeekModel_reads_the_model_field_without_mutating_the_body()
     {

--- a/tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs
@@ -1,3 +1,4 @@
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
 using AchieveAi.LmDotnetTools.LmTestUtils;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -12,8 +13,9 @@ public sealed class ModelResolverTests
 {
     /// <summary>
     ///     A real (sanitized) <c>GET /models</c> response body captured from
-    ///     <c>api.enterprise.githubcopilot.com</c> — 34 models, of which 7 support <c>/v1/messages</c>,
-    ///     including three concurrent <c>claude-opus-*</c> versions (4.6, 4.7, 4.8) in that upstream order.
+    ///     <c>api.enterprise.githubcopilot.com</c> — 34 models, of which 13 are servable (advertise a
+    ///     reachable endpoint and a non-excluded vendor), including three concurrent <c>claude-opus-*</c>
+    ///     versions (4.6, 4.7, 4.8) in that upstream order.
     /// </summary>
     private static string RealModelsResponseJson =>
         File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "copilot-models-real-response.json"));
@@ -49,32 +51,54 @@ public sealed class ModelResolverTests
     }
 
     [Fact]
-    public void ParseMessagesCapableModelIds_keeps_only_ids_whose_supported_endpoints_include_v1_messages()
+    public void ParseServableModels_keeps_models_with_a_reachable_endpoint_and_a_servable_vendor()
     {
         const string json = """
-            {"data":[
-                {"id":"claude-opus-4.8","supported_endpoints":["/v1/messages","/chat/completions"]},
-                {"id":"claude-sonnet-4.5","supported_endpoints":["/v1/messages"]},
-                {"id":"gpt-5.4","supported_endpoints":["/responses","ws:/responses"]},
-                {"id":"gemini-2.5-pro","supported_endpoints":["/chat/completions"]},
-                {"id":"gpt-4o"}
-            ]}
-            """;
+        {"data":[
+          {"id":"claude-opus-4.8","vendor":"Anthropic","supported_endpoints":["/v1/messages","/chat/completions"]},
+          {"id":"gpt-5.3-codex","vendor":"OpenAI","supported_endpoints":["/responses","ws:/responses"]},
+          {"id":"gemini-3.5-flash","vendor":"Google","supported_endpoints":["/chat/completions"]},
+          {"id":"mai-code-1-flash-picker","vendor":"Microsoft","supported_endpoints":["/responses"]},
+          {"id":"text-embedding-3-small","vendor":"Azure OpenAI","supported_endpoints":[]}
+        ]}
+        """;
 
-        ProxyModelResolver.ParseMessagesCapableModelIds(json).Should().Equal("claude-opus-4.8", "claude-sonnet-4.5");
+        var models = ProxyModelResolver.ParseServableModels(json);
+
+        models.Select(m => m.Id).Should().Equal("claude-opus-4.8", "gpt-5.3-codex");
+        models[0].Vendor.Should().Be("Anthropic");
+        models[0].Supports(CopilotModelsResponse.MessagesEndpoint).Should().BeTrue();
+        models[0].Supports(CopilotModelsResponse.ResponsesEndpoint).Should().BeFalse();
+        models[0].IsAnthropic.Should().BeTrue();
+        models[1].Supports(CopilotModelsResponse.ResponsesEndpoint).Should().BeTrue();
+        models[1].IsAnthropic.Should().BeFalse();
     }
 
     [Fact]
-    public void ParseMessagesCapableModelIds_falls_back_to_id_only_when_no_entry_has_endpoint_metadata()
+    public void ParseServableModels_falls_back_to_every_id_when_no_entry_has_endpoint_metadata()
     {
         const string json = """
-            {"data":[
-                {"id":"claude-opus-4.8"},
-                {"id":"claude-sonnet-4.5"}
-            ]}
-            """;
+        {"data":[{"id":"claude-opus-4.8"},{"id":"claude-sonnet-4.5"}]}
+        """;
 
-        ProxyModelResolver.ParseMessagesCapableModelIds(json).Should().Equal("claude-opus-4.8", "claude-sonnet-4.5");
+        var models = ProxyModelResolver.ParseServableModels(json);
+
+        models.Select(m => m.Id).Should().Equal("claude-opus-4.8", "claude-sonnet-4.5");
+        models.Should().OnlyContain(m => m.Endpoints.Count == 0, "no-metadata entries carry no endpoints");
+    }
+
+    [Fact]
+    public void Catalog_find_is_case_insensitive_and_returns_null_for_unknown_ids()
+    {
+        var catalog = new ProxyModelCatalog(
+            "claude-opus-4.8",
+            [new ProxyModelInfo("claude-opus-4.8", "Anthropic", [CopilotModelsResponse.MessagesEndpoint])]
+        );
+
+        catalog.Find("CLAUDE-OPUS-4.8")!.Id.Should().Be("claude-opus-4.8");
+        catalog.Find("nope").Should().BeNull();
+        catalog.Find(null).Should().BeNull();
+        catalog.Available.Should().Equal("claude-opus-4.8");
     }
 
     [Fact]
@@ -115,7 +139,7 @@ public sealed class ModelResolverTests
         );
 
         catalog.Default.Should().Be("claude-opus-4.8");
-        catalog.Available.Should().Equal("claude-sonnet-4.5", "claude-opus-4.8");
+        catalog.Available.Should().Equal("gpt-4o", "claude-sonnet-4.5", "claude-opus-4.8");
     }
 
     [Fact]
@@ -212,10 +236,11 @@ public sealed class ModelResolverTests
     }
 
     [Fact]
-    public void ParseMessagesCapableModelIds_matches_the_real_captured_copilot_response()
+    public void ParseServableModels_matches_the_real_captured_copilot_response()
     {
         ProxyModelResolver
-            .ParseMessagesCapableModelIds(RealModelsResponseJson)
+            .ParseServableModels(RealModelsResponseJson)
+            .Select(m => m.Id)
             .Should()
             .Equal(
                 "claude-opus-4.6",
@@ -223,6 +248,12 @@ public sealed class ModelResolverTests
                 "claude-opus-4.8",
                 "claude-sonnet-4.6",
                 "claude-sonnet-5",
+                "gpt-5.3-codex",
+                "gpt-5.4-mini",
+                "gpt-5.4-nano",
+                "gpt-5.4",
+                "gpt-5.5",
+                "gpt-5-mini",
                 "claude-sonnet-4.5",
                 "claude-haiku-4.5"
             );
@@ -249,6 +280,12 @@ public sealed class ModelResolverTests
                 "claude-opus-4.8",
                 "claude-sonnet-4.6",
                 "claude-sonnet-5",
+                "gpt-5.3-codex",
+                "gpt-5.4-mini",
+                "gpt-5.4-nano",
+                "gpt-5.4",
+                "gpt-5.5",
+                "gpt-5-mini",
                 "claude-sonnet-4.5",
                 "claude-haiku-4.5"
             );
@@ -265,7 +302,13 @@ public sealed class ModelResolverTests
         string expected
     )
     {
-        var catalog = new ProxyModelCatalog("claude-opus-4.8", ["claude-sonnet-4.5", "claude-opus-4.8"]);
+        var catalog = new ProxyModelCatalog(
+            "claude-opus-4.8",
+            [
+                new ProxyModelInfo("claude-sonnet-4.5", "Anthropic", [CopilotModelsResponse.MessagesEndpoint]),
+                new ProxyModelInfo("claude-opus-4.8", "Anthropic", [CopilotModelsResponse.MessagesEndpoint]),
+            ]
+        );
 
         ProxyModelResolver.SelectOutboundModel(incoming, catalog).Should().Be(expected);
     }
@@ -273,7 +316,13 @@ public sealed class ModelResolverTests
     [Fact]
     public void SelectOutboundModel_passes_through_a_non_default_available_model()
     {
-        var catalog = new ProxyModelCatalog("claude-opus-4.8", ["claude-sonnet-4.5", "claude-opus-4.8"]);
+        var catalog = new ProxyModelCatalog(
+            "claude-opus-4.8",
+            [
+                new ProxyModelInfo("claude-sonnet-4.5", "Anthropic", [CopilotModelsResponse.MessagesEndpoint]),
+                new ProxyModelInfo("claude-opus-4.8", "Anthropic", [CopilotModelsResponse.MessagesEndpoint]),
+            ]
+        );
 
         ProxyModelResolver.SelectOutboundModel("claude-sonnet-4.5", catalog).Should().Be("claude-sonnet-4.5");
     }

--- a/tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ModelResolverTests.cs
@@ -360,6 +360,68 @@ public sealed class ModelResolverTests
     }
 
     [Fact]
+    public void ParseServableModels_drops_metadata_free_entries_when_any_sibling_declares_endpoints()
+    {
+        // The all-or-nothing fallback only fires when NOT ONE entry carries supported_endpoints. In a
+        // MIXED response the metadata is trustworthy, so an entry that declares none declares that it
+        // serves none — keeping it would advertise a model every route then answers 404 for.
+        const string json = """
+        {"data":[
+          {"id":"claude-opus-4.8","vendor":"Anthropic","supported_endpoints":["/v1/messages"]},
+          {"id":"mystery-model","vendor":"Anthropic"},
+          {"id":"embedding-only","vendor":"Anthropic","supported_endpoints":[]}
+        ]}
+        """;
+
+        var models = ProxyModelResolver.ParseServableModels(json);
+
+        models.Select(m => m.Id).Should().Equal("claude-opus-4.8");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_gives_a_pinned_model_the_endpoints_the_operator_declared()
+    {
+        // Pinned mode skips discovery, so the catalog entry has no capability metadata and every
+        // dialect check answers "this model does not serve that endpoint" — which made the translated
+        // Anthropic-to-Responses route unreachable for a pinned GPT model. The operator can now supply
+        // the metadata discovery would have provided.
+        var handler = new FakeHttpMessageHandler(
+            (req, ct) => throw new InvalidOperationException("upstream must not be called when an override is set")
+        );
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://upstream.test") };
+
+        var catalog = await ProxyModelResolver.ResolveAsync(
+            client,
+            modelOverride: "gpt-5.3-codex",
+            NullLogger.Instance,
+            CancellationToken.None,
+            pinnedEndpoints: ["/responses"]
+        );
+
+        catalog.Default.Should().Be("gpt-5.3-codex");
+        catalog.Find("gpt-5.3-codex")!.Supports(CopilotModelsResponse.ResponsesEndpoint).Should().BeTrue();
+        catalog.Find("gpt-5.3-codex")!.Supports(CopilotModelsResponse.MessagesEndpoint).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_leaves_a_pinned_model_endpointless_when_the_operator_declared_nothing()
+    {
+        // Unchanged default: no metadata is not the same as "serves everything", and inventing the
+        // endpoints would make the proxy claim capabilities nobody verified.
+        var handler = new FakeHttpMessageHandler((req, ct) => throw new InvalidOperationException("no upstream"));
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://upstream.test") };
+
+        var catalog = await ProxyModelResolver.ResolveAsync(
+            client,
+            modelOverride: "my-pinned-model",
+            NullLogger.Instance,
+            CancellationToken.None
+        );
+
+        catalog.Find("my-pinned-model")!.Endpoints.Should().BeEmpty();
+    }
+
+    [Fact]
     public void PeekModel_reads_the_model_field_without_mutating_the_body()
     {
         var body = System.Text.Encoding.UTF8.GetBytes("{\"model\":\"claude-sonnet-4.5\",\"max_tokens\":5}");

--- a/tests/CopilotAnthropicProxy.Tests/ModelRewriteTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ModelRewriteTests.cs
@@ -173,4 +173,74 @@ public sealed class ModelRewriteTests
         JsonNode.Parse(forwardedBody!)!["model"]!.GetValue<string>()
             .Should().Be(ProxyWebAppFactory.ConfiguredModel);
     }
+
+    [Fact]
+    public void TryRewriteModel_strips_hosted_tools_but_keeps_client_defined_ones()
+    {
+        // Live-probed 2026-07-28: Copilot's /responses 400s on image_generation, local_shell,
+        // code_interpreter and mcp. It accepts web_search, which is dropped anyway because it is
+        // still a hosted tool and the translated Anthropic route drops web_search_20250305 too.
+        const string json = """
+        {
+          "model": "gpt-5.3-codex",
+          "tools": [
+            { "type": "function", "name": "shell", "parameters": { "type": "object" } },
+            { "type": "image_generation" },
+            { "type": "custom", "name": "apply_patch" },
+            { "type": "local_shell" },
+            { "type": "code_interpreter", "container": { "type": "auto" } },
+            { "type": "mcp", "server_label": "x" },
+            { "type": "web_search" }
+          ]
+        }
+        """;
+
+        var ok = ProxyModelResolver.TryRewriteModel(
+            Encoding.UTF8.GetBytes(json), "gpt-5.3-codex", out var rewritten, out _, stripHostedTools: true);
+
+        ok.Should().BeTrue();
+        var tools = JsonNode.Parse(rewritten)!["tools"]!.AsArray();
+        tools.Select(t => t!["type"]!.GetValue<string>()).Should().Equal("function", "custom");
+        tools[0]!["name"]!.GetValue<string>().Should().Be("shell");
+        tools[1]!["name"]!.GetValue<string>().Should().Be("apply_patch", "current Codex sends apply_patch as a freeform custom tool");
+    }
+
+    [Fact]
+    public void TryRewriteModel_removes_the_tools_key_when_every_tool_is_hosted()
+    {
+        var body = Encoding.UTF8.GetBytes("""{"model":"m","tools":[{"type":"image_generation"}]}""");
+
+        var ok = ProxyModelResolver.TryRewriteModel(
+            body, "gpt-5.3-codex", out var rewritten, out _, stripHostedTools: true);
+
+        ok.Should().BeTrue();
+        JsonNode.Parse(rewritten)!.AsObject().ContainsKey("tools").Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryRewriteModel_drops_tool_entries_that_are_not_typed_objects()
+    {
+        var body = Encoding.UTF8.GetBytes(
+            """{"model":"m","tools":["nonsense",42,null,{"noType":true},{"type":7},{"type":"function","name":"ok"}]}""");
+
+        var ok = ProxyModelResolver.TryRewriteModel(
+            body, "gpt-5.3-codex", out var rewritten, out _, stripHostedTools: true);
+
+        ok.Should().BeTrue();
+        var tools = JsonNode.Parse(rewritten)!["tools"]!.AsArray();
+        tools.Should().HaveCount(1);
+        tools[0]!["name"]!.GetValue<string>().Should().Be("ok");
+    }
+
+    [Fact]
+    public void TryRewriteModel_leaves_tools_alone_when_hosted_stripping_is_off()
+    {
+        // The Anthropic and Chat Completions routes forward tools verbatim; only Responses filters.
+        var body = Encoding.UTF8.GetBytes("""{"model":"m","tools":[{"type":"image_generation"}]}""");
+
+        var ok = ProxyModelResolver.TryRewriteModel(body, "opus-x", out var rewritten, out _);
+
+        ok.Should().BeTrue();
+        JsonNode.Parse(rewritten)!["tools"]!.AsArray().Should().HaveCount(1);
+    }
 }

--- a/tests/CopilotAnthropicProxy.Tests/ModelRewriteTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ModelRewriteTests.cs
@@ -243,4 +243,102 @@ public sealed class ModelRewriteTests
         ok.Should().BeTrue();
         JsonNode.Parse(rewritten)!["tools"]!.AsArray().Should().HaveCount(1);
     }
+
+    [Fact]
+    public void TryRewriteModel_drops_tool_choice_when_every_tool_was_stripped()
+    {
+        // Responses answers 400 "'tool_choice' is only allowed when 'tools' are specified". Removing the
+        // tools and leaving the choice behind converts a request Copilot merely could not run into one it
+        // refuses outright — the proxy manufacturing an invalid body out of a valid one.
+        var body = Encoding.UTF8.GetBytes(
+            """{"model":"m","tools":[{"type":"image_generation"}],"tool_choice":"required"}"""
+        );
+
+        var ok = ProxyModelResolver.TryRewriteModel(
+            body, "gpt-5.3-codex", out var rewritten, out _, stripHostedTools: true);
+
+        ok.Should().BeTrue();
+        var obj = JsonNode.Parse(rewritten)!.AsObject();
+        obj.ContainsKey("tools").Should().BeFalse();
+        obj.ContainsKey("tool_choice").Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryRewriteModel_drops_a_tool_choice_naming_a_tool_that_was_stripped()
+    {
+        var body = Encoding.UTF8.GetBytes(
+            """
+            {"model":"m",
+             "tools":[{"type":"function","name":"shell"},{"type":"image_generation","name":"draw"}],
+             "tool_choice":{"type":"function","name":"draw"}}
+            """
+        );
+
+        var ok = ProxyModelResolver.TryRewriteModel(
+            body, "gpt-5.3-codex", out var rewritten, out _, stripHostedTools: true);
+
+        ok.Should().BeTrue();
+        var obj = JsonNode.Parse(rewritten)!.AsObject();
+        obj["tools"]!.AsArray().Should().HaveCount(1);
+        obj.ContainsKey("tool_choice").Should().BeFalse("the named tool is no longer in the request");
+    }
+
+    [Fact]
+    public void TryRewriteModel_keeps_a_tool_choice_that_the_surviving_tools_can_still_satisfy()
+    {
+        // Over-removal is its own defect: dropping a satisfiable choice silently turns a forced tool call
+        // into an optional one, and the client cannot tell.
+        var body = Encoding.UTF8.GetBytes(
+            """
+            {"model":"m",
+             "tools":[{"type":"function","name":"shell"},{"type":"image_generation"}],
+             "tool_choice":{"type":"function","name":"shell"}}
+            """
+        );
+
+        var ok = ProxyModelResolver.TryRewriteModel(
+            body, "gpt-5.3-codex", out var rewritten, out _, stripHostedTools: true);
+
+        ok.Should().BeTrue();
+        var obj = JsonNode.Parse(rewritten)!.AsObject();
+        obj["tools"]!.AsArray().Should().HaveCount(1);
+        obj["tool_choice"]!["name"]!.GetValue<string>().Should().Be("shell");
+    }
+
+    [Theory]
+    [InlineData("\"auto\"")]
+    [InlineData("\"required\"")]
+    [InlineData("\"none\"")]
+    public void TryRewriteModel_keeps_a_bare_string_tool_choice_while_any_tool_survives(string choice)
+    {
+        var body = Encoding.UTF8.GetBytes(
+            $$"""
+            {"model":"m",
+             "tools":[{"type":"function","name":"shell"},{"type":"image_generation"}],
+             "tool_choice":{{choice}}}
+            """
+        );
+
+        var ok = ProxyModelResolver.TryRewriteModel(
+            body, "gpt-5.3-codex", out var rewritten, out _, stripHostedTools: true);
+
+        ok.Should().BeTrue();
+        JsonNode.Parse(rewritten)!.AsObject().ContainsKey("tool_choice").Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryRewriteModel_leaves_tool_choice_untouched_when_no_tool_was_stripped()
+    {
+        // Nothing was filtered, so nothing may be second-guessed: a choice naming a tool this proxy does
+        // not recognise is still the client's to send.
+        var body = Encoding.UTF8.GetBytes(
+            """{"model":"m","tools":[{"type":"function","name":"shell"}],"tool_choice":{"type":"custom","name":"unknown"}}"""
+        );
+
+        var ok = ProxyModelResolver.TryRewriteModel(
+            body, "gpt-5.3-codex", out var rewritten, out _, stripHostedTools: true);
+
+        ok.Should().BeTrue();
+        JsonNode.Parse(rewritten)!["tool_choice"]!["name"]!.GetValue<string>().Should().Be("unknown");
+    }
 }

--- a/tests/CopilotAnthropicProxy.Tests/ModelRouteTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ModelRouteTests.cs
@@ -1,0 +1,85 @@
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+public class ModelRouteTests
+{
+    private static ProxyModelInfo Dual =>
+        new("claude-opus-4.8", "Anthropic", [CopilotModelsResponse.MessagesEndpoint, ProxyModelResolver.ChatCompletionsEndpoint]);
+
+    private static ProxyModelInfo ResponsesOnly =>
+        new("gpt-5.3-codex", "OpenAI", [CopilotModelsResponse.ResponsesEndpoint]);
+
+    private static ProxyModelInfo ResponsesAndChat =>
+        new("gpt-5.4", "OpenAI", [CopilotModelsResponse.ResponsesEndpoint, ProxyModelResolver.ChatCompletionsEndpoint]);
+
+    private static ProxyModelInfo NoMetadata => new("pinned-model", "", []);
+
+    [Fact]
+    public void Anthropic_dialect_passes_through_for_a_messages_capable_model()
+    {
+        var route = ModelRouter.Resolve(ProxyDialect.AnthropicMessages, Dual);
+
+        route.Should().NotBeNull();
+        route!.Kind.Should().Be(ProxyRouteKind.Passthrough);
+        route.UpstreamPath.Should().Be("/v1/messages");
+    }
+
+    [Fact]
+    public void Anthropic_dialect_translates_for_a_responses_only_model()
+    {
+        var route = ModelRouter.Resolve(ProxyDialect.AnthropicMessages, ResponsesOnly);
+
+        route.Should().NotBeNull();
+        route!.Kind.Should().Be(ProxyRouteKind.TranslateAnthropicToResponses);
+        route.UpstreamPath.Should().Be("/responses");
+    }
+
+    [Fact]
+    public void Anthropic_dialect_prefers_passthrough_when_a_model_serves_both()
+    {
+        // gpt-5.4 advertises /responses AND /chat/completions but NOT /v1/messages, so it translates.
+        ModelRouter.Resolve(ProxyDialect.AnthropicMessages, ResponsesAndChat)!
+            .Kind.Should().Be(ProxyRouteKind.TranslateAnthropicToResponses);
+    }
+
+    [Fact]
+    public void A_model_with_no_endpoint_metadata_is_treated_as_anthropic_capable()
+    {
+        var route = ModelRouter.Resolve(ProxyDialect.AnthropicMessages, NoMetadata);
+
+        route.Should().NotBeNull();
+        route!.Kind.Should().Be(ProxyRouteKind.Passthrough);
+    }
+
+    [Fact]
+    public void Chat_completions_dialect_passes_through_only_for_models_that_advertise_it()
+    {
+        ModelRouter.Resolve(ProxyDialect.ChatCompletions, Dual)!.UpstreamPath.Should().Be("/chat/completions");
+        ModelRouter.Resolve(ProxyDialect.ChatCompletions, ResponsesOnly).Should().BeNull();
+    }
+
+    [Fact]
+    public void Responses_dialect_passes_through_only_for_models_that_advertise_it()
+    {
+        ModelRouter.Resolve(ProxyDialect.Responses, ResponsesOnly)!.UpstreamPath.Should().Be("/responses");
+        ModelRouter.Resolve(ProxyDialect.Responses, Dual).Should().BeNull();
+    }
+
+    [Fact]
+    public void A_pinned_model_cannot_serve_the_responses_dialect()
+    {
+        // Pinned mode has no endpoint metadata, so we cannot claim Responses support.
+        ModelRouter.Resolve(ProxyDialect.Responses, NoMetadata).Should().BeNull();
+    }
+
+    [Fact]
+    public void Servable_lists_the_ids_that_can_serve_a_dialect()
+    {
+        var catalog = new ProxyModelCatalog("claude-opus-4.8", [Dual, ResponsesOnly, ResponsesAndChat]);
+
+        ModelRouter.Servable(ProxyDialect.Responses, catalog).Should().Equal("gpt-5.3-codex", "gpt-5.4");
+        ModelRouter.Servable(ProxyDialect.ChatCompletions, catalog).Should().Equal("claude-opus-4.8", "gpt-5.4");
+    }
+}

--- a/tests/CopilotAnthropicProxy.Tests/ModelRouteTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ModelRouteTests.cs
@@ -75,10 +75,21 @@ public class ModelRouteTests
     }
 
     [Fact]
+    public void A_pinned_model_is_treated_as_chat_completions_capable()
+    {
+        var route = ModelRouter.Resolve(ProxyDialect.ChatCompletions, NoMetadata);
+
+        route.Should().NotBeNull();
+        route!.Kind.Should().Be(ProxyRouteKind.Passthrough);
+        route.UpstreamPath.Should().Be("/chat/completions");
+    }
+
+    [Fact]
     public void Servable_lists_the_ids_that_can_serve_a_dialect()
     {
         var catalog = new ProxyModelCatalog("claude-opus-4.8", [Dual, ResponsesOnly, ResponsesAndChat]);
 
+        ModelRouter.Servable(ProxyDialect.AnthropicMessages, catalog).Should().Equal("claude-opus-4.8", "gpt-5.3-codex", "gpt-5.4");
         ModelRouter.Servable(ProxyDialect.Responses, catalog).Should().Equal("gpt-5.3-codex", "gpt-5.4");
         ModelRouter.Servable(ProxyDialect.ChatCompletions, catalog).Should().Equal("claude-opus-4.8", "gpt-5.4");
     }

--- a/tests/CopilotAnthropicProxy.Tests/OpenAiDialectTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/OpenAiDialectTests.cs
@@ -163,30 +163,39 @@ public class OpenAiDialectTests
     }
 
     [Fact]
-    public async Task Messages_returns_a_translation_specific_404_for_a_responses_only_model()
+    public async Task Messages_serves_a_model_without_messages_support_by_translating_to_responses()
     {
-        await using var factory = Factory((_, _) => throw new InvalidOperationException("must not be forwarded"));
+        // Replaces an earlier test that pinned the interim "translation is not implemented yet" 404 —
+        // that branch is what this endpoint's translated path exists to remove. gpt-5.4 advertises
+        // /responses and /chat/completions but NOT /v1/messages, so an Anthropic Messages request for it
+        // is translated rather than routed away. TranslatedMessagesTests covers the translation itself;
+        // this keeps the dialect x model table in this file complete.
+        string? seenPath = null;
+        await using var factory = Factory(
+            (_, path) =>
+            {
+                seenPath = path;
+                return Task.FromResult(TestUpstream.Json("""{"id":"resp_2","model":"gpt-5.4","output":[]}"""));
+            }
+        );
         using var client = factory.CreateClient();
 
         var response = await client.PostAsJsonAsync(
             "/v1/messages",
-            new { model = "gpt-5.3-codex", messages = Array.Empty<object>() }
+            new
+            {
+                model = "gpt-5.4",
+                max_tokens = 64,
+                messages = Array.Empty<object>(),
+            }
         );
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        seenPath.Should().Be("/responses");
 
-        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
-        var message = error.RootElement.GetProperty("error").GetProperty("message").GetString();
-        message.Should().Contain("gpt-5.3-codex");
-        message
-            .Should()
-            .Contain("translat", "gpt-5.3-codex needs Anthropic-to-Responses translation, not a plain routing miss");
-        message
-            .Should()
-            .NotContain(
-                "available",
-                "a model pending translation support must not be described as available on this endpoint"
-            );
+        using var message = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        message.RootElement.GetProperty("type").GetString().Should().Be("message");
+        message.RootElement.GetProperty("model").GetString().Should().Be("gpt-5.4");
     }
 
     [Fact]

--- a/tests/CopilotAnthropicProxy.Tests/OpenAiDialectTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/OpenAiDialectTests.cs
@@ -1,0 +1,178 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+public class OpenAiDialectTests
+{
+    private const string DiscoveryJson = """
+    {"data":[
+      {"id":"claude-opus-4.8","vendor":"Anthropic","supported_endpoints":["/v1/messages","/chat/completions"]},
+      {"id":"gpt-5.4","vendor":"OpenAI","supported_endpoints":["/responses","/chat/completions"]},
+      {"id":"gpt-5.3-codex","vendor":"OpenAI","supported_endpoints":["/responses"]}
+    ]}
+    """;
+
+    /// <summary>
+    ///     Builds a factory whose upstream answers startup discovery from <see cref="DiscoveryJson"/>
+    ///     and hands every other request to <paramref name="onProxied"/>, recording the path it hit.
+    /// </summary>
+    private static ProxyWebAppFactory Factory(
+        Func<HttpRequestMessage, string, Task<HttpResponseMessage>> onProxied
+    ) =>
+        new(
+            async (request, _) =>
+            {
+                var path = request.RequestUri!.AbsolutePath;
+                if (request.Method == HttpMethod.Get && path.EndsWith("/models", StringComparison.Ordinal))
+                {
+                    return TestUpstream.Json(DiscoveryJson);
+                }
+
+                return await onProxied(request, path);
+            },
+            model: null
+        );
+
+    [Fact]
+    public async Task Chat_completions_forwards_to_the_upstream_chat_completions_path()
+    {
+        string? seenPath = null;
+        await using var factory = Factory(
+            (_, path) =>
+            {
+                seenPath = path;
+                return Task.FromResult(TestUpstream.Json("""{"id":"x","choices":[]}"""));
+            }
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/chat/completions",
+            new { model = "claude-opus-4.8", messages = Array.Empty<object>() }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        seenPath.Should().Be("/chat/completions");
+    }
+
+    [Fact]
+    public async Task Chat_completions_renames_max_tokens_for_a_non_anthropic_model()
+    {
+        string? body = null;
+        await using var factory = Factory(
+            async (request, _) =>
+            {
+                body = await request.Content!.ReadAsStringAsync();
+                return TestUpstream.Json("""{"id":"x","choices":[]}""");
+            }
+        );
+        using var client = factory.CreateClient();
+
+        _ = await client.PostAsJsonAsync(
+            "/v1/chat/completions",
+            new
+            {
+                model = "gpt-5.4",
+                max_tokens = 256,
+                messages = Array.Empty<object>(),
+            }
+        );
+
+        using var sent = JsonDocument.Parse(body!);
+        sent.RootElement.TryGetProperty("max_tokens", out _).Should().BeFalse();
+        sent.RootElement.GetProperty("max_completion_tokens").GetInt32().Should().Be(256);
+    }
+
+    [Fact]
+    public async Task Chat_completions_keeps_max_tokens_for_an_anthropic_model()
+    {
+        string? body = null;
+        await using var factory = Factory(
+            async (request, _) =>
+            {
+                body = await request.Content!.ReadAsStringAsync();
+                return TestUpstream.Json("""{"id":"x","choices":[]}""");
+            }
+        );
+        using var client = factory.CreateClient();
+
+        _ = await client.PostAsJsonAsync(
+            "/v1/chat/completions",
+            new
+            {
+                model = "claude-opus-4.8",
+                max_tokens = 256,
+                messages = Array.Empty<object>(),
+            }
+        );
+
+        using var sent = JsonDocument.Parse(body!);
+        sent.RootElement.GetProperty("max_tokens").GetInt32().Should().Be(256);
+        sent.RootElement.TryGetProperty("max_completion_tokens", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Responses_forwards_to_the_upstream_responses_path()
+    {
+        string? seenPath = null;
+        await using var factory = Factory(
+            (_, path) =>
+            {
+                seenPath = path;
+                return Task.FromResult(TestUpstream.Json("""{"id":"resp_1","output":[]}"""));
+            }
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/responses",
+            new { model = "gpt-5.3-codex", input = Array.Empty<object>() }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        seenPath.Should().Be("/responses");
+    }
+
+    [Fact]
+    public async Task Responses_returns_an_openai_shaped_404_for_a_model_that_cannot_serve_it()
+    {
+        await using var factory = Factory((_, _) => throw new InvalidOperationException("must not be forwarded"));
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/responses",
+            new { model = "claude-opus-4.8", input = Array.Empty<object>() }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var message = error.RootElement.GetProperty("error").GetProperty("message").GetString();
+        message.Should().Contain("claude-opus-4.8");
+        message.Should().Contain("gpt-5.4").And.Contain("gpt-5.3-codex", "the 404 must name what IS servable");
+    }
+
+    [Fact]
+    public async Task The_unprefixed_twins_are_bound_too()
+    {
+        await using var factory = Factory(
+            (_, _) => Task.FromResult(TestUpstream.Json("""{"id":"x","choices":[]}"""))
+        );
+        using var client = factory.CreateClient();
+
+        var chat = await client.PostAsJsonAsync(
+            "/chat/completions",
+            new { model = "claude-opus-4.8", messages = Array.Empty<object>() }
+        );
+        var responses = await client.PostAsJsonAsync(
+            "/responses",
+            new { model = "gpt-5.3-codex", input = Array.Empty<object>() }
+        );
+
+        chat.StatusCode.Should().Be(HttpStatusCode.OK);
+        responses.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/tests/CopilotAnthropicProxy.Tests/OpenAiDialectTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/OpenAiDialectTests.cs
@@ -137,6 +137,43 @@ public class OpenAiDialectTests
     }
 
     [Fact]
+    public async Task Responses_strips_hosted_tools_before_forwarding()
+    {
+        // Codex CLI advertises the hosted image_generation tool on every request and cannot be told
+        // not to, so this filter is the difference between Codex working through the proxy and a
+        // hard 400 from Copilot.
+        string? forwardedBody = null;
+        await using var factory = Factory(
+            async (request, _) =>
+            {
+                forwardedBody = await request.Content!.ReadAsStringAsync();
+                return TestUpstream.Json("""{"id":"resp_1","output":[]}""");
+            }
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/responses",
+            new
+            {
+                model = "gpt-5.3-codex",
+                input = Array.Empty<object>(),
+                tools = new object[]
+                {
+                    new { type = "image_generation" },
+                    new { type = "function", name = "shell" },
+                },
+            }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var sent = JsonDocument.Parse(forwardedBody!);
+        var tools = sent.RootElement.GetProperty("tools").EnumerateArray().ToArray();
+        tools.Should().HaveCount(1);
+        tools[0].GetProperty("name").GetString().Should().Be("shell");
+    }
+
+    [Fact]
     public async Task Responses_returns_an_openai_shaped_404_for_a_model_that_cannot_serve_it()
     {
         await using var factory = Factory((_, _) => throw new InvalidOperationException("must not be forwarded"));

--- a/tests/CopilotAnthropicProxy.Tests/OpenAiDialectTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/OpenAiDialectTests.cs
@@ -150,9 +150,43 @@ public class OpenAiDialectTests
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
         using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
-        var message = error.RootElement.GetProperty("error").GetProperty("message").GetString();
+        error.RootElement.TryGetProperty("type", out _).Should().BeFalse("an OpenAI error has no top-level type");
+
+        var err = error.RootElement.GetProperty("error");
+        err.GetProperty("type").GetString().Should().Be("not_found_error");
+        err.GetProperty("param").ValueKind.Should().Be(JsonValueKind.Null);
+        err.GetProperty("code").ValueKind.Should().Be(JsonValueKind.Null);
+
+        var message = err.GetProperty("message").GetString();
         message.Should().Contain("claude-opus-4.8");
         message.Should().Contain("gpt-5.4").And.Contain("gpt-5.3-codex", "the 404 must name what IS servable");
+    }
+
+    [Fact]
+    public async Task Messages_returns_a_translation_specific_404_for_a_responses_only_model()
+    {
+        await using var factory = Factory((_, _) => throw new InvalidOperationException("must not be forwarded"));
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            new { model = "gpt-5.3-codex", messages = Array.Empty<object>() }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var message = error.RootElement.GetProperty("error").GetProperty("message").GetString();
+        message.Should().Contain("gpt-5.3-codex");
+        message
+            .Should()
+            .Contain("translat", "gpt-5.3-codex needs Anthropic-to-Responses translation, not a plain routing miss");
+        message
+            .Should()
+            .NotContain(
+                "available",
+                "a model pending translation support must not be described as available on this endpoint"
+            );
     }
 
     [Fact]

--- a/tests/CopilotAnthropicProxy.Tests/PassthroughTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/PassthroughTests.cs
@@ -43,6 +43,34 @@ public sealed class PassthroughTests
     }
 
     [Fact]
+    public async Task An_upstream_response_header_nobody_asked_for_does_not_reach_the_client()
+    {
+        // Response headers are relayed by ALLOWLIST. A denylist forwards by default, so a provider or
+        // any intermediary between it and this proxy can plant something in the client's HTTP context —
+        // a cookie, a redirect, a tracking id — and it arrives until someone remembers to name it.
+        var headers = new Dictionary<string, string>
+        {
+            ["Set-Cookie"] = "session=stolen; Path=/",
+            ["x-some-gateway-trace"] = "internal-hostname-42",
+            ["request-id"] = "req_abc123",
+        };
+
+        await using var factory = new ProxyWebAppFactory(
+            (req, ct) => Task.FromResult(TestUpstream.Json("{\"type\":\"message\"}", HttpStatusCode.OK, headers))
+        );
+        using var client = factory.CreateClient();
+
+        using var response = await client.PostAsync("/v1/messages", ValidBody());
+
+        response.Headers.Contains("Set-Cookie").Should().BeFalse();
+        response.Headers.Contains("x-some-gateway-trace").Should().BeFalse();
+        response
+            .Headers.GetValues("request-id")
+            .Should()
+            .ContainSingle("the allowlist still has to carry what the client genuinely needs");
+    }
+
+    [Fact]
     public async Task Non_streaming_success_body_is_copied_verbatim()
     {
         const string upstreamBody = "{\"type\":\"message\",\"unknown_future_field\":{\"a\":1},\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}";

--- a/tests/CopilotAnthropicProxy.Tests/ProxyWebAppFactory.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ProxyWebAppFactory.cs
@@ -45,12 +45,23 @@ public sealed class ProxyWebAppFactory : WebApplicationFactory<Program>
     ///     Optional downstream SSE keep-alive interval (sets <c>COPILOT_ANTHROPIC_KEEPALIVE_SECONDS</c>);
     ///     used by the keep-alive test to make pings fire quickly against a silent upstream.
     /// </param>
+    /// <param name="maxBodyBytes">
+    ///     Optional cap on a buffered body (sets <c>COPILOT_ANTHROPIC_MAX_BODY_BYTES</c>); used by the
+    ///     oversized-reply test so a few kilobytes stand in for the 32 MB production default.
+    /// </param>
+    /// <param name="modelEndpoints">
+    ///     Optional pinned-model capability metadata (sets <c>COPILOT_ANTHROPIC_MODEL_ENDPOINTS</c>);
+    ///     only meaningful alongside a non-null <paramref name="model"/>, which otherwise has no
+    ///     discovered endpoint list.
+    /// </param>
     public ProxyWebAppFactory(
         Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> upstream,
         ICopilotTokenProvider? tokenProvider = null,
         string? model = ConfiguredModel,
         int? idleTimeoutSeconds = null,
-        int? keepAliveSeconds = null
+        int? keepAliveSeconds = null,
+        long? maxBodyBytes = null,
+        string? modelEndpoints = null
     )
     {
         ArgumentNullException.ThrowIfNull(upstream);
@@ -58,6 +69,7 @@ public sealed class ProxyWebAppFactory : WebApplicationFactory<Program>
         _upstreamHandler = new FakeHttpMessageHandler(upstream);
         _tokenProvider = tokenProvider ?? new FakeCopilotTokenProvider("fake-token");
         Environment.SetEnvironmentVariable("COPILOT_ANTHROPIC_MODEL", model);
+        Environment.SetEnvironmentVariable("COPILOT_ANTHROPIC_MODEL_ENDPOINTS", modelEndpoints);
         if (idleTimeoutSeconds is not null)
         {
             Environment.SetEnvironmentVariable(
@@ -71,6 +83,14 @@ public sealed class ProxyWebAppFactory : WebApplicationFactory<Program>
             Environment.SetEnvironmentVariable(
                 "COPILOT_ANTHROPIC_KEEPALIVE_SECONDS",
                 keepAliveSeconds.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            );
+        }
+
+        if (maxBodyBytes is not null)
+        {
+            Environment.SetEnvironmentVariable(
+                "COPILOT_ANTHROPIC_MAX_BODY_BYTES",
+                maxBodyBytes.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)
             );
         }
     }
@@ -102,8 +122,10 @@ public sealed class ProxyWebAppFactory : WebApplicationFactory<Program>
             if (disposing)
             {
                 Environment.SetEnvironmentVariable("COPILOT_ANTHROPIC_MODEL", null);
+                Environment.SetEnvironmentVariable("COPILOT_ANTHROPIC_MODEL_ENDPOINTS", null);
                 Environment.SetEnvironmentVariable("COPILOT_ANTHROPIC_IDLE_TIMEOUT_SECONDS", null);
                 Environment.SetEnvironmentVariable("COPILOT_ANTHROPIC_KEEPALIVE_SECONDS", null);
+                Environment.SetEnvironmentVariable("COPILOT_ANTHROPIC_MAX_BODY_BYTES", null);
             }
         }
     }

--- a/tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicJsonTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicJsonTests.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+public class ResponsesToAnthropicJsonTests
+{
+    private static JsonElement Translate(string responsesJson) =>
+        JsonDocument.Parse(ResponsesToAnthropicJson.Translate(responsesJson, "fallback-model")).RootElement.Clone();
+
+    [Fact]
+    public void Translates_a_text_response()
+    {
+        var result = Translate(
+            """
+            {"id":"resp_1","model":"gpt-5.3-codex",
+             "output":[{"type":"message","role":"assistant",
+                        "content":[{"type":"output_text","text":"Hello there"}]}],
+             "usage":{"input_tokens":12,"output_tokens":3}}
+            """
+        );
+
+        result.GetProperty("id").GetString().Should().Be("resp_1");
+        result.GetProperty("type").GetString().Should().Be("message");
+        result.GetProperty("role").GetString().Should().Be("assistant");
+        result.GetProperty("model").GetString().Should().Be("gpt-5.3-codex");
+        result.GetProperty("stop_reason").GetString().Should().Be("end_turn");
+        result.GetProperty("stop_sequence").ValueKind.Should().Be(JsonValueKind.Null);
+        result.GetProperty("usage").GetProperty("input_tokens").GetInt32().Should().Be(12);
+        result.GetProperty("usage").GetProperty("output_tokens").GetInt32().Should().Be(3);
+
+        var content = result.GetProperty("content");
+        content.GetArrayLength().Should().Be(1);
+        content[0].GetProperty("type").GetString().Should().Be("text");
+        content[0].GetProperty("text").GetString().Should().Be("Hello there");
+    }
+
+    [Fact]
+    public void Translates_a_function_call_into_a_tool_use_block()
+    {
+        var result = Translate(
+            """
+            {"id":"resp_2","model":"m",
+             "output":[{"type":"function_call","call_id":"call_9","name":"get_weather",
+                        "arguments":"{\"city\":\"Paris\"}"}],
+             "usage":{"input_tokens":1,"output_tokens":1}}
+            """
+        );
+
+        result.GetProperty("stop_reason").GetString().Should().Be("tool_use");
+
+        var block = result.GetProperty("content")[0];
+        block.GetProperty("type").GetString().Should().Be("tool_use");
+        block.GetProperty("id").GetString().Should().Be("call_9");
+        block.GetProperty("name").GetString().Should().Be("get_weather");
+        block.GetProperty("input").GetProperty("city").GetString().Should().Be("Paris");
+    }
+
+    [Fact]
+    public void Surfaces_a_reasoning_summary_as_a_thinking_block()
+    {
+        var result = Translate(
+            """
+            {"id":"r","model":"m",
+             "output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"weighing options"}]},
+                       {"type":"message","content":[{"type":"output_text","text":"Done"}]}],
+             "usage":{"input_tokens":1,"output_tokens":1}}
+            """
+        );
+
+        var content = result.GetProperty("content");
+        content[0].GetProperty("type").GetString().Should().Be("thinking");
+        content[0].GetProperty("thinking").GetString().Should().Be("weighing options");
+        content[1].GetProperty("type").GetString().Should().Be("text");
+    }
+
+    [Fact]
+    public void Reports_max_tokens_when_the_response_was_truncated()
+    {
+        var result = Translate(
+            """
+            {"id":"r","model":"m","incomplete_details":{"reason":"max_output_tokens"},
+             "output":[{"type":"message","content":[{"type":"output_text","text":"partial"}]}],
+             "usage":{"input_tokens":1,"output_tokens":16}}
+            """
+        );
+
+        result.GetProperty("stop_reason").GetString().Should().Be("max_tokens");
+    }
+
+    [Fact]
+    public void An_empty_output_yields_an_empty_content_array_not_a_placeholder_block()
+    {
+        // This is what Claude Code's `max_tokens: 1` model-validation probe can produce against a
+        // reasoning model. The envelope must be well-formed; the content must NOT be invented.
+        var result = Translate("""{"id":"r","model":"m","output":[],"usage":{"input_tokens":1,"output_tokens":0}}""");
+
+        result.GetProperty("content").GetArrayLength().Should().Be(0);
+        result.GetProperty("stop_reason").GetString().Should().Be("end_turn");
+        result.GetProperty("type").GetString().Should().Be("message");
+    }
+
+    [Fact]
+    public void Falls_back_to_the_supplied_model_when_the_response_omits_one()
+    {
+        var result = Translate("""{"id":"r","output":[]}""");
+
+        result.GetProperty("model").GetString().Should().Be("fallback-model");
+        result.GetProperty("usage").GetProperty("input_tokens").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public void Throws_ArgumentException_for_malformed_json_rather_than_a_raw_JsonException()
+    {
+        var act = () => ResponsesToAnthropicJson.Translate("{not valid json", "fallback-model");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Throws_ArgumentException_when_a_top_level_field_has_an_unexpected_type()
+    {
+        // "id" is a number here instead of a string: GetValue<string>() would otherwise leak an
+        // InvalidOperationException past the documented contract.
+        var act = () => ResponsesToAnthropicJson.Translate("""{"id":123,"output":[]}""", "fallback-model");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Throws_ArgumentException_when_the_top_level_value_is_not_an_object()
+    {
+        var act = () => ResponsesToAnthropicJson.Translate("[]", "fallback-model");
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicJsonTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicJsonTests.cs
@@ -155,12 +155,63 @@ public class ResponsesToAnthropicJsonTests
     }
 
     [Fact]
-    public void Malformed_function_call_arguments_degrade_to_an_empty_object_rather_than_failing_the_reply()
+    public void Malformed_function_call_arguments_fail_the_reply_rather_than_degrading_to_an_empty_object()
     {
+        // Degrading to {} used to produce a well-formed tool_use whose input had silently lost every
+        // argument the model chose, which the client cannot distinguish from a parameterless call.
+        var act = () =>
+            ResponsesToAnthropicJson.Translate(
+                """
+                {"id":"r","model":"m",
+                 "output":[{"type":"function_call","call_id":"call_1","name":"noop","arguments":"not json"}],
+                 "usage":{"input_tokens":1,"output_tokens":1}}
+                """,
+                "fallback-model"
+            );
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Missing_function_call_arguments_fail_the_reply()
+    {
+        var act = () =>
+            ResponsesToAnthropicJson.Translate(
+                """
+                {"id":"r","model":"m",
+                 "output":[{"type":"function_call","call_id":"call_1","name":"noop"}],
+                 "usage":{"input_tokens":1,"output_tokens":1}}
+                """,
+                "fallback-model"
+            );
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Function_call_arguments_that_are_not_a_json_object_fail_the_reply()
+    {
+        var act = () =>
+            ResponsesToAnthropicJson.Translate(
+                """
+                {"id":"r","model":"m",
+                 "output":[{"type":"function_call","call_id":"call_1","name":"noop","arguments":"[1,2]"}],
+                 "usage":{"input_tokens":1,"output_tokens":1}}
+                """,
+                "fallback-model"
+            );
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void An_explicit_empty_arguments_object_is_still_honoured()
+    {
+        // A genuinely parameterless call is not the failure case above: "{}" reads cleanly.
         var result = Translate(
             """
             {"id":"r","model":"m",
-             "output":[{"type":"function_call","call_id":"call_1","name":"noop","arguments":"not json"}],
+             "output":[{"type":"function_call","call_id":"call_1","name":"noop","arguments":"{}"}],
              "usage":{"input_tokens":1,"output_tokens":1}}
             """
         );
@@ -171,18 +222,58 @@ public class ResponsesToAnthropicJsonTests
     }
 
     [Fact]
-    public void Missing_function_call_arguments_degrade_to_an_empty_object()
+    public void An_output_field_that_is_not_an_array_fails_the_reply()
+    {
+        // Reading a present-but-wrong-kind output as "absent" turned an invalid upstream reply into a
+        // successful, empty Anthropic message.
+        var act = () => ResponsesToAnthropicJson.Translate("""{"id":"r","output":{}}""", "fallback-model");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Reports_refusal_when_a_classifier_stopped_the_turn()
     {
         var result = Translate(
             """
-            {"id":"r","model":"m",
-             "output":[{"type":"function_call","call_id":"call_1","name":"noop"}],
+            {"id":"r","model":"m","incomplete_details":{"reason":"content_filter"},
+             "output":[{"type":"message","content":[{"type":"output_text","text":"partial"}]}],
              "usage":{"input_tokens":1,"output_tokens":1}}
             """
         );
 
-        var block = result.GetProperty("content")[0];
-        block.GetProperty("type").GetString().Should().Be("tool_use");
-        block.GetProperty("input").EnumerateObject().Should().BeEmpty();
+        result.GetProperty("stop_reason").GetString().Should().Be("refusal");
+    }
+
+    [Fact]
+    public void A_classifier_stop_outranks_a_half_formed_function_call()
+    {
+        // A filtered turn can still carry the function call the model had begun. Reporting that as
+        // tool_use invites the client to execute it.
+        var result = Translate(
+            """
+            {"id":"r","model":"m","incomplete_details":{"reason":"content_filter"},
+             "output":[{"type":"function_call","call_id":"c","name":"rm","arguments":"{\"path\":\"/\"}"}],
+             "usage":{"input_tokens":1,"output_tokens":1}}
+            """
+        );
+
+        result.GetProperty("stop_reason").GetString().Should().Be("refusal");
+    }
+
+    [Theory]
+    // Copilot has been observed reporting counts that do not fit int, and whole numbers written in
+    // floating-point form. Both must read the same here as they do on the streaming path.
+    [InlineData("3000000000", 3000000000L)]
+    [InlineData("12.0", 12L)]
+    [InlineData("\"9\"", 0L)]
+    [InlineData("null", 0L)]
+    public void Token_counts_are_read_through_one_shared_policy(string literal, long expected)
+    {
+        var result = Translate(
+            $$"""{"id":"r","model":"m","output":[],"usage":{"input_tokens":{{literal}},"output_tokens":1} }"""
+        );
+
+        result.GetProperty("usage").GetProperty("input_tokens").GetInt64().Should().Be(expected);
     }
 }

--- a/tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicJsonTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicJsonTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using FluentAssertions;
 
 namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
@@ -133,5 +134,55 @@ public class ResponsesToAnthropicJsonTests
         var act = () => ResponsesToAnthropicJson.Translate("[]", "fallback-model");
 
         act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void DeriveStopReason_tolerates_a_non_string_output_item_type()
+    {
+        // Called directly (not via Translate), which is how ResponsesToAnthropicSse (Task 8) uses it,
+        // outside Translate's own try/catch. A non-string "type" must not throw.
+        var response = (JsonObject)JsonNode.Parse("""{"output":[{"type":123}]}""")!;
+
+        ResponsesToAnthropicJson.DeriveStopReason(response).Should().Be("end_turn");
+    }
+
+    [Fact]
+    public void DeriveStopReason_tolerates_a_non_string_incomplete_details_reason()
+    {
+        var response = (JsonObject)JsonNode.Parse("""{"output":[],"incomplete_details":{"reason":123}}""")!;
+
+        ResponsesToAnthropicJson.DeriveStopReason(response).Should().Be("end_turn");
+    }
+
+    [Fact]
+    public void Malformed_function_call_arguments_degrade_to_an_empty_object_rather_than_failing_the_reply()
+    {
+        var result = Translate(
+            """
+            {"id":"r","model":"m",
+             "output":[{"type":"function_call","call_id":"call_1","name":"noop","arguments":"not json"}],
+             "usage":{"input_tokens":1,"output_tokens":1}}
+            """
+        );
+
+        var block = result.GetProperty("content")[0];
+        block.GetProperty("type").GetString().Should().Be("tool_use");
+        block.GetProperty("input").EnumerateObject().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Missing_function_call_arguments_degrade_to_an_empty_object()
+    {
+        var result = Translate(
+            """
+            {"id":"r","model":"m",
+             "output":[{"type":"function_call","call_id":"call_1","name":"noop"}],
+             "usage":{"input_tokens":1,"output_tokens":1}}
+            """
+        );
+
+        var block = result.GetProperty("content")[0];
+        block.GetProperty("type").GetString().Should().Be("tool_use");
+        block.GetProperty("input").EnumerateObject().Should().BeEmpty();
     }
 }

--- a/tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicSseTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicSseTests.cs
@@ -4,12 +4,23 @@ namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
 
 public class ResponsesToAnthropicSseTests
 {
-    /// <summary>Feeds a scripted Responses stream and returns the concatenated Anthropic SSE output.</summary>
-    private static string Run(params string[] events)
+    /// <summary>Feeds a scripted Responses stream and returns the Anthropic SSE frames it produced.</summary>
+    private static IReadOnlyList<string> Frames(params string[] events)
     {
         var translator = new ResponsesToAnthropicSse("msg_test", "gpt-5.3-codex");
-        return string.Concat(events.SelectMany(translator.Next));
+        return [.. events.SelectMany(translator.Next)];
     }
+
+    /// <summary>Feeds a scripted Responses stream and returns the concatenated Anthropic SSE output.</summary>
+    private static string Run(params string[] events) => string.Concat(Frames(events));
+
+    /// <summary>
+    ///     The event name of each frame, in order. Substring assertions over the concatenated output
+    ///     are blind to both duplication and ordering — a second message_start, or a content block
+    ///     opening before message_start, still satisfies every <c>Contain</c>.
+    /// </summary>
+    private static IReadOnlyList<string> EventNames(params string[] events) =>
+        [.. Frames(events).Select(frame => frame.Split('\n')[0]["event: ".Length..])];
 
     [Fact]
     public void Emits_a_well_formed_text_stream()
@@ -35,6 +46,31 @@ public class ResponsesToAnthropicSseTests
         output.Should().Contain("\"output_tokens\":2");
         output.Should().EndWith("\n\n");
         output.Should().Contain("event: message_stop");
+    }
+
+    [Fact]
+    public void Emits_the_happy_path_frames_in_exactly_this_order()
+    {
+        var events = EventNames(
+            """{"type":"response.created","response":{"id":"resp_1","model":"gpt-5.3-codex"}}""",
+            """{"type":"response.content_part.added","part":{"type":"output_text","text":""}}""",
+            """{"type":"response.output_text.delta","delta":"Hel"}""",
+            """{"type":"response.output_text.delta","delta":"lo"}""",
+            """{"type":"response.content_part.done"}""",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":9,"output_tokens":2}}}"""
+        );
+
+        events
+            .Should()
+            .Equal(
+                "message_start",
+                "content_block_start",
+                "content_block_delta",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+                "message_stop"
+            );
     }
 
     [Fact]
@@ -180,6 +216,62 @@ public class ResponsesToAnthropicSseTests
         var afterTermination = translator.Next("""{"type":"response.output_text.delta","delta":"late"}""");
 
         afterTermination.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Never_writes_tool_arguments_into_a_block_that_is_not_a_tool_call()
+    {
+        // The output_item.added that would have opened the tool_use block is unreadable, so the text
+        // delta owns index 0. The arguments that follow must be DROPPED: splicing tool-call JSON into
+        // rendered assistant text is malformed, not degraded.
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.output_item.added","item":["not-an-object"]}""",
+            """{"type":"response.output_text.delta","delta":"hi"}""",
+            """{"type":"response.function_call_arguments.delta","delta":"{\"city\":\"Paris\"}"}""",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":1,"output_tokens":1}}}"""
+        );
+
+        output.Should().Contain("\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}");
+        output.Should().Contain("\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}");
+        output.Should().NotContain("input_json_delta");
+        output.Should().NotContain("Paris");
+        output.Should().NotContain("\"index\":1", "no second block was ever opened");
+    }
+
+    [Fact]
+    public void Switches_block_when_a_text_delta_interrupts_an_open_thinking_block()
+    {
+        // The upstream went straight from its reasoning summary to the answer without sending
+        // reasoning_summary_part.done. The thinking block must be closed and a text block opened at
+        // the next index — writing text_delta at the thinking block's index would be malformed.
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.reasoning_summary_part.added"}""",
+            """{"type":"response.reasoning_summary_text.delta","delta":"weighing"}""",
+            """{"type":"response.output_text.delta","delta":"answer"}""",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":1,"output_tokens":1}}}"""
+        );
+
+        output.Should().Contain("\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}");
+        output.Should().Contain("\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"weighing\"}");
+        output.Should().Contain("\"type\":\"content_block_stop\",\"index\":0");
+        output.Should().Contain("\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}");
+        output.Should().Contain("\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"answer\"}");
+        output.Should().NotContain("\"index\":0,\"delta\":{\"type\":\"text_delta\"");
+    }
+
+    [Fact]
+    public void Reports_a_token_count_the_upstream_sent_in_a_shape_int_cannot_hold()
+    {
+        // 9.0 is a whole number written in floating-point form, and the output figure exceeds int.
+        // Reporting 0 for either would silently zero the client's cost accounting.
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":9.0,"output_tokens":3000000000}}}"""
+        );
+
+        output.Should().Contain("\"input_tokens\":9,\"output_tokens\":3000000000");
     }
 
     [Fact]

--- a/tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicSseTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicSseTests.cs
@@ -219,11 +219,12 @@ public class ResponsesToAnthropicSseTests
     }
 
     [Fact]
-    public void Never_writes_tool_arguments_into_a_block_that_is_not_a_tool_call()
+    public void Fails_the_stream_when_tool_arguments_arrive_with_no_tool_block_to_hold_them()
     {
         // The output_item.added that would have opened the tool_use block is unreadable, so the text
-        // delta owns index 0. The arguments that follow must be DROPPED: splicing tool-call JSON into
-        // rendered assistant text is malformed, not degraded.
+        // delta owns index 0. The arguments that follow cannot be written anywhere: splicing tool-call
+        // JSON into rendered assistant text is malformed, and dropping them hands the client a tool
+        // call with no arguments and no way to know any existed. So the stream fails visibly.
         var output = Run(
             """{"type":"response.created","response":{"id":"r","model":"m"}}""",
             """{"type":"response.output_item.added","item":["not-an-object"]}""",
@@ -237,6 +238,114 @@ public class ResponsesToAnthropicSseTests
         output.Should().NotContain("input_json_delta");
         output.Should().NotContain("Paris");
         output.Should().NotContain("\"index\":1", "no second block was ever opened");
+
+        output.Should().Contain("event: error");
+        output.Should().Contain("\"type\":\"api_error\"");
+        output
+            .Should()
+            .NotContain("message_stop", "the turn did not complete; claiming it did is the silent failure");
+    }
+
+    [Fact]
+    public void The_open_block_is_closed_before_the_terminal_error_frame()
+    {
+        var events = EventNames(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.content_part.added","part":{"type":"output_text"}}""",
+            """{"type":"response.output_text.delta","delta":"partial"}""",
+            """{"type":"error","code":"server_error","message":"boom"}"""
+        );
+
+        events
+            .Should()
+            .Equal("message_start", "content_block_start", "content_block_delta", "content_block_stop", "error");
+    }
+
+    [Fact]
+    public void Translates_the_top_level_error_event_into_an_anthropic_error_frame()
+    {
+        // ResponseErrorEvent: {"type":"error","code":...,"message":...,"param":...}. It used to land in
+        // the silent default arm, so the client saw an unexplained truncation.
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"error","code":"rate_limit_exceeded","message":"You asked about Paris too often","param":null}"""
+        );
+
+        output.Should().Contain("event: error");
+        output.Should().Contain("\"type\":\"api_error\"");
+        output.Should().Contain("rate_limit_exceeded", "a token-shaped code is machine-readable, not prose");
+        output.Should().NotContain("Paris", "the upstream's free text can echo the prompt back");
+        output.Should().NotContain("message_stop");
+    }
+
+    [Fact]
+    public void Translates_response_failed_into_an_anthropic_error_frame()
+    {
+        // ResponseFailedEvent carries the same error object one level down, under response.error.
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.failed","response":{"status":"failed","error":{"code":"server_error","message":"upstream exploded"}}}"""
+        );
+
+        output.Should().Contain("event: error");
+        output.Should().Contain("server_error");
+        output.Should().NotContain("upstream exploded");
+        output.Should().NotContain("message_stop");
+    }
+
+    [Theory]
+    [InlineData("""{"type":"error","message":"no code at all"}""")]
+    [InlineData("""{"type":"error","code":"a sentence, with punctuation, that is really prose"}""")]
+    [InlineData("""{"type":"error","code":123}""")]
+    [InlineData("""{"type":"response.failed","response":{"error":null}}""")]
+    [InlineData("""{"type":"response.failed"}""")]
+    public void An_upstream_failure_with_no_usable_code_still_ends_the_stream(string failure)
+    {
+        var output = Run("""{"type":"response.created","response":{"id":"r","model":"m"}}""", failure);
+
+        output.Should().Contain("event: error");
+        output.Should().Contain("The upstream Copilot stream failed.");
+        output.Should().NotContain("Upstream code:");
+    }
+
+    [Fact]
+    public void Emits_nothing_after_a_terminal_error_frame()
+    {
+        var translator = new ResponsesToAnthropicSse("msg_test", "m");
+        _ = translator.Next("""{"type":"response.created","response":{"id":"r","model":"m"}}""");
+        _ = translator.Next("""{"type":"error","code":"server_error"}""");
+
+        var afterFailure = translator.Next(
+            """{"type":"response.completed","response":{"output":[],"usage":{}}}"""
+        );
+
+        afterFailure.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Reports_refusal_when_a_classifier_stopped_a_streamed_turn()
+    {
+        // The buffered and the streamed path share DeriveStopReason precisely so this cannot differ
+        // between them.
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.incomplete","response":{"output":[],"incomplete_details":{"reason":"content_filter"},"usage":{"input_tokens":1,"output_tokens":1}}}"""
+        );
+
+        output.Should().Contain("\"stop_reason\":\"refusal\"");
+        output.Should().Contain("event: message_stop");
+    }
+
+    [Fact]
+    public void A_streamed_classifier_stop_outranks_a_half_formed_function_call()
+    {
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.incomplete","response":{"output":[{"type":"function_call"}],"incomplete_details":{"reason":"content_filter"},"usage":{}}}"""
+        );
+
+        output.Should().Contain("\"stop_reason\":\"refusal\"");
+        output.Should().NotContain("\"stop_reason\":\"tool_use\"");
     }
 
     [Fact]

--- a/tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicSseTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicSseTests.cs
@@ -1,0 +1,243 @@
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+public class ResponsesToAnthropicSseTests
+{
+    /// <summary>Feeds a scripted Responses stream and returns the concatenated Anthropic SSE output.</summary>
+    private static string Run(params string[] events)
+    {
+        var translator = new ResponsesToAnthropicSse("msg_test", "gpt-5.3-codex");
+        return string.Concat(events.SelectMany(translator.Next));
+    }
+
+    [Fact]
+    public void Emits_a_well_formed_text_stream()
+    {
+        var output = Run(
+            """{"type":"response.created","response":{"id":"resp_1","model":"gpt-5.3-codex"}}""",
+            """{"type":"response.content_part.added","part":{"type":"output_text","text":""}}""",
+            """{"type":"response.output_text.delta","delta":"Hel"}""",
+            """{"type":"response.output_text.delta","delta":"lo"}""",
+            """{"type":"response.content_part.done"}""",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":9,"output_tokens":2}}}"""
+        );
+
+        output.Should().Contain("event: message_start");
+        output.Should().Contain("\"id\":\"resp_1\"");
+        output.Should().Contain("event: content_block_start");
+        output.Should().Contain("\"index\":0");
+        output.Should().Contain("\"type\":\"text_delta\",\"text\":\"Hel\"");
+        output.Should().Contain("\"type\":\"text_delta\",\"text\":\"lo\"");
+        output.Should().Contain("event: content_block_stop");
+        output.Should().Contain("\"stop_reason\":\"end_turn\"");
+        output.Should().Contain("\"input_tokens\":9");
+        output.Should().Contain("\"output_tokens\":2");
+        output.Should().EndWith("\n\n");
+        output.Should().Contain("event: message_stop");
+    }
+
+    [Fact]
+    public void Streams_a_tool_call_as_an_input_json_delta_block()
+    {
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_1","name":"get_weather"}}""",
+            """{"type":"response.function_call_arguments.delta","delta":"{\"city\":"}""",
+            """{"type":"response.function_call_arguments.delta","delta":"\"Paris\"}"}""",
+            """{"type":"response.output_item.done"}""",
+            """{"type":"response.completed","response":{"output":[{"type":"function_call"}],"usage":{"input_tokens":1,"output_tokens":5}}}"""
+        );
+
+        output.Should().Contain("\"type\":\"tool_use\"");
+        output.Should().Contain("\"id\":\"call_1\"");
+        output.Should().Contain("\"name\":\"get_weather\"");
+        output.Should().Contain("\"type\":\"input_json_delta\"");
+        output.Should().Contain("\"stop_reason\":\"tool_use\"");
+    }
+
+    [Fact]
+    public void Streams_a_reasoning_summary_as_a_thinking_block()
+    {
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.reasoning_summary_part.added"}""",
+            """{"type":"response.reasoning_summary_text.delta","delta":"thinking..."}""",
+            """{"type":"response.reasoning_summary_part.done"}""",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":1,"output_tokens":1}}}"""
+        );
+
+        output.Should().Contain("\"type\":\"thinking\"");
+        output.Should().Contain("\"type\":\"thinking_delta\"");
+    }
+
+    [Fact]
+    public void Closes_an_open_block_before_terminating()
+    {
+        // Upstream ends the response without closing its content part — the block must still be closed
+        // before message_delta, or the Anthropic stream is malformed.
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.content_part.added","part":{"type":"output_text"}}""",
+            """{"type":"response.output_text.delta","delta":"hi"}""",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":1,"output_tokens":1}}}"""
+        );
+
+        output
+            .IndexOf("content_block_stop", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(output.IndexOf("message_delta", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void A_response_with_no_content_still_produces_a_well_formed_envelope()
+    {
+        // Claude Code's `max_tokens: 1` validation probe. Zero content blocks, but message_start and
+        // message_stop MUST both be present or the model is judged unusable.
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":3,"output_tokens":0}}}"""
+        );
+
+        output.Should().Contain("event: message_start");
+        output.Should().Contain("event: message_delta");
+        output.Should().Contain("event: message_stop");
+        output.Should().NotContain("content_block_start", "no content is honest; a fabricated block is not");
+    }
+
+    [Fact]
+    public void Reports_max_tokens_for_an_incomplete_response()
+    {
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.incomplete","response":{"output":[],"incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":1,"output_tokens":16}}}"""
+        );
+
+        output.Should().Contain("\"stop_reason\":\"max_tokens\"");
+        output.Should().Contain("event: message_stop");
+    }
+
+    [Fact]
+    public void A_truncated_stream_is_not_capped_with_a_fabricated_terminator()
+    {
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.content_part.added","part":{"type":"output_text"}}""",
+            """{"type":"response.output_text.delta","delta":"partial"}"""
+        );
+
+        output.Should().Contain("event: message_start");
+        output.Should().NotContain("message_stop", "the upstream never terminated; inventing one hides the failure");
+    }
+
+    [Fact]
+    public void Ignores_unknown_and_malformed_events()
+    {
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.some_future_event","data":{}}""",
+            "not json at all",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":1,"output_tokens":1}}}"""
+        );
+
+        output.Should().Contain("event: message_stop");
+    }
+
+    [Fact]
+    public void Numbers_successive_content_blocks_from_zero_upwards()
+    {
+        // A reasoning model answers with a thinking block and then a text block. Anthropic requires a
+        // monotonically increasing index per block; reusing index 0 would make the client overwrite
+        // the thinking block with the answer.
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.reasoning_summary_part.added"}""",
+            """{"type":"response.reasoning_summary_text.delta","delta":"weighing"}""",
+            """{"type":"response.reasoning_summary_part.done"}""",
+            """{"type":"response.content_part.added","part":{"type":"output_text"}}""",
+            """{"type":"response.output_text.delta","delta":"answer"}""",
+            """{"type":"response.content_part.done"}""",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":1,"output_tokens":1}}}"""
+        );
+
+        output.Should().Contain("\"index\":0,\"content_block\":{\"type\":\"thinking\"");
+        output.Should().Contain("\"index\":1,\"content_block\":{\"type\":\"text\"");
+        output.Should().Contain("\"type\":\"thinking_delta\",\"thinking\":\"weighing\"");
+        output.Should().Contain("\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"answer\"}");
+        output.Should().Contain("\"type\":\"content_block_stop\",\"index\":0");
+        output.Should().Contain("\"type\":\"content_block_stop\",\"index\":1");
+    }
+
+    [Fact]
+    public void Emits_nothing_once_the_stream_has_terminated()
+    {
+        // Copilot sometimes trails a terminal event with further frames. A second message_stop would
+        // break any client that treats the first one as the end of the message.
+        var translator = new ResponsesToAnthropicSse("msg_test", "m");
+        translator.Next("""{"type":"response.created","response":{"id":"r","model":"m"}}""");
+        translator.Next("""{"type":"response.completed","response":{"output":[],"usage":{}}}""");
+
+        var afterTermination = translator.Next("""{"type":"response.output_text.delta","delta":"late"}""");
+
+        afterTermination.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Terminates_cleanly_when_the_terminal_event_carries_no_response()
+    {
+        // response.completed with no "response" body: there is nothing to derive a stop reason from,
+        // so end_turn stands in. The envelope still has to close.
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":"response.completed"}"""
+        );
+
+        output.Should().Contain("\"stop_reason\":\"end_turn\"");
+        output.Should().Contain("\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}\n\n");
+        output.Should().Contain("event: message_stop");
+    }
+
+    [Fact]
+    public void Tolerates_event_fields_of_an_unexpected_json_kind()
+    {
+        // Every read here would throw InvalidOperationException under a bare GetValue<string>(), and a
+        // throw mid-stream is an unexplained truncation the client cannot diagnose. Each frame must
+        // instead be skipped or degrade, and the stream must still terminate cleanly.
+        var output = Run(
+            """{"type":"response.created","response":{"id":"r","model":"m"}}""",
+            """{"type":123}""",
+            """{"type":"response.content_part.added","part":"not-an-object"}""",
+            """{"type":"response.output_item.added","item":["not-an-object"]}""",
+            """{"type":"response.output_text.delta","delta":{"nested":true}}""",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":1,"output_tokens":1}}}"""
+        );
+
+        output.Should().Contain("event: message_start");
+        output.Should().Contain("event: message_stop");
+        output.Should().NotContain("\"type\":\"tool_use\"", "the item that would have named the call was unreadable");
+        output.Should().NotContain("text_delta", "the delta itself was unreadable, so there is no text to report");
+
+        // The unreadable output_text.delta still opened a text block: the upstream did assert that it
+        // was emitting text, and an empty text block is the honest degradation. It is the ONLY block —
+        // neither the malformed part nor the malformed item opened one.
+        output.Should().Contain("\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}");
+        output.Should().Contain("\"type\":\"content_block_stop\",\"index\":0");
+        output.Should().NotContain("\"index\":1");
+    }
+
+    [Fact]
+    public void Falls_back_to_the_supplied_id_and_model_and_to_zero_usage()
+    {
+        // The upstream announced neither an id nor a model, and reported usage in a shape we cannot
+        // read. message_start still has to be well-formed.
+        var output = Run(
+            """{"type":"response.created","response":{"id":123,"model":null}}""",
+            """{"type":"response.completed","response":{"output":[],"usage":{"input_tokens":"9"}}}"""
+        );
+
+        output.Should().Contain("\"id\":\"msg_test\"");
+        output.Should().Contain("\"model\":\"gpt-5.3-codex\"");
+        output.Should().Contain("\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}\n\n");
+        output.Should().Contain("event: message_stop");
+    }
+}

--- a/tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicSseTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ResponsesToAnthropicSseTests.cs
@@ -304,7 +304,7 @@ public class ResponsesToAnthropicSseTests
         var output = Run("""{"type":"response.created","response":{"id":"r","model":"m"}}""", failure);
 
         output.Should().Contain("event: error");
-        output.Should().Contain("The upstream Copilot stream failed.");
+        output.Should().Contain("The upstream Copilot API reported a failure.");
         output.Should().NotContain("Upstream code:");
     }
 

--- a/tests/CopilotAnthropicProxy.Tests/ResponsesTranslationIntegrityTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ResponsesTranslationIntegrityTests.cs
@@ -1,0 +1,561 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+/// <summary>
+///     The cross-product regression matrix for the four translation invariants a second review found
+///     were fixed only at the exact spot each reproduction pointed at:
+///
+///     <list type="number">
+///         <item>a streamed tool call may never complete once its arguments are lost;</item>
+///         <item>a reply declaring a failed lifecycle may never translate as a successful turn;</item>
+///         <item>malformed elements INSIDE <c>output</c> must fail, not be filtered away;</item>
+///         <item>an official <c>refusal</c> must reach the client as <c>stop_reason: "refusal"</c>.</item>
+///     </list>
+///
+///     Each invariant is exercised across the axes the first pass missed — malformed vs valid vs
+///     absent, open vs absent block, streamed vs buffered, outer container vs inner element, classifier
+///     stop vs completed refusal — and each reviewer reproduction is pinned verbatim. Tests proving the
+///     translators do NOT over-reject sit alongside them: an invariant that fails a legitimate reply is
+///     a different outage, not a fix.
+/// </summary>
+public class ResponsesTranslationIntegrityTests
+{
+    private const string Created = """{"type":"response.created","response":{"id":"r","model":"m"}}""";
+
+    /// <summary>A terminal event whose payload asserts nothing beyond "the turn finished".</summary>
+    private const string Completed = """{"type":"response.completed","response":{"output":[],"usage":{}}}""";
+
+    /// <summary>A terminal event whose payload says a function call was produced.</summary>
+    private const string CompletedWithCall =
+        """{"type":"response.completed","response":{"output":[{"type":"function_call"}],"usage":{}}}""";
+
+    private static JsonElement Buffered(string responsesJson) =>
+        JsonDocument.Parse(ResponsesToAnthropicJson.Translate(responsesJson, "fallback-model")).RootElement.Clone();
+
+    private static Action Translating(string responsesJson) =>
+        () => ResponsesToAnthropicJson.Translate(responsesJson, "fallback-model");
+
+    private static string Streamed(params string[] events)
+    {
+        var translator = new ResponsesToAnthropicSse("msg_test", "gpt-5.3-codex");
+        return string.Concat(events.SelectMany(translator.Next));
+    }
+
+    /// <summary>
+    ///     The wire form of one <c>input_json_delta</c> carrying <paramref name="partialJson"/>, built
+    ///     through the same serializer the frames are, so the assertion is about the fragment rather than
+    ///     about how <c>"</c> happens to be escaped inside it.
+    /// </summary>
+    private static string ArgumentFragment(string partialJson) =>
+        new JsonObject { ["type"] = "input_json_delta", ["partial_json"] = partialJson }.ToJsonString();
+
+    // ---------------------------------------------------------------------------------------------
+    // 1. A streamed tool call may never complete after its arguments are lost.
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void The_reviewers_reproduction_an_announced_call_with_a_malformed_delta_never_completes()
+    {
+        // Verbatim: an announced `delete_all`, a malformed delta, and an output_item.done carrying the
+        // real arguments. This used to emit input:{}, stop_reason:"tool_use" and message_stop — an
+        // executable call stripped of the filter that made it safe.
+        var output = Streamed(
+            Created,
+            """{"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_1","name":"delete_all"}}""",
+            """{"type":"response.function_call_arguments.delta","delta":{"nested":true}}""",
+            """{"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_1","name":"delete_all","arguments":"{\"path\":\"/\"}"}}""",
+            CompletedWithCall
+        );
+
+        output.Should().Contain("event: error");
+        output.Should().Contain("\"type\":\"api_error\"");
+        output.Should().NotContain("\"stop_reason\":\"tool_use\"");
+        output.Should().NotContain("message_delta");
+        output.Should().NotContain("message_stop", "the turn did not complete; claiming it did is the silent failure");
+        output.Should().NotContain("input_json_delta", "no argument fragment was ever proven readable");
+
+        // The announcement was already on the wire when the malformed delta arrived, so the block start
+        // cannot be unsent. It is terminated by content_block_stop and then a terminal error with no
+        // message_stop — exactly the state Anthropic documents as "discard the partial output".
+        output.Should().Contain("\"index\":0,\"content_block\":{\"type\":\"tool_use\"");
+        output.Should().Contain("\"type\":\"content_block_stop\",\"index\":0");
+    }
+
+    [Theory]
+    [InlineData("""{"type":"response.function_call_arguments.delta","delta":123}""")]
+    [InlineData("""{"type":"response.function_call_arguments.delta","delta":{"nested":true}}""")]
+    [InlineData("""{"type":"response.function_call_arguments.delta","delta":["a"]}""")]
+    [InlineData("""{"type":"response.function_call_arguments.delta","delta":null}""")]
+    [InlineData("""{"type":"response.function_call_arguments.delta"}""")]
+    public void An_unreadable_argument_fragment_fails_the_stream_even_with_a_tool_block_open(string malformed)
+    {
+        // The earlier fix only covered the no-open-block case. With a block open the fragment became an
+        // empty string and was dropped, leaving the client concatenating a hole in the middle of the
+        // argument JSON — which either fails to parse or parses into a DIFFERENT call.
+        var output = Streamed(
+            Created,
+            """{"type":"response.output_item.added","item":{"type":"function_call","call_id":"c","name":"n"}}""",
+            """{"type":"response.function_call_arguments.delta","delta":"{\"city\":"}""",
+            malformed,
+            """{"type":"response.function_call_arguments.done","arguments":"{\"city\":\"Paris\"}"}""",
+            """{"type":"response.output_item.done"}""",
+            CompletedWithCall
+        );
+
+        output.Should().Contain("event: error");
+        output.Should().NotContain("message_stop");
+    }
+
+    [Fact]
+    public void An_argument_fragment_that_is_readable_but_empty_is_not_a_failure()
+    {
+        // "" is a fragment the upstream genuinely sent and we genuinely read. Only fragments that could
+        // not be READ break the reassembly; failing this one would be the mirror-image outage.
+        var output = Streamed(
+            Created,
+            """{"type":"response.output_item.added","item":{"type":"function_call","call_id":"c","name":"n"}}""",
+            """{"type":"response.function_call_arguments.delta","delta":""}""",
+            """{"type":"response.function_call_arguments.delta","delta":"{\"city\":\"Paris\"}"}""",
+            """{"type":"response.output_item.done"}""",
+            CompletedWithCall
+        );
+
+        output.Should().NotContain("event: error");
+        output.Should().Contain("\"stop_reason\":\"tool_use\"");
+        output.Should().Contain("event: message_stop");
+    }
+
+    [Theory]
+    // The COMPLETE argument string, in each of the two events that can carry it.
+    [InlineData("""{"type":"response.function_call_arguments.done","name":"n","arguments":"{\"city\":\"Paris\"}"}""")]
+    [InlineData(
+        """{"type":"response.output_item.done","item":{"type":"function_call","call_id":"c","name":"n","arguments":"{\"city\":\"Paris\"}"}}"""
+    )]
+    public void A_done_event_is_the_only_carrier_when_no_delta_ever_arrived(string done)
+    {
+        // Both done events used to be ignored outright, so a call whose deltas never arrived reached the
+        // client as input:{}. The complete string is authoritative and is forwarded.
+        var output = Streamed(
+            Created,
+            """{"type":"response.output_item.added","item":{"type":"function_call","call_id":"c","name":"n"}}""",
+            done,
+            """{"type":"response.output_item.done"}""",
+            CompletedWithCall
+        );
+
+        output.Should().NotContain("event: error");
+        output.Should().Contain(ArgumentFragment("""{"city":"Paris"}"""));
+        output.Should().Contain("\"stop_reason\":\"tool_use\"");
+        output.Should().Contain("event: message_stop");
+    }
+
+    [Fact]
+    public void Completed_arguments_that_contradict_the_streamed_fragments_fail_the_stream()
+    {
+        // The client has already been streamed "/tmp". No later frame can retract it, so the turn cannot
+        // be allowed to complete around a call the model did not make.
+        var output = Streamed(
+            Created,
+            """{"type":"response.output_item.added","item":{"type":"function_call","call_id":"c","name":"rm"}}""",
+            """{"type":"response.function_call_arguments.delta","delta":"{\"path\":\"/tmp\"}"}""",
+            """{"type":"response.output_item.done","item":{"type":"function_call","call_id":"c","name":"rm","arguments":"{\"path\":\"/\"}"}}""",
+            CompletedWithCall
+        );
+
+        output.Should().Contain("event: error");
+        output.Should().NotContain("message_stop");
+    }
+
+    [Fact]
+    public void Completed_arguments_that_match_the_streamed_fragments_are_not_resent()
+    {
+        var output = Streamed(
+            Created,
+            """{"type":"response.output_item.added","item":{"type":"function_call","call_id":"c","name":"rm"}}""",
+            """{"type":"response.function_call_arguments.delta","delta":"{\"path\":"}""",
+            """{"type":"response.function_call_arguments.delta","delta":"\"/tmp\"}"}""",
+            """{"type":"response.function_call_arguments.done","arguments":"{\"path\":\"/tmp\"}"}""",
+            """{"type":"response.output_item.done","item":{"type":"function_call","call_id":"c","name":"rm","arguments":"{\"path\":\"/tmp\"}"}}""",
+            CompletedWithCall
+        );
+
+        output.Should().NotContain("event: error");
+        output.Should().Contain(ArgumentFragment("""{"path":"""));
+        output.Should().Contain(ArgumentFragment("\"/tmp\"}"));
+        output
+            .Split("input_json_delta")
+            .Should()
+            .HaveCount(3, "exactly the two fragments the upstream streamed, with no replay of the whole string");
+        output.Should().Contain("event: message_stop");
+    }
+
+    [Theory]
+    // Truncated JSON, a JSON value that is not an object, and a block closed by an unrelated event
+    // before any arguments arrived: each leaves tool_use.input unusable.
+    [InlineData("""{"type":"response.function_call_arguments.delta","delta":"{\"city\":"}""")]
+    [InlineData("""{"type":"response.function_call_arguments.delta","delta":"[1,2]"}""")]
+    [InlineData("""{"type":"response.output_text.delta","delta":"meanwhile"}""")]
+    public void A_tool_block_never_closes_around_arguments_that_are_not_a_json_object(string middle)
+    {
+        var output = Streamed(
+            Created,
+            """{"type":"response.output_item.added","item":{"type":"function_call","call_id":"c","name":"n"}}""",
+            middle,
+            CompletedWithCall
+        );
+
+        output.Should().Contain("event: error");
+        output.Should().NotContain("\"stop_reason\":\"tool_use\"");
+        output.Should().NotContain("message_stop");
+    }
+
+    [Fact]
+    public void An_explicitly_parameterless_call_still_completes()
+    {
+        // "{}" reads cleanly and is a real call the model chose to make.
+        var output = Streamed(
+            Created,
+            """{"type":"response.output_item.added","item":{"type":"function_call","call_id":"c","name":"now"}}""",
+            """{"type":"response.function_call_arguments.delta","delta":"{}"}""",
+            """{"type":"response.output_item.done"}""",
+            CompletedWithCall
+        );
+
+        output.Should().NotContain("event: error");
+        output.Should().Contain("\"stop_reason\":\"tool_use\"");
+        output.Should().Contain("event: message_stop");
+    }
+
+    [Theory]
+    [InlineData("""{"type":"response.function_call_arguments.delta","delta":"{}"}""")]
+    [InlineData("""{"type":"response.function_call_arguments.done","arguments":"{}"}""")]
+    public void Argument_events_with_no_announced_call_fail_the_stream_in_both_forms(string orphan)
+    {
+        // The delta form was already covered; the done form landed in the silent default arm and let the
+        // turn complete as if no tool call had been attempted at all.
+        var output = Streamed(Created, orphan, Completed);
+
+        output.Should().Contain("event: error");
+        output.Should().NotContain("message_stop");
+    }
+
+    [Theory]
+    [InlineData("""{"type":"response.output_item.added","item":{"type":"function_call","name":"n"}}""")]
+    [InlineData("""{"type":"response.output_item.added","item":{"type":"function_call","call_id":"c"}}""")]
+    [InlineData("""{"type":"response.output_item.added","item":{"type":"function_call","call_id":"","name":"n"}}""")]
+    [InlineData("""{"type":"response.output_item.added","item":{"type":"function_call","call_id":123,"name":"n"}}""")]
+    public void A_call_announced_without_a_usable_id_and_name_fails_rather_than_opening_a_dead_block(string added)
+    {
+        // call_id is what the client echoes back in tool_result and name is what it dispatches on.
+        // Substituting "" produced a block that could be streamed and closed but never honoured.
+        var output = Streamed(
+            Created,
+            added,
+            """{"type":"response.function_call_arguments.delta","delta":"{}"}""",
+            CompletedWithCall
+        );
+
+        output.Should().Contain("event: error");
+        output.Should().NotContain("\"id\":\"\"");
+        output.Should().NotContain("message_stop");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // 2. A declared lifecycle failure may never translate as a successful turn.
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void The_reviewers_reproduction_a_failed_buffered_reply_is_refused() =>
+        // Verbatim. This became a normal Anthropic message with empty content and stop_reason
+        // "end_turn": an HTTP-2xx body that says it failed, reported to the client as a silent success.
+        Translating("""{"status":"failed","error":{"code":"server_error"},"output":[]}""")
+            .Should()
+            .Throw<ArgumentException>()
+            .WithInnerExceptionExactly<InvalidOperationException>()
+            .WithMessage("*server_error*", "the shaped upstream code is what the streaming path relays too");
+
+    [Theory]
+    // Carrying real content does not make an unfinished turn finished: reshaping it would report the
+    // fragment the upstream had produced so far as the model's complete answer.
+    [InlineData(
+        """{"id":"r","status":"failed","output":[{"type":"message","content":[{"type":"output_text","text":"half"}]}]}"""
+    )]
+    [InlineData(
+        """{"id":"r","status":"cancelled","output":[{"type":"message","content":[{"type":"output_text","text":"half"}]}]}"""
+    )]
+    [InlineData(
+        """{"id":"r","status":"in_progress","output":[{"type":"message","content":[{"type":"output_text","text":"half"}]}]}"""
+    )]
+    [InlineData("""{"id":"r","status":"queued","output":[]}""")]
+    [InlineData("""{"id":"r","status":"a_status_added_after_this_proxy_shipped","output":[]}""")]
+    public void A_buffered_reply_that_is_not_a_finished_turn_is_refused(string body) =>
+        Translating(body).Should().Throw<ArgumentException>();
+
+    [Theory]
+    // completed and incomplete are both finished turns, an absent status asserts nothing, and an
+    // explicitly null error is the shape the spec documents for every response that did not fail.
+    [InlineData("""{"id":"r","status":"completed","output":[]}""")]
+    [InlineData("""{"id":"r","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[]}""")]
+    [InlineData("""{"id":"r","output":[]}""")]
+    [InlineData("""{"id":"r","status":"completed","error":null,"output":[]}""")]
+    public void A_finished_turn_still_translates(string body) =>
+        Buffered(body).GetProperty("type").GetString().Should().Be("message");
+
+    [Fact]
+    public void An_error_object_outranks_a_status_claiming_success() =>
+        // The spec leaves `error` null unless the response failed, so its presence contradicts the
+        // status. Believing the status is how an upstream failure became an empty successful turn.
+        Translating(
+                """
+                {"id":"r","status":"completed","error":{"code":"rate_limit_exceeded","message":"slow down"},
+                 "output":[{"type":"message","content":[{"type":"output_text","text":"hi"}]}]}
+                """
+            )
+            .Should()
+            .Throw<ArgumentException>();
+
+    [Theory]
+    [InlineData(
+        """{"type":"response.completed","response":{"status":"failed","error":{"code":"server_error"},"output":[]}}"""
+    )]
+    [InlineData("""{"type":"response.completed","response":{"status":"cancelled","output":[]}}""")]
+    [InlineData("""{"type":"response.incomplete","response":{"status":"in_progress","output":[]}}""")]
+    [InlineData("""{"type":"response.completed","response":{"error":{"code":"server_error"},"output":[]}}""")]
+    public void A_terminal_event_declaring_a_failed_lifecycle_fails_the_stream_too(string terminal)
+    {
+        // The streamed twin of the buffered check, through the same shared predicate: a terminal event
+        // is not permission to ignore what its own payload says about the turn.
+        var output = Streamed(Created, terminal);
+
+        output.Should().Contain("event: error");
+        output.Should().Contain("\"type\":\"api_error\"");
+        output.Should().NotContain("message_stop");
+    }
+
+    [Fact]
+    public void A_buffered_and_a_streamed_failure_are_described_identically()
+    {
+        const string failure =
+            """{"status":"failed","error":{"code":"server_error","message":"echoing the prompt back"}}""";
+
+        var streamed = Streamed(Created, """{"type":"response.failed","response":""" + failure + "}");
+
+        var buffered = Translating(failure)
+            .Should()
+            .Throw<ArgumentException>()
+            .WithInnerExceptionExactly<InvalidOperationException>()
+            .Which.Message;
+
+        streamed.Should().Contain(buffered);
+        streamed.Should().NotContain("echoing the prompt back", "an upstream message can echo the prompt back");
+        buffered.Should().NotContain("echoing the prompt back");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // 3. Malformed elements INSIDE output must fail, not be filtered away.
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void The_reviewers_reproduction_a_corrupt_output_element_is_refused() =>
+        // Verbatim: {"output":["corrupt"]} translated to an HTTP-success-shaped content:[] with
+        // stop_reason "end_turn". OfType<JsonObject>() had simply dropped the corrupt element.
+        Translating("""{"output":["corrupt"]}""").Should().Throw<ArgumentException>();
+
+    [Theory]
+    [InlineData("""{"output":["corrupt"]}""")]
+    [InlineData("""{"output":[123]}""")]
+    [InlineData("""{"output":[null]}""")]
+    [InlineData("""{"output":[[]]}""")]
+    [InlineData("""{"output":[{"type":"message","content":[{"type":"output_text","text":"real"}]},"corrupt"]}""")]
+    [InlineData("""{"output":[{}]}""")]
+    [InlineData("""{"output":[{"type":123}]}""")]
+    public void A_malformed_output_element_is_refused(string body) =>
+        Translating(body).Should().Throw<ArgumentException>();
+
+    [Theory]
+    // The same defect one level further in: a recognised item whose own payload is corrupt.
+    [InlineData("""{"output":[{"type":"message","content":"not an array"}]}""")]
+    [InlineData("""{"output":[{"type":"message","content":["corrupt"]}]}""")]
+    [InlineData("""{"output":[{"type":"message","content":[{"type":"output_text"}]}]}""")]
+    [InlineData("""{"output":[{"type":"message","content":[{"type":"output_text","text":123}]}]}""")]
+    [InlineData("""{"output":[{"type":"message","content":[{"type":"refusal"}]}]}""")]
+    [InlineData("""{"output":[{"type":"message","content":[{"type":123}]}]}""")]
+    [InlineData("""{"output":[{"type":"reasoning","summary":"not an array"}]}""")]
+    [InlineData("""{"output":[{"type":"reasoning","summary":[123]}]}""")]
+    [InlineData("""{"output":[{"type":"reasoning","summary":[{"type":"summary_text","text":5}]}]}""")]
+    [InlineData("""{"output":[{"type":"function_call","name":"n","arguments":"{}"}]}""")]
+    [InlineData("""{"output":[{"type":"function_call","call_id":"c","arguments":"{}"}]}""")]
+    [InlineData("""{"output":[{"type":"function_call","call_id":123,"name":"n","arguments":"{}"}]}""")]
+    public void Malformed_content_inside_a_recognised_item_is_refused(string body) =>
+        Translating(body).Should().Throw<ArgumentException>();
+
+    [Theory]
+    // An unknown TYPE is an upstream newer than this proxy, not an upstream that is broken. Failing
+    // these would break the proxy on the next Responses release.
+    [InlineData("""{"output":[{"type":"web_search_call","status":"completed"}]}""")]
+    [InlineData("""{"output":[{"type":"mcp_call","name":"x","arguments":"not a json object"}]}""")]
+    [InlineData("""{"output":[{"type":"message","content":[{"type":"reasoning_text","text":"x"}]}]}""")]
+    [InlineData("""{"output":[{"type":"reasoning","summary":[{"type":"summary_text"}]}]}""")]
+    public void An_unrecognised_item_or_part_type_is_still_skipped_rather_than_refused(string body) =>
+        Buffered(body).GetProperty("content").GetArrayLength().Should().Be(0);
+
+    [Fact]
+    public void A_legitimate_reply_is_untouched_by_the_new_checks()
+    {
+        var content = Buffered(
+                """
+                {"id":"r","model":"m","status":"completed",
+                 "output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"weighing"}]},
+                           {"type":"web_search_call","status":"completed"},
+                           {"type":"message","content":[{"type":"output_text","text":"Paris","annotations":[]}]},
+                           {"type":"function_call","call_id":"c","name":"n","arguments":"{\"a\":1}"}],
+                 "usage":{"input_tokens":4,"output_tokens":9}}
+                """
+            )
+            .GetProperty("content");
+
+        content.GetArrayLength().Should().Be(3);
+        content[0].GetProperty("type").GetString().Should().Be("thinking");
+        content[1].GetProperty("text").GetString().Should().Be("Paris");
+        content[2].GetProperty("input").GetProperty("a").GetInt32().Should().Be(1);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // 4. An official refusal must reach the client as stop_reason "refusal".
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void The_reviewers_reproduction_a_completed_refusal_is_not_a_normal_completion()
+    {
+        // Verbatim: a valid {"type":"refusal","refusal":"..."} content part on a COMPLETED response. It
+        // was ignored outright, so a safety decline reached the client as empty content with stop_reason
+        // "end_turn". This is distinct from incomplete_details.reason "content_filter": there the turn
+        // was cut short, here the model answered and its answer was a refusal.
+        var result = Buffered(
+            """
+            {"id":"r","model":"m","status":"completed",
+             "output":[{"type":"message","role":"assistant",
+                        "content":[{"type":"refusal","refusal":"I'm sorry, I cannot assist with that request."}]}],
+             "usage":{"input_tokens":12,"output_tokens":9}}
+            """
+        );
+
+        result.GetProperty("stop_reason").GetString().Should().Be("refusal");
+
+        var content = result.GetProperty("content");
+        content.GetArrayLength().Should().Be(1);
+        content[0].GetProperty("type").GetString().Should().Be("text");
+        content[0].GetProperty("text").GetString().Should().Be("I'm sorry, I cannot assist with that request.");
+    }
+
+    [Fact]
+    public void A_refusal_outranks_a_function_call_in_the_same_completed_output() =>
+        // Reporting tool_use would invite the client to execute a call the model produced on its way to
+        // declining — the same reasoning Anthropic documents for its own refusal stop reason.
+        Buffered(
+                """
+                {"id":"r","model":"m","status":"completed",
+                 "output":[{"type":"function_call","call_id":"c","name":"rm","arguments":"{\"path\":\"/\"}"},
+                           {"type":"message","content":[{"type":"refusal","refusal":"No."}]}]}
+                """
+            )
+            .GetProperty("stop_reason")
+            .GetString()
+            .Should()
+            .Be("refusal");
+
+    [Fact]
+    public void A_streamed_refusal_reaches_the_client_as_text_and_a_refusal_stop_reason()
+    {
+        // response.refusal.delta / .done were both ignored, and the terminal payload can be lean, so a
+        // streamed decline arrived as an empty turn that looked like a normal answer.
+        var output = Streamed(
+            Created,
+            """{"type":"response.content_part.added","part":{"type":"refusal"}}""",
+            """{"type":"response.refusal.delta","delta":"I cannot "}""",
+            """{"type":"response.refusal.delta","delta":"help with that."}""",
+            """{"type":"response.refusal.done","refusal":"I cannot help with that."}""",
+            """{"type":"response.content_part.done","part":{"type":"refusal"}}""",
+            Completed
+        );
+
+        output.Should().Contain("\"type\":\"text_delta\",\"text\":\"I cannot \"");
+        output.Should().Contain("\"type\":\"text_delta\",\"text\":\"help with that.\"");
+        output
+            .Should()
+            .NotContain("\"text\":\"I cannot help with that.\"", "the done event repeats what the deltas carried");
+        output.Should().Contain("\"index\":0,\"content_block\":{\"type\":\"text\"");
+        output.Should().NotContain("\"index\":1", "one refusal is one block");
+        output.Should().Contain("\"stop_reason\":\"refusal\"");
+        output.Should().Contain("event: message_stop");
+    }
+
+    [Fact]
+    public void A_refusal_done_event_is_the_only_carrier_when_no_refusal_delta_arrived()
+    {
+        var output = Streamed(Created, """{"type":"response.refusal.done","refusal":"I will not."}""", Completed);
+
+        output.Should().Contain("\"type\":\"text_delta\",\"text\":\"I will not.\"");
+        output.Should().Contain("\"stop_reason\":\"refusal\"");
+        output.Should().Contain("event: message_stop");
+    }
+
+    [Fact]
+    public void A_streamed_refusal_outranks_a_function_call_in_the_terminal_payload()
+    {
+        var output = Streamed(Created, """{"type":"response.refusal.delta","delta":"No."}""", CompletedWithCall);
+
+        output.Should().Contain("\"stop_reason\":\"refusal\"");
+        output.Should().NotContain("\"stop_reason\":\"tool_use\"");
+    }
+
+    [Fact]
+    public void A_refusal_carried_only_by_the_terminal_payload_is_still_reported()
+    {
+        // No refusal.* event at all — the whole decline sits in the completed response's output, exactly
+        // as the buffered path would see it.
+        var output = Streamed(
+            Created,
+            """{"type":"response.completed","response":{"status":"completed","output":[{"type":"message","content":[{"type":"refusal","refusal":"No."}]}],"usage":{}}}"""
+        );
+
+        output.Should().Contain("\"stop_reason\":\"refusal\"");
+        output.Should().Contain("event: message_stop");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Cross-modality parity: the buffered and the streamed path may not disagree about a turn.
+    // ---------------------------------------------------------------------------------------------
+
+    public static TheoryData<string, string> StopReasonMatrix =>
+        new()
+        {
+            { """{"output":[{"type":"message","content":[{"type":"output_text","text":"hi"}]}]}""", "end_turn" },
+            { """{"output":[{"type":"message","content":[{"type":"refusal","refusal":"no"}]}]}""", "refusal" },
+            { """{"output":[{"type":"function_call","call_id":"c","name":"n","arguments":"{}"}]}""", "tool_use" },
+            { """{"output":[],"incomplete_details":{"reason":"max_output_tokens"}}""", "max_tokens" },
+            { """{"output":[],"incomplete_details":{"reason":"content_filter"}}""", "refusal" },
+            {
+                """{"output":[{"type":"function_call","call_id":"c","name":"n","arguments":"{}"},{"type":"message","content":[{"type":"refusal","refusal":"no"}]}]}""",
+                "refusal"
+            },
+            {
+                """{"output":[{"type":"function_call","call_id":"c","name":"n","arguments":"{}"}],"incomplete_details":{"reason":"max_output_tokens"}}""",
+                "tool_use"
+            },
+        };
+
+    [Theory]
+    [MemberData(nameof(StopReasonMatrix))]
+    public void The_buffered_and_the_streamed_path_derive_the_same_stop_reason(string body, string expected)
+    {
+        Buffered(body).GetProperty("stop_reason").GetString().Should().Be(expected);
+
+        Streamed(Created, """{"type":"response.completed","response":""" + body + "}")
+            .Should()
+            .Contain("\"stop_reason\":\"" + expected + "\"");
+    }
+}

--- a/tests/CopilotAnthropicProxy.Tests/StreamingTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/StreamingTests.cs
@@ -117,7 +117,7 @@ public sealed class StreamingTests
         await using var body = await response.Content.ReadAsStreamAsync();
 
         // Frame "a" arrives immediately; the keep-alive comment(s) follow while the gate is held closed.
-        var seen = await ReadUntilAsync(body, s => s.Contains(": copilot-anthropic-proxy keep-alive"),
+        var seen = await TestUpstream.ReadUntilAsync(body, s => s.Contains(": copilot-anthropic-proxy keep-alive"),
             TimeSpan.FromSeconds(15));
         seen.Should().Contain("event: a");
         seen.Should().Contain(": copilot-anthropic-proxy keep-alive",
@@ -128,33 +128,4 @@ public sealed class StreamingTests
         rest.Should().Contain("event: b", "real frames still flow after the keep-alives");
     }
 
-    /// <summary>Reads the response stream, accumulating text, until <paramref name="predicate"/> holds or the
-    /// timeout elapses. Keep-alive/frame content here is ASCII, so chunk boundaries don't corrupt matching.</summary>
-    private static async Task<string> ReadUntilAsync(Stream body, Func<string, bool> predicate, TimeSpan timeout)
-    {
-        var accumulated = new StringBuilder();
-        var buffer = new byte[256];
-        using var cts = new CancellationTokenSource(timeout);
-        while (!predicate(accumulated.ToString()))
-        {
-            int read;
-            try
-            {
-                read = await body.ReadAsync(buffer, cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-
-            if (read == 0)
-            {
-                break;
-            }
-
-            accumulated.Append(Encoding.UTF8.GetString(buffer, 0, read));
-        }
-
-        return accumulated.ToString();
-    }
 }

--- a/tests/CopilotAnthropicProxy.Tests/TestUpstream.cs
+++ b/tests/CopilotAnthropicProxy.Tests/TestUpstream.cs
@@ -44,6 +44,17 @@ internal static class TestUpstream
         content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("text/event-stream");
         return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
     }
+
+    /// <summary>
+    ///     An <c>application/json</c> response backed by a caller-controlled stream, so a BUFFERED reply
+    ///     can stall or drop part-way through its body the way a streamed one can.
+    /// </summary>
+    public static HttpResponseMessage JsonStream(Stream stream)
+    {
+        var content = new StreamContent(stream);
+        content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+        return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+    }
 }
 
 /// <summary>

--- a/tests/CopilotAnthropicProxy.Tests/TestUpstream.cs
+++ b/tests/CopilotAnthropicProxy.Tests/TestUpstream.cs
@@ -60,6 +60,19 @@ internal static class TestUpstream
     }
 
     /// <summary>
+    ///     A <c>text/event-stream</c> response whose body stream cannot be OPENED. This is the window
+    ///     between "2xx headers received" and "first byte read": the relay awaits
+    ///     <c>Content.ReadAsStreamAsync</c> there, so a drop or an idle timeout at that moment is a
+    ///     distinct failure from one inside the read loop.
+    /// </summary>
+    public static HttpResponseMessage SseThatCannotBeOpened(Func<CancellationToken, Task<Stream>> open)
+    {
+        var content = new UnopenableContent(open);
+        content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("text/event-stream");
+        return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+    }
+
+    /// <summary>
     ///     Reads the proxy's response stream, accumulating text, until <paramref name="predicate"/> holds
     ///     or <paramref name="timeout"/> elapses — the way to assert on a frame that has arrived while the
     ///     stream is still open. Everything matched this way (SSE event names, keep-alive comments) is
@@ -91,6 +104,31 @@ internal static class TestUpstream
         }
 
         return accumulated.ToString();
+    }
+}
+
+/// <summary>
+///     Content whose read stream is produced by a caller-supplied delegate, so opening the body can be
+///     made to throw or to block until the supplied token is cancelled.
+/// </summary>
+internal sealed class UnopenableContent : HttpContent
+{
+    private readonly Func<CancellationToken, Task<Stream>> _open;
+
+    public UnopenableContent(Func<CancellationToken, Task<Stream>> open) => _open = open;
+
+    protected override Task<Stream> CreateContentReadStreamAsync() => _open(CancellationToken.None);
+
+    protected override Task<Stream> CreateContentReadStreamAsync(CancellationToken cancellationToken) =>
+        _open(cancellationToken);
+
+    protected override Task SerializeToStreamAsync(Stream stream, System.Net.TransportContext? context) =>
+        _open(CancellationToken.None);
+
+    protected override bool TryComputeLength(out long length)
+    {
+        length = 0;
+        return false;
     }
 }
 

--- a/tests/CopilotAnthropicProxy.Tests/TestUpstream.cs
+++ b/tests/CopilotAnthropicProxy.Tests/TestUpstream.cs
@@ -3,7 +3,10 @@ using System.Text;
 
 namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
 
-/// <summary>Builders for fake upstream Copilot responses used by the proxy tests.</summary>
+/// <summary>
+///     Builders for fake upstream Copilot responses used by the proxy tests, plus the shared reader for
+///     the proxy's own streamed reply.
+/// </summary>
 internal static class TestUpstream
 {
     /// <summary>An <c>application/json</c> response with an optional status and extra response headers.</summary>
@@ -54,6 +57,40 @@ internal static class TestUpstream
         var content = new StreamContent(stream);
         content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
         return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+    }
+
+    /// <summary>
+    ///     Reads the proxy's response stream, accumulating text, until <paramref name="predicate"/> holds
+    ///     or <paramref name="timeout"/> elapses — the way to assert on a frame that has arrived while the
+    ///     stream is still open. Everything matched this way (SSE event names, keep-alive comments) is
+    ///     ASCII, so a chunk boundary cannot split a character and corrupt the match.
+    /// </summary>
+    public static async Task<string> ReadUntilAsync(Stream body, Func<string, bool> predicate, TimeSpan timeout)
+    {
+        var accumulated = new StringBuilder();
+        var buffer = new byte[256];
+        using var cts = new CancellationTokenSource(timeout);
+        while (!predicate(accumulated.ToString()))
+        {
+            int read;
+            try
+            {
+                read = await body.ReadAsync(buffer, cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+
+            if (read == 0)
+            {
+                break;
+            }
+
+            accumulated.Append(Encoding.UTF8.GetString(buffer, 0, read));
+        }
+
+        return accumulated.ToString();
     }
 }
 

--- a/tests/CopilotAnthropicProxy.Tests/TranslatedMessagesTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/TranslatedMessagesTests.cs
@@ -292,6 +292,35 @@ public class TranslatedMessagesTests
     }
 
     [Fact]
+    public async Task An_oversized_upstream_error_message_is_capped_before_it_reaches_the_client()
+    {
+        // Upstream-authored text is relayed verbatim, so its LENGTH is the upstream's choice unless the
+        // proxy caps it. A backend that echoes the offending request back inside `error.message` would
+        // otherwise turn one bad call into a megabyte of client-visible noise.
+        var huge = new string('x', 4096);
+        await using var factory = Factory(
+            (_, _) =>
+                Task.FromResult(
+                    TestUpstream.Json(
+                        "{\"error\":{\"message\":\"" + huge + "\"}}",
+                        HttpStatusCode.ServiceUnavailable
+                    )
+                )
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } })
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        error.RootElement.GetProperty("error").GetProperty("message").GetString().Should().HaveLength(500);
+    }
+
+    [Fact]
     public async Task An_untranslatable_upstream_reply_is_reported_as_400_not_500()
     {
         // ResponsesToAnthropicJson.Translate documents ArgumentException for a reply it cannot read, and
@@ -428,9 +457,10 @@ public class TranslatedMessagesTests
     [Fact]
     public async Task A_slow_but_steady_stream_is_not_killed_for_taking_longer_than_the_idle_timeout()
     {
-        // Three frames 1.2s apart is 3.6s of wall clock against a 2s idle timeout. The timeout measures
+        // Three frames 1.2s apart is 3.6s of wall clock against a 3s idle timeout. The timeout measures
         // the GAP BETWEEN BYTES, so a long generation must survive; a total-duration clock would cut it
-        // off after the first frame.
+        // off after the first frame. The per-gap margin is 1.8s — deliberately wide, because the failure
+        // this test would otherwise produce on a loaded machine is a flake, not a finding.
         var paced = new PacedStream(
             TimeSpan.FromMilliseconds(1200),
             "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_5\",\"model\":\"gpt-5.3-codex\"}}\n\n",
@@ -440,7 +470,7 @@ public class TranslatedMessagesTests
 
         await using var factory = Factory(
             (_, _) => Task.FromResult(TestUpstream.SseStream(paced)),
-            idleTimeoutSeconds: 2
+            idleTimeoutSeconds: 3
         );
         using var client = factory.CreateClient();
 
@@ -491,6 +521,174 @@ public class TranslatedMessagesTests
         gated.Release();
         var rest = await new StreamReader(body).ReadToEndAsync().WaitAsync(TimeSpan.FromSeconds(10));
         rest.Should().Contain("event: message_stop", "real frames still flow after the keep-alives");
+    }
+
+    [Fact]
+    public async Task A_streaming_request_answered_with_a_non_streaming_reply_is_reported_as_502()
+    {
+        // Copilot answering `stream: true` with application/json would translate to ZERO frames, i.e. an
+        // empty 200 indistinguishable from a successful empty turn. Nothing has been written at this
+        // point, so the envelope is still writable and the failure is visible instead of silent.
+        await using var factory = Factory(
+            (_, _) => Task.FromResult(TestUpstream.Json("""{"id":"resp_7","model":"gpt-5.3-codex","output":[]}"""))
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } }, stream: true)
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+        response.Content.Headers.ContentType!.MediaType.Should()
+            .Be("application/json", "the reply is an error envelope, not the SSE stream that was asked for");
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        error.RootElement.GetProperty("type").GetString().Should().Be("error");
+        error.RootElement.GetProperty("error").GetProperty("type").GetString().Should().Be("api_error");
+    }
+
+    [Fact]
+    public async Task A_stream_that_produces_no_frame_before_the_idle_timeout_answers_a_504_envelope()
+    {
+        // The upstream opens a real SSE response and then goes silent. Keep-alive is disabled on purpose:
+        // a ping would START the response, and the 504 envelope is only writable while nothing has been
+        // written. The lone SSE comment line keeps the stream open (an empty prefix would read as EOF and
+        // complete the turn normally) while producing no Anthropic frame.
+        var silent = new CancellationObservingStream(": awaiting-first-token\n");
+
+        await using var factory = Factory(
+            (_, _) => Task.FromResult(TestUpstream.SseStream(silent)),
+            idleTimeoutSeconds: 1,
+            keepAliveSeconds: 0
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } }, stream: true)
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.GatewayTimeout);
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        error.RootElement.GetProperty("type").GetString().Should().Be("error");
+        error.RootElement.GetProperty("error").GetProperty("type").GetString().Should().Be("api_error");
+    }
+
+    [Fact]
+    public async Task A_mid_stream_upstream_failure_truncates_without_a_message_stop()
+    {
+        // Two upstream events reach the client, then the connection dies. The relay must stop there: a
+        // synthetic message_stop would tell the client the turn ended normally, and a fabricated error
+        // frame is not something the Anthropic stream grammar has a place for.
+        var dropping = new ThrowingStream(
+            "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_8\",\"model\":\"gpt-5.3-codex\"}}\n\n"
+                + "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"half a th\"}\n\n"
+        );
+
+        await using var factory = Factory((_, _) => Task.FromResult(TestUpstream.SseStream(dropping)));
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } }, stream: true)
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "the failure arrived after the headers were sent");
+
+        var stream = await response.Content.ReadAsStringAsync();
+        stream.Should().Contain("half a th", "frames translated before the failure still reach the client");
+        Frames(stream)
+            .Select(f => f.Event)
+            .Should()
+            .Equal(
+                "message_start",
+                "content_block_start",
+                "content_block_delta"
+            );
+    }
+
+    [Fact]
+    public async Task A_buffered_reply_that_stalls_mid_body_answers_a_504_envelope()
+    {
+        // 200 + headers, then the body stops arriving. This read pulls from the socket (the reply is only
+        // headers-read so far) and the proxy's HttpClient has NO timeout, so if the idle token is not
+        // handed to it nothing at all ends the request.
+        var stalled = new CancellationObservingStream("""{"id":"resp_9","model":"gpt-5.3-codex",""");
+
+        await using var factory = Factory(
+            (_, _) => Task.FromResult(TestUpstream.JsonStream(stalled)),
+            idleTimeoutSeconds: 1
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } })
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.GatewayTimeout);
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        error.RootElement.GetProperty("error").GetProperty("type").GetString().Should().Be("api_error");
+
+        await stalled.Cancelled.WaitAsync(TimeSpan.FromSeconds(10));
+        stalled.Cancelled.IsCompletedSuccessfully.Should()
+            .BeTrue("the idle deadline must reach the upstream read, not merely abandon it");
+    }
+
+    [Fact]
+    public async Task A_buffered_reply_whose_connection_drops_is_reported_as_502()
+    {
+        // A body that dies half-way through is an upstream fault, not a translation fault: it must be the
+        // same 502 envelope the raw path produces, not an unhandled exception surfacing as a bare 500.
+        var dropping = new ThrowingStream("""{"id":"resp_10","model":"gpt-5.3-codex",""");
+
+        await using var factory = Factory((_, _) => Task.FromResult(TestUpstream.JsonStream(dropping)));
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } })
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        error.RootElement.GetProperty("type").GetString().Should().Be("error");
+        error.RootElement.GetProperty("error").GetProperty("type").GetString().Should().Be("api_error");
+    }
+
+    [Fact]
+    public async Task A_client_disconnect_cancels_the_translated_upstream_read()
+    {
+        // The translated relay must hand the client's abort to the upstream read, or a client that hangs
+        // up leaves a generation billing away against a socket nobody is reading.
+        var upstreamStream = new CancellationObservingStream(
+            "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_11\",\"model\":\"gpt-5.3-codex\"}}\n\n"
+        );
+
+        await using var factory = Factory((_, _) => Task.FromResult(TestUpstream.SseStream(upstreamStream)));
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/v1/messages")
+        {
+            Content = JsonContent.Create(TranslatedRequest(new[] { new { role = "user", content = "Hi" } }, stream: true)),
+        };
+
+        var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+        var body = await response.Content.ReadAsStreamAsync();
+
+        // Drain message_start so the relay is parked on the next upstream read.
+        var buffer = new byte[256];
+        _ = await body.ReadAsync(buffer);
+
+        body.Dispose();
+        response.Dispose();
+
+        await upstreamStream.Cancelled.WaitAsync(TimeSpan.FromSeconds(10));
+        upstreamStream.Cancelled.IsCompletedSuccessfully.Should().BeTrue();
     }
 
     /// <summary>Reads the response stream until <paramref name="predicate"/> holds or the timeout elapses.</summary>

--- a/tests/CopilotAnthropicProxy.Tests/TranslatedMessagesTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/TranslatedMessagesTests.cs
@@ -23,7 +23,8 @@ public class TranslatedMessagesTests
     private static ProxyWebAppFactory Factory(
         Func<HttpRequestMessage, string, Task<HttpResponseMessage>> onProxied,
         int? idleTimeoutSeconds = null,
-        int? keepAliveSeconds = null
+        int? keepAliveSeconds = null,
+        long? maxBodyBytes = null
     ) =>
         new(
             async (request, _) =>
@@ -38,7 +39,8 @@ public class TranslatedMessagesTests
             },
             model: null,
             idleTimeoutSeconds: idleTimeoutSeconds,
-            keepAliveSeconds: keepAliveSeconds
+            keepAliveSeconds: keepAliveSeconds,
+            maxBodyBytes: maxBodyBytes
         );
 
     private static object TranslatedRequest(object messages, int maxTokens = 1024, bool stream = false) =>
@@ -321,10 +323,40 @@ public class TranslatedMessagesTests
     }
 
     [Fact]
-    public async Task An_untranslatable_upstream_reply_is_reported_as_400_not_500()
+    public async Task An_upstream_error_body_with_no_recognised_message_field_is_not_relayed_verbatim()
     {
-        // ResponsesToAnthropicJson.Translate documents ArgumentException for a reply it cannot read, and
-        // documents that this caller branches on it to answer 400 rather than leaking a 500.
+        // A body the proxy cannot read is a body it cannot vouch for: relaying it verbatim would forward
+        // whatever an intermediary chose to write, HTML and all, into the client's error message.
+        await using var factory = Factory(
+            (_, _) =>
+                Task.FromResult(
+                    TestUpstream.Json(
+                        """{"detail":{"trace":"secret-internal-hostname"}}""",
+                        HttpStatusCode.BadGateway
+                    )
+                )
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } })
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var message = error.RootElement.GetProperty("error").GetProperty("message").GetString();
+        message.Should().NotContain("secret-internal-hostname");
+        message.Should().Contain("See the proxy log");
+    }
+
+    [Fact]
+    public async Task An_untranslatable_upstream_reply_is_reported_as_502_not_400_and_not_500()
+    {
+        // The client's request was accepted, forwarded, and answered 2xx; what failed is the UPSTREAM's
+        // reply. Calling that a 400 tells the client its own body was invalid, so Claude Code retries or
+        // gives up on the model — the one thing that cannot fix an upstream that answered HTML.
         await using var factory = Factory((_, _) => Task.FromResult(TestUpstream.Json("<html>not json</html>")));
         using var client = factory.CreateClient();
 
@@ -333,11 +365,61 @@ public class TranslatedMessagesTests
             TranslatedRequest(new[] { new { role = "user", content = "Hi" } })
         );
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.StatusCode.Should().Be(HttpStatusCode.BadGateway);
 
         using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         error.RootElement.GetProperty("type").GetString().Should().Be("error");
-        error.RootElement.GetProperty("error").GetProperty("type").GetString().Should().Be("invalid_request_error");
+        error.RootElement.GetProperty("error").GetProperty("type").GetString().Should().Be("api_error");
+    }
+
+    [Fact]
+    public async Task An_upstream_reply_whose_output_is_not_an_array_is_reported_as_502_not_an_empty_200()
+    {
+        // The dangerous shape is the one that PARSES: reading a present-but-wrong-kind `output` as
+        // "absent" produced a 200 carrying an empty assistant turn, which the client cannot tell from a
+        // model that genuinely said nothing.
+        await using var factory = Factory(
+            (_, _) => Task.FromResult(TestUpstream.Json("""{"id":"r","model":"m","output":{"type":"message"}}"""))
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } })
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+    }
+
+    [Fact]
+    public async Task An_upstream_reply_larger_than_the_body_cap_is_reported_as_502()
+    {
+        // The translated path buffers the whole reply and then builds a second copy of it. Without a cap
+        // a single upstream answer decides how much of the proxy's memory it gets to occupy.
+        var huge = new string('x', 200_000);
+        await using var factory = Factory(
+            (_, _) =>
+                Task.FromResult(
+                    TestUpstream.Json(
+                        $$"""
+                        {"id":"r","model":"m","output":[{"type":"message","content":[{"type":"output_text","text":"{{huge}}"}]}],
+                         "usage":{"input_tokens":1,"output_tokens":1} }
+                        """
+                    )
+                ),
+            maxBodyBytes: 4096
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } })
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        error.RootElement.GetProperty("error").GetProperty("type").GetString().Should().Be("api_error");
     }
 
     [Fact]
@@ -695,6 +777,225 @@ public class TranslatedMessagesTests
         upstreamStream.Cancelled.IsCompletedSuccessfully.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task An_upstream_stream_that_never_opens_answers_a_504_envelope()
+    {
+        // The idle deadline is armed before the body stream is acquired, and the linked token cancels for
+        // two reasons. Handling only the client-abort one let an idle timeout HERE escape as an unhandled
+        // OperationCanceledException — a bare 500 on the one path whose 504 contract is documented.
+        await using var factory = Factory(
+            (_, _) =>
+                Task.FromResult(
+                    TestUpstream.SseThatCannotBeOpened(async token =>
+                    {
+                        await Task.Delay(Timeout.Infinite, token);
+                        return Stream.Null;
+                    })
+                ),
+            idleTimeoutSeconds: 1,
+            keepAliveSeconds: 0
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } }, stream: true)
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.GatewayTimeout);
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        error.RootElement.GetProperty("type").GetString().Should().Be("error");
+        error.RootElement.GetProperty("error").GetProperty("type").GetString().Should().Be("api_error");
+    }
+
+    [Fact]
+    public async Task An_upstream_that_drops_before_its_stream_begins_answers_a_502_envelope()
+    {
+        await using var factory = Factory(
+            (_, _) =>
+                Task.FromResult(
+                    TestUpstream.SseThatCannotBeOpened(_ =>
+                        Task.FromException<Stream>(new IOException("Simulated drop before the first byte."))
+                    )
+                )
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } }, stream: true)
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        error.RootElement.GetProperty("error").GetProperty("type").GetString().Should().Be("api_error");
+    }
+
+    [Fact]
+    public async Task An_event_split_across_several_data_lines_is_reassembled_before_translation()
+    {
+        // SSE lets one event span several `data:` lines, joined with "\n" at the blank line that ends the
+        // event. Feeding each line to the translator alone makes every fragment fail to parse, and the
+        // translator's "unparseable payloads produce no frames" contract then drops the whole event in
+        // silence — a tool call or a text delta simply vanishing from the turn.
+        var multiline = string.Concat(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\n",
+            "data:  \"response\":{\"id\":\"resp_ml\",\"model\":\"gpt-5.3-codex\"}}\n",
+            "\n",
+            "event: response.output_text.delta\n",
+            "data: {\"type\":\"response.output_text.delta\",\n",
+            "data: \"delta\":\"reassembled\"}\n",
+            "\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n",
+            "\n"
+        );
+
+        await using var factory = Factory((_, _) => Task.FromResult(TestUpstream.Sse(multiline)));
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } }, stream: true)
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var stream = await response.Content.ReadAsStringAsync();
+        stream.Should().Contain("\"type\":\"text_delta\",\"text\":\"reassembled\"");
+        Frames(stream)
+            .Select(f => f.Event)
+            .Should()
+            .Equal(
+                "message_start",
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+                "message_stop"
+            );
+
+        using var start = JsonDocument.Parse(Frames(stream)[0].Data);
+        start
+            .RootElement.GetProperty("message")
+            .GetProperty("id")
+            .GetString()
+            .Should()
+            .Be("resp_ml", "the id lived on the continuation line, which a per-line translator never saw");
+    }
+
+    [Fact]
+    public async Task An_upstream_failure_event_becomes_a_terminal_anthropic_error_frame()
+    {
+        // Headers are already sent, so the failure cannot be a status code. It must be the `error` event
+        // Anthropic's own stream grammar defines — not a truncation the client has to guess at.
+        var failing = string.Concat(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_f\",\"model\":\"gpt-5.3-codex\"}}\n",
+            "\n",
+            "event: error\n",
+            "data: {\"type\":\"error\",\"code\":\"server_error\",\"message\":\"internal\"}\n",
+            "\n"
+        );
+
+        await using var factory = Factory((_, _) => Task.FromResult(TestUpstream.Sse(failing)));
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } }, stream: true)
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "the failure arrived after the headers were sent");
+
+        var stream = await response.Content.ReadAsStringAsync();
+        Frames(stream).Select(f => f.Event).Should().Equal("message_start", "error");
+
+        using var error = JsonDocument.Parse(Frames(stream)[1].Data);
+        error.RootElement.GetProperty("error").GetProperty("type").GetString().Should().Be("api_error");
+        error.RootElement.GetProperty("error").GetProperty("message").GetString().Should().Contain("server_error");
+    }
+
+    [Fact]
+    public async Task A_pinned_responses_only_model_reaches_the_translation_route()
+    {
+        // Pinning skips discovery, so the pinned entry carries no endpoint metadata and the router reads
+        // "no metadata" as Messages-capable — sending an Anthropic body straight at /v1/messages for a
+        // model that only serves /responses. COPILOT_ANTHROPIC_MODEL_ENDPOINTS supplies what discovery
+        // would have, making the translated route reachable for exactly the models it was built for.
+        string? path = null;
+        string? forwarded = null;
+
+        await using var factory = new ProxyWebAppFactory(
+            async (request, _) =>
+            {
+                path = request.RequestUri!.AbsolutePath;
+                forwarded = await request.Content!.ReadAsStringAsync();
+                return TestUpstream.Json(
+                    """
+                    {"id":"resp_pinned","model":"gpt-5.3-codex",
+                     "output":[{"type":"message","content":[{"type":"output_text","text":"pinned"}]}],
+                     "usage":{"input_tokens":1,"output_tokens":1}}
+                    """
+                );
+            },
+            model: "gpt-5.3-codex",
+            modelEndpoints: "/responses"
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } })
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        path.Should().Be("/responses", "the pinned model advertises only the Responses endpoint");
+
+        using var sent = JsonDocument.Parse(forwarded!);
+        sent.RootElement.TryGetProperty("max_output_tokens", out _)
+            .Should()
+            .BeTrue("the body was translated, not merely re-addressed");
+
+        using var received = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        received.RootElement.GetProperty("content")[0].GetProperty("text").GetString().Should().Be("pinned");
+    }
+
+    [Fact]
+    public async Task A_pinned_model_with_no_declared_endpoints_still_uses_the_messages_route()
+    {
+        // The historical behaviour, kept deliberately: absent metadata must not be read as a licence to
+        // translate every pinned model's traffic onto a different API.
+        string? path = null;
+
+        await using var factory = new ProxyWebAppFactory(
+            (request, _) =>
+            {
+                path = request.RequestUri!.AbsolutePath;
+                return Task.FromResult(
+                    TestUpstream.Json("""{"id":"msg_1","type":"message","role":"assistant","content":[]}""")
+                );
+            },
+            model: "claude-opus-4.8"
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            new
+            {
+                model = "claude-opus-4.8",
+                max_tokens = 100,
+                messages = new[] { new { role = "user", content = "Hi" } },
+            }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        path.Should().Be("/v1/messages");
+    }
 }
 
 /// <summary>

--- a/tests/CopilotAnthropicProxy.Tests/TranslatedMessagesTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/TranslatedMessagesTests.cs
@@ -1,0 +1,582 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+/// <summary>
+///     End-to-end coverage for the TRANSLATED branch of <c>/v1/messages</c>: an Anthropic Messages
+///     request for a model that only advertises <c>/responses</c> is rewritten into a Responses
+///     request, forwarded, and the reply translated back — buffered and streaming.
+/// </summary>
+public class TranslatedMessagesTests
+{
+    private const string DiscoveryJson = """
+        {"data":[
+          {"id":"claude-opus-4.8","vendor":"Anthropic","supported_endpoints":["/v1/messages","/chat/completions"]},
+          {"id":"gpt-5.3-codex","vendor":"OpenAI","supported_endpoints":["/responses"]}
+        ]}
+        """;
+
+    private static ProxyWebAppFactory Factory(
+        Func<HttpRequestMessage, string, Task<HttpResponseMessage>> onProxied,
+        int? idleTimeoutSeconds = null,
+        int? keepAliveSeconds = null
+    ) =>
+        new(
+            async (request, _) =>
+            {
+                var path = request.RequestUri!.AbsolutePath;
+                if (request.Method == HttpMethod.Get && path.EndsWith("/models", StringComparison.Ordinal))
+                {
+                    return TestUpstream.Json(DiscoveryJson);
+                }
+
+                return await onProxied(request, path);
+            },
+            model: null,
+            idleTimeoutSeconds: idleTimeoutSeconds,
+            keepAliveSeconds: keepAliveSeconds
+        );
+
+    private static object TranslatedRequest(object messages, int maxTokens = 1024, bool stream = false) =>
+        new
+        {
+            model = "gpt-5.3-codex",
+            max_tokens = maxTokens,
+            stream,
+            messages,
+        };
+
+    /// <summary>
+    ///     Splits an SSE body into ordered <c>(event, data)</c> pairs. Substring assertions cannot see a
+    ///     duplicated or misordered frame, so every streaming test asserts the exact event SEQUENCE.
+    /// </summary>
+    private static IReadOnlyList<(string Event, string Data)> Frames(string sse)
+    {
+        var frames = new List<(string, string)>();
+        foreach (var block in sse.Split("\n\n", StringSplitOptions.RemoveEmptyEntries))
+        {
+            string? name = null;
+            var data = string.Empty;
+            foreach (var line in block.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (line.StartsWith("event: ", StringComparison.Ordinal))
+                {
+                    name = line[7..];
+                }
+                else if (line.StartsWith("data: ", StringComparison.Ordinal))
+                {
+                    data = line[6..];
+                }
+            }
+
+            if (name is not null)
+            {
+                frames.Add((name, data));
+            }
+        }
+
+        return frames;
+    }
+
+    [Fact]
+    public async Task A_responses_only_model_is_reached_via_the_responses_endpoint()
+    {
+        string? path = null;
+        string? body = null;
+
+        await using var factory = Factory(
+            async (request, seen) =>
+            {
+                path = seen;
+                body = await request.Content!.ReadAsStringAsync();
+                return TestUpstream.Json(
+                    """
+                    {"id":"resp_1","model":"gpt-5.3-codex",
+                     "output":[{"type":"message","content":[{"type":"output_text","text":"Hi there"}]}],
+                     "usage":{"input_tokens":4,"output_tokens":2}}
+                    """
+                );
+            }
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            new
+            {
+                model = "gpt-5.3-codex",
+                max_tokens = 1024,
+                messages = new[] { new { role = "user", content = "Hello" } },
+            }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        path.Should().Be("/responses");
+
+        using var sent = JsonDocument.Parse(body!);
+        sent.RootElement.GetProperty("max_output_tokens").GetInt32().Should().Be(1024);
+        sent.RootElement.GetProperty("store").GetBoolean().Should().BeFalse();
+        sent.RootElement.GetProperty("model").GetString().Should().Be("gpt-5.3-codex");
+
+        using var received = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        received.RootElement.GetProperty("type").GetString().Should().Be("message");
+        received.RootElement.GetProperty("content")[0].GetProperty("text").GetString().Should().Be("Hi there");
+    }
+
+    [Fact]
+    public async Task A_streaming_request_is_translated_frame_by_frame()
+    {
+        await using var factory = Factory(
+            (_, _) =>
+                Task.FromResult(
+                    TestUpstream.Sse(
+                        string.Concat(
+                            """
+                            event: response.created
+                            data: {"type":"response.created","response":{"id":"resp_2","model":"gpt-5.3-codex"}}
+
+
+                            """.ReplaceLineEndings("\n"),
+                            """
+                            event: response.output_text.delta
+                            data: {"type":"response.output_text.delta","delta":"Hello"}
+
+
+                            """.ReplaceLineEndings("\n"),
+                            """
+                            event: response.completed
+                            data: {"type":"response.completed","response":{"output":[],"usage":{"input_tokens":4,"output_tokens":1}}}
+
+
+                            """.ReplaceLineEndings("\n")
+                        )
+                    )
+                )
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            new
+            {
+                model = "gpt-5.3-codex",
+                max_tokens = 1024,
+                stream = true,
+                messages = new[] { new { role = "user", content = "Hello" } },
+            }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("text/event-stream");
+
+        var stream = await response.Content.ReadAsStringAsync();
+        stream.Should().Contain("event: message_start");
+        stream.Should().Contain("\"type\":\"text_delta\",\"text\":\"Hello\"");
+        stream.Should().Contain("event: message_stop");
+        stream.Should().NotContain("response.created", "upstream frames must not leak through");
+
+        // Exact sequence: a substring assertion cannot see a repeated message_start or a delta emitted
+        // outside its block, which is the whole failure mode of a frame-by-frame translator.
+        Frames(stream)
+            .Select(f => f.Event)
+            .Should()
+            .Equal(
+                "message_start",
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+                "message_stop"
+            );
+    }
+
+    [Fact]
+    public async Task The_model_validation_probe_returns_a_well_formed_empty_message()
+    {
+        // Claude Code's first request against any new model: max_tokens 1, one text block, no retries.
+        string? body = null;
+
+        await using var factory = Factory(
+            async (request, _) =>
+            {
+                body = await request.Content!.ReadAsStringAsync();
+                return TestUpstream.Json(
+                    """{"id":"resp_3","model":"gpt-5.3-codex","output":[],"usage":{"input_tokens":3,"output_tokens":0}}"""
+                );
+            }
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            new
+            {
+                model = "gpt-5.3-codex",
+                max_tokens = 1,
+                messages = new[]
+                {
+                    new { role = "user", content = new[] { new { type = "text", text = "Hi" } } },
+                },
+            }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var sent = JsonDocument.Parse(body!);
+        sent.RootElement.GetProperty("max_output_tokens")
+            .GetInt32()
+            .Should()
+            .Be(16, "Responses rejects max_output_tokens below 16 and Claude Code would reject the model");
+
+        using var received = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        received.RootElement.GetProperty("type").GetString().Should().Be("message");
+        received.RootElement.GetProperty("content").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task An_upstream_error_is_reported_in_the_anthropic_error_shape()
+    {
+        await using var factory = Factory(
+            (_, _) =>
+                Task.FromResult(
+                    TestUpstream.Json(
+                        """{"error":{"message":"model is overloaded"}}""",
+                        HttpStatusCode.ServiceUnavailable
+                    )
+                )
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            new
+            {
+                model = "gpt-5.3-codex",
+                max_tokens = 100,
+                messages = new[] { new { role = "user", content = "Hi" } },
+            }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        error.RootElement.GetProperty("type").GetString().Should().Be("error");
+        error.RootElement.GetProperty("error").GetProperty("message").GetString().Should().Contain("overloaded");
+    }
+
+    [Fact]
+    public async Task An_upstream_error_body_of_an_unexpected_shape_still_produces_an_error_envelope()
+    {
+        // "error" as a STRING rather than an object: indexing it as one throws InvalidOperationException,
+        // which would turn a clean upstream error into an unhandled 500. The upstream status is 429 and
+        // not 500 precisely so that an unhandled 500 cannot masquerade as a correctly relayed one.
+        await using var factory = Factory(
+            (_, _) => Task.FromResult(TestUpstream.Json("""{"error":"boom"}""", HttpStatusCode.TooManyRequests))
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } })
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.TooManyRequests, "the upstream status must survive the reshape");
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        error.RootElement.GetProperty("type").GetString().Should().Be("error");
+        error.RootElement.GetProperty("error").GetProperty("message").GetString().Should().Contain("boom");
+    }
+
+    [Fact]
+    public async Task An_untranslatable_upstream_reply_is_reported_as_400_not_500()
+    {
+        // ResponsesToAnthropicJson.Translate documents ArgumentException for a reply it cannot read, and
+        // documents that this caller branches on it to answer 400 rather than leaking a 500.
+        await using var factory = Factory((_, _) => Task.FromResult(TestUpstream.Json("<html>not json</html>")));
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } })
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        error.RootElement.GetProperty("type").GetString().Should().Be("error");
+        error.RootElement.GetProperty("error").GetProperty("type").GetString().Should().Be("invalid_request_error");
+    }
+
+    [Fact]
+    public async Task A_request_the_translator_cannot_read_is_rejected_with_400_without_calling_upstream()
+    {
+        var upstreamCalls = 0;
+        await using var factory = Factory(
+            (_, _) =>
+            {
+                upstreamCalls++;
+                return Task.FromResult(TestUpstream.Json("{}"));
+            }
+        );
+        using var client = factory.CreateClient();
+
+        // max_tokens as a string: the request translator reads it as a number and throws. The client's
+        // own body is at fault, so this is a 400 — and the upstream must never see it.
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            new
+            {
+                model = "gpt-5.3-codex",
+                max_tokens = "lots",
+                messages = new[] { new { role = "user", content = "Hi" } },
+            }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        upstreamCalls.Should().Be(0, "a body we cannot translate must never reach Copilot");
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        error.RootElement.GetProperty("error").GetProperty("type").GetString().Should().Be("invalid_request_error");
+    }
+
+    [Fact]
+    public async Task An_echoed_unsigned_thinking_block_is_dropped_rather_than_forwarded_or_rejected()
+    {
+        // The streaming translator emits `thinking` blocks with no `signature` (fabricating one is
+        // forbidden), so a client that echoes assistant content back sends an UNSIGNED thinking block
+        // straight into the request translator on the next turn.
+        string? body = null;
+
+        await using var factory = Factory(
+            async (request, _) =>
+            {
+                body = await request.Content!.ReadAsStringAsync();
+                return TestUpstream.Json("""{"id":"resp_4","model":"gpt-5.3-codex","output":[]}""");
+            }
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(
+                new object[]
+                {
+                    new { role = "user", content = "Hi" },
+                    new
+                    {
+                        role = "assistant",
+                        content = new object[]
+                        {
+                            new { type = "thinking", thinking = "weighing the options" },
+                            new { type = "text", text = "Hello" },
+                        },
+                    },
+                    new { role = "user", content = "Again" },
+                }
+            )
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        body.Should().NotBeNull();
+        var forwarded = body!;
+        forwarded.Should()
+            .NotContain("thinking", "an unsigned thinking block cannot be replayed and must not be forwarded");
+        forwarded.Should().NotContain("weighing the options");
+
+        using var sent = JsonDocument.Parse(forwarded);
+        var input = sent.RootElement.GetProperty("input");
+        input.GetArrayLength().Should().Be(3, "the assistant turn survives, carrying only its text block");
+        input[1].GetProperty("role").GetString().Should().Be("assistant");
+        input[1].GetProperty("content").GetArrayLength().Should().Be(1);
+        input[1].GetProperty("content")[0].GetProperty("text").GetString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public async Task Count_tokens_is_not_served_for_a_responses_only_model()
+    {
+        var upstreamCalls = 0;
+        await using var factory = Factory(
+            (_, _) =>
+            {
+                upstreamCalls++;
+                return Task.FromResult(TestUpstream.Json("{}"));
+            }
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages/count_tokens",
+            new
+            {
+                model = "gpt-5.3-codex",
+                messages = new[] { new { role = "user", content = "Hi" } },
+            }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        upstreamCalls.Should().Be(0, "a token count must never be answered by running a generation");
+
+        using var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        error.RootElement.GetProperty("error").GetProperty("type").GetString().Should().Be("not_found_error");
+    }
+
+    [Fact]
+    public async Task A_slow_but_steady_stream_is_not_killed_for_taking_longer_than_the_idle_timeout()
+    {
+        // Three frames 1.2s apart is 3.6s of wall clock against a 2s idle timeout. The timeout measures
+        // the GAP BETWEEN BYTES, so a long generation must survive; a total-duration clock would cut it
+        // off after the first frame.
+        var paced = new PacedStream(
+            TimeSpan.FromMilliseconds(1200),
+            "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_5\",\"model\":\"gpt-5.3-codex\"}}\n\n",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"slow\"}\n\n",
+            "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+        );
+
+        await using var factory = Factory(
+            (_, _) => Task.FromResult(TestUpstream.SseStream(paced)),
+            idleTimeoutSeconds: 2
+        );
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/v1/messages",
+            TranslatedRequest(new[] { new { role = "user", content = "Hi" } }, stream: true)
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var stream = await response.Content.ReadAsStringAsync();
+        Frames(stream)
+            .Select(f => f.Event)
+            .Should()
+            .Equal(
+                "message_start",
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+                "message_stop"
+            );
+    }
+
+    [Fact]
+    public async Task A_silent_upstream_is_covered_by_keep_alive_pings()
+    {
+        var gated = new GatedStream(
+            "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_6\",\"model\":\"gpt-5.3-codex\"}}\n\n",
+            "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+        );
+
+        await using var factory = Factory((_, _) => Task.FromResult(TestUpstream.SseStream(gated)), keepAliveSeconds: 1);
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/v1/messages")
+        {
+            Content = JsonContent.Create(TranslatedRequest(new[] { new { role = "user", content = "Hi" } }, stream: true)),
+        };
+        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+        await using var body = await response.Content.ReadAsStreamAsync();
+
+        var seen = await ReadUntilAsync(body, s => s.Contains("event: ping", StringComparison.Ordinal), TimeSpan.FromSeconds(15));
+        seen.Should().Contain("event: message_start");
+        seen.Should()
+            .Contain("event: ping", "a silent upstream must be covered by pings or an intermediary drops the connection");
+
+        gated.Release();
+        var rest = await new StreamReader(body).ReadToEndAsync().WaitAsync(TimeSpan.FromSeconds(10));
+        rest.Should().Contain("event: message_stop", "real frames still flow after the keep-alives");
+    }
+
+    /// <summary>Reads the response stream until <paramref name="predicate"/> holds or the timeout elapses.</summary>
+    private static async Task<string> ReadUntilAsync(Stream body, Func<string, bool> predicate, TimeSpan timeout)
+    {
+        var accumulated = new StringBuilder();
+        var buffer = new byte[256];
+        using var cts = new CancellationTokenSource(timeout);
+        while (!predicate(accumulated.ToString()))
+        {
+            int read;
+            try
+            {
+                read = await body.ReadAsync(buffer, cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+
+            if (read == 0)
+            {
+                break;
+            }
+
+            accumulated.Append(Encoding.UTF8.GetString(buffer, 0, read));
+        }
+
+        return accumulated.ToString();
+    }
+}
+
+/// <summary>
+///     Emits each chunk only after a fixed gap has elapsed, so a stream can take longer in TOTAL than
+///     the proxy's idle timeout while never leaving a gap between bytes that long.
+/// </summary>
+internal sealed class PacedStream : Stream
+{
+    private readonly Queue<byte[]> _chunks;
+    private readonly TimeSpan _gap;
+    private byte[]? _current;
+    private int _offset;
+
+    public PacedStream(TimeSpan gap, params string[] chunks)
+    {
+        _gap = gap;
+        _chunks = new Queue<byte[]>(chunks.Select(Encoding.UTF8.GetBytes));
+    }
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        if (_current is null || _offset == _current.Length)
+        {
+            if (_chunks.Count == 0)
+            {
+                return 0;
+            }
+
+            await Task.Delay(_gap, cancellationToken).ConfigureAwait(false);
+            _current = _chunks.Dequeue();
+            _offset = 0;
+        }
+
+        var count = Math.Min(buffer.Length, _current.Length - _offset);
+        _current.AsMemory(_offset, count).CopyTo(buffer);
+        _offset += count;
+        return count;
+    }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override void Flush() { }
+
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+}

--- a/tests/CopilotAnthropicProxy.Tests/TranslatedMessagesTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/TranslatedMessagesTests.cs
@@ -513,7 +513,11 @@ public class TranslatedMessagesTests
         using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
         await using var body = await response.Content.ReadAsStreamAsync();
 
-        var seen = await ReadUntilAsync(body, s => s.Contains("event: ping", StringComparison.Ordinal), TimeSpan.FromSeconds(15));
+        var seen = await TestUpstream.ReadUntilAsync(
+            body,
+            s => s.Contains("event: ping", StringComparison.Ordinal),
+            TimeSpan.FromSeconds(15)
+        );
         seen.Should().Contain("event: message_start");
         seen.Should()
             .Contain("event: ping", "a silent upstream must be covered by pings or an intermediary drops the connection");
@@ -691,34 +695,6 @@ public class TranslatedMessagesTests
         upstreamStream.Cancelled.IsCompletedSuccessfully.Should().BeTrue();
     }
 
-    /// <summary>Reads the response stream until <paramref name="predicate"/> holds or the timeout elapses.</summary>
-    private static async Task<string> ReadUntilAsync(Stream body, Func<string, bool> predicate, TimeSpan timeout)
-    {
-        var accumulated = new StringBuilder();
-        var buffer = new byte[256];
-        using var cts = new CancellationTokenSource(timeout);
-        while (!predicate(accumulated.ToString()))
-        {
-            int read;
-            try
-            {
-                read = await body.ReadAsync(buffer, cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-
-            if (read == 0)
-            {
-                break;
-            }
-
-            accumulated.Append(Encoding.UTF8.GetString(buffer, 0, read));
-        }
-
-        return accumulated.ToString();
-    }
 }
 
 /// <summary>

--- a/tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs
+++ b/tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs
@@ -212,6 +212,10 @@ public sealed class CopilotAnthropicProxyLiveTests
         _output.WriteLine($"OBSERVED raw status field:       {ReadEcho(rawBody, "status")}");
         _output.WriteLine($"OBSERVED raw incomplete_details: {ReadEcho(rawBody, "incomplete_details")}");
 
+        // Named up front, so an upstream 400 fails as "the call did not succeed" rather than as a
+        // confusing "incomplete_details was missing" further down.
+        rawStatus.Should().Be(HttpStatusCode.OK, "a truncated reply is still a successful call: {0}", Truncate(rawBody, 400));
+
         var body = await PostProxyAsync(
             "/v1/messages",
             new
@@ -342,18 +346,21 @@ public sealed class CopilotAnthropicProxyLiveTests
     }
 
     /// <summary>
-    ///     Establishes whether Copilot EVER emits reasoning summaries, and if so under what request.
-    ///     It matters because <c>AnthropicToResponsesRequest</c> sends no <c>reasoning</c> field at all:
-    ///     if summaries only arrive when explicitly requested, the translators' <c>thinking</c> arms are
-    ///     unreachable on the translated route. Two captures, both text-only on a prompt that rewards
-    ///     thinking (a forced tool call short-circuits reasoning): one silent, one asking for summaries
-    ///     at a non-default effort. Recorded rather than asserted — the point is the observation.
+    ///     Establishes the asymmetry the README rests on: Copilot NEVER volunteers reasoning summaries,
+    ///     and does produce them when asked. That is why <c>AnthropicToResponsesRequest</c> sends
+    ///     <c>reasoning</c> on every translated request — without it the translators' <c>thinking</c>
+    ///     arms would be unreachable. Both captures are text-only on a prompt that rewards thinking; a
+    ///     forced tool call short-circuits reasoning and would fake a negative.
+    ///
+    ///     The "never volunteers" half is checked on one model, because it has held on every model on
+    ///     every run. The "produces when asked" half walks the catalog instead, because whether any ONE
+    ///     turn reasons is a coin flip — asserting it on a single sample failed a full-suite run.
     /// </summary>
     [SkippableFact]
     public async Task Responses_stream_reports_when_reasoning_summaries_arrive()
     {
         Skip.IfNot(_fixture.Available, _fixture.SkipReason);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(180));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(600));
 
         var model = await PickResponsesOnlyModelAsync(cts.Token);
         _output.WriteLine($"model: {model}");
@@ -364,33 +371,45 @@ public sealed class CopilotAnthropicProxyLiveTests
         );
         DumpCapture("raw streaming /responses, no reasoning field sent", silent);
 
-        var asked = await CaptureResponsesStreamAsync(
-            ReasoningResponsesRequest(model, ReasoningRequest.EffortAndSummary),
-            cts.Token
-        );
-        DumpCapture("raw streaming /responses, reasoning {effort: medium, summary: auto}", asked);
-
         var silentSummaries = ReasoningEventsIn(silent);
-        var askedSummaries = ReasoningEventsIn(asked);
-
         _output.WriteLine(
             "OBSERVED reasoning events, no reasoning field sent: "
                 + (silentSummaries.Count == 0 ? "<none>" : string.Join(", ", silentSummaries))
         );
-        _output.WriteLine(
-            "OBSERVED reasoning events, summaries requested:     "
-                + (askedSummaries.Count == 0 ? "<none>" : string.Join(", ", askedSummaries))
-        );
 
-        // Both statuses first: without them an upstream 400 prints "<none>" and reads as a genuine
-        // "Copilot volunteered nothing", which is the exact claim this probe is the sole evidence for.
+        // Status first: without it an upstream 400 prints "<none>" and reads as a genuine "Copilot
+        // volunteered nothing", which is the exact claim this half of the probe is the evidence for.
         silent.Status.Should().Be(HttpStatusCode.OK);
-        asked.Status.Should().Be(HttpStatusCode.OK);
-
-        askedSummaries.Should().NotBeEmpty("this is what asking for summaries is supposed to produce");
         silentSummaries
             .Should()
-            .BeEmpty("summaries arriving unasked would mean the translated route could emit thinking blocks");
+            .BeEmpty("summaries arriving unasked would mean the translated route needs no reasoning field");
+
+        var askedSummaries = new List<string>();
+        foreach (var candidate in await ResponsesCapableModelsAsync(cts.Token))
+        {
+            var asked = await CaptureResponsesStreamAsync(
+                ReasoningResponsesRequest(candidate, ReasoningRequest.EffortAndSummary),
+                cts.Token
+            );
+
+            asked.Status.Should().Be(HttpStatusCode.OK, "{0} must accept reasoning {{effort, summary}}", candidate);
+            askedSummaries = ReasoningEventsIn(asked);
+
+            _output.WriteLine(
+                $"{candidate,-24} reasoning {{effort: medium, summary: auto}} -> "
+                    + (askedSummaries.Count == 0 ? "<none>" : string.Join(", ", askedSummaries))
+            );
+
+            if (askedSummaries.Count > 0)
+            {
+                DumpCapture($"raw streaming /responses, {candidate}, reasoning {{effort: medium, summary: auto}}", asked);
+                break;
+            }
+        }
+
+        askedSummaries
+            .Should()
+            .NotBeEmpty("no served model produced a summary even when asked, so asking has stopped working");
     }
 
     /// <summary>
@@ -533,13 +552,16 @@ public sealed class CopilotAnthropicProxyLiveTests
     ///     turn that never reasons cannot summarise. Accepted-but-inert is the failure this catches,
     ///     and a status check alone would not: it looks identical to success.
     ///
-    ///     Which model produces a summary is NOT stable. Two sweeps minutes apart, same prompt, saw a
-    ///     different single model produce one; models defaulting to <c>effort: "none"</c> produced none
-    ///     either time. So this asserts only that SOME served model still produces summaries — read a
-    ///     failure here as "the field has stopped buying anything", not as a claim about one model.
+    ///     What it can and cannot assert. Acceptance is an invariant — all nine models have answered 200
+    ///     on every run — so that IS asserted. Productivity is not: sweeps minutes apart saw a different
+    ///     single model produce summaries, and one full-suite run saw all nine inert at once. An earlier
+    ///     revision asserted "some model produced summaries" and failed on exactly that run, so the
+    ///     split is now recorded rather than asserted. It is the evidence for the README's claim that
+    ///     summary-alone is unreliable, and the reason the shipped code derives an effort from the
+    ///     client instead of relying on this.
     /// </summary>
     [SkippableFact]
-    public async Task Summary_auto_alone_produces_reasoning_summaries()
+    public async Task Summary_auto_alone_is_accepted_everywhere_but_is_not_dependable()
     {
         Skip.IfNot(_fixture.Available, _fixture.SkipReason);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(600));
@@ -574,12 +596,12 @@ public sealed class CopilotAnthropicProxyLiveTests
         _output.WriteLine($"OBSERVED summaries produced by:  {(productive.Count == 0 ? "<none>" : string.Join(", ", productive))}");
         _output.WriteLine($"OBSERVED accepted but inert on:  {(inert.Count == 0 ? "<none>" : string.Join(", ", inert))}");
 
-        productive
+        // Deliberately no assertion on `productive`: an all-inert sweep is a real, observed outcome of
+        // this request shape, not a regression. Asserting it would be asserting a non-invariant, and
+        // `Thinking_enabled_makes_a_none_effort_model_reason` covers what the shipped code depends on.
+        inert.Concat(productive)
             .Should()
-            .NotBeEmpty(
-                "reasoning:{summary:auto} is only worth sending unconditionally if some served model "
-                    + "actually produces summaries from it"
-            );
+            .BeEquivalentTo(models, "every served model must have answered, or the sweep proves nothing");
     }
 
     /// <summary>
@@ -638,6 +660,187 @@ public sealed class CopilotAnthropicProxyLiveTests
             .BeEmpty(
                 "an unconditional reasoning field is only safe if every served /responses model accepts it"
             );
+    }
+
+    /// <summary>
+    ///     Does every served model accept every effort the budget mapping can produce? The mapping turns
+    ///     a client's <c>thinking.budget_tokens</c> into <c>low</c> / <c>medium</c> / <c>high</c>, so a
+    ///     model rejecting any one of them would 400 a request the client is entitled to send.
+    /// </summary>
+    [SkippableFact]
+    public async Task Every_responses_model_accepts_every_mapped_effort()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(600));
+
+        var models = await ResponsesCapableModelsAsync(cts.Token);
+        Skip.If(models.Count == 0, "This Copilot account exposes no /responses model the proxy will serve.");
+
+        var rejections = new List<string>();
+        foreach (var model in models)
+        {
+            foreach (var effort in MappedEfforts)
+            {
+                var (status, body) = await PostRawAsync(
+                    ModelRouter.ResponsesPath,
+                    new
+                    {
+                        model,
+                        store = false,
+                        max_output_tokens = 16,
+                        reasoning = new { effort, summary = "auto" },
+                        input = new[]
+                        {
+                            new
+                            {
+                                type = "message",
+                                role = "user",
+                                content = new[] { new { type = "input_text", text = "Reply with: ok" } },
+                            },
+                        },
+                    },
+                    cts.Token
+                );
+
+                _output.WriteLine($"{model,-24} effort={effort,-6} -> {(int)status} {status}  echo: {ReadEcho(body, "reasoning")}");
+
+                if (status != HttpStatusCode.OK)
+                {
+                    rejections.Add($"{model} effort={effort} -> {(int)status} {Truncate(body, 300)}");
+                }
+            }
+        }
+
+        rejections
+            .Should()
+            .BeEmpty("the budget mapping can emit any of these, so a model rejecting one would 400 a legitimate request");
+    }
+
+    /// <summary>
+    ///     THE PAYOFF for mapping <c>thinking.budget_tokens</c> onto an effort. Some models default to
+    ///     <c>effort: "none"</c> and provably never reason, so summaries alone can never produce a
+    ///     <c>thinking</c> block for them. This drives exactly those models through the ANTHROPIC
+    ///     endpoint with extended thinking enabled and reports whether one appears.
+    ///
+    ///     The mapping clearly works — models that could NEVER reason before now usually do — but it is
+    ///     not a guarantee. Over four runs, two had all four models produce a block and two had
+    ///     <c>gpt-5.4</c> alone stay silent. So this asserts that SOME rescued model reasoned, which is
+    ///     the claim the README makes, and logs the per-model split. Do not tighten this to "all
+    ///     models": that was tried, and the third run refuted it.
+    ///
+    ///     Statuses are checked first, or a 400 would masquerade as "this model cannot think".
+    /// </summary>
+    [SkippableFact]
+    public async Task Thinking_enabled_makes_a_none_effort_model_reason()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(900));
+
+        var models = await ResponsesCapableModelsAsync(cts.Token);
+        Skip.If(models.Count == 0, "This Copilot account exposes no /responses model the proxy will serve.");
+
+        // Read the defaults live rather than naming models: which model defaults to "none" is Copilot's
+        // choice and has already changed once during this task.
+        var neverReason = new List<string>();
+        foreach (var model in models)
+        {
+            var (status, body) = await PostRawAsync(
+                ModelRouter.ResponsesPath,
+                new
+                {
+                    model,
+                    store = false,
+                    max_output_tokens = 16,
+                    reasoning = new { summary = "auto" },
+                    input = new[]
+                    {
+                        new
+                        {
+                            type = "message",
+                            role = "user",
+                            content = new[] { new { type = "input_text", text = "Reply with: ok" } },
+                        },
+                    },
+                },
+                cts.Token
+            );
+
+            status.Should().Be(HttpStatusCode.OK, "{0} must answer before its default effort can be read", model);
+
+            if (ReadEchoedReasoningEffort(body) == "none")
+            {
+                neverReason.Add(model);
+            }
+        }
+
+        _output.WriteLine($"models defaulting to effort \"none\": {string.Join(", ", neverReason)}");
+        Skip.If(neverReason.Count == 0, "No served model defaults to effort \"none\", so there is nothing to rescue.");
+
+        var reasoned = new List<string>();
+        var stayedSilent = new List<string>();
+        foreach (var model in neverReason)
+        {
+            // Shaped like Claude Code's own extended-thinking request: budget below max_tokens, and a
+            // 10240 budget lands in the medium bucket.
+            var (status, body) = await SendProxyAsync(
+                "/v1/messages",
+                new
+                {
+                    model,
+                    max_tokens = 21333,
+                    stream = true,
+                    thinking = new { type = "enabled", budget_tokens = 10240 },
+                    messages = new[]
+                    {
+                        new
+                        {
+                            role = "user",
+                            content = "A bat and a ball cost $1.10 together. The bat costs $1.00 more than "
+                                + "the ball. How much does the ball cost? Answer with the amount only.",
+                        },
+                    },
+                },
+                cts.Token
+            );
+
+            status.Should().Be(HttpStatusCode.OK, "{0} failed the translated route with: {1}", model, Truncate(body, 400));
+
+            var thought = body.Contains("\"type\":\"thinking\"", StringComparison.Ordinal);
+            _output.WriteLine($"{model,-24} thinking enabled -> {(thought ? "THINKING BLOCK" : "no thinking block")}");
+            (thought ? reasoned : stayedSilent).Add(model);
+        }
+
+        _output.WriteLine($"OBSERVED reasoned once asked:    {(reasoned.Count == 0 ? "<none>" : string.Join(", ", reasoned))}");
+        _output.WriteLine($"OBSERVED still silent when asked: {(stayedSilent.Count == 0 ? "<none>" : string.Join(", ", stayedSilent))}");
+
+        reasoned
+            .Should()
+            .NotBeEmpty(
+                "these models default to effort \"none\" and can never emit a thinking block on their "
+                    + "own, so if none of them reasons even when thinking is enabled, mapping the "
+                    + "client's budget onto an effort has bought nothing"
+            );
+    }
+
+    /// <summary>The efforts <c>BuildReasoning</c>'s budget mapping can emit.</summary>
+    private static readonly string[] MappedEfforts = ["low", "medium", "high"];
+
+    /// <summary>Reads <c>reasoning.effort</c> out of a NON-streaming Responses reply.</summary>
+    private static string ReadEchoedReasoningEffort(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.TryGetProperty("reasoning", out var reasoning)
+                && reasoning.ValueKind == JsonValueKind.Object
+                && reasoning.TryGetProperty("effort", out var effort)
+                ? effort.ToString()
+                : "<absent>";
+        }
+        catch (JsonException)
+        {
+            return "<unparseable>";
+        }
     }
 
     /// <summary>
@@ -791,7 +994,14 @@ public sealed class CopilotAnthropicProxyLiveTests
         );
     }
 
-    /// <summary>Every model the proxy serves that advertises <c>/responses</c>, cheap tiers first.</summary>
+    /// <summary>
+    ///     Every model the proxy serves ONLY through <c>/responses</c>, cheap tiers first.
+    ///
+    ///     Excluding models that also advertise <c>/v1/messages</c> is not cosmetic: <c>ModelRoute</c>
+    ///     tries its Messages-passthrough arm FIRST, so an Anthropic request naming a dual-endpoint
+    ///     model never reaches the translator. A sweep that included one could report success for a
+    ///     model that never exercised the code under test.
+    /// </summary>
     private async Task<IReadOnlyList<string>> ResponsesCapableModelsAsync(CancellationToken cancellationToken)
     {
         var catalog = await _fixture.GetCatalogAsync(cancellationToken);
@@ -799,6 +1009,7 @@ public sealed class CopilotAnthropicProxyLiveTests
         [
             .. catalog
                 .Where(m => m.Advertises(ModelRouter.ResponsesPath))
+                .Where(m => !m.Advertises(ModelRouter.MessagesPath))
                 .Where(m => !ProxyExcludedVendors.Contains(m.Vendor, StringComparer.OrdinalIgnoreCase))
                 .Select(m => m.Id)
                 .OrderBy(id => CheapModelHints.Any(h => id.Contains(h, StringComparison.OrdinalIgnoreCase)) ? 0 : 1)

--- a/tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs
+++ b/tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs
@@ -743,6 +743,27 @@ public sealed class CopilotAnthropicProxyLiveTests
     ///
     ///     Statuses are checked first, or a 400 would masquerade as "this model cannot think".
     /// </summary>
+    /// <remarks>
+    ///     THE TOP BUCKET, RECORDED HERE BECAUSE NOTHING ELSE IN THE REPO HOLDS IT — and it is a probe
+    ///     observation, not a contract this test enforces. This test sends the <c>medium</c> bucket. The
+    ///     <c>high</c> one was measured by hand, read-only, on the same prompt through the same
+    ///     translated route: ten runs of <c>gpt-5.4</c> at <c>budget_tokens: 32768</c> gave a
+    ///     <c>thinking</c> block on 8 and none on 2. Both misses were complete, well-formed streams — one
+    ///     <c>text</c> block, <c>stop_reason: "end_turn"</c>, correct answer — so they are the model
+    ///     declining to reason, not truncation and not a transport failure. Deliberately not quoted as a
+    ///     rate: ten samples on one model and one prompt put the true one somewhere near 49-94%, and the
+    ///     medium bucket's 2-of-4 on this model is nowhere near separable from it. What the ten runs
+    ///     establish is only that misses happen at the largest budget too, which is what the README says
+    ///     and why nothing asserts it.
+    ///
+    ///     One precision, so a later reader need not reconstruct it: those runs observed the OUTCOME end
+    ///     to end, not the outbound <c>effort</c> field, because the translated route answers in
+    ///     Anthropic SSE and that carries no echo of the reasoning config. The link from 32768 to
+    ///     <c>"high"</c> is established deterministically by
+    ///     <c>AnthropicToResponsesRequestTests.Maps_the_thinking_budget_onto_a_reasoning_effort</c>, and
+    ///     live by <see cref="Every_responses_model_accepts_every_mapped_effort" />, which saw
+    ///     <c>gpt-5.4</c> echo <c>"effort":"high"</c> at 200.
+    /// </remarks>
     [SkippableFact]
     public async Task Thinking_enabled_makes_a_none_effort_model_reason()
     {

--- a/tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs
+++ b/tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs
@@ -164,8 +164,11 @@ public sealed class CopilotAnthropicProxyLiveTests
         doc.RootElement.GetProperty("role").GetString().Should().Be("assistant");
         doc.RootElement.TryGetProperty("stop_reason", out _).Should().BeTrue();
 
-        // Task 7 could only document what incomplete_details MIGHT look like, so record what actually
-        // came back rather than asserting a reason this repo has never observed.
+        // Left unasserted, and no longer because the shape is unknown: the sibling
+        // Truncated_reply_reports_incomplete_details_and_maps_to_max_tokens pins the
+        // incomplete_details -> max_tokens mapping outright. What is genuinely not ours to pin is which
+        // reason COPILOT picks for a one-token cap — truncate, or answer and end the turn — so record
+        // the live value rather than asserting the model's choice.
         _output.WriteLine($"OBSERVED stop_reason: {doc.RootElement.GetProperty("stop_reason").GetString()}");
     }
 
@@ -173,9 +176,10 @@ public sealed class CopilotAnthropicProxyLiveTests
     ///     Settles the one shape Task 7 could only guess at: what a TRUNCATED Responses reply looks
     ///     like. <c>ResponsesToAnthropicJson.DeriveStopReason</c> maps
     ///     <c>incomplete_details.reason == "max_output_tokens"</c> onto Anthropic's <c>max_tokens</c>,
-    ///     and every completed reply this repo has seen carries <c>incomplete_details: null</c> — so
-    ///     the mapping's only input has never been observed. Asks raw for the field's live spelling,
-    ///     then checks the proxy derives the right stop_reason from it.
+    ///     and every completed reply this repo had seen carried <c>incomplete_details: null</c>, so
+    ///     until this probe the mapping's only input had never been observed. Asks raw for the field's
+    ///     live spelling, then checks the proxy derives the right stop_reason from it — which is why
+    ///     nothing else in this file needs to hedge about that mapping.
     /// </summary>
     [SkippableFact]
     public async Task Truncated_reply_reports_incomplete_details_and_maps_to_max_tokens()

--- a/tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs
+++ b/tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs
@@ -352,8 +352,16 @@ public sealed class CopilotAnthropicProxyLiveTests
     ///     arms would be unreachable. Both captures are text-only on a prompt that rewards thinking; a
     ///     forced tool call short-circuits reasoning and would fake a negative.
     ///
-    ///     The "never volunteers" half is checked on one model, because it has held on every model on
-    ///     every run. The "produces when asked" half walks the catalog instead, because whether any ONE
+    ///     The "never volunteers" half runs on ONE model, and it is weaker evidence than a green
+    ///     assertion makes it look. This is the only request in the suite that sends NO reasoning field
+    ///     at all, so the shape has never been tried on a second model — and the model it picks is the
+    ///     cheapest tier, which Copilot defaults to <c>effort: "none"</c>. A turn that never reasons has
+    ///     nothing to summarise, so an empty result here cannot separate "Copilot volunteers no
+    ///     summaries" from "this model never reasons at all". The assertion stays because a summary
+    ///     arriving unasked would still be a genuine regression, not because it settles the general
+    ///     claim; widening it would mean sweeping this shape across the catalog.
+    ///
+    ///     The "produces when asked" half walks the catalog instead, because whether any ONE
     ///     turn reasons is a coin flip — asserting it on a single sample failed a full-suite run.
     /// </summary>
     [SkippableFact]
@@ -546,19 +554,19 @@ public sealed class CopilotAnthropicProxyLiveTests
     }
 
     /// <summary>
-    ///     SAFEGUARD (a) for shipping an unconditional <c>reasoning</c> field: does
-    ///     <c>{"summary": "auto"}</c> on its own actually PRODUCE summaries? The earlier evidence sent
-    ///     <c>effort</c> alongside it, and Copilot defaults these models to <c>effort: "none"</c> — a
-    ///     turn that never reasons cannot summarise. Accepted-but-inert is the failure this catches,
-    ///     and a status check alone would not: it looks identical to success.
+    ///     SAFEGUARD (a) for shipping an unconditional <c>reasoning</c> field: is
+    ///     <c>{"summary": "auto"}</c> on its own accepted everywhere, and does it actually PRODUCE
+    ///     summaries? The earlier evidence sent <c>effort</c> alongside it, and Copilot defaults some
+    ///     models to <c>effort: "none"</c> — a turn that never reasons cannot summarise.
     ///
-    ///     What it can and cannot assert. Acceptance is an invariant — all nine models have answered 200
-    ///     on every run — so that IS asserted. Productivity is not: sweeps minutes apart saw a different
-    ///     single model produce summaries, and one full-suite run saw all nine inert at once. An earlier
-    ///     revision asserted "some model produced summaries" and failed on exactly that run, so the
-    ///     split is now recorded rather than asserted. It is the evidence for the README's claim that
-    ///     summary-alone is unreliable, and the reason the shipped code derives an effort from the
-    ///     client instead of relying on this.
+    ///     ITS ONLY FAILURE MODE IS A MODEL ANSWERING SOMETHING OTHER THAN 200. Acceptance is the
+    ///     invariant, and it is asserted per model inside the loop. Productivity is recorded and never
+    ///     asserted: sweeps minutes apart saw a different single model produce summaries, and one
+    ///     full-suite run saw every swept model inert at once. An earlier revision asserted "some model
+    ///     produced summaries" and failed on exactly that run. So accepted-but-inert is what this probe
+    ///     DOCUMENTS, not what it catches — it is the evidence for the README's claim that summary-alone
+    ///     is unreliable, and the reason the shipped code derives an effort from the client instead of
+    ///     relying on this.
     /// </summary>
     [SkippableFact]
     public async Task Summary_auto_alone_is_accepted_everywhere_but_is_not_dependable()
@@ -569,9 +577,10 @@ public sealed class CopilotAnthropicProxyLiveTests
         var models = await ResponsesCapableModelsAsync(cts.Token);
         Skip.If(models.Count == 0, "This Copilot account exposes no /responses model the proxy will serve.");
 
-        // Swept across every served model, not just the cheap one: Copilot's DEFAULT effort is a
-        // per-model property, and "summary alone is inert" on a model that defaults to effort "none"
-        // says nothing about a model that defaults to a real one.
+        // Swept across every model the proxy serves through /responses ALONE — dual-endpoint models are
+        // excluded, see ResponsesCapableModelsAsync — rather than just the cheap one: Copilot's DEFAULT
+        // effort is a per-model property, and "summary alone is inert" on a model that defaults to
+        // effort "none" says nothing about a model that defaults to a real one.
         var inert = new List<string>();
         var productive = new List<string>();
 
@@ -596,20 +605,21 @@ public sealed class CopilotAnthropicProxyLiveTests
         _output.WriteLine($"OBSERVED summaries produced by:  {(productive.Count == 0 ? "<none>" : string.Join(", ", productive))}");
         _output.WriteLine($"OBSERVED accepted but inert on:  {(inert.Count == 0 ? "<none>" : string.Join(", ", inert))}");
 
-        // Deliberately no assertion on `productive`: an all-inert sweep is a real, observed outcome of
-        // this request shape, not a regression. Asserting it would be asserting a non-invariant, and
-        // `Thinking_enabled_makes_a_none_effort_model_reason` covers what the shipped code depends on.
-        inert.Concat(productive)
-            .Should()
-            .BeEquivalentTo(models, "every served model must have answered, or the sweep proves nothing");
+        // No assertion follows, deliberately. An all-inert sweep is a real, observed outcome of this
+        // request shape, not a regression, so `productive` is not asserted on; and a coverage assertion
+        // here would be a tautology — the loop above adds every model to exactly one of the two lists
+        // and never breaks, so `inert + productive == models` restates itself and cannot fail. The
+        // per-model 200 inside the loop is the whole contract. What the shipped code depends on is
+        // covered by `Thinking_enabled_makes_a_none_effort_model_reason`.
     }
 
     /// <summary>
     ///     SAFEGUARD (b): does ANY model this proxy serves through <c>/responses</c> reject a
-    ///     <c>reasoning</c> field? Every other probe in this file uses one cheap model, so an
-    ///     unconditional request field would be shipped on one model's evidence. This one sweeps the
-    ///     whole live <c>/responses</c> surface, non-reasoning-looking models included, and names any
-    ///     model that refuses.
+    ///     <c>reasoning</c> field? Several probes in this file use one cheap model, so an unconditional
+    ///     request field would otherwise be shipped on one model's evidence. This one sweeps every model
+    ///     the proxy routes to <c>/responses</c> — non-reasoning-looking models included, dual-endpoint
+    ///     models excluded because they never reach the translator, see
+    ///     <see cref="ResponsesCapableModelsAsync" /> — and names any model that refuses.
     /// </summary>
     [SkippableFact]
     public async Task Every_responses_model_accepts_a_reasoning_field()
@@ -723,10 +733,13 @@ public sealed class CopilotAnthropicProxyLiveTests
     ///     endpoint with extended thinking enabled and reports whether one appears.
     ///
     ///     The mapping clearly works — models that could NEVER reason before now usually do — but it is
-    ///     not a guarantee. Over four runs, two had all four models produce a block and two had
-    ///     <c>gpt-5.4</c> alone stay silent. So this asserts that SOME rescued model reasoned, which is
-    ///     the claim the README makes, and logs the per-model split. Do not tighten this to "all
-    ///     models": that was tried, and the third run refuted it.
+    ///     not a guarantee, and WHICH model falls silent is not stable either. Over five runs, two had
+    ///     all four models produce a block. On the other three at least one stayed silent:
+    ///     <c>gpt-5.4</c> on two of them and <c>gpt-5.4-nano</c> on the third, and on the two of those
+    ///     with a full per-model split recorded the remaining three models still produced one. So this
+    ///     asserts that SOME rescued model reasoned, which is the claim the README makes, and logs the
+    ///     per-model split. Do not tighten this to "all models": that was tried, and the third run
+    ///     refuted it — nor to "all but <c>gpt-5.4</c>", which the fifth run would have refuted.
     ///
     ///     Statuses are checked first, or a 400 would masquerade as "this model cannot think".
     /// </summary>
@@ -774,7 +787,18 @@ public sealed class CopilotAnthropicProxyLiveTests
         }
 
         _output.WriteLine($"models defaulting to effort \"none\": {string.Join(", ", neverReason)}");
-        Skip.If(neverReason.Count == 0, "No served model defaults to effort \"none\", so there is nothing to rescue.");
+        // A skip here is not a clean pass. This probe is the ONLY end-to-end enforcement of the
+        // budget-to-effort mapping, and it works by rescuing a model that provably cannot reason on its
+        // own — without one, a thinking block would not prove the effort we sent caused it. So say out
+        // loud what disappears, rather than substituting a weaker assertion on some other model.
+        Skip.If(
+            neverReason.Count == 0,
+            "No served model defaults to effort \"none\", so nothing here is being rescued and the ONLY "
+                + "end-to-end check of the budget-to-effort mapping just went silent. If Copilot has "
+                + "stopped defaulting any model to \"none\", the payoff cannot be demonstrated this way at "
+                + "all and the mapping needs a different live check — do not weaken this one to keep it "
+                + "running."
+        );
 
         var reasoned = new List<string>();
         var stayedSilent = new List<string>();
@@ -844,18 +868,29 @@ public sealed class CopilotAnthropicProxyLiveTests
     }
 
     /// <summary>
-    ///     The payoff probe for the unconditional <c>reasoning</c> field: a <c>thinking</c> block must
-    ///     actually reach an Anthropic client through the FULL translated route. The sweep above proves
-    ///     only that Copilot returns summary events on the raw Responses stream; this proves the request
-    ///     translator asks for them without being told to and the stream translator turns them into
-    ///     Anthropic frames.
+    ///     Drives the FULL translated route with a request naming no reasoning of any kind — all Claude
+    ///     Code sends when extended thinking is off. The request translator adds
+    ///     <c>reasoning: {"summary": "auto"}</c> by itself and the stream translator reframes whatever
+    ///     comes back, so this exercises both halves against every served model.
     ///
-    ///     Walks the catalog because which model reasons is Copilot's choice, not ours — cheap models
-    ///     default to <c>effort: "none"</c> and cannot summarise a turn they never reasoned through, so
-    ///     requiring the FIRST model to produce a block would fail for a reason that is not a defect.
+    ///     WHAT IT ASSERTS IS THE 200, NOT A THINKING BLOCK. The upstream shape it produces —
+    ///     summary-only, no effort — is byte-for-byte the one
+    ///     <see cref="Summary_auto_alone_is_accepted_everywhere_but_is_not_dependable" /> sends, just
+    ///     through the Anthropic front door instead of raw <c>/responses</c>. That probe records an
+    ///     all-inert sweep as a real outcome rather than a regression, and this file must not hold the
+    ///     opposite verdict on an identical observation, so the per-model split is logged and never
+    ///     asserted. An earlier revision threw when every model stayed silent; a run where none reasons
+    ///     is exactly what the other probe has already observed happening.
+    ///
+    ///     Nothing is lost by that. That a client sending no <c>thinking</c> field still gets
+    ///     <c>summary: "auto"</c> and no <c>effort</c> is pinned deterministically at fixture level by
+    ///     <c>AnthropicToResponsesRequestTests.Always_asks_for_reasoning_summaries</c>, and the chain
+    ///     from summary events to an Anthropic <c>thinking</c> block is ENFORCED end-to-end by
+    ///     <see cref="Thinking_enabled_makes_a_none_effort_model_reason" />, which sends an effort and is
+    ///     far more reliable for that reason.
     /// </summary>
     [SkippableFact]
-    public async Task Translated_route_emits_a_thinking_block_without_being_asked()
+    public async Task Translated_route_serves_every_model_without_a_reasoning_hint()
     {
         Skip.IfNot(_fixture.Available, _fixture.SkipReason);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(600));
@@ -863,11 +898,12 @@ public sealed class CopilotAnthropicProxyLiveTests
         var models = await ResponsesCapableModelsAsync(cts.Token);
         Skip.If(models.Count == 0, "This Copilot account exposes no /responses model the proxy will serve.");
 
+        var thought = new List<string>();
         var silent = new List<string>();
         foreach (var model in models)
         {
             // Deliberately NOT asking for reasoning anywhere in this request: the point is that the
-            // translator adds it. Claude Code has no way to request it through the Anthropic API.
+            // translator adds it. A client with extended thinking switched off sends exactly this.
             var (status, body) = await SendProxyAsync(
                 "/v1/messages",
                 new
@@ -892,20 +928,28 @@ public sealed class CopilotAnthropicProxyLiveTests
 
             if (body.Contains("\"type\":\"thinking\"", StringComparison.Ordinal))
             {
-                _output.WriteLine($"{model,-24} -> OBSERVED a thinking block on the translated route.");
-                _output.WriteLine(Truncate(body, 1500));
-                _output.WriteLine($"OBSERVED no thinking block from: {string.Join(", ", silent)}");
-                return;
+                _output.WriteLine($"{model,-24} -> 200 OK, thinking block");
+
+                // The first one only, as the evidence sample: these streams run to hundreds of lines
+                // and the per-model split below is what a reader of this log actually needs.
+                if (thought.Count == 0)
+                {
+                    _output.WriteLine(Truncate(body, 1500));
+                }
+
+                thought.Add(model);
+                continue;
             }
 
             _output.WriteLine($"{model,-24} -> 200 OK, no thinking block");
             silent.Add(model);
         }
 
-        throw new InvalidOperationException(
-            "No served /responses model produced a thinking block through the translated route, so the "
-                + $"unconditional reasoning field bought nothing. Silent models: {string.Join(", ", silent)}"
-        );
+        // Recorded, never asserted — see the summary above. An all-silent sweep of this request shape
+        // is an outcome `Summary_auto_alone_is_accepted_everywhere_but_is_not_dependable` has already
+        // observed on the raw endpoint, and this probe cannot call the same observation a regression.
+        _output.WriteLine($"OBSERVED a thinking block from:  {(thought.Count == 0 ? "<none>" : string.Join(", ", thought))}");
+        _output.WriteLine($"OBSERVED no thinking block from: {(silent.Count == 0 ? "<none>" : string.Join(", ", silent))}");
     }
 
     /// <summary>
@@ -997,10 +1041,10 @@ public sealed class CopilotAnthropicProxyLiveTests
     /// <summary>
     ///     Every model the proxy serves ONLY through <c>/responses</c>, cheap tiers first.
     ///
-    ///     Excluding models that also advertise <c>/v1/messages</c> is not cosmetic: <c>ModelRoute</c>
-    ///     tries its Messages-passthrough arm FIRST, so an Anthropic request naming a dual-endpoint
-    ///     model never reaches the translator. A sweep that included one could report success for a
-    ///     model that never exercised the code under test.
+    ///     Excluding models that also advertise <c>/v1/messages</c> is not cosmetic:
+    ///     <c>ModelRouter.Resolve</c> tries its Messages-passthrough arm FIRST, so an Anthropic request
+    ///     naming a dual-endpoint model never reaches the translator. A sweep that included one could
+    ///     report success for a model that never exercised the code under test.
     /// </summary>
     private async Task<IReadOnlyList<string>> ResponsesCapableModelsAsync(CancellationToken cancellationToken)
     {

--- a/tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs
+++ b/tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text;
 using System.Text.Json;
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
@@ -79,6 +80,766 @@ public sealed class CopilotAnthropicProxyLiveTests
         var sse = await response.Content.ReadAsStringAsync(cts.Token);
         _output.WriteLine($"SSE: {sse}");
         sse.Should().Contain("content_block_delta", "the streaming endpoint should emit incremental deltas");
+    }
+
+    // =================================================================================================
+    // The translated route: Anthropic Messages IN, OpenAI Responses OUT.
+    //
+    // Everything below drives a model this Copilot account exposes ONLY through /responses, so the
+    // proxy has to translate rather than relay bytes. These are the only tests anywhere in the repo
+    // that can confirm the live event NAMES and payload SHAPES the translators assume — a fixture can
+    // only prove the translators agree with themselves.
+    //
+    // The proxy must run in DISCOVERY mode for any of this to be reachable: a catalog pinned through
+    // COPILOT_ANTHROPIC_MODEL carries no endpoint metadata, and a metadata-free model always routes as
+    // Anthropic-Messages passthrough. CreateDiscoveringProxy clears the variable for that reason.
+    // =================================================================================================
+
+    /// <summary>
+    ///     THE GATE for the translated route: drive a Responses-only model through the ANTHROPIC
+    ///     endpoint and require a well-formed Anthropic stream back. This is the one quadrant that is
+    ///     real translation rather than passthrough.
+    /// </summary>
+    [SkippableFact]
+    public async Task Anthropic_endpoint_streams_a_responses_only_model()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+        var model = await PickResponsesOnlyModelAsync(cts.Token);
+        _output.WriteLine($"model: {model}");
+
+        var body = await PostProxyAsync(
+            "/v1/messages",
+            new
+            {
+                model,
+                max_tokens = 128,
+                stream = true,
+                messages = new[] { new { role = "user", content = "Reply with the single word: ok" } },
+            },
+            cts.Token
+        );
+
+        _output.WriteLine(body);
+
+        body.Should().Contain("event: message_start");
+        body.Should().Contain("content_block_delta");
+        body.Should().Contain("event: message_stop");
+        body.Should().NotContain("response.created", "upstream Responses frames must not leak through");
+    }
+
+    /// <summary>
+    ///     Confirms Claude Code's model-validation probe survives translation. It sends max_tokens: 1
+    ///     with maxRetries: 0 as the FIRST request against any new model; a 400 here makes the model
+    ///     look unusable before the user ever gets a turn.
+    /// </summary>
+    [SkippableFact]
+    public async Task Anthropic_endpoint_survives_the_max_tokens_one_validation_probe()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+        var model = await PickResponsesOnlyModelAsync(cts.Token);
+        _output.WriteLine($"model: {model}");
+
+        var body = await PostProxyAsync(
+            "/v1/messages",
+            new
+            {
+                model,
+                max_tokens = 1,
+                messages = new[]
+                {
+                    new { role = "user", content = new[] { new { type = "text", text = "Hi" } } },
+                },
+            },
+            cts.Token
+        );
+
+        _output.WriteLine(body);
+
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("type").GetString().Should().Be("message");
+        doc.RootElement.GetProperty("role").GetString().Should().Be("assistant");
+        doc.RootElement.TryGetProperty("stop_reason", out _).Should().BeTrue();
+
+        // Task 7 could only document what incomplete_details MIGHT look like, so record what actually
+        // came back rather than asserting a reason this repo has never observed.
+        _output.WriteLine($"OBSERVED stop_reason: {doc.RootElement.GetProperty("stop_reason").GetString()}");
+    }
+
+    /// <summary>
+    ///     Settles the one shape Task 7 could only guess at: what a TRUNCATED Responses reply looks
+    ///     like. <c>ResponsesToAnthropicJson.DeriveStopReason</c> maps
+    ///     <c>incomplete_details.reason == "max_output_tokens"</c> onto Anthropic's <c>max_tokens</c>,
+    ///     and every completed reply this repo has seen carries <c>incomplete_details: null</c> — so
+    ///     the mapping's only input has never been observed. Asks raw for the field's live spelling,
+    ///     then checks the proxy derives the right stop_reason from it.
+    /// </summary>
+    [SkippableFact]
+    public async Task Truncated_reply_reports_incomplete_details_and_maps_to_max_tokens()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+        var model = await PickResponsesOnlyModelAsync(cts.Token);
+        _output.WriteLine($"model: {model}");
+
+        const string LongAnswer = "Count slowly from 1 to 200, one number per line. Do not stop early.";
+
+        var (rawStatus, rawBody) = await PostRawAsync(
+            ModelRouter.ResponsesPath,
+            new
+            {
+                model,
+                store = false,
+                max_output_tokens = 16,
+                input = new[]
+                {
+                    new
+                    {
+                        type = "message",
+                        role = "user",
+                        content = new[] { new { type = "input_text", text = LongAnswer } },
+                    },
+                },
+            },
+            cts.Token
+        );
+
+        _output.WriteLine($"RAW {ModelRouter.ResponsesPath} max_output_tokens=16 -> {(int)rawStatus} {rawStatus}");
+        _output.WriteLine($"OBSERVED raw status field:       {ReadEcho(rawBody, "status")}");
+        _output.WriteLine($"OBSERVED raw incomplete_details: {ReadEcho(rawBody, "incomplete_details")}");
+
+        var body = await PostProxyAsync(
+            "/v1/messages",
+            new
+            {
+                model,
+                max_tokens = 16,
+                messages = new[] { new { role = "user", content = LongAnswer } },
+            },
+            cts.Token
+        );
+
+        _output.WriteLine(Truncate(body, 1500));
+
+        using var doc = JsonDocument.Parse(body);
+        var stopReason = doc.RootElement.GetProperty("stop_reason").GetString();
+        _output.WriteLine($"OBSERVED proxy stop_reason:      {stopReason}");
+
+        // Observed 2026-07-27 and asserted from here on: the spelling DeriveStopReason reads is real.
+        ReadEcho(rawBody, "incomplete_details")
+            .Should()
+            .Contain("max_output_tokens", "DeriveStopReason keys the max_tokens mapping off this exact reason");
+        stopReason.Should().Be("max_tokens");
+    }
+
+    /// <summary>
+    ///     A tool call end to end through the translated route. Every other streaming test is plain
+    ///     text, and <c>ResponsesToAnthropicSse</c>'s tool arms hinge on event names nothing in this
+    ///     repo has ever observed live. The translator deliberately DROPS a
+    ///     <c>function_call_arguments.delta</c> when no tool_use block is open rather than inventing an
+    ///     id and name, so a mis-guessed <c>output_item.added</c> spelling would make tool calls vanish
+    ///     with no diagnostic at all. This test is the only thing that catches that.
+    /// </summary>
+    [SkippableFact]
+    public async Task Anthropic_endpoint_streams_a_tool_call()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+        var model = await PickResponsesOnlyModelAsync(cts.Token);
+        _output.WriteLine($"model: {model}");
+
+        var body = await PostProxyAsync(
+            "/v1/messages",
+            new
+            {
+                model,
+                max_tokens = 512,
+                stream = true,
+                tools = new[]
+                {
+                    new
+                    {
+                        name = "get_weather",
+                        description = "Get the current weather for a city.",
+                        input_schema = new
+                        {
+                            type = "object",
+                            properties = new { city = new { type = "string", description = "City name" } },
+                            required = new[] { "city" },
+                        },
+                    },
+                },
+                tool_choice = new { type = "any" },
+                messages = new[] { new { role = "user", content = "What is the weather in Paris?" } },
+            },
+            cts.Token
+        );
+
+        _output.WriteLine(body);
+
+        body.Should().Contain("event: message_start");
+        body.Should()
+            .Contain(
+                "\"type\":\"tool_use\"",
+                "a forced tool call must reach the client as an Anthropic tool_use block"
+            );
+        body.Should()
+            .Contain(
+                "input_json_delta",
+                "the tool's arguments are streamed; dropping them leaves an un-callable tool_use block"
+            );
+        body.Should().Contain("event: message_stop");
+    }
+
+    /// <summary>
+    ///     Confirms the SSE framing assumptions the whole streaming translator rests on, by reading a
+    ///     RAW Responses stream (no proxy, no provider stack): the event NAMES, the Content-Type Task 9
+    ///     answers 502 for when it is missing, and — critically — whether any single event ever carries
+    ///     more than one <c>data:</c> line. The proxy's splitter feeds each <c>data:</c> line to the
+    ///     translator as a complete payload, so a spec-legal multi-line event would arrive in fragments,
+    ///     fail to parse, and be dropped in silence.
+    /// </summary>
+    [SkippableFact]
+    public async Task Responses_stream_uses_the_event_names_the_translator_assumes()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+        var model = await PickResponsesOnlyModelAsync(cts.Token);
+        _output.WriteLine($"model: {model}");
+
+        var capture = await CaptureResponsesStreamAsync(
+            ToolCallingResponsesRequest(model, requestReasoningSummaries: true),
+            cts.Token
+        );
+
+        DumpCapture("raw streaming /responses, tool forced, reasoning summaries requested", capture);
+
+        capture.Status.Should().Be(HttpStatusCode.OK);
+        capture
+            .ContentType.Should()
+            .StartWith("text/event-stream", "the proxy answers 502 for a streaming reply that is not SSE");
+        capture
+            .MaxDataLinesPerEvent.Should()
+            .Be(1, "the proxy treats every data: line as one complete payload; a multi-line event is dropped");
+        capture
+            .PayloadTypes.Should()
+            .Contain(
+                "response.output_item.added",
+                "ResponsesToAnthropicSse opens its tool_use block on this event and on nothing else"
+            );
+        capture
+            .PayloadTypes.Should()
+            .Contain(
+                "response.function_call_arguments.delta",
+                "the tool arguments arrive on this event; a different spelling drops them silently"
+            );
+    }
+
+    /// <summary>
+    ///     Establishes whether Copilot EVER emits reasoning summaries, and if so under what request.
+    ///     It matters because <c>AnthropicToResponsesRequest</c> sends no <c>reasoning</c> field at all:
+    ///     if summaries only arrive when explicitly requested, the translators' <c>thinking</c> arms are
+    ///     unreachable on the translated route. Two captures, both text-only on a prompt that rewards
+    ///     thinking (a forced tool call short-circuits reasoning): one silent, one asking for summaries
+    ///     at a non-default effort. Recorded rather than asserted — the point is the observation.
+    /// </summary>
+    [SkippableFact]
+    public async Task Responses_stream_reports_when_reasoning_summaries_arrive()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(180));
+
+        var model = await PickResponsesOnlyModelAsync(cts.Token);
+        _output.WriteLine($"model: {model}");
+
+        var silent = await CaptureResponsesStreamAsync(
+            ReasoningResponsesRequest(model, askForSummaries: false),
+            cts.Token
+        );
+        DumpCapture("raw streaming /responses, no reasoning field sent (what the proxy sends)", silent);
+
+        var asked = await CaptureResponsesStreamAsync(
+            ReasoningResponsesRequest(model, askForSummaries: true),
+            cts.Token
+        );
+        DumpCapture("raw streaming /responses, reasoning {effort: medium, summary: auto}", asked);
+
+        static List<string> SummaryEvents(RawSseCapture capture) =>
+            [.. capture.PayloadTypes.Where(t => t.Contains("reasoning", StringComparison.Ordinal))];
+
+        var silentSummaries = SummaryEvents(silent);
+        var askedSummaries = SummaryEvents(asked);
+
+        _output.WriteLine(
+            "OBSERVED reasoning events, no reasoning field sent: "
+                + (silentSummaries.Count == 0 ? "<none>" : string.Join(", ", silentSummaries))
+        );
+        _output.WriteLine(
+            "OBSERVED reasoning events, summaries requested:     "
+                + (askedSummaries.Count == 0 ? "<none>" : string.Join(", ", askedSummaries))
+        );
+    }
+
+    /// <summary>
+    ///     Settles whether <c>temperature</c> / <c>top_p</c> may be passed through to a Responses-only
+    ///     model. Reasoning models on the Responses API are documented to reject a non-default
+    ///     <c>temperature</c>, and <c>AnthropicToResponsesRequest</c> copies both across, so this is
+    ///     probed live rather than guessed: raw first (what the API itself says), then through the
+    ///     proxy (where the passthrough decision actually bites).
+    /// </summary>
+    [SkippableFact]
+    public async Task Responses_only_model_accepts_a_non_default_temperature()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+        var model = await PickResponsesOnlyModelAsync(cts.Token);
+        _output.WriteLine($"model: {model}");
+
+        var (rawStatus, rawBody) = await PostRawAsync(
+            ModelRouter.ResponsesPath,
+            new
+            {
+                model,
+                store = false,
+                temperature = 0.7,
+                top_p = 0.5,
+                max_output_tokens = 16,
+                input = new[]
+                {
+                    new
+                    {
+                        type = "message",
+                        role = "user",
+                        content = new[] { new { type = "input_text", text = "Reply with: ok" } },
+                    },
+                },
+            },
+            cts.Token
+        );
+
+        _output.WriteLine($"RAW /responses temperature=0.7 top_p=0.5 -> {(int)rawStatus} {rawStatus}");
+        _output.WriteLine($"RAW echoed temperature: {ReadEcho(rawBody, "temperature")}");
+        _output.WriteLine($"RAW echoed top_p: {ReadEcho(rawBody, "top_p")}");
+        _output.WriteLine(Truncate(rawBody, 2000));
+
+        var (proxyStatus, proxyBody) = await SendProxyAsync(
+            "/v1/messages",
+            new
+            {
+                model,
+                max_tokens = 16,
+                temperature = 0.7,
+                top_p = 0.5,
+                messages = new[] { new { role = "user", content = "Reply with: ok" } },
+            },
+            cts.Token
+        );
+
+        _output.WriteLine($"PROXY /v1/messages temperature=0.7 top_p=0.5 -> {(int)proxyStatus} {proxyStatus}");
+        _output.WriteLine(Truncate(proxyBody, 2000));
+
+        rawStatus.Should().Be(HttpStatusCode.OK, "the Responses API's own verdict on a non-default temperature");
+        proxyStatus.Should().Be(HttpStatusCode.OK, "the proxy copies temperature and top_p straight across");
+    }
+
+    /// <summary>
+    ///     <c>count_tokens</c> has no Responses counterpart, so the proxy answers an honest 404 rather
+    ///     than running a billed generation or inventing a number. Not a regression: the pre-translation
+    ///     proxy 404'd these too. Claude Code calls this endpoint, so the shape of the refusal is part
+    ///     of the contract.
+    /// </summary>
+    [SkippableFact]
+    public async Task Anthropic_count_tokens_404s_for_a_responses_only_model()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        var model = await PickResponsesOnlyModelAsync(cts.Token);
+        _output.WriteLine($"model: {model}");
+
+        var (status, body) = await SendProxyAsync(
+            "/v1/messages/count_tokens",
+            new
+            {
+                model,
+                messages = new[] { new { role = "user", content = "Hi" } },
+            },
+            cts.Token
+        );
+
+        _output.WriteLine($"status: {(int)status} {status}");
+        _output.WriteLine(body);
+
+        status.Should().Be(HttpStatusCode.NotFound);
+        body.Should().Contain("not_found_error");
+    }
+
+    /// <summary>Codex's quadrant: a Responses request must reach Copilot unchanged.</summary>
+    [SkippableFact]
+    public async Task Responses_endpoint_passes_through()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+        var model = await PickResponsesOnlyModelAsync(cts.Token);
+        _output.WriteLine($"model: {model}");
+
+        var body = await PostProxyAsync(
+            "/v1/responses",
+            new
+            {
+                model,
+                store = false,
+                input = new[]
+                {
+                    new
+                    {
+                        type = "message",
+                        role = "user",
+                        content = new[] { new { type = "input_text", text = "Reply with: ok" } },
+                    },
+                },
+            },
+            cts.Token
+        );
+
+        _output.WriteLine(body);
+        body.Should().Contain("\"output\"");
+    }
+
+    /// <summary>
+    ///     Picks a model this account serves ONLY through <c>/responses</c>, read from the live catalog
+    ///     rather than guessed from the id — guessing by name is what made an earlier probe pick a
+    ///     Responses-only model when it wanted a dual-endpoint one. Vendors the proxy refuses (Google,
+    ///     Microsoft) are excluded here too, or the proxy would answer 404 for a model that genuinely is
+    ///     Responses-only. Cheap tiers first: these tests spend real tokens.
+    ///     <c>COPILOT_OPENAI_MODEL</c> overrides, for pinning one specific model by hand.
+    /// </summary>
+    private async Task<string> PickResponsesOnlyModelAsync(CancellationToken cancellationToken)
+    {
+        var pinned = Environment.GetEnvironmentVariable("COPILOT_OPENAI_MODEL");
+        if (!string.IsNullOrWhiteSpace(pinned))
+        {
+            return pinned;
+        }
+
+        var catalog = await _fixture.GetCatalogAsync(cancellationToken);
+        var candidates = catalog
+            .Where(m => m.Advertises(ModelRouter.ResponsesPath))
+            .Where(m => !m.Advertises(ModelRouter.ChatCompletionsPath))
+            .Where(m => !m.Advertises(ModelRouter.MessagesPath))
+            .Where(m => !ProxyExcludedVendors.Contains(m.Vendor, StringComparer.OrdinalIgnoreCase))
+            .ToList();
+
+        Skip.If(candidates.Count == 0, "This Copilot account exposes no Responses-only model the proxy will serve.");
+
+        foreach (var hint in CheapModelHints)
+        {
+            var cheap = candidates.FirstOrDefault(m => m.Id.Contains(hint, StringComparison.OrdinalIgnoreCase));
+            if (cheap is not null)
+            {
+                return cheap.Id;
+            }
+        }
+
+        return candidates[0].Id;
+    }
+
+    /// <summary>Vendors <c>ProxyModelResolver</c> filters out of the catalog; picking one would 404.</summary>
+    private static readonly string[] ProxyExcludedVendors = ["Google", "Microsoft"];
+
+    /// <summary>Substrings that mark the cheap tier of a model family, most preferred first.</summary>
+    private static readonly string[] CheapModelHints = ["nano", "mini"];
+
+    /// <summary>
+    ///     A Responses request that forces a tool call, optionally asking for reasoning summaries.
+    ///     Returned as <see cref="object"/> so the two probes cannot drift apart on anything but the one
+    ///     field under test.
+    /// </summary>
+    private static object ToolCallingResponsesRequest(string model, bool requestReasoningSummaries)
+    {
+        var request = new Dictionary<string, object?>
+        {
+            ["model"] = model,
+            ["stream"] = true,
+            ["store"] = false,
+            ["max_output_tokens"] = 512,
+            ["tool_choice"] = "required",
+            ["tools"] = new object[]
+            {
+                new
+                {
+                    type = "function",
+                    name = "get_weather",
+                    description = "Get the current weather for a city.",
+                    parameters = new
+                    {
+                        type = "object",
+                        properties = new { city = new { type = "string", description = "City name" } },
+                        required = new[] { "city" },
+                    },
+                },
+            },
+            ["input"] = new object[]
+            {
+                new
+                {
+                    type = "message",
+                    role = "user",
+                    content = new[] { new { type = "input_text", text = "What is the weather in Paris?" } },
+                },
+            },
+        };
+
+        if (requestReasoningSummaries)
+        {
+            // effort as well as summary: Copilot defaults these models to effort "none", so asking only
+            // for a summary yields a turn that never reasons and therefore never summarises.
+            request["reasoning"] = new { effort = "medium", summary = "auto" };
+        }
+
+        return request;
+    }
+
+    /// <summary>
+    ///     A text-only Responses request on a prompt that rewards thinking, optionally asking for
+    ///     reasoning summaries at a non-default effort. No tools: <c>tool_choice: "required"</c> makes
+    ///     the model answer with a call immediately, which is exactly when it does not reason.
+    /// </summary>
+    private static object ReasoningResponsesRequest(string model, bool askForSummaries)
+    {
+        var request = new Dictionary<string, object?>
+        {
+            ["model"] = model,
+            ["stream"] = true,
+            ["store"] = false,
+            ["max_output_tokens"] = 512,
+            ["input"] = new object[]
+            {
+                new
+                {
+                    type = "message",
+                    role = "user",
+                    content = new[]
+                    {
+                        new
+                        {
+                            type = "input_text",
+                            text = "A bat and a ball cost $1.10 together. The bat costs $1.00 more than the ball. "
+                                + "How much does the ball cost? Answer with the amount only.",
+                        },
+                    },
+                },
+            },
+        };
+
+        if (askForSummaries)
+        {
+            // effort as well as summary: Copilot defaults these models to effort "none", so asking only
+            // for a summary yields a turn that never reasons and therefore never summarises.
+            request["reasoning"] = new { effort = "medium", summary = "auto" };
+        }
+
+        return request;
+    }
+
+    /// <summary>Everything a raw Responses SSE stream reveals about the framing the translator assumes.</summary>
+    private sealed record RawSseCapture(
+        HttpStatusCode Status,
+        string? ContentType,
+        IReadOnlyList<string> Lines,
+        IReadOnlyList<string> EventNames,
+        IReadOnlyList<string> PayloadTypes,
+        int MaxDataLinesPerEvent
+    );
+
+    /// <summary>
+    ///     Issues a RAW streaming <c>POST /responses</c> — no proxy, no provider stack — and captures
+    ///     the response Content-Type, every <c>event:</c> name, every payload <c>type</c>, and the most
+    ///     <c>data:</c> lines any single event carried.
+    /// </summary>
+    private async Task<RawSseCapture> CaptureResponsesStreamAsync(object payload, CancellationToken cancellationToken)
+    {
+        using var http = CopilotHttpClientFactory.Create(
+            _fixture.Options.BaseUrl,
+            _fixture.TokenProvider,
+            _fixture.Session,
+            _fixture.Options,
+            timeout: TimeSpan.FromSeconds(90)
+        );
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, ModelRouter.ResponsesPath)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"),
+        };
+
+        using var response = await http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+
+        var lines = new List<string>();
+        var eventNames = new List<string>();
+        var payloadTypes = new List<string>();
+        var maxDataLines = 0;
+        var dataLinesInEvent = 0;
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        while (await reader.ReadLineAsync(cancellationToken) is { } line)
+        {
+            lines.Add(line);
+
+            if (line.Length == 0)
+            {
+                dataLinesInEvent = 0;
+                continue;
+            }
+
+            if (line.StartsWith("event:", StringComparison.Ordinal))
+            {
+                RecordFirstSeen(eventNames, line[6..].Trim());
+                continue;
+            }
+
+            if (!line.StartsWith("data:", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            dataLinesInEvent++;
+            maxDataLines = Math.Max(maxDataLines, dataLinesInEvent);
+            RecordFirstSeen(payloadTypes, ReadPayloadType(line[5..].Trim()));
+        }
+
+        return new RawSseCapture(
+            response.StatusCode,
+            response.Content.Headers.ContentType?.ToString(),
+            lines,
+            eventNames,
+            payloadTypes,
+            maxDataLines
+        );
+    }
+
+    /// <summary>Appends in first-seen order, skipping blanks and repeats, so the dump is deterministic.</summary>
+    private static void RecordFirstSeen(List<string> seen, string value)
+    {
+        if (value.Length > 0 && !seen.Contains(value, StringComparer.Ordinal))
+        {
+            seen.Add(value);
+        }
+    }
+
+    /// <summary>Reads an SSE payload's <c>type</c>, labelling anything that is not a JSON object.</summary>
+    private static string ReadPayloadType(string payload)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(payload);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("type", out var type)
+                && type.ValueKind == JsonValueKind.String)
+            {
+                return type.GetString() ?? "(null type)";
+            }
+
+            return "(json, no string type)";
+        }
+        catch (JsonException)
+        {
+            return $"(not json) {Truncate(payload, 60)}";
+        }
+    }
+
+    private void DumpCapture(string label, RawSseCapture capture)
+    {
+        _output.WriteLine($"--- {label} ---");
+        _output.WriteLine($"status:                       {(int)capture.Status} {capture.Status}");
+        _output.WriteLine($"content-type:                 {capture.ContentType ?? "(none)"}");
+        _output.WriteLine($"max data: lines in one event: {capture.MaxDataLinesPerEvent}");
+        _output.WriteLine($"event: names:                 {string.Join(", ", capture.EventNames)}");
+        _output.WriteLine($"payload types:                {string.Join(", ", capture.PayloadTypes)}");
+        _output.WriteLine("raw frames:");
+        _output.WriteLine(Truncate(string.Join("\n", capture.Lines), 20000));
+    }
+
+    /// <summary>POSTs JSON straight to Copilot, bypassing the proxy entirely.</summary>
+    private async Task<(HttpStatusCode Status, string Body)> PostRawAsync(
+        string path,
+        object payload,
+        CancellationToken cancellationToken
+    )
+    {
+        using var http = CopilotHttpClientFactory.Create(
+            _fixture.Options.BaseUrl,
+            _fixture.TokenProvider,
+            _fixture.Session,
+            _fixture.Options,
+            timeout: TimeSpan.FromSeconds(90)
+        );
+
+        using var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+        using var response = await http.PostAsync(path, content, cancellationToken);
+        return (response.StatusCode, await response.Content.ReadAsStringAsync(cancellationToken));
+    }
+
+    /// <summary>POSTs JSON to a freshly booted proxy in discovery mode and returns status plus body.</summary>
+    private static async Task<(HttpStatusCode Status, string Body)> SendProxyAsync(
+        string path,
+        object payload,
+        CancellationToken cancellationToken
+    )
+    {
+        await using var factory = CreateDiscoveringProxy();
+        using var client = factory.CreateClient();
+        using var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync(path, content, cancellationToken);
+        return (response.StatusCode, await response.Content.ReadAsStringAsync(cancellationToken));
+    }
+
+    /// <summary>As <see cref="SendProxyAsync"/>, but requires a 200 and returns just the body.</summary>
+    private static async Task<string> PostProxyAsync(string path, object payload, CancellationToken cancellationToken)
+    {
+        var (status, body) = await SendProxyAsync(path, payload, cancellationToken);
+        status.Should().Be(HttpStatusCode.OK, "POST {0} failed with: {1}", path, Truncate(body, 2000));
+        return body;
+    }
+
+    /// <summary>
+    ///     Boots the proxy in DISCOVERY mode. Clearing <c>COPILOT_ANTHROPIC_MODEL</c> is load-bearing:
+    ///     a pinned catalog carries no endpoint metadata, so every model in it routes as Anthropic
+    ///     passthrough and the translated route becomes unreachable.
+    /// </summary>
+    private static ProxyHost CreateDiscoveringProxy()
+    {
+        Environment.SetEnvironmentVariable("COPILOT_ANTHROPIC_MODEL", null);
+        return new ProxyHost();
+    }
+
+    private static string Truncate(string value, int max) =>
+        value.Length <= max ? value : value[..max] + $"\n... [{value.Length - max} more chars]";
+
+    /// <summary>
+    ///     Reads a top-level scalar back out of a Responses reply so a probe can report what the API
+    ///     ECHOED rather than what it was sent — the difference between "accepted" and "silently reset
+    ///     to the default" is invisible in the status code alone.
+    /// </summary>
+    private static string ReadEcho(string json, string property)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.TryGetProperty(property, out var value) ? value.ToString() : "<absent>";
+        }
+        catch (JsonException)
+        {
+            return "<unparseable>";
+        }
     }
 
     /// <summary>Boots the proxy host with the resolved model pinned via the environment variable.</summary>

--- a/tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs
+++ b/tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs
@@ -524,7 +524,11 @@ public sealed class CopilotAnthropicProxyLiveTests
         body.Should().Contain("not_found_error");
     }
 
-    /// <summary>Codex's quadrant: a Responses request must reach Copilot unchanged.</summary>
+    /// <summary>
+    ///     Codex's quadrant: a Responses request must reach Copilot unchanged. Carrying no hosted
+    ///     tools, this body is forwarded byte-for-byte; the tool filter is covered by
+    ///     <see cref="Responses_passthrough_survives_a_hosted_tool_the_backend_rejects"/>.
+    /// </summary>
     [SkippableFact]
     public async Task Responses_endpoint_passes_through()
     {
@@ -554,6 +558,64 @@ public sealed class CopilotAnthropicProxyLiveTests
         );
 
         _output.WriteLine(body);
+        body.Should().Contain("\"output\"");
+    }
+
+    /// <summary>
+    ///     Copilot serves only client-defined tools on <c>/responses</c>. Probed 2026-07-28,
+    ///     <c>image_generation</c>, <c>local_shell</c>, <c>code_interpreter</c> and <c>mcp</c> each
+    ///     fail with 400 <c>"The requested tool &lt;type&gt; is not supported."</c> Codex CLI
+    ///     advertises <c>image_generation</c> on every request and cannot be told not to, so before
+    ///     the proxy filtered the array this exact body was a hard 400 and Codex could not use the
+    ///     proxy at all.
+    ///
+    ///     This is the only test that pins the REASON for the filter: the unit tests pin the filter's
+    ///     shape against a fake upstream, so they would keep passing if Copilot started accepting (or
+    ///     rejecting) a different set. Sending a hosted tool ALONGSIDE a real function tool also
+    ///     proves the filter is surgical rather than dropping <c>tools</c> wholesale.
+    /// </summary>
+    [SkippableFact]
+    public async Task Responses_passthrough_survives_a_hosted_tool_the_backend_rejects()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+        var model = await PickResponsesOnlyModelAsync(cts.Token);
+        _output.WriteLine($"model: {model}");
+
+        var (status, body) = await SendProxyAsync(
+            "/v1/responses",
+            new
+            {
+                model,
+                store = false,
+                input = new[]
+                {
+                    new
+                    {
+                        type = "message",
+                        role = "user",
+                        content = new[] { new { type = "input_text", text = "Reply with: ok" } },
+                    },
+                },
+                tools = new object[]
+                {
+                    new { type = "image_generation" },
+                    new
+                    {
+                        type = "function",
+                        name = "get_weather",
+                        description = "Look up the weather",
+                        parameters = new { type = "object", properties = new { } },
+                    },
+                },
+            },
+            cts.Token
+        );
+
+        _output.WriteLine(body);
+        status.Should().Be(HttpStatusCode.OK, "the hosted tool must be stripped, not forwarded: {0}", Truncate(body, 2000));
+        body.Should().NotContain("image_generation", "the stripped tool must not reach the backend");
         body.Should().Contain("\"output\"");
     }
 

--- a/tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs
+++ b/tests/CopilotLive.Tests/CopilotAnthropicProxyLiveTests.cs
@@ -359,22 +359,19 @@ public sealed class CopilotAnthropicProxyLiveTests
         _output.WriteLine($"model: {model}");
 
         var silent = await CaptureResponsesStreamAsync(
-            ReasoningResponsesRequest(model, askForSummaries: false),
+            ReasoningResponsesRequest(model, ReasoningRequest.None),
             cts.Token
         );
-        DumpCapture("raw streaming /responses, no reasoning field sent (what the proxy sends)", silent);
+        DumpCapture("raw streaming /responses, no reasoning field sent", silent);
 
         var asked = await CaptureResponsesStreamAsync(
-            ReasoningResponsesRequest(model, askForSummaries: true),
+            ReasoningResponsesRequest(model, ReasoningRequest.EffortAndSummary),
             cts.Token
         );
         DumpCapture("raw streaming /responses, reasoning {effort: medium, summary: auto}", asked);
 
-        static List<string> SummaryEvents(RawSseCapture capture) =>
-            [.. capture.PayloadTypes.Where(t => t.Contains("reasoning", StringComparison.Ordinal))];
-
-        var silentSummaries = SummaryEvents(silent);
-        var askedSummaries = SummaryEvents(asked);
+        var silentSummaries = ReasoningEventsIn(silent);
+        var askedSummaries = ReasoningEventsIn(asked);
 
         _output.WriteLine(
             "OBSERVED reasoning events, no reasoning field sent: "
@@ -384,6 +381,16 @@ public sealed class CopilotAnthropicProxyLiveTests
             "OBSERVED reasoning events, summaries requested:     "
                 + (askedSummaries.Count == 0 ? "<none>" : string.Join(", ", askedSummaries))
         );
+
+        // Both statuses first: without them an upstream 400 prints "<none>" and reads as a genuine
+        // "Copilot volunteered nothing", which is the exact claim this probe is the sole evidence for.
+        silent.Status.Should().Be(HttpStatusCode.OK);
+        asked.Status.Should().Be(HttpStatusCode.OK);
+
+        askedSummaries.Should().NotBeEmpty("this is what asking for summaries is supposed to produce");
+        silentSummaries
+            .Should()
+            .BeEmpty("summaries arriving unasked would mean the translated route could emit thinking blocks");
     }
 
     /// <summary>
@@ -447,6 +454,11 @@ public sealed class CopilotAnthropicProxyLiveTests
 
         rawStatus.Should().Be(HttpStatusCode.OK, "the Responses API's own verdict on a non-default temperature");
         proxyStatus.Should().Be(HttpStatusCode.OK, "the proxy copies temperature and top_p straight across");
+
+        // The echo, not just the status: Copilot reports 1 / 0.98 as its defaults when neither field is
+        // sent, so getting the sent values back is what distinguishes "honoured" from "silently reset".
+        ReadEcho(rawBody, "temperature").Should().Be("0.7");
+        ReadEcho(rawBody, "top_p").Should().Be("0.5");
     }
 
     /// <summary>
@@ -512,6 +524,320 @@ public sealed class CopilotAnthropicProxyLiveTests
 
         _output.WriteLine(body);
         body.Should().Contain("\"output\"");
+    }
+
+    /// <summary>
+    ///     SAFEGUARD (a) for shipping an unconditional <c>reasoning</c> field: does
+    ///     <c>{"summary": "auto"}</c> on its own actually PRODUCE summaries? The earlier evidence sent
+    ///     <c>effort</c> alongside it, and Copilot defaults these models to <c>effort: "none"</c> — a
+    ///     turn that never reasons cannot summarise. Accepted-but-inert is the failure this catches,
+    ///     and a status check alone would not: it looks identical to success.
+    ///
+    ///     Which model produces a summary is NOT stable. Two sweeps minutes apart, same prompt, saw a
+    ///     different single model produce one; models defaulting to <c>effort: "none"</c> produced none
+    ///     either time. So this asserts only that SOME served model still produces summaries — read a
+    ///     failure here as "the field has stopped buying anything", not as a claim about one model.
+    /// </summary>
+    [SkippableFact]
+    public async Task Summary_auto_alone_produces_reasoning_summaries()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(600));
+
+        var models = await ResponsesCapableModelsAsync(cts.Token);
+        Skip.If(models.Count == 0, "This Copilot account exposes no /responses model the proxy will serve.");
+
+        // Swept across every served model, not just the cheap one: Copilot's DEFAULT effort is a
+        // per-model property, and "summary alone is inert" on a model that defaults to effort "none"
+        // says nothing about a model that defaults to a real one.
+        var inert = new List<string>();
+        var productive = new List<string>();
+
+        foreach (var model in models)
+        {
+            var capture = await CaptureResponsesStreamAsync(
+                ReasoningResponsesRequest(model, ReasoningRequest.SummaryOnly),
+                cts.Token
+            );
+
+            var reasoningEvents = ReasoningEventsIn(capture);
+            _output.WriteLine(
+                $"{model,-24} -> {(int)capture.Status} {capture.Status}  "
+                    + $"effort={EchoedReasoningEffort(capture)}  "
+                    + $"reasoning events: {(reasoningEvents.Count == 0 ? "<none>" : string.Join(", ", reasoningEvents))}"
+            );
+
+            capture.Status.Should().Be(HttpStatusCode.OK, $"{model} must accept reasoning:{{summary:auto}}");
+            (reasoningEvents.Count == 0 ? inert : productive).Add(model);
+        }
+
+        _output.WriteLine($"OBSERVED summaries produced by:  {(productive.Count == 0 ? "<none>" : string.Join(", ", productive))}");
+        _output.WriteLine($"OBSERVED accepted but inert on:  {(inert.Count == 0 ? "<none>" : string.Join(", ", inert))}");
+
+        productive
+            .Should()
+            .NotBeEmpty(
+                "reasoning:{summary:auto} is only worth sending unconditionally if some served model "
+                    + "actually produces summaries from it"
+            );
+    }
+
+    /// <summary>
+    ///     SAFEGUARD (b): does ANY model this proxy serves through <c>/responses</c> reject a
+    ///     <c>reasoning</c> field? Every other probe in this file uses one cheap model, so an
+    ///     unconditional request field would be shipped on one model's evidence. This one sweeps the
+    ///     whole live <c>/responses</c> surface, non-reasoning-looking models included, and names any
+    ///     model that refuses.
+    /// </summary>
+    [SkippableFact]
+    public async Task Every_responses_model_accepts_a_reasoning_field()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(300));
+
+        var models = await ResponsesCapableModelsAsync(cts.Token);
+        Skip.If(models.Count == 0, "This Copilot account exposes no /responses model the proxy will serve.");
+
+        _output.WriteLine($"sweeping {models.Count} /responses models: {string.Join(", ", models)}");
+
+        var rejections = new List<string>();
+        foreach (var model in models)
+        {
+            var (status, body) = await PostRawAsync(
+                ModelRouter.ResponsesPath,
+                new
+                {
+                    model,
+                    store = false,
+                    max_output_tokens = 16,
+                    reasoning = new { summary = "auto" },
+                    input = new[]
+                    {
+                        new
+                        {
+                            type = "message",
+                            role = "user",
+                            content = new[] { new { type = "input_text", text = "Reply with: ok" } },
+                        },
+                    },
+                },
+                cts.Token
+            );
+
+            _output.WriteLine($"{model,-24} -> {(int)status} {status}  reasoning echo: {ReadEcho(body, "reasoning")}");
+
+            if (status != HttpStatusCode.OK)
+            {
+                rejections.Add($"{model} -> {(int)status} {Truncate(body, 300)}");
+                _output.WriteLine($"    REJECTED: {Truncate(body, 500)}");
+            }
+        }
+
+        rejections
+            .Should()
+            .BeEmpty(
+                "an unconditional reasoning field is only safe if every served /responses model accepts it"
+            );
+    }
+
+    /// <summary>
+    ///     The payoff probe for the unconditional <c>reasoning</c> field: a <c>thinking</c> block must
+    ///     actually reach an Anthropic client through the FULL translated route. The sweep above proves
+    ///     only that Copilot returns summary events on the raw Responses stream; this proves the request
+    ///     translator asks for them without being told to and the stream translator turns them into
+    ///     Anthropic frames.
+    ///
+    ///     Walks the catalog because which model reasons is Copilot's choice, not ours — cheap models
+    ///     default to <c>effort: "none"</c> and cannot summarise a turn they never reasoned through, so
+    ///     requiring the FIRST model to produce a block would fail for a reason that is not a defect.
+    /// </summary>
+    [SkippableFact]
+    public async Task Translated_route_emits_a_thinking_block_without_being_asked()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(600));
+
+        var models = await ResponsesCapableModelsAsync(cts.Token);
+        Skip.If(models.Count == 0, "This Copilot account exposes no /responses model the proxy will serve.");
+
+        var silent = new List<string>();
+        foreach (var model in models)
+        {
+            // Deliberately NOT asking for reasoning anywhere in this request: the point is that the
+            // translator adds it. Claude Code has no way to request it through the Anthropic API.
+            var (status, body) = await SendProxyAsync(
+                "/v1/messages",
+                new
+                {
+                    model,
+                    max_tokens = 512,
+                    stream = true,
+                    messages = new[]
+                    {
+                        new
+                        {
+                            role = "user",
+                            content = "A bat and a ball cost $1.10 together. The bat costs $1.00 more than "
+                                + "the ball. How much does the ball cost? Answer with the amount only.",
+                        },
+                    },
+                },
+                cts.Token
+            );
+
+            status.Should().Be(HttpStatusCode.OK, "{0} failed the translated route with: {1}", model, Truncate(body, 400));
+
+            if (body.Contains("\"type\":\"thinking\"", StringComparison.Ordinal))
+            {
+                _output.WriteLine($"{model,-24} -> OBSERVED a thinking block on the translated route.");
+                _output.WriteLine(Truncate(body, 1500));
+                _output.WriteLine($"OBSERVED no thinking block from: {string.Join(", ", silent)}");
+                return;
+            }
+
+            _output.WriteLine($"{model,-24} -> 200 OK, no thinking block");
+            silent.Add(model);
+        }
+
+        throw new InvalidOperationException(
+            "No served /responses model produced a thinking block through the translated route, so the "
+                + $"unconditional reasoning field bought nothing. Silent models: {string.Join(", ", silent)}"
+        );
+    }
+
+    /// <summary>
+    ///     Settles whether Copilot reports its cached prefix INSIDE the total <c>input_tokens</c> or
+    ///     alongside it. The README warns that the proxy over-reports cached input, and the size of that
+    ///     over-report depends entirely on which of the two it is — <c>cached_tokens: 0</c>, the only
+    ///     thing earlier probes ever saw, cannot tell them apart.
+    ///
+    ///     Method: send the same long prefix twice. The second call should hit the cache, and then
+    ///     <c>input_tokens</c> either stays put (inclusive) or drops by roughly the cached count
+    ///     (exclusive). Verdict is logged rather than asserted, because whether Copilot caches at all on
+    ///     a given day is its decision, not this test's — but both calls MUST succeed, or the run proves
+    ///     nothing and says so.
+    /// </summary>
+    [SkippableFact]
+    public async Task Cached_input_tokens_are_reported_inside_the_total()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(180));
+
+        var model = await PickResponsesOnlyModelAsync(cts.Token);
+
+        // Automatic prompt caching has a minimum prefix length, so this one probe cannot be tiny.
+        // Deterministic, because a cache hit needs the two prefixes to be byte-identical.
+        var prefix = string.Join(
+            "\n",
+            Enumerable.Range(0, 400).Select(i => $"Fact {i}: the value of item number {i} is {i * 7 % 43}.")
+        );
+
+        var usages = new List<(int Input, int Cached, int Total)>();
+        foreach (var attempt in new[] { "first", "second" })
+        {
+            var (status, body) = await PostRawAsync(
+                ModelRouter.ResponsesPath,
+                new
+                {
+                    model,
+                    store = false,
+                    max_output_tokens = 16,
+                    input = new[]
+                    {
+                        new
+                        {
+                            type = "message",
+                            role = "user",
+                            content = new[] { new { type = "input_text", text = $"{prefix}\n\nReply with: ok" } },
+                        },
+                    },
+                },
+                cts.Token
+            );
+
+            status.Should().Be(HttpStatusCode.OK, "the {0} call must succeed or the comparison is meaningless", attempt);
+
+            using var doc = JsonDocument.Parse(body);
+            var usage = doc.RootElement.GetProperty("usage");
+            var input = usage.GetProperty("input_tokens").GetInt32();
+            var total = usage.GetProperty("total_tokens").GetInt32();
+            var cached = usage.TryGetProperty("input_tokens_details", out var details)
+                && details.TryGetProperty("cached_tokens", out var cachedTokens)
+                ? cachedTokens.GetInt32()
+                : 0;
+
+            _output.WriteLine($"{attempt,-7} call -> input_tokens: {input}  cached_tokens: {cached}  total_tokens: {total}");
+            usages.Add((input, cached, total));
+        }
+
+        var (firstInput, _, _) = usages[0];
+        var (secondInput, secondCached, _) = usages[1];
+
+        if (secondCached == 0)
+        {
+            _output.WriteLine(
+                "OBSERVED: Copilot reported no cache hit on the repeated prefix, so this run CANNOT "
+                    + "distinguish an inclusive from an exclusive cached_tokens. Nothing is proven either way."
+            );
+            return;
+        }
+
+        // Inclusive: input_tokens counts the cached prefix too, so it barely moves between the calls.
+        // Exclusive: it drops by about the cached count.
+        var verdict = Math.Abs(secondInput - firstInput) <= secondCached / 2 ? "INSIDE the total" : "ALONGSIDE the total";
+        _output.WriteLine(
+            $"OBSERVED: cached_tokens {secondCached} is reported {verdict} "
+                + $"(input_tokens {firstInput} -> {secondInput})."
+        );
+    }
+
+    /// <summary>Every model the proxy serves that advertises <c>/responses</c>, cheap tiers first.</summary>
+    private async Task<IReadOnlyList<string>> ResponsesCapableModelsAsync(CancellationToken cancellationToken)
+    {
+        var catalog = await _fixture.GetCatalogAsync(cancellationToken);
+        return
+        [
+            .. catalog
+                .Where(m => m.Advertises(ModelRouter.ResponsesPath))
+                .Where(m => !ProxyExcludedVendors.Contains(m.Vendor, StringComparer.OrdinalIgnoreCase))
+                .Select(m => m.Id)
+                .OrderBy(id => CheapModelHints.Any(h => id.Contains(h, StringComparison.OrdinalIgnoreCase)) ? 0 : 1)
+                .ThenBy(id => id, StringComparer.OrdinalIgnoreCase),
+        ];
+    }
+
+    /// <summary>The reasoning-related payload types seen in a capture, first occurrence order.</summary>
+    private static List<string> ReasoningEventsIn(RawSseCapture capture) =>
+        [.. capture.PayloadTypes.Where(t => t.Contains("reasoning", StringComparison.Ordinal))];
+
+    /// <summary>
+    ///     The <c>reasoning.effort</c> Copilot echoed on the stream's first frame. This is the field
+    ///     that decides whether a summary request does anything: at <c>"none"</c> the turn never reasons.
+    /// </summary>
+    private static string EchoedReasoningEffort(RawSseCapture capture)
+    {
+        foreach (var line in capture.Lines.Where(l => l.StartsWith("data:", StringComparison.Ordinal)))
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(line["data:".Length..].Trim());
+                if (
+                    doc.RootElement.TryGetProperty("response", out var response)
+                    && response.TryGetProperty("reasoning", out var reasoning)
+                    && reasoning.ValueKind == JsonValueKind.Object
+                    && reasoning.TryGetProperty("effort", out var effort)
+                )
+                {
+                    return effort.ToString();
+                }
+            }
+            catch (JsonException)
+            {
+                // Not every frame carries a parseable response envelope; keep looking.
+            }
+        }
+
+        return "<absent>";
     }
 
     /// <summary>
@@ -613,7 +939,7 @@ public sealed class CopilotAnthropicProxyLiveTests
     ///     reasoning summaries at a non-default effort. No tools: <c>tool_choice: "required"</c> makes
     ///     the model answer with a call immediately, which is exactly when it does not reason.
     /// </summary>
-    private static object ReasoningResponsesRequest(string model, bool askForSummaries)
+    private static object ReasoningResponsesRequest(string model, ReasoningRequest reasoning)
     {
         var request = new Dictionary<string, object?>
         {
@@ -640,14 +966,29 @@ public sealed class CopilotAnthropicProxyLiveTests
             },
         };
 
-        if (askForSummaries)
+        // effort as well as summary in the third case: Copilot defaults these models to effort "none",
+        // and a turn that never reasons cannot summarise.
+        object? reasoningField = reasoning switch
         {
-            // effort as well as summary: Copilot defaults these models to effort "none", so asking only
-            // for a summary yields a turn that never reasons and therefore never summarises.
-            request["reasoning"] = new { effort = "medium", summary = "auto" };
+            ReasoningRequest.SummaryOnly => new { summary = "auto" },
+            ReasoningRequest.EffortAndSummary => new { effort = "medium", summary = "auto" },
+            _ => null,
+        };
+
+        if (reasoningField is not null)
+        {
+            request["reasoning"] = reasoningField;
         }
 
         return request;
+    }
+
+    /// <summary>How a probe asks for reasoning: not at all, summary only, or summary at a set effort.</summary>
+    private enum ReasoningRequest
+    {
+        None,
+        SummaryOnly,
+        EffortAndSummary,
     }
 
     /// <summary>Everything a raw Responses SSE stream reveals about the framing the translator assumes.</summary>

--- a/tests/CopilotLive.Tests/CopilotChatCompletionsProbeTests.cs
+++ b/tests/CopilotLive.Tests/CopilotChatCompletionsProbeTests.cs
@@ -105,9 +105,12 @@ public sealed class CopilotChatCompletionsProbeTests
     }
 
     /// <summary>
-    ///     Confirms the one quadrant that genuinely needs translation is real: a Responses-ONLY model
-    ///     (no <c>/chat/completions</c> in its advertised endpoints) should NOT be servable here.
-    ///     Recorded rather than hard-asserted — the point is to capture the observed behavior.
+    ///     The premise the whole translation layer rests on: a Responses-ONLY model (no
+    ///     <c>/chat/completions</c> among its advertised endpoints) is NOT servable over Chat
+    ///     Completions. If Copilot served one anyway, every one of these models would be reachable by
+    ///     passthrough and the Anthropic-in/Responses-out translator would be dead weight — so this is
+    ///     asserted rather than merely recorded. An earlier revision only logged the outcome, which
+    ///     meant the premise could quietly stop being true without any test noticing.
     /// </summary>
     [SkippableFact]
     public async Task ChatCompletions_rejects_a_responses_only_model()
@@ -122,17 +125,25 @@ public sealed class CopilotChatCompletionsProbeTests
         _output.WriteLine($"status: {(int)status} {status}");
         _output.WriteLine(Truncate(body, 2000));
 
-        _output.WriteLine(
-            status == HttpStatusCode.OK
-                ? "OBSERVED: Copilot served a Responses-only model over /chat/completions anyway."
-                : "OBSERVED: rejected, as the catalog implies. The Anthropic-in -> Responses-out "
-                    + "translation path is required for these models."
-        );
+        status
+            .Should()
+            .NotBe(
+                HttpStatusCode.OK,
+                "the catalog omits /chat/completions for this model, and the Anthropic-in -> Responses-out "
+                    + "translation path exists precisely because such models cannot be served by passthrough"
+            );
     }
 
-    /// <summary>Dumps each model's advertised endpoints, so the design rests on live data.</summary>
+    /// <summary>
+    ///     The catalog contract <c>ProxyModelResolver.ParseServableModels</c> reads: entries carry a
+    ///     non-empty string <c>id</c>, and <c>supported_endpoints</c> arrives as an ARRAY on at least one
+    ///     of them. The parser's all-or-nothing fallback treats a catalog with no endpoint metadata
+    ///     anywhere as legacy and keeps every id — so a live catalog that silently stopped publishing
+    ///     the field would make the proxy advertise models it cannot route, and no fixture test can
+    ///     notice that. Dumps the per-model endpoints as well, so the design keeps resting on live data.
+    /// </summary>
     [SkippableFact]
-    public async Task Dump_advertised_endpoints_per_model()
+    public async Task Advertised_endpoints_are_published_in_the_shape_the_resolver_reads()
     {
         Skip.IfNot(_fixture.Available, _fixture.SkipReason);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
@@ -143,6 +154,18 @@ public sealed class CopilotChatCompletionsProbeTests
             var endpoints = entry.Endpoints.Count == 0 ? "(none)" : string.Join(", ", entry.Endpoints);
             _output.WriteLine($"{entry.Id,-32} | {entry.Vendor,-14} | {endpoints}");
         }
+
+        catalog.Should().NotBeEmpty("the proxy resolves its default model from this catalog at startup");
+        catalog
+            .Should()
+            .OnlyContain(e => !string.IsNullOrWhiteSpace(e.Id), "an entry without an id is dropped unseen");
+        catalog
+            .Should()
+            .Contain(
+                e => e.Endpoints.Count > 0,
+                "with no endpoint metadata anywhere the resolver falls back to keeping every id, "
+                    + "including ones no route can serve"
+            );
     }
 
     private async Task<(HttpStatusCode Status, string Body)> PostChatCompletionsAsync(

--- a/tests/CopilotLive.Tests/CopilotChatCompletionsProbeTests.cs
+++ b/tests/CopilotLive.Tests/CopilotChatCompletionsProbeTests.cs
@@ -1,0 +1,293 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
+using FluentAssertions;
+using Xunit.Abstractions;
+
+namespace AchieveAi.LmDotnetTools.CopilotLive.Tests;
+
+/// <summary>
+///     Capability probes for Copilot's <c>/chat/completions</c> endpoint.
+///
+///     These exist to settle a design question that the captured <c>/models</c> fixture can only
+///     answer with evidence, not proof: the catalog ADVERTISES <c>/chat/completions</c> for Claude
+///     and for some GPT models, but advertising an endpoint is not the same as honoring it.
+///
+///     The answer decides how much translation code the CopilotAnthropicProxy sample needs:
+///     if <c>/chat/completions</c> is honored, opencode-style clients are a passthrough route and
+///     no Chat Completions translation layer has to exist at all.
+///
+///     Deliberately issues RAW HTTP rather than going through our provider stack, so the result
+///     describes the Copilot backend and not our own mappers.
+/// </summary>
+[Collection(CopilotLiveCollection.Name)]
+public sealed class CopilotChatCompletionsProbeTests
+{
+    private readonly CopilotLiveFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public CopilotChatCompletionsProbeTests(CopilotLiveFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    /// <summary>
+    ///     THE GATE: can a Claude model be driven over the OpenAI Chat Completions wire format,
+    ///     with streaming and a tool? This is exactly what opencode and most OpenAI SDKs emit.
+    /// </summary>
+    [SkippableFact]
+    public async Task ChatCompletions_serves_a_claude_model_with_streaming_and_tools()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+        var model = await PickByEndpointAsync("claude", "/chat/completions", supported: true, cts.Token);
+        _output.WriteLine($"model: {model}");
+
+        var (status, body) = await PostChatCompletionsAsync(model, cts.Token);
+        _output.WriteLine($"status: {(int)status} {status}");
+        _output.WriteLine(Truncate(body, 4000));
+
+        status
+            .Should()
+            .Be(
+                HttpStatusCode.OK,
+                "Copilot advertises /chat/completions for Claude models; if this is not 200 the proxy "
+                    + "must translate Chat Completions -> /v1/messages instead of passing through"
+            );
+
+        body.Should().Contain("data:", "a streaming Chat Completions response is SSE");
+        body.Should().Contain("tool_calls", "the prompt forces a tool call; args must survive the wire");
+        body.Should().Contain("[DONE]", "Chat Completions streams terminate with the [DONE] sentinel");
+    }
+
+    /// <summary>
+    ///     A GPT model that also advertises <c>/chat/completions</c>. Pins a live-confirmed asymmetry
+    ///     the proxy must handle: Claude accepts <c>max_tokens</c> on this endpoint, but GPT models
+    ///     reject it and demand <c>max_completion_tokens</c>. An opencode-style client sends
+    ///     <c>max_tokens</c>, so a naive byte-level passthrough to a GPT model 400s.
+    /// </summary>
+    [SkippableFact]
+    public async Task ChatCompletions_serves_a_dual_endpoint_gpt_model_but_renames_the_token_limit()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+        var model = await PickByEndpointAsync("gpt", "/chat/completions", supported: true, cts.Token);
+        _output.WriteLine($"model: {model}");
+
+        var (legacyStatus, legacyBody) = await PostChatCompletionsAsync(model, cts.Token, "max_tokens");
+        _output.WriteLine($"[max_tokens]            status: {(int)legacyStatus} {legacyStatus}");
+        _output.WriteLine(Truncate(legacyBody, 600));
+
+        legacyStatus
+            .Should()
+            .Be(
+                HttpStatusCode.BadRequest,
+                "GPT models on Copilot reject max_tokens; this is the asymmetry the proxy must absorb"
+            );
+        legacyBody.Should().Contain("max_completion_tokens");
+
+        var (status, body) = await PostChatCompletionsAsync(model, cts.Token, "max_completion_tokens");
+        _output.WriteLine($"[max_completion_tokens] status: {(int)status} {status}");
+        _output.WriteLine(Truncate(body, 3000));
+
+        status
+            .Should()
+            .Be(
+                HttpStatusCode.OK,
+                "with the parameter renamed, a dual-endpoint GPT model is servable over /chat/completions"
+            );
+        body.Should().Contain("[DONE]");
+    }
+
+    /// <summary>
+    ///     Confirms the one quadrant that genuinely needs translation is real: a Responses-ONLY model
+    ///     (no <c>/chat/completions</c> in its advertised endpoints) should NOT be servable here.
+    ///     Recorded rather than hard-asserted — the point is to capture the observed behavior.
+    /// </summary>
+    [SkippableFact]
+    public async Task ChatCompletions_rejects_a_responses_only_model()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+        var model = await PickByEndpointAsync("gpt", "/chat/completions", supported: false, cts.Token);
+        _output.WriteLine($"model: {model}");
+
+        var (status, body) = await PostChatCompletionsAsync(model, cts.Token);
+        _output.WriteLine($"status: {(int)status} {status}");
+        _output.WriteLine(Truncate(body, 2000));
+
+        _output.WriteLine(
+            status == HttpStatusCode.OK
+                ? "OBSERVED: Copilot served a Responses-only model over /chat/completions anyway."
+                : "OBSERVED: rejected, as the catalog implies. The Anthropic-in -> Responses-out "
+                    + "translation path is required for these models."
+        );
+    }
+
+    /// <summary>Dumps each model's advertised endpoints, so the design rests on live data.</summary>
+    [SkippableFact]
+    public async Task Dump_advertised_endpoints_per_model()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        var catalog = await GetCatalogAsync(cts.Token);
+        foreach (var entry in catalog)
+        {
+            var endpoints = entry.Endpoints.Count == 0 ? "(none)" : string.Join(", ", entry.Endpoints);
+            _output.WriteLine($"{entry.Id,-32} | {entry.Vendor,-14} | {endpoints}");
+        }
+    }
+
+    private async Task<(HttpStatusCode Status, string Body)> PostChatCompletionsAsync(
+        string model,
+        CancellationToken cancellationToken,
+        string tokenLimitParameter = "max_tokens"
+    )
+    {
+        using var http = CopilotHttpClientFactory.Create(
+            _fixture.Options.BaseUrl,
+            _fixture.TokenProvider,
+            _fixture.Session,
+            _fixture.Options,
+            timeout: TimeSpan.FromSeconds(90)
+        );
+
+        var payload = new Dictionary<string, object?>
+        {
+            ["model"] = model,
+            ["stream"] = true,
+            [tokenLimitParameter] = 256,
+            ["messages"] = new object[]
+            {
+                new { role = "user", content = "What is the weather in Paris? Use the get_weather tool." },
+            },
+            ["tools"] = new object[]
+            {
+                new
+                {
+                    type = "function",
+                    function = new
+                    {
+                        name = "get_weather",
+                        description = "Get the current weather for a city.",
+                        parameters = new
+                        {
+                            type = "object",
+                            properties = new
+                            {
+                                city = new { type = "string", description = "City name" },
+                                units = new { type = "string", @enum = new[] { "c", "f" } },
+                            },
+                            required = new[] { "city" },
+                        },
+                    },
+                },
+            },
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/chat/completions")
+        {
+            Content = JsonContent.Create(payload),
+        };
+
+        using var response = await http.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        var sb = new StringBuilder();
+        while (await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is { } line)
+        {
+            _ = sb.AppendLine(line);
+            if (sb.Length > 200_000)
+            {
+                break;
+            }
+        }
+
+        return (response.StatusCode, sb.ToString());
+    }
+
+    /// <summary>
+    ///     Picks a model of <paramref name="family"/> that DOES (or does not) advertise
+    ///     <paramref name="endpoint"/>, read from the live catalog rather than guessed from the id.
+    ///     Guessing by name is what made an earlier revision of this probe pick <c>gpt-5.4-mini</c>
+    ///     (Responses-only) when it wanted a dual-endpoint model.
+    /// </summary>
+    private async Task<string> PickByEndpointAsync(
+        string family,
+        string endpoint,
+        bool supported,
+        CancellationToken cancellationToken
+    )
+    {
+        var catalog = await GetCatalogAsync(cancellationToken).ConfigureAwait(false);
+
+        var match = catalog
+            .Where(m => m.Id.Contains(family, StringComparison.OrdinalIgnoreCase))
+            .Where(m => m.Endpoints.Count > 0)
+            .FirstOrDefault(m => m.Endpoints.Contains(endpoint, StringComparer.OrdinalIgnoreCase) == supported);
+
+        Skip.If(
+            match is null,
+            $"No '{family}' model that {(supported ? "advertises" : "omits")} '{endpoint}' is available on this account."
+        );
+
+        return match.Id;
+    }
+
+    private async Task<IReadOnlyList<CatalogEntry>> GetCatalogAsync(CancellationToken cancellationToken)
+    {
+        using var http = CopilotHttpClientFactory.Create(
+            _fixture.Options.BaseUrl,
+            _fixture.TokenProvider,
+            _fixture.Session,
+            _fixture.Options
+        );
+        using var response = await http.GetAsync("/models", cancellationToken).ConfigureAwait(false);
+        var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        var list = root.ValueKind == JsonValueKind.Object && root.TryGetProperty("data", out var data)
+            ? data
+            : root;
+
+        var entries = new List<CatalogEntry>();
+        foreach (var item in list.EnumerateArray())
+        {
+            var id = item.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                continue;
+            }
+
+            var vendor = item.TryGetProperty("vendor", out var vEl) ? vEl.GetString() ?? "?" : "?";
+            var endpoints =
+                item.TryGetProperty("supported_endpoints", out var epEl) && epEl.ValueKind == JsonValueKind.Array
+                    ? epEl.EnumerateArray().Select(e => e.GetString() ?? string.Empty).ToList()
+                    : [];
+
+            entries.Add(new CatalogEntry(id, vendor, endpoints));
+        }
+
+        return entries;
+    }
+
+    private sealed record CatalogEntry(string Id, string Vendor, IReadOnlyList<string> Endpoints);
+
+    private static string Truncate(string value, int max) =>
+        value.Length <= max ? value : value[..max] + $"\n... [{value.Length - max} more chars]";
+}

--- a/tests/CopilotLive.Tests/CopilotLiveFixture.cs
+++ b/tests/CopilotLive.Tests/CopilotLiveFixture.cs
@@ -12,7 +12,7 @@ namespace AchieveAi.LmDotnetTools.CopilotLive.Tests;
 public sealed class CopilotLiveFixture
 {
     private readonly SemaphoreSlim _modelsGate = new(1, 1);
-    private IReadOnlyList<string>? _models;
+    private IReadOnlyList<CopilotCatalogEntry>? _catalog;
 
     public CopilotLiveFixture()
     {
@@ -45,17 +45,28 @@ public sealed class CopilotLiveFixture
     /// <summary>Lists model ids from <c>GET {host}/models</c> (cached for the run).</summary>
     public async Task<IReadOnlyList<string>> GetModelsAsync(CancellationToken cancellationToken)
     {
-        if (_models is not null)
+        var catalog = await GetCatalogAsync(cancellationToken).ConfigureAwait(false);
+        return [.. catalog.Select(entry => entry.Id)];
+    }
+
+    /// <summary>
+    ///     Lists every model from <c>GET {host}/models</c> with its vendor and the transports it
+    ///     advertises (cached for the run). Selecting a model by the endpoints it ADVERTISES rather
+    ///     than by the shape of its id is what keeps a probe from silently testing the wrong quadrant.
+    /// </summary>
+    public async Task<IReadOnlyList<CopilotCatalogEntry>> GetCatalogAsync(CancellationToken cancellationToken)
+    {
+        if (_catalog is not null)
         {
-            return _models;
+            return _catalog;
         }
 
         await _modelsGate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            if (_models is not null)
+            if (_catalog is not null)
             {
-                return _models;
+                return _catalog;
             }
 
             using var http = CopilotHttpClientFactory.Create(Options.BaseUrl, TokenProvider, Session, Options);
@@ -63,8 +74,8 @@ public sealed class CopilotLiveFixture
             _ = response.EnsureSuccessStatusCode();
 
             var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            _models = ParseModelIds(json);
-            return _models;
+            _catalog = ParseCatalog(json);
+            return _catalog;
         }
         finally
         {
@@ -124,9 +135,9 @@ public sealed class CopilotLiveFixture
         return candidates[0];
     }
 
-    private static IReadOnlyList<string> ParseModelIds(string json)
+    private static IReadOnlyList<CopilotCatalogEntry> ParseCatalog(string json)
     {
-        var ids = new List<string>();
+        var entries = new List<CopilotCatalogEntry>();
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
@@ -134,25 +145,48 @@ public sealed class CopilotLiveFixture
             ? data
             : root;
 
-        if (list.ValueKind == JsonValueKind.Array)
+        if (list.ValueKind != JsonValueKind.Array)
         {
-            foreach (var item in list.EnumerateArray())
-            {
-                if (item.ValueKind == JsonValueKind.Object
-                    && item.TryGetProperty("id", out var idEl)
-                    && idEl.ValueKind == JsonValueKind.String)
-                {
-                    var id = idEl.GetString();
-                    if (!string.IsNullOrWhiteSpace(id))
-                    {
-                        ids.Add(id);
-                    }
-                }
-            }
+            return entries;
         }
 
-        return ids;
+        foreach (var item in list.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object
+                || !item.TryGetProperty("id", out var idEl)
+                || idEl.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var id = idEl.GetString();
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                continue;
+            }
+
+            var vendor = item.TryGetProperty("vendor", out var vendorEl) && vendorEl.ValueKind == JsonValueKind.String
+                ? vendorEl.GetString() ?? string.Empty
+                : string.Empty;
+
+            var endpoints =
+                item.TryGetProperty("supported_endpoints", out var endpointsEl)
+                && endpointsEl.ValueKind == JsonValueKind.Array
+                    ? endpointsEl.EnumerateArray().Select(e => e.GetString() ?? string.Empty).ToList()
+                    : [];
+
+            entries.Add(new CopilotCatalogEntry(id, vendor, endpoints));
+        }
+
+        return entries;
     }
+}
+
+/// <summary>One model as Copilot's <c>/models</c> describes it: id, vendor, and advertised transports.</summary>
+public sealed record CopilotCatalogEntry(string Id, string Vendor, IReadOnlyList<string> Endpoints)
+{
+    /// <summary>True when this model advertises <paramref name="endpoint"/> (case-insensitive).</summary>
+    public bool Advertises(string endpoint) => Endpoints.Contains(endpoint, StringComparer.OrdinalIgnoreCase);
 }
 
 /// <summary>xUnit collection so the fixture (token + session + model list) is shared across tests.</summary>


### PR DESCRIPTION
Makes `samples/CopilotAnthropicProxy.Sample` bidirectional: the same proxy now serves **Anthropic Messages**, **OpenAI Chat Completions**, and **OpenAI Responses**, so Claude Code, Codex CLI, and opencode can each drive any model Copilot exposes — regardless of which dialect that model natively speaks.

Purpose, in the user's words: *"we just want to use this proxy to make claude, codex, open-code etc to work on top of all the models exposed through copilot backend APIs"*.

## What changed

The catalog now carries each model's vendor and its **advertised endpoints**, and a routing table maps (incoming dialect × model's native endpoint) onto one of four outcomes:

| Client sends | Model speaks | Outcome |
|---|---|---|
| Anthropic Messages | Messages | passthrough |
| Chat Completions | Chat Completions | passthrough |
| Responses | Responses | passthrough |
| **Anthropic Messages** | **Responses only** | **translate** |

Three quadrants are passthrough. The fourth is a real wire-to-wire translation, split across four files under `Translation/`:

- `ModelRoute` — the routing table; unknown combinations 404 with an honest message rather than silently defaulting.
- `AnthropicToResponsesRequest` — Messages request → Responses request. Clamps `max_output_tokens` to the API's floor of 16 (Claude Code's model-validation probe sends `max_tokens: 1` as its *first* request against any new model, so without the clamp every model looks broken before the user gets a turn), and drops `tool_choice` when no `tools` are present, which Responses rejects.
- `ResponsesToAnthropicJson` — buffered replies, including tool calls and stop-reason derivation.
- `ResponsesToAnthropicSse` — streaming. Emits only frames it has actually observed upstream; there is no terminal flush and no `Finish()`, so there is nowhere to synthesize a `message_stop` that never arrived.

`/v1/models` serves a dual-dialect union, and the proxy defaults to port 8787.

## Reasoning

Copilot emits `reasoning_summary_*` only when the request asks for reasoning. `{"summary": "auto"}` on its own is **inert** on any model whose per-model default effort is `"none"` — 4 of the 9 served `/responses` models — which returns 200 and then silence. The fix maps the client's own budget onto effort:

| `thinking.budget_tokens` | `reasoning.effort` |
|---|---|
| absent | *no `effort` field* |
| enabled, no budget | `medium` |
| `< 8192` | `low` |
| `< 24576` | `medium` |
| `>= 24576` | `high` |

Thresholds track Claude Code's own tiers. With the mapping the `"none"` models can reason; without it they cannot, at any budget.

Thinking is never asserted as contractual — a probe of `gpt-5.4` at `budget_tokens: 32768` returned a thinking block on 8 of 10 runs, and both misses were complete, well-formed streams. That tally lives in a `<remarks>` block on the nearest live probe so the evidence ships with the claim.

## Hosted tools are stripped on `/responses`

Codex CLI was **dead on arrival** through the proxy until the last two commits. It advertises the hosted `image_generation` tool on every request, Copilot rejects it, and the request 400s before the model sees a token:

```
{"error":{"message":"The requested tool image_generation is not supported.",
          "code":"unsupported_value","param":"tools","type":"invalid_request_error"}}
```

`-c tools.image_generation=false` has **no effect** — the tool is not client-configurable, so no amount of user config makes Codex work. The proxy was behaving correctly (byte-for-byte passthrough); correct passthrough was simply unusable.

Live probe of what Copilot's `/responses` actually accepts — this is measured, not taken from the OpenAI docs, which list tools Copilot does not implement:

| tool type | verdict |
|---|---|
| `function` | 200 |
| `custom` | 200 |
| `web_search`, `web_search_preview` | 200 |
| `image_generation`, `local_shell`, `code_interpreter`, `mcp` | 400 |

`ProxyDialect.Responses` now filters `tools` to an **allowlist** of `function` + `custom`. Allowlist rather than denylist, so a hosted tool this proxy has never seen gets dropped instead of forwarded into the same 400 — the same reasoning that makes `AnthropicToResponsesRequest.BuildTools` key off `input_schema`.

Two deliberate calls:

- **`custom` must stay in the allowlist.** Current Codex sends `apply_patch` as a `custom` tool, so a `function`-only filter would silently break Codex's editing while leaving every test green.
- **`web_search` is dropped even though Copilot accepts it.** It is hosted, and the translated Anthropic route already drops its counterpart `web_search_20250305`; divergence between the two paths would be accidental rather than designed.

A request carrying no hosted tools is forwarded byte-for-byte, and the Anthropic and Chat Completions dialects are untouched.

## Review round (67418041)

The review on this PR is answered in one commit. Every Must finding is fixed with a regression test; the full list is in the commit message and in the reply on the review comment. Two additions are visible from the outside:

- `COPILOT_ANTHROPIC_MODEL_ENDPOINTS` — states which endpoints a pinned model serves. Pinning skips discovery, so a pinned Responses-only model had no endpoint metadata, and "no metadata" routes as Messages-capable — which made the translated route unreachable for exactly the models it exists for. Unset, nothing changes.
- `COPILOT_ANTHROPIC_MAX_BODY_BYTES` — one ceiling (32 MiB default) on both the inbound body and any upstream reply the proxy has to buffer whole in order to translate it. Streamed relays are unaffected.

Two structural suggestions were declined as disproportionate for a sample; the reasoning is in the reply on the review comment.

## Testing

- `CopilotAnthropicProxy.Tests`: **256 passed / 0 failed / 0 skipped**.
- `CopilotLive.Tests` (real Copilot backend, `[SkippableFact]`): **31 passed / 0 failed / 0 skipped**, covering all served models.
- Full solution suite re-run on this tree: no failure attributable to this branch. Two unrelated pre-existing failures were found and filed rather than patched here — #232 (LmWorkflow `resultTemplate` composes from a stale state snapshot under load) and #233 (AnthropicProvider offline tests reject a short `ANTHROPIC_API_KEY` placeholder).
- 0-warning solution build.

Coverage for the tool filter is deliberately split. The unit tests pin its *shape* against a fake upstream, so they would keep passing if Copilot changed which tools it accepts. `Responses_passthrough_survives_a_hosted_tool_the_backend_rejects` pins the *reason*: it sends a hosted tool alongside a real function tool at the real backend, and that same body was a hard 400 before the filter landed.

### Real-client verification

Wire-level tests are not proof a CLI works — the Codex breakage above would not have been caught by any of them, because no test thought to attach a tool the client attaches unconditionally. Each client was pointed at the running proxy:

| Client | Route | Result |
|---|---|---|
| `claude -p` → `gpt-5.3-codex` | translated (Anthropic → Responses) | PASS |
| `claude -p` → `claude-sonnet-4.6` | passthrough control | PASS |
| `claude -p --allowedTools "Glob"` → `gpt-5.3-codex` | translated + tools | PASS |
| `codex exec` → `gpt-5.3-codex` | `/responses` passthrough | PASS *(after the tool fix)* |
| `codex exec` with a shell tool | `/responses` + 2 tool turns | PASS |

The last row is the strongest single check: `tool_call → tool_result → tool_call → tool_result → text`, where Codex's own sandbox policy rejected the first command and the model retried. Multi-turn tool state survived the proxy intact.

**opencode is not verified.** It is not installed on the machine this was developed on, so its Chat Completions path has wire-level coverage only — the same category of coverage that missed the Codex defect. Reviewers should treat opencode support as plausible but untested.

## Scope

- **No changes under `src/`** — this is entirely sample + tests + docs.
- No hard-coded model ids in sample `.cs` files; ids appear only in README prose and test fixtures.
- Design doc: `docs/superpowers/specs/2026-07-27-copilot-proxy-bidirectional-api-design.md`. Implementation plan: `docs/superpowers/plans/2026-07-27-copilot-proxy-bidirectional-api.md`.

## Known limitations

Documented in the README under *Known request incompatibilities*: `temperature`/`top_p` pass through unchanged (verified live), hosted tools are stripped on `/responses` as described above, the translated route answers in Anthropic SSE which carries no echo of the outbound reasoning config, and whether a given turn produces a thinking block is a per-turn coin flip rather than a property of the model.

**No Codex-shaped model discovery.** Codex logs `failed to refresh available models: missing field 'models'` — it wants `{"models":[…]}`, where `/v1/models` serves the OpenAI-standard `{"object":"list","data":[…]}` that the OpenAI SDKs and opencode need. Both shapes cannot live on one path. The failure is non-fatal: Codex falls back to `-c model=…` and works, including tool calls.

