### PR TITLE
feat(proxy): compose GitHub-first MCP web tools

### DIFF
--- a/docs/superpowers/plans/2026-08-02-mcp-web-tools.md
+++ b/docs/superpowers/plans/2026-08-02-mcp-web-tools.md
@@ -1,0 +1,754 @@
+# MCP Web Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compose GitHub-first `web_search` and `web_fetch` tools into the existing `/mcp` endpoints, with local Jina fallback tools when a valid `JINA_API_KEY` is configured.
+
+**Architecture:** Keep the existing MCP byte relay as the default. Add a narrow JSON-RPC interceptor for single-object `tools/list` and locally-owned `tools/call` requests, plus a small process-local snapshot store keyed by endpoint and GitHub session. Reuse the existing Jina provider, web-tool handlers, validation, sanitization, and configuration from `src/Misc`.
+
+**Tech Stack:** .NET 9, ASP.NET Core minimal hosting, `System.Text.Json.Nodes`, MCP Streamable HTTP over JSON-RPC 2.0, existing `AchieveAi.LmDotnetTools.Misc` Jina tools, xUnit, FluentAssertions, `WebApplicationFactory<Program>`.
+
+## Global Constraints
+
+- Change only `/mcp` and `/mcp/readonly`; do not change Messages or Responses translation.
+- GitHub's exact-name tool definition wins independently for `web_search` and `web_fetch`.
+- Inject a local Jina fallback only when GitHub omits the exact name and `JINA_API_KEY` is nonblank with valid `WebToolsOptions`.
+- Do not fail over during a tool call.
+- Preserve GitHub `tools/list` transport, HTTP, and JSON-RPC failures.
+- Compose only single-page `application/json` catalogs tied to an `Mcp-Session-Id`.
+- Pass SSE-framed catalogs, paginated catalogs, and JSON-RPC batch arrays through unchanged.
+- Scope local routing by endpoint, session ID, and the `X-MCP-*` header provenance from the advertised catalog.
+- Preserve existing secret hygiene, SSRF protection, output limits, cancellation, and transparent MCP behavior outside the interceptor.
+- Do not use `LegacyHandlerAdapter`; it loses `IsError` and cancellation.
+- Do not create a second Jina implementation.
+- Do not commit unless the user explicitly requests commits.
+
+---
+
+## File map
+
+### Create
+
+- `samples/CopilotAnthropicProxy.Sample/Mcp/McpToolSnapshotStore.cs` — owns endpoint/session/header-scoped local-tool routing snapshots.
+- `samples/CopilotAnthropicProxy.Sample/Mcp/McpJinaToolCatalog.cs` — adapts existing Jina tool contracts and handlers to snake_case MCP definitions.
+- `samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs` — parses the two intercepted JSON-RPC methods, composes JSON catalogs, executes local calls, and emits MCP result/error envelopes.
+- `tests/CopilotAnthropicProxy.Tests/McpToolSnapshotStoreTests.cs` — snapshot and header-fingerprint unit tests.
+- `tests/CopilotAnthropicProxy.Tests/McpJinaToolCatalogTests.cs` — key/config gating and schema tests.
+- `tests/CopilotAnthropicProxy.Tests/McpToolCompositionTests.cs` — endpoint-level catalog, routing, transport, lifecycle, and security tests.
+
+### Modify
+
+- `samples/CopilotAnthropicProxy.Sample/CopilotAnthropicProxy.Sample.csproj:11-16` — reference `Misc` and correct the stale dependency comment.
+- `samples/CopilotAnthropicProxy.Sample/Program.cs:100-150` — register web options, Jina provider/catalog, snapshot store, and composition service.
+- `samples/CopilotAnthropicProxy.Sample/Program.cs:2452-2680` — capture the POST body once, delegate targeted requests, preserve default relay, and remove snapshots on DELETE/upstream 404.
+- `tests/CopilotAnthropicProxy.Tests/ProxyWebAppFactory.cs:23-131` — configure Jina environment and inject a separate fake Jina HTTP client.
+- `tests/CopilotAnthropicProxy.Tests/McpProxyTests.cs` — retain and extend transparent-relay regressions where the interception seam touches existing behavior.
+- `samples/CopilotAnthropicProxy.Sample/README.md:236-253` — document targeted composition instead of claiming total JSON-RPC blindness.
+- `samples/CopilotAnthropicProxy.Sample/README.md` environment table — document existing Jina/web-tool variables used by this host.
+
+---
+
+### Task 1: Add the `Misc` dependency without changing behavior
+
+**Files:**
+- Modify: `samples/CopilotAnthropicProxy.Sample/CopilotAnthropicProxy.Sample.csproj:11-16`
+
+**Interfaces:**
+- Consumes: `AchieveAi.LmDotnetTools.Misc.Configuration.WebToolsOptions`, `Misc.Web.Jina.JinaWebProvider`, `Misc.Utils.WebSearchTool`, and `Misc.Utils.WebFetchTool` in later tasks.
+- Produces: a buildable proxy project with access to the existing web-tool implementation.
+
+- [ ] **Step 1: Record the clean baseline**
+
+Run:
+
+```powershell
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --no-restore
+```
+
+Expected: the existing proxy suite passes before the project reference changes.
+
+- [ ] **Step 2: Add the project reference**
+
+Change the project-reference group to:
+
+```xml
+<ItemGroup>
+  <!-- Copilot transport and authentication live in GithubCopilotProvider. Web-tool
+       contracts, validation, output hygiene, and Jina integration live in Misc. -->
+  <ProjectReference Include="..\..\src\GithubCopilotProvider\AchieveAi.LmDotnetTools.GithubCopilotProvider.csproj" />
+  <ProjectReference Include="..\..\src\Misc\AchieveAi.LmDotnetTools.Misc.csproj" />
+</ItemGroup>
+```
+
+- [ ] **Step 3: Prove the dependency-only change is green**
+
+Run:
+
+```powershell
+dotnet build samples/CopilotAnthropicProxy.Sample/CopilotAnthropicProxy.Sample.csproj --no-restore
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --no-restore
+```
+
+Expected: build succeeds with zero warnings and the existing suite remains green.
+
+- [ ] **Step 4: Review checkpoint**
+
+Run `git diff --check` and inspect only the `.csproj` diff. Do not commit unless explicitly authorized.
+
+---
+
+### Task 2: Add snapshot routing keyed by endpoint, session, and MCP headers
+
+**Files:**
+- Create: `samples/CopilotAnthropicProxy.Sample/Mcp/McpToolSnapshotStore.cs`
+- Create: `tests/CopilotAnthropicProxy.Tests/McpToolSnapshotStoreTests.cs`
+
+**Interfaces:**
+- Produces:
+
+```csharp
+internal sealed record McpToolSnapshot(
+    IReadOnlySet<string> LocalToolNames,
+    string HeaderFingerprint
+);
+
+internal sealed class McpToolSnapshotStore
+{
+    public void Set(string endpointPath, string sessionId, McpToolSnapshot snapshot);
+    public bool TryGet(string endpointPath, string sessionId, out McpToolSnapshot snapshot);
+    public void Remove(string endpointPath, string sessionId);
+    public static string ComputeHeaderFingerprint(IHeaderDictionary headers);
+    public static bool HasToolFilterHeaders(IHeaderDictionary headers);
+}
+```
+
+- Consumes: request headers from `HttpContext.Request.Headers`.
+- Later tasks consume: `Set`, `TryGet`, `Remove`, and the fingerprint helpers.
+
+- [ ] **Step 1: Write failing fingerprint and isolation tests**
+
+Create tests with these exact cases:
+
+```csharp
+[Fact]
+public void Fingerprint_is_case_and_order_independent()
+{
+    var first = new HeaderDictionary
+    {
+        ["X-MCP-Tools"] = "web_search,issues",
+        ["X-MCP-Readonly"] = "true",
+    };
+    var second = new HeaderDictionary
+    {
+        ["x-mcp-readonly"] = "true",
+        ["x-mcp-tools"] = "web_search,issues",
+    };
+
+    McpToolSnapshotStore.ComputeHeaderFingerprint(first)
+        .Should().Be(McpToolSnapshotStore.ComputeHeaderFingerprint(second));
+}
+
+[Fact]
+public void Same_session_is_isolated_by_endpoint()
+{
+    var store = new McpToolSnapshotStore();
+    store.Set("/mcp", "session-1", new(new HashSet<string> { "web_search" }, "none"));
+
+    store.TryGet("/mcp/readonly", "session-1", out _).Should().BeFalse();
+}
+```
+
+Also test:
+
+- changing any `X-MCP-*` value changes the fingerprint;
+- non-`X-MCP-*` headers do not affect it;
+- `HasToolFilterHeaders` is false with no `X-MCP-*` headers and true with one;
+- a second `Set` atomically replaces local names;
+- `Remove` clears only the matching endpoint/session entry.
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --no-restore --filter "FullyQualifiedName~McpToolSnapshotStoreTests"
+```
+
+Expected: compile failure because `McpToolSnapshotStore` does not exist.
+
+- [ ] **Step 3: Implement the minimal store**
+
+Use a private `ConcurrentDictionary<(string EndpointPath, string SessionId), McpToolSnapshot>`.
+
+For the fingerprint:
+
+1. select every header whose name starts with `X-MCP-`, case-insensitively;
+2. normalize the header name to lower invariant;
+3. preserve each header's value sequence and join it with ``;
+4. order entries by normalized name using `StringComparer.Ordinal`;
+5. serialize as `name=value\n` and hash with SHA-256;
+6. return lowercase hexadecimal;
+7. return a stable sentinel such as `"none"` when no `X-MCP-*` header exists.
+
+Do not curate a subset of `X-MCP-*` headers. Over-inclusion safely routes a mismatch to GitHub instead of incorrectly invoking Jina.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run the Task 2 test command again.
+
+Expected: all snapshot-store tests pass.
+
+- [ ] **Step 5: Run formatting and review checks**
+
+Run:
+
+```powershell
+dotnet csharpier check samples/CopilotAnthropicProxy.Sample/Mcp/McpToolSnapshotStore.cs tests/CopilotAnthropicProxy.Tests/McpToolSnapshotStoreTests.cs
+git diff --check
+```
+
+If CSharpier reports changes needed, run `dotnet csharpier format` on these two files and rerun the tests. Do not commit unless authorized.
+
+---
+
+### Task 3: Adapt existing Jina handlers into MCP definitions
+
+**Files:**
+- Create: `samples/CopilotAnthropicProxy.Sample/Mcp/McpJinaToolCatalog.cs`
+- Create: `tests/CopilotAnthropicProxy.Tests/McpJinaToolCatalogTests.cs`
+
+**Interfaces:**
+- Consumes: `WebToolsOptions`, `JinaWebProvider`, `WebSearchTool`, `WebFetchTool`, `FunctionContract.GetJsonSchema()`, and `ToolHandler`.
+- Produces:
+
+```csharp
+internal sealed record McpLocalTool(
+    string Name,
+    JsonObject Definition,
+    ToolHandler Handler
+);
+
+internal sealed class McpJinaToolCatalog
+{
+    public McpJinaToolCatalog(
+        JinaWebProvider provider,
+        WebToolsOptions options,
+        ILoggerFactory loggerFactory
+    );
+
+    public bool IsEnabled { get; }
+    public IReadOnlyDictionary<string, McpLocalTool> Tools { get; }
+}
+```
+
+- `Definition` has MCP fields `name`, `description`, and `inputSchema`.
+- Later tasks consume `IsEnabled` and `Tools`.
+
+- [ ] **Step 1: Write failing catalog tests**
+
+Cover these exact rules:
+
+```csharp
+[Theory]
+[InlineData(null)]
+[InlineData("")]
+[InlineData("   ")]
+public void Blank_key_disables_both_tools(string? key)
+{
+    var options = new WebToolsOptions { JinaApiKey = key };
+    var catalog = CreateCatalog(options);
+
+    catalog.IsEnabled.Should().BeFalse();
+    catalog.Tools.Should().BeEmpty();
+}
+
+[Fact]
+public void Valid_key_exposes_snake_case_tools_with_existing_contract_schemas()
+{
+    var options = new WebToolsOptions { JinaApiKey = "secret-key" };
+    var catalog = CreateCatalog(options);
+
+    catalog.Tools.Keys.Should().BeEquivalentTo("web_search", "web_fetch");
+    catalog.Tools["web_search"].Definition["inputSchema"]!["properties"]!["query"]
+        .Should().NotBeNull();
+    catalog.Tools["web_fetch"].Definition["inputSchema"]!["properties"]!["url"]
+        .Should().NotBeNull();
+}
+```
+
+Also assert:
+
+- invalid `Backend`, nonpositive `OutputCap`, or nonpositive `TimeoutMs` disables both tools;
+- required arrays contain `query` and `url` respectively;
+- optional search properties are `count`, `country`, and `language`;
+- optional fetch properties are `targetSelector` and `noCache`;
+- definitions do not contain the Jina key;
+- each MCP definition uses its snake_case name while the handler remains the existing `ToolHandler`.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --no-restore --filter "FullyQualifiedName~McpJinaToolCatalogTests"
+```
+
+Expected: compile failure because the catalog does not exist.
+
+- [ ] **Step 3: Implement catalog construction**
+
+Implement these rules:
+
+```csharp
+IsEnabled = !string.IsNullOrWhiteSpace(options.JinaApiKey)
+    && options.Validate().Count == 0;
+```
+
+When enabled:
+
+1. create `WebSearchTool` and `WebFetchTool` using the same `JinaWebProvider` and options;
+2. convert each `FunctionContract.GetJsonSchema()` to a `JsonObject` by serializing with the repository's normal `JsonSerializer` options and parsing as `JsonNode`;
+3. build definitions with snake_case names but preserve existing descriptions and schemas;
+4. retain each modern `ToolHandler` directly.
+
+When disabled, expose an empty read-only dictionary. Do not attempt keyless `web_fetch` on this MCP surface.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run the Task 3 test command again.
+
+Expected: all catalog tests pass.
+
+- [ ] **Step 5: Run existing Misc security tests**
+
+Run:
+
+```powershell
+dotnet test tests/Misc.Tests/Misc.Tests.csproj --no-restore --filter "FullyQualifiedName~JinaSecretHygieneTests|FullyQualifiedName~WebInputValidatorTests|FullyQualifiedName~WebToolOutputTests"
+```
+
+Expected: existing Jina secret, SSRF, and output-hygiene tests remain green.
+
+---
+
+### Task 4: Compose `tools/list` while preserving unsupported transport shapes
+
+**Files:**
+- Create: `samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs`
+- Create: `tests/CopilotAnthropicProxy.Tests/McpToolCompositionTests.cs`
+- Modify: `samples/CopilotAnthropicProxy.Sample/Program.cs:2452-2680`
+- Modify: `tests/CopilotAnthropicProxy.Tests/ProxyWebAppFactory.cs:23-131`
+
+**Interfaces:**
+- Consumes: `McpJinaToolCatalog`, `McpToolSnapshotStore`, the authenticated Copilot `HttpClient`, existing request-header filtering, response-header copying, and body relay.
+- Produces:
+
+```csharp
+internal sealed class McpToolComposition
+{
+    public McpToolComposition(
+        McpJinaToolCatalog localCatalog,
+        McpToolSnapshotStore snapshots,
+        ILoggerFactory loggerFactory
+    );
+
+    public static bool TryParseSingleRequest(ReadOnlySpan<byte> body, out JsonObject? request);
+    public static bool IsTargetMethod(JsonObject request);
+
+    public Task<bool> TryHandleAsync(
+        HttpContext context,
+        JsonObject request,
+        byte[] rawBody,
+        HttpClient copilotClient,
+        TimeSpan idleTimeout,
+        TimeSpan keepAliveInterval
+    );
+}
+```
+
+`TryHandleAsync` returns `true` after writing the downstream response; `false` means `ProxyMcp` must forward the original raw body through its existing path.
+
+- [ ] **Step 1: Extend the test host for a separate Jina client**
+
+Add optional constructor parameters to `ProxyWebAppFactory`:
+
+```csharp
+string? jinaApiKey = null,
+int? webToolsOutputCap = null,
+int? webToolsTimeoutMs = null,
+Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>? jinaUpstream = null
+```
+
+Set and clear `JINA_API_KEY`, `WEB_TOOLS_OUTPUT_CAP`, and `WEB_TOOLS_TIMEOUT_MS` just like existing proxy environment variables.
+
+In `ConfigureTestServices`, replace `JinaWebProvider` only when `jinaUpstream` is supplied:
+
+```csharp
+services.RemoveAll<JinaWebProvider>();
+services.AddSingleton(sp => new JinaWebProvider(
+    new HttpClient(new FakeHttpMessageHandler(jinaUpstream)),
+    sp.GetRequiredService<WebToolsOptions>(),
+    sp.GetRequiredService<ILoggerFactory>().CreateLogger<JinaWebProvider>()
+));
+```
+
+Do not reuse the fake Copilot handler for Jina.
+
+- [ ] **Step 2: Write failing `tools/list` endpoint tests**
+
+Create helpers that send JSON-RPC requests with an explicit `Mcp-Session-Id`. Add these tests:
+
+- `Github_web_tool_definitions_win_and_remain_structurally_equal`
+- `Missing_web_tools_are_injected_with_valid_jina_key`
+- `Mixed_catalog_can_use_github_search_and_jina_fetch`
+- `Missing_or_invalid_jina_configuration_injects_nothing`
+- `Github_tools_list_json_rpc_error_passes_through_unchanged`
+- `Github_tools_list_http_error_passes_through_unchanged`
+- `Sessionless_catalog_injects_nothing`
+- `Paginated_catalog_with_nextCursor_passes_through_unchanged`
+- `Sse_catalog_passes_through_unchanged`
+- `Json_rpc_batch_array_passes_through_unchanged`
+
+For structural preservation, parse the original GitHub tool and the downstream tool and assert `JsonNode.DeepEquals`.
+
+For passthrough tests, assert status, content type, and body are unchanged. For the SSE case, return `TestUpstream.SseStream(...)` and ensure no Jina tool is added and existing streaming still completes.
+
+- [ ] **Step 3: Run list tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --no-restore --filter "FullyQualifiedName~McpToolCompositionTests"
+```
+
+Expected: list-composition tests fail because interception is not implemented.
+
+- [ ] **Step 4: Register web services in `Program.cs`**
+
+Near the existing service registrations, add process-lifetime services:
+
+```csharp
+var webToolsOptions = WebToolsOptions.FromEnvironment();
+services.AddSingleton(webToolsOptions);
+services.AddSingleton(sp => new JinaWebProvider(
+    webToolsOptions,
+    sp.GetRequiredService<ILoggerFactory>().CreateLogger<JinaWebProvider>()
+));
+services.AddSingleton<McpJinaToolCatalog>();
+services.AddSingleton<McpToolSnapshotStore>();
+services.AddSingleton<McpToolComposition>();
+```
+
+Log one bounded warning when a nonblank key is present but options are invalid. Do not log option values or the key. Blank key is normal and should not warn.
+
+- [ ] **Step 5: Add the narrow interception seam in `ProxyMcp`**
+
+Refactor POST buffering so `inboundBody` remains available after reading. Before constructing/sending the normal upstream request:
+
+```csharp
+if (
+    inboundBody is not null
+    && McpToolComposition.TryParseSingleRequest(inboundBody, out var rpcRequest)
+    && rpcRequest is not null
+    && McpToolComposition.IsTargetMethod(rpcRequest)
+)
+{
+    var composition = services.GetRequiredService<McpToolComposition>();
+    if (
+        await composition.TryHandleAsync(
+            ctx,
+            rpcRequest,
+            inboundBody,
+            httpClient,
+            idleTimeout,
+            keepAliveInterval
+        )
+    )
+    {
+        return;
+    }
+}
+```
+
+Expose focused `internal` helpers from `ProxyMcp` or `ProxyHttp` rather than duplicating policy:
+
+```csharp
+internal static void ApplyRequestHeaderAllowlist(...)
+internal static Task WriteMcpErrorAsync(...)
+```
+
+Use the existing `ProxyHttp.CopyResponseHeaders` and `ProxyHttp.CopyBodyAsync` for unchanged upstream responses.
+
+- [ ] **Step 6: Implement the list branch minimally**
+
+The list branch must:
+
+1. send the original raw request once to GitHub using the same authenticated client and request-header policy;
+2. preserve non-success HTTP responses and JSON-RPC errors unchanged;
+3. inspect `Content-Type` before reading the body;
+4. relay SSE unchanged and record no snapshot;
+5. buffer only an `application/json` list response;
+6. require `result.tools` to be an array, `Mcp-Session-Id` to be nonblank, and `result.nextCursor` to be absent/null/empty;
+7. preserve all existing JSON nodes and append only missing Jina definitions;
+8. atomically store the injected names plus header fingerprint;
+9. serialize the modified root as JSON with the original request ID untouched.
+
+If any shape guard fails, return the original buffered bytes unchanged and remove any previous snapshot for that endpoint/session so stale local ownership is not retained.
+
+- [ ] **Step 7: Run list tests and verify GREEN**
+
+Run the Task 4 focused command again.
+
+Expected: all list composition and passthrough tests pass.
+
+- [ ] **Step 8: Run the original MCP regression suite**
+
+Run:
+
+```powershell
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --no-restore --filter "FullyQualifiedName~McpProxyTests|FullyQualifiedName~McpToolCompositionTests"
+```
+
+Expected: existing raw forwarding, headers, SSE, DELETE, and errors remain green alongside composition.
+
+---
+
+### Task 5: Route locally advertised `tools/call` requests
+
+**Files:**
+- Modify: `samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs`
+- Modify: `tests/CopilotAnthropicProxy.Tests/McpToolCompositionTests.cs`
+
+**Interfaces:**
+- Consumes: latest `McpToolSnapshot`, local `McpLocalTool.Handler`, JSON-RPC `params.name` and `params.arguments`.
+- Produces MCP call results with this exact shape:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "result": {
+    "content": [{ "type": "text", "text": "..." }],
+    "isError": false
+  }
+}
+```
+
+For `ToolHandlerResult.Deferred`, return a resolved MCP error result because this endpoint has no deferred-resolution channel:
+
+```json
+{
+  "content": [{ "type": "text", "text": "Deferred tool execution is not supported by this MCP endpoint." }],
+  "isError": true
+}
+```
+
+- [ ] **Step 1: Write failing call-routing tests**
+
+Add exact tests:
+
+- `Locally_injected_search_call_uses_jina_and_preserves_request_id`
+- `Locally_injected_fetch_call_uses_jina`
+- `Github_owned_call_is_forwarded_and_never_hits_jina`
+- `Github_call_failure_does_not_fall_back_to_jina`
+- `A_second_successful_list_can_change_ownership`
+- `Matching_filter_headers_allow_local_dispatch`
+- `No_filter_headers_allow_latest_snapshot_dispatch`
+- `Mismatched_filter_headers_forward_to_github`
+- `No_matching_snapshot_forwards_to_github`
+- `Local_validation_failure_sets_isError_true`
+- `Client_cancellation_reaches_local_handler`
+- `Local_fetch_still_blocks_loopback_and_private_targets`
+- `Local_output_respects_WEB_TOOLS_OUTPUT_CAP`
+- `Local_errors_and_logs_do_not_contain_JINA_API_KEY_or_raw_jina_body`
+
+Use the real `JinaWebProvider` with a fake Jina HTTP handler. Count GitHub and Jina requests separately to prove routing and no mid-call fallback.
+
+- [ ] **Step 2: Run call tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --no-restore --filter "FullyQualifiedName~McpToolCompositionTests"
+```
+
+Expected: call-routing tests fail because local dispatch is not implemented.
+
+- [ ] **Step 3: Implement local dispatch**
+
+Parse conservatively:
+
+```csharp
+var name = request["params"]?["name"]?.GetValue<string>();
+var arguments = request["params"]?["arguments"];
+```
+
+Route locally only when all are true:
+
+- endpoint and `Mcp-Session-Id` match a snapshot;
+- snapshot contains the exact name;
+- either the call has no `X-MCP-*` headers, or its fingerprint matches the snapshot;
+- the local catalog still contains the name.
+
+Otherwise return `false` so the existing relay sends the raw request to GitHub.
+
+Invoke the modern handler:
+
+```csharp
+var handlerResult = await localTool.Handler(
+    arguments?.ToJsonString() ?? "{}",
+    new ToolCallContext { ToolCallId = request["id"]?.ToJsonString() },
+    context.RequestAborted
+);
+```
+
+Pattern-match `ToolHandlerResult.Resolved` and `Deferred`; do not read `ResultText` blindly. Build `result.content` from `Payload.Text`, propagate `Payload.IsError`, and retain `Payload.ErrorCode` only if the MCP result shape has an agreed extension point—otherwise omit it rather than inventing a wire field.
+
+Malformed intercepted local calls return JSON-RPC `-32602` with the original `id`. Unknown or GitHub-owned tool names pass through.
+
+- [ ] **Step 4: Run call tests and verify GREEN**
+
+Run the Task 5 focused command again.
+
+Expected: all call-routing, error, cancellation, SSRF, cap, and hygiene tests pass.
+
+- [ ] **Step 5: Re-run existing Jina security tests**
+
+Run the Task 3 Misc security command again.
+
+Expected: existing security tests and new MCP end-to-end security tests are green.
+
+---
+
+### Task 6: Clean snapshots on DELETE and expired GitHub sessions
+
+**Files:**
+- Modify: `samples/CopilotAnthropicProxy.Sample/Program.cs:2501-2635`
+- Modify: `tests/CopilotAnthropicProxy.Tests/McpToolCompositionTests.cs`
+
+**Interfaces:**
+- Consumes: `McpToolSnapshotStore.Remove(endpointPath, sessionId)`.
+- Produces: cleanup after forwarded DELETE and any upstream 404 for a session-bound request.
+
+- [ ] **Step 1: Write failing lifecycle tests**
+
+Add:
+
+- `Delete_removes_snapshot_even_when_github_returns_405`
+- `Upstream_404_removes_snapshot`
+- `Cleanup_for_mcp_does_not_remove_readonly_snapshot_with_same_session_id`
+
+Test cleanup behavior by:
+
+1. composing a local tool snapshot;
+2. sending DELETE or a request that receives 404;
+3. sending a matching `tools/call` afterward;
+4. asserting it forwards to GitHub rather than Jina.
+
+- [ ] **Step 2: Run lifecycle tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --no-restore --filter "FullyQualifiedName~McpToolCompositionTests"
+```
+
+Expected: lifecycle tests fail because snapshots survive.
+
+- [ ] **Step 3: Add cleanup to the common relay path**
+
+After receiving the upstream status, and before returning from `ForwardAsync`, remove the matching snapshot when:
+
+```csharp
+requestMethodIsDelete || upstream.StatusCode == HttpStatusCode.NotFound
+```
+
+Use the request endpoint path and inbound `Mcp-Session-Id`. Cleanup must run even when DELETE returns 405, matching the approved spec.
+
+Ensure the composition-owned GitHub `tools/list` round-trip applies the same 404 cleanup rule before it returns.
+
+- [ ] **Step 4: Run lifecycle tests and verify GREEN**
+
+Run the Task 6 focused command again.
+
+Expected: all lifecycle and endpoint-isolation tests pass.
+
+---
+
+### Task 7: Document behavior and run final verification
+
+**Files:**
+- Modify: `samples/CopilotAnthropicProxy.Sample/README.md:236-253`
+- Modify: `samples/CopilotAnthropicProxy.Sample/README.md` environment/configuration section
+- Modify: `tests/CopilotAnthropicProxy.Tests/McpProxyTests.cs` only if a final regression gap is found
+
+**Interfaces:**
+- Produces user-facing documentation for configuration, availability rules, transport limitations, and the optional live smoke test.
+
+- [ ] **Step 1: Update the MCP documentation**
+
+Replace the claim that the endpoint performs no JSON-RPC parsing with a precise statement:
+
+- most MCP traffic remains a transparent relay;
+- single-page JSON `tools/list` may gain Jina fallbacks;
+- locally advertised `tools/call` requests execute locally;
+- GitHub exact-name definitions win;
+- SSE/paginated catalogs and batches pass through unchanged;
+- routing is tied to endpoint/session/filter context.
+
+- [ ] **Step 2: Document configuration**
+
+Document:
+
+- `JINA_API_KEY` enables both local MCP fallbacks;
+- `WEB_TOOLS_BACKEND` must remain `jina`;
+- `WEB_TOOLS_OUTPUT_CAP` defaults to `50000`;
+- `WEB_TOOLS_TIMEOUT_MS` defaults to `30000`;
+- invalid configuration disables only local fallbacks and leaves GitHub MCP available.
+
+Do not claim a `WEB_TOOLS_MAX_QUERY_LENGTH` environment variable; none exists.
+
+- [ ] **Step 3: Document the conditional live probe**
+
+Provide a short manual checklist rather than embedding credentials or adding a permanently skipped test:
+
+1. start the proxy with GitHub credentials and optional `JINA_API_KEY`;
+2. send `initialize` and retain `Mcp-Session-Id`;
+3. send `tools/list`;
+4. verify each exact name appears at most once;
+5. call each advertised web tool with arguments matching its advertised schema;
+6. confirm GitHub wins when present and Jina fills only missing names.
+
+- [ ] **Step 4: Run focused and full verification**
+
+Run:
+
+```powershell
+dotnet csharpier check samples/CopilotAnthropicProxy.Sample tests/CopilotAnthropicProxy.Tests
+dotnet build samples/CopilotAnthropicProxy.Sample/CopilotAnthropicProxy.Sample.csproj --no-restore
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --no-restore
+dotnet test tests/Misc.Tests/Misc.Tests.csproj --no-restore --filter "FullyQualifiedName~JinaSecretHygieneTests|FullyQualifiedName~WebInputValidatorTests|FullyQualifiedName~WebToolOutputTests|FullyQualifiedName~WebSearchToolTests|FullyQualifiedName~WebFetchToolTests"
+git diff --check
+git status --short
+```
+
+Expected:
+
+- formatting check passes;
+- builds have zero warnings and errors;
+- all proxy tests pass;
+- all focused Misc web-tool/security tests pass;
+- `git diff --check` emits no output;
+- status lists only intended source, test, documentation, spec, plan, and conversation scratchpad changes.
+
+- [ ] **Step 5: Final proof summary**
+
+Report:
+
+- exact tests and counts;
+- whether the live authenticated probe ran or was skipped;
+- which backend owned each tool in the probe;
+- any unsupported upstream shape observed;
+- no completion claim if any required test is failing.
+
+Do not commit unless explicitly authorized.

--- a/docs/superpowers/specs/2026-08-02-mcp-web-tools-design.md
+++ b/docs/superpowers/specs/2026-08-02-mcp-web-tools-design.md
@@ -1,0 +1,181 @@
+# MCP Web Tools Design
+
+## Goal
+
+Expose dependable `web_search` and `web_fetch` tools through the existing Copilot proxy `/mcp` and `/mcp/readonly` endpoints.
+
+For each exact tool name, use GitHub's upstream MCP implementation when GitHub advertises it. Otherwise, expose a local Jina-backed implementation when `JINA_API_KEY` is configured.
+
+This work changes only the MCP endpoint. It does not alter Anthropic Messages translation, OpenAI Responses translation, or native server-tool handling.
+
+## Availability rules
+
+| GitHub advertises name | Jina key configured | Advertised implementation |
+|---|---|---|
+| Yes | Either | GitHub definition, unchanged |
+| No | Yes | Local Jina definition |
+| No | No | Tool omitted |
+
+These rules apply independently to `web_search` and `web_fetch`, so mixed catalogs are valid.
+
+The backend selected by a successful `tools/list` response remains authoritative until that client requests a new tool list. There is no mid-call failover because GitHub and Jina may expose different schemas.
+
+If GitHub's `tools/list` request fails, preserve that failure. Do not replace the complete GitHub catalog with a Jina-only catalog.
+
+## Architecture
+
+Add a targeted JSON-RPC composition layer before the existing `ProxyMcp` byte relay.
+
+The layer understands only:
+
+- A single-object POST request whose method is `tools/list`.
+- A single-object POST request whose method is `tools/call`.
+- MCP DELETE for local snapshot cleanup after forwarding it upstream.
+
+Everything else remains transparent, including `initialize`, client notifications, prompts, resources, unknown methods, GET/SSE, and JSON-RPC batch arrays.
+
+GitHub handles `initialize` and remains the MCP session owner. Existing `Mcp-Session-Id`, `Mcp-Protocol-Version`, `Last-Event-ID`, and `X-MCP-*` forwarding remains unchanged.
+
+### Transport boundary
+
+The composition path supports GitHub `tools/list` responses with `Content-Type: application/json`.
+
+MCP also permits a POST response to use `text/event-stream`. Rewriting an SSE response would require buffering and re-framing the stream, which is outside this feature's narrow scope. If GitHub returns SSE for `tools/list`, pass that response through unchanged and do not advertise local fallbacks from that response. Log a bounded warning without response content or credentials.
+
+Local `tools/call` results are returned as `application/json`. GitHub-owned calls retain GitHub's original response content type and streaming behavior.
+
+JSON-RPC batch arrays pass through unchanged. The current MCP Streamable HTTP protocol requires one JSON-RPC message per POST, so the proxy does not split or recombine batch items.
+
+### Tool listing
+
+For a single-page, successful GitHub `tools/list` JSON response:
+
+1. Preserve every GitHub tool object, including unknown fields and schemas.
+2. Determine whether GitHub advertised the exact names `web_search` and `web_fetch`.
+3. If Jina is enabled, append a local definition for each missing name.
+4. Store the names injected locally, together with the endpoint and relevant GitHub tool-filter header fingerprint.
+5. Return the composed JSON-RPC result with the original request ID and applicable upstream response headers.
+
+The design deliberately supports the single-page catalog shape currently observed from GitHub. If a response contains a nonempty `nextCursor`, return it unchanged and do not inject or record local fallbacks. Pagination composition can be added later if GitHub is observed using it.
+
+Each successful composed listing atomically replaces the previous snapshot for that MCP session and endpoint.
+
+### Tool calls
+
+For a single-object `tools/call` request:
+
+- If the requested name was locally injected in the latest matching snapshot, execute the local Jina-backed handler.
+- Otherwise, forward the request to GitHub unchanged.
+- A GitHub-owned call that fails returns GitHub's error; it does not fall back to Jina.
+
+The relevant `X-MCP-*` tool-filter headers are part of catalog provenance because they can change GitHub's advertised tools. A call may use the latest snapshot when it sends no tool-filter headers. If it sends tool-filter headers, they must match the snapshot fingerprint for local dispatch; otherwise, forward the call to GitHub rather than guessing.
+
+Local fallbacks require an `Mcp-Session-Id` supplied by GitHub. If GitHub does not create a session, preserve its catalog unchanged and do not inject local tools because later calls cannot be routed safely to the schema that client received.
+
+## Snapshot lifecycle
+
+Use a process-local concurrent dictionary keyed by MCP endpoint and `Mcp-Session-Id`. Each snapshot contains only:
+
+- Names injected locally.
+- A deterministic fingerprint of relevant `X-MCP-*` tool-filter headers from the listing request.
+
+A new successful composed `tools/list` replaces the snapshot atomically. After forwarding MCP DELETE, remove the matching snapshot regardless of whether GitHub accepts session termination. A GitHub HTTP 404 for a session-bound request also removes the snapshot.
+
+The proxy is loopback-only and single-developer oriented, so no speculative capacity limit, pagination accumulator, notification parser, or eviction policy is added. Process restart clears abandoned snapshots.
+
+## Local Jina tools
+
+Reuse the existing implementation in `src/Misc`:
+
+- `JinaWebProvider`
+- `WebSearchTool`
+- `WebFetchTool`
+- `WebToolsOptions`
+- `WebInputValidator`
+- `WebToolOutput`
+
+Add a project reference from `CopilotAnthropicProxy.Sample` to `Misc`, and update the project comment that currently says the GitHub Copilot provider is its only required reference. Do not introduce another Jina HTTP client or duplicate validation and sanitization logic.
+
+Expose snake_case MCP names:
+
+- `web_search`
+- `web_fetch`
+
+Their argument schemas otherwise reflect the existing tool contracts. Invoke the modern `ToolHandler` directly and convert its payload into MCP `CallToolResult` content. Preserve its `IsError` value and pass request cancellation through.
+
+Do not use `LegacyHandlerAdapter`; it loses `IsError` and cancellation. Existing PascalCase wording inside bounded handler error text is acceptable and is not rewritten in this feature.
+
+## Configuration
+
+Use the existing web-tool environment configuration:
+
+- `JINA_API_KEY`
+- `WEB_TOOLS_OUTPUT_CAP`
+- `WEB_TOOLS_TIMEOUT_MS`
+- Other settings already supported by `WebToolsOptions`
+
+Per the requested product rule, local fallback for either tool is enabled only when `JINA_API_KEY` is nonblank and the options validate successfully. Although the underlying Jina fetch implementation can operate keyless, this MCP surface intentionally requires the key for predictable availability and limits.
+
+Invalid Jina configuration produces a bounded startup warning and disables local fallbacks. It does not prevent the proxy from serving GitHub's MCP endpoint.
+
+## Errors and security
+
+- Malformed single-object JSON-RPC requests that target local interception return a JSON-RPC error with the original request ID when available.
+- Local execution failures return MCP `CallToolResult` with `isError: true`.
+- GitHub JSON-RPC results and errors pass through unchanged for GitHub-owned tools.
+- GitHub `tools/list` transport and JSON-RPC errors remain errors.
+- HTTP request cancellation flows into the local `ToolHandler` and Jina HTTP operation.
+- Error text remains bounded and excludes raw upstream bodies.
+
+The local tools retain existing protections:
+
+- URL scheme and structure validation.
+- Blocking loopback, private, link-local, multicast, unspecified, and local-name destinations.
+- IPv4-mapped IPv6 handling.
+- Header-injection protection for selector inputs.
+- Untrusted-content framing.
+- Output sanitization and truncation.
+- Secret-safe logging and error mapping.
+
+The Jina key must never appear in MCP definitions, results, errors, logs, or GitHub-bound traffic.
+
+## `/mcp/readonly`
+
+`/mcp/readonly` uses the same composition logic and has a separate snapshot namespace from `/mcp`. GitHub's readonly and tool-filter controls remain authoritative and continue upstream unchanged.
+
+The local Jina tools are read-only and may be injected under the same availability rules.
+
+## Tests
+
+Extend focused proxy tests to prove:
+
+1. GitHub `web_search` and `web_fetch` definitions win and remain structurally unchanged.
+2. Each absent name is injected from Jina only with a valid key.
+3. No key or invalid Jina configuration means no local fallbacks.
+4. Mixed catalogs work, such as GitHub search plus Jina fetch.
+5. Calls route according to the latest snapshot advertised for that endpoint and session.
+6. A subsequent successful list can change ownership and atomically replace the snapshot.
+7. Matching, absent, and mismatched `X-MCP-*` filter headers follow the provenance rule.
+8. GitHub-owned call failures do not trigger Jina fallback.
+9. GitHub `tools/list` failures remain failures.
+10. SSE-framed and paginated `tools/list` responses pass through unchanged without recording local fallbacks.
+11. JSON-RPC batch arrays pass through unchanged.
+12. DELETE and upstream session 404 remove snapshots.
+13. Local handler failures preserve `isError: true`, and cancellation reaches the handler.
+14. Existing SSRF, output-cap, and secret-hygiene behavior remains enforced through MCP.
+15. Unrelated JSON-RPC, headers, GET/SSE, and unsupported methods retain existing behavior.
+16. `/mcp/readonly` composes independently without weakening GitHub restrictions.
+17. A GitHub session without `Mcp-Session-Id` remains unchanged and receives no local tools.
+
+Use a fake GitHub upstream and fake Jina HTTP handler for focused tests. When real credentials are available, also run an authenticated smoke test that initializes an MCP session, lists tools, and calls each advertised web tool.
+
+## Completion criteria
+
+The feature is complete when an MCP client connected to the existing endpoint:
+
+- Sees at most one definition for each exact web-tool name.
+- Sees GitHub's definition whenever GitHub advertises it in a supported, single-page JSON catalog.
+- Otherwise sees the Jina definition only when Jina is configured and routing can be tied to a GitHub session.
+- Has each call routed consistently with the definition and tool-filter context it received.
+- Retains existing transparent behavior outside the targeted interception paths.
+- Passes focused security, routing, protocol, and regression tests.

--- a/samples/CopilotAnthropicProxy.Sample/CopilotAnthropicProxy.Sample.csproj
+++ b/samples/CopilotAnthropicProxy.Sample/CopilotAnthropicProxy.Sample.csproj
@@ -10,10 +10,13 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <!-- The Copilot transport (CopilotHttpClientFactory / CopilotHeadersHandler / token providers /
-         CopilotOptions / CopilotSessionContext) lives in GithubCopilotProvider, which references
-         LmCore transitively. This is the only project reference the proxy needs. -->
+    <!-- Copilot transport and authentication live in GithubCopilotProvider. Web-tool contracts,
+         validation, output hygiene, and the Jina integration live in Misc. -->
     <ProjectReference Include="..\..\src\GithubCopilotProvider\AchieveAi.LmDotnetTools.GithubCopilotProvider.csproj" />
+    <ProjectReference Include="..\..\src\Misc\AchieveAi.LmDotnetTools.Misc.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="CopilotAnthropicProxy.Tests" />
   </ItemGroup>
   <ItemGroup>
     <!-- Structured JSONL logging (Serilog + CompactJsonFormatter), matching LmStreaming.Sample

--- a/samples/CopilotAnthropicProxy.Sample/Mcp/McpJinaToolCatalog.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Mcp/McpJinaToolCatalog.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.LmCore.Utils;
 using AchieveAi.LmDotnetTools.Misc.Configuration;
 using AchieveAi.LmDotnetTools.Misc.Utils;
 using AchieveAi.LmDotnetTools.Misc.Web.Jina;
@@ -71,7 +72,7 @@ internal sealed class McpJinaToolCatalog
         var schema = contract.GetJsonSchema();
         var schemaNode = schema is null
             ? new JsonObject { ["type"] = "object", ["properties"] = new JsonObject() }
-            : JsonNode.Parse(JsonSerializer.Serialize(schema)) as JsonObject ?? [];
+            : JsonNode.Parse(JsonSerializer.Serialize(schema, JsonSchemaValidator.SchemaSerializationOptions)) as JsonObject ?? [];
         var definition = new JsonObject
         {
             ["name"] = name,

--- a/samples/CopilotAnthropicProxy.Sample/Mcp/McpJinaToolCatalog.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Mcp/McpJinaToolCatalog.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.Misc.Configuration;
+using AchieveAi.LmDotnetTools.Misc.Utils;
+using AchieveAi.LmDotnetTools.Misc.Web.Jina;
+
+internal sealed record McpLocalTool(string Name, JsonObject Definition, ToolHandler Handler);
+
+internal sealed class McpJinaToolCatalog
+{
+    public const string WebSearchName = "web_search";
+    public const string WebFetchName = "web_fetch";
+
+    public McpJinaToolCatalog(JinaWebProvider provider, WebToolsOptions options, ILoggerFactory loggerFactory)
+    {
+        var validationErrors = options.Validate();
+        IsEnabled = !string.IsNullOrWhiteSpace(options.JinaApiKey) && validationErrors.Count == 0;
+        if (!IsEnabled)
+        {
+            if (!string.IsNullOrWhiteSpace(options.JinaApiKey) && validationErrors.Count > 0)
+            {
+                loggerFactory
+                    .CreateLogger<McpJinaToolCatalog>()
+                    .LogWarning(
+                        "Local MCP web tools are disabled because configuration is invalid: {Errors}",
+                        string.Join("; ", validationErrors)
+                    );
+            }
+
+            Tools = new Dictionary<string, McpLocalTool>();
+            return;
+        }
+
+        var search = new WebSearchTool(provider, options, loggerFactory.CreateLogger<WebSearchTool>());
+        var fetch = new WebFetchTool(provider, options, loggerFactory.CreateLogger<WebFetchTool>());
+        Tools = new Dictionary<string, McpLocalTool>(StringComparer.Ordinal)
+        {
+            [WebSearchName] = BuildTool(WebSearchName, search.Contract, search.Handler),
+            [WebFetchName] = BuildTool(WebFetchName, fetch.Contract, fetch.Handler),
+        };
+    }
+
+    public bool IsEnabled { get; }
+
+    public IReadOnlyDictionary<string, McpLocalTool> Tools { get; }
+
+    public IReadOnlyList<McpLocalTool> SelectInjectable(IHeaderDictionary headers, IEnumerable<string> githubNames)
+    {
+        if (!IsEnabled || IsTruthy(headers["X-MCP-Lockdown"].FirstOrDefault()))
+        {
+            return [];
+        }
+
+        var github = githubNames.ToHashSet(StringComparer.Ordinal);
+        var allowlist = ParseNames(headers["X-MCP-Tools"]);
+        var exclusions = ParseNames(headers["X-MCP-Exclude-Tools"]);
+        var hasAllowlist = headers.ContainsKey("X-MCP-Tools");
+
+        return
+        [
+            .. Tools.Values
+                .Where(tool => !github.Contains(tool.Name))
+                .Where(tool => !hasAllowlist || allowlist.Contains(tool.Name))
+                .Where(tool => !exclusions.Contains(tool.Name)),
+        ];
+    }
+
+    private static McpLocalTool BuildTool(string name, AchieveAi.LmDotnetTools.LmCore.Core.FunctionContract contract, ToolHandler handler)
+    {
+        var schema = contract.GetJsonSchema();
+        var schemaNode = schema is null
+            ? new JsonObject { ["type"] = "object", ["properties"] = new JsonObject() }
+            : JsonNode.Parse(JsonSerializer.Serialize(schema)) as JsonObject ?? [];
+        var definition = new JsonObject
+        {
+            ["name"] = name,
+            ["description"] = contract.Description,
+            ["inputSchema"] = schemaNode,
+        };
+        return new McpLocalTool(name, definition, handler);
+    }
+
+    private static HashSet<string> ParseNames(Microsoft.Extensions.Primitives.StringValues values) =>
+        values
+            .SelectMany(value => (value ?? string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .ToHashSet(StringComparer.Ordinal);
+
+    private static bool IsTruthy(string? value) =>
+        !string.IsNullOrWhiteSpace(value)
+        && value.Trim() is not ("0" or "false" or "f" or "no" or "n" or "off");
+}

--- a/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs
@@ -239,9 +239,14 @@ internal sealed class McpToolComposition
         var isJson = string.Equals(mediaType, "application/json", StringComparison.OrdinalIgnoreCase);
         var isSse = string.Equals(mediaType, "text/event-stream", StringComparison.OrdinalIgnoreCase);
         var hasBoundedSseBody = isSse && upstream.Content.Headers.ContentLength is { } sseLength && sseLength <= maxBodyBytes;
-        if (!upstream.IsSuccessStatusCode || (!isJson && !hasBoundedSseBody))
+        if (!upstream.IsSuccessStatusCode)
         {
             return null;
+        }
+
+        if (!isJson && !hasBoundedSseBody)
+        {
+            return new McpComposedList(null, endpoint, sessionId, McpSnapshotAction.Remove, Generation: generation);
         }
 
         var original = await ProxyHttp.ReadCappedBytesAsync(

--- a/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs
@@ -164,10 +164,9 @@ internal sealed class McpToolComposition
         }
 
         var mediaType = upstream.Content.Headers.ContentType?.MediaType;
-        if (
-            !upstream.IsSuccessStatusCode
-            || !string.Equals(mediaType, "application/json", StringComparison.OrdinalIgnoreCase)
-        )
+        var isJson = string.Equals(mediaType, "application/json", StringComparison.OrdinalIgnoreCase);
+        var isSse = string.Equals(mediaType, "text/event-stream", StringComparison.OrdinalIgnoreCase);
+        if (!upstream.IsSuccessStatusCode || (!isJson && !isSse))
         {
             Invalidate();
             return null;
@@ -181,9 +180,24 @@ internal sealed class McpToolComposition
         }
 
         ReplaceContent(upstream, original, mediaType);
+        var jsonBytes = original;
+        string? ssePrefix = null;
+        string? sseSuffix = null;
+        if (isSse)
+        {
+            var sse = Encoding.UTF8.GetString(original);
+            if (!TryReadSingleSseMessage(sse, out ssePrefix, out var json, out sseSuffix))
+            {
+                Invalidate();
+                return original;
+            }
+
+            jsonBytes = Encoding.UTF8.GetBytes(json);
+        }
+
         try
         {
-            var root = JsonNode.Parse(original) as JsonObject;
+            var root = JsonNode.Parse(jsonBytes) as JsonObject;
             var result = root?["result"] as JsonObject;
             var tools = result?["tools"] as JsonArray;
             if (
@@ -224,7 +238,10 @@ internal sealed class McpToolComposition
             }
 
             upstream.Headers.ETag = null;
-            var composed = Encoding.UTF8.GetBytes(root!.ToJsonString());
+            var composedJson = root!.ToJsonString();
+            var composed = isSse
+                ? Encoding.UTF8.GetBytes(ssePrefix + composedJson + sseSuffix)
+                : Encoding.UTF8.GetBytes(composedJson);
             _logger.LogInformation(
                 "MCP tools listed endpoint={Endpoint} backend={Backend} status={Status} localToolCount={LocalToolCount}",
                 endpoint,
@@ -254,6 +271,50 @@ internal sealed class McpToolComposition
 
     private static string ToolCallId(JsonNode id) =>
         id is JsonValue value && value.TryGetValue<string>(out var text) ? text : id.ToJsonString();
+
+    private static bool TryReadSingleSseMessage(
+        string sse,
+        out string prefix,
+        out string json,
+        out string suffix
+    )
+    {
+        prefix = string.Empty;
+        json = string.Empty;
+        suffix = string.Empty;
+        var newline = sse.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
+        var terminator = newline + newline;
+        if (!sse.EndsWith(terminator, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var lines = sse[..^terminator.Length].Split(newline, StringSplitOptions.None);
+        var dataIndexes = lines
+            .Select((line, index) => (line, index))
+            .Where(item => item.line.StartsWith("data:", StringComparison.Ordinal))
+            .Select(item => item.index)
+            .ToArray();
+        if (dataIndexes.Length != 1 || lines.Any(string.IsNullOrWhiteSpace))
+        {
+            return false;
+        }
+
+        var dataIndex = dataIndexes[0];
+        var dataLine = lines[dataIndex];
+        var separatorLength = dataLine.StartsWith("data: ", StringComparison.Ordinal) ? 6 : 5;
+        json = dataLine[separatorLength..];
+        prefix = string.Join(newline, lines[..dataIndex]);
+        if (dataIndex > 0)
+        {
+            prefix += newline;
+        }
+        prefix += dataLine[..separatorLength];
+        suffix = dataIndex + 1 < lines.Length
+            ? newline + string.Join(newline, lines[(dataIndex + 1)..]) + terminator
+            : terminator;
+        return true;
+    }
 
     private static void ReplaceContent(HttpResponseMessage upstream, byte[] body, string? mediaType)
     {

--- a/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs
@@ -97,8 +97,7 @@ internal sealed class McpToolComposition
         var endpoint = context.Request.Path.Value;
         if (request["params"] is not JsonObject parameters)
         {
-            await WriteInvalidParamsAsync(context, request["id"]!);
-            return true;
+            return false;
         }
 
         var name = Text(parameters["name"]);

--- a/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs
@@ -5,6 +5,13 @@ using System.Text.Json.Nodes;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
 
+internal sealed record McpComposedList(
+    byte[] Body,
+    string? Endpoint,
+    string? SessionId,
+    McpToolSnapshot? Snapshot
+);
+
 internal sealed class McpToolComposition
 {
     private readonly McpJinaToolCatalog _catalog;
@@ -132,12 +139,14 @@ internal sealed class McpToolComposition
         return true;
     }
 
-    public async Task<byte[]?> ComposeListAsync(
+    public async Task<McpComposedList?> ComposeListAsync(
         HttpContext context,
         JsonObject request,
         HttpResponseMessage upstream,
         long maxBodyBytes,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        CancellationTokenSource idleCts,
+        TimeSpan idleTimeout
     )
     {
         if (!IsEnabled || !IsToolsList(request))
@@ -172,11 +181,17 @@ internal sealed class McpToolComposition
             return null;
         }
 
-        var original = await ProxyHttp.ReadCappedBytesAsync(upstream.Content, maxBodyBytes, cancellationToken);
+        var original = await ProxyHttp.ReadCappedBytesAsync(
+            upstream.Content,
+            maxBodyBytes,
+            cancellationToken,
+            idleCts,
+            idleTimeout
+        );
         if (original is null)
         {
             Invalidate();
-            return [];
+            return new McpComposedList([], endpoint, sessionId, null);
         }
 
         ReplaceContent(upstream, original, mediaType);
@@ -189,7 +204,7 @@ internal sealed class McpToolComposition
             if (!TryReadSingleSseMessage(sse, out ssePrefix, out var json, out sseSuffix))
             {
                 Invalidate();
-                return original;
+                return new McpComposedList(original, endpoint, sessionId, null);
             }
 
             jsonBytes = Encoding.UTF8.GetBytes(json);
@@ -211,7 +226,7 @@ internal sealed class McpToolComposition
             )
             {
                 Invalidate();
-                return original;
+                return new McpComposedList(original, endpoint, sessionId, null);
             }
 
             var githubNames = tools
@@ -226,15 +241,14 @@ internal sealed class McpToolComposition
                 tools.Add(local.Definition.DeepClone());
             }
 
-            _snapshots.Set(
-                endpoint,
-                sessionId,
-                new McpToolSnapshot(injectable.Select(tool => tool.Name).ToHashSet(StringComparer.Ordinal), headerContext)
+            var snapshot = new McpToolSnapshot(
+                injectable.Select(tool => tool.Name).ToHashSet(StringComparer.Ordinal),
+                headerContext
             );
 
             if (injectable.Count == 0)
             {
-                return original;
+                return new McpComposedList(original, endpoint, sessionId, snapshot);
             }
 
             upstream.Headers.ETag = null;
@@ -249,13 +263,25 @@ internal sealed class McpToolComposition
                 (int)upstream.StatusCode,
                 injectable.Count
             );
-            return composed;
+            return new McpComposedList(composed, endpoint, sessionId, snapshot);
         }
         catch (Exception ex) when (ex is JsonException or InvalidOperationException)
         {
             Invalidate();
             _logger.LogWarning(ex, "MCP tool-list composition failed; returning the original upstream response");
-            return original;
+            return new McpComposedList(original, endpoint, sessionId, null);
+        }
+    }
+
+    public void PublishSnapshot(McpComposedList composed)
+    {
+        if (
+            composed.Snapshot is not null
+            && !string.IsNullOrWhiteSpace(composed.Endpoint)
+            && !string.IsNullOrWhiteSpace(composed.SessionId)
+        )
+        {
+            _snapshots.Set(composed.Endpoint, composed.SessionId, composed.Snapshot);
         }
     }
 

--- a/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs
@@ -68,7 +68,7 @@ internal sealed class McpToolComposition
 
         var sessionId = context.Request.Headers["Mcp-Session-Id"].FirstOrDefault();
         var endpoint = context.Request.Path.Value;
-        var requestId = request["params"]?["requestId"];
+        var requestId = (request["params"] as JsonObject)?["requestId"];
         if (
             string.IsNullOrWhiteSpace(endpoint)
             || string.IsNullOrWhiteSpace(sessionId)
@@ -80,7 +80,14 @@ internal sealed class McpToolComposition
 
         if (_localCalls.TryGetValue((endpoint, sessionId, requestId.ToJsonString()), out var cancellation))
         {
-            cancellation.Cancel();
+            try
+            {
+                cancellation.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The local call completed between lookup and cancellation; treat it as already finished.
+            }
         }
 
         return false;
@@ -217,20 +224,11 @@ internal sealed class McpToolComposition
         var endpoint = context.Request.Path.Value;
         var sessionId = context.Request.Headers["Mcp-Session-Id"].FirstOrDefault();
 
-        void Invalidate()
-        {
-            if (!string.IsNullOrWhiteSpace(endpoint) && !string.IsNullOrWhiteSpace(sessionId))
-            {
-                _snapshots.Remove(endpoint, sessionId);
-            }
-        }
-
         var mediaType = upstream.Content.Headers.ContentType?.MediaType;
         var isJson = string.Equals(mediaType, "application/json", StringComparison.OrdinalIgnoreCase);
         var isSse = string.Equals(mediaType, "text/event-stream", StringComparison.OrdinalIgnoreCase);
         if (!upstream.IsSuccessStatusCode || (!isJson && !isSse))
         {
-            Invalidate();
             return null;
         }
 
@@ -243,7 +241,6 @@ internal sealed class McpToolComposition
         );
         if (original is null)
         {
-            Invalidate();
             return new McpComposedList([], endpoint, sessionId, McpSnapshotAction.Remove);
         }
 
@@ -256,7 +253,6 @@ internal sealed class McpToolComposition
             var sse = Encoding.UTF8.GetString(original);
             if (!TryReadSingleSseMessage(sse, out ssePrefix, out var json, out sseSuffix))
             {
-                Invalidate();
                 return new McpComposedList(original, endpoint, sessionId, McpSnapshotAction.Remove);
             }
 
@@ -278,7 +274,6 @@ internal sealed class McpToolComposition
                 || !McpToolSnapshotStore.TryBuildHeaderContext(context.Request.Headers, out var headerContext)
             )
             {
-                Invalidate();
                 return new McpComposedList(original, endpoint, sessionId, McpSnapshotAction.Remove);
             }
 
@@ -320,7 +315,6 @@ internal sealed class McpToolComposition
         }
         catch (Exception ex) when (ex is JsonException or InvalidOperationException)
         {
-            Invalidate();
             _logger.LogWarning(ex, "MCP tool-list composition failed; returning the original upstream response");
             return new McpComposedList(original, endpoint, sessionId, McpSnapshotAction.Remove);
         }

--- a/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs
@@ -1,0 +1,264 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+
+internal sealed class McpToolComposition
+{
+    private readonly McpJinaToolCatalog _catalog;
+    private readonly McpToolSnapshotStore _snapshots;
+    private readonly ILogger _logger;
+
+    public McpToolComposition(
+        McpJinaToolCatalog catalog,
+        McpToolSnapshotStore snapshots,
+        ILoggerFactory loggerFactory
+    )
+    {
+        _catalog = catalog;
+        _snapshots = snapshots;
+        _logger = loggerFactory.CreateLogger("CopilotAnthropicProxy.McpTools");
+    }
+
+    public bool IsEnabled => _catalog.IsEnabled;
+
+    public static bool TryParseSingleRequest(ReadOnlySpan<byte> body, out JsonObject? request)
+    {
+        request = null;
+        try
+        {
+            request = JsonNode.Parse(body) as JsonObject;
+            return request is not null;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    public static bool IsToolsList(JsonObject request) => Text(request["method"]) == "tools/list";
+
+    public static bool IsToolsCall(JsonObject request) => Text(request["method"]) == "tools/call";
+
+    public async Task<bool> TryHandleCallAsync(HttpContext context, JsonObject request)
+    {
+        if (!IsEnabled || !IsToolsCall(request) || !request.ContainsKey("id") || request["id"] is null)
+        {
+            return false;
+        }
+
+        var sessionId = context.Request.Headers["Mcp-Session-Id"].FirstOrDefault();
+        var endpoint = context.Request.Path.Value;
+        var name = Text(request["params"]?["name"]);
+        if (
+            string.IsNullOrWhiteSpace(sessionId)
+            || string.IsNullOrWhiteSpace(endpoint)
+            || string.IsNullOrWhiteSpace(name)
+            || !_snapshots.TryGet(endpoint, sessionId, out var snapshot)
+            || !snapshot.LocalToolNames.Contains(name)
+            || !_catalog.Tools.TryGetValue(name, out var tool)
+        )
+        {
+            return false;
+        }
+
+        if (
+            McpToolSnapshotStore.HasToolFilterHeaders(context.Request.Headers)
+            && (
+                !McpToolSnapshotStore.TryBuildHeaderContext(context.Request.Headers, out var contextHeaders)
+                || !string.Equals(contextHeaders, snapshot.HeaderContext, StringComparison.Ordinal)
+            )
+        )
+        {
+            return false;
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        ToolHandlerResult result;
+        try
+        {
+            var arguments = request["params"]?["arguments"]?.ToJsonString() ?? "{}";
+            result = await tool.Handler(
+                arguments,
+                new ToolCallContext { ToolCallId = ToolCallId(request["id"]!) },
+                context.RequestAborted
+            );
+        }
+        catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+        {
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Local MCP tool {ToolName} failed unexpectedly", name);
+            result = ToolHandlerResult.FromError("The local MCP tool failed unexpectedly.");
+        }
+
+        var payload = result switch
+        {
+            ToolHandlerResult.Resolved resolved => resolved.Payload,
+            ToolHandlerResult.Deferred => new ToolHandlerResultPayload(
+                "Deferred tool execution is not supported by this MCP endpoint.",
+                IsError: true
+            ),
+            _ => new ToolHandlerResultPayload("The local MCP tool returned an unsupported result.", IsError: true),
+        };
+
+        var response = new JsonObject
+        {
+            ["jsonrpc"] = "2.0",
+            ["id"] = request["id"]!.DeepClone(),
+            ["result"] = new JsonObject
+            {
+                ["content"] = new JsonArray(new JsonObject { ["type"] = "text", ["text"] = payload.Text }),
+                ["isError"] = payload.IsError,
+            },
+        };
+        var bytes = Encoding.UTF8.GetBytes(response.ToJsonString());
+        context.Response.StatusCode = StatusCodes.Status200OK;
+        context.Response.ContentType = "application/json";
+        await context.Response.Body.WriteAsync(bytes, context.RequestAborted);
+        _logger.LogInformation(
+            "MCP tool handled endpoint={Endpoint} backend={Backend} tool={ToolName} status={Status} elapsedMs={ElapsedMs} isError={IsError}",
+            endpoint,
+            "jina-local",
+            name,
+            StatusCodes.Status200OK,
+            stopwatch.ElapsedMilliseconds,
+            payload.IsError
+        );
+        return true;
+    }
+
+    public async Task<byte[]?> ComposeListAsync(
+        HttpContext context,
+        JsonObject request,
+        HttpResponseMessage upstream,
+        long maxBodyBytes,
+        CancellationToken cancellationToken
+    )
+    {
+        if (!IsEnabled || !IsToolsList(request))
+        {
+            return null;
+        }
+
+        var endpoint = context.Request.Path.Value;
+        var sessionId = context.Request.Headers["Mcp-Session-Id"].FirstOrDefault();
+        if (
+            sessionId is null
+            && upstream.Headers.TryGetValues("Mcp-Session-Id", out var responseSessionIds)
+        )
+        {
+            sessionId = responseSessionIds.FirstOrDefault();
+        }
+
+        void Invalidate()
+        {
+            if (!string.IsNullOrWhiteSpace(endpoint) && !string.IsNullOrWhiteSpace(sessionId))
+            {
+                _snapshots.Remove(endpoint, sessionId);
+            }
+        }
+
+        var mediaType = upstream.Content.Headers.ContentType?.MediaType;
+        if (
+            !upstream.IsSuccessStatusCode
+            || !string.Equals(mediaType, "application/json", StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            Invalidate();
+            return null;
+        }
+
+        var original = await ProxyHttp.ReadCappedBytesAsync(upstream.Content, maxBodyBytes, cancellationToken);
+        if (original is null)
+        {
+            Invalidate();
+            return [];
+        }
+
+        ReplaceContent(upstream, original, mediaType);
+        try
+        {
+            var root = JsonNode.Parse(original) as JsonObject;
+            var result = root?["result"] as JsonObject;
+            var tools = result?["tools"] as JsonArray;
+            if (
+                root?["error"] is not null
+                || result is null
+                || tools is null
+                || !string.IsNullOrWhiteSpace(Text(result["nextCursor"]))
+                || string.IsNullOrWhiteSpace(endpoint)
+                || string.IsNullOrWhiteSpace(sessionId)
+                || !McpToolSnapshotStore.TryBuildHeaderContext(context.Request.Headers, out var headerContext)
+            )
+            {
+                Invalidate();
+                return original;
+            }
+
+            var githubNames = tools
+                .OfType<JsonObject>()
+                .Select(tool => Text(tool["name"]))
+                .Where(name => name is not null)
+                .Cast<string>()
+                .ToHashSet(StringComparer.Ordinal);
+            var injectable = _catalog.SelectInjectable(context.Request.Headers, githubNames);
+            foreach (var local in injectable)
+            {
+                tools.Add(local.Definition.DeepClone());
+            }
+
+            _snapshots.Set(
+                endpoint,
+                sessionId,
+                new McpToolSnapshot(injectable.Select(tool => tool.Name).ToHashSet(StringComparer.Ordinal), headerContext)
+            );
+
+            if (injectable.Count == 0)
+            {
+                return original;
+            }
+
+            upstream.Headers.ETag = null;
+            var composed = Encoding.UTF8.GetBytes(root!.ToJsonString());
+            _logger.LogInformation(
+                "MCP tools listed endpoint={Endpoint} backend={Backend} status={Status} localToolCount={LocalToolCount}",
+                endpoint,
+                "github+jina-local",
+                (int)upstream.StatusCode,
+                injectable.Count
+            );
+            return composed;
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException)
+        {
+            Invalidate();
+            _logger.LogWarning(ex, "MCP tool-list composition failed; returning the original upstream response");
+            return original;
+        }
+    }
+
+    public void RemoveSnapshot(string endpoint, string? sessionId)
+    {
+        if (!string.IsNullOrWhiteSpace(sessionId))
+        {
+            _snapshots.Remove(endpoint, sessionId);
+        }
+    }
+
+    private static string? Text(JsonNode? node) => node is JsonValue value && value.TryGetValue<string>(out var text) ? text : null;
+
+    private static string ToolCallId(JsonNode id) =>
+        id is JsonValue value && value.TryGetValue<string>(out var text) ? text : id.ToJsonString();
+
+    private static void ReplaceContent(HttpResponseMessage upstream, byte[] body, string? mediaType)
+    {
+        upstream.Content.Dispose();
+        upstream.Content = new ByteArrayContent(body);
+        upstream.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(mediaType ?? "application/json");
+    }
+}

--- a/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs
@@ -18,7 +18,8 @@ internal sealed record McpComposedList(
     string? Endpoint,
     string? SessionId,
     McpSnapshotAction SnapshotAction,
-    McpToolSnapshot? Snapshot = null
+    McpToolSnapshot? Snapshot = null,
+    long Generation = 0
 );
 
 internal sealed class McpToolComposition
@@ -206,6 +207,15 @@ internal sealed class McpToolComposition
         return true;
     }
 
+    public long CaptureListGeneration(HttpContext context, JsonObject request)
+    {
+        var endpoint = context.Request.Path.Value;
+        var sessionId = context.Request.Headers["Mcp-Session-Id"].FirstOrDefault();
+        return IsToolsList(request) && !string.IsNullOrWhiteSpace(endpoint) && !string.IsNullOrWhiteSpace(sessionId)
+            ? _snapshots.Generation(endpoint, sessionId)
+            : 0;
+    }
+
     public async Task<McpComposedList?> ComposeListAsync(
         HttpContext context,
         JsonObject request,
@@ -213,7 +223,8 @@ internal sealed class McpToolComposition
         long maxBodyBytes,
         CancellationToken cancellationToken,
         CancellationTokenSource idleCts,
-        TimeSpan idleTimeout
+        TimeSpan idleTimeout,
+        long generation
     )
     {
         if (!IsEnabled || !IsToolsList(request))
@@ -227,7 +238,8 @@ internal sealed class McpToolComposition
         var mediaType = upstream.Content.Headers.ContentType?.MediaType;
         var isJson = string.Equals(mediaType, "application/json", StringComparison.OrdinalIgnoreCase);
         var isSse = string.Equals(mediaType, "text/event-stream", StringComparison.OrdinalIgnoreCase);
-        if (!upstream.IsSuccessStatusCode || (!isJson && !isSse))
+        var hasBoundedSseBody = isSse && upstream.Content.Headers.ContentLength is { } sseLength && sseLength <= maxBodyBytes;
+        if (!upstream.IsSuccessStatusCode || (!isJson && !hasBoundedSseBody))
         {
             return null;
         }
@@ -241,7 +253,7 @@ internal sealed class McpToolComposition
         );
         if (original is null)
         {
-            return new McpComposedList([], endpoint, sessionId, McpSnapshotAction.Remove);
+            return new McpComposedList([], endpoint, sessionId, McpSnapshotAction.None, Generation: generation);
         }
 
         ReplaceContent(upstream, original, mediaType);
@@ -253,7 +265,7 @@ internal sealed class McpToolComposition
             var sse = Encoding.UTF8.GetString(original);
             if (!TryReadSingleSseMessage(sse, out ssePrefix, out var json, out sseSuffix))
             {
-                return new McpComposedList(original, endpoint, sessionId, McpSnapshotAction.Remove);
+                return new McpComposedList(original, endpoint, sessionId, McpSnapshotAction.None, Generation: generation);
             }
 
             jsonBytes = Encoding.UTF8.GetBytes(json);
@@ -274,7 +286,7 @@ internal sealed class McpToolComposition
                 || !McpToolSnapshotStore.TryBuildHeaderContext(context.Request.Headers, out var headerContext)
             )
             {
-                return new McpComposedList(original, endpoint, sessionId, McpSnapshotAction.Remove);
+                return new McpComposedList(original, endpoint, sessionId, McpSnapshotAction.None, Generation: generation);
             }
 
             var githubNames = tools
@@ -296,7 +308,7 @@ internal sealed class McpToolComposition
 
             if (injectable.Count == 0)
             {
-                return new McpComposedList(original, endpoint, sessionId, McpSnapshotAction.Set, snapshot);
+                return new McpComposedList(original, endpoint, sessionId, McpSnapshotAction.Set, snapshot, generation);
             }
 
             upstream.Headers.ETag = null;
@@ -311,12 +323,12 @@ internal sealed class McpToolComposition
                 (int)upstream.StatusCode,
                 injectable.Count
             );
-            return new McpComposedList(composed, endpoint, sessionId, McpSnapshotAction.Set, snapshot);
+            return new McpComposedList(composed, endpoint, sessionId, McpSnapshotAction.Set, snapshot, generation);
         }
         catch (Exception ex) when (ex is JsonException or InvalidOperationException)
         {
             _logger.LogWarning(ex, "MCP tool-list composition failed; returning the original upstream response");
-            return new McpComposedList(original, endpoint, sessionId, McpSnapshotAction.Remove);
+            return new McpComposedList(original, endpoint, sessionId, McpSnapshotAction.None, Generation: generation);
         }
     }
 
@@ -330,7 +342,12 @@ internal sealed class McpToolComposition
         switch (composed.SnapshotAction)
         {
             case McpSnapshotAction.Set when composed.Snapshot is not null:
-                _snapshots.Set(composed.Endpoint, composed.SessionId, composed.Snapshot);
+                _snapshots.SetIfGeneration(
+                    composed.Endpoint,
+                    composed.SessionId,
+                    composed.Generation,
+                    composed.Snapshot
+                );
                 break;
             case McpSnapshotAction.Set:
                 throw new InvalidOperationException("A snapshot is required for the set action.");

--- a/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolComposition.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
@@ -5,17 +6,26 @@ using System.Text.Json.Nodes;
 using AchieveAi.LmDotnetTools.LmCore.Messages;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
 
+internal enum McpSnapshotAction
+{
+    None,
+    Set,
+    Remove,
+}
+
 internal sealed record McpComposedList(
-    byte[] Body,
+    byte[]? Body,
     string? Endpoint,
     string? SessionId,
-    McpToolSnapshot? Snapshot
+    McpSnapshotAction SnapshotAction,
+    McpToolSnapshot? Snapshot = null
 );
 
 internal sealed class McpToolComposition
 {
     private readonly McpJinaToolCatalog _catalog;
     private readonly McpToolSnapshotStore _snapshots;
+    private readonly ConcurrentDictionary<(string Endpoint, string SessionId, string RequestId), CancellationTokenSource> _localCalls = [];
     private readonly ILogger _logger;
 
     public McpToolComposition(
@@ -49,6 +59,33 @@ internal sealed class McpToolComposition
 
     public static bool IsToolsCall(JsonObject request) => Text(request["method"]) == "tools/call";
 
+    public bool TryHandleCancellation(HttpContext context, JsonObject request)
+    {
+        if (Text(request["method"]) != "notifications/cancelled")
+        {
+            return false;
+        }
+
+        var sessionId = context.Request.Headers["Mcp-Session-Id"].FirstOrDefault();
+        var endpoint = context.Request.Path.Value;
+        var requestId = request["params"]?["requestId"];
+        if (
+            string.IsNullOrWhiteSpace(endpoint)
+            || string.IsNullOrWhiteSpace(sessionId)
+            || requestId is null
+        )
+        {
+            return false;
+        }
+
+        if (_localCalls.TryGetValue((endpoint, sessionId, requestId.ToJsonString()), out var cancellation))
+        {
+            cancellation.Cancel();
+        }
+
+        return false;
+    }
+
     public async Task<bool> TryHandleCallAsync(HttpContext context, JsonObject request)
     {
         if (!IsEnabled || !IsToolsCall(request) || !request.ContainsKey("id") || request["id"] is null)
@@ -58,7 +95,13 @@ internal sealed class McpToolComposition
 
         var sessionId = context.Request.Headers["Mcp-Session-Id"].FirstOrDefault();
         var endpoint = context.Request.Path.Value;
-        var name = Text(request["params"]?["name"]);
+        if (request["params"] is not JsonObject parameters)
+        {
+            await WriteInvalidParamsAsync(context, request["id"]!);
+            return true;
+        }
+
+        var name = Text(parameters["name"]);
         if (
             string.IsNullOrWhiteSpace(sessionId)
             || string.IsNullOrWhiteSpace(endpoint)
@@ -82,18 +125,32 @@ internal sealed class McpToolComposition
             return false;
         }
 
+        if (parameters["arguments"] is not null and not JsonObject)
+        {
+            await WriteInvalidParamsAsync(context, request["id"]!);
+            return true;
+        }
+
         var stopwatch = Stopwatch.StartNew();
+        var requestKey = (endpoint, sessionId, request["id"]!.ToJsonString());
+        using var localCts = CancellationTokenSource.CreateLinkedTokenSource(context.RequestAborted);
+        if (!_localCalls.TryAdd(requestKey, localCts))
+        {
+            await WriteInvalidParamsAsync(context, request["id"]!);
+            return true;
+        }
+
         ToolHandlerResult result;
         try
         {
-            var arguments = request["params"]?["arguments"]?.ToJsonString() ?? "{}";
+            var arguments = parameters["arguments"]?.ToJsonString() ?? "{}";
             result = await tool.Handler(
                 arguments,
                 new ToolCallContext { ToolCallId = ToolCallId(request["id"]!) },
-                context.RequestAborted
+                localCts.Token
             );
         }
-        catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+        catch (OperationCanceledException) when (localCts.IsCancellationRequested)
         {
             return true;
         }
@@ -101,6 +158,10 @@ internal sealed class McpToolComposition
         {
             _logger.LogError(ex, "Local MCP tool {ToolName} failed unexpectedly", name);
             result = ToolHandlerResult.FromError("The local MCP tool failed unexpectedly.");
+        }
+        finally
+        {
+            _localCalls.TryRemove(requestKey, out _);
         }
 
         var payload = result switch
@@ -156,13 +217,6 @@ internal sealed class McpToolComposition
 
         var endpoint = context.Request.Path.Value;
         var sessionId = context.Request.Headers["Mcp-Session-Id"].FirstOrDefault();
-        if (
-            sessionId is null
-            && upstream.Headers.TryGetValues("Mcp-Session-Id", out var responseSessionIds)
-        )
-        {
-            sessionId = responseSessionIds.FirstOrDefault();
-        }
 
         void Invalidate()
         {
@@ -191,7 +245,7 @@ internal sealed class McpToolComposition
         if (original is null)
         {
             Invalidate();
-            return new McpComposedList([], endpoint, sessionId, null);
+            return new McpComposedList([], endpoint, sessionId, McpSnapshotAction.Remove);
         }
 
         ReplaceContent(upstream, original, mediaType);
@@ -204,7 +258,7 @@ internal sealed class McpToolComposition
             if (!TryReadSingleSseMessage(sse, out ssePrefix, out var json, out sseSuffix))
             {
                 Invalidate();
-                return new McpComposedList(original, endpoint, sessionId, null);
+                return new McpComposedList(original, endpoint, sessionId, McpSnapshotAction.Remove);
             }
 
             jsonBytes = Encoding.UTF8.GetBytes(json);
@@ -226,7 +280,7 @@ internal sealed class McpToolComposition
             )
             {
                 Invalidate();
-                return new McpComposedList(original, endpoint, sessionId, null);
+                return new McpComposedList(original, endpoint, sessionId, McpSnapshotAction.Remove);
             }
 
             var githubNames = tools
@@ -248,7 +302,7 @@ internal sealed class McpToolComposition
 
             if (injectable.Count == 0)
             {
-                return new McpComposedList(original, endpoint, sessionId, snapshot);
+                return new McpComposedList(original, endpoint, sessionId, McpSnapshotAction.Set, snapshot);
             }
 
             upstream.Headers.ETag = null;
@@ -263,25 +317,37 @@ internal sealed class McpToolComposition
                 (int)upstream.StatusCode,
                 injectable.Count
             );
-            return new McpComposedList(composed, endpoint, sessionId, snapshot);
+            return new McpComposedList(composed, endpoint, sessionId, McpSnapshotAction.Set, snapshot);
         }
         catch (Exception ex) when (ex is JsonException or InvalidOperationException)
         {
             Invalidate();
             _logger.LogWarning(ex, "MCP tool-list composition failed; returning the original upstream response");
-            return new McpComposedList(original, endpoint, sessionId, null);
+            return new McpComposedList(original, endpoint, sessionId, McpSnapshotAction.Remove);
         }
     }
 
     public void PublishSnapshot(McpComposedList composed)
     {
-        if (
-            composed.Snapshot is not null
-            && !string.IsNullOrWhiteSpace(composed.Endpoint)
-            && !string.IsNullOrWhiteSpace(composed.SessionId)
-        )
+        if (string.IsNullOrWhiteSpace(composed.Endpoint) || string.IsNullOrWhiteSpace(composed.SessionId))
         {
-            _snapshots.Set(composed.Endpoint, composed.SessionId, composed.Snapshot);
+            return;
+        }
+
+        switch (composed.SnapshotAction)
+        {
+            case McpSnapshotAction.Set when composed.Snapshot is not null:
+                _snapshots.Set(composed.Endpoint, composed.SessionId, composed.Snapshot);
+                break;
+            case McpSnapshotAction.Set:
+                throw new InvalidOperationException("A snapshot is required for the set action.");
+            case McpSnapshotAction.Remove:
+                _snapshots.Remove(composed.Endpoint, composed.SessionId);
+                break;
+            case McpSnapshotAction.None:
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
         }
     }
 
@@ -291,6 +357,22 @@ internal sealed class McpToolComposition
         {
             _snapshots.Remove(endpoint, sessionId);
         }
+    }
+
+    private static async Task WriteInvalidParamsAsync(HttpContext context, JsonNode id)
+    {
+        var response = new JsonObject
+        {
+            ["jsonrpc"] = "2.0",
+            ["id"] = id.DeepClone(),
+            ["error"] = new JsonObject { ["code"] = -32602, ["message"] = "Invalid params" },
+        };
+        context.Response.StatusCode = StatusCodes.Status200OK;
+        context.Response.ContentType = "application/json";
+        await context.Response.Body.WriteAsync(
+            Encoding.UTF8.GetBytes(response.ToJsonString()),
+            context.RequestAborted
+        );
     }
 
     private static string? Text(JsonNode? node) => node is JsonValue value && value.TryGetValue<string>(out var text) ? text : null;

--- a/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolSnapshotStore.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolSnapshotStore.cs
@@ -1,0 +1,36 @@
+using System.Collections.Concurrent;
+
+internal sealed record McpToolSnapshot(IReadOnlySet<string> LocalToolNames, string HeaderContext);
+
+internal sealed class McpToolSnapshotStore
+{
+    private const char EntrySeparator = '';
+    private const string ValueSeparator = "";
+    private const int MaxHeaderContextLength = 8 * 1024;
+    private readonly ConcurrentDictionary<(string EndpointPath, string SessionId), McpToolSnapshot> _snapshots = [];
+
+    public void Set(string endpointPath, string sessionId, McpToolSnapshot snapshot) =>
+        _snapshots[(endpointPath, sessionId)] = snapshot;
+
+    public bool TryGet(string endpointPath, string sessionId, out McpToolSnapshot snapshot) =>
+        _snapshots.TryGetValue((endpointPath, sessionId), out snapshot!);
+
+    public void Remove(string endpointPath, string sessionId) => _snapshots.TryRemove((endpointPath, sessionId), out _);
+
+    public static string BuildHeaderContext(IHeaderDictionary headers) =>
+        TryBuildHeaderContext(headers, out var context) ? context : string.Empty;
+
+    public static bool TryBuildHeaderContext(IHeaderDictionary headers, out string context)
+    {
+        var entries = headers
+            .Where(header => header.Key.StartsWith("X-MCP-", StringComparison.OrdinalIgnoreCase))
+            .Select(header => $"{header.Key.ToLowerInvariant()}={string.Join(ValueSeparator, header.Value.ToArray())}")
+            .OrderBy(entry => entry, StringComparer.Ordinal);
+
+        context = string.Join(EntrySeparator, entries);
+        return context.Length <= MaxHeaderContextLength;
+    }
+
+    public static bool HasToolFilterHeaders(IHeaderDictionary headers) =>
+        headers.Keys.Any(key => key.StartsWith("X-MCP-", StringComparison.OrdinalIgnoreCase));
+}

--- a/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolSnapshotStore.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolSnapshotStore.cs
@@ -5,17 +5,38 @@ internal sealed record McpToolSnapshot(IReadOnlySet<string> LocalToolNames, stri
 internal sealed class McpToolSnapshotStore
 {
     private const char EntrySeparator = '';
+    private readonly ConcurrentDictionary<(string EndpointPath, string SessionId), long> _generations = [];
     private const string ValueSeparator = "";
     private const int MaxHeaderContextLength = 8 * 1024;
     private readonly ConcurrentDictionary<(string EndpointPath, string SessionId), McpToolSnapshot> _snapshots = [];
 
+    public long Generation(string endpointPath, string sessionId) =>
+        _generations.GetOrAdd((endpointPath, sessionId), 0);
+
     public void Set(string endpointPath, string sessionId, McpToolSnapshot snapshot) =>
         _snapshots[(endpointPath, sessionId)] = snapshot;
+
+    public void SetIfGeneration(
+        string endpointPath,
+        string sessionId,
+        long expectedGeneration,
+        McpToolSnapshot snapshot
+    )
+    {
+        if (Generation(endpointPath, sessionId) == expectedGeneration)
+        {
+            _snapshots[(endpointPath, sessionId)] = snapshot;
+        }
+    }
 
     public bool TryGet(string endpointPath, string sessionId, out McpToolSnapshot snapshot) =>
         _snapshots.TryGetValue((endpointPath, sessionId), out snapshot!);
 
-    public void Remove(string endpointPath, string sessionId) => _snapshots.TryRemove((endpointPath, sessionId), out _);
+    public void Remove(string endpointPath, string sessionId)
+    {
+        _generations.AddOrUpdate((endpointPath, sessionId), 1, (_, current) => current + 1);
+        _snapshots.TryRemove((endpointPath, sessionId), out _);
+    }
 
     public static string BuildHeaderContext(IHeaderDictionary headers) =>
         TryBuildHeaderContext(headers, out var context) ? context : string.Empty;

--- a/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolSnapshotStore.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Mcp/McpToolSnapshotStore.cs
@@ -5,16 +5,27 @@ internal sealed record McpToolSnapshot(IReadOnlySet<string> LocalToolNames, stri
 internal sealed class McpToolSnapshotStore
 {
     private const char EntrySeparator = '';
-    private readonly ConcurrentDictionary<(string EndpointPath, string SessionId), long> _generations = [];
     private const string ValueSeparator = "";
     private const int MaxHeaderContextLength = 8 * 1024;
-    private readonly ConcurrentDictionary<(string EndpointPath, string SessionId), McpToolSnapshot> _snapshots = [];
+    private readonly ConcurrentDictionary<(string EndpointPath, string SessionId), SessionState> _states = [];
 
-    public long Generation(string endpointPath, string sessionId) =>
-        _generations.GetOrAdd((endpointPath, sessionId), 0);
+    public long Generation(string endpointPath, string sessionId)
+    {
+        var state = _states.GetOrAdd((endpointPath, sessionId), _ => new SessionState());
+        lock (state)
+        {
+            return state.Generation;
+        }
+    }
 
-    public void Set(string endpointPath, string sessionId, McpToolSnapshot snapshot) =>
-        _snapshots[(endpointPath, sessionId)] = snapshot;
+    public void Set(string endpointPath, string sessionId, McpToolSnapshot snapshot)
+    {
+        var state = _states.GetOrAdd((endpointPath, sessionId), _ => new SessionState());
+        lock (state)
+        {
+            state.Snapshot = snapshot;
+        }
+    }
 
     public void SetIfGeneration(
         string endpointPath,
@@ -23,19 +34,44 @@ internal sealed class McpToolSnapshotStore
         McpToolSnapshot snapshot
     )
     {
-        if (Generation(endpointPath, sessionId) == expectedGeneration)
+        var state = _states.GetOrAdd((endpointPath, sessionId), _ => new SessionState());
+        lock (state)
         {
-            _snapshots[(endpointPath, sessionId)] = snapshot;
+            if (state.Generation == expectedGeneration)
+            {
+                state.Snapshot = snapshot;
+            }
         }
     }
 
-    public bool TryGet(string endpointPath, string sessionId, out McpToolSnapshot snapshot) =>
-        _snapshots.TryGetValue((endpointPath, sessionId), out snapshot!);
+    public bool TryGet(string endpointPath, string sessionId, out McpToolSnapshot snapshot)
+    {
+        snapshot = null!;
+        if (!_states.TryGetValue((endpointPath, sessionId), out var state))
+        {
+            return false;
+        }
+
+        lock (state)
+        {
+            if (state.Snapshot is null)
+            {
+                return false;
+            }
+
+            snapshot = state.Snapshot;
+            return true;
+        }
+    }
 
     public void Remove(string endpointPath, string sessionId)
     {
-        _generations.AddOrUpdate((endpointPath, sessionId), 1, (_, current) => current + 1);
-        _snapshots.TryRemove((endpointPath, sessionId), out _);
+        var state = _states.GetOrAdd((endpointPath, sessionId), _ => new SessionState());
+        lock (state)
+        {
+            state.Generation++;
+            state.Snapshot = null;
+        }
     }
 
     public static string BuildHeaderContext(IHeaderDictionary headers) =>
@@ -54,4 +90,10 @@ internal sealed class McpToolSnapshotStore
 
     public static bool HasToolFilterHeaders(IHeaderDictionary headers) =>
         headers.Keys.Any(key => key.StartsWith("X-MCP-", StringComparison.OrdinalIgnoreCase));
+
+    private sealed class SessionState
+    {
+        public long Generation { get; set; }
+        public McpToolSnapshot? Snapshot { get; set; }
+    }
 }

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -2585,6 +2585,7 @@ internal static class ProxyMcp
         using var upstreamRequest = new HttpRequestMessage(new HttpMethod(ctx.Request.Method), upstreamPath);
         byte[]? inboundBody = null;
         JsonObject? rpcRequest = null;
+        long listGeneration = 0;
         var composition = services.GetRequiredService<McpToolComposition>();
 
         if (string.Equals(ctx.Request.Method, "POST", StringComparison.OrdinalIgnoreCase))
@@ -2601,6 +2602,7 @@ internal static class ProxyMcp
                 && rpcRequest is not null
             )
             {
+                listGeneration = composition.CaptureListGeneration(ctx, rpcRequest);
                 _ = composition.TryHandleCancellation(ctx, rpcRequest);
                 if (await composition.TryHandleCallAsync(ctx, rpcRequest))
                 {
@@ -2697,7 +2699,8 @@ internal static class ProxyMcp
                         maxBodyBytes,
                         linked.Token,
                         idleCts,
-                        idleTimeout
+                        idleTimeout,
+                        listGeneration
                     );
                 }
                 catch (OperationCanceledException) when (ctx.RequestAborted.IsCancellationRequested)
@@ -2710,7 +2713,8 @@ internal static class ProxyMcp
                     await WriteMcpErrorAsync(
                         ctx,
                         StatusCodes.Status504GatewayTimeout,
-                        "Timed out waiting for the upstream Copilot MCP server to respond."
+                        "Timed out waiting for the upstream Copilot MCP server to respond.",
+                        rpcRequest?["id"]
                     );
                     return;
                 }
@@ -2720,7 +2724,8 @@ internal static class ProxyMcp
                     await WriteMcpErrorAsync(
                         ctx,
                         StatusCodes.Status502BadGateway,
-                        "The upstream Copilot MCP server dropped the connection before its reply was complete."
+                        "The upstream Copilot MCP server dropped the connection before its reply was complete.",
+                        rpcRequest?["id"]
                     );
                     return;
                 }
@@ -2730,7 +2735,8 @@ internal static class ProxyMcp
                     await WriteMcpErrorAsync(
                         ctx,
                         StatusCodes.Status502BadGateway,
-                        $"Upstream MCP reply exceeded the {maxBodyBytes}-byte relay cap."
+                        $"Upstream MCP reply exceeded the {maxBodyBytes}-byte relay cap.",
+                        rpcRequest?["id"]
                     );
                     return;
                 }
@@ -2770,7 +2776,7 @@ internal static class ProxyMcp
                     idleCts,
                     linked,
                     logger,
-                    WriteMcpErrorAsync,
+                    (errorContext, status, message) => WriteMcpErrorAsync(errorContext, status, message),
                     isSse,
                     keepAliveInterval
                 );
@@ -2816,7 +2822,12 @@ internal static class ProxyMcp
     ///     are always passed through verbatim). Per the MCP spec, an error response for input the server
     ///     could not accept has no <c>id</c>.
     /// </summary>
-    private static async Task WriteMcpErrorAsync(HttpContext ctx, int status, string message)
+    private static async Task WriteMcpErrorAsync(
+        HttpContext ctx,
+        int status,
+        string message,
+        JsonNode? requestId = null
+    )
     {
         if (ctx.Response.HasStarted)
         {
@@ -2825,10 +2836,20 @@ internal static class ProxyMcp
 
         ctx.Response.StatusCode = status;
         ctx.Response.ContentType = "application/json";
-        var payload = JsonSerializer.SerializeToUtf8Bytes(
-            new { jsonrpc = "2.0", error = new { code = -32000, message } }
+        var response = new JsonObject
+        {
+            ["jsonrpc"] = "2.0",
+            ["error"] = new JsonObject { ["code"] = -32000, ["message"] = message },
+        };
+        if (requestId is not null)
+        {
+            response["id"] = requestId.DeepClone();
+        }
+
+        await ctx.Response.Body.WriteAsync(
+            Encoding.UTF8.GetBytes(response.ToJsonString()),
+            ctx.RequestAborted
         );
-        await ctx.Response.Body.WriteAsync(payload, ctx.RequestAborted);
     }
 }
 

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -2653,7 +2653,7 @@ internal static class ProxyMcp
         catch (InvalidOperationException ex)
         {
             // Token acquisition failure surfaces from CopilotHeadersHandler before the first byte.
-            logger.LogError("Copilot token acquisition failed: {Reason}", ex.Message);
+            logger.LogError(ex, "Copilot token acquisition failed while forwarding an MCP request.");
             await WriteMcpErrorAsync(
                 ctx,
                 StatusCodes.Status401Unauthorized,
@@ -2665,7 +2665,7 @@ internal static class ProxyMcp
         }
         catch (HttpRequestException ex)
         {
-            logger.LogError("Upstream MCP connection failed: {Reason}", ex.Message);
+            logger.LogError(ex, "Upstream MCP connection failed while forwarding an MCP request.");
             await WriteMcpErrorAsync(
                 ctx,
                 StatusCodes.Status502BadGateway,

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -1808,7 +1808,9 @@ internal static class ProxyHttp
     internal static async Task<byte[]?> ReadCappedBytesAsync(
         HttpContent content,
         long maxBytes,
-        CancellationToken token
+        CancellationToken token,
+        CancellationTokenSource? idleCts = null,
+        TimeSpan? idleTimeout = null
     )
     {
         if (content.Headers.ContentLength is { } declared && declared > maxBytes)
@@ -1827,6 +1829,11 @@ internal static class ProxyHttp
                 if (read == 0)
                 {
                     return buffer.ToArray();
+                }
+
+                if (idleCts is not null && idleTimeout is not null)
+                {
+                    idleCts.CancelAfter(idleTimeout.Value);
                 }
 
                 if (buffer.Length + read > maxBytes)
@@ -2675,17 +2682,19 @@ internal static class ProxyMcp
                 composition.RemoveSnapshot(endpoint, sessionId);
             }
 
-            byte[]? composedBody = null;
+            McpComposedList? composedList = null;
             if (rpcRequest is not null && McpToolComposition.IsToolsList(rpcRequest))
             {
                 try
                 {
-                    composedBody = await composition.ComposeListAsync(
+                    composedList = await composition.ComposeListAsync(
                         ctx,
                         rpcRequest,
                         upstream,
                         maxBodyBytes,
-                        linked.Token
+                        linked.Token,
+                        idleCts,
+                        idleTimeout
                     );
                 }
                 catch (OperationCanceledException) when (ctx.RequestAborted.IsCancellationRequested)
@@ -2703,7 +2712,7 @@ internal static class ProxyMcp
                     return;
                 }
 
-                if (composedBody is { Length: 0 })
+                if (composedList?.Body is { Length: 0 })
                 {
                     await WriteMcpErrorAsync(
                         ctx,
@@ -2734,9 +2743,10 @@ internal static class ProxyMcp
 
             ctx.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
 
-            if (composedBody is not null)
+            if (composedList is not null)
             {
-                await ctx.Response.Body.WriteAsync(composedBody, ctx.RequestAborted);
+                await ctx.Response.Body.WriteAsync(composedList.Body, ctx.RequestAborted);
+                composition.PublishSnapshot(composedList);
             }
             else
             {

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -2714,6 +2714,16 @@ internal static class ProxyMcp
                     );
                     return;
                 }
+                catch (Exception ex) when (ex is HttpRequestException or IOException)
+                {
+                    logger.LogWarning(ex, "Upstream MCP tool-list body failed while being buffered.");
+                    await WriteMcpErrorAsync(
+                        ctx,
+                        StatusCodes.Status502BadGateway,
+                        "The upstream Copilot MCP server dropped the connection before its reply was complete."
+                    );
+                    return;
+                }
 
                 if (composedList?.Body is { Length: 0 })
                 {

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -9,6 +9,8 @@ using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Models;
+using AchieveAi.LmDotnetTools.Misc.Configuration;
+using AchieveAi.LmDotnetTools.Misc.Web.Jina;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Primitives;
 using Serilog;
@@ -46,8 +48,9 @@ using ILogger = Microsoft.Extensions.Logging.ILogger;
 // is dropped on both (Copilot 400s the whole request over one unrecognised value).
 // Copilot auth/headers come from the proven GithubCopilotProvider transport, and
 // responses stream back without buffering.
-// It also exposes Copilot's MCP server (Streamable HTTP transport) as a transparent
-// byte-level proxy on /mcp and /mcp/readonly, with Copilot auth attached the same way.
+// It also exposes Copilot's MCP server (Streamable HTTP transport) on /mcp and
+// /mcp/readonly. Most traffic remains byte-transparent; supported JSON tool catalogs may gain
+// keyed Jina fallbacks, whose calls are handled locally against the exact advertised schema.
 //
 // Point Claude Code, Codex CLI or opencode at it via that client's base-URL setting.
 // SECURITY: binds to loopback only and attaches the developer's Copilot credentials
@@ -133,6 +136,18 @@ builder.Services.AddSingleton(sp =>
         innerHandler: sp.GetService<HttpMessageHandler>()
     )
 );
+
+var webToolsOptions = WebToolsOptions.FromEnvironment();
+builder.Services.AddSingleton(webToolsOptions);
+builder.Services.AddSingleton(sp =>
+    new JinaWebProvider(
+        webToolsOptions,
+        sp.GetRequiredService<ILoggerFactory>().CreateLogger<JinaWebProvider>()
+    )
+);
+builder.Services.AddSingleton<McpJinaToolCatalog>();
+builder.Services.AddSingleton<McpToolSnapshotStore>();
+builder.Services.AddSingleton<McpToolComposition>();
 
 var app = builder.Build();
 var logger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("CopilotAnthropicProxy");
@@ -302,8 +317,14 @@ foreach (var path in new[] { "/v1/responses", "/responses" })
 // /mcp and /mcp/readonly — transparent MCP (Streamable HTTP) proxy. Every HTTP method is routed
 // here (not just GET/POST/DELETE) so an unsupported method gets ProxyMcp's own MCP/JSON-RPC-shaped
 // 405, not the shared Anthropic-shaped fallback 404.
-app.Map("/mcp", ctx => ProxyMcp.ForwardAsync(ctx, config.IdleTimeout, config.KeepAliveInterval));
-app.Map("/mcp/readonly", ctx => ProxyMcp.ForwardAsync(ctx, config.IdleTimeout, config.KeepAliveInterval));
+app.Map(
+    "/mcp",
+    ctx => ProxyMcp.ForwardAsync(ctx, config.IdleTimeout, config.KeepAliveInterval, config.MaxBodyBytes)
+);
+app.Map(
+    "/mcp/readonly",
+    ctx => ProxyMcp.ForwardAsync(ctx, config.IdleTimeout, config.KeepAliveInterval, config.MaxBodyBytes)
+);
 
 // Unknown route -> Anthropic-shaped 404.
 app.MapFallback(ctx =>
@@ -1784,6 +1805,40 @@ internal static class ProxyHttp
     ///     <paramref name="maxBytes" />. A declared <c>Content-Length</c> short-circuits the read
     ///     entirely; a chunked reply is measured as it arrives, so nothing over the cap is ever held.
     /// </summary>
+    internal static async Task<byte[]?> ReadCappedBytesAsync(
+        HttpContent content,
+        long maxBytes,
+        CancellationToken token
+    )
+    {
+        if (content.Headers.ContentLength is { } declared && declared > maxBytes)
+        {
+            return null;
+        }
+
+        var stream = await content.ReadAsStreamAsync(token).ConfigureAwait(false);
+        await using (stream.ConfigureAwait(false))
+        {
+            using var buffer = new MemoryStream();
+            var chunk = new byte[BufferSize];
+            while (true)
+            {
+                var read = await stream.ReadAsync(chunk, token).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    return buffer.ToArray();
+                }
+
+                if (buffer.Length + read > maxBytes)
+                {
+                    return null;
+                }
+
+                buffer.Write(chunk, 0, read);
+            }
+        }
+    }
+
     private static async Task<string?> ReadCappedStringAsync(
         HttpContent content,
         long maxBytes,
@@ -2450,12 +2505,11 @@ internal static class ProxyHttp
 // =============================================================================
 
 /// <summary>
-///     Transparent reverse proxy for GitHub Copilot's MCP server (Streamable HTTP transport). Forwards
-///     GET/POST/DELETE on <c>/mcp</c> and <c>/mcp/readonly</c> verbatim: no JSON-RPC parsing and no
-///     proxy-side session bookkeeping — the <c>Mcp-Session-Id</c> the upstream server assigns on
-///     <c>initialize</c> is just another response header this proxy copies through, and the caller is
-///     responsible for echoing it back on subsequent requests exactly as it would talk to Copilot
-///     directly.
+///     Reverse proxy for GitHub Copilot's MCP server (Streamable HTTP transport). Most traffic remains
+///     byte-transparent. With valid local web-tool configuration, supported JSON <c>tools/list</c>
+///     responses may gain missing Jina fallbacks and matching <c>tools/call</c> requests execute locally.
+///     GitHub remains the session owner; the proxy keeps only the local routing snapshot and clears it on
+///     DELETE or an upstream session 404.
 /// </summary>
 internal static class ProxyMcp
 {
@@ -2498,7 +2552,12 @@ internal static class ProxyMcp
     private static readonly string[] AllowedMethods = ["GET", "POST", "DELETE"];
 
     /// <summary>Forwards GET/POST/DELETE on the MCP endpoint to Copilot and streams the response back.</summary>
-    public static async Task ForwardAsync(HttpContext ctx, TimeSpan idleTimeout, TimeSpan keepAliveInterval)
+    public static async Task ForwardAsync(
+        HttpContext ctx,
+        TimeSpan idleTimeout,
+        TimeSpan keepAliveInterval,
+        long maxBodyBytes
+    )
     {
         if (!AllowedMethods.Contains(ctx.Request.Method, StringComparer.OrdinalIgnoreCase))
         {
@@ -2517,14 +2576,26 @@ internal static class ProxyMcp
 
         var upstreamPath = ctx.Request.Path.Value + ctx.Request.QueryString.Value;
         using var upstreamRequest = new HttpRequestMessage(new HttpMethod(ctx.Request.Method), upstreamPath);
+        byte[]? inboundBody = null;
+        JsonObject? rpcRequest = null;
+        var composition = services.GetRequiredService<McpToolComposition>();
 
         if (string.Equals(ctx.Request.Method, "POST", StringComparison.OrdinalIgnoreCase))
         {
-            byte[] inboundBody;
             using (var memory = new MemoryStream())
             {
                 await ctx.Request.Body.CopyToAsync(memory, ctx.RequestAborted);
                 inboundBody = memory.ToArray();
+            }
+
+            if (
+                composition.IsEnabled
+                && McpToolComposition.TryParseSingleRequest(inboundBody, out rpcRequest)
+                && rpcRequest is not null
+                && await composition.TryHandleCallAsync(ctx, rpcRequest)
+            )
+            {
+                return;
             }
 
             upstreamRequest.Content = new ByteArrayContent(inboundBody);
@@ -2591,6 +2662,58 @@ internal static class ProxyMcp
 
         using (upstream)
         {
+            var endpoint = ctx.Request.Path.Value ?? string.Empty;
+            var sessionId = ctx.Request.Headers["Mcp-Session-Id"].FirstOrDefault();
+            if (
+                !string.IsNullOrWhiteSpace(sessionId)
+                && (
+                    string.Equals(ctx.Request.Method, "DELETE", StringComparison.OrdinalIgnoreCase)
+                    || upstream.StatusCode == HttpStatusCode.NotFound
+                )
+            )
+            {
+                composition.RemoveSnapshot(endpoint, sessionId);
+            }
+
+            byte[]? composedBody = null;
+            if (rpcRequest is not null && McpToolComposition.IsToolsList(rpcRequest))
+            {
+                try
+                {
+                    composedBody = await composition.ComposeListAsync(
+                        ctx,
+                        rpcRequest,
+                        upstream,
+                        maxBodyBytes,
+                        linked.Token
+                    );
+                }
+                catch (OperationCanceledException) when (ctx.RequestAborted.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (OperationCanceledException) when (idleCts.IsCancellationRequested)
+                {
+                    logger.LogWarning("Upstream MCP tool-list body timed out while being buffered.");
+                    await WriteMcpErrorAsync(
+                        ctx,
+                        StatusCodes.Status504GatewayTimeout,
+                        "Timed out waiting for the upstream Copilot MCP server to respond."
+                    );
+                    return;
+                }
+
+                if (composedBody is { Length: 0 })
+                {
+                    await WriteMcpErrorAsync(
+                        ctx,
+                        StatusCodes.Status502BadGateway,
+                        $"Upstream MCP reply exceeded the {maxBodyBytes}-byte relay cap."
+                    );
+                    return;
+                }
+            }
+
             // Lock status + headers verbatim (minus hop-by-hop/framing) — this is what carries
             // Mcp-Session-Id back to the client on the initialize response.
             ctx.Response.StatusCode = (int)upstream.StatusCode;
@@ -2611,17 +2734,24 @@ internal static class ProxyMcp
 
             ctx.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
 
-            await ProxyHttp.CopyBodyAsync(
-                ctx,
-                upstream,
-                idleTimeout,
-                idleCts,
-                linked,
-                logger,
-                WriteMcpErrorAsync,
-                isSse,
-                keepAliveInterval
-            );
+            if (composedBody is not null)
+            {
+                await ctx.Response.Body.WriteAsync(composedBody, ctx.RequestAborted);
+            }
+            else
+            {
+                await ProxyHttp.CopyBodyAsync(
+                    ctx,
+                    upstream,
+                    idleTimeout,
+                    idleCts,
+                    linked,
+                    logger,
+                    WriteMcpErrorAsync,
+                    isSse,
+                    keepAliveInterval
+                );
+            }
 
             logger.LogInformation(
                 "{Method} {Path} mcp-session={SessionId} upstream={Status} {Elapsed}ms",

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -2645,7 +2645,8 @@ internal static class ProxyMcp
             await WriteMcpErrorAsync(
                 ctx,
                 StatusCodes.Status504GatewayTimeout,
-                "Timed out waiting for the upstream Copilot MCP server to respond."
+                "Timed out waiting for the upstream Copilot MCP server to respond.",
+                rpcRequest?["id"]
             );
             return;
         }
@@ -2657,7 +2658,8 @@ internal static class ProxyMcp
                 ctx,
                 StatusCodes.Status401Unauthorized,
                 "Failed to acquire a GitHub Copilot token. Re-authenticate with the GitHub Copilot CLI or "
-                    + "`gh auth login`, or set GITHUB_COPILOT_TOKEN / GH_TOKEN."
+                    + "`gh auth login`, or set GITHUB_COPILOT_TOKEN / GH_TOKEN.",
+                rpcRequest?["id"]
             );
             return;
         }
@@ -2667,7 +2669,8 @@ internal static class ProxyMcp
             await WriteMcpErrorAsync(
                 ctx,
                 StatusCodes.Status502BadGateway,
-                "Failed to reach the upstream Copilot MCP server."
+                "Failed to reach the upstream Copilot MCP server.",
+                rpcRequest?["id"]
             );
             return;
         }
@@ -2762,7 +2765,7 @@ internal static class ProxyMcp
 
             ctx.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
 
-            if (composedList is not null)
+            if (composedList?.Body is not null)
             {
                 await ctx.Response.Body.WriteAsync(composedList.Body, ctx.RequestAborted);
                 composition.PublishSnapshot(composedList);
@@ -2776,10 +2779,15 @@ internal static class ProxyMcp
                     idleCts,
                     linked,
                     logger,
-                    (errorContext, status, message) => WriteMcpErrorAsync(errorContext, status, message),
+                    (errorContext, status, message) =>
+                        WriteMcpErrorAsync(errorContext, status, message, rpcRequest?["id"]),
                     isSse,
                     keepAliveInterval
                 );
+                if (composedList is not null)
+                {
+                    composition.PublishSnapshot(composedList);
+                }
             }
 
             logger.LogInformation(

--- a/samples/CopilotAnthropicProxy.Sample/Program.cs
+++ b/samples/CopilotAnthropicProxy.Sample/Program.cs
@@ -2599,10 +2599,13 @@ internal static class ProxyMcp
                 composition.IsEnabled
                 && McpToolComposition.TryParseSingleRequest(inboundBody, out rpcRequest)
                 && rpcRequest is not null
-                && await composition.TryHandleCallAsync(ctx, rpcRequest)
             )
             {
-                return;
+                _ = composition.TryHandleCancellation(ctx, rpcRequest);
+                if (await composition.TryHandleCallAsync(ctx, rpcRequest))
+                {
+                    return;
+                }
             }
 
             upstreamRequest.Content = new ByteArrayContent(inboundBody);

--- a/samples/CopilotAnthropicProxy.Sample/README.md
+++ b/samples/CopilotAnthropicProxy.Sample/README.md
@@ -233,12 +233,21 @@ transport) on:
 - `GET` / `POST` / `DELETE` `/mcp` — the full read/write toolset
 - `GET` / `POST` / `DELETE` `/mcp/readonly` — the read-only toolset
 
-This is a **byte-level reverse proxy**, not an MCP-aware reimplementation: there's no JSON-RPC
-parsing and no proxy-side session bookkeeping. Point any MCP Streamable-HTTP client at
-`http://127.0.0.1:8787/mcp` (or `/mcp/readonly`) exactly as you would point it at
-`https://api.enterprise.githubcopilot.com/mcp` (or `/mcp/readonly`) directly — request/response
-bodies, status codes, and headers are relayed verbatim, including SSE responses (same raw-byte
-streaming as `/v1/messages`).
+This remains a **byte-level reverse proxy** for almost all MCP traffic. When valid Jina web-tool
+configuration is present, it narrowly composes supported single-page JSON `tools/list` responses and
+handles calls for local fallback tools. GitHub remains the MCP session owner; the proxy stores only the
+local routing snapshot required to keep a call consistent with the catalog the client received.
+
+For each exact name, `web_search` and `web_fetch`, GitHub's advertised definition and call path wins.
+When GitHub omits a name, the proxy adds the existing Jina-backed definition only when `JINA_API_KEY`
+is configured. Client restrictions remain authoritative: `X-MCP-Tools` allowlists local tools,
+`X-MCP-Exclude-Tools` excludes them, and lockdown suppresses local injection. There is no mid-call
+failover.
+
+SSE-framed and paginated tool catalogs, JSON-RPC batches, sessionless catalogs, and unrelated methods
+remain raw pass-through and do not gain local fallback tools. `DELETE` and an upstream session `404`
+clear the corresponding local routing snapshot. `/mcp` and `/mcp/readonly` keep independent snapshots.
+Point MCP Streamable-HTTP clients at `http://127.0.0.1:8787/mcp` or `/mcp/readonly` as before.
 
 **Header policy**: every inbound header is forwarded verbatim **except** `Authorization` (the
 proxy attaches its own Copilot bearer token instead, via the same `CopilotHeadersHandler` used for
@@ -275,6 +284,12 @@ host/cross-site guard described in the warning above.
 | `COPILOT_ANTHROPIC_IDLE_TIMEOUT_SECONDS` | `180` | Per-request idle timeout, reset after each streamed upstream read. The total exchange has no deadline, so long generations are not cut off; this only fires when the upstream produces *nothing* for the whole window. |
 | `COPILOT_ANTHROPIC_KEEPALIVE_SECONDS` | `15` | While an SSE upstream is silent, emit a downstream SSE keep-alive this often so the client's own read timeout does not fire mid-generation. Keep-alives don't reset the idle timeout above. Set `0` to disable. |
 | `COPILOT_ANTHROPIC_ENABLE_DEVICE_FLOW` | `false` | When truthy, allow an interactive GitHub device-flow login at startup (composite provider). Off by default — the request path never blocks on device flow. |
+| `JINA_API_KEY` | (none) | Enables Jina-backed `web_search` and `web_fetch` fallback through `/mcp*` when GitHub does not advertise the exact tool name. Without a key, MCP remains byte-transparent. |
+| `WEB_TOOLS_BACKEND` | `jina` | Backend selector for local MCP web tools. Only `jina` is supported. |
+| `WEB_TOOLS_OUTPUT_CAP` | `50000` | Maximum characters returned from a local Jina web-tool call before truncation. |
+| `WEB_TOOLS_TIMEOUT_MS` | `30000` | Total timeout budget for a local Jina web-tool call, including retries. |
+
+The Proxy sample reuses web tooling from the `Misc` project rather than duplicating the Jina client and security logic. That project reference also brings `Microsoft.Data.Sqlite` and its native SQLite assets transitively. The measured framework-dependent publish-size increase for this change was approximately 0.9 MB; no SQLite service is constructed by the Proxy.
 
 ## Logs
 

--- a/samples/CopilotAnthropicProxy.Sample/README.md
+++ b/samples/CopilotAnthropicProxy.Sample/README.md
@@ -244,7 +244,9 @@ is configured. Client restrictions remain authoritative: `X-MCP-Tools` allowlist
 `X-MCP-Exclude-Tools` excludes them, and lockdown suppresses local injection. There is no mid-call
 failover.
 
-SSE-framed and paginated tool catalogs, JSON-RPC batches, sessionless catalogs, and unrelated methods
+GitHub currently returns `tools/list` as a single `event: message` SSE block containing one JSON-RPC
+`data:` line. The proxy composes that bounded shape while preserving its SSE framing; multi-event or
+multi-data-line SSE, paginated catalogs, JSON-RPC batches, sessionless catalogs, and unrelated methods
 remain raw pass-through and do not gain local fallback tools. `DELETE` and an upstream session `404`
 clear the corresponding local routing snapshot. `/mcp` and `/mcp/readonly` keep independent snapshots.
 Point MCP Streamable-HTTP clients at `http://127.0.0.1:8787/mcp` or `/mcp/readonly` as before.

--- a/tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj
+++ b/tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\..\samples\CopilotAnthropicProxy.Sample\CopilotAnthropicProxy.Sample.csproj" />
     <ProjectReference Include="..\..\src\GithubCopilotProvider\AchieveAi.LmDotnetTools.GithubCopilotProvider.csproj" />
     <ProjectReference Include="..\..\src\LmTestUtils\LmTestUtils.csproj" />
+    <ProjectReference Include="..\..\src\Misc\AchieveAi.LmDotnetTools.Misc.csproj" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/tests/CopilotAnthropicProxy.Tests/McpJinaToolCatalogTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/McpJinaToolCatalogTests.cs
@@ -1,0 +1,86 @@
+using System.Text.Json.Nodes;
+using AchieveAi.LmDotnetTools.Misc.Configuration;
+using AchieveAi.LmDotnetTools.Misc.Web.Jina;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+public class McpJinaToolCatalogTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BlankKey_DisablesBothTools(string? key)
+    {
+        var catalog = CreateCatalog(new WebToolsOptions { JinaApiKey = key });
+
+        catalog.IsEnabled.Should().BeFalse();
+        catalog.Tools.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void InvalidOptions_DisableBothTools()
+    {
+        var catalog = CreateCatalog(new WebToolsOptions { JinaApiKey = "secret", OutputCap = 0 });
+
+        catalog.IsEnabled.Should().BeFalse();
+        catalog.Tools.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ValidKey_ExposesSnakeCaseToolsWithExistingSchemas()
+    {
+        var catalog = CreateCatalog(new WebToolsOptions { JinaApiKey = "secret" });
+
+        catalog.Tools.Keys.Should().BeEquivalentTo("web_search", "web_fetch");
+        var search = catalog.Tools["web_search"].Definition;
+        var fetch = catalog.Tools["web_fetch"].Definition;
+        search["name"]!.GetValue<string>().Should().Be("web_search");
+        fetch["name"]!.GetValue<string>().Should().Be("web_fetch");
+        (search["inputSchema"]?["properties"] as JsonObject)!.Should().ContainKey("query");
+        (fetch["inputSchema"]?["properties"] as JsonObject)!.Should().ContainKey("url");
+        search.ToJsonString().Should().NotContain("secret");
+        fetch.ToJsonString().Should().NotContain("secret");
+    }
+
+    [Fact]
+    public void Selection_RespectsAllowlistExcludeAndLockdown()
+    {
+        var catalog = CreateCatalog(new WebToolsOptions { JinaApiKey = "secret" });
+        var headers = new HeaderDictionary
+        {
+            ["X-MCP-Tools"] = "web_search, web_fetch",
+            ["X-MCP-Exclude-Tools"] = "web_fetch",
+        };
+
+        catalog.SelectInjectable(headers, []).Select(t => t.Name).Should().ContainSingle().Which.Should().Be("web_search");
+
+        headers["X-MCP-Lockdown"] = "true";
+        catalog.SelectInjectable(headers, []).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Selection_DoesNotDuplicateGithubNames()
+    {
+        var catalog = CreateCatalog(new WebToolsOptions { JinaApiKey = "secret" });
+
+        catalog.SelectInjectable(new HeaderDictionary(), ["web_search"])
+            .Select(t => t.Name)
+            .Should().ContainSingle().Which.Should().Be("web_fetch");
+    }
+
+    private static McpJinaToolCatalog CreateCatalog(WebToolsOptions options)
+    {
+        var provider = new JinaWebProvider(new HttpClient(new StubHandler()), options);
+        return new McpJinaToolCatalog(provider, options, NullLoggerFactory.Instance);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+    }
+}

--- a/tests/CopilotAnthropicProxy.Tests/McpToolCompositionTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/McpToolCompositionTests.cs
@@ -191,6 +191,44 @@ public class McpToolCompositionTests
     }
 
     [Fact]
+    public async Task ToolsList_DroppedBodyReturnsJsonRpcBadGateway()
+    {
+        await using var factory = new ProxyWebAppFactory(
+            (_, _) => Task.FromResult(TestUpstream.JsonStream(new ThrowingStream(""))),
+            jinaApiKey: "jina-key",
+            jinaUpstream: (_, _) => Task.FromResult(TestUpstream.Json("{\"data\":[]}"))
+        );
+        using var client = factory.CreateClient();
+
+        using var response = await SendAsync(client, "/mcp", ListRequest(), "session-1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("\"jsonrpc\":\"2.0\"");
+    }
+
+    [Fact]
+    public async Task CancellationNotificationWithMalformedParamsPassesThroughWithoutThrowing()
+    {
+        var githubCalls = 0;
+        await using var factory = new ProxyWebAppFactory(
+            (_, _) =>
+            {
+                githubCalls++;
+                return Task.FromResult(TestUpstream.Json("{}", HttpStatusCode.Accepted));
+            },
+            jinaApiKey: "jina-key",
+            jinaUpstream: (_, _) => Task.FromResult(TestUpstream.Json("{\"data\":[]}"))
+        );
+        using var client = factory.CreateClient();
+        const string malformed = "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/cancelled\",\"params\":[]}";
+
+        using var response = await SendAsync(client, "/mcp", malformed, "session-1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        githubCalls.Should().Be(1);
+    }
+
+    [Fact]
     public async Task ToolsList_IdleTimeoutReturnsBoundedGatewayTimeout()
     {
         await using var factory = new ProxyWebAppFactory(

--- a/tests/CopilotAnthropicProxy.Tests/McpToolCompositionTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/McpToolCompositionTests.cs
@@ -1,0 +1,428 @@
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+public class McpToolCompositionTests
+{
+    [Fact]
+    public async Task ToolsList_GithubDefinitionWinsAndMissingFetchUsesJina()
+    {
+        var githubBody = """
+            {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"web_search","description":"github","inputSchema":{"type":"object","properties":{"q":{"type":"string"}}},"unknown":"kept"}]}}
+            """;
+        await using var factory = CreateFactory(githubBody);
+        using var client = factory.CreateClient();
+
+        using var response = await SendAsync(client, "/mcp", ListRequest(), sessionId: "session-1");
+        var body = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+        var tools = body["result"]!["tools"]!.AsArray();
+
+        tools.Should().HaveCount(2);
+        tools.Single(t => t!["name"]!.GetValue<string>() == "web_search")!["unknown"]!.GetValue<string>().Should().Be("kept");
+        tools.Single(t => t!["name"]!.GetValue<string>() == "web_fetch").Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ToolsList_NoJinaKeyIsByteTransparent()
+    {
+        const string githubBody = "{ \"jsonrpc\": \"2.0\", \"id\": 1, \"result\": { \"tools\": [] } }";
+        await using var factory = new ProxyWebAppFactory((_, _) => Task.FromResult(TestUpstream.Json(githubBody)));
+        using var client = factory.CreateClient();
+
+        using var response = await SendAsync(client, "/mcp", ListRequest(), sessionId: "session-1");
+
+        (await response.Content.ReadAsStringAsync()).Should().Be(githubBody);
+    }
+
+    [Fact]
+    public async Task ToolsList_AllowlistDoesNotReintroduceFilteredTool()
+    {
+        await using var factory = CreateFactory(EmptyListResponse());
+        using var client = factory.CreateClient();
+
+        using var response = await SendAsync(
+            client,
+            "/mcp",
+            ListRequest(),
+            sessionId: "session-1",
+            headers: new Dictionary<string, string> { ["X-MCP-Tools"] = "web_search" }
+        );
+        var tools = JsonNode.Parse(await response.Content.ReadAsStringAsync())!["result"]!["tools"]!.AsArray();
+
+        tools.Select(t => t!["name"]!.GetValue<string>()).Should().ContainSingle().Which.Should().Be("web_search");
+    }
+
+    [Fact]
+    public async Task ToolsList_GithubFailuresPassThroughWithoutJinaFallback()
+    {
+        var jinaCalls = 0;
+        const string rpcError = "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32000,\"message\":\"failed\"}}";
+        await using var rpcFactory = CreateFactory(
+            rpcError,
+            jina: (_, _) =>
+            {
+                jinaCalls++;
+                return Task.FromResult(TestUpstream.Json("{\"data\":[]}"));
+            }
+        );
+        using var rpcClient = rpcFactory.CreateClient();
+
+        using var rpcResponse = await SendAsync(rpcClient, "/mcp", ListRequest(), "session-1");
+        (await rpcResponse.Content.ReadAsStringAsync()).Should().Be(rpcError);
+
+        const string httpError = "{\"error\":\"upstream\"}";
+        await using var httpFactory = new ProxyWebAppFactory(
+            (_, _) => Task.FromResult(TestUpstream.Json(httpError, HttpStatusCode.InternalServerError)),
+            jinaApiKey: "jina-key",
+            jinaUpstream: (_, _) =>
+            {
+                jinaCalls++;
+                return Task.FromResult(TestUpstream.Json("{\"data\":[]}"));
+            }
+        );
+        using var httpClient = httpFactory.CreateClient();
+        using var httpResponse = await SendAsync(httpClient, "/mcp", ListRequest(), "session-2");
+
+        httpResponse.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        (await httpResponse.Content.ReadAsStringAsync()).Should().Be(httpError);
+        jinaCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ToolsList_SseAndBatchPassThroughWithoutLocalOwnership()
+    {
+        var githubCalls = 0;
+        const string sse = "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}\n\n";
+        await using var factory = new ProxyWebAppFactory(
+            (_, _) =>
+            {
+                githubCalls++;
+                return Task.FromResult(githubCalls == 1 ? TestUpstream.Sse(sse) : TestUpstream.Json("{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"content\":[]}}"));
+            },
+            jinaApiKey: "jina-key",
+            jinaUpstream: (_, _) => throw new InvalidOperationException("Jina must not run")
+        );
+        using var client = factory.CreateClient();
+
+        using var list = await SendAsync(client, "/mcp", ListRequest(), "session-1");
+        (await list.Content.ReadAsStringAsync()).Should().Be(sse);
+        using var call = await SendAsync(client, "/mcp", CallRequest("web_search", 2), "session-1");
+        githubCalls.Should().Be(2);
+
+        var batch = $"[{ListRequest()}]";
+        using var batchResponse = await SendAsync(client, "/mcp", batch, "session-1");
+        githubCalls.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task ToolsCall_GithubOwnedFailureNeverFallsBackToJina()
+    {
+        var jinaCalls = 0;
+        var githubCalls = 0;
+        var catalog = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"web_search\",\"inputSchema\":{\"type\":\"object\"}}]}}";
+        var error = "{\"jsonrpc\":\"2.0\",\"id\":2,\"error\":{\"code\":-32000,\"message\":\"github failed\"}}";
+        await using var factory = CreateFactory(
+            catalog,
+            github: (_, _) => Task.FromResult(TestUpstream.Json(++githubCalls == 1 ? catalog : error)),
+            jina: (_, _) =>
+            {
+                jinaCalls++;
+                return Task.FromResult(TestUpstream.Json("{\"data\":[]}"));
+            }
+        );
+        using var client = factory.CreateClient();
+
+        using var list = await SendAsync(client, "/mcp", ListRequest(), "session-1");
+        using var call = await SendAsync(client, "/mcp", CallRequest("web_search", 2), "session-1");
+
+        (await call.Content.ReadAsStringAsync()).Should().Be(error);
+        githubCalls.Should().Be(2);
+        jinaCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ToolsCall_MatchingFilterHeadersDispatchLocally()
+    {
+        var jinaCalls = 0;
+        await using var factory = CreateFactory(
+            EmptyListResponse(),
+            jina: (_, _) =>
+            {
+                jinaCalls++;
+                return Task.FromResult(TestUpstream.Json("{\"data\":[]}"));
+            }
+        );
+        using var client = factory.CreateClient();
+        var headers = new Dictionary<string, string> { ["X-MCP-Tools"] = "web_search" };
+
+        using var list = await SendAsync(client, "/mcp", ListRequest(), "session-1", headers);
+        using var call = await SendAsync(client, "/mcp", CallRequest("web_search", 2, "{\"query\":\"status\"}"), "session-1", headers);
+
+        jinaCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ToolsList_IdleTimeoutReturnsBoundedGatewayTimeout()
+    {
+        await using var factory = new ProxyWebAppFactory(
+            (_, _) => Task.FromResult(TestUpstream.JsonStream(new CancellationObservingStream(""))),
+            idleTimeoutSeconds: 1,
+            jinaApiKey: "jina-key",
+            jinaUpstream: (_, _) => Task.FromResult(TestUpstream.Json("{\"data\":[]}"))
+        );
+        using var client = factory.CreateClient();
+
+        using var response = await SendAsync(client, "/mcp", ListRequest(), "session-1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.GatewayTimeout);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("Timed out waiting");
+    }
+
+    [Fact]
+    public async Task ToolsList_PaginatedResponsePassesThroughAndDoesNotRouteLocally()
+    {
+        const string paginated = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[],\"nextCursor\":\"next\"}}";
+        var githubCalls = 0;
+        await using var factory = CreateFactory(
+            paginated,
+            github: (request, _) =>
+            {
+                githubCalls++;
+                return Task.FromResult(
+                    request.Content is null ? TestUpstream.Json("{}") : TestUpstream.Json(githubCalls == 1 ? paginated : "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"github\"}]}}")
+                );
+            }
+        );
+        using var client = factory.CreateClient();
+
+        using var list = await SendAsync(client, "/mcp", ListRequest(), "session-1");
+        (await list.Content.ReadAsStringAsync()).Should().Be(paginated);
+        using var call = await SendAsync(client, "/mcp", CallRequest("web_search", 2), "session-1");
+
+        (await call.Content.ReadAsStringAsync()).Should().Contain("github");
+        githubCalls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ToolsCall_LocallyInjectedToolUsesJinaAndPreservesNumericId()
+    {
+        var githubCalls = 0;
+        var jinaCalls = 0;
+        await using var factory = CreateFactory(
+            EmptyListResponse(),
+            github: (_, _) =>
+            {
+                githubCalls++;
+                return Task.FromResult(TestUpstream.Json(EmptyListResponse()));
+            },
+            jina: (_, _) =>
+            {
+                jinaCalls++;
+                return Task.FromResult(TestUpstream.Json("{\"data\":[]}"));
+            }
+        );
+        using var client = factory.CreateClient();
+
+        using var list = await SendAsync(client, "/mcp", ListRequest(), "session-1");
+        using var call = await SendAsync(
+            client,
+            "/mcp",
+            CallRequest("web_search", 42, "{\"query\":\"release notes\"}"),
+            "session-1"
+        );
+        var body = JsonNode.Parse(await call.Content.ReadAsStringAsync())!;
+
+        body["id"]!.GetValue<int>().Should().Be(42);
+        body["result"]!["isError"]!.GetValue<bool>().Should().BeFalse();
+        githubCalls.Should().Be(1);
+        jinaCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ToolsCall_ValidationFailurePreservesMcpIsError()
+    {
+        await using var factory = CreateFactory(EmptyListResponse());
+        using var client = factory.CreateClient();
+
+        using var list = await SendAsync(client, "/mcp", ListRequest(), "session-1");
+        using var call = await SendAsync(client, "/mcp", CallRequest("web_fetch", "call-1", "{\"url\":\"http://127.0.0.1/secret\"}"), "session-1");
+        var body = JsonNode.Parse(await call.Content.ReadAsStringAsync())!;
+
+        body["id"]!.GetValue<string>().Should().Be("call-1");
+        body["result"]!["isError"]!.GetValue<bool>().Should().BeTrue();
+        body["result"]!["content"]![0]!["text"]!.GetValue<string>().Should().NotContain("jina-key");
+    }
+
+    [Fact]
+    public async Task Delete_RemovesLocalSnapshotEvenWhenGithubReturns405()
+    {
+        var githubCalls = 0;
+        var jinaCalls = 0;
+        await using var factory = CreateFactory(
+            EmptyListResponse(),
+            github: (request, _) =>
+            {
+                githubCalls++;
+                if (request.Method == HttpMethod.Delete)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.MethodNotAllowed));
+                }
+
+                var body = githubCalls == 1
+                    ? EmptyListResponse()
+                    : "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"github\"}]}}";
+                return Task.FromResult(TestUpstream.Json(body));
+            },
+            jina: (_, _) =>
+            {
+                jinaCalls++;
+                return Task.FromResult(TestUpstream.Json("{\"data\":[]}"));
+            }
+        );
+        using var client = factory.CreateClient();
+
+        using var list = await SendAsync(client, "/mcp", ListRequest(), "session-1");
+        using (var delete = new HttpRequestMessage(HttpMethod.Delete, "/mcp"))
+        {
+            delete.Headers.TryAddWithoutValidation("Mcp-Session-Id", "session-1");
+            using var deleted = await client.SendAsync(delete);
+            deleted.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+        }
+        using var call = await SendAsync(client, "/mcp", CallRequest("web_search", 2), "session-1");
+
+        (await call.Content.ReadAsStringAsync()).Should().Contain("github");
+        jinaCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Session404_RemovesOnlyMatchingEndpointSnapshot()
+    {
+        var githubCalls = 0;
+        await using var factory = CreateFactory(
+            EmptyListResponse(),
+            github: (_, _) =>
+            {
+                githubCalls++;
+                var response = githubCalls switch
+                {
+                    1 or 2 => TestUpstream.Json(EmptyListResponse()),
+                    3 => TestUpstream.Json("{}", HttpStatusCode.NotFound),
+                    _ => TestUpstream.Json("{\"jsonrpc\":\"2.0\",\"id\":4,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"github\"}]}}"),
+                };
+                return Task.FromResult(response);
+            }
+        );
+        using var client = factory.CreateClient();
+
+        using var regularList = await SendAsync(client, "/mcp", ListRequest(), "session-1");
+        using var readonlyList = await SendAsync(client, "/mcp/readonly", ListRequest(), "session-1");
+        using var expired = await SendAsync(client, "/mcp", "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"resources/list\"}", "session-1");
+        expired.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        using var regularCall = await SendAsync(client, "/mcp", CallRequest("web_search", 4), "session-1");
+
+        (await regularCall.Content.ReadAsStringAsync()).Should().Contain("github");
+        using var readonlyCall = await SendAsync(
+            client,
+            "/mcp/readonly",
+            CallRequest("web_search", 5, "{\"query\":\"release notes\"}"),
+            "session-1"
+        );
+        (await readonlyCall.Content.ReadAsStringAsync()).Should().NotContain("github");
+    }
+
+    [Fact]
+    public async Task ToolsCall_ClientCancellationReachesJinaRequest()
+    {
+        var upstreamStream = new CancellationObservingStream("");
+        await using var factory = CreateFactory(
+            EmptyListResponse(),
+            jina: (_, _) => Task.FromResult(TestUpstream.JsonStream(upstreamStream))
+        );
+        using var client = factory.CreateClient();
+        using var list = await SendAsync(client, "/mcp", ListRequest(), "session-1");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/mcp")
+        {
+            Content = new StringContent(
+                CallRequest("web_search", 2, "{\"query\":\"status\"}"),
+                Encoding.UTF8,
+                "application/json"
+            ),
+        };
+        request.Headers.TryAddWithoutValidation("Mcp-Session-Id", "session-1");
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        var act = async () => await client.SendAsync(request, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        await upstreamStream.Cancelled.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task ToolsCall_MismatchedMcpContextForwardsToGithub()
+    {
+        var githubCalls = 0;
+        await using var factory = CreateFactory(
+            EmptyListResponse(),
+            github: (_, _) =>
+            {
+                githubCalls++;
+                var body = githubCalls == 1 ? EmptyListResponse() : "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"github\"}]}}";
+                return Task.FromResult(TestUpstream.Json(body));
+            }
+        );
+        using var client = factory.CreateClient();
+
+        using var list = await SendAsync(client, "/mcp", ListRequest(), "session-1", new Dictionary<string, string> { ["X-MCP-Host"] = "one" });
+        using var call = await SendAsync(client, "/mcp", CallRequest("web_search", 2), "session-1", new Dictionary<string, string> { ["X-MCP-Host"] = "two" });
+
+        (await call.Content.ReadAsStringAsync()).Should().Contain("github");
+        githubCalls.Should().Be(2);
+    }
+
+    private static ProxyWebAppFactory CreateFactory(
+        string githubBody,
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>? github = null,
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>? jina = null
+    ) =>
+        new(
+            github ?? ((_, _) => Task.FromResult(TestUpstream.Json(githubBody))),
+            jinaApiKey: "jina-key",
+            jinaUpstream: jina ?? ((_, _) => Task.FromResult(TestUpstream.Json("{\"data\":[]}")))
+        );
+
+    private static async Task<HttpResponseMessage> SendAsync(
+        HttpClient client,
+        string path,
+        string body,
+        string? sessionId = null,
+        IReadOnlyDictionary<string, string>? headers = null
+    )
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, path)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+        if (sessionId is not null)
+        {
+            request.Headers.TryAddWithoutValidation("Mcp-Session-Id", sessionId);
+        }
+        if (headers is not null)
+        {
+            foreach (var (name, value) in headers)
+            {
+                request.Headers.TryAddWithoutValidation(name, value);
+            }
+        }
+        return await client.SendAsync(request);
+    }
+
+    private static string ListRequest() => "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{}}";
+
+    private static string CallRequest(string name, JsonNode id, string arguments = "{}") =>
+        $"{{\"jsonrpc\":\"2.0\",\"id\":{id.ToJsonString()},\"method\":\"tools/call\",\"params\":{{\"name\":\"{name}\",\"arguments\":{arguments}}}}}";
+
+    private static string EmptyListResponse() => "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}";
+}

--- a/tests/CopilotAnthropicProxy.Tests/McpToolCompositionTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/McpToolCompositionTests.cs
@@ -92,29 +92,55 @@ public class McpToolCompositionTests
     }
 
     [Fact]
-    public async Task ToolsList_SseAndBatchPassThroughWithoutLocalOwnership()
+    public async Task ToolsList_SseMessageComposesLocalFallbackAndPreservesFraming()
+    {
+        var jinaCalls = 0;
+        const string sse = "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}\n\n";
+        await using var factory = new ProxyWebAppFactory(
+            (_, _) => Task.FromResult(TestUpstream.Sse(sse)),
+            jinaApiKey: "jina-key",
+            jinaUpstream: (_, _) =>
+            {
+                jinaCalls++;
+                return Task.FromResult(TestUpstream.Json("{\"data\":[]}"));
+            }
+        );
+        using var client = factory.CreateClient();
+
+        using var list = await SendAsync(client, "/mcp", ListRequest(), "session-1");
+        var listed = await list.Content.ReadAsStringAsync();
+        listed.Should().StartWith("event: message\ndata: ").And.EndWith("\n\n");
+        var data = listed.Split('\n').Single(line => line.StartsWith("data: ", StringComparison.Ordinal))[6..];
+        var tools = JsonNode.Parse(data)!["result"]!["tools"]!.AsArray();
+        tools.Select(tool => tool!["name"]!.GetValue<string>()).Should().BeEquivalentTo("web_search", "web_fetch");
+
+        using var call = await SendAsync(
+            client,
+            "/mcp",
+            CallRequest("web_search", 2, "{\"query\":\"status\"}"),
+            "session-1"
+        );
+        jinaCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ToolsList_BatchPassesThroughWithoutLocalOwnership()
     {
         var githubCalls = 0;
-        const string sse = "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}\n\n";
         await using var factory = new ProxyWebAppFactory(
             (_, _) =>
             {
                 githubCalls++;
-                return Task.FromResult(githubCalls == 1 ? TestUpstream.Sse(sse) : TestUpstream.Json("{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"content\":[]}}"));
+                return Task.FromResult(TestUpstream.Json("{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"content\":[]}}"));
             },
             jinaApiKey: "jina-key",
             jinaUpstream: (_, _) => throw new InvalidOperationException("Jina must not run")
         );
         using var client = factory.CreateClient();
 
-        using var list = await SendAsync(client, "/mcp", ListRequest(), "session-1");
-        (await list.Content.ReadAsStringAsync()).Should().Be(sse);
-        using var call = await SendAsync(client, "/mcp", CallRequest("web_search", 2), "session-1");
-        githubCalls.Should().Be(2);
-
         var batch = $"[{ListRequest()}]";
         using var batchResponse = await SendAsync(client, "/mcp", batch, "session-1");
-        githubCalls.Should().Be(3);
+        githubCalls.Should().Be(1);
     }
 
     [Fact]

--- a/tests/CopilotAnthropicProxy.Tests/McpToolCompositionTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/McpToolCompositionTests.cs
@@ -268,17 +268,46 @@ public class McpToolCompositionTests
     }
 
     [Fact]
-    public async Task ToolsCall_MalformedParamsReturnsJsonRpcInvalidParams()
+    public async Task ToolsCall_MalformedParamsForUnknownOwnershipPassesThrough()
     {
-        await using var factory = CreateFactory(EmptyListResponse());
+        const string malformed = "{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"tools/call\",\"params\":[]}";
+        var githubCalls = 0;
+        await using var factory = CreateFactory(
+            EmptyListResponse(),
+            github: (_, _) =>
+            {
+                githubCalls++;
+                return Task.FromResult(
+                    TestUpstream.Json(
+                        githubCalls == 1
+                            ? EmptyListResponse()
+                            : "{\"jsonrpc\":\"2.0\",\"id\":7,\"error\":{\"code\":-32602,\"message\":\"github invalid params\"}}"
+                    )
+                );
+            }
+        );
         using var client = factory.CreateClient();
         using var list = await SendAsync(client, "/mcp", ListRequest(), "session-1");
-        const string malformed = "{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"tools/call\",\"params\":[]}";
 
         using var call = await SendAsync(client, "/mcp", malformed, "session-1");
         var body = JsonNode.Parse(await call.Content.ReadAsStringAsync())!;
 
-        body["id"]!.GetValue<int>().Should().Be(7);
+        body["error"]!["message"]!.GetValue<string>().Should().Be("github invalid params");
+        githubCalls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ToolsCall_MalformedArgumentsForLocalToolReturnsJsonRpcInvalidParams()
+    {
+        await using var factory = CreateFactory(EmptyListResponse());
+        using var client = factory.CreateClient();
+        using var list = await SendAsync(client, "/mcp", ListRequest(), "session-1");
+        const string malformed = "{\"jsonrpc\":\"2.0\",\"id\":8,\"method\":\"tools/call\",\"params\":{\"name\":\"web_search\",\"arguments\":[]}}";
+
+        using var call = await SendAsync(client, "/mcp", malformed, "session-1");
+        var body = JsonNode.Parse(await call.Content.ReadAsStringAsync())!;
+
+        body["id"]!.GetValue<int>().Should().Be(8);
         body["error"]!["code"]!.GetValue<int>().Should().Be(-32602);
     }
 

--- a/tests/CopilotAnthropicProxy.Tests/McpToolCompositionTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/McpToolCompositionTests.cs
@@ -268,6 +268,41 @@ public class McpToolCompositionTests
     }
 
     [Fact]
+    public async Task ToolsCall_MalformedParamsReturnsJsonRpcInvalidParams()
+    {
+        await using var factory = CreateFactory(EmptyListResponse());
+        using var client = factory.CreateClient();
+        using var list = await SendAsync(client, "/mcp", ListRequest(), "session-1");
+        const string malformed = "{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"tools/call\",\"params\":[]}";
+
+        using var call = await SendAsync(client, "/mcp", malformed, "session-1");
+        var body = JsonNode.Parse(await call.Content.ReadAsStringAsync())!;
+
+        body["id"]!.GetValue<int>().Should().Be(7);
+        body["error"]!["code"]!.GetValue<int>().Should().Be(-32602);
+    }
+
+    [Fact]
+    public async Task ToolsList_SessionlessResponseHeaderDoesNotInjectLocalTools()
+    {
+        await using var factory = new ProxyWebAppFactory(
+            (_, _) => Task.FromResult(
+                TestUpstream.Json(
+                    EmptyListResponse(),
+                    headers: new Dictionary<string, string> { ["Mcp-Session-Id"] = "upstream-session" }
+                )
+            ),
+            jinaApiKey: "jina-key",
+            jinaUpstream: (_, _) => throw new InvalidOperationException("Jina must not run")
+        );
+        using var client = factory.CreateClient();
+
+        using var list = await SendAsync(client, "/mcp", ListRequest());
+
+        (await list.Content.ReadAsStringAsync()).Should().Be(EmptyListResponse());
+    }
+
+    [Fact]
     public async Task ToolsCall_ValidationFailurePreservesMcpIsError()
     {
         await using var factory = CreateFactory(EmptyListResponse());

--- a/tests/CopilotAnthropicProxy.Tests/McpToolSnapshotStoreTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/McpToolSnapshotStoreTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+
+namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
+
+public class McpToolSnapshotStoreTests
+{
+    [Fact]
+    public void HeaderContext_IsCaseAndOrderIndependent()
+    {
+        var first = new HeaderDictionary
+        {
+            ["X-MCP-Tools"] = "web_search,issues",
+            ["X-MCP-Readonly"] = "true",
+        };
+        var second = new HeaderDictionary
+        {
+            ["x-mcp-readonly"] = "true",
+            ["x-mcp-tools"] = "web_search,issues",
+        };
+
+        McpToolSnapshotStore.BuildHeaderContext(first).Should().Be(McpToolSnapshotStore.BuildHeaderContext(second));
+    }
+
+    [Fact]
+    public void HeaderContext_DistinguishesAmbiguousHeaderSets()
+    {
+        var split = new HeaderDictionary { ["X-MCP-A"] = "1", ["X-MCP-B"] = "2" };
+        var combined = new HeaderDictionary { ["X-MCP-A"] = "1x-mcp-b=2" };
+
+        McpToolSnapshotStore.BuildHeaderContext(split)
+            .Should().NotBe(McpToolSnapshotStore.BuildHeaderContext(combined));
+    }
+
+    [Fact]
+    public void HeaderContext_IgnoresNonMcpHeaders()
+    {
+        var first = new HeaderDictionary { ["X-MCP-Tools"] = "web_search" };
+        var second = new HeaderDictionary { ["X-MCP-Tools"] = "web_search", ["X-Custom"] = "different" };
+
+        McpToolSnapshotStore.BuildHeaderContext(first).Should().Be(McpToolSnapshotStore.BuildHeaderContext(second));
+    }
+
+    [Fact]
+    public void Snapshot_IsIsolatedByEndpointAndSession()
+    {
+        var store = new McpToolSnapshotStore();
+        store.Set("/mcp", "session-1", new(new HashSet<string> { "web_search" }, "context"));
+
+        store.TryGet("/mcp", "session-1", out var snapshot).Should().BeTrue();
+        snapshot.LocalToolNames.Should().ContainSingle().Which.Should().Be("web_search");
+        store.TryGet("/mcp/readonly", "session-1", out _).Should().BeFalse();
+        store.TryGet("/mcp", "session-2", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Set_ReplacesSnapshotAndRemoveClearsOnlyMatch()
+    {
+        var store = new McpToolSnapshotStore();
+        store.Set("/mcp", "session-1", new(new HashSet<string> { "web_search" }, "first"));
+        store.Set("/mcp/readonly", "session-1", new(new HashSet<string> { "web_fetch" }, "other"));
+        store.Set("/mcp", "session-1", new(new HashSet<string> { "web_fetch" }, "second"));
+
+        store.TryGet("/mcp", "session-1", out var snapshot).Should().BeTrue();
+        snapshot.HeaderContext.Should().Be("second");
+        snapshot.LocalToolNames.Should().ContainSingle().Which.Should().Be("web_fetch");
+
+        store.Remove("/mcp", "session-1");
+        store.TryGet("/mcp", "session-1", out _).Should().BeFalse();
+        store.TryGet("/mcp/readonly", "session-1", out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void OversizedMcpHeaderContext_IsRejected()
+    {
+        var headers = new HeaderDictionary { ["X-MCP-Tools"] = new string('x', 9_000) };
+
+        McpToolSnapshotStore.TryBuildHeaderContext(headers, out _).Should().BeFalse();
+    }
+}

--- a/tests/CopilotAnthropicProxy.Tests/ProxyWebAppFactory.cs
+++ b/tests/CopilotAnthropicProxy.Tests/ProxyWebAppFactory.cs
@@ -1,10 +1,13 @@
 using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
 using AchieveAi.LmDotnetTools.LmTestUtils;
+using AchieveAi.LmDotnetTools.Misc.Configuration;
+using AchieveAi.LmDotnetTools.Misc.Web.Jina;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace AchieveAi.LmDotnetTools.CopilotAnthropicProxy.Tests;
 
@@ -27,6 +30,7 @@ public sealed class ProxyWebAppFactory : WebApplicationFactory<Program>
 
     private readonly HttpMessageHandler _upstreamHandler;
     private readonly ICopilotTokenProvider _tokenProvider;
+    private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>? _jinaUpstream;
 
     /// <summary>Creates a factory whose upstream is driven by <paramref name="upstream"/>.</summary>
     /// <param name="upstream">Fake upstream handler invoked for every forwarded request.</param>
@@ -54,6 +58,10 @@ public sealed class ProxyWebAppFactory : WebApplicationFactory<Program>
     ///     only meaningful alongside a non-null <paramref name="model"/>, which otherwise has no
     ///     discovered endpoint list.
     /// </param>
+    /// <param name="jinaApiKey">Optional Jina key that enables local MCP web-tool fallback.</param>
+    /// <param name="webToolsOutputCap">Optional local web-tool output character cap.</param>
+    /// <param name="webToolsTimeoutMs">Optional local web-tool timeout in milliseconds.</param>
+    /// <param name="jinaUpstream">Optional fake Jina transport, isolated from the fake Copilot transport.</param>
     public ProxyWebAppFactory(
         Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> upstream,
         ICopilotTokenProvider? tokenProvider = null,
@@ -61,14 +69,22 @@ public sealed class ProxyWebAppFactory : WebApplicationFactory<Program>
         int? idleTimeoutSeconds = null,
         int? keepAliveSeconds = null,
         long? maxBodyBytes = null,
-        string? modelEndpoints = null
+        string? modelEndpoints = null,
+        string? jinaApiKey = null,
+        int? webToolsOutputCap = null,
+        int? webToolsTimeoutMs = null,
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>? jinaUpstream = null
     )
     {
         ArgumentNullException.ThrowIfNull(upstream);
 
         _upstreamHandler = new FakeHttpMessageHandler(upstream);
         _tokenProvider = tokenProvider ?? new FakeCopilotTokenProvider("fake-token");
+        _jinaUpstream = jinaUpstream;
         Environment.SetEnvironmentVariable("COPILOT_ANTHROPIC_MODEL", model);
+        Environment.SetEnvironmentVariable("JINA_API_KEY", jinaApiKey);
+        Environment.SetEnvironmentVariable("WEB_TOOLS_OUTPUT_CAP", webToolsOutputCap?.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        Environment.SetEnvironmentVariable("WEB_TOOLS_TIMEOUT_MS", webToolsTimeoutMs?.ToString(System.Globalization.CultureInfo.InvariantCulture));
         Environment.SetEnvironmentVariable("COPILOT_ANTHROPIC_MODEL_ENDPOINTS", modelEndpoints);
         if (idleTimeoutSeconds is not null)
         {
@@ -108,6 +124,22 @@ public sealed class ProxyWebAppFactory : WebApplicationFactory<Program>
 
             services.RemoveAll<HttpMessageHandler>();
             services.AddSingleton(_upstreamHandler);
+
+            if (_jinaUpstream is not null)
+            {
+                services.RemoveAll<JinaWebProvider>();
+                services.AddSingleton(sp =>
+                    new JinaWebProvider(
+                        new HttpClient(new FakeHttpMessageHandler(_jinaUpstream)),
+                        sp.GetRequiredService<WebToolsOptions>(),
+                        sp.GetRequiredService<ILoggerFactory>().CreateLogger<JinaWebProvider>()
+                    )
+                );
+                services.RemoveAll<McpJinaToolCatalog>();
+                services.AddSingleton<McpJinaToolCatalog>();
+                services.RemoveAll<McpToolComposition>();
+                services.AddSingleton<McpToolComposition>();
+            }
         });
     }
 
@@ -126,6 +158,9 @@ public sealed class ProxyWebAppFactory : WebApplicationFactory<Program>
                 Environment.SetEnvironmentVariable("COPILOT_ANTHROPIC_IDLE_TIMEOUT_SECONDS", null);
                 Environment.SetEnvironmentVariable("COPILOT_ANTHROPIC_KEEPALIVE_SECONDS", null);
                 Environment.SetEnvironmentVariable("COPILOT_ANTHROPIC_MAX_BODY_BYTES", null);
+                Environment.SetEnvironmentVariable("JINA_API_KEY", null);
+                Environment.SetEnvironmentVariable("WEB_TOOLS_OUTPUT_CAP", null);
+                Environment.SetEnvironmentVariable("WEB_TOOLS_TIMEOUT_MS", null);
             }
         }
     }


### PR DESCRIPTION
## Summary

Expose GitHub-first `web_search` and `web_fetch` tools through the Proxy app's existing `/mcp` and `/mcp/readonly` endpoints.

GitHub's exact-name MCP tool definition and call path remains authoritative when available. When GitHub omits a name, the proxy adds the existing hardened Jina implementation only with valid Jina configuration.

## Changes

- Add narrow MCP `tools/list` composition and local `tools/call` routing.
- Preserve transparent forwarding for unrelated, SSE, paginated, batch, and sessionless MCP traffic.
- Respect `X-MCP-Tools`, `X-MCP-Exclude-Tools`, lockdown, session, endpoint, and filter-context boundaries.
- Reuse existing Jina validation, SSRF protection, cancellation, output limits, and secret-safe error handling.
- Add focused routing, transport, lifecycle, failure, cancellation, and security coverage.
- Document MCP availability rules, configuration, limitations, and cleanup behavior.

## Testing

- CSharpier: clean
- Proxy build: 0 warnings, 0 errors
- Proxy tests: 359/359 passed
- Focused Jina/security tests: 106/106 passed
- Publish-size impact: +900,987 bytes from the `Misc` dependency, documented in the README
- Live MCP smoke probe: skipped because `JINA_API_KEY` was unavailable in this session

## Key Decisions

- Scope is limited to the Proxy app's `/mcp` and `/mcp/readonly` surfaces.
- GitHub exact-name tools always win; Jina only fills missing names.
- No mid-call failover between GitHub and Jina.
- Client MCP filters remain authoritative and cannot be bypassed by local injection.
- Unsupported MCP shapes remain byte-transparent.
- Relay and composition share one GitHub transport, timeout, error, and body-cap path.

## Dependency Impact

The Proxy now references `Misc` to reuse its Jina tooling and security implementation. This transitively adds SQLite native assets and increased the measured framework-dependent publish output by approximately 0.9 MB. No SQLite service is constructed by the Proxy.

## Related Issues

Fixes #247
