### PR TITLE
feat(sample): mirror conversation transcripts into the workspace as JSONL

### DIFF
--- a/docs/adrs/0011-workspace-transcript-files.md
+++ b/docs/adrs/0011-workspace-transcript-files.md
@@ -1,0 +1,131 @@
+# ADR 0011: Mirror each conversation's transcript into its own workspace, readable by anyone who can reach the workspace
+
+* Status: Accepted
+* Date: 2026-08-03
+* Related issues, PRs, or commits: [#251](https://github.com/achieveai/LmDotnetTools/issues/251)
+
+## Context
+
+A conversation in `LmStreaming.Sample` already persists every message through `IConversationStore`, and
+already exposes them over HTTP — the conversation's own `/messages` route, the cross-agent transcript
+endpoint, and the `GetAgentTranscript` tool. What it does not do is put them anywhere an *agent* can read
+with ordinary file tools. An agent inside the sandbox has a workspace, a shell, `Read`, `Grep` and `Glob`;
+it has no way to consult the record of what it or a sibling actually did except by asking the host over
+HTTP, which is a different trust path with a different answer.
+
+#251 asks for the file. Each conversation's messages, mirrored as JSONL into `.conversations/` inside that
+conversation's sandbox workspace, appended at each turn boundary, at full fidelity — reasoning included —
+so a person or an agent can `cat`, `grep`, or point DuckDB at it.
+
+Three forces shape the decision, and each has an obvious wrong answer.
+
+**The obvious wrong answer for placement** is somewhere private to the conversation. But conversations
+share workspaces: the workspace is bound to the work, not to the chat about it. A transcript inside a
+shared workspace is therefore reachable by every other conversation bound to that same workspace. That is
+not an accident to be engineered away — acceptance criterion 26 is literally *"conversation B reads A's
+transcript"*. Removing the cross-conversation read removes the feature.
+
+**The obvious wrong answer for exposure** is a feature flag. A flag turns a durable artifact into a
+sometimes-artifact: a reader cannot tell "no transcript" from "transcript disabled", and every consumer
+grows a branch. The owner overruled a flag. What the exposure does need is a guard against the transcript
+leaving the machine, because a workspace is frequently a git checkout.
+
+**The obvious wrong answer for containment** is to do nothing, on the grounds that a transcript in a
+workspace is just a file. It is not just a file for the agent that wrote it. An agent asked to summarise or
+explore its own workspace would walk `.conversations/`, ingest its own output, and describe itself — every
+turn, growing every turn. Containment is a precondition of the feature, not a polish item.
+
+There is also a documentation force. ADR 0009 records that in a collaboration *"contact and read permission
+are separate axes, and that separation is load-bearing … only the transcript policy decides who may read
+one"*, and that a caller *"must not be able to read past the policy with a direct GET"*. A transcript on a
+shared filesystem does exactly what that sentence forbids, by a route that sentence does not mention. The
+two records must not quietly disagree.
+
+## Decision
+
+**The transcript is a workspace artifact, not an API projection. Its readership is whoever can reach the
+workspace, and that is stated rather than defended.**
+
+An always-on, sample-local mirror appends each conversation's persisted messages to
+`.conversations/{slug(title)}-{shortThreadId}.jsonl` inside that conversation's sandbox workspace, one file
+per sub-agent under a sibling `..._agents/` directory. Ordering is carried by a derived `uid` /
+`parent_uid` chain. Nothing under `src/` changes.
+
+Three properties are decided deliberately, and are the substance of this record:
+
+**1. `.conversations/` is readable across conversations, by design.** Two conversations bound to one
+workspace can each read the other's transcript with `cat`. This is a **deliberate filesystem bypass of the
+visibility policy** that ADR 0009 draws: `cat` reads past what a GET cannot. It is not a leak to be fixed
+later, because it is the requested behaviour (AC 26). **This annotates ADR 0009 rather than editing it** —
+ADRs here are append-only. ADR 0009's claim remains exactly true of the surface it describes, the
+collaboration's addressing and read APIs. It is not true of the filesystem, and after this record it does
+not claim to be: the transcript policy governs who may read a transcript *through the collaboration*, and
+the workspace governs who may read one *through the filesystem*. A deployment that needs the stricter
+property must not co-bind conversations to a shared workspace.
+
+**2. The transcript survives conversation delete.** Deleting a conversation removes the agent and the
+store's copy; it never `rm`s the transcript. Eviction drops the in-memory writer entry only. This makes an
+otherwise unpleasant ordering hazard benign — deletion removes the agent before the store, so a final flush
+can fire against a conversation being deleted — because the artifact is *meant* to outlive the
+conversation. A person investigating what happened is precisely the person whose conversation is gone.
+
+**3. The transcript is normalized and includes reasoning.** The mirror calls
+`TranscriptProjection.Normalize(messages, excludeReasoning: false)`. It is a fourth caller of that method
+and is **not exempted from normalization** — skipping it would put known-broken legacy rows
+(`server_tool_use` discriminators, doubled tool-call args) into every transcript and force each future
+reader to re-implement the fix. It is exempted from the *reasoning exclusion*, deliberately: the exclusion
+exists for cross-agent reads, and this is the conversation's own full-fidelity record.
+
+Containment is enforced in three places, none of which is a security boundary: the `workspace-summary` and
+`repo-explorer` skills list `.conversations` among the directories they ignore; `FilePreviewPolicy` refuses
+inline preview of any file under a dot-directory (`.jsonl` is allowlisted, so the extension check alone
+would not have stopped it); and a `.gitignore` containing `*` is written into `.conversations/` on first
+flush, so an agent running `git add -A && push` does not publish its own and its siblings' unredacted
+reasoning off-machine, irrecoverably. Recursive `Read`/`Grep` exclusion is delegated to the gateway; if the
+gateway does not already behave that way, the deliverable is a gateway-repo issue, not code here.
+
+## Consequences
+
+The transcript becomes a first-class, greppable artifact with no new API, no new store, and no new plumbing
+in `src/`. A DuckDB read over `read_ndjson_objects` with `ignore_errors=true` answers questions that
+previously needed a running host.
+
+The cost is a set of limits that are real and are named here rather than discovered later.
+
+**`parent_uid` recovers sequence, not turn structure.** The parent pointer is store adjacency — the `uid`
+of the previous row in `LoadMessagesAsync` order. It tells a reader what came before what. It does not tell
+a reader where one turn ended and the next began, and it cannot be made to: closing that gap needs a
+persisted turn identifier, which the locked decisions exclude. AC 17 stays partial on purpose, and a reader
+who assumes the chain encodes turn boundaries will be wrong.
+
+Five gaps are accepted, not absorbed:
+
+1. **A deferred tool result can freeze as a placeholder.** A late client-tool or `AskUserQuestion` answer
+   arrives through `ReplaceMessageAsync`, which mutates the row in place, keeping its `Id` and `Timestamp`
+   — so its `uid` is unchanged, the watermark has already passed it, and the transcript keeps the question
+   but never receives the answer. This is not exotic; both are first-class features of this sample.
+   Re-emitting with the same `uid` was rejected because it contradicts the uniqueness criterion.
+2. **A run cancelled mid-flight is not flushed at that moment.** Cancellation never reaches run completion,
+   so no completion message is published. The next completed run picks it up, because the watermark is
+   cumulative. There is deliberately no disposal-time flush: an awaited flush at process shutdown loses a
+   race with the session registry's disposal guard and is swallowed anyway, so the "fixed" version does not
+   reliably work either.
+3. **Service-to-service conversations get no transcript at all in v1.** A background flush has no inbound
+   HTTP request and can only present a null credential, which conflicts permanently with an S2S-owned
+   session binding. The result is a deliberate no-op: no file, no directory, no error, a debug log only.
+   Interactive-UI conversations are unaffected. The owner was told plainly that S2S — a daemon run nobody
+   watches live — is where transcripts would be most useful, and chose UI-only for v1; a follow-up issue
+   tracks it.
+4. **A dropped subscriber cannot be told apart from a disposed one.** Both end the message enumerator
+   normally, with no exception and no log. An identity check against the agent pool mitigates it — if the
+   pool still holds the same instance and our own cancellation was not requested, we were dropped and
+   re-subscribe — but the ambiguity itself remains, and is stated here rather than left to be rediscovered
+   as a silent-stop bug.
+5. **`.conversations/` is readable across conversations and survives conversation delete.** Both are owner
+   decisions, restated here as consequences because they are the two properties most likely to surprise
+   someone who did not read the decision.
+
+Finally, this feature adds a seventh copy of a title-slug function, on purpose: the six existing copies are
+Unicode-aware `char.IsLetterOrDigit` implementations that pass CJK and accents through, none of which is
+safe for a filename here and none of which is reachable from this assembly. Consolidation is a deferral,
+recorded so its absence reads as a decision.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -53,3 +53,4 @@ What improved, what became more complex, and what future work this implies.
 * [0007 — Observe turns and context at the seam where the fact settles](0007-observe-at-the-settling-seam.md)
 * [0008 — Dispatch provider tool requests off the stdio read loop, bounded and refusing](0008-asynchronous-provider-tool-dispatch.md)
 * [0009 — Scope agent collaboration to a root-owned directory, and leave delivery with the owner](0009-hierarchy-wide-agent-collaboration.md)
+* [0011 — Mirror each conversation's transcript into its own workspace, readable by anyone who can reach the workspace](0011-workspace-transcript-files.md)

--- a/samples/LmStreaming.Sample/ClientApp/src/types/fileBrowser.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/types/fileBrowser.ts
@@ -39,7 +39,7 @@ export interface NoSessionState {
 /** Result of the preview endpoint. `text` is present only when `previewable` is true. */
 export interface PreviewResult {
   previewable: boolean;
-  /** Why a file is not previewable, e.g. `binary` | `too_large` | `not_utf8` | `not_a_file`. */
+  /** Why a file is not previewable, e.g. `binary` | `too_large` | `not_utf8` | `not_a_file` | `excluded`. */
   reason?: string;
   text?: string;
   lineCount?: number;

--- a/samples/LmStreaming.Sample/Controllers/ConversationsController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ConversationsController.cs
@@ -174,7 +174,8 @@ public class ConversationsController(
     WorkflowRunRegistry workflowRunRegistry,
     ILogger<ConversationsController> logger,
     ILogger<AgentHierarchyService> hierarchyLogger,
-    SubAgentScanCoverageCache scanCoverageCache) : ControllerBase
+    SubAgentScanCoverageCache scanCoverageCache,
+    ConversationDescendantScanner descendantScanner) : ControllerBase
 {
     /// <summary>
     /// Warning returned from a mode/provider switch that recreated the agent while a <c>Wait</c> was
@@ -571,112 +572,26 @@ public class ConversationsController(
         agent is not null || await store.LoadMetadataAsync(threadId, ct) is not null;
 
     /// <summary>
-    /// Page size and total cap for the persisted sub-agent scan. <see cref="IConversationStore"/> has
-    /// no property index, so rebuilding the roster means scanning thread metadata; the cap bounds the
-    /// work on a long-lived store and truncation is logged rather than silently swallowed.
-    /// </summary>
-    private const int SubAgentScanPageSize = 200;
-    private const int SubAgentScanMaxThreads = 2000;
-
-    /// <summary>
-    /// The single bounded store scan both the flat and recursive listings are built from — every
-    /// stamped sub-agent thread, projected via the no-filter
-    /// <see cref="SubAgentProvenance.TryProject(ThreadMetadata)"/> overload, regardless of who its
-    /// parent is. Callers filter or index the result in memory; nothing here queries the store again
-    /// per node, satisfying the "one bounded scan per request" requirement even for the recursive,
-    /// arbitrary-depth graph.
-    /// </summary>
-    private async Task<IReadOnlyList<SubAgentSummary>> ScanAllPersistedSubAgentNodesAsync(
-        string requestingThreadId,
-        CancellationToken ct)
-    {
-        var found = new List<SubAgentSummary>();
-        var scanned = 0;
-
-        while (scanned < SubAgentScanMaxThreads)
-        {
-            var page = await store.ListThreadsAsync(SubAgentScanPageSize, scanned, ct) ?? [];
-            if (page.Count == 0)
-            {
-                return found;
-            }
-
-            scanned += page.Count;
-            foreach (var metadata in page)
-            {
-                var node = SubAgentProvenance.TryProject(metadata);
-                if (node is not null)
-                {
-                    found.Add(node);
-                }
-            }
-
-            if (page.Count < SubAgentScanPageSize)
-            {
-                return found;
-            }
-        }
-
-        logger.LogWarning(
-            "Sub-agent scan for {ThreadId} stopped at the {MaxThreads}-thread cap; "
-                + "children persisted beyond that point are not listed.",
-            requestingThreadId,
-            SubAgentScanMaxThreads);
-        return found;
-    }
-
-    /// <summary>
     /// Builds the versioned recursive descendant graph (schema v1) for <paramref name="rootThreadId"/>:
-    /// one bounded store scan (<see cref="ScanAllPersistedSubAgentNodesAsync"/>), one in-memory
-    /// parent→children index built from it, then a visited-set BFS from the root. Deliberately
-    /// persisted-only — no live <c>SubAgentManager</c> union — because no current spawn path creates
-    /// a depth-&gt;1 tree anyway (nested live Agent delegation stays disabled); this reader exists to
-    /// answer "what does the persisted graph say", which is exactly what a restarted host or a
-    /// finished run still has. The root itself is never emitted as a node, only its descendants.
+    /// one bounded store scan, one in-memory parent→children index built from it, then a visited-set
+    /// BFS from the root — all of which now lives in <see cref="ConversationDescendantScanner"/>, which
+    /// the transcript writer shares (issue #251). Deliberately persisted-only — no live
+    /// <c>SubAgentManager</c> union — because no current spawn path creates a depth-&gt;1 tree anyway
+    /// (nested live Agent delegation stays disabled); this reader exists to answer "what does the
+    /// persisted graph say", which is exactly what a restarted host or a finished run still has. The
+    /// root itself is never emitted as a node, only its descendants.
     /// </summary>
+    /// <remarks>
+    /// Calls the UNCACHED <see cref="ConversationDescendantScanner.ScanAsync"/>, not the cached
+    /// <c>GetOrScanAsync</c>: this endpoint observes no agent activity of its own, so it has nothing to
+    /// refresh a cached graph with, and serving a remembered answer here would silently change the
+    /// route's contract from "what the store says now" to "what it said at some earlier poll".
+    /// </remarks>
     private async Task<IActionResult> BuildDescendantTreeAsync(string rootThreadId, CancellationToken ct)
     {
-        var allNodes = await ScanAllPersistedSubAgentNodesAsync(rootThreadId, ct);
-        var childrenByParent = allNodes
-            .GroupBy(n => n.ParentThreadId!, StringComparer.Ordinal)
-            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.Ordinal);
+        var ordered = await descendantScanner.ScanAsync(rootThreadId, ct);
 
-        var discovered = new List<SubAgentSummary>();
-        var visited = new HashSet<string>(StringComparer.Ordinal) { rootThreadId };
-        var queue = new Queue<(string ThreadId, int Depth)>();
-        queue.Enqueue((rootThreadId, 0));
-
-        while (queue.Count > 0)
-        {
-            var (parentId, depth) = queue.Dequeue();
-            if (!childrenByParent.TryGetValue(parentId, out var children))
-            {
-                continue;
-            }
-
-            foreach (var child in children)
-            {
-                if (!visited.Add(child.ThreadId))
-                {
-                    // Cycle cut (or a diamond re-reachable via a second path) — the visited set has
-                    // already placed this thread at an earlier, shallower position. Log opaque ids
-                    // only: never Name/Template/Task, which may carry caller-supplied free text.
-                    logger.LogWarning(
-                        "Sub-agent recursive scan for {RootThreadId} cut a repeat visit at thread "
-                            + "{ThreadId} (parent {ParentThreadId})",
-                        rootThreadId,
-                        child.ThreadId,
-                        parentId);
-                    continue;
-                }
-
-                var childDepth = depth + 1;
-                discovered.Add(child with { Depth = childDepth });
-                queue.Enqueue((child.ThreadId, childDepth));
-            }
-        }
-
-        if (discovered.Count == 0)
+        if (ordered.Count == 0)
         {
             agentPool.TryGet(rootThreadId, out var agent);
             if (!await IsKnownThreadAsync(rootThreadId, agent, ct))
@@ -684,12 +599,6 @@ public class ConversationsController(
                 return NotFound(new { error = $"Conversation '{rootThreadId}' not found.", code = "unknown_thread" });
             }
         }
-
-        var ordered = discovered
-            .OrderBy(n => n.Depth)
-            .ThenBy(n => n.ParentThreadId, StringComparer.Ordinal)
-            .ThenBy(n => n.ThreadId, StringComparer.Ordinal)
-            .ToList();
 
         return Ok(new SubAgentTreeResponse(SchemaVersion: 1, Nodes: ordered));
     }

--- a/samples/LmStreaming.Sample/Controllers/FileBrowserController.cs
+++ b/samples/LmStreaming.Sample/Controllers/FileBrowserController.cs
@@ -156,6 +156,13 @@ public sealed class FileBrowserController(
             }
 
             var name = LastComponent(target.ServerPath);
+            // Machine-owned bookkeeping directories are excluded BEFORE the allowlist: a conversation's own
+            // `.conversations/*.jsonl` transcript is allowlisted by extension and must not be readable here.
+            if (FilePreviewPolicy.IsUnderDotDirectory(target.ServerPath))
+            {
+                return Ok(new PreviewResultDto(false, "excluded", null, null));
+            }
+
             // Server-authoritative allowlist decides eligibility BEFORE any read.
             if (!FilePreviewPolicy.IsPreviewable(name))
             {

--- a/samples/LmStreaming.Sample/FileBrowser/FileBrowserModels.cs
+++ b/samples/LmStreaming.Sample/FileBrowser/FileBrowserModels.cs
@@ -32,7 +32,7 @@ public sealed record NoSessionStateDto(string State, string? WorkspaceId)
     public static NoSessionStateDto For(string? workspaceId) => new(StateValue, workspaceId);
 }
 
-/// <summary>A text-preview result. When <see cref="Previewable"/> is false, <see cref="Reason"/> explains why (binary/too_large/not_utf8/not_a_file).</summary>
+/// <summary>A text-preview result. When <see cref="Previewable"/> is false, <see cref="Reason"/> explains why (binary/too_large/not_utf8/not_a_file/excluded).</summary>
 public sealed record PreviewResultDto(bool Previewable, string? Reason, string? Text, int? LineCount);
 
 /// <summary>The per-file upload outcome (one file per request). <see cref="Name"/> echoes the relative path when the upload carried one, otherwise the base file name.</summary>

--- a/samples/LmStreaming.Sample/FileBrowser/FilePreviewPolicy.cs
+++ b/samples/LmStreaming.Sample/FileBrowser/FilePreviewPolicy.cs
@@ -4,7 +4,8 @@ namespace LmStreaming.Sample.FileBrowser;
 /// The single, centralized, server-side allowlist that decides whether a workspace file is eligible for
 /// inline text preview (WI #195). The server is authoritative — the client only renders whatever the
 /// preview endpoint returns. Eligibility is by file extension (or a small set of well-known extension-less
-/// names); a non-listed file is treated as binary and offered as download-only.
+/// names); a non-listed file is treated as binary and offered as download-only. A file under a
+/// dot-directory is excluded outright, ahead of the allowlist — see <see cref="IsUnderDotDirectory"/>.
 /// </summary>
 public static class FilePreviewPolicy
 {
@@ -44,5 +45,33 @@ public static class FilePreviewPolicy
         }
 
         return PreviewableExactNames.Contains(name);
+    }
+
+    /// <summary>
+    /// True when any DIRECTORY component of <paramref name="serverPath"/> is a dot-directory — the file lives
+    /// under machine-owned bookkeeping such as <c>.conversations/</c> or <c>.git/</c> rather than under content
+    /// a person put there. Such a file is never previewable, whatever its extension: the workspace transcript
+    /// mirror (#251) writes every message of a conversation into <c>.conversations/*.jsonl</c>, and
+    /// <c>.jsonl</c> is on the allowlist, so without this an agent previewing its own workspace reads its own
+    /// transcript back. The FINAL component is deliberately not considered — a dot-FILE such as
+    /// <c>.gitignore</c> stays previewable, which is why this is not folded into <see cref="IsPreviewable"/>.
+    /// </summary>
+    public static bool IsUnderDotDirectory(string serverPath)
+    {
+        if (string.IsNullOrEmpty(serverPath))
+        {
+            return false;
+        }
+
+        var components = serverPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 0; i < components.Length - 1; i++)
+        {
+            if (components[i].StartsWith('.'))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -202,6 +202,28 @@ try
     _ = builder.Services.AddSingleton(sp => new SubAgentScanCoverageCache(
         sp.GetRequiredService<AgentCollaborationHostOptions>().MaxPersistedHierarchyEntries));
 
+    // Per-root memory of the persisted DESCENDANT graph (issue #251) — a different question from the
+    // direct-child roster above, and deliberately a different cache; see ConversationDescendantScanner's
+    // remarks for why reusing SubAgentScanCoverageCache here would be a correctness bug.
+    _ = builder.Services.AddSingleton(sp => new ConversationDescendantScanner(
+        sp.GetRequiredService<IConversationStore>(),
+        sp.GetRequiredService<ILogger<ConversationDescendantScanner>>(),
+        sp.GetRequiredService<AgentCollaborationHostOptions>().MaxPersistedHierarchyEntries));
+
+    // Mirror every conversation into its own workspace as JSONL (issue #251). Always on: a conversation
+    // with no workspace bound resolves no sandbox session, so its flush is a no-op and costs nothing.
+    // The pool is reached through a lookup delegate rather than injected — the pool's own registration
+    // resolves this singleton, so a direct dependency would close a DI construction cycle. The delegate
+    // only runs when a subscription ends, long after both singletons exist.
+    _ = builder.Services.AddSingleton(sp => new WorkspaceTranscriptMirror(
+        threadId => sp.GetRequiredService<MultiTurnAgentPool>().TryGet(threadId, out var agent)
+            ? agent
+            : null,
+        sp.GetRequiredService<IConversationStore>(),
+        sp.GetRequiredService<IWorkspaceFileBrowser>(),
+        sp.GetRequiredService<ConversationDescendantScanner>(),
+        sp.GetRequiredService<ILoggerFactory>()));
+
     // Mock provider host: eagerly-started in-process Kestrel app that the *-mock providers
     // point at. Singleton-as-IHostedService so it boots in Host.StartAsync; the registry
     // dependency below reads its IsRunning flag for availability gating.
@@ -660,6 +682,10 @@ try
         var mockHostLifetime = sp.GetRequiredService<MockProviderHostLifetime>();
         var sandboxRegistryForCleanup = sp.GetRequiredService<SandboxSessionRegistry>();
         var workflowRunRegistry = sp.GetRequiredService<WorkflowRunRegistry>();
+        var descendantScanner = sp.GetRequiredService<ConversationDescendantScanner>();
+        // Workspace transcript mirror (#251). Captured here so the per-thread factory below can attach
+        // each agent it builds; eviction is wired into the pool's ThreadRemoved handler further down.
+        var transcriptMirror = sp.GetRequiredService<WorkspaceTranscriptMirror>();
         // Lifecycle observation / tool approval (#227). Resolved once for the process — the bundle's
         // sequence allocator owns the producer epoch, and loops that share it share that epoch, which
         // is what lets a subscriber tell "producer restarted" from "events were lost". Handed to the
@@ -1765,6 +1791,12 @@ subAgentFactory,
                         collaboration: rootCollaboration
                     );
 
+                    // Start mirroring this conversation's messages into its workspace (#251). Attached
+                    // after construction and before the agent is handed to the pool, so no turn boundary
+                    // can be missed. A mode switch builds a replacement agent for the same threadId and
+                    // re-attaches here; the mirror swaps the subscription and keeps the writer.
+                    transcriptMirror.Attach(agent);
+
                     return new MultiTurnAgentPool.AgentCreationResult(agent, ownedResources) { StagedBinding = stagedBinding };
                 }
                 catch
@@ -1812,6 +1844,13 @@ subAgentFactory,
             // hand, so the cleanest contract is to ask the registry to scrub.
             sandboxRegistryForCleanup.UnregisterThreadFromAllSessions(threadId);
             workflowRunRegistry.Remove(threadId);
+            // Drop the remembered descendant graph too (#251): the pool is not a dependency of the
+            // scanner (that would be a construction cycle), so invalidation is wired here instead.
+            descendantScanner.Forget(threadId);
+            // Stop mirroring it as well (#251). This drops the in-memory writer and its subscription
+            // only — the transcript already in the workspace is RETAINED on purpose, since outliving
+            // the conversation is the whole point of writing it there.
+            transcriptMirror.Evict(threadId);
         };
 
         return pool;

--- a/samples/LmStreaming.Sample/Services/AgentHierarchyService.cs
+++ b/samples/LmStreaming.Sample/Services/AgentHierarchyService.cs
@@ -365,11 +365,10 @@ public sealed class AgentHierarchyService(
         };
 
     /// <summary>
-    ///     Page size and total cap for the persisted sub-agent scan. <see cref="IConversationStore"/> has
+    ///     Total cap for the persisted sub-agent scan. <see cref="IConversationStore"/> has
     ///     no property index, so rebuilding a persisted child roster means scanning thread metadata; the
     ///     cap bounds the work on a long-lived store rather than scanning it unboundedly per request.
     /// </summary>
-    private const int SubAgentScanPageSize = 200;
     private const int SubAgentScanMaxThreads = 2000;
 
     /// <summary>
@@ -405,42 +404,45 @@ public sealed class AgentHierarchyService(
     ///     (<c>ConversationsController.BuildDescendantTreeAsync</c>), the flat listing never needs the
     ///     whole persisted graph, just this one conversation's own children.
     /// </summary>
+    /// <remarks>
+    ///     <b>One call, deliberately — not a paging loop.</b>
+    ///     <see cref="IConversationStore.ListThreadsAsync"/> is contractually "ordered by last updated
+    ///     descending", so paging with a growing offset sorts on a column the live conversations being
+    ///     scanned are mutating: a thread touched between two pages moves toward the front and pushes an
+    ///     unread neighbour back across the offset boundary, where the next page skips it. The roster that
+    ///     loses is then recorded in <see cref="SubAgentScanCoverageCache"/>, which holds its entries for
+    ///     the process lifetime — so the skip outlives the scan that caused it. A single call has no
+    ///     boundary to shift across; one more than the cap is requested so a full result stays
+    ///     distinguishable from a truncated one. Kept identical to
+    ///     <c>ConversationDescendantScanner.ScanAllPersistedSubAgentNodesAsync</c> on purpose: same store,
+    ///     same hazard, and fixing one of the pair alone is how the other one gets forgotten.
+    /// </remarks>
     private async Task<IReadOnlyList<SubAgentSummary>> ScanPersistedSubAgentChildrenAsync(
         string threadId,
         CancellationToken ct)
     {
+        var threads = await store.ListThreadsAsync(SubAgentScanMaxThreads + 1, 0, ct) ?? [];
+
+        var scanned = Math.Min(threads.Count, SubAgentScanMaxThreads);
         var found = new List<SubAgentSummary>();
-        var scanned = 0;
-
-        while (scanned < SubAgentScanMaxThreads)
+        for (var i = 0; i < scanned; i++)
         {
-            var page = await store.ListThreadsAsync(SubAgentScanPageSize, scanned, ct) ?? [];
-            if (page.Count == 0)
+            var node = SubAgentProvenance.TryProject(threads[i], threadId);
+            if (node is not null)
             {
-                return found;
-            }
-
-            scanned += page.Count;
-            foreach (var metadata in page)
-            {
-                var node = SubAgentProvenance.TryProject(metadata, threadId);
-                if (node is not null)
-                {
-                    found.Add(node);
-                }
-            }
-
-            if (page.Count < SubAgentScanPageSize)
-            {
-                return found;
+                found.Add(node);
             }
         }
 
-        logger.LogWarning(
-            "Sub-agent scan for {ThreadId} stopped at the {MaxThreads}-thread cap; "
-                + "children persisted beyond that point are not listed.",
-            threadId,
-            SubAgentScanMaxThreads);
+        if (threads.Count > SubAgentScanMaxThreads)
+        {
+            logger.LogWarning(
+                "Sub-agent scan for {ThreadId} stopped at the {MaxThreads}-thread cap; "
+                    + "children persisted beyond that point are not listed.",
+                threadId,
+                SubAgentScanMaxThreads);
+        }
+
         return found;
     }
 }

--- a/samples/LmStreaming.Sample/Services/ConversationDescendantScanner.cs
+++ b/samples/LmStreaming.Sample/Services/ConversationDescendantScanner.cs
@@ -1,0 +1,312 @@
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
+using LmStreaming.Sample.Models;
+using LmStreaming.Sample.Persistence;
+
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+///     Reconstructs the persisted descendant graph (children, grandchildren, ...) reachable from one root
+///     conversation, and remembers the answer per root so repeated readers do not each pay for a full
+///     store scan.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The traversal is lifted verbatim out of <c>ConversationsController.BuildDescendantTreeAsync</c>
+///         (issue #251, phase 2): one bounded <see cref="IConversationStore.ListThreadsAsync"/> paging
+///         scan, one in-memory parent→children index built from it, then a visited-set BFS from the root.
+///         Deliberately persisted-only — no live <c>SubAgentManager</c> union — because no current spawn
+///         path creates a depth-&gt;1 tree anyway (nested live Agent delegation stays disabled); this
+///         reader answers "what does the persisted graph say", which is exactly what a restarted host or
+///         a finished run still has. The root itself is never emitted as a node, only its descendants.
+///     </para>
+///     <para>
+///         <b>Why the cache is mandatory, not an optimisation.</b>
+///         <see cref="FileConversationStore.ListThreadsAsync"/> has no offset index: every call enumerates
+///         EVERY thread directory, deserializes every <c>metadata.json</c> (falling back to deserializing
+///         a whole <c>messages.json</c> when metadata is missing), sorts the lot, and only then applies
+///         <c>Skip(offset).Take(limit)</c>. A paged scan therefore costs pages × TotalThreadsInStore file
+///         reads, all serialized behind that store's single process-wide semaphore — so an uncached scan
+///         on every transcript flush would stall every other conversation in the host, not just this one.
+///     </para>
+///     <para>
+///         <b>Why this does NOT reuse <see cref="SubAgentScanCoverageCache"/>.</b> That cache answers a
+///         different question and reusing it here would be a correctness bug, not just a poor fit:
+///         (1) it caches the DIRECT-CHILD roster
+///         (<see cref="AgentHierarchyService.ScanPersistedSubAgentChildrenAsync"/>), not the transitive
+///         descendant graph this class builds; (2) it is keyed by (threadId, live-manager owner) with
+///         reference-equality owner matching, and its entries live for the process lifetime — the writer
+///         calling in here has no <c>SubAgentManager</c> to key on and would collapse onto the shared
+///         <see cref="SubAgentScanCoverageCache.NoLiveManager"/> sentinel; and (3) it deliberately caches
+///         EMPTY rosters as a valid "genuinely childless" answer, so a hit taken on a conversation that
+///         had no children at first flush would keep reporting "no descendants" forever and never
+///         discover a sub-agent spawned later in the same run. This cache is keyed by root alone and is
+///         explicitly refreshable (<see cref="NoteAgentActivity"/>) precisely so that a newly spawned
+///         sub-agent is discovered.
+///     </para>
+///     <para>
+///         <b>Refresh policy.</b> Discovery happens ONCE per conversation and is repeated only when a
+///         caller reports it observed new Agent-tool activity on that root — not once per turn, and never
+///         once per flush. <see cref="Forget"/> drops a root outright and is wired to
+///         <c>MultiTurnAgentPool.ThreadRemoved</c> by the composition root (the pool is deliberately not a
+///         constructor dependency: this type depends only on the store, so nothing in the pool's own
+///         construction graph can cycle back into it).
+///     </para>
+///     <para>
+///         <b>Bounded retention.</b> <see cref="_capacity"/> caps the number of distinct roots tracked;
+///         the oldest entry BY LAST WRITE is evicted first. Losing an entry only costs the next caller one
+///         extra scan — it does not lose data.
+///     </para>
+/// </remarks>
+public sealed class ConversationDescendantScanner
+{
+    /// <summary>Default cap on distinct roots tracked; mirrors <c>WorkflowRunRegistry</c>'s default.</summary>
+    public const int DefaultCapacity = WorkflowRunRegistry.DefaultMaxPersistedEntriesPerConversation;
+
+    /// <summary>
+    ///     Page size and total cap for the persisted sub-agent scan. <see cref="IConversationStore"/> has
+    ///     no property index, so rebuilding the roster means scanning thread metadata; the cap bounds the
+    ///     work on a long-lived store and truncation is logged rather than silently swallowed.
+    /// </summary>
+    private const int SubAgentScanPageSize = 200;
+    private const int SubAgentScanMaxThreads = 2000;
+
+    /// <summary>
+    ///     One root's cache slot. <see cref="Version"/> is bumped by <see cref="NoteAgentActivity"/>;
+    ///     <see cref="Nodes"/> is only served when <see cref="NodesVersion"/> still matches, so a refresh
+    ///     signalled WHILE a scan was in flight discards that scan's now-stale answer instead of recording
+    ///     it as fresh.
+    /// </summary>
+    private sealed class RootState
+    {
+        public long Version;
+        public long NodesVersion = -1;
+        public IReadOnlyList<SubAgentSummary>? Nodes;
+    }
+
+    private readonly IConversationStore _store;
+    private readonly ILogger<ConversationDescendantScanner> _logger;
+    private readonly int _capacity;
+
+    /// <summary>Guards both collections below; only in-memory bookkeeping is done under it, never a
+    /// store scan, so contention is negligible.</summary>
+    private readonly object _gate = new();
+    private readonly Dictionary<string, LinkedListNode<KeyValuePair<string, RootState>>> _byRoot = new(
+        StringComparer.Ordinal
+    );
+    private readonly LinkedList<KeyValuePair<string, RootState>> _writeOrder = new();
+
+    public ConversationDescendantScanner(
+        IConversationStore store,
+        ILogger<ConversationDescendantScanner> logger,
+        int capacity = DefaultCapacity)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(capacity, 1);
+        _store = store;
+        _logger = logger;
+        _capacity = capacity;
+    }
+
+    /// <summary>
+    ///     The uncached descendant graph for <paramref name="rootThreadId"/>, in the response order the
+    ///     recursive listing contract promises (depth, then parent thread id, then thread id — all
+    ///     ordinal). Always pays for a full store scan; callers that poll should use
+    ///     <see cref="GetOrScanAsync"/> instead.
+    /// </summary>
+    public async Task<IReadOnlyList<SubAgentSummary>> ScanAsync(
+        string rootThreadId,
+        CancellationToken ct = default)
+    {
+        var allNodes = await ScanAllPersistedSubAgentNodesAsync(rootThreadId, ct);
+        var childrenByParent = allNodes
+            .GroupBy(n => n.ParentThreadId!, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.Ordinal);
+
+        var discovered = new List<SubAgentSummary>();
+        var visited = new HashSet<string>(StringComparer.Ordinal) { rootThreadId };
+        var queue = new Queue<(string ThreadId, int Depth)>();
+        queue.Enqueue((rootThreadId, 0));
+
+        while (queue.Count > 0)
+        {
+            var (parentId, depth) = queue.Dequeue();
+            if (!childrenByParent.TryGetValue(parentId, out var children))
+            {
+                continue;
+            }
+
+            foreach (var child in children)
+            {
+                if (!visited.Add(child.ThreadId))
+                {
+                    // Cycle cut (or a diamond re-reachable via a second path) — the visited set has
+                    // already placed this thread at an earlier, shallower position. Log opaque ids
+                    // only: never Name/Template/Task, which may carry caller-supplied free text.
+                    _logger.LogWarning(
+                        "Sub-agent recursive scan for {RootThreadId} cut a repeat visit at thread "
+                            + "{ThreadId} (parent {ParentThreadId})",
+                        rootThreadId,
+                        child.ThreadId,
+                        parentId);
+                    continue;
+                }
+
+                var childDepth = depth + 1;
+                discovered.Add(child with { Depth = childDepth });
+                queue.Enqueue((child.ThreadId, childDepth));
+            }
+        }
+
+        return
+        [
+            .. discovered
+                .OrderBy(n => n.Depth)
+                .ThenBy(n => n.ParentThreadId, StringComparer.Ordinal)
+                .ThenBy(n => n.ThreadId, StringComparer.Ordinal),
+        ];
+    }
+
+    /// <summary>
+    ///     The descendant graph for <paramref name="rootThreadId"/>, scanned once and then served from
+    ///     memory until <see cref="NoteAgentActivity"/> or <see cref="Forget"/> says otherwise. An empty
+    ///     result is cached like any other: a root with no sub-agents must not re-scan on every call, and
+    ///     the refresh signal — not a cache miss — is what makes a later spawn visible.
+    /// </summary>
+    public async Task<IReadOnlyList<SubAgentSummary>> GetOrScanAsync(
+        string rootThreadId,
+        CancellationToken ct = default)
+    {
+        long observedVersion;
+        lock (_gate)
+        {
+            var state = GetOrAddState(rootThreadId);
+            if (state.Nodes is not null && state.NodesVersion == state.Version)
+            {
+                return state.Nodes;
+            }
+
+            observedVersion = state.Version;
+        }
+
+        // Scanned outside the lock: two callers that both miss simply both scan (redundant, not
+        // incorrect — equivalent data, last write wins), which beats holding a lock across store IO.
+        var nodes = await ScanAsync(rootThreadId, ct);
+
+        lock (_gate)
+        {
+            var state = GetOrAddState(rootThreadId);
+            if (state.Version == observedVersion)
+            {
+                state.Nodes = nodes;
+                state.NodesVersion = observedVersion;
+            }
+        }
+
+        return nodes;
+    }
+
+    /// <summary>
+    ///     Signals that new Agent-tool activity was observed on <paramref name="rootThreadId"/>, so the
+    ///     next <see cref="GetOrScanAsync"/> rediscovers its descendants. This is the ONLY refresh trigger
+    ///     besides <see cref="Forget"/> — callers must not call it once per turn or once per flush, only
+    ///     when they actually saw agent activity, since each call costs one full store scan.
+    /// </summary>
+    public void NoteAgentActivity(string rootThreadId)
+    {
+        lock (_gate)
+        {
+            // A root with no slot has nothing cached to invalidate, and its first GetOrScanAsync scans
+            // anyway — so recording a version for it would only grow the cache for no benefit.
+            if (_byRoot.TryGetValue(rootThreadId, out var node))
+            {
+                node.Value.Value.Version++;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Drops any remembered graph for <paramref name="rootThreadId"/>. Wired to
+    ///     <c>MultiTurnAgentPool.ThreadRemoved</c> so an evicted or deleted conversation cannot keep a
+    ///     stale graph alive — and so a later reuse of the same (client-suppliable) thread id never
+    ///     resurrects the previous conversation's descendants.
+    /// </summary>
+    public void Forget(string rootThreadId)
+    {
+        lock (_gate)
+        {
+            if (_byRoot.Remove(rootThreadId, out var node))
+            {
+                _writeOrder.Remove(node);
+            }
+        }
+    }
+
+    /// <summary>Returns the slot for <paramref name="rootThreadId"/>, creating (and bound-evicting) one
+    /// on first use. Callers must hold <see cref="_gate"/>.</summary>
+    private RootState GetOrAddState(string rootThreadId)
+    {
+        if (_byRoot.TryGetValue(rootThreadId, out var existing))
+        {
+            return existing.Value.Value;
+        }
+
+        var state = new RootState();
+        _byRoot[rootThreadId] = _writeOrder.AddLast(
+            new KeyValuePair<string, RootState>(rootThreadId, state));
+
+        while (_byRoot.Count > _capacity)
+        {
+            var oldest = _writeOrder.First!;
+            _writeOrder.RemoveFirst();
+            _ = _byRoot.Remove(oldest.Value.Key);
+        }
+
+        return state;
+    }
+
+    /// <summary>
+    ///     The single bounded store scan the descendant graph is built from — every stamped sub-agent
+    ///     thread, projected via the no-filter
+    ///     <see cref="SubAgentProvenance.TryProject(ThreadMetadata)"/> overload, regardless of who its
+    ///     parent is. The caller indexes the result in memory; nothing here queries the store again per
+    ///     node, satisfying the "one bounded scan per request" requirement even for the recursive,
+    ///     arbitrary-depth graph.
+    /// </summary>
+    private async Task<IReadOnlyList<SubAgentSummary>> ScanAllPersistedSubAgentNodesAsync(
+        string requestingThreadId,
+        CancellationToken ct)
+    {
+        var found = new List<SubAgentSummary>();
+        var scanned = 0;
+
+        while (scanned < SubAgentScanMaxThreads)
+        {
+            var page = await _store.ListThreadsAsync(SubAgentScanPageSize, scanned, ct) ?? [];
+            if (page.Count == 0)
+            {
+                return found;
+            }
+
+            scanned += page.Count;
+            foreach (var metadata in page)
+            {
+                var node = SubAgentProvenance.TryProject(metadata);
+                if (node is not null)
+                {
+                    found.Add(node);
+                }
+            }
+
+            if (page.Count < SubAgentScanPageSize)
+            {
+                return found;
+            }
+        }
+
+        _logger.LogWarning(
+            "Sub-agent scan for {ThreadId} stopped at the {MaxThreads}-thread cap; "
+                + "children persisted beyond that point are not listed.",
+            requestingThreadId,
+            SubAgentScanMaxThreads);
+        return found;
+    }
+}

--- a/samples/LmStreaming.Sample/Services/ConversationDescendantScanner.cs
+++ b/samples/LmStreaming.Sample/Services/ConversationDescendantScanner.cs
@@ -52,9 +52,12 @@ namespace LmStreaming.Sample.Services;
 ///         construction graph can cycle back into it).
 ///     </para>
 ///     <para>
-///         <b>Bounded retention.</b> <see cref="_capacity"/> caps the number of distinct roots tracked;
-///         the oldest entry BY LAST WRITE is evicted first. Losing an entry only costs the next caller one
-///         extra scan — it does not lose data.
+///         <b>Bounded retention.</b> <see cref="_capacity"/> caps the number of distinct roots tracked and
+///         the LEAST RECENTLY USED entry is evicted first — every read, every write-back and every
+///         reported activity renews its root, so a conversation that is actively mirroring cannot be
+///         dropped ahead of an idle one that merely happens to have been created later. Losing an entry
+///         only costs the next caller one extra scan — it does not lose data — which is why the renewal is
+///         an O(1) list splice and nothing more elaborate.
 ///     </para>
 /// </remarks>
 public sealed class ConversationDescendantScanner
@@ -93,7 +96,7 @@ public sealed class ConversationDescendantScanner
     private readonly Dictionary<string, LinkedListNode<KeyValuePair<string, RootState>>> _byRoot = new(
         StringComparer.Ordinal
     );
-    private readonly LinkedList<KeyValuePair<string, RootState>> _writeOrder = new();
+    private readonly LinkedList<KeyValuePair<string, RootState>> _usageOrder = new();
 
     public ConversationDescendantScanner(
         IConversationStore store,
@@ -219,6 +222,11 @@ public sealed class ConversationDescendantScanner
             if (_byRoot.TryGetValue(rootThreadId, out var node))
             {
                 node.Value.Value.Version++;
+
+                // Activity is USE, and the strongest signal there is that this conversation is live: the
+                // caller only raises it when it actually saw an Agent tool run. Renewing keeps a root that
+                // is spawning sub-agents right now from being evicted ahead of an idle one.
+                Renew(node);
             }
         }
     }
@@ -235,32 +243,46 @@ public sealed class ConversationDescendantScanner
         {
             if (_byRoot.Remove(rootThreadId, out var node))
             {
-                _writeOrder.Remove(node);
+                _usageOrder.Remove(node);
             }
         }
     }
 
-    /// <summary>Returns the slot for <paramref name="rootThreadId"/>, creating (and bound-evicting) one
-    /// on first use. Callers must hold <see cref="_gate"/>.</summary>
+    /// <summary>Returns the slot for <paramref name="rootThreadId"/>, renewing it as most-recently-used and
+    /// creating (and bound-evicting) one on first use. Callers must hold <see cref="_gate"/>.</summary>
     private RootState GetOrAddState(string rootThreadId)
     {
         if (_byRoot.TryGetValue(rootThreadId, out var existing))
         {
+            Renew(existing);
             return existing.Value.Value;
         }
 
         var state = new RootState();
-        _byRoot[rootThreadId] = _writeOrder.AddLast(
+        _byRoot[rootThreadId] = _usageOrder.AddLast(
             new KeyValuePair<string, RootState>(rootThreadId, state));
 
         while (_byRoot.Count > _capacity)
         {
-            var oldest = _writeOrder.First!;
-            _writeOrder.RemoveFirst();
+            var oldest = _usageOrder.First!;
+            _usageOrder.RemoveFirst();
             _ = _byRoot.Remove(oldest.Value.Key);
         }
 
         return state;
+    }
+
+    /// <summary>Moves a resident slot to the most-recently-used end. Callers must hold
+    /// <see cref="_gate"/>.</summary>
+    /// <remarks>
+    ///     An unlink and a re-link of a node the caller already holds — O(1), no rehash and no copy — which
+    ///     is the whole reason the order is a linked list beside the dictionary rather than a timestamp
+    ///     someone has to sort.
+    /// </remarks>
+    private void Renew(LinkedListNode<KeyValuePair<string, RootState>> node)
+    {
+        _usageOrder.Remove(node);
+        _usageOrder.AddLast(node);
     }
 
     /// <summary>

--- a/samples/LmStreaming.Sample/Services/ConversationDescendantScanner.cs
+++ b/samples/LmStreaming.Sample/Services/ConversationDescendantScanner.cs
@@ -79,6 +79,11 @@ public sealed class ConversationDescendantScanner
     ///     signalled WHILE a scan was in flight discards that scan's now-stale answer instead of recording
     ///     it as fresh.
     /// </summary>
+    /// <remarks>
+    ///     The INSTANCE is the slot's lifecycle identity and a scan in flight is bound to the one it
+    ///     started against — <see cref="Version"/> is a refresh counter, not a generation, and restarts at
+    ///     zero on every replacement slot, so it cannot by itself tell a slot apart from its successor.
+    /// </remarks>
     private sealed class RootState
     {
         public long Version;
@@ -178,16 +183,17 @@ public sealed class ConversationDescendantScanner
         string rootThreadId,
         CancellationToken ct = default)
     {
+        RootState observed;
         long observedVersion;
         lock (_gate)
         {
-            var state = GetOrAddState(rootThreadId);
-            if (state.Nodes is not null && state.NodesVersion == state.Version)
+            observed = GetOrAddState(rootThreadId);
+            if (observed.Nodes is not null && observed.NodesVersion == observed.Version)
             {
-                return state.Nodes;
+                return observed.Nodes;
             }
 
-            observedVersion = state.Version;
+            observedVersion = observed.Version;
         }
 
         // Scanned outside the lock: two callers that both miss simply both scan (redundant, not
@@ -196,11 +202,27 @@ public sealed class ConversationDescendantScanner
 
         lock (_gate)
         {
-            var state = GetOrAddState(rootThreadId);
-            if (state.Version == observedVersion)
+            // The SLOT INSTANCE, not the key, is what this scan's answer belongs to. A version match
+            // alone is not enough: Version starts at 0 on every new RootState, so if this root's slot was
+            // dropped mid-scan — by Forget, or by the bound-eviction in GetOrAddState — a slot re-created
+            // afterwards compares equal to the version observed before the drop, and this scan's answer
+            // (the PREVIOUS conversation's descendants, since a thread id is client-suppliable and may be
+            // reused) would be committed as the replacement's cached graph, then served to every later
+            // reader and mirrored into the wrong workspace.
+            //
+            // Looked up rather than GetOrAddState'd on purpose: when the original slot is gone there is
+            // nothing this answer may be written into, and creating one only to discard the result would
+            // grow the cache and can bound-evict a live root for nothing.
+            if (_byRoot.TryGetValue(rootThreadId, out var node)
+                && ReferenceEquals(node.Value.Value, observed))
             {
-                state.Nodes = nodes;
-                state.NodesVersion = observedVersion;
+                // A completed write-back is USE, so the slot is renewed even when the answer is stale.
+                Renew(node);
+                if (observed.Version == observedVersion)
+                {
+                    observed.Nodes = nodes;
+                    observed.NodesVersion = observedVersion;
+                }
             }
         }
 

--- a/samples/LmStreaming.Sample/Services/ConversationDescendantScanner.cs
+++ b/samples/LmStreaming.Sample/Services/ConversationDescendantScanner.cs
@@ -24,9 +24,9 @@ namespace LmStreaming.Sample.Services;
 ///         <see cref="FileConversationStore.ListThreadsAsync"/> has no offset index: every call enumerates
 ///         EVERY thread directory, deserializes every <c>metadata.json</c> (falling back to deserializing
 ///         a whole <c>messages.json</c> when metadata is missing), sorts the lot, and only then applies
-///         <c>Skip(offset).Take(limit)</c>. A paged scan therefore costs pages × TotalThreadsInStore file
-///         reads, all serialized behind that store's single process-wide semaphore — so an uncached scan
-///         on every transcript flush would stall every other conversation in the host, not just this one.
+///         <c>Skip(offset).Take(limit)</c>. A scan therefore costs TotalThreadsInStore file reads, all
+///         serialized behind that store's single process-wide semaphore — so an uncached scan on every
+///         transcript flush would stall every other conversation in the host, not just this one.
 ///     </para>
 ///     <para>
 ///         <b>Why this does NOT reuse <see cref="SubAgentScanCoverageCache"/>.</b> That cache answers a
@@ -66,11 +66,10 @@ public sealed class ConversationDescendantScanner
     public const int DefaultCapacity = WorkflowRunRegistry.DefaultMaxPersistedEntriesPerConversation;
 
     /// <summary>
-    ///     Page size and total cap for the persisted sub-agent scan. <see cref="IConversationStore"/> has
-    ///     no property index, so rebuilding the roster means scanning thread metadata; the cap bounds the
-    ///     work on a long-lived store and truncation is logged rather than silently swallowed.
+    ///     Total cap for the persisted sub-agent scan. <see cref="IConversationStore"/> has no property
+    ///     index, so rebuilding the roster means scanning thread metadata; the cap bounds the work on a
+    ///     long-lived store and truncation is logged rather than silently swallowed.
     /// </summary>
-    private const int SubAgentScanPageSize = 200;
     private const int SubAgentScanMaxThreads = 2000;
 
     /// <summary>
@@ -315,42 +314,46 @@ public sealed class ConversationDescendantScanner
     ///     node, satisfying the "one bounded scan per request" requirement even for the recursive,
     ///     arbitrary-depth graph.
     /// </summary>
+    /// <remarks>
+    ///     <b>One call, deliberately — not a paging loop.</b> Offset pagination over this store is unsound
+    ///     here, and not only in theory: <see cref="IConversationStore.ListThreadsAsync"/> is CONTRACTUALLY
+    ///     "ordered by last updated descending", so every implementation sorts on a column that the live
+    ///     conversations being scanned are mutating underneath the scan. A thread touched between page N
+    ///     and page N+1 moves toward the front and pushes an unread neighbour backwards across the offset
+    ///     boundary, where the next page's offset skips it for good — and the roster that skip corrupts is
+    ///     then CACHED, so one sub-agent silently loses its transcript for the life of the entry. A single
+    ///     call has no boundary to shift across. Asking for one more than the cap is what keeps the
+    ///     truncation warning honest, since a full page is otherwise indistinguishable from a truncated
+    ///     one. It is also cheaper on the store this class is most afraid of: per the note above,
+    ///     <see cref="FileConversationStore"/> re-enumerates EVERY thread directory per call, so paging
+    ///     multiplied that cost by the page count for no benefit.
+    /// </remarks>
     private async Task<IReadOnlyList<SubAgentSummary>> ScanAllPersistedSubAgentNodesAsync(
         string requestingThreadId,
         CancellationToken ct)
     {
+        var threads = await _store.ListThreadsAsync(SubAgentScanMaxThreads + 1, 0, ct) ?? [];
+
+        var scanned = Math.Min(threads.Count, SubAgentScanMaxThreads);
         var found = new List<SubAgentSummary>();
-        var scanned = 0;
-
-        while (scanned < SubAgentScanMaxThreads)
+        for (var i = 0; i < scanned; i++)
         {
-            var page = await _store.ListThreadsAsync(SubAgentScanPageSize, scanned, ct) ?? [];
-            if (page.Count == 0)
+            var node = SubAgentProvenance.TryProject(threads[i]);
+            if (node is not null)
             {
-                return found;
-            }
-
-            scanned += page.Count;
-            foreach (var metadata in page)
-            {
-                var node = SubAgentProvenance.TryProject(metadata);
-                if (node is not null)
-                {
-                    found.Add(node);
-                }
-            }
-
-            if (page.Count < SubAgentScanPageSize)
-            {
-                return found;
+                found.Add(node);
             }
         }
 
-        _logger.LogWarning(
-            "Sub-agent scan for {ThreadId} stopped at the {MaxThreads}-thread cap; "
-                + "children persisted beyond that point are not listed.",
-            requestingThreadId,
-            SubAgentScanMaxThreads);
+        if (threads.Count > SubAgentScanMaxThreads)
+        {
+            _logger.LogWarning(
+                "Sub-agent scan for {ThreadId} stopped at the {MaxThreads}-thread cap; "
+                    + "children persisted beyond that point are not listed.",
+                requestingThreadId,
+                SubAgentScanMaxThreads);
+        }
+
         return found;
     }
 }

--- a/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
+++ b/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
@@ -1077,10 +1077,13 @@ public sealed class ConversationTranscriptWriter
     ///     the name this code reasons about and the name the kernel opens are different names.
     ///     </para>
     ///     <para>
-    ///     Every OTHER consumer of this listing compares a name for EQUALITY against one it already holds
-    ///     (<c>FileBrowserController</c>, four call sites), so a traversing name there never matches
-    ///     anything. This is the only consumer that adopts a name it did not compute, which is why the
-    ///     check belongs here rather than in the browser.
+    ///     <c>FileBrowserController</c> lists the same way at five call sites. Four of them compare a name
+    ///     for EQUALITY against one they already hold, so a traversing name there never matches anything.
+    ///     The fifth does not: it projects every entry into a DTO for DISPLAY. That is a different risk
+    ///     class — a name that is rendered rather than one that is spliced into a path — and it is not what
+    ///     this predicate is for. What matters here is that this is the only consumer that ADDRESSES the
+    ///     filesystem with a name it did not compute, which is why the check belongs in this projection
+    ///     rather than in the browser.
     ///     </para>
     /// </remarks>
     private static bool IsAddressableName(SandboxDirectoryEntry entry) =>

--- a/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
+++ b/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
@@ -92,16 +92,20 @@ public enum TranscriptFlushOutcome
 ///     </para>
 ///     <para>
 ///     <b>The filesystem surface is a closed set of six calls</b>, listed here so the next reader can check
-///     coverage by enumeration rather than by searching. Three successive review rounds each fixed one
-///     surface and left another, because nobody had written down how many there were.
+///     coverage by enumeration rather than by searching. Four successive review rounds each fixed one
+///     surface and left another, because nobody had written down how many there were — and the round that
+///     first wrote this list down still recorded a wrong reason for leaving the sixth alone. Members rather
+///     than line numbers: a line-number table is stale by the next commit and reads as authoritative anyway.
 ///     <list type="table">
 ///         <item>
-///             <description><see cref="AdoptExistingLeafAsync"/> — lists the directory. The only one that is
-///             deliberately unguarded; see the rejection recorded on that method.</description>
+///             <description><see cref="AdoptExistingLeafAsync"/> — lists the directory. Reads names, never
+///             content, and writes nothing; its guard is therefore a SHAPE guard rather than a redirection
+///             one, because this is the only call that takes a path component from outside. See
+///             <see cref="IsAddressableName"/>.</description>
 ///         </item>
 ///         <item>
 ///             <description><see cref="AppendAsync"/> — PUTs the staged payload. Guarded by
-///             <see cref="IsPathSafeAsync"/> per append.</description>
+///             <see cref="IsPathSafeAsync"/> per append, uncached.</description>
 ///         </item>
 ///         <item>
 ///             <description><see cref="AppendAsync"/> — runs <see cref="AppendScript"/>. Guards its three
@@ -109,17 +113,25 @@ public enum TranscriptFlushOutcome
 ///         </item>
 ///         <item>
 ///             <description><see cref="RecoverWatermarkAsync"/> — runs <see cref="WatermarkProbeScript"/>.
-///             Guards in-script.</description>
+///             Guards in-script; its output is bounded per line and is never logged.</description>
 ///         </item>
 ///         <item>
 ///             <description><see cref="EnsureGitignoreAsync"/> — PUTs the <c>.gitignore</c>. Guarded by
-///             <see cref="IsPathSafeAsync"/>.</description>
+///             <see cref="IsPathSafeAsync"/>. This is the write that DESTROYS rather than leaks.</description>
 ///         </item>
 ///         <item>
 ///             <description><see cref="TryMoveAsync"/> — runs <see cref="MoveScript"/>. Guards both operands
 ///             in-script and additionally refuses a destination that resolves to a directory.</description>
 ///         </item>
 ///     </list>
+///     </para>
+///     <para>
+///     <b>What none of the six can cover.</b> <c>[ -L ]</c> does not see a HARD link, and no shell test
+///     does; a hard link planted at a transcript's name is written through with every guard reporting
+///     clean. That is left uncovered deliberately rather than overlooked — closing it needs
+///     <c>O_NOFOLLOW</c>/<c>st_nlink</c> checks the gateway does not expose, and Linux's
+///     <c>fs.protected_hardlinks</c> already blocks the interesting targets, which are files the sandboxed
+///     user neither owns nor may write.
 ///     </para>
 ///     <para>
 ///     <b>Concurrency:</b> <see cref="FlushAsync"/> is not re-entrant and must not be called concurrently
@@ -953,15 +965,19 @@ public sealed class ConversationTranscriptWriter
     ///     preferable to starting a second one.
     ///     </para>
     ///     <para>
-    ///     <b>Deliberately unguarded, and the reason is the guards downstream — not the listing.</b> A
+    ///     <b>The downstream guards are not enough on their own; the name needs a shape check here.</b> A
     ///     redirected <c>.conversations</c> makes this listing return attacker-chosen entries, and one of
-    ///     them can be adopted as the leaf. That is contained rather than trusted: the adopted stem must
-    ///     satisfy <see cref="IsThisConversation"/>, so it carries this conversation's own short id; it is
-    ///     used only as the source operand of <see cref="MoveScript"/>, which guards <i>both</i> operands,
-    ///     so a planted symlink is refused at the rename rather than followed; and every write that could
-    ///     follow is guarded at its own call site. A directory entry name cannot contain a separator, so an
-    ///     entry cannot widen the path it is spliced into. What an attacker gets is a mirror that refuses
-    ///     and defers — an availability cost, not a disclosure.
+    ///     them can be adopted as the leaf. Most of that is genuinely contained downstream: the adopted stem
+    ///     must satisfy <see cref="IsThisConversation"/>, it reaches the filesystem as the guarded source
+    ///     operand of <see cref="MoveScript"/>, and every write that follows is guarded at its own call
+    ///     site. What is NOT contained downstream is a name that is not a single path component. An earlier
+    ///     revision of this note claimed a directory entry name cannot contain a separator and concluded the
+    ///     exposure was availability rather than disclosure; that was wrong, and wrong in the direction that
+    ///     matters. This code does not read <c>readdir</c> — it reads a <c>name</c> field out of the
+    ///     gateway's JSON, and nothing between the two enforces the invariant. A separator in that name
+    ///     walks straight out of the transcript directory past an ancestor check that has nothing to refuse,
+    ///     because <c>..</c> is a real directory. See <see cref="IsAddressableName"/>, which is the check
+    ///     that closes it.
     ///     </para>
     /// </remarks>
     private async Task<(bool Listed, string? Leaf)> AdoptExistingLeafAsync(
@@ -989,7 +1005,7 @@ public sealed class ConversationTranscriptWriter
         }
 
         var stale = entries
-            .Where(entry => entry.Type == SandboxEntryType.File && !entry.NameLossy)
+            .Where(entry => entry.Type == SandboxEntryType.File && IsAddressableName(entry))
             .Select(entry => entry.Name)
             .Where(name => name.EndsWith(TranscriptExtension, StringComparison.Ordinal))
             .Select(name => name[..^TranscriptExtension.Length])
@@ -1004,7 +1020,7 @@ public sealed class ConversationTranscriptWriter
             _agentsDirectoryTouched
             || entries.Any(entry =>
                 entry.Type == SandboxEntryType.Directory
-                && !entry.NameLossy
+                && IsAddressableName(entry)
                 && string.Equals(entry.Name, subject + AgentsDirectorySuffix, StringComparison.Ordinal));
 
         if (stale is null)
@@ -1034,6 +1050,45 @@ public sealed class ConversationTranscriptWriter
     private bool IsThisConversation(string stem) =>
         string.Equals(stem, _shortThreadId, StringComparison.Ordinal)
         || stem.EndsWith($"-{_shortThreadId}", StringComparison.Ordinal);
+
+    /// <summary>
+    ///     Whether a listed entry's name may be used to BUILD a path. Both halves are about addressability:
+    ///     a lossy name cannot round-trip to the bytes on disk, and a name that is not a single path
+    ///     component is not the thing the caller thinks it is.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <b>The adopted leaf is the one path component in this type that the writer does not compute.</b>
+    ///     Every other segment — the transcript directory, the temp name, the <c>.gitignore</c>, the
+    ///     title-derived slug — is minted here. An adopted stem arrives as a <c>name</c> field in the
+    ///     gateway's JSON, and <see cref="SandboxDirectoryEntry.Name"/> documents itself as a non-recursive
+    ///     name "excluding <c>.</c> and <c>..</c>" WITHOUT enforcing it:
+    ///     <c>SandboxClient.ListDirectoryEntriesAsync</c> checks only that a name is present and states that
+    ///     per-entry validation is left to each caller's projection. This is that projection.
+    ///     </para>
+    ///     <para>
+    ///     A name carrying <c>/</c> would defeat every other guard here, and not narrowly. The ancestor walk
+    ///     tests each component with <c>[ -L ]</c>, and <c>..</c> is a real directory rather than a symlink,
+    ///     so the walk passes; the path then reaches <c>cat &gt;&gt; "$3"</c> inside the container, which no
+    ///     gateway path validation mediates because it is argv to a shell, not a file API call. The
+    ///     unredacted transcript would land outside <c>.conversations</c> — outside the <c>.gitignore</c>
+    ///     that is the whole containment mechanism — at exit code 0, taking the <c>_agents</c> directory
+    ///     with it. A NUL is rejected on the same footing: it truncates the path at the exec boundary, so
+    ///     the name this code reasons about and the name the kernel opens are different names.
+    ///     </para>
+    ///     <para>
+    ///     Every OTHER consumer of this listing compares a name for EQUALITY against one it already holds
+    ///     (<c>FileBrowserController</c>, four call sites), so a traversing name there never matches
+    ///     anything. This is the only consumer that adopts a name it did not compute, which is why the
+    ///     check belongs here rather than in the browser.
+    ///     </para>
+    /// </remarks>
+    private static bool IsAddressableName(SandboxDirectoryEntry entry) =>
+        !entry.NameLossy
+        && entry.Name.Length > 0
+        && entry.Name.AsSpan().IndexOfAny('/', '\0') < 0
+        && !string.Equals(entry.Name, ".", StringComparison.Ordinal)
+        && !string.Equals(entry.Name, "..", StringComparison.Ordinal);
 
     /// <summary>Renames one transcript file and, when asked, its sibling sub-agent directory.</summary>
     /// <returns>Whether the FILE moved — the only condition under which the new leaf may be adopted.</returns>
@@ -1622,11 +1677,19 @@ public sealed class ConversationTranscriptWriter
     ///     and "this could not be checked" alike, and both are reasons to leave the workspace untouched.
     /// </summary>
     /// <remarks>
+    ///     <para>
     ///     Only the two writes that reach the workspace WITHOUT a shell need this — the staged payload and
     ///     the <c>.gitignore</c>. Everything the shell writes carries its guard inside the same script it
     ///     writes with, which is both cheaper (no extra round trip) and tighter (no gap between the check
     ///     and the write). See <see cref="UnsafePathExitCode"/> for why the answer is refusal rather than
     ///     repair.
+    ///     </para>
+    ///     <para>
+    ///     This is one of six filesystem entry points, and the six are enumerated ONCE, on the class. Keep
+    ///     them there rather than restating them here: two copies of a coverage table drift, and a drifted
+    ///     coverage table is worse than none, because the reason to enumerate is to be able to trust the
+    ///     count. Anything new that touches <c>_fileBrowser</c> belongs in that list.
+    ///     </para>
     /// </remarks>
     private async Task<bool> IsPathSafeAsync(string sessionId, string path, CancellationToken ct)
     {

--- a/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
+++ b/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
@@ -1,0 +1,887 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmAgentInfra.Agents;
+using AchieveAi.LmDotnetTools.LmAgentInfra.Sandbox;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
+using AchieveAi.LmDotnetTools.Sandbox;
+using LmStreaming.Sample.Models;
+
+namespace LmStreaming.Sample.Services;
+
+/// <summary>What one <see cref="ConversationTranscriptWriter.FlushAsync"/> attempt achieved.</summary>
+/// <remarks>
+///     The mirror is best-effort, so this is advisory rather than a status code: its only real consumer
+///     decision is "should I schedule another flush?", and only <see cref="Deferred"/> answers yes.
+///     <see cref="Unavailable"/> deliberately does NOT ask for a re-schedule — a conversation with no
+///     sandbox session would otherwise spin the drain loop forever.
+/// </remarks>
+public enum TranscriptFlushOutcome
+{
+    /// <summary>Every file already ended at the current watermark; nothing was appended.</summary>
+    UpToDate,
+
+    /// <summary>At least one transcript file was appended to and its watermark advanced.</summary>
+    Written,
+
+    /// <summary>
+    ///     Work remains: a read never settled, a gateway call failed, or the sub-agent fan-out was capped.
+    ///     The watermarks involved are unadvanced, so a later flush repeats the work. <b>Re-schedule.</b>
+    /// </summary>
+    Deferred,
+
+    /// <summary>
+    ///     There is no workspace session to write into (no workspace bound, no session, credential
+    ///     conflict, gateway unreachable). Nothing was written and nothing is pending.
+    /// </summary>
+    Unavailable,
+}
+
+/// <summary>
+///     Mirrors ONE conversation's persisted messages into <c>.conversations/</c> inside that
+///     conversation's sandbox workspace, as append-only JSONL (#251) — the main thread into
+///     <c>{slug(title)}-{shortThreadId}.jsonl</c>, each sub-agent into a file under the sibling
+///     <c>{slug(title)}-{shortThreadId}_agents/</c> directory. One instance per conversation; it owns
+///     that conversation's watermarks and its last-known file leaf.
+/// </summary>
+/// <remarks>
+///     <para>
+///     <b>Failure policy: best-effort, never propagating.</b> Every path catches, logs, and leaves the
+///     watermark unadvanced. The failure direction is always duplicate-on-retry, never silent loss — a
+///     reader deduplicates on <c>uid</c> (which is a pure function of the persisted row id), so a repeated
+///     append costs bytes, whereas a skipped append costs the record itself.
+///     </para>
+///     <para>
+///     <b>Writes go through exactly one shell call site</b> (<see cref="AppendScript"/>).
+///     <c>ExecuteWorkspaceCommandAsync</c> is a native argv vector with no implicit shell, so a shell is
+///     invoked explicitly. The script text is a compile-time constant and <i>no dynamic value is ever
+///     interpolated into it</i>: the destination directory, the temp file and the destination file arrive
+///     as positional parameters <c>$1</c>/<c>$2</c>/<c>$3</c>. That matters because the file leaf is
+///     derived from a user-authored conversation title. <c>--</c> on the pure-argv calls stops option
+///     parsing, which is worth having, but it is the positional parameters — not <c>--</c> — that make a
+///     title containing <c>$(…)</c> or whitespace inert.
+///     </para>
+///     <para>
+///     <b>Concurrency:</b> <see cref="FlushAsync"/> is not re-entrant and must not be called concurrently
+///     with itself for the same conversation. <see cref="TranscriptFlushScheduler"/> guarantees that (a
+///     single drain loop). The sub-agent fan-out inside one flush is likewise strictly sequential; see
+///     <see cref="FlushSubAgentsAsync"/>.
+///     </para>
+/// </remarks>
+public sealed class ConversationTranscriptWriter
+{
+    /// <summary>Workspace-relative directory every transcript file lives under.</summary>
+    public const string TranscriptDirectory = ".conversations";
+
+    /// <summary>Extension of every transcript file.</summary>
+    public const string TranscriptExtension = ".jsonl";
+
+    /// <summary>Suffix appended to the main file leaf to form the sibling sub-agent directory.</summary>
+    public const string AgentsDirectorySuffix = "_agents";
+
+    /// <summary>Extension of the staged temp file the splice consumes.</summary>
+    public const string TempExtension = ".part";
+
+    /// <summary>Directory the staged temp file is PUT into, workspace-relative.</summary>
+    public const string TempDirectory = TranscriptDirectory + "/.tmp";
+
+    /// <summary>Name of the containment file written once per conversation.</summary>
+    public const string GitignoreName = "gitignore";
+
+    /// <summary>
+    ///     How many trailing lines the cold-start watermark probe asks <c>tail</c> for. Five, not one:
+    ///     a previous run can have been killed mid-splice, leaving a torn final line that will not parse.
+    ///     Reading a window and walking it bottom-up finds the last INTACT record instead of concluding
+    ///     "unreadable" and re-appending the whole history.
+    /// </summary>
+    public const int WatermarkTailLines = 5;
+
+    /// <summary>
+    ///     How many times a re-read may disagree with its predecessor before the flush gives up. See
+    ///     <see cref="ReadStableAsync"/> for why reading twice is not optional.
+    /// </summary>
+    public const int MaxStabilityAttempts = 3;
+
+    /// <summary>Default cap on sub-agent files written per flush. See <see cref="FlushSubAgentsAsync"/>.</summary>
+    public const int DefaultMaxSubAgentFilesPerFlush = 8;
+
+    /// <summary>
+    ///     Default pause between the two reads of the stability probe. Long enough for the fire-and-forget
+    ///     persistence task of a just-completed turn to land, short enough to be invisible on a background
+    ///     drain. Overridable (tests pass <see cref="TimeSpan.Zero"/>).
+    /// </summary>
+    public static readonly TimeSpan DefaultReadSettleDelay = TimeSpan.FromMilliseconds(150);
+
+    /// <summary>
+    ///     Key in <see cref="ThreadMetadata.Properties"/> holding the conversation title. Deliberately the
+    ///     UN-namespaced key <c>ConversationsController</c> writes on <c>PUT {threadId}/metadata</c>; a
+    ///     retitle never reaches the message stream, so this metadata read is the mirror's only way to
+    ///     notice one.
+    /// </summary>
+    private const string TitlePropertyKey = "title";
+
+    /// <summary>
+    ///     THE one shell call site. Built from concatenated literals rather than a raw string literal so
+    ///     the line endings are LF regardless of how this source file is checked out — a script carrying
+    ///     CR bytes fails inside the container in ways that are tedious to diagnose.
+    /// </summary>
+    /// <remarks>
+    ///     <para><c>$1</c> destination directory, <c>$2</c> staged temp file, <c>$3</c> destination file.</para>
+    ///     <para>
+    ///     The middle line is the <b>newline weld</b>. If a previous splice was interrupted the destination
+    ///     can end mid-record with no trailing newline; appending straight onto it would fuse two records
+    ///     into one unparseable line, destroying the intact record as well as the torn one. Welding a
+    ///     newline on first costs one blank-ish boundary and keeps the damage to the single torn line.
+    ///     </para>
+    ///     <para>
+    ///     <c>rm -f "$2"</c> is chained after a successful append, so a failure leaks at most one
+    ///     <c>.part</c> file per conversation — a name no <c>**/*.jsonl</c> scan matches, in a directory a
+    ///     <c>.gitignore</c> already covers.
+    ///     </para>
+    /// </remarks>
+    private const string AppendScript =
+        "mkdir -p \"$1\" || exit 1\n"
+        + "if [ -s \"$3\" ] && [ -n \"$(tail -c1 \"$3\")\" ]; then printf '\\n' >> \"$3\" || exit 1; fi\n"
+        + "cat \"$2\" >> \"$3\" && rm -f \"$2\"\n";
+
+    private readonly IConversationStore _store;
+    private readonly IWorkspaceFileBrowser _fileBrowser;
+    private readonly ConversationDescendantScanner _descendants;
+    private readonly ILogger<ConversationTranscriptWriter> _logger;
+    private readonly TimeSpan _readSettleDelay;
+    private readonly int _maxSubAgentFilesPerFlush;
+    private readonly string _shortThreadId;
+    private readonly string _tempPath;
+
+    /// <summary>
+    ///     Last appended <c>uid</c> per file, keyed by the THREAD whose rows that file holds — the
+    ///     conversation for the main file, the sub-agent's own thread for an <c>_agents/</c> file. Keyed by
+    ///     thread and not by path on purpose: a retitle renames the file, and a watermark that moved with
+    ///     the name would restart the whole history every time somebody edits a title.
+    /// </summary>
+    private readonly Dictionary<string, string> _watermarks = new(StringComparer.Ordinal);
+
+    /// <summary>
+    ///     The <c>parent_uid</c> each sub-agent file's first line was minted with, so it stays stable for
+    ///     the life of the process instead of drifting with the main file's watermark.
+    /// </summary>
+    private readonly Dictionary<string, string?> _agentRootParentUids = new(StringComparer.Ordinal);
+
+    /// <summary>Files already warned about, so the "appending everything" warning stays a one-off.</summary>
+    private readonly HashSet<string> _fullAppendWarned = new(StringComparer.Ordinal);
+
+    private string? _leaf;
+    private bool _gitignoreWritten;
+    private bool _agentsDirectoryTouched;
+    private int _subAgentCursor;
+    private int _sawSubAgentActivity;
+
+    /// <summary>Creates the writer for one conversation.</summary>
+    /// <param name="threadId">The conversation's thread id.</param>
+    /// <param name="store">Source of the persisted rows and of the conversation's metadata.</param>
+    /// <param name="fileBrowser">The sandbox seam: session resolution, file PUT, command execution.</param>
+    /// <param name="descendants">Cached sub-agent graph used for the fan-out.</param>
+    /// <param name="logger">Every failure reports here; nothing is thrown to the caller.</param>
+    /// <param name="readSettleDelay">Overrides <see cref="DefaultReadSettleDelay"/>.</param>
+    /// <param name="maxSubAgentFilesPerFlush">Overrides <see cref="DefaultMaxSubAgentFilesPerFlush"/>.</param>
+    /// <exception cref="ArgumentException"><paramref name="threadId"/> is blank.</exception>
+    /// <exception cref="ArgumentNullException">A required dependency is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxSubAgentFilesPerFlush"/> is not positive.</exception>
+    public ConversationTranscriptWriter(
+        string threadId,
+        IConversationStore store,
+        IWorkspaceFileBrowser fileBrowser,
+        ConversationDescendantScanner descendants,
+        ILogger<ConversationTranscriptWriter> logger,
+        TimeSpan? readSettleDelay = null,
+        int maxSubAgentFilesPerFlush = DefaultMaxSubAgentFilesPerFlush)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(threadId);
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(fileBrowser);
+        ArgumentNullException.ThrowIfNull(descendants);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxSubAgentFilesPerFlush);
+
+        ThreadId = threadId;
+        _store = store;
+        _fileBrowser = fileBrowser;
+        _descendants = descendants;
+        _logger = logger;
+        _readSettleDelay = readSettleDelay ?? DefaultReadSettleDelay;
+        _maxSubAgentFilesPerFlush = maxSubAgentFilesPerFlush;
+        _shortThreadId = WorkspaceTranscriptLine.ShortId(threadId);
+        _tempPath = $"{TempDirectory}/{_shortThreadId}{TempExtension}";
+    }
+
+    /// <summary>The conversation this writer mirrors.</summary>
+    public string ThreadId { get; }
+
+    /// <summary>
+    ///     Records that sub-agent activity was observed (a relayed sub-agent result or notification), so
+    ///     the next flush refreshes the descendant graph before fanning out.
+    /// </summary>
+    /// <remarks>
+    ///     Separate from scheduling on purpose. A sub-agent finishing does not publish the conversation's
+    ///     <c>RunCompletedMessage</c>, so a mirror that only listened for run completion would never write
+    ///     an <c>_agents/</c> file for a sub-agent whose parent turn had already ended. It is also the only
+    ///     safe trigger for <see cref="ConversationDescendantScanner.NoteAgentActivity"/>, which costs a
+    ///     full store scan and must not be called once per flush. Cheap and thread-safe: callable straight
+    ///     from the message-subscriber hot path.
+    /// </remarks>
+    public void NoteSubAgentActivity() => Interlocked.Exchange(ref _sawSubAgentActivity, 1);
+
+    /// <summary>
+    ///     Mirrors everything this conversation has persisted since the last successful flush. Never
+    ///     throws: a failure is logged, the affected watermark is left unadvanced, and the outcome says
+    ///     whether the caller should schedule another attempt.
+    /// </summary>
+    public async Task<TranscriptFlushOutcome> FlushAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            return await FlushCoreAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Host shutdown, not a fault. Swallowed rather than rethrown because the mirror's contract is
+            // that it never propagates; the interrupted work is picked up by the next completed run.
+            _logger.LogDebug("Transcript flush for thread {ThreadId} cancelled", ThreadId);
+            return TranscriptFlushOutcome.Unavailable;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Transcript flush for thread {ThreadId} failed", ThreadId);
+            return TranscriptFlushOutcome.Unavailable;
+        }
+    }
+
+    private async Task<TranscriptFlushOutcome> FlushCoreAsync(CancellationToken ct)
+    {
+        // Metadata carries BOTH values the flush needs — the workspace binding for step 1 and the title
+        // for the retitle check — so it is read once here rather than twice at the two points of use.
+        var metadata = await _store.LoadMetadataAsync(ThreadId, ct).ConfigureAwait(false);
+
+        var sessionId = await ResolveSessionAsync(metadata, ct).ConfigureAwait(false);
+        if (sessionId is null)
+        {
+            return TranscriptFlushOutcome.Unavailable;
+        }
+
+        var messages = await ReadStableAsync(ThreadId, ct).ConfigureAwait(false);
+        if (messages is null)
+        {
+            return TranscriptFlushOutcome.Deferred;
+        }
+
+        // Step 4, and it must stay ahead of every append in this drain: a retitle that is noticed only
+        // after the append leaves a second file holding a duplicate of the entire history.
+        await ApplyRetitleAsync(sessionId, metadata, ct).ConfigureAwait(false);
+        var leaf = _leaf!;
+
+        var lines = WorkspaceTranscriptLine.ChainMessages(messages);
+        var mainResult = await AppendAsync(
+            sessionId,
+            TranscriptDirectory,
+            $"{TranscriptDirectory}/{leaf}{TranscriptExtension}",
+            ThreadId,
+            lines,
+            ct
+        ).ConfigureAwait(false);
+
+        var wrote = mainResult == AppendResult.Appended;
+        var deferred = mainResult == AppendResult.Failed;
+
+        var (agentsWrote, agentsDeferred) = await FlushSubAgentsAsync(sessionId, leaf, ct).ConfigureAwait(false);
+        wrote = wrote || agentsWrote;
+
+        if (wrote)
+        {
+            await EnsureGitignoreAsync(sessionId, ct).ConfigureAwait(false);
+        }
+
+        return (deferred || agentsDeferred) ? TranscriptFlushOutcome.Deferred
+            : wrote ? TranscriptFlushOutcome.Written
+            : TranscriptFlushOutcome.UpToDate;
+    }
+
+    // -------- Step 1: session --------
+
+    /// <summary>
+    ///     Resolves the conversation's workspace session, or reports null for every reason a background
+    ///     flush legitimately has none.
+    /// </summary>
+    /// <remarks>
+    ///     The credential is always null: a flush has no inbound HTTP request to borrow one from. That is
+    ///     also why an S2S-owned session reports <c>CredentialConflict</c> forever and gets no transcript
+    ///     in v1 — an accepted, recorded gap (ADR 0011), not a bug to retry around.
+    /// </remarks>
+    private async Task<string?> ResolveSessionAsync(ThreadMetadata? metadata, CancellationToken ct)
+    {
+        var workspaceId = ReadWorkspaceId(metadata);
+        if (workspaceId is null)
+        {
+            _logger.LogDebug("No workspace bound to thread {ThreadId}; transcript flush skipped", ThreadId);
+            return null;
+        }
+
+        SandboxSessionResolution resolution;
+        try
+        {
+            resolution = await _fileBrowser
+                .ResolveThreadWorkspaceSessionAsync(ThreadId, workspaceId, requestCredential: null, ct)
+                .ConfigureAwait(false);
+        }
+        catch (SandboxSessionUnavailableException ex)
+        {
+            // The gateway could not recreate an idle-evicted session. Expected background weather, not an
+            // error the operator needs to see once per turn.
+            _logger.LogDebug(ex, "Sandbox session unavailable for thread {ThreadId}; transcript flush skipped", ThreadId);
+            return null;
+        }
+        catch (SandboxException ex)
+        {
+            _logger.LogWarning(ex, "Sandbox rejected session resolution for thread {ThreadId}", ThreadId);
+            return null;
+        }
+
+        if (resolution is { Outcome: SandboxSessionResolutionOutcome.Resolved, Session: { } session })
+        {
+            return session.SessionId;
+        }
+
+        if (resolution.Outcome == SandboxSessionResolutionOutcome.CredentialConflict)
+        {
+            _logger.LogWarning(
+                "Transcript flush for thread {ThreadId} skipped: session is owned by {ExistingAppId}",
+                ThreadId,
+                resolution.ExistingAppId ?? "(none)"
+            );
+            return null;
+        }
+
+        _logger.LogDebug("No sandbox session for thread {ThreadId}; transcript flush skipped", ThreadId);
+        return null;
+    }
+
+    // -------- Step 2: read until stable --------
+
+    /// <summary>
+    ///     Reads a thread's rows twice and only accepts them once two consecutive reads agree, then
+    ///     normalizes (step 3). Reports null when the rows never settled, which leaves every watermark
+    ///     unadvanced and asks the caller to re-schedule.
+    /// </summary>
+    /// <remarks>
+    ///     <b>Not defensive padding.</b> <c>MultiTurnAgentBase.AddToHistory</c> persists on a discarded,
+    ///     unawaited task, and <c>CompleteRunAsync</c> publishes run completion without joining those
+    ///     tasks — so at the instant a flush is triggered the turn's final assistant and reasoning rows are
+    ///     commonly still in flight. Appending the truncated list would be bad enough on its own; the worse
+    ///     half is that the late row then lands at the file tail on the NEXT flush, giving it a
+    ///     <c>parent_uid</c> pointing at a row it did not follow. Comparing row ids is comparing uids: a
+    ///     uid is a pure function of the persisted id.
+    /// </remarks>
+    private async Task<List<PersistedMessage>?> ReadStableAsync(string threadId, CancellationToken ct)
+    {
+        var previous = await _store.LoadMessagesAsync(threadId, ct).ConfigureAwait(false);
+        for (var attempt = 0; attempt < MaxStabilityAttempts; attempt++)
+        {
+            if (_readSettleDelay > TimeSpan.Zero)
+            {
+                await Task.Delay(_readSettleDelay, ct).ConfigureAwait(false);
+            }
+
+            var current = await _store.LoadMessagesAsync(threadId, ct).ConfigureAwait(false);
+            if (SameSequence(previous, current))
+            {
+                return TranscriptProjection.Normalize(current, excludeReasoning: false);
+            }
+
+            previous = current;
+        }
+
+        _logger.LogDebug(
+            "Thread {ThreadId} rows did not settle in {Attempts} attempts; transcript flush deferred",
+            threadId,
+            MaxStabilityAttempts
+        );
+        return null;
+    }
+
+    private static bool SameSequence(IReadOnlyList<PersistedMessage> left, IReadOnlyList<PersistedMessage> right)
+    {
+        if (left.Count != right.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < left.Count; i++)
+        {
+            if (!string.Equals(left[i].Id, right[i].Id, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // -------- Step 4: retitle --------
+
+    /// <summary>
+    ///     Notices a title change and renames the conversation's file (and, when this writer has written
+    ///     any, its sub-agent directory) before anything is appended this flush.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Adoption of the new leaf is gated on the FILE move succeeding: on failure the flush keeps
+    ///     writing to the old path — which a failed <c>mv</c> left in place, complete and readable — and
+    ///     retries next time.
+    ///     </para>
+    ///     <para>
+    ///     The directory move is attempted only after the file move succeeded and only when this writer has
+    ///     actually written a sub-agent file. A conversation with no sub-agents has no directory to move,
+    ///     and issuing the <c>mv</c> anyway would fail every time and wedge the rename. If the directory
+    ///     move does fail, the in-memory sub-agent watermarks describe files that did not move, so they are
+    ///     dropped: the directory is rebuilt in full under the new name (duplicate rows, which dedupe on
+    ///     <c>uid</c>) rather than silently resuming past rows the new files do not contain.
+    ///     </para>
+    /// </remarks>
+    private async Task ApplyRetitleAsync(string sessionId, ThreadMetadata? metadata, CancellationToken ct)
+    {
+        var leaf = WorkspaceTranscriptLine.MainFileLeaf(ReadTitle(metadata), _shortThreadId);
+        if (_leaf is null)
+        {
+            // Cold start: nothing to rename. A title changed while this process was down is recovered by
+            // the watermark probe against the new path, which finds no file and appends everything.
+            _leaf = leaf;
+            return;
+        }
+
+        if (string.Equals(_leaf, leaf, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var previous = _leaf;
+        var moved = await TryMoveAsync(
+            sessionId,
+            $"{TranscriptDirectory}/{previous}{TranscriptExtension}",
+            $"{TranscriptDirectory}/{leaf}{TranscriptExtension}",
+            ct
+        ).ConfigureAwait(false);
+
+        if (!moved)
+        {
+            return;
+        }
+
+        if (_agentsDirectoryTouched
+            && !await TryMoveAsync(
+                sessionId,
+                $"{TranscriptDirectory}/{previous}{AgentsDirectorySuffix}",
+                $"{TranscriptDirectory}/{leaf}{AgentsDirectorySuffix}",
+                ct
+            ).ConfigureAwait(false))
+        {
+            DropSubAgentState();
+        }
+
+        _leaf = leaf;
+    }
+
+    private void DropSubAgentState()
+    {
+        foreach (var key in _agentRootParentUids.Keys)
+        {
+            _ = _watermarks.Remove(key);
+        }
+
+        _agentRootParentUids.Clear();
+        _agentsDirectoryTouched = false;
+    }
+
+    // -------- Sub-agent fan-out --------
+
+    /// <summary>
+    ///     Mirrors each descendant thread through the same pipeline, one file per sub-agent.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <b>STRICTLY SEQUENTIAL — a hard requirement, not a style preference.</b> Every file in this
+    ///     conversation is spliced through ONE staged temp path, so two overlapping writes would PUT over
+    ///     each other's bytes and <c>cat</c> the survivor into both destinations. Do not "optimise" this
+    ///     loop into <c>Task.WhenAll</c>. (Even without that, <c>FileConversationStore</c> serializes every
+    ///     read behind one process-wide semaphore, so the parallel version would not be faster.)
+    ///     </para>
+    ///     <para>
+    ///     <b>Bounded per flush</b> for the same reason: a conversation with dozens of descendants would
+    ///     otherwise hold that store semaphore for dozens of full-thread reads at every turn boundary. The
+    ///     window advances round-robin so a large fan-out is covered across successive flushes instead of
+    ///     starving its tail, and a truncated pass reports <c>deferred</c> so another flush follows.
+    ///     </para>
+    /// </remarks>
+    private async Task<(bool Wrote, bool Deferred)> FlushSubAgentsAsync(
+        string sessionId,
+        string leaf,
+        CancellationToken ct)
+    {
+        if (Interlocked.Exchange(ref _sawSubAgentActivity, 0) == 1)
+        {
+            _descendants.NoteAgentActivity(ThreadId);
+        }
+
+        IReadOnlyList<SubAgentSummary> agents = await _descendants.GetOrScanAsync(ThreadId, ct).ConfigureAwait(false);
+        if (agents.Count == 0)
+        {
+            return (false, false);
+        }
+
+        var take = Math.Min(agents.Count, _maxSubAgentFilesPerFlush);
+        var capped = take < agents.Count;
+        var deferred = false;
+        var wrote = false;
+        var directory = $"{TranscriptDirectory}/{leaf}{AgentsDirectorySuffix}";
+
+        for (var i = 0; i < take; i++)
+        {
+            var agent = agents[(_subAgentCursor + i) % agents.Count];
+            var messages = await ReadStableAsync(agent.ThreadId, ct).ConfigureAwait(false);
+            if (messages is null)
+            {
+                deferred = true;
+                continue;
+            }
+
+            if (messages.Count == 0)
+            {
+                continue;
+            }
+
+            var path = $"{directory}/{WorkspaceTranscriptLine.AgentFileLeaf(agent.Name, WorkspaceTranscriptLine.ShortId(agent.AgentId))}{TranscriptExtension}";
+            var lines = WorkspaceTranscriptLine.ChainMessages(messages, agent.Name, RootParentUidFor(agent.ThreadId));
+
+            var result = await AppendAsync(sessionId, directory, path, agent.ThreadId, lines, ct).ConfigureAwait(false);
+            if (result == AppendResult.Appended)
+            {
+                wrote = true;
+                _agentsDirectoryTouched = true;
+            }
+            else if (result == AppendResult.Failed)
+            {
+                deferred = true;
+            }
+        }
+
+        _subAgentCursor = agents.Count == 0 ? 0 : (_subAgentCursor + take) % agents.Count;
+
+        // A capped pass asks for a follow-up only when it actually mirrored something. Reporting Deferred
+        // purely because descendants outnumber the cap would be true on EVERY flush forever, and a caller
+        // that re-schedules on Deferred would then spin: the cursor keeps moving but the condition never
+        // clears. Gating on progress converges — the first pass that finds its slice already up to date
+        // ends the chain.
+        return (wrote, deferred || (capped && wrote));
+    }
+
+    /// <summary>
+    ///     The <c>parent_uid</c> a sub-agent file's first line hangs off: the main file's watermark at the
+    ///     moment that file is first written, which is a row that genuinely exists in the main file — so a
+    ///     reader resolves the chain across the conversation's whole file set. Pinned per sub-agent so it
+    ///     does not drift as the main file grows.
+    /// </summary>
+    private string? RootParentUidFor(string agentThreadId)
+    {
+        if (_agentRootParentUids.TryGetValue(agentThreadId, out var pinned))
+        {
+            return pinned;
+        }
+
+        _ = _watermarks.TryGetValue(ThreadId, out var rootUid);
+        _agentRootParentUids[agentThreadId] = rootUid;
+        return rootUid;
+    }
+
+    // -------- Steps 5-7: watermark, write, advance --------
+
+    private enum AppendResult
+    {
+        UpToDate,
+        Appended,
+        Failed,
+    }
+
+    private async Task<AppendResult> AppendAsync(
+        string sessionId,
+        string directory,
+        string path,
+        string watermarkKey,
+        IReadOnlyList<WorkspaceTranscriptLine> lines,
+        CancellationToken ct)
+    {
+        if (lines.Count == 0)
+        {
+            return AppendResult.UpToDate;
+        }
+
+        var start = await ResolveStartIndexAsync(sessionId, path, watermarkKey, lines, ct).ConfigureAwait(false);
+        if (start >= lines.Count)
+        {
+            return AppendResult.UpToDate;
+        }
+
+        var payload = new StringBuilder();
+        for (var i = start; i < lines.Count; i++)
+        {
+            _ = payload.Append(WorkspaceTranscriptLine.Serialize(lines[i])).Append('\n');
+        }
+
+        try
+        {
+            await _fileBrowser
+                .WriteWorkspaceFileBytesAsync(sessionId, _tempPath, Encoding.UTF8.GetBytes(payload.ToString()), ct)
+                .ConfigureAwait(false);
+        }
+        catch (SandboxException ex)
+        {
+            _logger.LogWarning(ex, "Staging transcript bytes for {Path} failed", path);
+            return AppendResult.Failed;
+        }
+
+        var spliced = await RunAsync(sessionId, ["sh", "-c", AppendScript, "sh", directory, _tempPath, path], ct)
+            .ConfigureAwait(false);
+        if (spliced is not { ExitCode: 0 })
+        {
+            // Step 7: the watermark advances ONLY on exit code 0, so the next flush recomputes the same
+            // suffix and appends it again. Duplicate-on-retry, never silent loss.
+            _logger.LogWarning(
+                "Transcript splice into {Path} failed with exit {ExitCode}: {Error}",
+                path,
+                spliced?.ExitCode ?? -1,
+                spliced?.StandardError ?? "(no result)"
+            );
+            return AppendResult.Failed;
+        }
+
+        _watermarks[watermarkKey] = lines[^1].Uid;
+        return AppendResult.Appended;
+    }
+
+    /// <summary>
+    ///     Step 5. Reports the index of the first line that still needs appending — the watermark's
+    ///     successor when the watermark is known and present, and otherwise zero.
+    /// </summary>
+    /// <remarks>
+    ///     The fallback is ALWAYS "append everything". Every other candidate (append nothing, append the
+    ///     tail, guess by timestamp) trades a duplicate for a permanently missing record, and a duplicate
+    ///     is recoverable by any reader that groups on <c>uid</c>.
+    /// </remarks>
+    private async Task<int> ResolveStartIndexAsync(
+        string sessionId,
+        string path,
+        string watermarkKey,
+        IReadOnlyList<WorkspaceTranscriptLine> lines,
+        CancellationToken ct)
+    {
+        if (!_watermarks.TryGetValue(watermarkKey, out var watermark))
+        {
+            var (hadContent, recovered) = await RecoverWatermarkAsync(sessionId, path, ct).ConfigureAwait(false);
+            if (recovered is null)
+            {
+                if (hadContent)
+                {
+                    WarnFullAppend(path, "its tail held no readable record");
+                }
+
+                return 0;
+            }
+
+            watermark = recovered;
+        }
+
+        for (var i = 0; i < lines.Count; i++)
+        {
+            if (string.Equals(lines[i].Uid, watermark, StringComparison.Ordinal))
+            {
+                return i + 1;
+            }
+        }
+
+        WarnFullAppend(path, $"uid {watermark} is absent from the computed transcript");
+        return 0;
+    }
+
+    /// <summary>
+    ///     Recovers a cold-start watermark from the destination's last few lines.
+    /// </summary>
+    /// <remarks>
+    ///     <c>tail</c> rather than <c>ReadWorkspaceFileBytesAsync</c> on purpose: a GET downloads the WHOLE
+    ///     transcript, and these files reach tens of megabytes in practice — paying that once per process
+    ///     per conversation to learn eight characters is not a micro-optimisation to skip.
+    /// </remarks>
+    private async Task<(bool HadContent, string? Uid)> RecoverWatermarkAsync(
+        string sessionId,
+        string path,
+        CancellationToken ct)
+    {
+        var tailed = await RunAsync(
+            sessionId,
+            ["tail", "-n", WatermarkTailLines.ToString(CultureInfo.InvariantCulture), "--", path],
+            ct
+        ).ConfigureAwait(false);
+
+        // A non-zero exit is overwhelmingly "no such file" — the ordinary first-flush case, not a fault.
+        if (tailed is not { ExitCode: 0 } || string.IsNullOrWhiteSpace(tailed.StandardOutput))
+        {
+            return (false, null);
+        }
+
+        var window = tailed.StandardOutput.Split('\n');
+        for (var i = window.Length - 1; i >= 0; i--)
+        {
+            if (TryReadUid(window[i]) is { } uid)
+            {
+                return (true, uid);
+            }
+        }
+
+        return (true, null);
+    }
+
+    private static string? TryReadUid(string line)
+    {
+        var trimmed = line.Trim();
+        if (trimmed.Length == 0)
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(trimmed);
+            return document.RootElement.ValueKind == JsonValueKind.Object
+                && document.RootElement.TryGetProperty("uid", out var uid)
+                && uid.ValueKind == JsonValueKind.String
+                ? uid.GetString()
+                : null;
+        }
+        catch (JsonException)
+        {
+            // A torn line. Expected — it is the reason the probe reads a window instead of one line.
+            return null;
+        }
+    }
+
+    private void WarnFullAppend(string path, string reason)
+    {
+        if (_fullAppendWarned.Add(path))
+        {
+            _logger.LogWarning("Appending the full transcript to {Path}: {Reason}", path, reason);
+        }
+    }
+
+    // -------- Step 8: containment --------
+
+    /// <summary>
+    ///     Writes <c>.conversations/.gitignore</c> containing <c>*</c>, once per conversation, on the first
+    ///     successful flush.
+    /// </summary>
+    /// <remarks>
+    ///     A workspace is frequently a git checkout and an agent frequently runs <c>git add -A</c>. Without
+    ///     this, the first such commit publishes this conversation's and its siblings' unredacted reasoning
+    ///     off-machine, irrecoverably. Written after the first successful append rather than before, so a
+    ///     conversation that never produced a transcript leaves no directory behind.
+    /// </remarks>
+    private async Task EnsureGitignoreAsync(string sessionId, CancellationToken ct)
+    {
+        if (_gitignoreWritten)
+        {
+            return;
+        }
+
+        try
+        {
+            await _fileBrowser
+                .WriteWorkspaceFileBytesAsync(
+                    sessionId,
+                    $"{TranscriptDirectory}/.{GitignoreName}",
+                    Encoding.UTF8.GetBytes("*\n"),
+                    ct
+                )
+                .ConfigureAwait(false);
+            _gitignoreWritten = true;
+        }
+        catch (SandboxException ex)
+        {
+            // Retried on the next flush. The transcript itself is already written; refusing to keep the
+            // rows because their ignore file failed would be the wrong trade.
+            _logger.LogWarning(ex, "Writing the transcript .gitignore for thread {ThreadId} failed", ThreadId);
+        }
+    }
+
+    // -------- Gateway helpers --------
+
+    private async Task<bool> TryMoveAsync(string sessionId, string from, string to, CancellationToken ct)
+    {
+        var result = await RunAsync(sessionId, ["mv", "--", from, to], ct).ConfigureAwait(false);
+        if (result is { ExitCode: 0 })
+        {
+            return true;
+        }
+
+        _logger.LogWarning(
+            "Renaming transcript {From} to {To} failed with exit {ExitCode}: {Error}",
+            from,
+            to,
+            result?.ExitCode ?? -1,
+            result?.StandardError ?? "(no result)"
+        );
+        return false;
+    }
+
+    private async Task<SandboxCommandResult?> RunAsync(
+        string sessionId,
+        IReadOnlyList<string> arguments,
+        CancellationToken ct)
+    {
+        try
+        {
+            return await _fileBrowser
+                .ExecuteWorkspaceCommandAsync(sessionId, new SandboxCommand(arguments), ct)
+                .ConfigureAwait(false);
+        }
+        catch (SandboxException ex)
+        {
+            _logger.LogWarning(ex, "Transcript command {Command} failed for thread {ThreadId}", arguments[0], ThreadId);
+            return null;
+        }
+    }
+
+    // -------- Metadata --------
+
+    /// <summary>
+    ///     Extracts the persisted workspace id, accepting only a genuine string (raw or
+    ///     <see cref="JsonElement"/>) exactly as the file-browser route does — a workspace binding is not a
+    ///     value to coerce.
+    /// </summary>
+    private static string? ReadWorkspaceId(ThreadMetadata? metadata) =>
+        ReadStringProperty(metadata, MultiTurnAgentPool.WorkspacePropertyKey);
+
+    private static string? ReadTitle(ThreadMetadata? metadata) =>
+        ReadStringProperty(metadata, TitlePropertyKey);
+
+    private static string? ReadStringProperty(ThreadMetadata? metadata, string key)
+    {
+        if (metadata?.Properties is null || !metadata.Properties.TryGetValue(key, out var value))
+        {
+            return null;
+        }
+
+        var text = value switch
+        {
+            string raw => raw,
+            JsonElement { ValueKind: JsonValueKind.String } element => element.GetString(),
+            _ => null,
+        };
+
+        return string.IsNullOrWhiteSpace(text) ? null : text.Trim();
+    }
+}

--- a/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
+++ b/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
@@ -123,6 +123,42 @@ public sealed class ConversationTranscriptWriter
     public const int WatermarkMissingExitCode = 42;
 
     /// <summary>
+    ///     Exit code <see cref="WatermarkProbeScript"/> reports when the window was read successfully but
+    ///     the destination's last byte is NOT a newline — it ends mid-record, so the final line of the
+    ///     window is torn and must not be adopted as a watermark. Chosen on the same grounds as
+    ///     <see cref="WatermarkMissingExitCode"/>: outside every code the probe's own commands can mint.
+    /// </summary>
+    /// <remarks>
+    ///     Tornness cannot be re-derived from the bytes any more, because the probe TRUNCATES each line to
+    ///     <see cref="WatermarkTailChars"/> characters — every line it returns looks torn. So the shell,
+    ///     which is the only party that can still see the whole file, answers the question directly.
+    /// </remarks>
+    public const int WatermarkPartialExitCode = 43;
+
+    /// <summary>
+    ///     How many leading characters of each windowed line the probe returns. This is what bounds the
+    ///     probe's output, and bounding it is not an optimisation.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     A single transcript line carries a whole message, and on this revision a tool result is stored
+    ///     inline, so one line reaches MEGABYTES. Returning five of those through the gateway's command
+    ///     channel exceeds its output cap; the SDK throws, <c>RunAsync</c> reports the transport fault as
+    ///     an indeterminate probe, and the flush defers. A cold start re-probes every time, so it defers
+    ///     again, and again, until the retry budget is spent — the transcript is then never mirrored at
+    ///     all. Capping per line makes the probe's output a small CONSTANT (<see cref="WatermarkTailLines"/>
+    ///     x this, plus newlines) no matter how large the file or its lines.
+    ///     </para>
+    ///     <para>
+    ///     The cap is safe because <c>WorkspaceTranscriptLine.Serialize</c> pins the key ORDER, writing
+    ///     <c>schema_version</c>, <c>type</c> and then <c>uid</c> — so the uid always ends within roughly
+    ///     the first 53 bytes of a line, whatever follows it. 256 leaves a wide margin for that layout to
+    ///     grow without anyone having to remember this constant exists.
+    ///     </para>
+    /// </remarks>
+    public const int WatermarkTailChars = 256;
+
+    /// <summary>
     ///     How many times a re-read may disagree with its predecessor before the flush gives up. See
     ///     <see cref="ReadStableAsync"/> for why reading twice is not optional.
     /// </summary>
@@ -171,8 +207,8 @@ public sealed class ConversationTranscriptWriter
         + "cat \"$2\" >> \"$3\" && rm -f \"$2\"\n";
 
     /// <summary>
-    ///     The cold-start watermark probe. <c>$1</c> destination file, <c>$2</c> trailing line count.
-    ///     Reads nothing and writes nothing.
+    ///     The cold-start watermark probe. <c>$1</c> destination file, <c>$2</c> trailing line count,
+    ///     <c>$3</c> per-line character cap. Reads nothing and writes nothing.
     /// </summary>
     /// <remarks>
     ///     <para>
@@ -186,22 +222,49 @@ public sealed class ConversationTranscriptWriter
     ///     status keeps its ordinary meaning — an indeterminate failure the caller must DEFER on.
     ///     </para>
     ///     <para>
-    ///     A race between the test and the <c>exec</c> is harmless in the direction that matters: a file
+    ///     <b><c>cut -c</c> is what keeps the probe's output a small constant</b> — see
+    ///     <see cref="WatermarkTailChars"/> for the wedge it prevents. It truncates per LINE, after
+    ///     <c>tail</c> has chosen the lines: a plain byte budget over the whole window
+    ///     (<c>tail -c</c>, or <c>head -c</c> downstream) is not equivalent, because one multi-megabyte
+    ///     line would swallow the entire budget and leave no uid to find. <c>cut</c> is POSIX and present
+    ///     in the sandbox image (<c>mcr.microsoft.com/dotnet/sdk:10.0-noble</c>, GNU coreutils).
+    ///     </para>
+    ///     <para>
+    ///     Truncating costs the ability to tell a torn last line from an intact one by parsing, so the
+    ///     LAST line answers that separately through <see cref="WatermarkPartialExitCode"/>, using the same
+    ///     <c>tail -c1</c> idiom <see cref="AppendScript"/> already welds newlines with. It is read AFTER
+    ///     the window on purpose: a concurrent append landing between the two reads can then only make the
+    ///     probe MORE conservative (an intact window reported partial re-appends one row the reader dedupes
+    ///     on uid), never less (a torn window reported intact would adopt a torn uid and lose rows).
+    ///     </para>
+    ///     <para>
+    ///     A race between the test and the window read is harmless in the direction that matters: a file
     ///     created in between makes <c>tail</c> succeed, and one deleted in between makes it exit 1, which
     ///     is read as indeterminate and defers. The reverse — a real absence read as a failure — costs one
     ///     repeated flush, never a duplicated transcript.
     ///     </para>
     ///     <para>
     ///     Built from concatenated literals for the same LF reason as <see cref="AppendScript"/>, and the
-    ///     title-derived path arrives as a positional parameter for the same inertness reason. The exit
-    ///     code is spliced in from the constant rather than typed twice, so the two cannot drift.
+    ///     title-derived path arrives as a positional parameter for the same inertness reason. Both exit
+    ///     codes are spliced in from their constants rather than typed twice, so they cannot drift.
     ///     </para>
     /// </remarks>
     private static readonly string WatermarkProbeScript =
         "[ -e \"$1\" ] || exit "
         + WatermarkMissingExitCode.ToString(CultureInfo.InvariantCulture)
         + "\n"
-        + "exec tail -n \"$2\" -- \"$1\"\n";
+        + "tail -n \"$2\" -- \"$1\" | cut -c \"1-$3\" || exit 1\n"
+        + "end=$(tail -c1 -- \"$1\") || exit 1\n"
+        + "[ -z \"$end\" ] || exit "
+        + WatermarkPartialExitCode.ToString(CultureInfo.InvariantCulture)
+        + "\n";
+
+    /// <summary>
+    ///     The one property <see cref="TryReadUid"/> looks for, as UTF-8 so the reader can compare it
+    ///     without materialising the name. Must match the key <c>WorkspaceTranscriptLine.Serialize</c>
+    ///     writes.
+    /// </summary>
+    private static ReadOnlySpan<byte> UidPropertyName => "uid"u8;
 
     private readonly IConversationStore _store;
     private readonly IWorkspaceFileBrowser _fileBrowser;
@@ -797,11 +860,40 @@ public sealed class ConversationTranscriptWriter
     ///     asking — "this slice wrote nothing" says nothing about the descendants OUTSIDE it, and the one
     ///     that changed is exactly as likely to be out there — but asking under the caller's FAILURE budget
     ///     caps the roster a single trigger can ever reach at (budget + 1) x cap, silently truncating
-    ///     anything larger. So the sweep tracks which descendants it has visited since the last external
-    ///     trigger and keeps asking only while some remain. That terminates on its own: each pass visits at
-    ///     least one descendant it has not visited before, over a finite roster. A descendant is marked
-    ///     visited whether or not its own read succeeded — a failed read reports <c>deferred</c>, which is
-    ///     what the failure budget is actually for.
+    ///     anything larger. So the sweep tracks which descendants it has COVERED since the last external
+    ///     trigger and keeps asking only while some remain.
+    ///     </para>
+    ///     <para>
+    ///     <b>A descendant counts as covered only once it has actually been processed</b> — appended, or
+    ///     read successfully and found to have nothing new. A descendant whose read or splice FAILED is
+    ///     left uncovered, so a later pass retries it. Marking it covered anyway loses it outright: with a
+    ///     roster larger than the cap, slice 1 could fail on descendant A and report <c>deferred</c>, the
+    ///     caller's retry could run slice 2, slice 2 could succeed, and A — already marked — would leave
+    ///     the sweep complete with A never mirrored and no further pass owed.
+    ///     </para>
+    ///     <para>
+    ///     <b>Termination.</b> <c>progressing</c> means only "unfailed ground is still uncovered": it
+    ///     excludes both the covered set and the descendants that failed in THIS pass, so a failure can
+    ///     never by itself keep the chain alive. The two ways a pass can end therefore both make progress
+    ///     against a finite bound:
+    ///     <list type="bullet">
+    ///     <item><description>
+    ///     If a pass fails on any descendant it reports <c>deferred</c>, and the caller charges that to its
+    ///     failure budget — at most <c>MaxDeferredRetries</c> of those exist per trigger.
+    ///     </description></item>
+    ///     <item><description>
+    ///     If a pass fails on none, every descendant in its window becomes covered. The window is
+    ///     <c>take</c> CONSECUTIVE slots and the cursor advances by exactly <c>take</c>, so successive
+    ///     windows tile the ring: any ceil(count / take) consecutive passes visit every descendant. So a
+    ///     run of failure-free passes covers the whole roster within ceil(count / take) passes, after which
+    ///     nothing is uncovered and <c>progressing</c> is false.
+    ///     </description></item>
+    ///     </list>
+    ///     A <c>progressing</c> pass costs no budget, but it cannot repeat indefinitely: within every
+    ///     ceil(count / take) passes the ring is fully visited, so either the roster becomes covered
+    ///     (chain ends) or a descendant fails again (budget charged). The chain is therefore bounded by
+    ///     (MaxDeferredRetries + 2) x ceil(count / take) passes, and a PERMANENTLY failing descendant ends
+    ///     it by exhausting the failure budget rather than by looping.
     ///     </para>
     /// </remarks>
     private async Task<(bool Wrote, bool Deferred, bool Progressing)> FlushSubAgentsAsync(
@@ -826,24 +918,28 @@ public sealed class ConversationTranscriptWriter
         }
 
         var take = Math.Min(agents.Count, _maxSubAgentFilesPerFlush);
-        var deferred = false;
         var wrote = false;
         var directory = $"{TranscriptDirectory}/{leaf}{AgentsDirectorySuffix}";
+
+        // Failures of THIS pass. They stay out of _sweptAgents so a later pass retries them, and out of
+        // the progressing test so they cannot keep the chain alive on their own. See the termination
+        // argument above.
+        var failed = new HashSet<string>(StringComparer.Ordinal);
 
         for (var i = 0; i < take; i++)
         {
             var agent = agents[(_subAgentCursor + i) % agents.Count];
-            _ = _sweptAgents.Add(agent.ThreadId);
 
             var messages = await ReadStableAsync(agent.ThreadId, ct).ConfigureAwait(false);
             if (messages is null)
             {
-                deferred = true;
+                _ = failed.Add(agent.ThreadId);
                 continue;
             }
 
             if (messages.Count == 0)
             {
+                _ = _sweptAgents.Add(agent.ThreadId);
                 continue;
             }
 
@@ -851,21 +947,26 @@ public sealed class ConversationTranscriptWriter
             var lines = WorkspaceTranscriptLine.ChainMessages(messages, agent.Name, RootParentUidFor(agent.ThreadId));
 
             var result = await AppendAsync(sessionId, directory, path, agent.ThreadId, lines, ct).ConfigureAwait(false);
+            if (result == AppendResult.Failed)
+            {
+                _ = failed.Add(agent.ThreadId);
+                continue;
+            }
+
+            _ = _sweptAgents.Add(agent.ThreadId);
             if (result == AppendResult.Appended)
             {
                 wrote = true;
                 _agentsDirectoryTouched = true;
             }
-            else if (result == AppendResult.Failed)
-            {
-                deferred = true;
-            }
         }
 
         _subAgentCursor = (_subAgentCursor + take) % agents.Count;
 
-        var progressing = agents.Any(agent => !_sweptAgents.Contains(agent.ThreadId));
-        return (wrote, deferred, progressing);
+        var progressing = agents.Any(agent =>
+            !_sweptAgents.Contains(agent.ThreadId) && !failed.Contains(agent.ThreadId)
+        );
+        return (wrote, failed.Count > 0, progressing);
     }
 
     /// <summary>
@@ -1047,7 +1148,9 @@ public sealed class ConversationTranscriptWriter
     ///     transcript, and these files reach tens of megabytes in practice — paying that once per process
     ///     per conversation to learn eight characters is not a micro-optimisation to skip. What the probe
     ///     must never do is answer an indeterminate failure the way it answers a genuine absence; see
-    ///     <see cref="WatermarkProbe"/> and <see cref="WatermarkProbeScript"/>.
+    ///     <see cref="WatermarkProbe"/> and <see cref="WatermarkProbeScript"/>. Its output is bounded per
+    ///     line, so an individual multi-megabyte row cannot make this call itself unanswerable — see
+    ///     <see cref="WatermarkTailChars"/>.
     /// </remarks>
     private async Task<WatermarkProbe> RecoverWatermarkAsync(
         string sessionId,
@@ -1063,6 +1166,7 @@ public sealed class ConversationTranscriptWriter
                 "sh",
                 path,
                 WatermarkTailLines.ToString(CultureInfo.InvariantCulture),
+                WatermarkTailChars.ToString(CultureInfo.InvariantCulture),
             ],
             ct
         ).ConfigureAwait(false);
@@ -1079,7 +1183,7 @@ public sealed class ConversationTranscriptWriter
             return WatermarkProbe.Absent;
         }
 
-        if (tailed.ExitCode != 0)
+        if (tailed.ExitCode is not (0 or WatermarkPartialExitCode))
         {
             _logger.LogWarning(
                 "Transcript watermark probe of {Path} failed with exit {ExitCode}: {Error}",
@@ -1091,7 +1195,21 @@ public sealed class ConversationTranscriptWriter
         }
 
         var window = tailed.StandardOutput.Split('\n');
-        for (var i = window.Length - 1; i >= 0; i--)
+
+        var last = window.Length - 1;
+        while (last >= 0 && window[last].Trim().Length == 0)
+        {
+            last--;
+        }
+
+        if (tailed.ExitCode == WatermarkPartialExitCode)
+        {
+            // The file ends mid-record, so the window's last line is the torn half of a row that was never
+            // fully written. Adopting its uid would silently skip the row it belongs to for good.
+            last--;
+        }
+
+        for (var i = last; i >= 0; i--)
         {
             if (TryReadUid(window[i]) is { } uid)
             {
@@ -1099,9 +1217,9 @@ public sealed class ConversationTranscriptWriter
             }
         }
 
-        // Exit 0 with nothing readable is still a DEFINITE answer: the file is there and holds no intact
-        // record — empty, or torn across its whole window. Only the second of those is worth a warning,
-        // which is what HadContent distinguishes.
+        // A readable window with nothing usable in it is still a DEFINITE answer: the file is there and
+        // holds no adoptable record — empty, or torn across its whole window. Only the second of those is
+        // worth a warning, which is what HadContent distinguishes.
         return new WatermarkProbe(
             Settled: true,
             HadContent: !string.IsNullOrWhiteSpace(tailed.StandardOutput),
@@ -1109,6 +1227,16 @@ public sealed class ConversationTranscriptWriter
         );
     }
 
+    /// <summary>
+    ///     Reads the <c>uid</c> out of one windowed line, which by construction may be only the LEADING
+    ///     <see cref="WatermarkTailChars"/> characters of the real row.
+    /// </summary>
+    /// <remarks>
+    ///     Hence <c>isFinalBlock: false</c> rather than <see cref="JsonDocument"/>: it tells the reader the
+    ///     buffer is a PREFIX, so a token cut off at the end means "no more data yet" — <c>Read</c> simply
+    ///     returns false — instead of a syntax error. A whole intact line parses through the same path
+    ///     unchanged, since a complete object is also a valid prefix of itself.
+    /// </remarks>
     private static string? TryReadUid(string line)
     {
         var trimmed = line.Trim();
@@ -1119,16 +1247,39 @@ public sealed class ConversationTranscriptWriter
 
         try
         {
-            using var document = JsonDocument.Parse(trimmed);
-            return document.RootElement.ValueKind == JsonValueKind.Object
-                && document.RootElement.TryGetProperty("uid", out var uid)
-                && uid.ValueKind == JsonValueKind.String
-                ? uid.GetString()
-                : null;
+            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(trimmed), isFinalBlock: false, state: default);
+            if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
+            {
+                return null;
+            }
+
+            while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+            {
+                var isUid = reader.ValueTextEquals(UidPropertyName);
+                if (!reader.Read())
+                {
+                    return null;
+                }
+
+                if (isUid)
+                {
+                    return reader.TokenType == JsonTokenType.String ? reader.GetString() : null;
+                }
+
+                // TrySkip, not Skip: Skip THROWS on a value the prefix does not finish, which is the
+                // ordinary case here rather than an error.
+                if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray && !reader.TrySkip())
+                {
+                    return null;
+                }
+            }
+
+            return null;
         }
         catch (JsonException)
         {
-            // A torn line. Expected — it is the reason the probe reads a window instead of one line.
+            // A line torn BEFORE its uid, or one that was never JSON. Expected — it is the reason the
+            // probe reads a window instead of one line.
             return null;
         }
     }

--- a/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
+++ b/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
@@ -69,21 +69,26 @@ public enum TranscriptFlushOutcome
 ///     append costs bytes, whereas a skipped append costs the record itself.
 ///     </para>
 ///     <para>
-///     <b>Writes go through exactly one shell call site</b> (<see cref="AppendScript"/>); the other two
-///     shell invocations, <see cref="WatermarkProbeScript"/> and <see cref="PathGuardScript"/>, read and
-///     write nothing. <c>ExecuteWorkspaceCommandAsync</c> is a native argv vector with no implicit shell,
-///     so a shell is invoked explicitly. All three script texts are fixed at compile time and <i>no
-///     dynamic value is ever interpolated into any of them</i>: the destination directory, the temp file
-///     and the destination file arrive as positional parameters <c>$1</c>/<c>$2</c>/<c>$3</c>. That
-///     matters because the file leaf is derived from a user-authored conversation title. <c>--</c> on the
-///     pure-argv calls stops option parsing, which is worth having, but it is the positional parameters —
-///     not <c>--</c> — that make a title containing <c>$(…)</c> or whitespace inert.
+///     <b>Every workspace call goes through a shell, and every script text is fixed at compile time.</b>
+///     Two scripts change the workspace — <see cref="AppendScript"/>, which splices bytes in, and
+///     <see cref="MoveScript"/>, which renames on a retitle — while <see cref="WatermarkProbeScript"/>
+///     and <see cref="PathGuardScript"/> read and write nothing. <c>ExecuteWorkspaceCommandAsync</c> is a
+///     native argv vector with no implicit shell, so a shell is invoked explicitly; the rename used to be
+///     issued as a bare <c>mv</c> argv instead, which left it the one workspace mutation with no guard in
+///     scope. <i>No dynamic value is ever interpolated into any script</i>: the destination directory, the
+///     temp file, the destination file and the two rename operands all arrive as positional parameters
+///     <c>$1</c>/<c>$2</c>/<c>$3</c>. That matters because the file leaf is derived from a user-authored
+///     conversation title — it is the positional parameters, not <c>--</c>, that make a title containing
+///     <c>$(…)</c> or whitespace inert.
 ///     </para>
 ///     <para>
-///     <b>No path is written to before it has been checked for redirection.</b> Every script guards its
-///     own path parameters, and the two writes that bypass the shell entirely — the staged payload and the
-///     <c>.gitignore</c>, both PUT by the gateway — are guarded by <see cref="IsPathSafeAsync"/> first. A
-///     redirected path is refused and left alone, never unlinked; see <see cref="UnsafePathExitCode"/>.
+///     <b>No path is written to before it has been checked for redirection, and the check is never
+///     cached.</b> Every script guards its own path parameters, and the two writes that bypass the shell
+///     entirely — the staged payload and the <c>.gitignore</c>, both PUT by the gateway — are guarded by
+///     <see cref="IsPathSafeAsync"/> immediately before each PUT. The staging guard in particular runs per
+///     APPEND rather than per flush: one flush stages the main transcript and every descendant through the
+///     same path, with a full gateway round trip between consecutive PUTs. A redirected path is refused and
+///     left alone, never unlinked; see <see cref="UnsafePathExitCode"/>.
 ///     </para>
 ///     <para>
 ///     <b>Concurrency:</b> <see cref="FlushAsync"/> is not re-entrant and must not be called concurrently
@@ -166,6 +171,22 @@ public sealed class ConversationTranscriptWriter
     ///     </para>
     /// </remarks>
     public const int UnsafePathExitCode = 44;
+
+    /// <summary>
+    ///     Exit code <see cref="MoveScript"/> reports when a rename's DESTINATION resolves to a directory,
+    ///     which is the one shape under which <c>mv</c> writes somewhere other than the name it was given.
+    ///     Chosen on the same grounds as <see cref="WatermarkMissingExitCode"/>: outside every code the
+    ///     scripts' own commands can mint (GNU <c>mv</c> answers 0 or 1; a BSD <c>mv</c> rejecting an
+    ///     option answers 64).
+    /// </summary>
+    /// <remarks>
+    ///     Distinct from <see cref="UnsafePathExitCode"/> because it is a different fact: the destination
+    ///     need not be a symlink at all. A real directory sitting where the transcript's new name goes
+    ///     makes <c>mv</c> move the file INSIDE it, which for the <c>_agents</c> rename means nesting the
+    ///     old directory under the new one rather than renaming it. Both readings are wrong and both are
+    ///     refused, but they are worth telling apart in a log.
+    /// </remarks>
+    public const int MoveTargetDirectoryExitCode = 45;
 
     /// <summary>
     ///     How many leading characters of each windowed line the probe returns. This is what bounds the
@@ -362,6 +383,67 @@ public sealed class ConversationTranscriptWriter
         + "\n";
 
     /// <summary>
+    ///     The retitle rename. <c>$1</c> is the existing path, <c>$2</c> the new one. It is a shell script
+    ///     rather than a bare <c>mv</c> argv because a rename needs the same guard every other path here
+    ///     gets, and a native argv vector has nowhere to put one.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <b><c>mv A B</c> does NOT simply replace the path <c>B</c>, and an earlier revision left this
+    ///     call unguarded on the belief that it did. That belief was wrong for the case that matters.</b>
+    ///     When <c>B</c> resolves to a DIRECTORY — including through a symlink — <c>mv</c> moves <c>A</c>
+    ///     INSIDE it. A link planted at the transcript's next name therefore relocates the whole
+    ///     unredacted file out of <c>.conversations</c> and out from under the <c>.gitignore</c>, at exit
+    ///     code 0, with nothing left behind to notice. Directly observed, not inferred:
+    ///     <c>mv -- covered/old.jsonl covered/new.jsonl</c> with <c>covered/new.jsonl</c> a symlink to a
+    ///     directory leaves the transcript at <c>&lt;target&gt;/old.jsonl</c> and the link untouched. The
+    ///     <c>_agents</c> rename has the identical shape and the identical exposure.
+    ///     </para>
+    ///     <para>
+    ///     A symlink to a FILE is a different matter and never was the hazard: <c>rename(2)</c> replaces
+    ///     the link itself, so the link's target is not written through. Resolving to a directory is the
+    ///     whole of it, which is why <c>[ ! -d ]</c> is an exact test rather than a conservative one.
+    ///     </para>
+    ///     <para>
+    ///     <c>mv -T</c> (<c>--no-target-directory</c>) is tried FIRST because it treats the destination as
+    ///     a name rather than a directory, which closes the window between the check and the move instead
+    ///     of merely narrowing it: against the same fixture it renames onto the link, leaves the link's
+    ///     target empty, and reports 0. It is a GNU extension, present in the sandbox image
+    ///     (<c>mcr.microsoft.com/dotnet/sdk:10.0-noble</c>, GNU coreutils) but absent from a BSD
+    ///     <c>mv</c> — and these scripts also run against a developer machine's own <c>sh</c> under test,
+    ///     so an unconditional <c>-T</c> would wedge every retitle on such a host. Hence the fallback.
+    ///     </para>
+    ///     <para>
+    ///     <b>The fallback is safe only because of the <c>target</c> check, and only because that check is
+    ///     re-run ahead of it.</b> A bare <c>mv -T … || mv …</c> is a trap: <c>mv -T</c> also fails on a
+    ///     destination that is a real NON-EMPTY directory, and the plain <c>mv</c> behind it would then
+    ///     nest the source inside — which is precisely the <c>_agents</c> case. Refusing a directory
+    ///     destination outright removes that branch, and repeating the check keeps the fallback's exposure
+    ///     no wider than the primary's.
+    ///     </para>
+    ///     <para>
+    ///     What remains is the same residual TOCTOU every other path here carries: a link planted between
+    ///     the check and the <c>mv</c> is still followed on a host without <c>-T</c>. Closing it needs
+    ///     <c>O_NOFOLLOW</c>/<c>renameat2</c>, which no shell exposes. See <see cref="UnsafePathExitCode"/>
+    ///     for why the answer is refusal rather than repair — the link is never unlinked, and a refused
+    ///     rename simply keeps the transcript under its old name, which <see cref="MoveLeafAsync"/> already
+    ///     treats as the safe outcome.
+    ///     </para>
+    /// </remarks>
+    private static readonly string MoveScript =
+        PathGuardPreamble
+        + "target() { guard \"$1\" || exit "
+        + UnsafePathExitCode.ToString(CultureInfo.InvariantCulture)
+        + "; [ ! -d \"$1\" ] || exit "
+        + MoveTargetDirectoryExitCode.ToString(CultureInfo.InvariantCulture)
+        + "; }\n"
+        + GuardLine("$1")
+        + "target \"$2\"\n"
+        + "mv -T -- \"$1\" \"$2\" 2>/dev/null && exit 0\n"
+        + "target \"$2\"\n"
+        + "mv -- \"$1\" \"$2\"\n";
+
+    /// <summary>
     ///     The one property <see cref="TryReadUid"/> looks for, as UTF-8 so the reader can compare it
     ///     without materialising the name. Must match the key <c>WorkspaceTranscriptLine.Serialize</c>
     ///     writes.
@@ -412,14 +494,6 @@ public sealed class ConversationTranscriptWriter
     ///     transcript an earlier process left behind.
     /// </summary>
     private bool _transcriptExists;
-
-    /// <summary>
-    ///     Whether THIS flush has already checked that the staging path is not redirected. Per flush
-    ///     rather than per writer: the path never varies within one flush, so re-checking it for each of
-    ///     the sub-agent files would buy nothing, while remembering the answer for the writer's whole life
-    ///     would miss a link planted between flushes. See <see cref="IsPathSafeAsync"/>.
-    /// </summary>
-    private bool _tempPathGuarded;
 
     private bool _agentsDirectoryTouched;
     private int _subAgentCursor;
@@ -524,8 +598,6 @@ public sealed class ConversationTranscriptWriter
 
     private async Task<TranscriptFlushOutcome> FlushCoreAsync(CancellationToken ct)
     {
-        _tempPathGuarded = false;
-
         // Metadata carries BOTH values the flush needs — the workspace binding for step 1 and the title
         // for the retitle check — so it is read once here rather than twice at the two points of use.
         var metadata = await _store.LoadMetadataAsync(ThreadId, ct).ConfigureAwait(false);
@@ -1196,15 +1268,18 @@ public sealed class ConversationTranscriptWriter
         // The staging path is guarded for the same reason the destination is, and it cannot be guarded by
         // AppendScript: the payload is PUT here BEFORE any script runs. Its name is no less guessable than
         // the transcript's — a compile-time directory plus a hash of the thread id — and the bytes it
-        // carries are the same unredacted rows. Once per flush, because the path does not vary within one.
-        if (!_tempPathGuarded)
+        // carries are the same unredacted rows.
+        //
+        // Guarded before EVERY staging PUT, and deliberately NOT cached for the flush. One flush stages
+        // the main transcript and each descendant through this ONE path, and between two consecutive PUTs
+        // sits a whole AppendScript shell execution — a gateway round trip, not a millisecond. A cached
+        // answer would let a link planted in that window be followed by every PUT after it, once per
+        // descendant. The rationale for caching was that the path does not vary within a flush; the path
+        // not varying says nothing about the FILESYSTEM AT that path not varying, which is the only thing
+        // this guard reads.
+        if (!await IsPathSafeAsync(sessionId, _tempPath, ct).ConfigureAwait(false))
         {
-            if (!await IsPathSafeAsync(sessionId, _tempPath, ct).ConfigureAwait(false))
-            {
-                return AppendResult.Failed;
-            }
-
-            _tempPathGuarded = true;
+            return AppendResult.Failed;
         }
 
         try
@@ -1544,10 +1619,27 @@ public sealed class ConversationTranscriptWriter
 
     private async Task<bool> TryMoveAsync(string sessionId, string from, string to, CancellationToken ct)
     {
-        var result = await RunAsync(sessionId, ["mv", "--", from, to], ct).ConfigureAwait(false);
+        var result = await RunAsync(sessionId, ["sh", "-c", MoveScript, "sh", from, to], ct)
+            .ConfigureAwait(false);
         if (result is { ExitCode: 0 })
         {
             return true;
+        }
+
+        if (result is { ExitCode: UnsafePathExitCode or MoveTargetDirectoryExitCode })
+        {
+            _logger.LogWarning(
+                "Refusing to rename transcript {From} to {To} for thread {ThreadId} (exit {ExitCode}): one "
+                    + "of the two paths is a symlink or lies under one, or the destination resolves to a "
+                    + "directory — in which case mv moves the transcript INSIDE it, out of the directory "
+                    + "the .gitignore covers. Nothing is renamed and nothing is unlinked; the transcript "
+                    + "keeps its old name and the next flush tries again.",
+                from,
+                to,
+                ThreadId,
+                result.ExitCode
+            );
+            return false;
         }
 
         _logger.LogWarning(

--- a/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
+++ b/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
@@ -12,9 +12,13 @@ namespace LmStreaming.Sample.Services;
 /// <summary>What one <see cref="ConversationTranscriptWriter.FlushAsync"/> attempt achieved.</summary>
 /// <remarks>
 ///     The mirror is best-effort, so this is advisory rather than a status code: its only real consumer
-///     decision is "should I schedule another flush?", and only <see cref="Deferred"/> answers yes.
-///     <see cref="Unavailable"/> deliberately does NOT ask for a re-schedule — a conversation with no
-///     sandbox session would otherwise spin the drain loop forever.
+///     decision is "should I schedule another flush?", and two members answer yes —
+///     <see cref="Deferred"/> and <see cref="Progressing"/>. They are kept DISTINCT because the caller
+///     bounds them differently: a deferral means something FAILED and must be retried a bounded number of
+///     times, whereas progress means the pass did what it could and a continuation is owed. Folding the
+///     second into the first makes an orderly continuation spend a failure budget, which caps how far a
+///     single trigger can ever get. <see cref="Unavailable"/> deliberately does NOT ask for a re-schedule
+///     — a conversation with no sandbox session would otherwise spin the drain loop forever.
 /// </remarks>
 public enum TranscriptFlushOutcome
 {
@@ -25,9 +29,9 @@ public enum TranscriptFlushOutcome
     Written,
 
     /// <summary>
-    ///     Work remains: a read never settled, a gateway call failed, the sub-agent fan-out was capped, or
-    ///     the containment <c>.gitignore</c> is not yet on disk. The watermarks involved are unadvanced, so
-    ///     a later flush repeats the work. <b>Re-schedule.</b>
+    ///     Something FAILED: a read never settled, a gateway call failed, or the containment
+    ///     <c>.gitignore</c> could not be written. The watermarks involved are unadvanced, so a later flush
+    ///     repeats the work. <b>Re-schedule, bounded.</b>
     /// </summary>
     Deferred,
 
@@ -36,6 +40,18 @@ public enum TranscriptFlushOutcome
     ///     conflict, gateway unreachable). Nothing was written and nothing is pending.
     /// </summary>
     Unavailable,
+
+    /// <summary>
+    ///     Nothing failed, and the pass stopped short of the work it knows about: the sub-agent fan-out is
+    ///     bounded per flush and descendants outside this slice have not been visited yet.
+    ///     <b>Re-schedule, and do NOT count it as a failed attempt.</b> This terminates on its own — each
+    ///     pass covers at least one descendant it has not covered before, over a finite roster.
+    /// </summary>
+    /// <remarks>
+    ///     Appended at the END of the enum on purpose: the existing members keep their numeric values, so
+    ///     anything that persisted or compared one is unaffected.
+    /// </remarks>
+    Progressing,
 }
 
 /// <summary>
@@ -171,20 +187,29 @@ public sealed class ConversationTranscriptWriter
     /// <summary>Files already warned about, so the "appending everything" warning stays a one-off.</summary>
     private readonly HashSet<string> _fullAppendWarned = new(StringComparer.Ordinal);
 
+    /// <summary>
+    ///     The descendants the CURRENT coverage sweep has already visited. A capped fan-out asks for a
+    ///     follow-up only while some descendant is missing from this set, which is what makes the chain of
+    ///     continuations terminate without spending the caller's failure budget.
+    /// </summary>
+    private readonly HashSet<string> _sweptAgents = new(StringComparer.Ordinal);
+
     private string? _leaf;
     private bool _gitignoreWritten;
 
     /// <summary>
     ///     Whether this conversation has a transcript in the workspace at all — set when an append lands
     ///     and when the cold-start probe finds an existing file. Distinct from
-    ///     <see cref="_gitignoreWritten"/> and from "this flush wrote something": see
-    ///     <see cref="ContainAsync"/> for why conflating the three is what leaves the ignore file missing.
+    ///     <see cref="_gitignoreWritten"/> and from "this flush wrote something": it is what lets
+    ///     <see cref="EnsureContainedAsync"/> be attempted on a flush that appends nothing, for a
+    ///     transcript an earlier process left behind.
     /// </summary>
     private bool _transcriptExists;
 
     private bool _agentsDirectoryTouched;
     private int _subAgentCursor;
     private int _sawSubAgentActivity;
+    private int _sweepRestartRequested;
 
     /// <summary>Creates the writer for one conversation.</summary>
     /// <param name="threadId">The conversation's thread id.</param>
@@ -242,6 +267,22 @@ public sealed class ConversationTranscriptWriter
     public void NoteSubAgentActivity() => Interlocked.Exchange(ref _sawSubAgentActivity, 1);
 
     /// <summary>
+    ///     Records that an independent external trigger arrived (a completed run, a sub-agent
+    ///     notification, a recovered subscription), so the next flush starts a FRESH coverage sweep of the
+    ///     descendant roster rather than continuing the one the previous trigger left half-finished.
+    /// </summary>
+    /// <remarks>
+    ///     Deliberately separate from <see cref="NoteSubAgentActivity"/>. A sweep restart is cheap — it
+    ///     clears a set — whereas noting sub-agent activity forces the descendant scanner's full store
+    ///     scan, which must stay rare. Every trigger owes a fresh sweep; only sub-agent evidence owes a
+    ///     rescan. Restarting on an external trigger rather than whenever a sweep completes is also what
+    ///     stops the writer alternating forever between "sweep finished" and "sweep restarted" on a
+    ///     conversation where nothing is happening. Cheap and thread-safe: callable straight from the
+    ///     message-subscriber hot path.
+    /// </remarks>
+    public void NoteExternalTrigger() => Interlocked.Exchange(ref _sweepRestartRequested, 1);
+
+    /// <summary>
     ///     Mirrors everything this conversation has persisted since the last successful flush. Never
     ///     throws: a failure is logged, the affected watermark is left unadvanced, and the outcome says
     ///     whether the caller should schedule another attempt.
@@ -285,11 +326,24 @@ public sealed class ConversationTranscriptWriter
         }
 
         // Step 4, and it must stay ahead of every append in this drain: a retitle that is noticed only
-        // after the append leaves a second file holding a duplicate of the entire history.
-        await ApplyRetitleAsync(sessionId, metadata, ct).ConfigureAwait(false);
+        // after the append leaves a second file holding a duplicate of the entire history. It reports
+        // false when the workspace could not be INSPECTED, which is not the same as finding nothing —
+        // see AdoptExistingLeafAsync.
+        if (!await ApplyRetitleAsync(sessionId, metadata, ct).ConfigureAwait(false))
+        {
+            return TranscriptFlushOutcome.Deferred;
+        }
+
         var leaf = _leaf!;
 
         var lines = WorkspaceTranscriptLine.ChainMessages(messages);
+
+        // Containment BEFORE the first transcript byte. See EnsureContainedAsync.
+        if ((lines.Count > 0 || _transcriptExists) && !await EnsureContainedAsync(sessionId, ct).ConfigureAwait(false))
+        {
+            return TranscriptFlushOutcome.Deferred;
+        }
+
         var mainResult = await AppendAsync(
             sessionId,
             TranscriptDirectory,
@@ -308,54 +362,53 @@ public sealed class ConversationTranscriptWriter
             // on a FIRST flush every sub-agent file would be pinned to null and the two files would never
             // be one lineage again. No later flush revisits a pinned anchor. Deferring costs one repeated
             // pass; a wrong anchor is not recoverable.
-            return await ContainAsync(sessionId, TranscriptFlushOutcome.Deferred, ct).ConfigureAwait(false);
+            return TranscriptFlushOutcome.Deferred;
         }
 
         var wrote = mainResult == AppendResult.Appended;
-        var (agentsWrote, agentsDeferred) = await FlushSubAgentsAsync(sessionId, leaf, ct).ConfigureAwait(false);
+        var (agentsWrote, agentsDeferred, agentsProgressing) =
+            await FlushSubAgentsAsync(sessionId, leaf, ct).ConfigureAwait(false);
         wrote = wrote || agentsWrote;
 
-        return await ContainAsync(
-            sessionId,
-            agentsDeferred ? TranscriptFlushOutcome.Deferred
-                : wrote ? TranscriptFlushOutcome.Written
-                : TranscriptFlushOutcome.UpToDate,
-            ct
-        ).ConfigureAwait(false);
+        // Deferred outranks Progressing: a failure has to be retried under a bound whether or not the
+        // sweep also has ground left to cover, and the continuation the sweep wants comes for free with
+        // the retry. Progressing outranks Written/UpToDate — both of those tell the caller to stop.
+        return agentsDeferred ? TranscriptFlushOutcome.Deferred
+            : agentsProgressing ? TranscriptFlushOutcome.Progressing
+            : wrote ? TranscriptFlushOutcome.Written
+            : TranscriptFlushOutcome.UpToDate;
     }
 
     /// <summary>
-    ///     Makes sure this conversation's transcript directory is contained by a <c>.gitignore</c> before
-    ///     the flush reports <paramref name="outcome"/>, downgrading to
-    ///     <see cref="TranscriptFlushOutcome.Deferred"/> when it is not.
+    ///     Makes sure this conversation's transcript directory is covered by a <c>.gitignore</c>, reporting
+    ///     false when it is not. <b>Every caller must treat false as "write nothing".</b>
     /// </summary>
     /// <remarks>
-    ///     <b>Containment is tracked separately from message progress, and this is the highest-consequence
-    ///     rule in the type.</b> The obvious shape — write the ignore file only on a flush that appended
-    ///     something — fails in both directions at once: the attempt is skipped on every flush that finds
-    ///     nothing new (so a transcript written by an earlier process, or one whose only appending flush
-    ///     already happened, is never covered), and a failed attempt changes nothing about the flush's
-    ///     result (so the ONE trigger that could retry it is a future flush that also appends, which for a
-    ///     finished conversation never comes). Both leave the file permanently absent, and this
-    ///     <c>.gitignore</c> is the entire opt-out for the feature: without it the next <c>git add -A</c>
-    ///     an agent runs in that workspace publishes every conversation's unredacted reasoning off-machine,
-    ///     irrecoverably. So: attempt it whenever a transcript exists and the file is not known to be
-    ///     present, and treat failure as work still pending.
+    ///     <para>
+    ///     <b>Containment is established BEFORE any transcript byte reaches the workspace, and this is the
+    ///     highest-consequence rule in the type.</b> This <c>.gitignore</c> is the entire opt-out for the
+    ///     feature: without it the next <c>git add -A</c> an agent runs in that workspace publishes the
+    ///     conversation's unredacted reasoning off-machine, irrecoverably. Ordering it first makes
+    ///     "transcript on disk, uncovered" a state the writer cannot be left in — not by a failed write,
+    ///     not by an exhausted retry budget, not by a process that exits between the two calls. A
+    ///     conversation that never gets its ignore file simply never gets a transcript either, which is
+    ///     the safe side of the trade.
+    ///     </para>
+    ///     <para>
+    ///     Writing it AFTERWARDS cannot be repaired by retrying harder, and that is why the ordering
+    ///     rather than the retry is the fix. The append advances the watermark on success, so by the time
+    ///     a failed containment is discovered the bytes are already there; the retry then depends on a
+    ///     later flush arriving, and for a conversation whose last turn has happened none ever does.
+    ///     </para>
+    ///     <para>
+    ///     Callers gate on <c>lines.Count > 0 || _transcriptExists</c> so a conversation that never
+    ///     produces a transcript leaves no directory behind. That gate cannot be wrong in the unsafe
+    ///     direction: rows in hand means an append is about to happen, and no rows plus no known transcript
+    ///     means there is nothing in the workspace to cover.
+    ///     </para>
     /// </remarks>
-    private async Task<TranscriptFlushOutcome> ContainAsync(
-        string sessionId,
-        TranscriptFlushOutcome outcome,
-        CancellationToken ct)
-    {
-        if (!_transcriptExists || _gitignoreWritten)
-        {
-            return outcome;
-        }
-
-        return await EnsureGitignoreAsync(sessionId, ct).ConfigureAwait(false)
-            ? outcome
-            : TranscriptFlushOutcome.Deferred;
-    }
+    private async Task<bool> EnsureContainedAsync(string sessionId, CancellationToken ct) =>
+        _gitignoreWritten || await EnsureGitignoreAsync(sessionId, ct).ConfigureAwait(false);
 
     // -------- Step 1: session --------
 
@@ -508,38 +561,65 @@ public sealed class ConversationTranscriptWriter
     ///     whatever slug it was last named, and the same move path adopts it.
     ///     </para>
     /// </remarks>
-    private async Task ApplyRetitleAsync(string sessionId, ThreadMetadata? metadata, CancellationToken ct)
+    private async Task<bool> ApplyRetitleAsync(string sessionId, ThreadMetadata? metadata, CancellationToken ct)
     {
         var leaf = WorkspaceTranscriptLine.MainFileLeaf(ReadTitle(metadata), _shortThreadId);
         if (_leaf is null)
         {
-            _leaf = await AdoptExistingLeafAsync(sessionId, leaf, ct).ConfigureAwait(false) ?? leaf;
-            return;
+            var (listed, adopted) = await AdoptExistingLeafAsync(sessionId, leaf, ct).ConfigureAwait(false);
+            if (!listed)
+            {
+                return false;
+            }
+
+            _leaf = adopted ?? leaf;
+            return true;
         }
 
         if (string.Equals(_leaf, leaf, StringComparison.Ordinal))
         {
-            return;
+            return true;
         }
 
         if (await MoveLeafAsync(sessionId, _leaf, leaf, _agentsDirectoryTouched, ct).ConfigureAwait(false))
         {
             _leaf = leaf;
         }
+
+        return true;
     }
 
     /// <summary>
     ///     On cold start, finds this conversation's existing transcript under a DIFFERENT slug and renames
-    ///     it (and its sub-agent directory) onto <paramref name="leaf"/>. Reports the leaf actually in
-    ///     force afterwards, or null when there was nothing to adopt.
+    ///     it (and its sub-agent directory) onto <paramref name="leaf"/>.
     /// </summary>
+    /// <returns>
+    ///     <c>Listed</c> is whether the workspace could be inspected at all; when it is false the caller
+    ///     must abandon the flush without writing anything. <c>Leaf</c> is the leaf actually in force
+    ///     afterwards, or null when the listing succeeded and there was nothing to adopt.
+    /// </returns>
     /// <remarks>
-    ///     A listing failure, an unreadable directory, or a move that does not take are all answered the
-    ///     same way: keep using the file that is there. Reporting the stale leaf rather than the new one
-    ///     is what stops a failed adoption from splitting the transcript in two anyway — appending to the
-    ///     old name is always preferable to starting a second file.
+    ///     <para>
+    ///     <b>"The directory holds nothing" and "the directory could not be listed" must be answered
+    ///     differently, and only the first is a definite miss.</b> Treating a transport, protocol or
+    ///     session failure as an absence makes the writer adopt the computed leaf and append the entire
+    ///     history into a SECOND file — the split-transcript defect this method exists to prevent, except
+    ///     triggered by a momentary gateway fault instead of a real absence, and unrecoverable afterwards
+    ///     because the second file IS the computed leaf from then on, so adoption never runs again. Only
+    ///     <see cref="SandboxException.IsDefiniteMissingPath"/> means "nothing there"; anything else defers
+    ///     the whole flush, which costs one repeated pass. This follows the discrimination established at
+    ///     <c>SandboxClient.Files.cs</c> and in the daemon's session adapter.
+    ///     </para>
+    ///     <para>
+    ///     A move that does not take is a different matter and is still absorbed: reporting the stale leaf
+    ///     rather than the new one keeps the writer appending to the file that is there, which is always
+    ///     preferable to starting a second one.
+    ///     </para>
     /// </remarks>
-    private async Task<string?> AdoptExistingLeafAsync(string sessionId, string leaf, CancellationToken ct)
+    private async Task<(bool Listed, string? Leaf)> AdoptExistingLeafAsync(
+        string sessionId,
+        string leaf,
+        CancellationToken ct)
     {
         IReadOnlyList<SandboxDirectoryEntry> entries;
         try
@@ -548,10 +628,16 @@ public sealed class ConversationTranscriptWriter
                 .ListWorkspaceDirectoryAsync(sessionId, TranscriptDirectory, ct)
                 .ConfigureAwait(false);
         }
+        catch (SandboxException ex) when (ex.IsDefiniteMissingPath)
+        {
+            // The ordinary first flush of a workspace that has never held a transcript.
+            _logger.LogDebug(ex, "No {Directory} yet for thread {ThreadId}", TranscriptDirectory, ThreadId);
+            return (true, null);
+        }
         catch (SandboxException ex)
         {
             _logger.LogDebug(ex, "Listing {Directory} for thread {ThreadId} failed", TranscriptDirectory, ThreadId);
-            return null;
+            return (false, null);
         }
 
         var stale = entries
@@ -575,7 +661,7 @@ public sealed class ConversationTranscriptWriter
 
         if (stale is null)
         {
-            return null;
+            return (true, null);
         }
 
         _transcriptExists = true;
@@ -585,9 +671,11 @@ public sealed class ConversationTranscriptWriter
             stale,
             leaf);
 
-        return await MoveLeafAsync(sessionId, stale, leaf, _agentsDirectoryTouched, ct).ConfigureAwait(false)
-            ? leaf
-            : stale;
+        return (
+            true,
+            await MoveLeafAsync(sessionId, stale, leaf, _agentsDirectoryTouched, ct).ConfigureAwait(false)
+                ? leaf
+                : stale);
     }
 
     /// <summary>
@@ -660,10 +748,21 @@ public sealed class ConversationTranscriptWriter
     ///     <b>Bounded per flush</b> for the same reason: a conversation with dozens of descendants would
     ///     otherwise hold that store semaphore for dozens of full-thread reads at every turn boundary. The
     ///     window advances round-robin so a large fan-out is covered across successive flushes instead of
-    ///     starving its tail, and a truncated pass reports <c>deferred</c> so another flush follows.
+    ///     starving its tail, and a truncated pass reports <c>progressing</c> so another flush follows.
+    ///     </para>
+    ///     <para>
+    ///     <b>The continuation is sized by COVERAGE, not by a retry budget.</b> A capped pass has to keep
+    ///     asking — "this slice wrote nothing" says nothing about the descendants OUTSIDE it, and the one
+    ///     that changed is exactly as likely to be out there — but asking under the caller's FAILURE budget
+    ///     caps the roster a single trigger can ever reach at (budget + 1) x cap, silently truncating
+    ///     anything larger. So the sweep tracks which descendants it has visited since the last external
+    ///     trigger and keeps asking only while some remain. That terminates on its own: each pass visits at
+    ///     least one descendant it has not visited before, over a finite roster. A descendant is marked
+    ///     visited whether or not its own read succeeded — a failed read reports <c>deferred</c>, which is
+    ///     what the failure budget is actually for.
     ///     </para>
     /// </remarks>
-    private async Task<(bool Wrote, bool Deferred)> FlushSubAgentsAsync(
+    private async Task<(bool Wrote, bool Deferred, bool Progressing)> FlushSubAgentsAsync(
         string sessionId,
         string leaf,
         CancellationToken ct)
@@ -673,14 +772,18 @@ public sealed class ConversationTranscriptWriter
             _descendants.NoteAgentActivity(ThreadId);
         }
 
+        if (Interlocked.Exchange(ref _sweepRestartRequested, 0) == 1)
+        {
+            _sweptAgents.Clear();
+        }
+
         IReadOnlyList<SubAgentSummary> agents = await _descendants.GetOrScanAsync(ThreadId, ct).ConfigureAwait(false);
         if (agents.Count == 0)
         {
-            return (false, false);
+            return (false, false, false);
         }
 
         var take = Math.Min(agents.Count, _maxSubAgentFilesPerFlush);
-        var capped = take < agents.Count;
         var deferred = false;
         var wrote = false;
         var directory = $"{TranscriptDirectory}/{leaf}{AgentsDirectorySuffix}";
@@ -688,6 +791,8 @@ public sealed class ConversationTranscriptWriter
         for (var i = 0; i < take; i++)
         {
             var agent = agents[(_subAgentCursor + i) % agents.Count];
+            _ = _sweptAgents.Add(agent.ThreadId);
+
             var messages = await ReadStableAsync(agent.ThreadId, ct).ConfigureAwait(false);
             if (messages is null)
             {
@@ -715,18 +820,10 @@ public sealed class ConversationTranscriptWriter
             }
         }
 
-        _subAgentCursor = agents.Count == 0 ? 0 : (_subAgentCursor + take) % agents.Count;
+        _subAgentCursor = (_subAgentCursor + take) % agents.Count;
 
-        // A capped pass asks for a follow-up whether or not it mirrored anything, because "this slice
-        // wrote nothing" says nothing at all about the descendants OUTSIDE the slice — and the one that
-        // changed is exactly as likely to be out there. Gating on progress looked convergent and was
-        // instead a way to stop one step short: the pass that found its own slice up to date ended the
-        // chain, leaving the changed descendant beyond the cap unwritten until some later trigger
-        // happened to come along. What terminates the chain is the mirror's bounded retry budget
-        // (WorkspaceTranscriptMirror.MaxDeferredRetries), which is reset at each turn boundary — so a
-        // large fan-out is covered a slice per attempt and paced, rather than either spinning or being
-        // silently truncated.
-        return (wrote, deferred || capped);
+        var progressing = agents.Any(agent => !_sweptAgents.Contains(agent.ThreadId));
+        return (wrote, deferred, progressing);
     }
 
     /// <summary>
@@ -936,9 +1033,9 @@ public sealed class ConversationTranscriptWriter
     /// <remarks>
     ///     A workspace is frequently a git checkout and an agent frequently runs <c>git add -A</c>. Without
     ///     this, the first such commit publishes this conversation's and its siblings' unredacted reasoning
-    ///     off-machine, irrecoverably. It is written only once a transcript exists, so a conversation that
-    ///     never produced one leaves no directory behind — see <see cref="ContainAsync"/>, which owns that
-    ///     condition and the retry that a <c>false</c> here earns.
+    ///     off-machine, irrecoverably. It is written BEFORE the first transcript byte and skipped entirely
+    ///     for a conversation that will not produce a transcript, so no directory is left behind — see
+    ///     <see cref="EnsureContainedAsync"/>, which owns that condition and what a <c>false</c> here costs.
     /// </remarks>
     private async Task<bool> EnsureGitignoreAsync(string sessionId, CancellationToken ct)
     {

--- a/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
+++ b/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
@@ -69,11 +69,12 @@ public enum TranscriptFlushOutcome
 ///     append costs bytes, whereas a skipped append costs the record itself.
 ///     </para>
 ///     <para>
-///     <b>Writes go through exactly one shell call site</b> (<see cref="AppendScript"/>).
+///     <b>Writes go through exactly one shell call site</b> (<see cref="AppendScript"/>); the only other
+///     shell invocation is <see cref="WatermarkProbeScript"/>, which reads and writes nothing.
 ///     <c>ExecuteWorkspaceCommandAsync</c> is a native argv vector with no implicit shell, so a shell is
-///     invoked explicitly. The script text is a compile-time constant and <i>no dynamic value is ever
-///     interpolated into it</i>: the destination directory, the temp file and the destination file arrive
-///     as positional parameters <c>$1</c>/<c>$2</c>/<c>$3</c>. That matters because the file leaf is
+///     invoked explicitly. Both script texts are fixed at compile time and <i>no dynamic value is ever
+///     interpolated into either</i>: the destination directory, the temp file and the destination file
+///     arrive as positional parameters <c>$1</c>/<c>$2</c>/<c>$3</c>. That matters because the file leaf is
 ///     derived from a user-authored conversation title. <c>--</c> on the pure-argv calls stops option
 ///     parsing, which is worth having, but it is the positional parameters — not <c>--</c> — that make a
 ///     title containing <c>$(…)</c> or whitespace inert.
@@ -114,6 +115,14 @@ public sealed class ConversationTranscriptWriter
     public const int WatermarkTailLines = 5;
 
     /// <summary>
+    ///     Exit code <see cref="WatermarkProbeScript"/> reports when the destination is DEFINITELY not
+    ///     there. Deliberately outside every code the probe's own commands can produce — <c>tail</c>
+    ///     answers 0 or 1, <c>sh</c> reserves 126 and 127, and a signalled child reports 128+n — so no
+    ///     failure can mint it by accident.
+    /// </summary>
+    public const int WatermarkMissingExitCode = 42;
+
+    /// <summary>
     ///     How many times a re-read may disagree with its predecessor before the flush gives up. See
     ///     <see cref="ReadStableAsync"/> for why reading twice is not optional.
     /// </summary>
@@ -138,9 +147,9 @@ public sealed class ConversationTranscriptWriter
     private const string TitlePropertyKey = "title";
 
     /// <summary>
-    ///     THE one shell call site. Built from concatenated literals rather than a raw string literal so
-    ///     the line endings are LF regardless of how this source file is checked out — a script carrying
-    ///     CR bytes fails inside the container in ways that are tedious to diagnose.
+    ///     THE one shell call site that writes. Built from concatenated literals rather than a raw string
+    ///     literal so the line endings are LF regardless of how this source file is checked out — a script
+    ///     carrying CR bytes fails inside the container in ways that are tedious to diagnose.
     /// </summary>
     /// <remarks>
     ///     <para><c>$1</c> destination directory, <c>$2</c> staged temp file, <c>$3</c> destination file.</para>
@@ -160,6 +169,39 @@ public sealed class ConversationTranscriptWriter
         "mkdir -p \"$1\" || exit 1\n"
         + "if [ -s \"$3\" ] && [ -n \"$(tail -c1 \"$3\")\" ]; then printf '\\n' >> \"$3\" || exit 1; fi\n"
         + "cat \"$2\" >> \"$3\" && rm -f \"$2\"\n";
+
+    /// <summary>
+    ///     The cold-start watermark probe. <c>$1</c> destination file, <c>$2</c> trailing line count.
+    ///     Reads nothing and writes nothing.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     The existence test is the entire point of running this through a shell instead of invoking
+    ///     <c>tail</c> directly. <c>tail</c> answers a missing file, an unreadable one and an I/O error with
+    ///     the SAME status 1, and its stderr wording is locale-dependent, so "there is no transcript" is not
+    ///     a conclusion its exit code can support. Guessing it wrong is expensive in one direction only:
+    ///     the caller reads "no transcript", starts from row zero and re-appends the ENTIRE history onto a
+    ///     file that already holds it. So the script decides existence itself with <c>[ -e ]</c> and
+    ///     reports that one answer through <see cref="WatermarkMissingExitCode"/>; every other non-zero
+    ///     status keeps its ordinary meaning — an indeterminate failure the caller must DEFER on.
+    ///     </para>
+    ///     <para>
+    ///     A race between the test and the <c>exec</c> is harmless in the direction that matters: a file
+    ///     created in between makes <c>tail</c> succeed, and one deleted in between makes it exit 1, which
+    ///     is read as indeterminate and defers. The reverse — a real absence read as a failure — costs one
+    ///     repeated flush, never a duplicated transcript.
+    ///     </para>
+    ///     <para>
+    ///     Built from concatenated literals for the same LF reason as <see cref="AppendScript"/>, and the
+    ///     title-derived path arrives as a positional parameter for the same inertness reason. The exit
+    ///     code is spliced in from the constant rather than typed twice, so the two cannot drift.
+    ///     </para>
+    /// </remarks>
+    private static readonly string WatermarkProbeScript =
+        "[ -e \"$1\" ] || exit "
+        + WatermarkMissingExitCode.ToString(CultureInfo.InvariantCulture)
+        + "\n"
+        + "exec tail -n \"$2\" -- \"$1\"\n";
 
     private readonly IConversationStore _store;
     private readonly IWorkspaceFileBrowser _fileBrowser;
@@ -853,6 +895,31 @@ public sealed class ConversationTranscriptWriter
         Failed,
     }
 
+    /// <summary>
+    ///     What a cold-start watermark probe established about the destination file.
+    /// </summary>
+    /// <param name="Settled">
+    ///     Whether the probe reached a DEFINITE answer. False means the destination could not be inspected
+    ///     — the call threw, or the probe exited non-zero for a reason that is not a definite absence — and
+    ///     the flush must then append nothing at all. The alternative reading, "there is no transcript",
+    ///     restarts the file from row zero and re-appends the whole persisted history onto one that already
+    ///     holds it, once per cold writer, so a host restarting in a loop multiplies it indefinitely.
+    /// </param>
+    /// <param name="HadContent">
+    ///     Whether the destination exists AND its tail window held bytes. False for a definite absence and
+    ///     for an empty file, both of which are the ordinary first flush rather than something to warn
+    ///     about.
+    /// </param>
+    /// <param name="Uid">The last intact <c>uid</c> in the tail window, when there was one.</param>
+    private readonly record struct WatermarkProbe(bool Settled, bool HadContent, string? Uid)
+    {
+        /// <summary>The destination could not be inspected. Nothing may be appended off the back of it.</summary>
+        public static WatermarkProbe Unsettled => new(Settled: false, HadContent: false, Uid: null);
+
+        /// <summary>The destination is definitely not there — the ordinary first flush.</summary>
+        public static WatermarkProbe Absent => new(Settled: true, HadContent: false, Uid: null);
+    }
+
     private async Task<AppendResult> AppendAsync(
         string sessionId,
         string directory,
@@ -866,7 +933,16 @@ public sealed class ConversationTranscriptWriter
             return AppendResult.UpToDate;
         }
 
-        var start = await ResolveStartIndexAsync(sessionId, path, watermarkKey, lines, ct).ConfigureAwait(false);
+        var resolved = await ResolveStartIndexAsync(sessionId, path, watermarkKey, lines, ct)
+            .ConfigureAwait(false);
+        if (resolved is not { } start)
+        {
+            // The destination could not be INSPECTED, which is not the same as finding nothing in it.
+            // Deferring costs one repeated pass; the alternative costs a duplicate of the whole history.
+            // This returns before anything is staged, so the flush leaves no bytes behind either.
+            return AppendResult.Failed;
+        }
+
         if (start >= lines.Count)
         {
             return AppendResult.UpToDate;
@@ -912,14 +988,17 @@ public sealed class ConversationTranscriptWriter
 
     /// <summary>
     ///     Step 5. Reports the index of the first line that still needs appending — the watermark's
-    ///     successor when the watermark is known and present, and otherwise zero.
+    ///     successor when the watermark is known and present, and otherwise zero. Null means the
+    ///     destination could not be INSPECTED and the caller must append nothing at all.
     /// </summary>
     /// <remarks>
-    ///     The fallback is ALWAYS "append everything". Every other candidate (append nothing, append the
-    ///     tail, guess by timestamp) trades a duplicate for a permanently missing record, and a duplicate
-    ///     is recoverable by any reader that groups on <c>uid</c>.
+    ///     The fallback, once the destination HAS been inspected, is ALWAYS "append everything". Every other
+    ///     candidate (append nothing, append the tail, guess by timestamp) trades a duplicate for a
+    ///     permanently missing record, and a duplicate is recoverable by any reader that groups on
+    ///     <c>uid</c>. An UNINSPECTED destination is the one case that is not a choice between those two:
+    ///     see <see cref="WatermarkProbe"/>.
     /// </remarks>
-    private async Task<int> ResolveStartIndexAsync(
+    private async Task<int?> ResolveStartIndexAsync(
         string sessionId,
         string path,
         string watermarkKey,
@@ -928,11 +1007,16 @@ public sealed class ConversationTranscriptWriter
     {
         if (!_watermarks.TryGetValue(watermarkKey, out var watermark))
         {
-            var (hadContent, recovered) = await RecoverWatermarkAsync(sessionId, path, ct).ConfigureAwait(false);
-            _transcriptExists = _transcriptExists || hadContent;
-            if (recovered is null)
+            var probe = await RecoverWatermarkAsync(sessionId, path, ct).ConfigureAwait(false);
+            if (!probe.Settled)
             {
-                if (hadContent)
+                return null;
+            }
+
+            _transcriptExists = _transcriptExists || probe.HadContent;
+            if (probe.Uid is null)
+            {
+                if (probe.HadContent)
                 {
                     WarnFullAppend(path, "its tail held no readable record");
                 }
@@ -940,7 +1024,7 @@ public sealed class ConversationTranscriptWriter
                 return 0;
             }
 
-            watermark = recovered;
+            watermark = probe.Uid;
         }
 
         for (var i = 0; i < lines.Count; i++)
@@ -961,23 +1045,49 @@ public sealed class ConversationTranscriptWriter
     /// <remarks>
     ///     <c>tail</c> rather than <c>ReadWorkspaceFileBytesAsync</c> on purpose: a GET downloads the WHOLE
     ///     transcript, and these files reach tens of megabytes in practice — paying that once per process
-    ///     per conversation to learn eight characters is not a micro-optimisation to skip.
+    ///     per conversation to learn eight characters is not a micro-optimisation to skip. What the probe
+    ///     must never do is answer an indeterminate failure the way it answers a genuine absence; see
+    ///     <see cref="WatermarkProbe"/> and <see cref="WatermarkProbeScript"/>.
     /// </remarks>
-    private async Task<(bool HadContent, string? Uid)> RecoverWatermarkAsync(
+    private async Task<WatermarkProbe> RecoverWatermarkAsync(
         string sessionId,
         string path,
         CancellationToken ct)
     {
         var tailed = await RunAsync(
             sessionId,
-            ["tail", "-n", WatermarkTailLines.ToString(CultureInfo.InvariantCulture), "--", path],
+            [
+                "sh",
+                "-c",
+                WatermarkProbeScript,
+                "sh",
+                path,
+                WatermarkTailLines.ToString(CultureInfo.InvariantCulture),
+            ],
             ct
         ).ConfigureAwait(false);
 
-        // A non-zero exit is overwhelmingly "no such file" — the ordinary first-flush case, not a fault.
-        if (tailed is not { ExitCode: 0 } || string.IsNullOrWhiteSpace(tailed.StandardOutput))
+        if (tailed is null)
         {
-            return (false, null);
+            // RunAsync answers null for a thrown SandboxException — a transport or gateway fault, which
+            // says nothing whatsoever about whether the file is there.
+            return WatermarkProbe.Unsettled;
+        }
+
+        if (tailed.ExitCode == WatermarkMissingExitCode)
+        {
+            return WatermarkProbe.Absent;
+        }
+
+        if (tailed.ExitCode != 0)
+        {
+            _logger.LogWarning(
+                "Transcript watermark probe of {Path} failed with exit {ExitCode}: {Error}",
+                path,
+                tailed.ExitCode,
+                tailed.StandardError
+            );
+            return WatermarkProbe.Unsettled;
         }
 
         var window = tailed.StandardOutput.Split('\n');
@@ -985,11 +1095,18 @@ public sealed class ConversationTranscriptWriter
         {
             if (TryReadUid(window[i]) is { } uid)
             {
-                return (true, uid);
+                return new WatermarkProbe(Settled: true, HadContent: true, Uid: uid);
             }
         }
 
-        return (true, null);
+        // Exit 0 with nothing readable is still a DEFINITE answer: the file is there and holds no intact
+        // record — empty, or torn across its whole window. Only the second of those is worth a warning,
+        // which is what HadContent distinguishes.
+        return new WatermarkProbe(
+            Settled: true,
+            HadContent: !string.IsNullOrWhiteSpace(tailed.StandardOutput),
+            Uid: null
+        );
     }
 
     private static string? TryReadUid(string line)

--- a/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
+++ b/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
@@ -91,6 +91,37 @@ public enum TranscriptFlushOutcome
 ///     left alone, never unlinked; see <see cref="UnsafePathExitCode"/>.
 ///     </para>
 ///     <para>
+///     <b>The filesystem surface is a closed set of six calls</b>, listed here so the next reader can check
+///     coverage by enumeration rather than by searching. Three successive review rounds each fixed one
+///     surface and left another, because nobody had written down how many there were.
+///     <list type="table">
+///         <item>
+///             <description><see cref="AdoptExistingLeafAsync"/> — lists the directory. The only one that is
+///             deliberately unguarded; see the rejection recorded on that method.</description>
+///         </item>
+///         <item>
+///             <description><see cref="AppendAsync"/> — PUTs the staged payload. Guarded by
+///             <see cref="IsPathSafeAsync"/> per append.</description>
+///         </item>
+///         <item>
+///             <description><see cref="AppendAsync"/> — runs <see cref="AppendScript"/>. Guards its three
+///             path parameters in-script.</description>
+///         </item>
+///         <item>
+///             <description><see cref="RecoverWatermarkAsync"/> — runs <see cref="WatermarkProbeScript"/>.
+///             Guards in-script.</description>
+///         </item>
+///         <item>
+///             <description><see cref="EnsureGitignoreAsync"/> — PUTs the <c>.gitignore</c>. Guarded by
+///             <see cref="IsPathSafeAsync"/>.</description>
+///         </item>
+///         <item>
+///             <description><see cref="TryMoveAsync"/> — runs <see cref="MoveScript"/>. Guards both operands
+///             in-script and additionally refuses a destination that resolves to a directory.</description>
+///         </item>
+///     </list>
+///     </para>
+///     <para>
 ///     <b>Concurrency:</b> <see cref="FlushAsync"/> is not re-entrant and must not be called concurrently
 ///     with itself for the same conversation. <see cref="TranscriptFlushScheduler"/> guarantees that (a
 ///     single drain loop). The sub-agent fan-out inside one flush is likewise strictly sequential; see
@@ -920,6 +951,17 @@ public sealed class ConversationTranscriptWriter
     ///     A move that does not take is a different matter and is still absorbed: reporting the stale leaf
     ///     rather than the new one keeps the writer appending to the file that is there, which is always
     ///     preferable to starting a second one.
+    ///     </para>
+    ///     <para>
+    ///     <b>Deliberately unguarded, and the reason is the guards downstream — not the listing.</b> A
+    ///     redirected <c>.conversations</c> makes this listing return attacker-chosen entries, and one of
+    ///     them can be adopted as the leaf. That is contained rather than trusted: the adopted stem must
+    ///     satisfy <see cref="IsThisConversation"/>, so it carries this conversation's own short id; it is
+    ///     used only as the source operand of <see cref="MoveScript"/>, which guards <i>both</i> operands,
+    ///     so a planted symlink is refused at the rename rather than followed; and every write that could
+    ///     follow is guarded at its own call site. A directory entry name cannot contain a separator, so an
+    ///     entry cannot widen the path it is spliced into. What an attacker gets is a mirror that refuses
+    ///     and defers — an availability cost, not a disclosure.
     ///     </para>
     /// </remarks>
     private async Task<(bool Listed, string? Leaf)> AdoptExistingLeafAsync(

--- a/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
+++ b/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
@@ -69,15 +69,21 @@ public enum TranscriptFlushOutcome
 ///     append costs bytes, whereas a skipped append costs the record itself.
 ///     </para>
 ///     <para>
-///     <b>Writes go through exactly one shell call site</b> (<see cref="AppendScript"/>); the only other
-///     shell invocation is <see cref="WatermarkProbeScript"/>, which reads and writes nothing.
-///     <c>ExecuteWorkspaceCommandAsync</c> is a native argv vector with no implicit shell, so a shell is
-///     invoked explicitly. Both script texts are fixed at compile time and <i>no dynamic value is ever
-///     interpolated into either</i>: the destination directory, the temp file and the destination file
-///     arrive as positional parameters <c>$1</c>/<c>$2</c>/<c>$3</c>. That matters because the file leaf is
-///     derived from a user-authored conversation title. <c>--</c> on the pure-argv calls stops option
-///     parsing, which is worth having, but it is the positional parameters — not <c>--</c> — that make a
-///     title containing <c>$(…)</c> or whitespace inert.
+///     <b>Writes go through exactly one shell call site</b> (<see cref="AppendScript"/>); the other two
+///     shell invocations, <see cref="WatermarkProbeScript"/> and <see cref="PathGuardScript"/>, read and
+///     write nothing. <c>ExecuteWorkspaceCommandAsync</c> is a native argv vector with no implicit shell,
+///     so a shell is invoked explicitly. All three script texts are fixed at compile time and <i>no
+///     dynamic value is ever interpolated into any of them</i>: the destination directory, the temp file
+///     and the destination file arrive as positional parameters <c>$1</c>/<c>$2</c>/<c>$3</c>. That
+///     matters because the file leaf is derived from a user-authored conversation title. <c>--</c> on the
+///     pure-argv calls stops option parsing, which is worth having, but it is the positional parameters —
+///     not <c>--</c> — that make a title containing <c>$(…)</c> or whitespace inert.
+///     </para>
+///     <para>
+///     <b>No path is written to before it has been checked for redirection.</b> Every script guards its
+///     own path parameters, and the two writes that bypass the shell entirely — the staged payload and the
+///     <c>.gitignore</c>, both PUT by the gateway — are guarded by <see cref="IsPathSafeAsync"/> first. A
+///     redirected path is refused and left alone, never unlinked; see <see cref="UnsafePathExitCode"/>.
 ///     </para>
 ///     <para>
 ///     <b>Concurrency:</b> <see cref="FlushAsync"/> is not re-entrant and must not be called concurrently
@@ -136,6 +142,32 @@ public sealed class ConversationTranscriptWriter
     public const int WatermarkPartialExitCode = 43;
 
     /// <summary>
+    ///     Exit code every script reports when a path it was handed — or any directory on the way to it —
+    ///     is a SYMLINK, so the write would land somewhere other than where it reads like it lands. Chosen
+    ///     on the same grounds as <see cref="WatermarkMissingExitCode"/>: outside every code the scripts'
+    ///     own commands can mint.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Not a theoretical hazard. The workspace is shared with the agents working in it, and the
+    ///     transcript's file name is derived from the conversation TITLE, so it is guessable long before it
+    ///     exists. An agent that drops a symlink at that name redirects the whole unredacted transcript to
+    ///     wherever the link points — a tracked source file, say, which is precisely what the
+    ///     <c>.gitignore</c> beside the transcript exists to keep it away from. Every shell primitive here
+    ///     follows links silently: <c>&gt;&gt;</c> writes through, <c>mkdir -p</c> on a symlinked directory
+    ///     succeeds with nothing to do, and <c>[ -e ]</c> and <c>tail</c> report on the target.
+    ///     </para>
+    ///     <para>
+    ///     <b>A redirected path is REFUSED, never repaired.</b> Unlinking it and writing a fresh file would
+    ///     destroy whatever it pointed at — the very file the refusal exists to protect — and this code
+    ///     cannot tell a hostile link from a deliberate one. So it treats the destination as indeterminate
+    ///     and defers, exactly as it does for a probe it could not read. Deferring costs a repeated flush;
+    ///     there is no undo for having overwritten someone's source file.
+    ///     </para>
+    /// </remarks>
+    public const int UnsafePathExitCode = 44;
+
+    /// <summary>
     ///     How many leading characters of each windowed line the probe returns. This is what bounds the
     ///     probe's output, and bounding it is not an optimisation.
     /// </summary>
@@ -183,6 +215,55 @@ public sealed class ConversationTranscriptWriter
     private const string TitlePropertyKey = "title";
 
     /// <summary>
+    ///     Defines the <c>guard</c> shell function every script opens with: it walks a path and each of its
+    ///     ancestor directories and fails if ANY of them is a symlink. Prepended, never interpolated into.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Walking the ancestors is the half that is easy to leave out and impossible to do without. A
+    ///     symlinked <c>.conversations</c> redirects every file beneath it — the transcripts and the
+    ///     <c>.gitignore</c> that is supposed to be covering them — while the leaf itself tests perfectly
+    ///     clean, because at that point the leaf does not exist yet. <c>mkdir -p</c> reports success on a
+    ///     symlinked directory precisely because there is nothing left for it to create.
+    ///     </para>
+    ///     <para>
+    ///     <c>return</c>, not <c>exit</c>: an <c>exit</c> inside a function ends the whole script, so the
+    ///     caller could not attach <see cref="UnsafePathExitCode"/> to the failure. The trailing
+    ///     <c>return 0</c> is likewise load-bearing — without it the function's status is that of the last
+    ///     <c>[ -L ]</c> it ran, which is 1 for every safe path.
+    ///     </para>
+    ///     <para>
+    ///     This narrows the window rather than closing it: a link planted between the guard and the write
+    ///     is still followed. Closing it needs <c>O_NOFOLLOW</c>, which neither the gateway's file PUT nor
+    ///     a POSIX shell redirection exposes. The residue is a race an attacker must win against a
+    ///     millisecond; what it replaces is a symlink that could be planted at leisure, days ahead, and
+    ///     would be followed with certainty.
+    ///     </para>
+    /// </remarks>
+    private const string PathGuardPreamble =
+        "guard() { p=\"$1\"; while [ -n \"$p\" ] && [ \"$p\" != \".\" ] && [ \"$p\" != \"/\" ]; do "
+        + "if [ -L \"$p\" ]; then return 1; fi; p=$(dirname \"$p\"); done; return 0; }\n";
+
+    /// <summary>
+    ///     One guard invocation for the given positional parameter, reporting
+    ///     <see cref="UnsafePathExitCode"/>. A method rather than three literals so the exit code cannot
+    ///     drift between the parameters.
+    /// </summary>
+    private static string GuardLine(string parameter) =>
+        "guard \""
+        + parameter
+        + "\" || exit "
+        + UnsafePathExitCode.ToString(CultureInfo.InvariantCulture)
+        + "\n";
+
+    /// <summary>
+    ///     The guard on its own, for the two writes that reach the workspace WITHOUT a shell — the staged
+    ///     payload and the <c>.gitignore</c>, both of which the gateway PUTs directly. <c>$1</c> is the
+    ///     path. Reads nothing, writes nothing. See <see cref="IsPathSafeAsync"/>.
+    /// </summary>
+    private static readonly string PathGuardScript = PathGuardPreamble + GuardLine("$1");
+
+    /// <summary>
     ///     THE one shell call site that writes. Built from concatenated literals rather than a raw string
     ///     literal so the line endings are LF regardless of how this source file is checked out — a script
     ///     carrying CR bytes fails inside the container in ways that are tedious to diagnose.
@@ -200,9 +281,21 @@ public sealed class ConversationTranscriptWriter
     ///     <c>.part</c> file per conversation — a name no <c>**/*.jsonl</c> scan matches, in a directory a
     ///     <c>.gitignore</c> already covers.
     ///     </para>
+    ///     <para>
+    ///     All three parameters are guarded, not just the destination. <c>$3</c> is the obvious one —
+    ///     <c>&gt;&gt;</c> writes straight through a link. <c>$1</c> catches the redirected directory that
+    ///     <c>mkdir -p</c> would silently accept, which is how a sub-agent's whole transcript leaves
+    ///     through a symlinked <c>_agents</c> folder. <c>$2</c> is guarded because <c>cat</c> reads through
+    ///     a link too, and a staged payload that is really a pointer at some other file would splice that
+    ///     file's contents into the transcript. See <see cref="UnsafePathExitCode"/>.
+    ///     </para>
     /// </remarks>
-    private const string AppendScript =
-        "mkdir -p \"$1\" || exit 1\n"
+    private static readonly string AppendScript =
+        PathGuardPreamble
+        + GuardLine("$1")
+        + GuardLine("$2")
+        + GuardLine("$3")
+        + "mkdir -p \"$1\" || exit 1\n"
         + "if [ -s \"$3\" ] && [ -n \"$(tail -c1 \"$3\")\" ]; then printf '\\n' >> \"$3\" || exit 1; fi\n"
         + "cat \"$2\" >> \"$3\" && rm -f \"$2\"\n";
 
@@ -248,9 +341,18 @@ public sealed class ConversationTranscriptWriter
     ///     title-derived path arrives as a positional parameter for the same inertness reason. Both exit
     ///     codes are spliced in from their constants rather than typed twice, so they cannot drift.
     ///     </para>
+    ///     <para>
+    ///     The guard runs first because <c>[ -e ]</c> and <c>tail</c> both report on a link's TARGET. A
+    ///     redirected destination would otherwise be probed as though it were the transcript, and the
+    ///     watermark read out of some unrelated file would decide how much of the history to append into
+    ///     it. Reporting <see cref="UnsafePathExitCode"/> lands in the same "indeterminate" branch as any
+    ///     other unexpected status, which is the correct reading: nothing about that path is known.
+    ///     </para>
     /// </remarks>
     private static readonly string WatermarkProbeScript =
-        "[ -e \"$1\" ] || exit "
+        PathGuardPreamble
+        + GuardLine("$1")
+        + "[ -e \"$1\" ] || exit "
         + WatermarkMissingExitCode.ToString(CultureInfo.InvariantCulture)
         + "\n"
         + "tail -n \"$2\" -- \"$1\" | cut -c \"1-$3\" || exit 1\n"
@@ -310,6 +412,14 @@ public sealed class ConversationTranscriptWriter
     ///     transcript an earlier process left behind.
     /// </summary>
     private bool _transcriptExists;
+
+    /// <summary>
+    ///     Whether THIS flush has already checked that the staging path is not redirected. Per flush
+    ///     rather than per writer: the path never varies within one flush, so re-checking it for each of
+    ///     the sub-agent files would buy nothing, while remembering the answer for the writer's whole life
+    ///     would miss a link planted between flushes. See <see cref="IsPathSafeAsync"/>.
+    /// </summary>
+    private bool _tempPathGuarded;
 
     private bool _agentsDirectoryTouched;
     private int _subAgentCursor;
@@ -414,6 +524,8 @@ public sealed class ConversationTranscriptWriter
 
     private async Task<TranscriptFlushOutcome> FlushCoreAsync(CancellationToken ct)
     {
+        _tempPathGuarded = false;
+
         // Metadata carries BOTH values the flush needs — the workspace binding for step 1 and the title
         // for the retitle check — so it is read once here rather than twice at the two points of use.
         var metadata = await _store.LoadMetadataAsync(ThreadId, ct).ConfigureAwait(false);
@@ -443,7 +555,9 @@ public sealed class ConversationTranscriptWriter
 
         var lines = WorkspaceTranscriptLine.ChainMessages(messages);
 
-        // Containment BEFORE the first transcript byte. See EnsureContainedAsync.
+        // Containment, first line. The load-bearing one is inside AppendAsync, which every byte of every
+        // file goes through; this one additionally covers a transcript an earlier process left behind,
+        // which may never be appended to at all. See EnsureContainedAsync.
         if ((lines.Count > 0 || _transcriptExists) && !await EnsureContainedAsync(sessionId, ct).ConfigureAwait(false))
         {
             return TranscriptFlushOutcome.Deferred;
@@ -506,10 +620,25 @@ public sealed class ConversationTranscriptWriter
     ///     later flush arriving, and for a conversation whose last turn has happened none ever does.
     ///     </para>
     ///     <para>
-    ///     Callers gate on <c>lines.Count > 0 || _transcriptExists</c> so a conversation that never
-    ///     produces a transcript leaves no directory behind. That gate cannot be wrong in the unsafe
-    ///     direction: rows in hand means an append is about to happen, and no rows plus no known transcript
-    ///     means there is nothing in the workspace to cover.
+    ///     <b>The load-bearing call is inside <c>AppendAsync</c></b> — the one path every transcript byte
+    ///     passes through, main file and sub-agent file alike — so the rule holds by construction rather
+    ///     than by each call site remembering it. Enforcing it only at the top of the flush was not enough,
+    ///     and the gap was not merely a narrow race: both of the flush's brakes are keyed to the MAIN
+    ///     conversation, while the bytes at stake can belong to a DESCENDANT. A root with no stable rows
+    ///     and no known transcript answers "no" to <c>lines.Count > 0 || _transcriptExists</c> and so skips
+    ///     the check; its own append then reports <c>UpToDate</c> rather than <c>Failed</c>, so the guard
+    ///     that skips the fan-out on a failed main append does not fire either; and the fan-out writes
+    ///     sub-agent transcripts into an uncovered directory. A sub-agent's reasoning is no less
+    ///     publishable than the root's.
+    ///     </para>
+    ///     <para>
+    ///     The flush-level check is KEPT, as a first line rather than the only one, because it still covers
+    ///     what an append cannot: a transcript an EARLIER process left in the workspace, which this writer
+    ///     may adopt with nothing further to append and therefore never append to at all. Its
+    ///     <c>lines.Count > 0 || _transcriptExists</c> condition cannot be wrong in the unsafe direction —
+    ///     rows in hand means an append is about to happen, and no rows plus no known transcript means
+    ///     there is nothing of this conversation's own in the workspace to cover — and gating on it is what
+    ///     keeps a conversation that never produces a transcript from leaving a directory behind.
     ///     </para>
     /// </remarks>
     private async Task<bool> EnsureContainedAsync(string sessionId, CancellationToken ct) =>
@@ -1049,10 +1178,33 @@ public sealed class ConversationTranscriptWriter
             return AppendResult.UpToDate;
         }
 
+        // Containment BEFORE the first transcript byte, enforced HERE because this is the one path every
+        // byte of every file passes through — the main transcript and each sub-agent file alike. See
+        // EnsureContainedAsync. Below this line the workspace is written to; the staged payload lands
+        // inside the very directory the ignore file covers, so it is a transcript byte like any other.
+        if (!await EnsureContainedAsync(sessionId, ct).ConfigureAwait(false))
+        {
+            return AppendResult.Failed;
+        }
+
         var payload = new StringBuilder();
         for (var i = start; i < lines.Count; i++)
         {
             _ = payload.Append(WorkspaceTranscriptLine.Serialize(lines[i])).Append('\n');
+        }
+
+        // The staging path is guarded for the same reason the destination is, and it cannot be guarded by
+        // AppendScript: the payload is PUT here BEFORE any script runs. Its name is no less guessable than
+        // the transcript's — a compile-time directory plus a hash of the thread id — and the bytes it
+        // carries are the same unredacted rows. Once per flush, because the path does not vary within one.
+        if (!_tempPathGuarded)
+        {
+            if (!await IsPathSafeAsync(sessionId, _tempPath, ct).ConfigureAwait(false))
+            {
+                return AppendResult.Failed;
+            }
+
+            _tempPathGuarded = true;
         }
 
         try
@@ -1299,11 +1451,20 @@ public sealed class ConversationTranscriptWriter
     ///     whether the file is now known to be present.
     /// </summary>
     /// <remarks>
+    ///     <para>
     ///     A workspace is frequently a git checkout and an agent frequently runs <c>git add -A</c>. Without
     ///     this, the first such commit publishes this conversation's and its siblings' unredacted reasoning
     ///     off-machine, irrecoverably. It is written BEFORE the first transcript byte and skipped entirely
     ///     for a conversation that will not produce a transcript, so no directory is left behind — see
     ///     <see cref="EnsureContainedAsync"/>, which owns that condition and what a <c>false</c> here costs.
+    ///     </para>
+    ///     <para>
+    ///     The path is guarded first, and a redirected one fails containment outright. This write is the
+    ///     one that DESTROYS rather than leaks: it is a PUT of <c>*</c>, so through a symlink it replaces
+    ///     the target's entire contents with a single character. Refusing also covers every transcript
+    ///     byte behind it at no extra cost, because the ignore path shares all its ancestors with them —
+    ///     a redirected <c>.conversations</c> is caught here, before anything is staged.
+    ///     </para>
     /// </remarks>
     private async Task<bool> EnsureGitignoreAsync(string sessionId, CancellationToken ct)
     {
@@ -1312,15 +1473,16 @@ public sealed class ConversationTranscriptWriter
             return true;
         }
 
+        var path = $"{TranscriptDirectory}/.{GitignoreName}";
+        if (!await IsPathSafeAsync(sessionId, path, ct).ConfigureAwait(false))
+        {
+            return false;
+        }
+
         try
         {
             await _fileBrowser
-                .WriteWorkspaceFileBytesAsync(
-                    sessionId,
-                    $"{TranscriptDirectory}/.{GitignoreName}",
-                    Encoding.UTF8.GetBytes("*\n"),
-                    ct
-                )
+                .WriteWorkspaceFileBytesAsync(sessionId, path, Encoding.UTF8.GetBytes("*\n"), ct)
                 .ConfigureAwait(false);
             _gitignoreWritten = true;
             return true;
@@ -1336,6 +1498,49 @@ public sealed class ConversationTranscriptWriter
     }
 
     // -------- Gateway helpers --------
+
+    /// <summary>
+    ///     Reports whether <paramref name="path"/> and every directory on the way to it are ordinary,
+    ///     un-redirected entries. <b>False means write nothing there</b> — it covers "this is a symlink"
+    ///     and "this could not be checked" alike, and both are reasons to leave the workspace untouched.
+    /// </summary>
+    /// <remarks>
+    ///     Only the two writes that reach the workspace WITHOUT a shell need this — the staged payload and
+    ///     the <c>.gitignore</c>. Everything the shell writes carries its guard inside the same script it
+    ///     writes with, which is both cheaper (no extra round trip) and tighter (no gap between the check
+    ///     and the write). See <see cref="UnsafePathExitCode"/> for why the answer is refusal rather than
+    ///     repair.
+    /// </remarks>
+    private async Task<bool> IsPathSafeAsync(string sessionId, string path, CancellationToken ct)
+    {
+        var guarded = await RunAsync(sessionId, ["sh", "-c", PathGuardScript, "sh", path], ct)
+            .ConfigureAwait(false);
+
+        if (guarded is { ExitCode: 0 })
+        {
+            return true;
+        }
+
+        if (guarded is { ExitCode: UnsafePathExitCode })
+        {
+            _logger.LogWarning(
+                "Transcript path {Path} for thread {ThreadId} is a symlink, or lies under one. Refusing to "
+                    + "write through it: the bytes would land outside the directory the .gitignore covers. "
+                    + "The link is left exactly as it is — removing it would destroy whatever it points at.",
+                path,
+                ThreadId
+            );
+            return false;
+        }
+
+        _logger.LogWarning(
+            "Transcript path guard for {Path} failed with exit {ExitCode}: {Error}",
+            path,
+            guarded?.ExitCode ?? -1,
+            guarded?.StandardError ?? "(no result)"
+        );
+        return false;
+    }
 
     private async Task<bool> TryMoveAsync(string sessionId, string from, string to, CancellationToken ct)
     {

--- a/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
+++ b/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
@@ -25,8 +25,9 @@ public enum TranscriptFlushOutcome
     Written,
 
     /// <summary>
-    ///     Work remains: a read never settled, a gateway call failed, or the sub-agent fan-out was capped.
-    ///     The watermarks involved are unadvanced, so a later flush repeats the work. <b>Re-schedule.</b>
+    ///     Work remains: a read never settled, a gateway call failed, the sub-agent fan-out was capped, or
+    ///     the containment <c>.gitignore</c> is not yet on disk. The watermarks involved are unadvanced, so
+    ///     a later flush repeats the work. <b>Re-schedule.</b>
     /// </summary>
     Deferred,
 
@@ -172,6 +173,15 @@ public sealed class ConversationTranscriptWriter
 
     private string? _leaf;
     private bool _gitignoreWritten;
+
+    /// <summary>
+    ///     Whether this conversation has a transcript in the workspace at all — set when an append lands
+    ///     and when the cold-start probe finds an existing file. Distinct from
+    ///     <see cref="_gitignoreWritten"/> and from "this flush wrote something": see
+    ///     <see cref="ContainAsync"/> for why conflating the three is what leaves the ignore file missing.
+    /// </summary>
+    private bool _transcriptExists;
+
     private bool _agentsDirectoryTouched;
     private int _subAgentCursor;
     private int _sawSubAgentActivity;
@@ -289,20 +299,62 @@ public sealed class ConversationTranscriptWriter
             ct
         ).ConfigureAwait(false);
 
-        var wrote = mainResult == AppendResult.Appended;
-        var deferred = mainResult == AppendResult.Failed;
+        if (mainResult == AppendResult.Failed)
+        {
+            // The fan-out is SKIPPED, not merely reported alongside a failed main append. A sub-agent
+            // file's first line anchors to the main file's watermark, and RootParentUidFor pins whatever
+            // it reads the first time it is asked — permanently, for the life of this writer. Running the
+            // fan-out here would mint that anchor from a watermark this failed append left unadvanced, so
+            // on a FIRST flush every sub-agent file would be pinned to null and the two files would never
+            // be one lineage again. No later flush revisits a pinned anchor. Deferring costs one repeated
+            // pass; a wrong anchor is not recoverable.
+            return await ContainAsync(sessionId, TranscriptFlushOutcome.Deferred, ct).ConfigureAwait(false);
+        }
 
+        var wrote = mainResult == AppendResult.Appended;
         var (agentsWrote, agentsDeferred) = await FlushSubAgentsAsync(sessionId, leaf, ct).ConfigureAwait(false);
         wrote = wrote || agentsWrote;
 
-        if (wrote)
+        return await ContainAsync(
+            sessionId,
+            agentsDeferred ? TranscriptFlushOutcome.Deferred
+                : wrote ? TranscriptFlushOutcome.Written
+                : TranscriptFlushOutcome.UpToDate,
+            ct
+        ).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Makes sure this conversation's transcript directory is contained by a <c>.gitignore</c> before
+    ///     the flush reports <paramref name="outcome"/>, downgrading to
+    ///     <see cref="TranscriptFlushOutcome.Deferred"/> when it is not.
+    /// </summary>
+    /// <remarks>
+    ///     <b>Containment is tracked separately from message progress, and this is the highest-consequence
+    ///     rule in the type.</b> The obvious shape — write the ignore file only on a flush that appended
+    ///     something — fails in both directions at once: the attempt is skipped on every flush that finds
+    ///     nothing new (so a transcript written by an earlier process, or one whose only appending flush
+    ///     already happened, is never covered), and a failed attempt changes nothing about the flush's
+    ///     result (so the ONE trigger that could retry it is a future flush that also appends, which for a
+    ///     finished conversation never comes). Both leave the file permanently absent, and this
+    ///     <c>.gitignore</c> is the entire opt-out for the feature: without it the next <c>git add -A</c>
+    ///     an agent runs in that workspace publishes every conversation's unredacted reasoning off-machine,
+    ///     irrecoverably. So: attempt it whenever a transcript exists and the file is not known to be
+    ///     present, and treat failure as work still pending.
+    /// </remarks>
+    private async Task<TranscriptFlushOutcome> ContainAsync(
+        string sessionId,
+        TranscriptFlushOutcome outcome,
+        CancellationToken ct)
+    {
+        if (!_transcriptExists || _gitignoreWritten)
         {
-            await EnsureGitignoreAsync(sessionId, ct).ConfigureAwait(false);
+            return outcome;
         }
 
-        return (deferred || agentsDeferred) ? TranscriptFlushOutcome.Deferred
-            : wrote ? TranscriptFlushOutcome.Written
-            : TranscriptFlushOutcome.UpToDate;
+        return await EnsureGitignoreAsync(sessionId, ct).ConfigureAwait(false)
+            ? outcome
+            : TranscriptFlushOutcome.Deferred;
     }
 
     // -------- Step 1: session --------
@@ -428,8 +480,9 @@ public sealed class ConversationTranscriptWriter
     // -------- Step 4: retitle --------
 
     /// <summary>
-    ///     Notices a title change and renames the conversation's file (and, when this writer has written
-    ///     any, its sub-agent directory) before anything is appended this flush.
+    ///     Notices a title change and renames the conversation's file (and, when there is one, its
+    ///     sub-agent directory) before anything is appended this flush — including a title change that
+    ///     happened while this process was not running.
     /// </summary>
     /// <remarks>
     ///     <para>
@@ -438,12 +491,21 @@ public sealed class ConversationTranscriptWriter
     ///     retries next time.
     ///     </para>
     ///     <para>
-    ///     The directory move is attempted only after the file move succeeded and only when this writer has
-    ///     actually written a sub-agent file. A conversation with no sub-agents has no directory to move,
-    ///     and issuing the <c>mv</c> anyway would fail every time and wedge the rename. If the directory
-    ///     move does fail, the in-memory sub-agent watermarks describe files that did not move, so they are
-    ///     dropped: the directory is rebuilt in full under the new name (duplicate rows, which dedupe on
-    ///     <c>uid</c>) rather than silently resuming past rows the new files do not contain.
+    ///     The directory move is attempted only after the file move succeeded and only when there is a
+    ///     directory to move. A conversation with no sub-agents has none, and issuing the <c>mv</c> anyway
+    ///     would fail every time and wedge the rename. If the directory move does fail, the in-memory
+    ///     sub-agent watermarks describe files that did not move, so they are dropped: the directory is
+    ///     rebuilt in full under the new name (duplicate rows, which dedupe on <c>uid</c>) rather than
+    ///     silently resuming past rows the new files do not contain.
+    ///     </para>
+    ///     <para>
+    ///     <b>Cold start is a retitle too.</b> A title edited while the host was down is invisible to this
+    ///     writer's in-memory state, so simply adopting the computed leaf produced a SECOND transcript for
+    ///     the same conversation — the old file frozen at its last row under the old slug, the new one
+    ///     starting the history again from zero, plus an orphaned <c>_agents/</c> directory beside the
+    ///     wrong name. The short id in the leaf is what makes the old file findable: it is stable across
+    ///     any number of retitles, so a directory listing identifies the conversation's own file under
+    ///     whatever slug it was last named, and the same move path adopts it.
     ///     </para>
     /// </remarks>
     private async Task ApplyRetitleAsync(string sessionId, ThreadMetadata? metadata, CancellationToken ct)
@@ -451,9 +513,7 @@ public sealed class ConversationTranscriptWriter
         var leaf = WorkspaceTranscriptLine.MainFileLeaf(ReadTitle(metadata), _shortThreadId);
         if (_leaf is null)
         {
-            // Cold start: nothing to rename. A title changed while this process was down is recovered by
-            // the watermark probe against the new path, which finds no file and appends everything.
-            _leaf = leaf;
+            _leaf = await AdoptExistingLeafAsync(sessionId, leaf, ct).ConfigureAwait(false) ?? leaf;
             return;
         }
 
@@ -462,31 +522,114 @@ public sealed class ConversationTranscriptWriter
             return;
         }
 
-        var previous = _leaf;
-        var moved = await TryMoveAsync(
-            sessionId,
-            $"{TranscriptDirectory}/{previous}{TranscriptExtension}",
-            $"{TranscriptDirectory}/{leaf}{TranscriptExtension}",
-            ct
-        ).ConfigureAwait(false);
-
-        if (!moved)
+        if (await MoveLeafAsync(sessionId, _leaf, leaf, _agentsDirectoryTouched, ct).ConfigureAwait(false))
         {
-            return;
+            _leaf = leaf;
+        }
+    }
+
+    /// <summary>
+    ///     On cold start, finds this conversation's existing transcript under a DIFFERENT slug and renames
+    ///     it (and its sub-agent directory) onto <paramref name="leaf"/>. Reports the leaf actually in
+    ///     force afterwards, or null when there was nothing to adopt.
+    /// </summary>
+    /// <remarks>
+    ///     A listing failure, an unreadable directory, or a move that does not take are all answered the
+    ///     same way: keep using the file that is there. Reporting the stale leaf rather than the new one
+    ///     is what stops a failed adoption from splitting the transcript in two anyway — appending to the
+    ///     old name is always preferable to starting a second file.
+    /// </remarks>
+    private async Task<string?> AdoptExistingLeafAsync(string sessionId, string leaf, CancellationToken ct)
+    {
+        IReadOnlyList<SandboxDirectoryEntry> entries;
+        try
+        {
+            entries = await _fileBrowser
+                .ListWorkspaceDirectoryAsync(sessionId, TranscriptDirectory, ct)
+                .ConfigureAwait(false);
+        }
+        catch (SandboxException ex)
+        {
+            _logger.LogDebug(ex, "Listing {Directory} for thread {ThreadId} failed", TranscriptDirectory, ThreadId);
+            return null;
         }
 
-        if (_agentsDirectoryTouched
+        var stale = entries
+            .Where(entry => entry.Type == SandboxEntryType.File && !entry.NameLossy)
+            .Select(entry => entry.Name)
+            .Where(name => name.EndsWith(TranscriptExtension, StringComparison.Ordinal))
+            .Select(name => name[..^TranscriptExtension.Length])
+            .FirstOrDefault(stem => IsThisConversation(stem) && !string.Equals(stem, leaf, StringComparison.Ordinal));
+
+        // The flag means "there is a sub-agent directory a later retitle has to move", which until now
+        // only a write in THIS process could set. A restart forgot it, so the first retitle after one
+        // moved the file and left the directory orphaned under the old name — the same defect as the file
+        // itself, one level down. The listing is the answer for both.
+        var subject = stale ?? leaf;
+        _agentsDirectoryTouched =
+            _agentsDirectoryTouched
+            || entries.Any(entry =>
+                entry.Type == SandboxEntryType.Directory
+                && !entry.NameLossy
+                && string.Equals(entry.Name, subject + AgentsDirectorySuffix, StringComparison.Ordinal));
+
+        if (stale is null)
+        {
+            return null;
+        }
+
+        _transcriptExists = true;
+        _logger.LogInformation(
+            "Adopting the transcript of thread {ThreadId} left under {Stale} as {Leaf}",
+            ThreadId,
+            stale,
+            leaf);
+
+        return await MoveLeafAsync(sessionId, stale, leaf, _agentsDirectoryTouched, ct).ConfigureAwait(false)
+            ? leaf
+            : stale;
+    }
+
+    /// <summary>
+    ///     Whether a file stem is this conversation's own — i.e. carries its short id in the position
+    ///     <see cref="WorkspaceTranscriptLine.MainFileLeaf"/> puts it, either as the whole stem (the title
+    ///     slugged to nothing) or after the separator.
+    /// </summary>
+    private bool IsThisConversation(string stem) =>
+        string.Equals(stem, _shortThreadId, StringComparison.Ordinal)
+        || stem.EndsWith($"-{_shortThreadId}", StringComparison.Ordinal);
+
+    /// <summary>Renames one transcript file and, when asked, its sibling sub-agent directory.</summary>
+    /// <returns>Whether the FILE moved — the only condition under which the new leaf may be adopted.</returns>
+    private async Task<bool> MoveLeafAsync(
+        string sessionId,
+        string from,
+        string to,
+        bool moveAgents,
+        CancellationToken ct)
+    {
+        if (!await TryMoveAsync(
+                sessionId,
+                $"{TranscriptDirectory}/{from}{TranscriptExtension}",
+                $"{TranscriptDirectory}/{to}{TranscriptExtension}",
+                ct
+            ).ConfigureAwait(false))
+        {
+            return false;
+        }
+
+        if (moveAgents
             && !await TryMoveAsync(
                 sessionId,
-                $"{TranscriptDirectory}/{previous}{AgentsDirectorySuffix}",
-                $"{TranscriptDirectory}/{leaf}{AgentsDirectorySuffix}",
+                $"{TranscriptDirectory}/{from}{AgentsDirectorySuffix}",
+                $"{TranscriptDirectory}/{to}{AgentsDirectorySuffix}",
                 ct
             ).ConfigureAwait(false))
         {
             DropSubAgentState();
         }
 
-        _leaf = leaf;
+        return true;
     }
 
     private void DropSubAgentState()
@@ -574,12 +717,16 @@ public sealed class ConversationTranscriptWriter
 
         _subAgentCursor = agents.Count == 0 ? 0 : (_subAgentCursor + take) % agents.Count;
 
-        // A capped pass asks for a follow-up only when it actually mirrored something. Reporting Deferred
-        // purely because descendants outnumber the cap would be true on EVERY flush forever, and a caller
-        // that re-schedules on Deferred would then spin: the cursor keeps moving but the condition never
-        // clears. Gating on progress converges — the first pass that finds its slice already up to date
-        // ends the chain.
-        return (wrote, deferred || (capped && wrote));
+        // A capped pass asks for a follow-up whether or not it mirrored anything, because "this slice
+        // wrote nothing" says nothing at all about the descendants OUTSIDE the slice — and the one that
+        // changed is exactly as likely to be out there. Gating on progress looked convergent and was
+        // instead a way to stop one step short: the pass that found its own slice up to date ended the
+        // chain, leaving the changed descendant beyond the cap unwritten until some later trigger
+        // happened to come along. What terminates the chain is the mirror's bounded retry budget
+        // (WorkspaceTranscriptMirror.MaxDeferredRetries), which is reset at each turn boundary — so a
+        // large fan-out is covered a slice per attempt and paced, rather than either spinning or being
+        // silently truncated.
+        return (wrote, deferred || capped);
     }
 
     /// <summary>
@@ -662,6 +809,7 @@ public sealed class ConversationTranscriptWriter
         }
 
         _watermarks[watermarkKey] = lines[^1].Uid;
+        _transcriptExists = true;
         return AppendResult.Appended;
     }
 
@@ -684,6 +832,7 @@ public sealed class ConversationTranscriptWriter
         if (!_watermarks.TryGetValue(watermarkKey, out var watermark))
         {
             var (hadContent, recovered) = await RecoverWatermarkAsync(sessionId, path, ct).ConfigureAwait(false);
+            _transcriptExists = _transcriptExists || hadContent;
             if (recovered is null)
             {
                 if (hadContent)
@@ -781,20 +930,21 @@ public sealed class ConversationTranscriptWriter
     // -------- Step 8: containment --------
 
     /// <summary>
-    ///     Writes <c>.conversations/.gitignore</c> containing <c>*</c>, once per conversation, on the first
-    ///     successful flush.
+    ///     Writes <c>.conversations/.gitignore</c> containing <c>*</c>, once per conversation. Reports
+    ///     whether the file is now known to be present.
     /// </summary>
     /// <remarks>
     ///     A workspace is frequently a git checkout and an agent frequently runs <c>git add -A</c>. Without
     ///     this, the first such commit publishes this conversation's and its siblings' unredacted reasoning
-    ///     off-machine, irrecoverably. Written after the first successful append rather than before, so a
-    ///     conversation that never produced a transcript leaves no directory behind.
+    ///     off-machine, irrecoverably. It is written only once a transcript exists, so a conversation that
+    ///     never produced one leaves no directory behind — see <see cref="ContainAsync"/>, which owns that
+    ///     condition and the retry that a <c>false</c> here earns.
     /// </remarks>
-    private async Task EnsureGitignoreAsync(string sessionId, CancellationToken ct)
+    private async Task<bool> EnsureGitignoreAsync(string sessionId, CancellationToken ct)
     {
         if (_gitignoreWritten)
         {
-            return;
+            return true;
         }
 
         try
@@ -808,12 +958,15 @@ public sealed class ConversationTranscriptWriter
                 )
                 .ConfigureAwait(false);
             _gitignoreWritten = true;
+            return true;
         }
         catch (SandboxException ex)
         {
-            // Retried on the next flush. The transcript itself is already written; refusing to keep the
-            // rows because their ignore file failed would be the wrong trade.
+            // Retried on the next flush, and the flush reports Deferred so there IS a next one. The rows
+            // themselves stay written: refusing to keep them because their ignore file failed would be the
+            // wrong trade, and the watermark is what guarantees the retry is a no-op for them.
             _logger.LogWarning(ex, "Writing the transcript .gitignore for thread {ThreadId} failed", ThreadId);
+            return false;
         }
     }
 

--- a/samples/LmStreaming.Sample/Services/TranscriptFlushScheduler.cs
+++ b/samples/LmStreaming.Sample/Services/TranscriptFlushScheduler.cs
@@ -68,6 +68,25 @@ public sealed class TranscriptFlushScheduler : IDisposable
     private readonly object _gate = new();
     private readonly HashSet<string> _pending = new(StringComparer.Ordinal);
     private Task _drain = Task.CompletedTask;
+
+    /// <summary>
+    ///     Whether a drain loop is live, tracked explicitly under <see cref="_gate"/> rather than inferred
+    ///     from <c>_drain.IsCompleted</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <b>This flag is the fix for a lost wakeup, not a convenience.</b> <see cref="DrainAsync"/>
+    ///     decides to stop from INSIDE the lock, but the <see cref="Task"/> it returns only transitions to
+    ///     completed after the lock is released and the state machine unwinds. In that window a concurrent
+    ///     <see cref="Schedule"/> takes the gate, adds its key, observes <c>_drain.IsCompleted == false</c>
+    ///     and starts nothing — while the loop it assumed was running has already committed to exiting and
+    ///     will never look at the pending set again. That key then waits for an unrelated future
+    ///     <c>Schedule</c>, which for a conversation whose last turn just ended never comes: the transcript
+    ///     silently stops at the previous turn. Setting and clearing the flag at the same two points
+    ///     INSIDE the lock closes the window, because the decision to exit and the publication of that
+    ///     decision become one atomic step.
+    /// </remarks>
+    private bool _draining;
+
     private bool _disposed;
 
     /// <summary>Creates a scheduler that drains pending keys through <paramref name="flush" />.</summary>
@@ -115,8 +134,9 @@ public sealed class TranscriptFlushScheduler : IDisposable
             }
 
             _ = _pending.Add(key);
-            if (_drain.IsCompleted)
+            if (!_draining)
             {
+                _draining = true;
                 _drain = DrainAsync();
             }
         }
@@ -141,6 +161,9 @@ public sealed class TranscriptFlushScheduler : IDisposable
             {
                 if (_disposed || _pending.Count == 0)
                 {
+                    // Cleared HERE, under the same lock that made the decision — see _draining. Any
+                    // Schedule that reaches the gate after this point starts a fresh loop.
+                    _draining = false;
                     return;
                 }
 
@@ -156,6 +179,11 @@ public sealed class TranscriptFlushScheduler : IDisposable
             {
                 // Shutdown cancelled this flush. Not an error, and not worth reporting: the accepted gap is
                 // that a run interrupted mid-flight is flushed by the next completed run instead.
+                lock (_gate)
+                {
+                    _draining = false;
+                }
+
                 return;
             }
             catch (Exception ex)

--- a/samples/LmStreaming.Sample/Services/TranscriptFlushScheduler.cs
+++ b/samples/LmStreaming.Sample/Services/TranscriptFlushScheduler.cs
@@ -1,0 +1,230 @@
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+///     Coalescing background drain for the workspace transcript mirror (#251). Callers <see cref="Schedule" />
+///     a key (a conversation's threadId) from the message-subscriber hot path; a single background loop later
+///     invokes the flush callback once per pending key. The point of the indirection is that the subscriber
+///     never awaits I/O — a transcript flush talks to the sandbox gateway, and blocking the loop body on that
+///     would add gateway latency to every turn boundary.
+/// </summary>
+/// <remarks>
+///     <para>
+///     <b>This is a deliberate COPY of <c>UsagePersistenceWriter</c>'s Schedule/Drain shape, not a duplicate to
+///     be deleted.</b> That type is <c>internal sealed</c> in <c>AchieveAi.LmDotnetTools.LmMultiTurn</c>, and its
+///     <c>InternalsVisibleTo</c> grants cover only the <i>test</i> assemblies (<c>LmMultiTurn.Tests</c>,
+///     <c>LmWorkflow.Tests</c>, <c>LmStreaming.Sample.Tests</c>) — <b>not</b> this sample's production assembly.
+///     It is therefore unreachable from here, and this copy carries its own tests; "already reviewed elsewhere"
+///     does not transfer.
+///     </para>
+///     <para>
+///     Three deliberate differences from the original:
+///     </para>
+///     <list type="number">
+///         <item>
+///             A <see cref="HashSet{T}" /> of pending keys rather than one <c>bool _pending</c> slot. A single
+///             slot silently drops conversation A's pending flush the moment conversation B schedules.
+///         </item>
+///         <item>
+///             <b>Failures are caught per key and the loop continues.</b> The original's catch re-arms the
+///             pending flag and <i>returns</i>, aborting the whole drain — with N keys that strands every other
+///             conversation behind one failing one, and because the failing key is re-armed a restarted drain
+///             picks it first and aborts again. One permanently-broken conversation would block the mirror
+///             indefinitely.
+///         </item>
+///         <item>
+///             <see cref="Schedule" /> stays strictly non-blocking, and <c>await Task.Yield()</c> stays the
+///             drain's first statement (see <see cref="DrainAsync" /> for why that line is load-bearing).
+///         </item>
+///     </list>
+///     <para>
+///     <b>Deliberately NOT implemented:</b> there is no <c>FlushAsync()</c> and no disposal-time flush.
+///     <c>Schedule()</c> at disposal flushes nothing, and an <i>awaited</i> flush at process shutdown loses a
+///     race with <c>SandboxSessionRegistry</c>'s <c>ObjectDisposedException.ThrowIf</c> guard and is swallowed
+///     anyway — so the "fixed" version does not reliably work either. A run cancelled or shut down mid-flight is
+///     picked up by the next completed run (the mirror's watermark is cumulative); that is an <b>accepted,
+///     documented gap</b>, not an oversight.
+///     </para>
+///     <para>
+///     <b>Disposal is synchronous <see cref="IDisposable" /> on purpose</b> — never <c>IAsyncDisposable</c>-only.
+///     The sample host is torn down with the synchronous <c>IHost.Dispose()</c> in tests
+///     (<c>BrowserWebAppFactory</c>), and a container-tracked <c>IAsyncDisposable</c>-only singleton makes
+///     <c>ServiceProvider.Dispose()</c> throw <i>"only implements IAsyncDisposable"</i>, which would break every
+///     E2E test. See the verbatim note at <c>Program.cs</c> where <c>SqliteConnectionFactory</c> is constructed
+///     inline for exactly this reason.
+///     </para>
+/// </remarks>
+public sealed class TranscriptFlushScheduler : IDisposable
+{
+    /// <summary>
+    ///     How long <see cref="Dispose" /> waits on an in-flight flush before giving up on it. Bounded because
+    ///     shutdown must not hang on a gateway call; the abandoned flush's work is recovered by the next run.
+    /// </summary>
+    public static readonly TimeSpan DefaultShutdownDrainTimeout = TimeSpan.FromSeconds(2);
+
+    private readonly Func<string, CancellationToken, Task> _flush;
+    private readonly Action<string, Exception>? _onError;
+    private readonly TimeSpan _shutdownDrainTimeout;
+    private readonly CancellationTokenSource _shutdown = new();
+    private readonly object _gate = new();
+    private readonly HashSet<string> _pending = new(StringComparer.Ordinal);
+    private Task _drain = Task.CompletedTask;
+    private bool _disposed;
+
+    /// <summary>Creates a scheduler that drains pending keys through <paramref name="flush" />.</summary>
+    /// <param name="flush">
+    ///     Invoked once per pending key on the drain loop. Never invoked concurrently with itself — the drain is
+    ///     a single loop — so an implementation may assume flushes are serialized process-wide.
+    /// </param>
+    /// <param name="onError">
+    ///     Reports a flush failure (the key, then the exception) so the owner can log it. The drain continues
+    ///     regardless, and a throwing <paramref name="onError" /> is itself swallowed: the error channel must
+    ///     never be able to stop the loop.
+    /// </param>
+    /// <param name="shutdownDrainTimeout">
+    ///     Overrides <see cref="DefaultShutdownDrainTimeout" /> (tests use a short one).
+    /// </param>
+    public TranscriptFlushScheduler(
+        Func<string, CancellationToken, Task> flush,
+        Action<string, Exception>? onError = null,
+        TimeSpan? shutdownDrainTimeout = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(flush);
+        _flush = flush;
+        _onError = onError;
+        _shutdownDrainTimeout = shutdownDrainTimeout ?? DefaultShutdownDrainTimeout;
+    }
+
+    /// <summary>
+    ///     Requests a flush of <paramref name="key" />. <b>Strictly non-blocking</b> and fire-and-forget: it
+    ///     takes a short lock and returns, doing no I/O on the caller's thread. Repeat calls for the same key
+    ///     coalesce — while a key's flush is in flight the key is already out of the pending set, so a
+    ///     re-schedule re-adds it and earns exactly one more flush rather than being lost or duplicated.
+    ///     A no-op after <see cref="Dispose" /> (the mirror is best-effort; shutdown must not throw into a
+    ///     message-subscriber loop).
+    /// </summary>
+    public void Schedule(string key)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _ = _pending.Add(key);
+            if (_drain.IsCompleted)
+            {
+                _drain = DrainAsync();
+            }
+        }
+    }
+
+    private async Task DrainAsync()
+    {
+        // LOAD-BEARING, and must stay the first statement. Schedule() calls DrainAsync() while holding _gate,
+        // so without this yield the whole synchronous prologue — including the first _flush(...) call, up to
+        // its own first real await — would run on the caller's thread inside the lock. That would put gateway
+        // I/O straight back on the subscriber hot path, which is the one thing this type exists to prevent.
+        await Task.Yield();
+
+        // Captured once: the token is handed to every flush, and re-reading _shutdown.Token after the source
+        // is disposed would throw. Dispose() only disposes the source once this loop has finished.
+        var shutdownToken = _shutdown.Token;
+
+        while (true)
+        {
+            string key;
+            lock (_gate)
+            {
+                if (_disposed || _pending.Count == 0)
+                {
+                    return;
+                }
+
+                key = _pending.First();
+                _ = _pending.Remove(key);
+            }
+
+            try
+            {
+                await _flush(key, shutdownToken);
+            }
+            catch (OperationCanceledException) when (shutdownToken.IsCancellationRequested)
+            {
+                // Shutdown cancelled this flush. Not an error, and not worth reporting: the accepted gap is
+                // that a run interrupted mid-flight is flushed by the next completed run instead.
+                return;
+            }
+            catch (Exception ex)
+            {
+                // THE line this copy exists for: one key's failure must not strand the others. Report it and
+                // move on to the next pending key rather than aborting the loop.
+                ReportError(key, ex);
+            }
+        }
+    }
+
+    private void ReportError(string key, Exception error)
+    {
+        try
+        {
+            _onError?.Invoke(key, error);
+        }
+        catch (Exception)
+        {
+            // A throwing error channel would fault the drain task and leave it unobserved. Swallowed on
+            // purpose: there is nowhere left to report a failure of the thing that reports failures.
+        }
+    }
+
+    /// <summary>
+    ///     Stops accepting work, drops anything still pending, and waits <b>bounded</b> on the in-flight flush.
+    ///     It does not flush pending keys — see the type remarks for why that trigger is deliberately absent.
+    /// </summary>
+    public void Dispose()
+    {
+        Task drain;
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _pending.Clear();
+            drain = _drain;
+        }
+
+        try
+        {
+            _shutdown.Cancel();
+        }
+        catch (Exception)
+        {
+            // Cancel() surfaces exceptions thrown by callbacks registered downstream on our token. Shutdown
+            // proceeds regardless — Dispose() must not throw out of host teardown.
+        }
+
+        var drainFinished = true;
+        try
+        {
+            drainFinished = drain.Wait(_shutdownDrainTimeout);
+        }
+        catch (Exception)
+        {
+            // A faulted/cancelled drain is a finished drain. Per-key failures were already reported.
+        }
+
+        if (drainFinished)
+        {
+            // Only safe once nothing can still be holding the token: an abandoned in-flight flush would see
+            // ObjectDisposedException from a disposed source. Leaking the source in that case is harmless —
+            // it holds no OS handle unless its WaitHandle was taken, and the process is shutting down.
+            _shutdown.Dispose();
+        }
+    }
+}

--- a/samples/LmStreaming.Sample/Services/TranscriptProjection.cs
+++ b/samples/LmStreaming.Sample/Services/TranscriptProjection.cs
@@ -13,6 +13,13 @@ namespace LmStreaming.Sample.Services;
 ///     own <c>/messages</c> route, the cross-agent transcript endpoint, and the
 ///     <c>GetAgentTranscript</c> tool must apply the SAME normalization and the SAME exclusions. Split
 ///     across three call sites, one of them eventually forgets — and the thing it forgets is reasoning.
+///     <para>
+///     A fourth caller, the workspace transcript mirror (#251), passes <c>excludeReasoning: false</c>. It
+///     is NOT exempted from normalization — it is normalized like every other reader, and deliberately
+///     includes reasoning: the mirror writes the conversation's own full-fidelity record into its own
+///     workspace, which is the one read that is not cross-agent. See ADR
+///     <c>0011-workspace-transcript-files</c>.
+///     </para>
 /// </remarks>
 public static class TranscriptProjection
 {

--- a/samples/LmStreaming.Sample/Services/WorkspaceTranscriptLine.cs
+++ b/samples/LmStreaming.Sample/Services/WorkspaceTranscriptLine.cs
@@ -66,8 +66,30 @@ public sealed record WorkspaceTranscriptLine
     /// <summary>Length in characters of a derived <see cref="Uid"/>.</summary>
     public const int UidLength = 8;
 
-    /// <summary>Length in characters of a short id used inside a file leaf.</summary>
-    public const int ShortIdLength = 4;
+    /// <summary>
+    ///     Length in characters of a short id used inside a file leaf — 50 bits of hash, base32.
+    /// </summary>
+    /// <remarks>
+    ///     <b>A file leaf's short id is an identity, not a display abbreviation, so it is sized for
+    ///     collision resistance rather than for looks.</b> Two conversations whose titles slug the same
+    ///     (the common case: "Untitled", "Code review", the empty slug) differ only by this suffix, so a
+    ///     collision does not produce two similar names — it produces ONE file that both conversations
+    ///     append to, interleaved, each one's watermark rewinding the other's, and no downstream reader can
+    ///     separate them again. At 4 characters (20 bits) that is a ~3% chance across 256 same-slug files
+    ///     in one workspace and a coin flip by ~1200, which is well inside what a long-lived agent
+    ///     workspace accumulates. Ten characters (50 bits) puts the same 256-file workspace at ~3e-11.
+    ///     <para>
+    ///     Deliberately NOT the same value as <see cref="UidLength"/>. A uid is scoped to one file and one
+    ///     conversation's rows; this is scoped to every conversation that ever wrote into a workspace, so
+    ///     they carry different collision domains and must be tuned separately.
+    ///     </para>
+    ///     <para>
+    ///     The cost is 6 characters of leaf. With <see cref="MaxSlugLength"/> at 80 the longest leaf is
+    ///     80 + 1 + 10 = 91 characters plus <c>.jsonl</c> or <c>_agents</c> — still far inside the 255-byte
+    ///     path-component cap.
+    ///     </para>
+    /// </remarks>
+    public const int ShortIdLength = 10;
 
     /// <summary>Leaf pinned for a sub-agent whose display name is null or slugs to nothing.</summary>
     public const string UnnamedAgentLeafPrefix = "agent";
@@ -324,8 +346,13 @@ public sealed record WorkspaceTranscriptLine
     /// <summary>
     ///     Derives the short id a file leaf carries. Hashed rather than prefix-sliced because ids in this
     ///     sample share prefixes (<c>subagent-</c>) and may contain characters a filename cannot, so a
-    ///     prefix would be neither unique nor legal.
+    ///     prefix would be neither legal nor discriminating.
     /// </summary>
+    /// <remarks>
+    ///     A truncated hash is collision-RESISTANT, not collision-free; <see cref="ShortIdLength"/> is what
+    ///     sets the margin, and its remarks state the numbers. Nothing downstream may treat this value as
+    ///     an injective encoding of <paramref name="id"/>.
+    /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="id"/> is null.</exception>
     public static string ShortId(string id)
     {
@@ -335,7 +362,9 @@ public sealed record WorkspaceTranscriptLine
 
     /// <summary>
     ///     Main transcript file leaf (no extension): <c>{slug(title)}-{shortThreadId}</c>. The short-id
-    ///     suffix is what guarantees a non-empty, unique leaf even when the title slugs to nothing.
+    ///     suffix is what keeps the leaf non-empty when the title slugs to nothing, and what separates two
+    ///     conversations whose titles slug identically — to within <see cref="ShortIdLength"/>'s collision
+    ///     margin, which is the only thing standing between them and one interleaved file.
     /// </summary>
     /// <exception cref="ArgumentException"><paramref name="shortThreadId"/> is blank.</exception>
     public static string MainFileLeaf(string? title, string shortThreadId)
@@ -349,7 +378,8 @@ public sealed record WorkspaceTranscriptLine
     /// <summary>
     ///     Sub-agent transcript file leaf (no extension): <c>{slug(name)}-{shortAgentId}</c>, pinned to
     ///     <c>agent-{shortAgentId}</c> when the name is null or slugs to nothing. Two sub-agents sharing a
-    ///     display name still get distinct leaves, because the short id comes from the agent id.
+    ///     display name still get distinct leaves, because the short id comes from the agent id — again to
+    ///     within <see cref="ShortIdLength"/>'s margin.
     /// </summary>
     /// <exception cref="ArgumentException"><paramref name="shortAgentId"/> is blank.</exception>
     public static string AgentFileLeaf(string? agentName, string shortAgentId)

--- a/samples/LmStreaming.Sample/Services/WorkspaceTranscriptLine.cs
+++ b/samples/LmStreaming.Sample/Services/WorkspaceTranscriptLine.cs
@@ -1,0 +1,484 @@
+using System.Buffers;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
+using LmStreaming.Sample.Persistence;
+
+// The envelope has its own `Role` property, so the enum needs an alias to stay addressable inside
+// this type — an unaliased `Role.None` binds to the property and does not compile.
+using MessageRole = AchieveAi.LmDotnetTools.LmCore.Messages.Role;
+
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+///     One line of a workspace transcript file (<c>.conversations/*.jsonl</c>) — the envelope, its
+///     <c>uid</c> derivation, the file-leaf slug, and the exact bytes each line serializes to.
+/// </summary>
+/// <remarks>
+///     <para>
+///     Everything here is PURE: no I/O, no async, no clock, no DI. Given the same
+///     <see cref="PersistedMessage"/> this type produces the same bytes in every process, on every
+///     flush, forever — which is what makes <c>uid</c> usable as an append watermark and as the
+///     de-duplication key a reader collapses on.
+///     </para>
+///     <para>
+///     <b><c>message_json</c> is an OPAQUE STRING, always.</b> It carries
+///     <see cref="PersistedMessage.MessageJson"/> verbatim as a JSON <i>string</i> value, never as an
+///     inlined object. A reader that wants the message parses that string itself. This is deliberate:
+///     an object-or-string union is exactly the shape that gets silently dropped by a tolerant JSONL
+///     reader (<c>read_ndjson_objects</c> with <c>ignore_errors=true</c>), and inlining would let a
+///     provider's arbitrary message shape widen the transcript's own schema.
+///     </para>
+///     <para>
+///     <b>Casing asymmetry, on purpose.</b> The envelope's <c>role</c> is PascalCase (<c>"User"</c>) —
+///     it passes through <see cref="PersistedMessage.Role"/>, which is written as
+///     <c>message.Role.ToString()</c>. The same role <i>inside</i> <c>message_json</c> is lowercase
+///     (<c>"user"</c>), because <see cref="MessageRole"/> carries <c>JsonPropertyName</c> attributes.
+///     Readers must not assume one casing across both layers.
+///     </para>
+///     <para>
+///     <b>Known gap, stated where a reader will see it:</b> a deferred tool result (a late client-tool
+///     or <c>AskUserQuestion</c> answer) is written back through <c>ReplaceMessageAsync</c>, which
+///     mutates the stored row IN PLACE — same <see cref="PersistedMessage.Id"/>, same
+///     <see cref="PersistedMessage.Timestamp"/>, therefore the same <c>uid</c>. The append watermark has
+///     already passed that <c>uid</c>, so the transcript keeps the question and never gets the answer.
+///     Re-emitting under the same <c>uid</c> was rejected: it would break the "distinct uid count ==
+///     line count" guarantee.
+///     </para>
+/// </remarks>
+public sealed record WorkspaceTranscriptLine
+{
+    /// <summary>
+    ///     Schema version stamped on every line. <b>Bump rule:</b> bump when a field is REMOVED or
+    ///     RETYPED. Adding a new nullable field does NOT bump — a reader that ignores unknown keys keeps
+    ///     working, which is the whole point of versioning per line rather than per file.
+    /// </summary>
+    public const int CurrentSchemaVersion = 1;
+
+    /// <summary>Discriminator value for a persisted-message line.</summary>
+    public const string MessageLineType = "message";
+
+    /// <summary>Discriminator value for a conversation-state line (title / mode / provider).</summary>
+    public const string StateLineType = "state";
+
+    /// <summary>Length in characters of a derived <see cref="Uid"/>.</summary>
+    public const int UidLength = 8;
+
+    /// <summary>Length in characters of a short id used inside a file leaf.</summary>
+    public const int ShortIdLength = 4;
+
+    /// <summary>Leaf pinned for a sub-agent whose display name is null or slugs to nothing.</summary>
+    public const string UnnamedAgentLeafPrefix = "agent";
+
+    /// <summary>
+    ///     Longest slug retained in a file leaf. A title is user-authored and unbounded; most filesystems
+    ///     cap a path component at 255 bytes, and the leaf still has to fit a short id, a separator and
+    ///     <c>.jsonl</c>.
+    /// </summary>
+    private const int MaxSlugLength = 80;
+
+    /// <summary>RFC 4648 base32 alphabet, lowercased — the encoding <see cref="Uid"/> uses.</summary>
+    private const string Base32Alphabet = "abcdefghijklmnopqrstuvwxyz234567";
+
+    /// <summary>Per-line schema version. See <see cref="CurrentSchemaVersion"/> for the bump rule.</summary>
+    public int SchemaVersion { get; init; } = CurrentSchemaVersion;
+
+    /// <summary>
+    ///     The discriminator — <see cref="MessageLineType"/> or <see cref="StateLineType"/>. Every
+    ///     message-specific member below is nullable precisely so a state line is constructible:
+    ///     <see cref="PersistedMessage"/> has seven <c>required</c> members and a state line has none of
+    ///     them.
+    /// </summary>
+    public required string Type { get; init; }
+
+    /// <summary>
+    ///     Stable identity of this line: truncated SHA-256 of the source id, base32 lowercase, exactly
+    ///     <see cref="UidLength"/> characters. Deterministic across flushes and across processes.
+    /// </summary>
+    public required string Uid { get; init; }
+
+    /// <summary>
+    ///     <c>uid</c> of the previous line in store order, or null for the first line of a file.
+    ///     <b>Honest caveat:</b> this is STORE ADJACENCY. It recovers <i>sequence</i>, not turn
+    ///     structure — a reader can replay the order rows were persisted in, but cannot infer from the
+    ///     chain alone which rows belonged to the same turn.
+    /// </summary>
+    public string? ParentUid { get; init; }
+
+    /// <summary>Thread the line belongs to.</summary>
+    public required string ThreadId { get; init; }
+
+    /// <summary>ISO-8601 UTC instant, round-trip ("O") format.</summary>
+    public required string Timestamp { get; init; }
+
+    /// <summary>
+    ///     Sub-agent DISPLAY NAME, from <see cref="SubAgentProvenance.NameKey"/>; null on a main-file
+    ///     line. Never <see cref="PersistedMessage.FromAgent"/> — providers put a provider message id in
+    ///     that field, so sourcing <c>agent</c> from it would fill the column with opaque ids.
+    /// </summary>
+    public string? Agent { get; init; }
+
+    /// <summary>Run the message was produced in. Message lines only.</summary>
+    public string? RunId { get; init; }
+
+    /// <summary>Parent run, for branched lineage. Message lines only.</summary>
+    public string? ParentRunId { get; init; }
+
+    /// <summary>Generation (turn) the message belongs to. Message lines only.</summary>
+    public string? GenerationId { get; init; }
+
+    /// <summary>Order of the message within its generation. Message lines only.</summary>
+    public int? MessageOrderIdx { get; init; }
+
+    /// <summary>Concrete message type name (e.g. <c>TextMessage</c>). Message lines only.</summary>
+    public string? MessageType { get; init; }
+
+    /// <summary>PascalCase role — see the casing note on the type. Message lines only.</summary>
+    public string? Role { get; init; }
+
+    /// <summary>The persisted row's own id, the input the <see cref="Uid"/> was derived from.</summary>
+    public string? Id { get; init; }
+
+    /// <summary>
+    ///     The serialized message, as an OPAQUE STRING. Message lines only. See the type remarks.
+    /// </summary>
+    public string? MessageJson { get; init; }
+
+    /// <summary>State key (<c>title</c> / <c>mode</c> / <c>provider</c>). State lines only.</summary>
+    public string? Key { get; init; }
+
+    /// <summary>State value. State lines only.</summary>
+    public string? Value { get; init; }
+
+    /// <summary>
+    ///     Builds a message line from a persisted row. <paramref name="parentUid"/> is the previous
+    ///     line's <see cref="Uid"/> in store order (null for the first line of a file);
+    ///     <paramref name="agent"/> is the sub-agent display name for an <c>_agents/</c> file, null for
+    ///     the main file.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="message"/> is null.</exception>
+    public static WorkspaceTranscriptLine ForMessage(
+        PersistedMessage message,
+        string? parentUid = null,
+        string? agent = null)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        // No fallback branch for a missing id: PersistedMessage.Id is `required`, so the 6-tuple
+        // fallback the issue body sketched is unreachable code and is deliberately not written.
+        return new WorkspaceTranscriptLine
+        {
+            Type = MessageLineType,
+            Uid = DeriveUid(message.Id),
+            ParentUid = parentUid,
+            ThreadId = message.ThreadId,
+            Timestamp = FormatTimestamp(message.Timestamp),
+            Agent = agent,
+            RunId = message.RunId,
+            ParentRunId = message.ParentRunId,
+            GenerationId = message.GenerationId,
+            MessageOrderIdx = message.MessageOrderIdx,
+            MessageType = message.MessageType,
+            Role = NormalizeRole(message.Role),
+            Id = message.Id,
+            MessageJson = message.MessageJson,
+        };
+    }
+
+    /// <summary>
+    ///     Builds a conversation-state line (<c>title</c> / <c>mode</c> / <c>provider</c>). Its
+    ///     <see cref="Uid"/> is derived from the whole tuple including the instant, so a retitle back to
+    ///     an earlier value is still a distinct line rather than a silent duplicate.
+    /// </summary>
+    /// <exception cref="ArgumentException"><paramref name="threadId"/> or <paramref name="key"/> is blank.</exception>
+    public static WorkspaceTranscriptLine ForState(
+        string threadId,
+        string key,
+        string? value,
+        DateTimeOffset timestamp,
+        string? parentUid = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(threadId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        var millis = timestamp.ToUnixTimeMilliseconds();
+
+        return new WorkspaceTranscriptLine
+        {
+            Type = StateLineType,
+            // U+001F (unit separator) cannot occur in a thread id, key or value that reached here from
+            // JSON-backed metadata, so the seed is unambiguous without escaping.
+            Uid = DeriveUid($"state\u001f{threadId}\u001f{key}\u001f{value}\u001f{millis}"),
+            ParentUid = parentUid,
+            ThreadId = threadId,
+            Timestamp = FormatTimestamp(millis),
+            Key = key,
+            Value = value,
+        };
+    }
+
+    /// <summary>
+    ///     Projects a sequence of persisted rows into chained message lines: each line's
+    ///     <see cref="ParentUid"/> is the previous line's <see cref="Uid"/>, and the first line's is
+    ///     <paramref name="rootParentUid"/>. For an <c>_agents/</c> file that root pointer is the
+    ///     <c>uid</c> of the line in the MAIN file the sub-agent hangs off, which is what makes the chain
+    ///     resolvable across the conversation's whole file set rather than only within one file.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="messages"/> is null.</exception>
+    public static IReadOnlyList<WorkspaceTranscriptLine> ChainMessages(
+        IReadOnlyList<PersistedMessage> messages,
+        string? agent = null,
+        string? rootParentUid = null)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+
+        var lines = new List<WorkspaceTranscriptLine>(messages.Count);
+        var parentUid = rootParentUid;
+        foreach (var message in messages)
+        {
+            var line = ForMessage(message, parentUid, agent);
+            lines.Add(line);
+            parentUid = line.Uid;
+        }
+
+        return lines;
+    }
+
+    /// <summary>
+    ///     Serializes one line to its exact on-disk JSON — compact, single-line, snake_case, with a
+    ///     PINNED key order and a PINNED key SET per <see cref="Type"/>.
+    /// </summary>
+    /// <remarks>
+    ///     Written by hand rather than via reflection so two guarantees are structural instead of
+    ///     incidental: (1) every message line carries the SAME key set regardless of message kind —
+    ///     absent values are emitted as JSON <c>null</c>, never omitted, so a columnar reader sees one
+    ///     stable schema; (2) <c>message_json</c> is emitted with <c>WriteString</c>, so it cannot ever
+    ///     become an object. The default encoder escapes control characters, so an embedded newline is
+    ///     written as <c>\n</c> and one record is always exactly one line.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="line"/> is null.</exception>
+    public static string Serialize(WorkspaceTranscriptLine line)
+    {
+        ArgumentNullException.ThrowIfNull(line);
+
+        var buffer = new ArrayBufferWriter<byte>(512);
+        using (var writer = new Utf8JsonWriter(buffer, new JsonWriterOptions { Indented = false }))
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("schema_version", line.SchemaVersion);
+            writer.WriteString("type", line.Type);
+            writer.WriteString("uid", line.Uid);
+            WriteNullableString(writer, "parent_uid", line.ParentUid);
+
+            if (string.Equals(line.Type, StateLineType, StringComparison.Ordinal))
+            {
+                writer.WriteString("thread_id", line.ThreadId);
+                writer.WriteString("timestamp", line.Timestamp);
+                WriteNullableString(writer, "key", line.Key);
+                WriteNullableString(writer, "value", line.Value);
+            }
+            else
+            {
+                WriteNullableString(writer, "agent", line.Agent);
+                writer.WriteString("thread_id", line.ThreadId);
+                WriteNullableString(writer, "run_id", line.RunId);
+                WriteNullableString(writer, "parent_run_id", line.ParentRunId);
+                WriteNullableString(writer, "generation_id", line.GenerationId);
+                if (line.MessageOrderIdx is { } idx)
+                {
+                    writer.WriteNumber("message_order_idx", idx);
+                }
+                else
+                {
+                    writer.WriteNull("message_order_idx");
+                }
+
+                writer.WriteString("timestamp", line.Timestamp);
+                WriteNullableString(writer, "message_type", line.MessageType);
+                WriteNullableString(writer, "role", line.Role);
+                WriteNullableString(writer, "id", line.Id);
+                WriteNullableString(writer, "message_json", line.MessageJson);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+
+    /// <summary>
+    ///     Derives a line identity from <paramref name="seed"/>: SHA-256, truncated, base32 lowercase,
+    ///     exactly <see cref="UidLength"/> characters. Pure and deterministic — the same seed yields the
+    ///     same value in every process and on every flush, which is what lets an already-appended line be
+    ///     recognized rather than re-appended.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="seed"/> is null.</exception>
+    public static string DeriveUid(string seed)
+    {
+        ArgumentNullException.ThrowIfNull(seed);
+        return Base32Lower(SHA256.HashData(Encoding.UTF8.GetBytes(seed)), UidLength);
+    }
+
+    /// <summary>
+    ///     Derives the short id a file leaf carries. Hashed rather than prefix-sliced because ids in this
+    ///     sample share prefixes (<c>subagent-</c>) and may contain characters a filename cannot, so a
+    ///     prefix would be neither unique nor legal.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="id"/> is null.</exception>
+    public static string ShortId(string id)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        return Base32Lower(SHA256.HashData(Encoding.UTF8.GetBytes(id)), ShortIdLength);
+    }
+
+    /// <summary>
+    ///     Main transcript file leaf (no extension): <c>{slug(title)}-{shortThreadId}</c>. The short-id
+    ///     suffix is what guarantees a non-empty, unique leaf even when the title slugs to nothing.
+    /// </summary>
+    /// <exception cref="ArgumentException"><paramref name="shortThreadId"/> is blank.</exception>
+    public static string MainFileLeaf(string? title, string shortThreadId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(shortThreadId);
+
+        var slug = Slug(title);
+        return slug.Length == 0 ? shortThreadId : $"{slug}-{shortThreadId}";
+    }
+
+    /// <summary>
+    ///     Sub-agent transcript file leaf (no extension): <c>{slug(name)}-{shortAgentId}</c>, pinned to
+    ///     <c>agent-{shortAgentId}</c> when the name is null or slugs to nothing. Two sub-agents sharing a
+    ///     display name still get distinct leaves, because the short id comes from the agent id.
+    /// </summary>
+    /// <exception cref="ArgumentException"><paramref name="shortAgentId"/> is blank.</exception>
+    public static string AgentFileLeaf(string? agentName, string shortAgentId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(shortAgentId);
+
+        var slug = Slug(agentName);
+        return slug.Length == 0
+            ? $"{UnnamedAgentLeafPrefix}-{shortAgentId}"
+            : $"{slug}-{shortAgentId}";
+    }
+
+    /// <summary>Formats a Unix-milliseconds instant as ISO-8601 UTC, round-trip ("O") format.</summary>
+    public static string FormatTimestamp(long unixMillis) =>
+        DateTimeOffset
+            .FromUnixTimeMilliseconds(unixMillis)
+            .UtcDateTime.ToString("O", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    ///     Canonicalizes a persisted role string to the PascalCase name of a <see cref="MessageRole"/>
+    ///     member. Parsing is case-insensitive so a row stored in either casing lands on the same value,
+    ///     and an unrecognized or absent role reports <see cref="MessageRole.None"/> rather than being
+    ///     dropped — <c>None</c> is a real member, not an error code, and it must classify like the other
+    ///     four.
+    /// </summary>
+    public static string NormalizeRole(string? role) =>
+        Enum.TryParse<MessageRole>(role, ignoreCase: true, out var parsed)
+            ? parsed.ToString()
+            : nameof(MessageRole.None);
+
+    /// <summary>
+    ///     ASCII-only slugifier: lowercases, keeps <c>[a-z0-9]</c>, collapses every other run to a single
+    ///     hyphen, never emits a leading or trailing hyphen, and truncates to
+    ///     <see cref="MaxSlugLength"/>. A title containing <c>/</c>, <c>\</c>, <c>..</c> or a leading
+    ///     <c>/</c> therefore produces a flat, legal leaf and never throws.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <b>This is a deliberate SEVENTH copy of a slug helper in this repo — none of the six existing
+    ///     ones is usable here.</b> All six branch on <c>char.IsLetterOrDigit</c>, which is
+    ///     Unicode-aware: it answers true for CJK ideographs, Cyrillic, accented Latin and more, so they
+    ///     pass those characters straight through into a filename. This one must not — a transcript leaf
+    ///     is written into a Linux sandbox by a shell splice and read back by tooling that assumes ASCII
+    ///     paths. Three of the six also live in <c>CodeReviewDaemon.Sample</c> (a different assembly) and
+    ///     the rest are <c>private</c>, so none was reachable either. Consolidating the seven is a
+    ///     recorded, locked deferral.
+    ///     </para>
+    ///     <para>
+    ///     Existing copies, for whoever does that consolidation:
+    ///     <c>AnthropicCompatProviders.Slugify</c>, <c>WorkflowRunRegistry</c>'s inline thread-id
+    ///     sanitizer, <c>ReviewBranchManager.Slug</c>, <c>KnowledgeAgent.Slugify</c>,
+    ///     <c>KnowledgeAgent.SlugFromRelPath</c>, <c>DaemonReviewStageExecutor.SlugSegment</c>.
+    ///     </para>
+    /// </remarks>
+    internal static string Slug(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(Math.Min(value.Length, MaxSlugLength));
+        var pendingSeparator = false;
+
+        foreach (var ch in value)
+        {
+            var lower = ch is >= 'A' and <= 'Z' ? (char)(ch + ('a' - 'A')) : ch;
+            if (lower is not ((>= 'a' and <= 'z') or (>= '0' and <= '9')))
+            {
+                // Everything else — punctuation, path separators, whitespace, and every non-ASCII
+                // character — becomes a pending separator that is only emitted if another kept
+                // character follows. That is what keeps leading/trailing hyphens out.
+                pendingSeparator = true;
+                continue;
+            }
+
+            if (pendingSeparator && builder.Length > 0)
+            {
+                if (builder.Length + 1 >= MaxSlugLength)
+                {
+                    break;
+                }
+
+                _ = builder.Append('-');
+            }
+
+            _ = builder.Append(lower);
+            pendingSeparator = false;
+
+            if (builder.Length >= MaxSlugLength)
+            {
+                break;
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static void WriteNullableString(Utf8JsonWriter writer, string name, string? value)
+    {
+        if (value is null)
+        {
+            writer.WriteNull(name);
+        }
+        else
+        {
+            writer.WriteString(name, value);
+        }
+    }
+
+    /// <summary>
+    ///     Encodes the leading bits of <paramref name="hash"/> as RFC 4648 base32, lowercased, MSB-first,
+    ///     unpadded — <paramref name="length"/> characters carry <c>length * 5</c> bits.
+    /// </summary>
+    private static string Base32Lower(ReadOnlySpan<byte> hash, int length)
+    {
+        var chars = new char[length];
+        for (var i = 0; i < length; i++)
+        {
+            var bitOffset = i * 5;
+            var byteIndex = bitOffset >> 3;
+            var bitIndex = bitOffset & 7;
+
+            // Read a 16-bit window starting at byteIndex, then slide the wanted 5 bits down to the
+            // bottom. SHA-256 is 32 bytes, so the window never runs past the end for any length here.
+            var window = (hash[byteIndex] << 8) | hash[byteIndex + 1];
+            chars[i] = Base32Alphabet[(window >> (11 - bitIndex)) & 0x1F];
+        }
+
+        return new string(chars);
+    }
+}

--- a/samples/LmStreaming.Sample/Services/WorkspaceTranscriptLine.cs
+++ b/samples/LmStreaming.Sample/Services/WorkspaceTranscriptLine.cs
@@ -230,9 +230,13 @@ public sealed record WorkspaceTranscriptLine
         return new WorkspaceTranscriptLine
         {
             Type = StateLineType,
-            // U+001F (unit separator) cannot occur in a thread id, key or value that reached here from
-            // JSON-backed metadata, so the seed is unambiguous without escaping.
-            Uid = DeriveUid($"state\u001f{threadId}\u001f{key}\u001f{value}\u001f{millis}"),
+            Uid = DeriveUid(
+                "state"
+                + SeedField(threadId)
+                + SeedField(key)
+                + SeedField(value)
+                + SeedField(millis.ToString(CultureInfo.InvariantCulture))
+            ),
             ParentUid = parentUid,
             ThreadId = threadId,
             Timestamp = FormatTimestamp(millis),
@@ -240,6 +244,31 @@ public sealed record WorkspaceTranscriptLine
             Value = value,
         };
     }
+
+    /// <summary>
+    ///     Encodes one field into a uid seed as <c>{charCount}:{chars}</c>, or <c>~</c> when it is null.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Length-prefixed rather than separator-joined, and the null marker is the point of it. A state
+    ///     line's <c>value</c> is nullable, and null and empty serialise to DIFFERENT lines
+    ///     (<c>"value": null</c> against <c>"value": ""</c>) — but interpolated into a joined seed both
+    ///     contribute nothing, so "the title was cleared" and "the title was removed" minted ONE uid for
+    ///     two lines. The uid is the whole identity here: the watermark and every reader's dedupe key off
+    ///     it alone, so the second of the two would be read as already written and dropped for good.
+    ///     </para>
+    ///     <para>
+    ///     What this guarantees, and only this: the field list is recoverable from the seed — a reader
+    ///     takes <c>~</c>, or a count and then exactly that many characters — so no field can absorb the
+    ///     next one's text or fake a boundary. That covers the case a delimiter cannot, a value CONTAINING
+    ///     the delimiter (a key/value split moved one character left no longer produces identical text).
+    ///     It claims nothing about collisions beyond that: equal seeds mean equal fields, and the uid is
+    ///     still a TRUNCATED hash of the seed, which is <see cref="UidLength"/>'s business rather than
+    ///     this method's.
+    ///     </para>
+    /// </remarks>
+    private static string SeedField(string? value) =>
+        value is null ? "~" : $"{value.Length.ToString(CultureInfo.InvariantCulture)}:{value}";
 
     /// <summary>
     ///     Projects a sequence of persisted rows into chained message lines: each line's

--- a/samples/LmStreaming.Sample/Services/WorkspaceTranscriptMirror.cs
+++ b/samples/LmStreaming.Sample/Services/WorkspaceTranscriptMirror.cs
@@ -255,6 +255,13 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
     ///     gateway I/O ever reaches the caller. And it cannot throw into the pool's factory — a failure to
     ///     subscribe is logged and leaves this conversation unmirrored, like every other failure here.
     ///     </para>
+    ///     <para>
+    ///     <b>The <c>catch</c> below is the narrow door, not the usual one.</b> It only fires for a
+    ///     subscription that throws SYNCHRONOUSLY, which the production agent does not: its
+    ///     <c>SubscribeAsync</c> is an async iterator, so its prologue's failures come back as a faulted
+    ///     <c>ValueTask</c> and are handled where they surface, in <see cref="PumpAsync"/>. Both doors have
+    ///     to undo the registration, which is why they share <see cref="Retire"/>.
+    ///     </para>
     /// </remarks>
     private void StartPump(Subscription subscription)
     {
@@ -296,36 +303,23 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
     ///     rest of its life rather than for one attempt.
     ///     </para>
     ///     <para>
-    ///     <b>Removed by reference, never by key.</b> A concurrent <see cref="Attach"/> — a mode switch is
-    ///     the ordinary case — may already have replaced this mapping with a live successor's; deleting the
-    ///     key would then cancel nothing but silently unregister the subscription that is actually working.
-    ///     </para>
-    ///     <para>
     ///     <b>Nothing here may throw or block.</b> <see cref="Attach"/> runs inside the pool's agent
     ///     factory. The enumerator — which exists when <c>MoveNextAsync</c> is what threw, and holds that
     ///     subscriber's channel registration until it is disposed — is therefore drained off-thread through
-    ///     a path that swallows its own faults.
+    ///     a path that swallows its own faults. It is disposed HERE and nowhere else: no pump ever ran for
+    ///     this subscription, so <see cref="ConsumeAsync"/>'s <c>finally</c> never claimed it.
     ///     </para>
     /// </remarks>
     private void AbandonFailedSubscription(Subscription subscription, IAsyncEnumerator<IMessage>? enumerator)
     {
-        var threadId = subscription.Agent.ThreadId;
-
-        lock (_gate)
-        {
-            if (_subscriptions.TryGetValue(threadId, out var current)
-                && ReferenceEquals(current, subscription))
-            {
-                _ = _subscriptions.Remove(threadId);
-            }
-        }
-
-        Cancel(subscription);
+        Retire(subscription);
 
         if (enumerator is null)
         {
             return;
         }
+
+        var threadId = subscription.Agent.ThreadId;
 
         _ = Task.Run(async () =>
         {
@@ -341,6 +335,42 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
                     threadId);
             }
         });
+    }
+
+    /// <summary>
+    ///     Ends one subscription's life in this mirror: drops its registration and cancels its token.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <b>Removed by reference, never by key.</b> A concurrent <see cref="Attach"/> — a mode switch is
+    ///     the ordinary case — may already have replaced this mapping with a live successor's; deleting the
+    ///     key would then cancel nothing but silently unregister the subscription that is actually working.
+    ///     The pool makes that the NORMAL ordering rather than a narrow race:
+    ///     <c>MultiTurnAgentPool.SwapAgentUnderLockAsync</c> builds the replacement through the agent
+    ///     factory — which is where <see cref="Attach"/> is called from — and publishes it into its own map
+    ///     only afterwards, so by the time anything can observe the new agent, the new mapping is already
+    ///     in place.
+    ///     </para>
+    ///     <para>
+    ///     <b>Disposes nothing.</b> Every enumerator is owned by whoever created it:
+    ///     <see cref="ConsumeAsync"/>'s <c>finally</c> for a subscription that got as far as a pump, and
+    ///     <see cref="AbandonFailedSubscription"/> for one that never did.
+    ///     </para>
+    /// </remarks>
+    private void Retire(Subscription subscription)
+    {
+        var threadId = subscription.Agent.ThreadId;
+
+        lock (_gate)
+        {
+            if (_subscriptions.TryGetValue(threadId, out var current)
+                && ReferenceEquals(current, subscription))
+            {
+                _ = _subscriptions.Remove(threadId);
+            }
+        }
+
+        Cancel(subscription);
     }
 
     /// <summary>
@@ -445,6 +475,29 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
     ///     Reference equality on the agent, not on the threadId, is therefore what separates "we were
     ///     dropped from a conversation that is still live" from an ordinary teardown.
     ///     </para>
+    ///     <para>
+    ///     <b>Every exit retires the subscription.</b> A pump that has returned is draining nothing, so a
+    ///     registration left behind turns <see cref="Attach"/>'s idempotent early return — which compares
+    ///     the agent INSTANCE — from "mirroring ended for this conversation" into "this conversation can
+    ///     never be mirrored again, not even by an explicit re-attach". The exit that reaches this in
+    ///     production is a FAULT, and it does not arrive through <see cref="StartPump"/>'s <c>try</c>:
+    ///     <c>MultiTurnAgentBase.SubscribeAsync</c> is an async iterator, so a throw in its prologue —
+    ///     where it creates the channel and joins the fan-out under the replay lock — is captured by the
+    ///     compiler-generated state machine into a FAULTED <c>ValueTask</c> returned by the first
+    ///     <c>MoveNextAsync</c> rather than thrown out of it, and surfaces here instead.
+    ///     </para>
+    ///     <para>
+    ///     Retiring in a <c>finally</c> rather than on the faulting return is deliberate.
+    ///     <see cref="ConsumeAsync"/> reports fault and cancellation as one <c>bool</c>, so singling the
+    ///     fault out would mean widening that contract for no behavioural gain — on the three exits that
+    ///     were already safe, <see cref="Retire"/> is a provable no-op. Cancellation is only ever ours to
+    ///     request and every requester (<see cref="Evict"/>, <see cref="Dispose"/>, <see cref="Attach"/>'s
+    ///     replacement) fixes the mapping first; an agent gone from the pool takes <see cref="Evict"/> with
+    ///     it, since the pool removes the entry before raising <c>ThreadRemoved</c>; and a REPLACED agent's
+    ///     successor has already overwritten the mapping, which the reference comparison leaves alone. The
+    ///     <c>finally</c> additionally covers an exit by EXCEPTION — <see cref="_agentLookup"/> is injected
+    ///     code and this task's fault is discarded by its caller — which no return-site fix can see.
+    ///     </para>
     /// </remarks>
     private async Task PumpAsync(
         Subscription subscription,
@@ -455,59 +508,66 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
         var threadId = agent.ThreadId;
         var ct = subscription.Cancellation.Token;
 
-        while (true)
+        try
         {
-            if (await ConsumeAsync(threadId, enumerator, pending).ConfigureAwait(false)
-                || ct.IsCancellationRequested
-                || _agentLookup(threadId) is not { } current
-                || !ReferenceEquals(current, agent))
+            while (true)
             {
-                return;
-            }
+                if (await ConsumeAsync(threadId, enumerator, pending).ConfigureAwait(false)
+                    || ct.IsCancellationRequested
+                    || _agentLookup(threadId) is not { } current
+                    || !ReferenceEquals(current, agent))
+                {
+                    return;
+                }
 
-            _ = Interlocked.Increment(ref _resubscribeCount);
-            _logger.LogWarning(
-                "Transcript subscription for thread {ThreadId} was dropped (its output channel filled); "
-                    + "re-subscribing. Turns published during the gap are still recovered — the writer's "
-                    + "watermark is cumulative and the next flush re-reads the whole thread.",
-                threadId);
+                _ = Interlocked.Increment(ref _resubscribeCount);
+                _logger.LogWarning(
+                    "Transcript subscription for thread {ThreadId} was dropped (its output channel filled); "
+                        + "re-subscribing. Turns published during the gap are still recovered — the writer's "
+                        + "watermark is cumulative and the next flush re-reads the whole thread.",
+                    threadId);
 
-            try
-            {
-                await Task.Delay(_resubscribeDelay, ct).ConfigureAwait(false);
-                enumerator = agent.SubscribeAsync(ct).GetAsyncEnumerator(ct);
-                pending = enumerator.MoveNextAsync();
-            }
-            catch (OperationCanceledException)
-            {
-                return;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Re-subscribing the transcript mirror to thread {ThreadId} failed", threadId);
-                return;
-            }
+                try
+                {
+                    await Task.Delay(_resubscribeDelay, ct).ConfigureAwait(false);
+                    enumerator = agent.SubscribeAsync(ct).GetAsyncEnumerator(ct);
+                    pending = enumerator.MoveNextAsync();
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Re-subscribing the transcript mirror to thread {ThreadId} failed", threadId);
+                    return;
+                }
 
-            // The gap between the drop and this re-subscription is EXACTLY where a turn boundary goes
-            // unobserved: the channel filled, so the messages that overflowed it — the run completion
-            // among them — reached no subscriber, and nothing will republish them. The recovery the log
-            // line above promises ("the next flush re-reads the whole thread") only holds if a flush
-            // actually happens, and without this line the only thing that can trigger one is a LATER turn
-            // that may never come. Scheduling here is free when nothing changed: a flush with no new rows
-            // is UpToDate and issues no gateway write. It is a fresh generation of work like any other
-            // trigger — the drop is new evidence, and inheriting a spent budget from before it would give
-            // the recovery a single pass.
-            //
-            // It also forces a DESCENDANT RESCAN, which the other two triggers deliberately do not. What
-            // was lost here is unknown by definition, and a spawn call or completion notification is
-            // exactly the kind of message that can have been among it. If an earlier flush cached a roster
-            // taken before a child was persisted, and that child's only announcement went down with the
-            // channel, the cache is stale with nothing left to invalidate it and the child is never
-            // mirrored at all. The other two call sites are the opposite case: they run because a message
-            // ARRIVED, so the message itself is the signal — sub-agent activity already arms a rescan
-            // through NoteSubAgentActivity, and a run completion is not evidence about descendants.
-            ScheduleFreshAttempt(threadId, forceDescendantRescan: true);
+                // The gap between the drop and this re-subscription is EXACTLY where a turn boundary goes
+                // unobserved: the channel filled, so the messages that overflowed it — the run completion
+                // among them — reached no subscriber, and nothing will republish them. The recovery the log
+                // line above promises ("the next flush re-reads the whole thread") only holds if a flush
+                // actually happens, and without this line the only thing that can trigger one is a LATER turn
+                // that may never come. Scheduling here is free when nothing changed: a flush with no new rows
+                // is UpToDate and issues no gateway write. It is a fresh generation of work like any other
+                // trigger — the drop is new evidence, and inheriting a spent budget from before it would give
+                // the recovery a single pass.
+                //
+                // It also forces a DESCENDANT RESCAN, which the other two triggers deliberately do not. What
+                // was lost here is unknown by definition, and a spawn call or completion notification is
+                // exactly the kind of message that can have been among it. If an earlier flush cached a roster
+                // taken before a child was persisted, and that child's only announcement went down with the
+                // channel, the cache is stale with nothing left to invalidate it and the child is never
+                // mirrored at all. The other two call sites are the opposite case: they run because a message
+                // ARRIVED, so the message itself is the signal — sub-agent activity already arms a rescan
+                // through NoteSubAgentActivity, and a run completion is not evidence about descendants.
+                ScheduleFreshAttempt(threadId, forceDescendantRescan: true);
 
+            }
+        }
+        finally
+        {
+            Retire(subscription);
         }
     }
 

--- a/samples/LmStreaming.Sample/Services/WorkspaceTranscriptMirror.cs
+++ b/samples/LmStreaming.Sample/Services/WorkspaceTranscriptMirror.cs
@@ -539,6 +539,11 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
                 }
                 catch (Exception ex)
                 {
+                    // Near-unreachable for the shape the production agent has: SubscribeAsync is an async
+                    // iterator, so a failure to re-subscribe does not throw out of these two lines — it comes
+                    // back as a faulted ValueTask and re-enters through ConsumeAsync above. This return is
+                    // covered for free by the finally, not handled separately; it is written out only so the
+                    // next reader does not have to re-derive that it is safe.
                     _logger.LogWarning(ex, "Re-subscribing the transcript mirror to thread {ThreadId} failed", threadId);
                     return;
                 }

--- a/samples/LmStreaming.Sample/Services/WorkspaceTranscriptMirror.cs
+++ b/samples/LmStreaming.Sample/Services/WorkspaceTranscriptMirror.cs
@@ -55,16 +55,23 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
     ///     re-schedule on before the mirror stops chasing it until something new happens.
     /// </summary>
     /// <remarks>
-    ///     <b>The bound is what makes the retry chain terminate at all.</b> <c>Deferred</c> is reported for
-    ///     three quite different reasons — a read that never settled, a gateway call that failed, and a
-    ///     sub-agent fan-out capped by <c>MaxSubAgentFilesPerFlush</c> — and the first two do not
-    ///     self-terminate: a workspace whose gateway is refusing writes, or a conversation being written to
+    ///     <para>
+    ///     <b>The bound is what makes the retry chain terminate at all.</b> <c>Deferred</c> means something
+    ///     FAILED — a read that never settled, or a gateway call that did not land — and neither
+    ///     self-terminates: a workspace whose gateway is refusing writes, or a conversation being written to
     ///     faster than its rows settle, defers every attempt forever. An unbounded re-schedule against that
     ///     is a hot loop on the single drain thread that also starves every OTHER conversation's flush.
-    ///     Four attempts per trigger (the original plus <see cref="MaxDeferredRetries"/>) covers the
-    ///     ordinary capped fan-out — the default cap is 8 files, so 32 descendants — and the budget resets
-    ///     at every turn boundary and on every attempt that is not deferred, so a conversation that is
-    ///     merely large is never permanently abandoned, only paced.
+    ///     </para>
+    ///     <para>
+    ///     <b>This budget covers failures and NOTHING else.</b> An orderly continuation — the sub-agent
+    ///     fan-out being capped per flush — reports <see cref="TranscriptFlushOutcome.Progressing"/>
+    ///     instead, and is re-scheduled without touching the budget. Charging progress to a failure budget
+    ///     puts a hard ceiling of (this + 1) x the per-flush cap on how many descendants a single trigger
+    ///     can ever reach, and silently strands the tail of any roster larger than that; the writer's own
+    ///     coverage sweep is what terminates the progressing chain instead. The budget is per TRIGGER —
+    ///     reset by every independent external trigger, not only by a completed run — so a transient outage
+    ///     cannot silence a conversation permanently.
+    ///     </para>
     /// </remarks>
     public const int MaxDeferredRetries = 3;
 
@@ -409,8 +416,10 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
             // line above promises ("the next flush re-reads the whole thread") only holds if a flush
             // actually happens, and without this line the only thing that can trigger one is a LATER turn
             // that may never come. Scheduling here is free when nothing changed: a flush with no new rows
-            // is UpToDate and issues no gateway write.
-            _scheduler.Schedule(threadId);
+            // is UpToDate and issues no gateway write. It is a fresh generation of work like any other
+            // trigger — the drop is new evidence, and inheriting a spent budget from before it would give
+            // the recovery a single pass.
+            ScheduleFreshAttempt(threadId);
         }
     }
 
@@ -469,10 +478,8 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
 
         if (message is RunCompletedMessage)
         {
-            // The turn boundary. Also the point the deferred-retry budget resets: whatever made the last
-            // chain give up, a new turn is new evidence and earns a fresh set of attempts.
-            _ = _deferredAttempts.TryRemove(threadId, out _);
-            _scheduler.Schedule(threadId);
+            // The turn boundary.
+            ScheduleFreshAttempt(threadId);
             return;
         }
 
@@ -484,8 +491,30 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
             // parent's last turn publishes no RunCompletedMessage and nothing follows it, so a mirror that
             // scheduled only on run completion left that child's transcript unwritten forever — for the
             // whole life of the conversation, not until the next turn.
-            _scheduler.Schedule(threadId);
+            ScheduleFreshAttempt(threadId);
         }
+    }
+
+    /// <summary>
+    ///     Schedules a flush of <paramref name="threadId"/> as a NEW generation of work: the bounded
+    ///     deferred-retry budget is released and the writer's descendant coverage sweep starts over.
+    /// </summary>
+    /// <remarks>
+    ///     <b>Every independent external trigger goes through here, not just the turn boundary.</b> The
+    ///     budget and the sweep are both scoped to "one trigger's worth of attempts", so a trigger that
+    ///     inherits an exhausted budget gets a single pass and is then abandoned — and the trigger most
+    ///     likely to inherit one is the least recoverable, a background sub-agent completing after its
+    ///     parent's last turn, because nothing follows it to try again.
+    /// </remarks>
+    private void ScheduleFreshAttempt(string threadId)
+    {
+        _ = _deferredAttempts.TryRemove(threadId, out _);
+        if (_writers.TryGetValue(threadId, out var writer))
+        {
+            writer.NoteExternalTrigger();
+        }
+
+        _scheduler.Schedule(threadId);
     }
 
     /// <summary>
@@ -530,10 +559,18 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
 
     /// <summary>
     ///     The scheduler's drain callback: resolves the conversation's writer and flushes it. A key whose
-    ///     writer has since been evicted is a no-op, and a <see cref="TranscriptFlushOutcome.Deferred"/>
-    ///     result asks for another attempt — up to <see cref="MaxDeferredRetries"/> consecutive ones, which
-    ///     is what stops a permanently-deferring conversation from spinning the drain loop.
+    ///     writer has since been evicted is a no-op.
     /// </summary>
+    /// <remarks>
+    ///     Two outcomes ask for another attempt and they are budgeted differently.
+    ///     <see cref="TranscriptFlushOutcome.Deferred"/> means something FAILED and is retried at most
+    ///     <see cref="MaxDeferredRetries"/> consecutive times, which is what stops a permanently-deferring
+    ///     conversation from spinning the drain loop. <see cref="TranscriptFlushOutcome.Progressing"/>
+    ///     means the pass stopped short of work it knows about — the capped sub-agent fan-out — and is
+    ///     re-scheduled WITHOUT spending the failure budget; it terminates on the writer's own coverage
+    ///     sweep instead. It does not reset the budget either: a conversation that alternates between
+    ///     failing and progressing must still be bounded.
+    /// </remarks>
     private async Task FlushAsync(string threadId, CancellationToken ct)
     {
         if (!_writers.TryGetValue(threadId, out var writer))
@@ -541,7 +578,14 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
             return;
         }
 
-        if (await writer.FlushAsync(ct).ConfigureAwait(false) != TranscriptFlushOutcome.Deferred)
+        var outcome = await writer.FlushAsync(ct).ConfigureAwait(false);
+        if (outcome == TranscriptFlushOutcome.Progressing)
+        {
+            _scheduler.Schedule(threadId);
+            return;
+        }
+
+        if (outcome != TranscriptFlushOutcome.Deferred)
         {
             _ = _deferredAttempts.TryRemove(threadId, out _);
             return;
@@ -552,8 +596,10 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
         {
             _logger.LogWarning(
                 "Transcript flush for thread {ThreadId} deferred {Attempts} times in a row; giving up until "
-                    + "the next turn or sub-agent update. Nothing is lost — every watermark involved is "
-                    + "unadvanced, so the next flush repeats the work.",
+                    + "the next turn or sub-agent update. No transcript rows were lost — a deferral leaves "
+                    + "the watermark of whatever it failed to write unadvanced, and the persisted "
+                    + "conversation itself is untouched — but this conversation's workspace copy now stops "
+                    + "short until something triggers it again.",
                 threadId,
                 attempt);
             return;

--- a/samples/LmStreaming.Sample/Services/WorkspaceTranscriptMirror.cs
+++ b/samples/LmStreaming.Sample/Services/WorkspaceTranscriptMirror.cs
@@ -50,6 +50,24 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
     /// </summary>
     public static readonly TimeSpan DefaultResubscribeDelay = TimeSpan.FromMilliseconds(250);
 
+    /// <summary>
+    ///     How many consecutive <see cref="TranscriptFlushOutcome.Deferred"/> results one conversation may
+    ///     re-schedule on before the mirror stops chasing it until something new happens.
+    /// </summary>
+    /// <remarks>
+    ///     <b>The bound is what makes the retry chain terminate at all.</b> <c>Deferred</c> is reported for
+    ///     three quite different reasons — a read that never settled, a gateway call that failed, and a
+    ///     sub-agent fan-out capped by <c>MaxSubAgentFilesPerFlush</c> — and the first two do not
+    ///     self-terminate: a workspace whose gateway is refusing writes, or a conversation being written to
+    ///     faster than its rows settle, defers every attempt forever. An unbounded re-schedule against that
+    ///     is a hot loop on the single drain thread that also starves every OTHER conversation's flush.
+    ///     Four attempts per trigger (the original plus <see cref="MaxDeferredRetries"/>) covers the
+    ///     ordinary capped fan-out — the default cap is 8 files, so 32 descendants — and the budget resets
+    ///     at every turn boundary and on every attempt that is not deferred, so a conversation that is
+    ///     merely large is never permanently abandoned, only paced.
+    /// </remarks>
+    public const int MaxDeferredRetries = 3;
+
     /// <summary>One conversation's live subscription: the agent instance it is bound to, and the token
     /// that ends it. The instance is load-bearing — see <see cref="PumpAsync"/>'s drop detection.</summary>
     private sealed record Subscription(IMultiTurnAgent Agent, CancellationTokenSource Cancellation);
@@ -72,6 +90,13 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
     /// </summary>
     private readonly ConcurrentDictionary<string, ConversationTranscriptWriter> _writers =
         new(StringComparer.Ordinal);
+
+    /// <summary>
+    ///     Consecutive deferred flushes per conversation, against <see cref="MaxDeferredRetries"/>. Reset
+    ///     whenever a flush is not deferred and at every turn boundary, so the budget bounds one stuck
+    ///     chain rather than the conversation's lifetime.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, int> _deferredAttempts = new(StringComparer.Ordinal);
 
     /// <summary>Guards <see cref="_subscriptions"/> and <see cref="_disposed"/>. Never held across
     /// cancellation or I/O — see <see cref="Attach"/>.</summary>
@@ -184,7 +209,55 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
         // Outside the lock: Cancel() runs its registrations inline, and one of those resumes a pump that
         // may call straight back into this type.
         Cancel(replaced);
-        _ = Task.Run(() => PumpAsync(subscription));
+        StartPump(subscription);
+    }
+
+    /// <summary>
+    ///     Establishes the subscription <b>on the calling thread</b>, then hands the already-running
+    ///     enumerator to a worker that consumes it.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <b>The registration must happen-before <see cref="Attach"/> returns.</b>
+    ///     <c>MultiTurnAgentBase.SubscribeAsync</c> is an async iterator that adds the subscriber to the
+    ///     fan-out under the agent's replay lock in its synchronous prologue — that is, inside the FIRST
+    ///     <c>MoveNextAsync()</c>, on whichever thread calls it. Starting the whole pump with
+    ///     <c>Task.Run</c> therefore let <c>Attach</c> return before the subscriber existed, and everything
+    ///     published in that window went to nobody. That window is not theoretical: the sample attaches
+    ///     from the pool's agent factory, on the same request that then starts the run, so a short
+    ///     conversation could complete its ONLY run before the worker was scheduled — no turn boundary was
+    ///     ever observed, no flush was ever scheduled, and the conversation ended with no transcript at
+    ///     all rather than with a stale one.
+    ///     </para>
+    ///     <para>
+    ///     Only the registration is synchronous. <c>MoveNextAsync</c> is started, not awaited: its
+    ///     continuation and every message after it run on the worker, so no message handling and no
+    ///     gateway I/O ever reaches the caller. And it cannot throw into the pool's factory — a failure to
+    ///     subscribe is logged and leaves this conversation unmirrored, like every other failure here.
+    ///     </para>
+    /// </remarks>
+    private void StartPump(Subscription subscription)
+    {
+        var agent = subscription.Agent;
+        var ct = subscription.Cancellation.Token;
+
+        IAsyncEnumerator<IMessage> enumerator;
+        ValueTask<bool> pending;
+        try
+        {
+            enumerator = agent.SubscribeAsync(ct).GetAsyncEnumerator(ct);
+            pending = enumerator.MoveNextAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Subscribing the transcript mirror to thread {ThreadId} failed",
+                agent.ThreadId);
+            return;
+        }
+
+        _ = Task.Run(() => PumpAsync(subscription, enumerator, pending));
     }
 
     /// <summary>
@@ -200,6 +273,7 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
         }
 
         _ = _writers.TryRemove(threadId, out _);
+        _ = _deferredAttempts.TryRemove(threadId, out _);
 
         Subscription? removed;
         lock (_gate)
@@ -235,6 +309,7 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
         }
 
         _writers.Clear();
+        _deferredAttempts.Clear();
         _scheduler.Dispose();
     }
 
@@ -286,34 +361,19 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
     ///     dropped from a conversation that is still live" from an ordinary teardown.
     ///     </para>
     /// </remarks>
-    private async Task PumpAsync(Subscription subscription)
+    private async Task PumpAsync(
+        Subscription subscription,
+        IAsyncEnumerator<IMessage> enumerator,
+        ValueTask<bool> pending)
     {
         var agent = subscription.Agent;
         var threadId = agent.ThreadId;
         var ct = subscription.Cancellation.Token;
 
-        while (!ct.IsCancellationRequested)
+        while (true)
         {
-            try
-            {
-                await foreach (var message in agent.SubscribeAsync(ct).ConfigureAwait(false))
-                {
-                    Observe(threadId, message);
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                return;
-            }
-            catch (Exception ex)
-            {
-                // Best-effort, like every other path in this feature: a faulted stream ends the mirror for
-                // this conversation rather than looping on a failure that is not going to clear.
-                _logger.LogWarning(ex, "Transcript subscription for thread {ThreadId} faulted", threadId);
-                return;
-            }
-
-            if (ct.IsCancellationRequested
+            if (await ConsumeAsync(threadId, enumerator, pending).ConfigureAwait(false)
+                || ct.IsCancellationRequested
                 || _agentLookup(threadId) is not { } current
                 || !ReferenceEquals(current, agent))
             {
@@ -330,10 +390,70 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
             try
             {
                 await Task.Delay(_resubscribeDelay, ct).ConfigureAwait(false);
+                enumerator = agent.SubscribeAsync(ct).GetAsyncEnumerator(ct);
+                pending = enumerator.MoveNextAsync();
             }
             catch (OperationCanceledException)
             {
                 return;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Re-subscribing the transcript mirror to thread {ThreadId} failed", threadId);
+                return;
+            }
+
+            // The gap between the drop and this re-subscription is EXACTLY where a turn boundary goes
+            // unobserved: the channel filled, so the messages that overflowed it — the run completion
+            // among them — reached no subscriber, and nothing will republish them. The recovery the log
+            // line above promises ("the next flush re-reads the whole thread") only holds if a flush
+            // actually happens, and without this line the only thing that can trigger one is a LATER turn
+            // that may never come. Scheduling here is free when nothing changed: a flush with no new rows
+            // is UpToDate and issues no gateway write.
+            _scheduler.Schedule(threadId);
+        }
+    }
+
+    /// <summary>
+    ///     Drains one subscription's enumerator to its end, applying every message. Reports whether it
+    ///     ended in a FAULT — a normal end is what both a silent drop and an ordinary teardown look like,
+    ///     and telling those two apart is the caller's job.
+    /// </summary>
+    private async Task<bool> ConsumeAsync(
+        string threadId,
+        IAsyncEnumerator<IMessage> enumerator,
+        ValueTask<bool> pending)
+    {
+        try
+        {
+            while (await pending.ConfigureAwait(false))
+            {
+                Observe(threadId, enumerator.Current);
+                pending = enumerator.MoveNextAsync();
+            }
+
+            return false;
+        }
+        catch (OperationCanceledException)
+        {
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // Best-effort, like every other path in this feature: a faulted stream ends the mirror for
+            // this conversation rather than looping on a failure that is not going to clear.
+            _logger.LogWarning(ex, "Transcript subscription for thread {ThreadId} faulted", threadId);
+            return true;
+        }
+        finally
+        {
+            try
+            {
+                await enumerator.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Disposing the transcript subscription for thread {ThreadId} threw", threadId);
             }
         }
     }
@@ -341,15 +461,29 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
     /// <summary>Applies one observed message to this conversation's mirror state.</summary>
     private void Observe(string threadId, IMessage message)
     {
-        if (IsSubAgentActivity(message) && _writers.TryGetValue(threadId, out var writer))
+        var subAgentActivity = IsSubAgentActivity(message);
+        if (subAgentActivity && _writers.TryGetValue(threadId, out var writer))
         {
             writer.NoteSubAgentActivity();
         }
 
         if (message is RunCompletedMessage)
         {
-            // The turn boundary, and the ONLY flush trigger. Non-blocking by contract, so no gateway
-            // latency ever reaches this loop.
+            // The turn boundary. Also the point the deferred-retry budget resets: whatever made the last
+            // chain give up, a new turn is new evidence and earns a fresh set of attempts.
+            _ = _deferredAttempts.TryRemove(threadId, out _);
+            _scheduler.Schedule(threadId);
+            return;
+        }
+
+        if (subAgentActivity)
+        {
+            // The SECOND trigger, and the only one a background child produces. Noting the activity is not
+            // enough on its own: NoteSubAgentActivity only arms the next flush's descendant rescan, and if
+            // that flush never happens the arming does nothing. A sub-agent that finishes after its
+            // parent's last turn publishes no RunCompletedMessage and nothing follows it, so a mirror that
+            // scheduled only on run completion left that child's transcript unwritten forever — for the
+            // whole life of the conversation, not until the next turn.
             _scheduler.Schedule(threadId);
         }
     }
@@ -397,8 +531,8 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
     /// <summary>
     ///     The scheduler's drain callback: resolves the conversation's writer and flushes it. A key whose
     ///     writer has since been evicted is a no-op, and a <see cref="TranscriptFlushOutcome.Deferred"/>
-    ///     result asks for exactly one more attempt (the writer's own capping is what makes that chain
-    ///     terminate rather than spin).
+    ///     result asks for another attempt — up to <see cref="MaxDeferredRetries"/> consecutive ones, which
+    ///     is what stops a permanently-deferring conversation from spinning the drain loop.
     /// </summary>
     private async Task FlushAsync(string threadId, CancellationToken ct)
     {
@@ -407,9 +541,24 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
             return;
         }
 
-        if (await writer.FlushAsync(ct).ConfigureAwait(false) == TranscriptFlushOutcome.Deferred)
+        if (await writer.FlushAsync(ct).ConfigureAwait(false) != TranscriptFlushOutcome.Deferred)
         {
-            _scheduler.Schedule(threadId);
+            _ = _deferredAttempts.TryRemove(threadId, out _);
+            return;
         }
+
+        var attempt = _deferredAttempts.AddOrUpdate(threadId, 1, (_, previous) => previous + 1);
+        if (attempt > MaxDeferredRetries)
+        {
+            _logger.LogWarning(
+                "Transcript flush for thread {ThreadId} deferred {Attempts} times in a row; giving up until "
+                    + "the next turn or sub-agent update. Nothing is lost — every watermark involved is "
+                    + "unadvanced, so the next flush repeats the work.",
+                threadId,
+                attempt);
+            return;
+        }
+
+        _scheduler.Schedule(threadId);
     }
 }

--- a/samples/LmStreaming.Sample/Services/WorkspaceTranscriptMirror.cs
+++ b/samples/LmStreaming.Sample/Services/WorkspaceTranscriptMirror.cs
@@ -99,11 +99,24 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
         new(StringComparer.Ordinal);
 
     /// <summary>
-    ///     Consecutive deferred flushes per conversation, against <see cref="MaxDeferredRetries"/>. Reset
-    ///     whenever a flush is not deferred and at every turn boundary, so the budget bounds one stuck
-    ///     chain rather than the conversation's lifetime.
+    ///     Consecutive deferred flushes per conversation, against <see cref="MaxDeferredRetries"/>, stamped
+    ///     with the generation that accrued them. Reset whenever a flush is not deferred and at every turn
+    ///     boundary, so the budget bounds one stuck chain rather than the conversation's lifetime.
     /// </summary>
-    private readonly ConcurrentDictionary<string, int> _deferredAttempts = new(StringComparer.Ordinal);
+    /// <remarks>
+    ///     The stamp exists because a flush is asynchronous and a trigger is not. <see cref="FlushAsync"/>
+    ///     can still be awaiting gateway I/O when a fresh trigger clears this counter on the subscriber
+    ///     thread; without the stamp, that older flush's <c>Deferred</c> outcome re-creates the counter at 1
+    ///     and the new generation silently starts one attempt down.
+    /// </remarks>
+    private readonly ConcurrentDictionary<string, DeferredBudget> _deferredAttempts =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    ///     Monotonic generation per conversation, bumped by <see cref="ScheduleFreshAttempt"/>. Identifies
+    ///     which trigger's work a completing flush belongs to.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, int> _generations = new(StringComparer.Ordinal);
 
     /// <summary>Guards <see cref="_subscriptions"/> and <see cref="_disposed"/>. Never held across
     /// cancellation or I/O — see <see cref="Attach"/>.</summary>
@@ -281,6 +294,7 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
 
         _ = _writers.TryRemove(threadId, out _);
         _ = _deferredAttempts.TryRemove(threadId, out _);
+        _ = _generations.TryRemove(threadId, out _);
 
         Subscription? removed;
         lock (_gate)
@@ -317,6 +331,7 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
 
         _writers.Clear();
         _deferredAttempts.Clear();
+        _generations.Clear();
         _scheduler.Dispose();
     }
 
@@ -419,7 +434,17 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
             // is UpToDate and issues no gateway write. It is a fresh generation of work like any other
             // trigger — the drop is new evidence, and inheriting a spent budget from before it would give
             // the recovery a single pass.
-            ScheduleFreshAttempt(threadId);
+            //
+            // It also forces a DESCENDANT RESCAN, which the other two triggers deliberately do not. What
+            // was lost here is unknown by definition, and a spawn call or completion notification is
+            // exactly the kind of message that can have been among it. If an earlier flush cached a roster
+            // taken before a child was persisted, and that child's only announcement went down with the
+            // channel, the cache is stale with nothing left to invalidate it and the child is never
+            // mirrored at all. The other two call sites are the opposite case: they run because a message
+            // ARRIVED, so the message itself is the signal — sub-agent activity already arms a rescan
+            // through NoteSubAgentActivity, and a run completion is not evidence about descendants.
+            ScheduleFreshAttempt(threadId, forceDescendantRescan: true);
+
         }
     }
 
@@ -499,6 +524,12 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
     ///     Schedules a flush of <paramref name="threadId"/> as a NEW generation of work: the bounded
     ///     deferred-retry budget is released and the writer's descendant coverage sweep starts over.
     /// </summary>
+    /// <param name="threadId">The conversation to flush.</param>
+    /// <param name="forceDescendantRescan">
+    ///     Also invalidates the cached descendant roster, for a trigger that means messages were LOST
+    ///     rather than delivered. Only the drop-recovery path passes true; see its call site for why the
+    ///     other two must not.
+    /// </param>
     /// <remarks>
     ///     <b>Every independent external trigger goes through here, not just the turn boundary.</b> The
     ///     budget and the sweep are both scoped to "one trigger's worth of attempts", so a trigger that
@@ -506,12 +537,20 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
     ///     likely to inherit one is the least recoverable, a background sub-agent completing after its
     ///     parent's last turn, because nothing follows it to try again.
     /// </remarks>
-    private void ScheduleFreshAttempt(string threadId)
+    private void ScheduleFreshAttempt(string threadId, bool forceDescendantRescan = false)
     {
+        // Bump BEFORE clearing, so a flush still in flight for the old generation can already tell that
+        // its outcome is stale by the time it returns.
+        _ = _generations.AddOrUpdate(threadId, 1, (_, previous) => previous + 1);
         _ = _deferredAttempts.TryRemove(threadId, out _);
+
         if (_writers.TryGetValue(threadId, out var writer))
         {
             writer.NoteExternalTrigger();
+            if (forceDescendantRescan)
+            {
+                writer.NoteSubAgentActivity();
+            }
         }
 
         _scheduler.Schedule(threadId);
@@ -570,6 +609,13 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
     ///     re-scheduled WITHOUT spending the failure budget; it terminates on the writer's own coverage
     ///     sweep instead. It does not reset the budget either: a conversation that alternates between
     ///     failing and progressing must still be bounded.
+    ///     <para>
+    ///     All of that accounting is scoped to the GENERATION this flush started in. A fresh trigger can
+    ///     land while the flush below is awaiting gateway I/O, and that trigger has already released the
+    ///     budget and scheduled its own attempt; letting this one's outcome land afterwards would charge
+    ///     the new generation for the old one's failure. So a superseded outcome is dropped outright —
+    ///     including its re-schedule, which the new generation has already issued.
+    ///     </para>
     /// </remarks>
     private async Task FlushAsync(string threadId, CancellationToken ct)
     {
@@ -578,7 +624,14 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
             return;
         }
 
+        var generation = _generations.GetOrAdd(threadId, 0);
+
         var outcome = await writer.FlushAsync(ct).ConfigureAwait(false);
+        if (generation != _generations.GetOrAdd(threadId, 0))
+        {
+            return;
+        }
+
         if (outcome == TranscriptFlushOutcome.Progressing)
         {
             _scheduler.Schedule(threadId);
@@ -587,12 +640,30 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
 
         if (outcome != TranscriptFlushOutcome.Deferred)
         {
-            _ = _deferredAttempts.TryRemove(threadId, out _);
+            if (_deferredAttempts.TryGetValue(threadId, out var spent) && spent.Generation == generation)
+            {
+                _ = _deferredAttempts.TryRemove(new KeyValuePair<string, DeferredBudget>(threadId, spent));
+            }
+
             return;
         }
 
-        var attempt = _deferredAttempts.AddOrUpdate(threadId, 1, (_, previous) => previous + 1);
-        if (attempt > MaxDeferredRetries)
+        // A counter left by an older generation is REPLACED rather than added to. It can only exist if
+        // that generation's flush lost the race against the check above, and it is not this generation's
+        // budget to spend.
+        var budget = _deferredAttempts.AddOrUpdate(
+            threadId,
+            _ => new DeferredBudget(generation, 1),
+            (_, previous) =>
+                previous.Generation == generation
+                    ? previous with
+                    {
+                        Attempts = previous.Attempts + 1,
+                    }
+                    : new DeferredBudget(generation, 1)
+        );
+
+        if (budget.Attempts > MaxDeferredRetries)
         {
             _logger.LogWarning(
                 "Transcript flush for thread {ThreadId} deferred {Attempts} times in a row; giving up until "
@@ -601,10 +672,13 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
                     + "conversation itself is untouched — but this conversation's workspace copy now stops "
                     + "short until something triggers it again.",
                 threadId,
-                attempt);
+                budget.Attempts);
             return;
         }
 
         _scheduler.Schedule(threadId);
     }
+
+    /// <summary>One conversation's consecutive-deferral count, and the generation that accrued it.</summary>
+    private readonly record struct DeferredBudget(int Generation, int Attempts);
 }

--- a/samples/LmStreaming.Sample/Services/WorkspaceTranscriptMirror.cs
+++ b/samples/LmStreaming.Sample/Services/WorkspaceTranscriptMirror.cs
@@ -261,7 +261,7 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
         var agent = subscription.Agent;
         var ct = subscription.Cancellation.Token;
 
-        IAsyncEnumerator<IMessage> enumerator;
+        IAsyncEnumerator<IMessage>? enumerator = null;
         ValueTask<bool> pending;
         try
         {
@@ -274,10 +274,73 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
                 ex,
                 "Subscribing the transcript mirror to thread {ThreadId} failed",
                 agent.ThreadId);
+            AbandonFailedSubscription(subscription, enumerator);
             return;
         }
 
         _ = Task.Run(() => PumpAsync(subscription, enumerator, pending));
+    }
+
+    /// <summary>
+    ///     Undoes a subscription whose setup failed, so the conversation is merely unmirrored rather than
+    ///     permanently unmirrorable.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <b>The registration has to go.</b> <see cref="Attach"/> records the subscription before starting
+    ///     the pump — deliberately, so no message can be published into the window between the two — which
+    ///     means a failure here leaves behind a mapping no pump is consuming. <see cref="Attach"/> treats an
+    ///     existing mapping for the SAME agent instance as an idempotent no-op, so the pool re-attaching
+    ///     that instance (a request that reuses the pooled agent, say) would return without ever
+    ///     re-subscribing, and a transient setup failure would cost the conversation its transcript for the
+    ///     rest of its life rather than for one attempt.
+    ///     </para>
+    ///     <para>
+    ///     <b>Removed by reference, never by key.</b> A concurrent <see cref="Attach"/> — a mode switch is
+    ///     the ordinary case — may already have replaced this mapping with a live successor's; deleting the
+    ///     key would then cancel nothing but silently unregister the subscription that is actually working.
+    ///     </para>
+    ///     <para>
+    ///     <b>Nothing here may throw or block.</b> <see cref="Attach"/> runs inside the pool's agent
+    ///     factory. The enumerator — which exists when <c>MoveNextAsync</c> is what threw, and holds that
+    ///     subscriber's channel registration until it is disposed — is therefore drained off-thread through
+    ///     a path that swallows its own faults.
+    ///     </para>
+    /// </remarks>
+    private void AbandonFailedSubscription(Subscription subscription, IAsyncEnumerator<IMessage>? enumerator)
+    {
+        var threadId = subscription.Agent.ThreadId;
+
+        lock (_gate)
+        {
+            if (_subscriptions.TryGetValue(threadId, out var current)
+                && ReferenceEquals(current, subscription))
+            {
+                _ = _subscriptions.Remove(threadId);
+            }
+        }
+
+        Cancel(subscription);
+
+        if (enumerator is null)
+        {
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await enumerator.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(
+                    ex,
+                    "Disposing the failed transcript subscription for thread {ThreadId} threw",
+                    threadId);
+            }
+        });
     }
 
     /// <summary>

--- a/samples/LmStreaming.Sample/Services/WorkspaceTranscriptMirror.cs
+++ b/samples/LmStreaming.Sample/Services/WorkspaceTranscriptMirror.cs
@@ -1,0 +1,415 @@
+using System.Collections.Concurrent;
+using AchieveAi.LmDotnetTools.LmAgentInfra.Sandbox;
+using AchieveAi.LmDotnetTools.LmCore.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Messages;
+using AchieveAi.LmDotnetTools.LmMultiTurn.Persistence;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+
+namespace LmStreaming.Sample.Services;
+
+/// <summary>
+///     Composition root of the workspace transcript mirror (#251): owns one
+///     <see cref="ConversationTranscriptWriter"/> per live conversation, the single
+///     <see cref="TranscriptFlushScheduler"/> that drains them, and the per-conversation message
+///     subscription that decides WHEN to schedule a drain.
+/// </summary>
+/// <remarks>
+///     <para>
+///     <b>Always on.</b> There is no feature flag. Every pooled agent is attached, and a conversation
+///     with no workspace bound simply produces <see cref="TranscriptFlushOutcome.Unavailable"/> on each
+///     flush — no gateway call, no file, no cost. The only opt-out is the <c>.gitignore</c> the writer
+///     drops into <c>.conversations/</c>.
+///     </para>
+///     <para>
+///     <b>S2S is UI-only for v1 — deliberately, not by omission.</b> A background flush has no inbound
+///     request to borrow a credential from, so a session an S2S caller owns resolves as
+///     <c>CredentialConflict</c> forever and that conversation gets no transcript. Recorded in ADR 0011.
+///     </para>
+///     <para>
+///     <b>Disposal is synchronous <see cref="IDisposable"/>, never <c>IAsyncDisposable</c>-only.</b> This
+///     is the single hardest constraint on the type. <c>BrowserWebAppFactory</c> tears the sample host
+///     down with the synchronous <c>IHost.Dispose()</c>, and a container-tracked
+///     <c>IAsyncDisposable</c>-only singleton makes <c>ServiceProvider.Dispose()</c> throw
+///     <i>"only implements IAsyncDisposable"</i> — which breaks every E2E test at teardown, for a reason
+///     that looks nothing like this feature. The same trap is documented verbatim at the
+///     <c>SqliteConnectionFactory</c> construction in <c>Program.cs</c>.
+///     </para>
+///     <para>
+///     <b>The transcript is RETAINED when a conversation is deleted.</b> <see cref="Evict"/> drops the
+///     in-memory writer and its subscription and touches nothing in the workspace: the point of mirroring
+///     a conversation into its workspace is that the record outlives the conversation.
+///     </para>
+/// </remarks>
+public sealed class WorkspaceTranscriptMirror : IDisposable
+{
+    /// <summary>
+    ///     How long a dropped subscription waits before re-subscribing. Non-zero so a conversation whose
+    ///     channel is genuinely saturated re-attaches at a bounded rate rather than spinning a hot loop
+    ///     against an agent that will only drop it again. Tests pass <see cref="TimeSpan.Zero"/>.
+    /// </summary>
+    public static readonly TimeSpan DefaultResubscribeDelay = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>One conversation's live subscription: the agent instance it is bound to, and the token
+    /// that ends it. The instance is load-bearing — see <see cref="PumpAsync"/>'s drop detection.</summary>
+    private sealed record Subscription(IMultiTurnAgent Agent, CancellationTokenSource Cancellation);
+
+    private readonly Func<string, IMultiTurnAgent?> _agentLookup;
+    private readonly IConversationStore _store;
+    private readonly IWorkspaceFileBrowser _fileBrowser;
+    private readonly ConversationDescendantScanner _descendants;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger<WorkspaceTranscriptMirror> _logger;
+    private readonly TimeSpan _resubscribeDelay;
+    private readonly TimeSpan? _readSettleDelay;
+    private readonly TranscriptFlushScheduler _scheduler;
+
+    /// <summary>
+    ///     One writer per conversation, keyed by threadId. Concurrent because the drain loop reads it
+    ///     while <see cref="Attach"/> may be adding to it. Survives a mode switch (same threadId, new
+    ///     agent instance) on purpose: the writer owns that conversation's watermarks, and rebuilding it
+    ///     would re-append the whole history.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, ConversationTranscriptWriter> _writers =
+        new(StringComparer.Ordinal);
+
+    /// <summary>Guards <see cref="_subscriptions"/> and <see cref="_disposed"/>. Never held across
+    /// cancellation or I/O — see <see cref="Attach"/>.</summary>
+    private readonly object _gate = new();
+    private readonly Dictionary<string, Subscription> _subscriptions = new(StringComparer.Ordinal);
+
+    private bool _disposed;
+    private int _resubscribeCount;
+
+    /// <summary>Creates the mirror.</summary>
+    /// <param name="agentLookup">
+    ///     Resolves the pool's CURRENT agent for a threadId, or null when the pool no longer holds one.
+    ///     A delegate rather than the pool itself because the pool's own registration resolves this type
+    ///     — taking <c>MultiTurnAgentPool</c> as a constructor dependency would close a DI cycle. The
+    ///     delegate is only invoked when a subscription ends, long after both singletons exist.
+    /// </param>
+    /// <param name="store">Source of persisted rows and metadata, handed to each writer.</param>
+    /// <param name="fileBrowser">The sandbox seam, handed to each writer.</param>
+    /// <param name="descendants">Shared descendant cache, handed to each writer.</param>
+    /// <param name="loggerFactory">Builds this type's logger and each writer's.</param>
+    /// <param name="resubscribeDelay">Overrides <see cref="DefaultResubscribeDelay"/>.</param>
+    /// <param name="readSettleDelay">
+    ///     Overrides <see cref="ConversationTranscriptWriter.DefaultReadSettleDelay"/> on every writer
+    ///     this mirror creates.
+    /// </param>
+    public WorkspaceTranscriptMirror(
+        Func<string, IMultiTurnAgent?> agentLookup,
+        IConversationStore store,
+        IWorkspaceFileBrowser fileBrowser,
+        ConversationDescendantScanner descendants,
+        ILoggerFactory loggerFactory,
+        TimeSpan? resubscribeDelay = null,
+        TimeSpan? readSettleDelay = null)
+    {
+        ArgumentNullException.ThrowIfNull(agentLookup);
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(fileBrowser);
+        ArgumentNullException.ThrowIfNull(descendants);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
+        _agentLookup = agentLookup;
+        _store = store;
+        _fileBrowser = fileBrowser;
+        _descendants = descendants;
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory.CreateLogger<WorkspaceTranscriptMirror>();
+        _resubscribeDelay = resubscribeDelay ?? DefaultResubscribeDelay;
+        _readSettleDelay = readSettleDelay;
+        _scheduler = new TranscriptFlushScheduler(
+            FlushAsync,
+            (threadId, error) => _logger.LogWarning(
+                error,
+                "Transcript flush for thread {ThreadId} faulted on the drain loop",
+                threadId));
+    }
+
+    /// <summary>
+    ///     How many times a subscription was detected as silently dropped and re-established. Zero on a
+    ///     healthy host; a climbing value means some conversation is publishing faster than this mirror
+    ///     consumes. Exposed so the drop path is assertable rather than only observable in logs.
+    /// </summary>
+    public int ResubscribeCount => Volatile.Read(ref _resubscribeCount);
+
+    /// <summary>
+    ///     Starts mirroring <paramref name="agent"/>'s conversation. Called from the sample's agent
+    ///     factory for every agent the pool creates, including the replacement built by a mode switch —
+    ///     that case cancels the previous subscription and keeps the existing writer.
+    /// </summary>
+    /// <remarks>Idempotent for the same instance: re-attaching an already-attached agent is a no-op.</remarks>
+    public void Attach(IMultiTurnAgent agent)
+    {
+        ArgumentNullException.ThrowIfNull(agent);
+
+        var threadId = agent.ThreadId;
+        if (string.IsNullOrEmpty(threadId))
+        {
+            return;
+        }
+
+        _ = _writers.GetOrAdd(
+            threadId,
+            id => new ConversationTranscriptWriter(
+                id,
+                _store,
+                _fileBrowser,
+                _descendants,
+                _loggerFactory.CreateLogger<ConversationTranscriptWriter>(),
+                _readSettleDelay));
+
+        Subscription? replaced;
+        Subscription subscription;
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (_subscriptions.TryGetValue(threadId, out var existing)
+                && ReferenceEquals(existing.Agent, agent))
+            {
+                return;
+            }
+
+            replaced = existing;
+            subscription = new Subscription(agent, new CancellationTokenSource());
+            _subscriptions[threadId] = subscription;
+        }
+
+        // Outside the lock: Cancel() runs its registrations inline, and one of those resumes a pump that
+        // may call straight back into this type.
+        Cancel(replaced);
+        _ = Task.Run(() => PumpAsync(subscription));
+    }
+
+    /// <summary>
+    ///     Stops mirroring <paramref name="threadId"/> and forgets its writer. Wired to
+    ///     <c>MultiTurnAgentPool.ThreadRemoved</c>. <b>Never deletes the transcript</b> — the file is the
+    ///     durable record and outliving the conversation is the point.
+    /// </summary>
+    public void Evict(string threadId)
+    {
+        if (string.IsNullOrEmpty(threadId))
+        {
+            return;
+        }
+
+        _ = _writers.TryRemove(threadId, out _);
+
+        Subscription? removed;
+        lock (_gate)
+        {
+            _ = _subscriptions.Remove(threadId, out removed);
+        }
+
+        Cancel(removed);
+    }
+
+    /// <summary>
+    ///     Ends every subscription and stops the drain loop. Synchronous, non-throwing, and does not wait
+    ///     on the pumps — see the type remarks for why this must never become <c>IAsyncDisposable</c>-only.
+    /// </summary>
+    public void Dispose()
+    {
+        List<Subscription> live;
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            live = [.. _subscriptions.Values];
+            _subscriptions.Clear();
+        }
+
+        foreach (var subscription in live)
+        {
+            Cancel(subscription);
+        }
+
+        _writers.Clear();
+        _scheduler.Dispose();
+    }
+
+    /// <summary>
+    ///     Cancels one subscription. The source is deliberately NOT disposed: its token is still held by a
+    ///     pump that may be parked inside <c>SubscribeAsync</c>, and a token whose source was disposed
+    ///     throws on the next registration. A cancelled source holds no OS handle (no WaitHandle is ever
+    ///     taken from it) and is reclaimed by GC once the pump lets go.
+    /// </summary>
+    private void Cancel(Subscription? subscription)
+    {
+        if (subscription is null)
+        {
+            return;
+        }
+
+        try
+        {
+            subscription.Cancellation.Cancel();
+        }
+        catch (Exception ex)
+        {
+            // Cancel() surfaces whatever a downstream registration threw. Teardown continues regardless:
+            // neither Evict nor Dispose may throw into the pool's ThreadRemoved fan-out or host shutdown.
+            _logger.LogDebug(ex, "Cancelling the transcript subscription for {ThreadId} threw", subscription.Agent.ThreadId);
+        }
+    }
+
+    /// <summary>
+    ///     Consumes one conversation's message stream, scheduling a flush at every turn boundary — and
+    ///     recovering from a subscription the agent silently dropped.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <b>Why the drop check exists.</b> <c>MultiTurnAgentBase.PublishToSubscriber</c> publishes with
+    ///     <c>TryWrite</c>; when a subscriber's bounded channel is full the subscriber is REMOVED from the
+    ///     fan-out and its channel completed. The enumerator then ends <i>normally, with no exception</i>,
+    ///     so a naive <c>await foreach</c> would exit as if the conversation had finished and every later
+    ///     turn of a still-live conversation would go unmirrored — silently, with nothing in the logs.
+    ///     </para>
+    ///     <para>
+    ///     <b>Why the identity comparison is the right discriminator.</b> Three things end an enumeration:
+    ///     the drop, <see cref="Evict"/>/<see cref="Dispose"/> (our own token), and the agent being
+    ///     disposed. The last two are distinguishable because <c>MultiTurnAgentPool.RemoveAgentAsync</c>
+    ///     removes the entry from its map BEFORE disposing it, and <c>RecreateAgentWithModeAsync</c>
+    ///     likewise swaps the entry before disposing the old agent — so by the time a disposal completes
+    ///     our channel, the pool either no longer holds this threadId or holds a DIFFERENT instance.
+    ///     Reference equality on the agent, not on the threadId, is therefore what separates "we were
+    ///     dropped from a conversation that is still live" from an ordinary teardown.
+    ///     </para>
+    /// </remarks>
+    private async Task PumpAsync(Subscription subscription)
+    {
+        var agent = subscription.Agent;
+        var threadId = agent.ThreadId;
+        var ct = subscription.Cancellation.Token;
+
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                await foreach (var message in agent.SubscribeAsync(ct).ConfigureAwait(false))
+                {
+                    Observe(threadId, message);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                // Best-effort, like every other path in this feature: a faulted stream ends the mirror for
+                // this conversation rather than looping on a failure that is not going to clear.
+                _logger.LogWarning(ex, "Transcript subscription for thread {ThreadId} faulted", threadId);
+                return;
+            }
+
+            if (ct.IsCancellationRequested
+                || _agentLookup(threadId) is not { } current
+                || !ReferenceEquals(current, agent))
+            {
+                return;
+            }
+
+            _ = Interlocked.Increment(ref _resubscribeCount);
+            _logger.LogWarning(
+                "Transcript subscription for thread {ThreadId} was dropped (its output channel filled); "
+                    + "re-subscribing. Turns published during the gap are still recovered — the writer's "
+                    + "watermark is cumulative and the next flush re-reads the whole thread.",
+                threadId);
+
+            try
+            {
+                await Task.Delay(_resubscribeDelay, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+
+    /// <summary>Applies one observed message to this conversation's mirror state.</summary>
+    private void Observe(string threadId, IMessage message)
+    {
+        if (IsSubAgentActivity(message) && _writers.TryGetValue(threadId, out var writer))
+        {
+            writer.NoteSubAgentActivity();
+        }
+
+        if (message is RunCompletedMessage)
+        {
+            // The turn boundary, and the ONLY flush trigger. Non-blocking by contract, so no gateway
+            // latency ever reaches this loop.
+            _scheduler.Schedule(threadId);
+        }
+    }
+
+    /// <summary>
+    ///     Whether <paramref name="message"/> is evidence that a sub-agent exists or progressed, which is
+    ///     what makes the next flush refresh the descendant graph before fanning out.
+    /// </summary>
+    /// <remarks>
+    ///     Two shapes, because a sub-agent is visible to its parent at two distinct moments: the
+    ///     <c>Agent</c> tool call that spawns it, and the notification it (or a descendant of it) pushes
+    ///     back. Matching only the notification would miss a foreground spawn whose result never travels
+    ///     as a <see cref="NotifyMessage"/>; matching only the tool call would miss a background spawn
+    ///     that was already running when this process attached.
+    /// </remarks>
+    private static bool IsSubAgentActivity(IMessage message) =>
+        message switch
+        {
+            NotifyMessage notify => notify.NotifyKind is NotifyKinds.SubAgentCompletion
+                or NotifyKinds.DescendantQuestion,
+            ToolsCallAggregateMessage aggregate => HasSpawnCall(aggregate.ToolsCallMessage),
+            ICanGetToolCalls calls => HasSpawnCall(calls),
+            _ => false,
+        };
+
+    private static bool HasSpawnCall(ICanGetToolCalls message)
+    {
+        var calls = message.GetToolCalls();
+        if (calls is null)
+        {
+            return false;
+        }
+
+        foreach (var call in calls)
+        {
+            if (string.Equals(call.FunctionName, SubAgentToolProvider.SpawnToolName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     The scheduler's drain callback: resolves the conversation's writer and flushes it. A key whose
+    ///     writer has since been evicted is a no-op, and a <see cref="TranscriptFlushOutcome.Deferred"/>
+    ///     result asks for exactly one more attempt (the writer's own capping is what makes that chain
+    ///     terminate rather than spin).
+    /// </summary>
+    private async Task FlushAsync(string threadId, CancellationToken ct)
+    {
+        if (!_writers.TryGetValue(threadId, out var writer))
+        {
+            return;
+        }
+
+        if (await writer.FlushAsync(ct).ConfigureAwait(false) == TranscriptFlushOutcome.Deferred)
+        {
+            _scheduler.Schedule(threadId);
+        }
+    }
+}

--- a/samples/LmStreaming.Sample/sandbox-skills/repo-explorer/SKILL.md
+++ b/samples/LmStreaming.Sample/sandbox-skills/repo-explorer/SKILL.md
@@ -9,7 +9,7 @@ Turn an unfamiliar repository into a deterministic, structured manifest. Follow 
 
 ## Procedure
 
-1. **List the tree.** Run `Bash: ls` at the workspace root, then `Glob **/*` (cap depth ~3). Ignore `node_modules`, `target`, `.git`, `bin`, `obj`, `dist`, and `.venv`. Note the top-level directories.
+1. **List the tree.** Run `Bash: ls` at the workspace root, then `Glob **/*` (cap depth ~3). Ignore `node_modules`, `target`, `.git`, `bin`, `obj`, `dist`, `.venv`, and `.conversations`. Note the top-level directories. (`.conversations` holds this conversation's own message transcript, not repository content — it says nothing about what the project is.)
 
 2. **Detect languages & manifests.** Look for `package.json` (JS/TS), `*.csproj`/`*.sln` (C#), `Cargo.toml` (Rust), `pyproject.toml`/`requirements.txt` (Python), `go.mod` (Go), `pom.xml`/`build.gradle` (JVM). Each manifest implies a language and a toolchain.
 

--- a/samples/LmStreaming.Sample/sandbox-skills/workspace-summary/SKILL.md
+++ b/samples/LmStreaming.Sample/sandbox-skills/workspace-summary/SKILL.md
@@ -9,7 +9,7 @@ Turn the current workspace into a deterministic, structured inventory. Follow th
 
 ## Procedure
 
-1. **Enumerate files.** Use `Glob` with pattern `**/*` from the workspace root. Ignore noise directories: `node_modules`, `.git`, `target`, `bin`, `obj`, `dist`, `.venv`, `__pycache__`. Collect the relative path of every regular file.
+1. **Enumerate files.** Use `Glob` with pattern `**/*` from the workspace root. Ignore noise directories: `node_modules`, `.git`, `target`, `bin`, `obj`, `dist`, `.venv`, `__pycache__`, `.conversations`. Collect the relative path of every regular file. (`.conversations` holds this conversation's own message transcript — counting or summarizing it would fold your own output back into the inventory.)
 
 2. **Group by extension.** For each file, take its lowercase extension (or `"(none)"` when it has none). Count files per extension and, where cheap, sum their sizes. Use `Bash` (e.g. `ls -l`, `du`, `wc`) only for read-only size/line measurements when needed.
 

--- a/tests/LmStreaming.Sample.Tests/Controllers/AgentOwnedThreadRouteTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/AgentOwnedThreadRouteTests.cs
@@ -328,5 +328,6 @@ public sealed class AgentOwnedThreadRouteTests
             new WorkflowRunRegistry(),
             NullLogger<ConversationsController>.Instance,
             NullLogger<AgentHierarchyService>.Instance,
-            new SubAgentScanCoverageCache());
+            new SubAgentScanCoverageCache(),
+            new ConversationDescendantScanner(store, NullLogger<ConversationDescendantScanner>.Instance));
 }

--- a/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerS2SAuthTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerS2SAuthTests.cs
@@ -48,7 +48,8 @@ public class ConversationsControllerS2SAuthTests
             new WorkflowRunRegistry(),
             NullLogger<ConversationsController>.Instance,
             NullLogger<AgentHierarchyService>.Instance,
-            new SubAgentScanCoverageCache());
+            new SubAgentScanCoverageCache(),
+            new ConversationDescendantScanner(store, NullLogger<ConversationDescendantScanner>.Instance));
     }
 
     private static IChatModeStore ModeStoreResolvingSystemModes()

--- a/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerS2SPipelineTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerS2SPipelineTests.cs
@@ -63,6 +63,9 @@ public sealed class ConversationsControllerS2SPipelineTests
                         _ = services.AddSingleton(TimeProvider.System);
                         _ = services.AddSingleton<LmStreaming.Sample.Services.WorkflowRunRegistry>();
                         _ = services.AddSingleton<SubAgentScanCoverageCache>();
+                        _ = services.AddSingleton(sp => new ConversationDescendantScanner(
+                            sp.GetRequiredService<IConversationStore>(),
+                            NullLogger<ConversationDescendantScanner>.Instance));
                         _ = services
                             .AddControllers()
                             .AddApplicationPart(typeof(ConversationsController).Assembly);

--- a/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerSubAgentsTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerSubAgentsTests.cs
@@ -53,7 +53,8 @@ public sealed class ConversationsControllerSubAgentsTests
             workflowRunRegistry,
             NullLogger<ConversationsController>.Instance,
             NullLogger<AgentHierarchyService>.Instance,
-            cache);
+            cache,
+            new ConversationDescendantScanner(store, NullLogger<ConversationDescendantScanner>.Instance));
     }
 
     private static MultiTurnAgentPool CreateFakeAgentPool()

--- a/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerTests.cs
@@ -42,7 +42,8 @@ public class ConversationsControllerTests
             new WorkflowRunRegistry(),
             NullLogger<ConversationsController>.Instance,
             NullLogger<AgentHierarchyService>.Instance,
-            new SubAgentScanCoverageCache());
+            new SubAgentScanCoverageCache(),
+            new ConversationDescendantScanner(store, NullLogger<ConversationDescendantScanner>.Instance));
     }
 
     /// <summary>Resolves any real system mode id (default mode, math-helper, etc.) — for tests that

--- a/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerWorkspaceTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ConversationsControllerWorkspaceTests.cs
@@ -77,7 +77,10 @@ public class ConversationsControllerWorkspaceTests
             new WorkflowRunRegistry(),
             NullLogger<ConversationsController>.Instance,
             NullLogger<AgentHierarchyService>.Instance,
-            new SubAgentScanCoverageCache());
+            new SubAgentScanCoverageCache(),
+            new ConversationDescendantScanner(
+                store.Object,
+                NullLogger<ConversationDescendantScanner>.Instance));
     }
 
     private static MultiTurnAgentPool CreatePool()

--- a/tests/LmStreaming.Sample.Tests/Controllers/ConversationsRestContractTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ConversationsRestContractTests.cs
@@ -236,7 +236,8 @@ public class ConversationsRestContractTests
             new WorkflowRunRegistry(),
             NullLogger<ConversationsController>.Instance,
             NullLogger<AgentHierarchyService>.Instance,
-            new SubAgentScanCoverageCache());
+            new SubAgentScanCoverageCache(),
+            new ConversationDescendantScanner(store, NullLogger<ConversationDescendantScanner>.Instance));
     }
 
     private static IChatModeStore ModeStoreResolvingSystemModes()

--- a/tests/LmStreaming.Sample.Tests/Controllers/FileBrowserControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/FileBrowserControllerTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Text;
 using AchieveAi.LmDotnetTools.Sandbox;
 using LmStreaming.Sample.FileBrowser;
+using LmStreaming.Sample.Tests.TestDoubles;
 using Microsoft.AspNetCore.Http;
 
 namespace LmStreaming.Sample.Tests.Controllers;
@@ -16,63 +17,6 @@ namespace LmStreaming.Sample.Tests.Controllers;
 public class FileBrowserControllerTests
 {
     private const string ThreadId = "t1";
-
-    private static SandboxSession LiveSession => new("default", "sess-1", "/workspace", "/host/ws");
-
-    private sealed class FakeFileBrowser : IWorkspaceFileBrowser
-    {
-        public SandboxSessionResolution Resolution { get; set; } =
-            new(SandboxSessionResolutionOutcome.Resolved, LiveSession, "app", null);
-
-        public Exception? ResolveThrows { get; set; }
-
-        /// <summary>The <c>persistedWorkspaceId</c> the controller passed to the last resolve call (the value
-        /// <c>ReadWorkspaceId</c> extracted from metadata) — asserted by the JsonElement regression tests.</summary>
-        public string? LastPersistedWorkspaceId { get; private set; }
-
-        public Dictionary<string, IReadOnlyList<SandboxDirectoryEntry>> Listings { get; } = new(StringComparer.Ordinal);
-        public byte[] FileBytes { get; set; } = [];
-        public Exception? ReadThrows { get; set; }
-        public Exception? WriteThrows { get; set; }
-        public SandboxCommandResult ExecResult { get; set; } = new() { ExitCode = 0, StandardOutput = "", StandardError = "", OperationId = "op" };
-        public List<(string Path, byte[] Bytes)> Writes { get; } = [];
-        public List<SandboxCommand> Commands { get; } = [];
-        public int ReadCalls { get; private set; }
-
-        public Task<SandboxSessionResolution> ResolveThreadWorkspaceSessionAsync(string threadId, string persistedWorkspaceId, SandboxCredential? requestCredential, CancellationToken ct = default)
-        {
-            LastPersistedWorkspaceId = persistedWorkspaceId;
-            return ResolveThrows is not null ? Task.FromException<SandboxSessionResolution>(ResolveThrows) : Task.FromResult(Resolution);
-        }
-
-        public Task<IReadOnlyList<SandboxDirectoryEntry>> ListWorkspaceDirectoryAsync(string sessionId, string relativePath, CancellationToken ct = default) =>
-            Listings.TryGetValue(relativePath, out var entries)
-                ? Task.FromResult(entries)
-                : Task.FromResult<IReadOnlyList<SandboxDirectoryEntry>>([]);
-
-        public Task<byte[]> ReadWorkspaceFileBytesAsync(string sessionId, string relativePath, long? maxBytes, CancellationToken ct = default)
-        {
-            ReadCalls++;
-            return ReadThrows is not null ? Task.FromException<byte[]>(ReadThrows) : Task.FromResult(FileBytes);
-        }
-
-        public Task WriteWorkspaceFileBytesAsync(string sessionId, string relativePath, byte[] bytes, CancellationToken ct = default)
-        {
-            if (WriteThrows is not null)
-            {
-                return Task.FromException(WriteThrows);
-            }
-
-            Writes.Add((relativePath, bytes));
-            return Task.CompletedTask;
-        }
-
-        public Task<SandboxCommandResult> ExecuteWorkspaceCommandAsync(string sessionId, SandboxCommand command, CancellationToken ct = default)
-        {
-            Commands.Add(command);
-            return Task.FromResult(ExecResult);
-        }
-    }
 
     private sealed class FakeFormFile(string fileName, byte[] content, long? declaredLength = null) : IFormFile
     {
@@ -384,6 +328,21 @@ public class FileBrowserControllerTests
         var preview = result.Should().BeOfType<OkObjectResult>().Which.Value.Should().BeOfType<PreviewResultDto>().Which;
         preview.Previewable.Should().BeFalse();
         preview.Reason.Should().Be("binary");
+        browser.ReadCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Preview_UnderDotDirectory_ReturnsExcluded_WithoutReading()
+    {
+        // A conversation's own transcript (#251) lives in `.conversations/*.jsonl` and `.jsonl` IS on the
+        // allowlist, so the dot-directory exclusion — not the allowlist — is what keeps it unreadable here.
+        var (controller, browser) = Build();
+        browser.Listings[""] = [Dir(".conversations")];
+        browser.Listings[".conversations"] = [File("fix-the-login-bug-a3f9.jsonl", size: 10)];
+        var result = await controller.Preview(ThreadId, ".conversations/fix-the-login-bug-a3f9.jsonl", CancellationToken.None);
+        var preview = result.Should().BeOfType<OkObjectResult>().Which.Value.Should().BeOfType<PreviewResultDto>().Which;
+        preview.Previewable.Should().BeFalse();
+        preview.Reason.Should().Be("excluded");
         browser.ReadCalls.Should().Be(0);
     }
 

--- a/tests/LmStreaming.Sample.Tests/FileBrowser/FilePreviewPolicyTests.cs
+++ b/tests/LmStreaming.Sample.Tests/FileBrowser/FilePreviewPolicyTests.cs
@@ -1,0 +1,36 @@
+using LmStreaming.Sample.FileBrowser;
+
+namespace LmStreaming.Sample.Tests.FileBrowser;
+
+/// <summary>
+/// Covers <see cref="FilePreviewPolicy"/>: the extension/exact-name allowlist, and the dot-directory
+/// exclusion that keeps a conversation's own <c>.conversations/*.jsonl</c> transcript (#251) out of the
+/// preview surface even though <c>.jsonl</c> is allowlisted.
+/// </summary>
+public class FilePreviewPolicyTests
+{
+    [Theory]
+    [InlineData(".conversations/fix-the-login-bug-a3f9.jsonl")]
+    [InlineData(".conversations/fix-the-login-bug-a3f9_agents/reviewer-7c21.jsonl")]
+    [InlineData("nested/.conversations/notes.md")]
+    [InlineData(".git/COMMIT_EDITMSG")]
+    public void IsUnderDotDirectory_FileBeneathADotDirectory_IsExcluded(string serverPath) =>
+        FilePreviewPolicy.IsUnderDotDirectory(serverPath).Should().BeTrue();
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("readme.md")]
+    [InlineData(".gitignore")]
+    [InlineData("src/.editorconfig")]
+    [InlineData("src/app/main.cs")]
+    public void IsUnderDotDirectory_DotFilesAndOrdinaryPaths_AreNotExcluded(string serverPath) =>
+        FilePreviewPolicy.IsUnderDotDirectory(serverPath).Should().BeFalse();
+
+    [Fact]
+    public void IsUnderDotDirectory_IsIndependentOfTheAllowlist()
+    {
+        // The exclusion has to be checked separately: the transcript's own extension is previewable.
+        FilePreviewPolicy.IsPreviewable("reviewer-7c21.jsonl").Should().BeTrue();
+        FilePreviewPolicy.IsUnderDotDirectory(".conversations/reviewer-7c21.jsonl").Should().BeTrue();
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/AgentHierarchyServiceTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/AgentHierarchyServiceTests.cs
@@ -102,6 +102,70 @@ public sealed class AgentHierarchyServiceTests
         child.Template.Should().Be("worker");
     }
 
+    /// <summary>
+    /// The twin of
+    /// <c>ConversationDescendantScannerTests.ScanAsync_ListsEveryChild_WhenAThreadIsTouchedWhileTheScanIsRunning</c>,
+    /// against the flat cold-path scan. A child touched while the scan runs must still be listed:
+    /// <see cref="IConversationStore.ListThreadsAsync"/> orders by a MUTABLE column, so an offset-paged
+    /// scan lets a thread slide forward past an offset it has already stepped over. Here the loss is
+    /// permanent by construction — <see cref="SubAgentScanCoverageCache"/> records what the scan
+    /// recovered and keeps it for the process lifetime, so the skipped child is never reconsidered.
+    /// </summary>
+    [Fact]
+    public async Task BuildAsync_ListsEveryPersistedChild_WhenAThreadIsTouchedWhileTheScanIsRunning()
+    {
+        // More children than the pre-fix 200-row page, so the scan has a page boundary at all.
+        const int childCount = 250;
+        // A child that a paged scan has NOT read yet when the touch happens (it sorts into page 2).
+        const string touchedAgentId = "child-010";
+        var touchedThreadId = $"subagent-{touchedAgentId}";
+
+        var store = new InMemoryConversationStore();
+        for (var i = 0; i < childCount; i++)
+        {
+            var agentId = $"child-{i:D3}";
+            var childThreadId = $"subagent-{agentId}";
+            await store.SaveMetadataAsync(
+                childThreadId,
+                new ThreadMetadata
+                {
+                    ThreadId = childThreadId,
+                    // Distinct stamps so "ordered by last updated descending" is unambiguous.
+                    LastUpdated = i + 1,
+                    Properties = SubAgentProvenance.Build(
+                        RootThread,
+                        new SubAgentSnapshot(
+                            agentId,
+                            Name: agentId,
+                            TemplateName: "worker",
+                            Task: $"task for {agentId}",
+                            Status: SubAgentStatus.Completed,
+                            ThreadId: childThreadId,
+                            LastActivityUtc: DateTimeOffset.UtcNow,
+                            TerminalAtUtc: DateTimeOffset.UtcNow)),
+                });
+        }
+
+        // No live loop for RootThread, so the cold-path persisted scan is the only route to these children.
+        await using var pool = CreateFakeAgentPool();
+        var service = new AgentHierarchyService(
+            pool,
+            new WorkflowRunRegistry(),
+            new TouchingConversationStore(store, touchedThreadId),
+            NullLogger<AgentHierarchyService>.Instance,
+            new SubAgentScanCoverageCache());
+
+        var (rows, _, _) = await service.BuildAsync(RootThread, viewerAgentId: null, CancellationToken.None);
+
+        rows.Select(r => r.AgentId)
+            .Should()
+            .Contain(
+                touchedAgentId,
+                "a child that was merely touched mid-scan must still be listed — what this scan recovers "
+                    + "is recorded in the coverage cache for the process lifetime, so a skip is permanent");
+        rows.Should().HaveCount(childCount);
+    }
+
     [Fact]
     public async Task BuildAsync_ForALiveNonMultiTurnAgentLoop_NeverCallsListThreadsAsync()
     {
@@ -224,14 +288,13 @@ public sealed class AgentHierarchyServiceTests
     [Fact]
     public async Task ScanPersistedSubAgentChildren_WarnsWhenTheThreadCapIsReached()
     {
-        // Seeds exactly as many threads as the scan's cap so every page comes back full (200) and the
-        // loop exhausts scanned == cap without a short final page ever triggering an early return —
-        // the one path that reaches the "stopped at the cap" warning rather than silently returning
-        // whatever it found. Without the warning an operator has no signal that the sub-agent listing
-        // for a very long-lived store became incomplete.
+        // Seeds ONE MORE thread than the scan's cap, which is exactly what truncation is: the scan asks for
+        // cap + 1 and gets it back full, so it knows a thread it will not look at exists. Without the
+        // warning an operator has no signal that the sub-agent listing for a very long-lived store became
+        // incomplete — and the incomplete roster is then cached for the process lifetime.
         const int scanCap = 2000;
         var store = new InMemoryConversationStore();
-        for (var i = 0; i < scanCap; i++)
+        for (var i = 0; i <= scanCap; i++)
         {
             var id = $"thread-cap-{i}";
             await store.SaveMetadataAsync(id, new ThreadMetadata { ThreadId = id, LastUpdated = i });
@@ -250,6 +313,32 @@ public sealed class AgentHierarchyServiceTests
                 && e.Message.Contains(RootThread, StringComparison.Ordinal)
                 && e.Message.Contains(scanCap.ToString(), StringComparison.Ordinal),
             "hitting the scan cap must be observable, not a silent truncation");
+    }
+
+    [Fact]
+    public async Task ScanPersistedSubAgentChildren_DoesNotWarnWhenTheStoreHoldsExactlyTheCap()
+    {
+        // The other side of the boundary, and the reason the scan asks for cap + 1 rather than cap: a store
+        // holding exactly the cap is read COMPLETELY, so warning about it would be a false alarm — and a
+        // truncation warning that fires when nothing was truncated is one an operator learns to ignore.
+        const int scanCap = 2000;
+        var store = new InMemoryConversationStore();
+        for (var i = 0; i < scanCap; i++)
+        {
+            var id = $"thread-cap-{i}";
+            await store.SaveMetadataAsync(id, new ThreadMetadata { ThreadId = id, LastUpdated = i });
+        }
+
+        await using var pool = CreateFakeAgentPool();
+        var logger = new CapturingLogger<AgentHierarchyService>();
+        var service = new AgentHierarchyService(
+            pool, new WorkflowRunRegistry(), store, logger, new SubAgentScanCoverageCache());
+
+        _ = await service.BuildAsync(RootThread, viewerAgentId: null, CancellationToken.None);
+
+        logger.Entries.Should().NotContain(
+            e => e.Level == LogLevel.Warning && e.Message.Contains("cap", StringComparison.Ordinal),
+            "the store was read in full, so there is nothing to warn about");
     }
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/Services/AgentTranscriptAccessTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/AgentTranscriptAccessTests.cs
@@ -648,7 +648,8 @@ public sealed class AgentTranscriptAccessTests
             workflowRunRegistry,
             NullLogger<ConversationsController>.Instance,
             NullLogger<AgentHierarchyService>.Instance,
-            scanCoverageCache ?? new SubAgentScanCoverageCache());
+            scanCoverageCache ?? new SubAgentScanCoverageCache(),
+            new ConversationDescendantScanner(store, NullLogger<ConversationDescendantScanner>.Instance));
 
     private static MultiTurnAgentPool CreateFakeAgentPool() =>
         new(

--- a/tests/LmStreaming.Sample.Tests/Services/ConversationDescendantScannerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ConversationDescendantScannerTests.cs
@@ -2,6 +2,7 @@ using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Tests.Agents;
 using LmStreaming.Sample.Tests.TestDoubles;
+using Microsoft.Extensions.Logging;
 
 namespace LmStreaming.Sample.Tests.Services;
 
@@ -13,12 +14,17 @@ namespace LmStreaming.Sample.Tests.Services;
 /// </summary>
 public sealed class ConversationDescendantScannerTests
 {
-    private static ConversationDescendantScanner CreateScanner(IConversationStore store, int? capacity = null) =>
+    private static ConversationDescendantScanner CreateScanner(
+        IConversationStore store,
+        int? capacity = null,
+        ILogger<ConversationDescendantScanner>? logger = null) =>
         capacity is null
-            ? new ConversationDescendantScanner(store, NullLogger<ConversationDescendantScanner>.Instance)
+            ? new ConversationDescendantScanner(
+                store,
+                logger ?? NullLogger<ConversationDescendantScanner>.Instance)
             : new ConversationDescendantScanner(
                 store,
-                NullLogger<ConversationDescendantScanner>.Instance,
+                logger ?? NullLogger<ConversationDescendantScanner>.Instance,
                 capacity.Value);
 
     /// <summary>Seeds one persisted sub-agent thread stamped as <paramref name="parentThreadId"/>'s child.</summary>
@@ -428,6 +434,107 @@ public sealed class ConversationDescendantScannerTests
         var callsBefore = counting.ListThreadsCallCount;
         _ = await scanner.GetOrScanAsync("root-2");
         counting.ListThreadsCallCount.Should().BeGreaterThan(callsBefore);
+    }
+
+    /// <summary>
+    /// A conversation touched WHILE the scan is running must not be able to hide a sibling from the
+    /// roster. <see cref="IConversationStore.ListThreadsAsync"/> is contractually "ordered by last updated
+    /// descending", so an offset-paged scan sorts on a column the live system is mutating underneath it:
+    /// a thread that moves toward the front pushes an unread neighbour backwards across the offset
+    /// boundary, and the next page's offset steps straight over it. What makes it more than a lost read is
+    /// that the result is CACHED — the skipped sub-agent stays missing for the life of the entry, so its
+    /// transcript is never mirrored.
+    /// </summary>
+    [Fact]
+    public async Task ScanAsync_ListsEveryChild_WhenAThreadIsTouchedWhileTheScanIsRunning()
+    {
+        const string root = "thread-drift-root";
+        // More children than the pre-fix 200-row page, so the scan has a page boundary at all.
+        const int childCount = 250;
+        // A child that a paged scan has NOT read yet when the touch happens (it sorts into page 2).
+        const string touched = "subagent-010";
+
+        var store = new InMemoryConversationStore();
+        await store.SaveMetadataAsync(root, new ThreadMetadata { ThreadId = root, LastUpdated = 0 });
+        for (var i = 0; i < childCount; i++)
+        {
+            var childThreadId = $"subagent-{i:D3}";
+            await store.SaveMetadataAsync(
+                childThreadId,
+                new ThreadMetadata
+                {
+                    ThreadId = childThreadId,
+                    // Distinct stamps so "ordered by last updated descending" is unambiguous.
+                    LastUpdated = i + 1,
+                    Properties = SubAgentProvenance.Build(
+                        root,
+                        new SubAgentSnapshot(
+                            childThreadId,
+                            Name: childThreadId,
+                            TemplateName: "worker",
+                            Task: $"task for {childThreadId}",
+                            Status: SubAgentStatus.Completed,
+                            ThreadId: childThreadId,
+                            LastActivityUtc: DateTimeOffset.UtcNow,
+                            TerminalAtUtc: DateTimeOffset.UtcNow)),
+                });
+        }
+
+        var nodes = await CreateScanner(new TouchingConversationStore(store, touched)).ScanAsync(root);
+
+        nodes.Select(n => n.ThreadId)
+            .Should()
+            .Contain(
+                touched,
+                "a child that was merely touched mid-scan must still be listed — the roster this scan "
+                    + "produces is cached, so anything it skips stays skipped");
+        nodes.Should().HaveCount(childCount);
+    }
+
+    /// <summary>
+    /// The scan is bounded, so a store that outgrows the bound must say so: the roster it returns is
+    /// cached, and a descendant persisted past the cap is not merely absent from one response but absent
+    /// for the life of the entry. Truncation is what the scan asks for one row MORE than the cap to
+    /// detect — a page filled exactly to the cap is otherwise indistinguishable from a complete read.
+    /// </summary>
+    [Fact]
+    public async Task ScanAsync_WarnsWhenTheStoreHoldsMoreThreadsThanTheCap()
+    {
+        const int scanCap = 2000;
+        var logger = new CapturingLogger<ConversationDescendantScanner>();
+        var store = new InMemoryConversationStore();
+        for (var i = 0; i <= scanCap; i++)
+        {
+            var id = $"thread-cap-{i}";
+            await store.SaveMetadataAsync(id, new ThreadMetadata { ThreadId = id, LastUpdated = i });
+        }
+
+        _ = await CreateScanner(store, logger: logger).ScanAsync("thread-cap-0");
+
+        logger.Entries.Should().Contain(
+            e => e.Level == LogLevel.Warning
+                && e.Message.Contains(scanCap.ToString(), StringComparison.Ordinal),
+            "hitting the scan cap must be observable, not a silent truncation");
+    }
+
+    /// <summary>The other side of that boundary: a store read IN FULL must not raise a false alarm.</summary>
+    [Fact]
+    public async Task ScanAsync_DoesNotWarnWhenTheStoreHoldsExactlyTheCap()
+    {
+        const int scanCap = 2000;
+        var logger = new CapturingLogger<ConversationDescendantScanner>();
+        var store = new InMemoryConversationStore();
+        for (var i = 0; i < scanCap; i++)
+        {
+            var id = $"thread-cap-{i}";
+            await store.SaveMetadataAsync(id, new ThreadMetadata { ThreadId = id, LastUpdated = i });
+        }
+
+        _ = await CreateScanner(store, logger: logger).ScanAsync("thread-cap-0");
+
+        logger.Entries.Should().NotContain(
+            e => e.Level == LogLevel.Warning && e.Message.Contains("cap", StringComparison.Ordinal),
+            "the store was read in full, so there is nothing to warn about");
     }
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/Services/ConversationDescendantScannerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ConversationDescendantScannerTests.cs
@@ -1,0 +1,374 @@
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Tests.Agents;
+using LmStreaming.Sample.Tests.TestDoubles;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="ConversationDescendantScanner"/> — the persisted descendant-graph reader lifted
+/// out of <c>ConversationsController.BuildDescendantTreeAsync</c> (issue #251) so the transcript writer
+/// and the recursive HTTP listing share one traversal, and so the writer can poll without paying for a
+/// full store scan every flush.
+/// </summary>
+public sealed class ConversationDescendantScannerTests
+{
+    private static ConversationDescendantScanner CreateScanner(IConversationStore store, int? capacity = null) =>
+        capacity is null
+            ? new ConversationDescendantScanner(store, NullLogger<ConversationDescendantScanner>.Instance)
+            : new ConversationDescendantScanner(
+                store,
+                NullLogger<ConversationDescendantScanner>.Instance,
+                capacity.Value);
+
+    /// <summary>Seeds one persisted sub-agent thread stamped as <paramref name="parentThreadId"/>'s child.</summary>
+    private static Task SeedChildAsync(
+        IConversationStore store,
+        string parentThreadId,
+        string agentId,
+        string childThreadId) =>
+        store.SaveMetadataAsync(
+            childThreadId,
+            new ThreadMetadata
+            {
+                ThreadId = childThreadId,
+                LastUpdated = 0,
+                Properties = SubAgentProvenance.Build(
+                    parentThreadId,
+                    new SubAgentSnapshot(
+                        agentId,
+                        Name: agentId,
+                        TemplateName: "worker",
+                        Task: $"task for {agentId}",
+                        Status: SubAgentStatus.Completed,
+                        ThreadId: childThreadId,
+                        LastActivityUtc: DateTimeOffset.UtcNow,
+                        TerminalAtUtc: DateTimeOffset.UtcNow)),
+            });
+
+    private static MultiTurnAgentPool CreateFakeAgentPool() =>
+        new(
+            (threadId, _, _) => new MultiTurnAgentPool.AgentCreationResult(new FakeMultiTurnAgent(threadId)),
+            NullLogger<MultiTurnAgentPool>.Instance);
+
+    /// <summary>
+    /// The traversal contract lifted verbatim from the controller: transitive descendants only (the root
+    /// is never a node), each stamped with its BFS depth, ordered by depth then parent then thread id.
+    /// This is the regression anchor for "the extraction did not change behaviour".
+    /// </summary>
+    [Fact]
+    public async Task ScanAsync_ReturnsTheTransitiveGraph_WithDepthsAndOrdering()
+    {
+        const string root = "thread-root";
+        var store = new InMemoryConversationStore();
+        await store.SaveMetadataAsync(root, new ThreadMetadata { ThreadId = root, LastUpdated = 0 });
+        await SeedChildAsync(store, root, "child-b", "subagent-b");
+        await SeedChildAsync(store, root, "child-a", "subagent-a");
+        await SeedChildAsync(store, "subagent-a", "grandchild", "subagent-a1");
+        await SeedChildAsync(store, "subagent-a1", "great-grandchild", "subagent-a1x");
+        // An unrelated tree that must not leak into this root's answer.
+        await SeedChildAsync(store, "thread-other-root", "stranger", "subagent-stranger");
+
+        var nodes = await CreateScanner(store).ScanAsync(root);
+
+        nodes.Select(n => n.ThreadId).Should().Equal("subagent-a", "subagent-b", "subagent-a1", "subagent-a1x");
+        nodes.Select(n => n.Depth).Should().Equal(1, 1, 2, 3);
+        nodes.Should().NotContain(n => n.ThreadId == root);
+    }
+
+    /// <summary>A cycle in the persisted parent stamps must be cut, not looped on.</summary>
+    [Fact]
+    public async Task ScanAsync_CutsARepeatVisit_WhenPersistedParentStampsFormACycle()
+    {
+        const string root = "thread-cyclic-root";
+        var store = new InMemoryConversationStore();
+        await SeedChildAsync(store, root, "one", "subagent-one");
+        // The root is itself stamped as its own descendant's child — the BFS must cut the repeat visit
+        // (the root is seeded into the visited set) instead of looping forever.
+        await SeedChildAsync(store, "subagent-one", "root-again", root);
+
+        var nodes = await CreateScanner(store).ScanAsync(root);
+
+        nodes.Select(n => n.ThreadId).Should().Equal("subagent-one");
+        nodes.Select(n => n.Depth).Should().Equal(1);
+    }
+
+    /// <summary>
+    /// The recursive HTTP listing must still answer exactly what the scanner computes — the controller is
+    /// now only response shaping around this class.
+    /// </summary>
+    [Fact]
+    public async Task ScanAsync_MatchesTheTreeTheRecursiveEndpointReturns()
+    {
+        const string root = "thread-parity-root";
+        var store = new InMemoryConversationStore();
+        await store.SaveMetadataAsync(root, new ThreadMetadata { ThreadId = root, LastUpdated = 0 });
+        await SeedChildAsync(store, root, "p-child", "subagent-p1");
+        await SeedChildAsync(store, "subagent-p1", "p-grandchild", "subagent-p2");
+
+        await using var pool = CreateFakeAgentPool();
+        var scanner = CreateScanner(store);
+        var controller = CreateController(store, pool, scanner);
+
+        var scanned = await scanner.ScanAsync(root);
+        var response = Assert.IsType<SubAgentTreeResponse>(
+            Assert.IsType<OkObjectResult>(await controller.ListSubAgents(root, recursive: true)).Value);
+
+        response.SchemaVersion.Should().Be(1);
+        response.Nodes.Should().BeEquivalentTo(scanned, o => o.WithStrictOrdering());
+    }
+
+    /// <summary>An unknown root still 404s through the recursive branch after the extraction.</summary>
+    [Fact]
+    public async Task RecursiveEndpoint_StillReturns404_ForAnUnknownThread()
+    {
+        var store = new InMemoryConversationStore();
+        await using var pool = CreateFakeAgentPool();
+        var controller = CreateController(store, pool, CreateScanner(store));
+
+        var result = await controller.ListSubAgents("thread-never-existed", recursive: true);
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetOrScanAsync_SecondCall_ReadsTheStoreOnlyOnce()
+    {
+        const string root = "thread-cached-root";
+        var store = new InMemoryConversationStore();
+        await SeedChildAsync(store, root, "cached-child", "subagent-cached");
+        var counting = new CountingConversationStore(store);
+        var scanner = CreateScanner(counting);
+
+        var first = await scanner.GetOrScanAsync(root);
+        var callsAfterFirst = counting.ListThreadsCallCount;
+        var second = await scanner.GetOrScanAsync(root);
+
+        callsAfterFirst.Should().BeGreaterThan(0, "the cold scan must actually read the store");
+        counting.ListThreadsCallCount.Should().Be(
+            callsAfterFirst,
+            "a cache hit must not touch the store at all");
+        second.Should().BeEquivalentTo(first, o => o.WithStrictOrdering());
+    }
+
+    /// <summary>
+    /// An empty answer is cached like any other. This is the exact behaviour that makes reusing
+    /// <see cref="SubAgentScanCoverageCache"/> unsafe (it would ONLY ever cache, never refresh); here it
+    /// is safe because <see cref="ConversationDescendantScanner.NoteAgentActivity"/> exists.
+    /// </summary>
+    [Fact]
+    public async Task GetOrScanAsync_CachesAnEmptyGraph_AndDoesNotRescanUntilActivityIsNoted()
+    {
+        const string root = "thread-childless-root";
+        var store = new InMemoryConversationStore();
+        var counting = new CountingConversationStore(store);
+        var scanner = CreateScanner(counting);
+
+        (await scanner.GetOrScanAsync(root)).Should().BeEmpty();
+        var callsAfterFirst = counting.ListThreadsCallCount;
+
+        // A child is spawned and persisted, but nobody told the scanner — the cached answer stands.
+        await SeedChildAsync(store, root, "late-child", "subagent-late");
+        (await scanner.GetOrScanAsync(root)).Should().BeEmpty();
+        counting.ListThreadsCallCount.Should().Be(callsAfterFirst);
+
+        scanner.NoteAgentActivity(root);
+        var refreshed = await scanner.GetOrScanAsync(root);
+
+        refreshed.Select(n => n.ThreadId).Should().Equal("subagent-late");
+        counting.ListThreadsCallCount.Should().BeGreaterThan(callsAfterFirst);
+    }
+
+    [Fact]
+    public async Task NoteAgentActivity_RefreshesOnlyTheNotedRoot()
+    {
+        const string notedRoot = "thread-noted-root";
+        const string quietRoot = "thread-quiet-root";
+        var store = new InMemoryConversationStore();
+        await SeedChildAsync(store, notedRoot, "noted-child", "subagent-noted");
+        await SeedChildAsync(store, quietRoot, "quiet-child", "subagent-quiet");
+        var counting = new CountingConversationStore(store);
+        var scanner = CreateScanner(counting);
+
+        _ = await scanner.GetOrScanAsync(notedRoot);
+        _ = await scanner.GetOrScanAsync(quietRoot);
+        var callsAfterCold = counting.ListThreadsCallCount;
+
+        scanner.NoteAgentActivity(notedRoot);
+        _ = await scanner.GetOrScanAsync(quietRoot);
+        counting.ListThreadsCallCount.Should().Be(
+            callsAfterCold,
+            "activity on one root must not invalidate another root's graph");
+
+        _ = await scanner.GetOrScanAsync(notedRoot);
+        counting.ListThreadsCallCount.Should().BeGreaterThan(callsAfterCold);
+    }
+
+    /// <summary>
+    /// A refresh signalled WHILE a scan is in flight must not be swallowed by that scan's own write —
+    /// otherwise the writer's "I just saw a new agent" notice is lost and the new child stays invisible.
+    /// </summary>
+    [Fact]
+    public async Task NoteAgentActivity_DuringAnInFlightScan_StillForcesTheNextCallToRescan()
+    {
+        const string root = "thread-inflight-root";
+        var store = new InMemoryConversationStore();
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var scanner = CreateScanner(new BlockingListThreadsStore(store, gate.Task));
+
+        var inFlight = scanner.GetOrScanAsync(root);
+        scanner.NoteAgentActivity(root);
+        gate.SetResult();
+        (await inFlight).Should().BeEmpty();
+
+        // The in-flight scan's answer predates the notice, so it must not have been recorded as fresh:
+        // the next call has to rescan and see the child that arrived with that activity.
+        await SeedChildAsync(store, root, "raced-child", "subagent-raced");
+
+        var afterNotice = await scanner.GetOrScanAsync(root);
+
+        afterNotice.Select(n => n.ThreadId).Should().Equal("subagent-raced");
+    }
+
+    [Fact]
+    public async Task Forget_DropsTheRootsGraph_SoTheNextCallRescans()
+    {
+        const string root = "thread-forgotten-root";
+        var store = new InMemoryConversationStore();
+        await SeedChildAsync(store, root, "forgotten-child", "subagent-forgotten");
+        var counting = new CountingConversationStore(store);
+        var scanner = CreateScanner(counting);
+
+        _ = await scanner.GetOrScanAsync(root);
+        var callsAfterCold = counting.ListThreadsCallCount;
+
+        scanner.Forget(root);
+        _ = await scanner.GetOrScanAsync(root);
+
+        counting.ListThreadsCallCount.Should().BeGreaterThan(callsAfterCold);
+    }
+
+    /// <summary>
+    /// The composition root wires <c>MultiTurnAgentPool.ThreadRemoved</c> to <c>Forget</c> (the pool is
+    /// deliberately NOT a constructor dependency). This proves that wiring actually invalidates, and that
+    /// a reused thread id cannot inherit the removed conversation's descendants.
+    /// </summary>
+    [Fact]
+    public async Task ThreadRemoved_InvalidatesTheCachedGraph_WhenWiredTheWayTheHostWiresIt()
+    {
+        const string root = "thread-removed-root";
+        var store = new InMemoryConversationStore();
+        await SeedChildAsync(store, root, "removed-child", "subagent-removed");
+        var scanner = CreateScanner(store);
+
+        await using var pool = CreateFakeAgentPool();
+        pool.ThreadRemoved += scanner.Forget;
+        _ = pool.GetOrCreateAgent(root, SystemChatModes.GetById(SystemChatModes.DefaultModeId)!);
+
+        (await scanner.GetOrScanAsync(root)).Should().ContainSingle(n => n.ThreadId == "subagent-removed");
+
+        // The conversation goes away, its persisted child with it, and the id is later reused.
+        await store.DeleteThreadAsync("subagent-removed", CancellationToken.None);
+        await pool.RemoveAgentAsync(root);
+
+        (await scanner.GetOrScanAsync(root)).Should().BeEmpty(
+            "ThreadRemoved must drop the cached graph so a reused thread id cannot inherit it");
+    }
+
+    [Fact]
+    public async Task Cache_EvictsTheLeastRecentlyWrittenRoot_WhenCapacityIsExceeded()
+    {
+        var store = new InMemoryConversationStore();
+        var counting = new CountingConversationStore(store);
+        var scanner = CreateScanner(counting, capacity: 2);
+
+        _ = await scanner.GetOrScanAsync("root-1");
+        _ = await scanner.GetOrScanAsync("root-2");
+        _ = await scanner.GetOrScanAsync("root-3");
+        var callsAfterThree = counting.ListThreadsCallCount;
+
+        // root-2 and root-3 are still resident; root-1 was evicted and must rescan.
+        _ = await scanner.GetOrScanAsync("root-3");
+        _ = await scanner.GetOrScanAsync("root-2");
+        counting.ListThreadsCallCount.Should().Be(callsAfterThree);
+
+        _ = await scanner.GetOrScanAsync("root-1");
+        counting.ListThreadsCallCount.Should().BeGreaterThan(callsAfterThree);
+    }
+
+    [Fact]
+    public void Constructor_RejectsANonPositiveCapacity()
+    {
+        var act = () => CreateScanner(new InMemoryConversationStore(), capacity: 0);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    private static ConversationsController CreateController(
+        IConversationStore store,
+        MultiTurnAgentPool pool,
+        ConversationDescendantScanner scanner) =>
+        new(
+            store,
+            pool,
+            Mock.Of<IChatModeStore>(),
+            Mock.Of<IWorkspaceStore>(),
+            new FakeProviderRegistry(defaultProviderId: "test", available: ["test"]).ToReal(),
+            new ConversationStatusResolver(store, new InMemoryConversationStore()),
+            TimeProvider.System,
+            new WorkflowRunRegistry(),
+            NullLogger<ConversationsController>.Instance,
+            NullLogger<AgentHierarchyService>.Instance,
+            new SubAgentScanCoverageCache(),
+            scanner);
+
+    /// <summary>Holds the first <c>ListThreadsAsync</c> open until a gate completes, so a test can signal
+    /// a refresh while a scan is genuinely in flight.</summary>
+    private sealed class BlockingListThreadsStore(IConversationStore inner, Task gate) : IConversationStore
+    {
+        private int _calls;
+
+        public async Task<IReadOnlyList<ThreadMetadata>> ListThreadsAsync(
+            int limit = 50,
+            int offset = 0,
+            CancellationToken ct = default)
+        {
+            if (Interlocked.Increment(ref _calls) == 1)
+            {
+                await gate;
+            }
+
+            return await inner.ListThreadsAsync(limit, offset, ct);
+        }
+
+        public Task AppendMessagesAsync(
+            string threadId,
+            IReadOnlyList<PersistedMessage> messages,
+            CancellationToken ct = default) => inner.AppendMessagesAsync(threadId, messages, ct);
+
+        public Task<IReadOnlyList<PersistedMessage>> LoadMessagesAsync(
+            string threadId,
+            CancellationToken ct = default) => inner.LoadMessagesAsync(threadId, ct);
+
+        public Task ReplaceMessageAsync(
+            string threadId,
+            PersistedMessage replacement,
+            CancellationToken ct = default) => inner.ReplaceMessageAsync(threadId, replacement, ct);
+
+        public Task SaveMetadataAsync(
+            string threadId,
+            ThreadMetadata metadata,
+            CancellationToken ct = default) => inner.SaveMetadataAsync(threadId, metadata, ct);
+
+        public Task<ThreadMetadata?> LoadMetadataAsync(string threadId, CancellationToken ct = default) =>
+            inner.LoadMetadataAsync(threadId, ct);
+
+        public Task UpdateMetadataAsync(
+            string threadId,
+            Func<ThreadMetadata?, ThreadMetadata> update,
+            CancellationToken ct = default) => inner.UpdateMetadataAsync(threadId, update, ct);
+
+        public Task DeleteThreadAsync(string threadId, CancellationToken ct = default) =>
+            inner.DeleteThreadAsync(threadId, ct);
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/ConversationDescendantScannerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ConversationDescendantScannerTests.cs
@@ -230,6 +230,83 @@ public sealed class ConversationDescendantScannerTests
         afterNotice.Select(n => n.ThreadId).Should().Equal("subagent-raced");
     }
 
+    /// <summary>
+    /// A scan in flight belongs to the cache slot it STARTED against, and to no later one. When that slot
+    /// is dropped mid-scan the answer in flight describes the conversation that is gone — and a thread id
+    /// is client-suppliable and gets reused — so committing it into whatever slot the root has by then
+    /// serves the PREVIOUS conversation's descendants to every later reader: the recursive listing lists
+    /// them, and the transcript mirror fans a workspace copy out to them.
+    /// </summary>
+    /// <remarks>
+    /// The version stamp cannot catch this on its own. <c>Version</c> is a refresh counter that starts at
+    /// zero on every replacement slot, so the version observed before the drop compares EQUAL to a slot
+    /// created after it and the staleness check passes. This is the <see cref="ConversationDescendantScanner.Forget"/>
+    /// trigger; the bound-eviction trigger is the next test.
+    /// </remarks>
+    [Fact]
+    public async Task GetOrScanAsync_DiscardsAnInFlightScan_WhenTheRootWasForgottenMidScan()
+    {
+        const string root = "thread-reused-after-forget";
+        var store = new InMemoryConversationStore();
+        await SeedChildAsync(store, root, "old-child", "subagent-old");
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var blocking = new BlockingListThreadsStore(store, gate.Task);
+        var scanner = CreateScanner(blocking);
+
+        // Parked holding the OLD conversation's roster.
+        var inFlight = scanner.GetOrScanAsync(root);
+        await blocking.FirstReadCompleted;
+
+        // The conversation is removed and the same thread id is reused by a different one.
+        scanner.Forget(root);
+        await store.DeleteThreadAsync("subagent-old", CancellationToken.None);
+        await SeedChildAsync(store, root, "new-child", "subagent-new");
+
+        gate.SetResult();
+        (await inFlight).Select(n => n.ThreadId).Should().Equal("subagent-old");
+
+        // The reader after the reuse must see the NEW conversation's descendants. Serving "subagent-old"
+        // here means the parked scan was committed into the slot that replaced the one it started against.
+        var afterReuse = await scanner.GetOrScanAsync(root);
+
+        afterReuse.Select(n => n.ThreadId).Should().Equal("subagent-new");
+    }
+
+    /// <summary>
+    /// The same defect, reached by its other trigger: the slot is not removed by
+    /// <see cref="ConversationDescendantScanner.Forget"/> but dropped by the LRU bound while the scan is in
+    /// flight. Nothing about the commit path distinguishes the two — both leave the root with a fresh,
+    /// zero-versioned slot — so both have to be covered, and a fix that only checks for an explicit forget
+    /// still mis-attributes an evicted root's scan.
+    /// </summary>
+    [Fact]
+    public async Task GetOrScanAsync_DiscardsAnInFlightScan_WhenTheRootWasEvictedMidScan()
+    {
+        const string root = "thread-reused-after-eviction";
+        const string other = "thread-evicting-root";
+        var store = new InMemoryConversationStore();
+        await SeedChildAsync(store, root, "old-child", "subagent-old");
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var blocking = new BlockingListThreadsStore(store, gate.Task);
+        var scanner = CreateScanner(blocking, capacity: 1);
+
+        var inFlight = scanner.GetOrScanAsync(root);
+        await blocking.FirstReadCompleted;
+
+        // A second root claims the only slot, so the in-flight scan's slot is bound-evicted under it.
+        _ = await scanner.GetOrScanAsync(other);
+
+        await store.DeleteThreadAsync("subagent-old", CancellationToken.None);
+        await SeedChildAsync(store, root, "new-child", "subagent-new");
+
+        gate.SetResult();
+        (await inFlight).Select(n => n.ThreadId).Should().Equal("subagent-old");
+
+        var afterReuse = await scanner.GetOrScanAsync(root);
+
+        afterReuse.Select(n => n.ThreadId).Should().Equal("subagent-new");
+    }
+
     [Fact]
     public async Task Forget_DropsTheRootsGraph_SoTheNextCallRescans()
     {
@@ -379,23 +456,35 @@ public sealed class ConversationDescendantScannerTests
             new SubAgentScanCoverageCache(),
             scanner);
 
-    /// <summary>Holds the first <c>ListThreadsAsync</c> open until a gate completes, so a test can signal
-    /// a refresh while a scan is genuinely in flight.</summary>
+    /// <summary>Holds the first <c>ListThreadsAsync</c> open until a gate completes, so a test can act while
+    /// a scan is genuinely in flight.</summary>
+    /// <remarks>
+    /// The inner read happens BEFORE the park and its result is what the gated call eventually returns, so
+    /// the parked scan is carrying a genuinely stale answer — which is what makes "where does that answer
+    /// get committed" observable at all.
+    /// </remarks>
     private sealed class BlockingListThreadsStore(IConversationStore inner, Task gate) : IConversationStore
     {
+        private readonly TaskCompletionSource _read = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private int _calls;
+
+        /// <summary>Completes once the gated call has read the store and parked on the gate.</summary>
+        public Task FirstReadCompleted => _read.Task;
 
         public async Task<IReadOnlyList<ThreadMetadata>> ListThreadsAsync(
             int limit = 50,
             int offset = 0,
             CancellationToken ct = default)
         {
-            if (Interlocked.Increment(ref _calls) == 1)
+            var first = Interlocked.Increment(ref _calls) == 1;
+            var page = await inner.ListThreadsAsync(limit, offset, ct);
+            if (first)
             {
+                _read.SetResult();
                 await gate;
             }
 
-            return await inner.ListThreadsAsync(limit, offset, ct);
+            return page;
         }
 
         public Task AppendMessagesAsync(

--- a/tests/LmStreaming.Sample.Tests/Services/ConversationDescendantScannerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ConversationDescendantScannerTests.cs
@@ -296,6 +296,63 @@ public sealed class ConversationDescendantScannerTests
         counting.ListThreadsCallCount.Should().BeGreaterThan(callsAfterThree);
     }
 
+    /// <summary>
+    /// Pins the retention policy the class documents: LEAST RECENTLY USED, not insertion order. The two
+    /// differ exactly when an early root is still being used — under insertion order it is evicted anyway,
+    /// so the roots that are actually mirroring are the ones thrown out while an idle conversation that
+    /// merely happens to be newer survives, and the eviction lands where it costs the most. Losing an entry
+    /// only costs one extra scan, which is why this is worth an O(1) splice and not more.
+    /// </summary>
+    [Fact]
+    public async Task Cache_RenewsARootOnAccess_SoAnActiveEarlyRootOutlivesAnIdleLaterOne()
+    {
+        var store = new InMemoryConversationStore();
+        var counting = new CountingConversationStore(store);
+        var scanner = CreateScanner(counting, capacity: 2);
+
+        _ = await scanner.GetOrScanAsync("root-1");
+        _ = await scanner.GetOrScanAsync("root-2");
+
+        // root-1 is used again, which makes root-2 the least recently used of the two.
+        _ = await scanner.GetOrScanAsync("root-1");
+        _ = await scanner.GetOrScanAsync("root-3");
+        var callsAfterThree = counting.ListThreadsCallCount;
+
+        // The renewed root survived and serves from cache...
+        _ = await scanner.GetOrScanAsync("root-1");
+        counting.ListThreadsCallCount.Should().Be(callsAfterThree);
+
+        // ...and the one that went untouched longest is the one that had to be rescanned.
+        _ = await scanner.GetOrScanAsync("root-2");
+        counting.ListThreadsCallCount.Should().BeGreaterThan(callsAfterThree);
+    }
+
+    /// <summary>
+    /// The same renewal, applied consistently: reported agent activity is USE. It is the strongest possible
+    /// signal that a conversation is live — the caller only raises it when it actually saw an Agent tool
+    /// run — so a root that is spawning sub-agents right now must not be the next one evicted just because
+    /// its last read was a while ago. The invalidation still costs the next reader one scan; what it must
+    /// not cost is the slot itself.
+    /// </summary>
+    [Fact]
+    public async Task Cache_RenewsARootOnReportedActivity_SoALiveRootIsNotEvictedForAnIdleOne()
+    {
+        var store = new InMemoryConversationStore();
+        var counting = new CountingConversationStore(store);
+        var scanner = CreateScanner(counting, capacity: 2);
+
+        _ = await scanner.GetOrScanAsync("root-1");
+        _ = await scanner.GetOrScanAsync("root-2");
+
+        scanner.NoteAgentActivity("root-1");
+        _ = await scanner.GetOrScanAsync("root-3");
+
+        // root-1 was renewed by the activity report, so root-2 is the one that went.
+        var callsBefore = counting.ListThreadsCallCount;
+        _ = await scanner.GetOrScanAsync("root-2");
+        counting.ListThreadsCallCount.Should().BeGreaterThan(callsBefore);
+    }
+
     [Fact]
     public void Constructor_RejectsANonPositiveCapacity()
     {

--- a/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
@@ -366,6 +366,45 @@ public sealed class ConversationTranscriptWriterTests
         _ = Encoding.UTF8.GetString(gitignores[0].Bytes).Should().Be("*\n");
     }
 
+    /// <summary>
+    /// The containment file is the entire opt-out for the feature, so "we tried once and it did not work"
+    /// is not an acceptable resting state: the transcript is on disk, unignored, and the next
+    /// <c>git add -A</c> an agent runs in that workspace publishes the conversation's unredacted reasoning
+    /// off-machine. Two things have to be true for the retry to exist at all — the flush that failed must
+    /// report work still pending, and a later flush must attempt the write even though it appends NOTHING.
+    /// Tying the attempt to "this flush wrote rows" fails the second: for a conversation whose only
+    /// appending flush already happened, the trigger never comes again.
+    /// </summary>
+    [Fact]
+    public async Task Gitignore_IsRetriedOnAFlushThatAppendsNothing_AfterItsFirstWriteFails()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+
+        // ONLY the containment file fails. The rows themselves land — which is exactly the combination
+        // that makes the gap invisible: a complete transcript sitting in a git checkout with nothing
+        // covering it.
+        var browser = new FakeFileBrowser
+        {
+            WriteFailure = path =>
+                path == GitignorePath ? new SandboxException(SandboxErrorKind.Protocol, "gateway said no") : null,
+        };
+        var writer = CreateWriter(store, browser);
+
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = browser.Writes.Select(w => w.Path).Should().NotContain(GitignorePath);
+
+        // The next flush has nothing whatsoever to append — and must still write the file.
+        browser.WriteFailure = null;
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.UpToDate);
+        _ = browser.Writes.Should().ContainSingle(w => w.Path == GitignorePath);
+
+        // Deferring for containment must not re-appear as duplicated rows: the watermark advanced with the
+        // successful splice, so exactly one staged payload was ever written.
+        _ = browser.Writes.Where(w => w.Path == TempPath).Should().ContainSingle();
+    }
+
     // ---------------------------------------------------------------- AC 7, 12
 
     /// <summary>
@@ -414,6 +453,51 @@ public sealed class ConversationTranscriptWriterTests
         var uids = UidsIn(string.Concat(Enumerable.Range(0, 4).Select(i => Written(browser, i))));
         _ = uids.Should().HaveCount(5);
         _ = uids.Distinct(StringComparer.Ordinal).Should().HaveCount(5);
+    }
+
+    /// <summary>
+    /// A FAILED main append must skip the fan-out entirely, and this is the one failure in the pipeline
+    /// that is not recoverable by retrying. Every sub-agent file's first line hangs off the main file's
+    /// watermark, and that anchor is resolved once and then PINNED for the life of the writer — no later
+    /// flush revisits a file that already has a first line. Running the fan-out beside a failed append
+    /// mints those anchors from a watermark the failure left unadvanced, so on a first flush every
+    /// descendant file is pinned to null and the conversation's files are never one lineage again.
+    /// Deferring costs one repeated pass; a wrong anchor costs the chain permanently.
+    /// </summary>
+    [Fact]
+    public async Task FailedMainAppend_SkipsTheFanOut_SoNoSubAgentFileIsRootedInANullAnchor()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        PersistedMessage[] main = [Msg("m1", 1, "User"), Msg("m2", 2)];
+        await store.AppendMessagesAsync(ThreadId, main);
+        PersistedMessage[] child = [Msg("a1a", 10, threadId: "subagent-a1")];
+        await SeedSubAgentAsync(store, "a1", "alpha", child);
+
+        // Only the MAIN file's splice fails; a sub-agent splice would succeed if one were attempted, which
+        // is what makes the wrong-anchor write reachable rather than hypothetical.
+        var browser = new FakeFileBrowser
+        {
+            ExecuteHandler = command =>
+                command.Arguments[0] == "sh" && command.Arguments[6] == MainPath(Title)
+                    ? Fail("no space left on device")
+                    : Ok(),
+        };
+        var writer = CreateWriter(store, browser);
+
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+            .Should().Equal(MainPath(Title));
+
+        browser.ExecuteHandler = null;
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+
+        // The child's first line chains off the main file's real tail — a row that genuinely exists in the
+        // main file — instead of off nothing.
+        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+            .Should().Equal(MainPath(Title), MainPath(Title), AgentPath(Title, "a1", "alpha"));
+        _ = Written(browser, 2).Should()
+            .Be(ExpectedAppend(child, agent: "alpha", rootParentUid: WorkspaceTranscriptLine.DeriveUid("m2")));
     }
 
     /// <summary>
@@ -479,12 +563,50 @@ public sealed class ConversationTranscriptWriterTests
         _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
             .Should().Equal(AgentPath(Title, "b2", "beta"));
 
-        // And it TERMINATES. Deferred is gated on a pass having mirrored something, so the first capped
-        // pass that finds its slice already current stops asking for another flush — a caller that
-        // re-schedules on Deferred would otherwise spin forever on any conversation above the cap.
+        // A capped pass keeps asking, whether or not its own slice had anything to write: "this slice is
+        // current" says nothing about the descendants outside it. What terminates the chain is the caller's
+        // bounded retry budget (WorkspaceTranscriptMirror.MaxDeferredRetries), reset at each turn boundary
+        // — so a large fan-out is paced a slice per attempt instead of either spinning or stopping one step
+        // short of the descendant that actually changed.
         browser.Commands.Clear();
-        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.UpToDate);
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
         _ = browser.Commands.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The consequence of the rule above, at the only scale where it is visible: the descendant that
+    /// changed is OUTSIDE the current slice. Ending the chain on the first capped pass whose own slice was
+    /// already current stops exactly one step short of it — the pass that would have covered it never runs,
+    /// and the sub-agent's rows sit unmirrored until some unrelated later trigger happens along. There is
+    /// no ordering that avoids this: the cursor cannot know which descendant moved without reading it.
+    /// </summary>
+    [Fact]
+    public async Task SubAgentFanOut_KeepsAskingWhileCapped_SoAChangeBeyondTheSliceIsStillMirrored()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+        await SeedSubAgentAsync(store, "a1", "alpha", Msg("a1a", 10, threadId: "subagent-a1"));
+        await SeedSubAgentAsync(store, "b2", "beta", Msg("b2a", 20, threadId: "subagent-b2"));
+
+        var browser = new FakeFileBrowser();
+        var writer = CreateWriter(store, browser, maxSubAgentFilesPerFlush: 1);
+
+        // Two passes bring both descendants current and return the cursor to the first one.
+        _ = await writer.FlushAsync();
+        _ = await writer.FlushAsync();
+
+        // Only the descendant the NEXT slice will not look at moves.
+        await store.AppendMessagesAsync("subagent-b2", [Msg("b2b", 21, threadId: "subagent-b2")]);
+
+        browser.Commands.Clear();
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Should().BeEmpty();
+
+        browser.Commands.Clear();
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+            .Should().Equal(AgentPath(Title, "b2", "beta"));
     }
 
     /// <summary>
@@ -589,6 +711,58 @@ public sealed class ConversationTranscriptWriterTests
         _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(Title), MainPath(RetitledTo));
         _ = browser.Commands[1].Arguments[6].Should().Be(MainPath(RetitledTo));
         _ = Written(browser, 3).Should().Be(ExpectedAppend(everything, skip: 2));
+    }
+
+    /// <summary>
+    /// A retitle that happens while nothing is mirroring — the host restarts, or the conversation is
+    /// evicted and later re-attached — reaches a writer that has no idea what its file used to be called.
+    /// Adopting the CURRENT title outright leaves the transcript already on disk unseen, and the
+    /// conversation ends up SPLIT: the old file frozen at its last row under the old slug, a second file
+    /// restarting the history from zero, and the old <c>_agents/</c> directory orphaned beside the wrong
+    /// name. The short id in the leaf is what makes this recoverable — it identifies the conversation
+    /// independently of the title, across any number of retitles — so a cold writer looks for its own file
+    /// before it creates one.
+    /// </summary>
+    [Fact]
+    public async Task ColdStartAfterARetitle_AdoptsTheExistingFile_InsteadOfStartingASecondTranscript()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+        await SeedSubAgentAsync(store, "a1", "alpha", Msg("a1a", 10, threadId: "subagent-a1"));
+
+        // What a previous process left in the workspace, under the title in force when it ran. This writer
+        // is brand new: its only route to that name is the listing.
+        var stale = WorkspaceTranscriptLine.MainFileLeaf(RetitledTo, ShortThreadId);
+        var browser = new FakeFileBrowser();
+        browser.Listings[ConversationTranscriptWriter.TranscriptDirectory] =
+        [
+            new SandboxDirectoryEntry(
+                $"{stale}{ConversationTranscriptWriter.TranscriptExtension}",
+                SandboxEntryType.File,
+                128,
+                NameLossy: false
+            ),
+            new SandboxDirectoryEntry(
+                $"{stale}{ConversationTranscriptWriter.AgentsDirectorySuffix}",
+                SandboxEntryType.Directory,
+                null,
+                NameLossy: false
+            ),
+        ];
+
+        _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+
+        // Adopted by the same move the warm path uses, and BEFORE the tail that recovers the watermark —
+        // otherwise the watermark is read from a file this flush is about to stop writing to.
+        _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(RetitledTo), MainPath(Title));
+        _ = browser.Commands[1].Arguments.Should()
+            .Equal("mv", "--", AgentsDirectory(RetitledTo), AgentsDirectory(Title));
+        _ = browser.Commands[2].Arguments.Should().Equal("tail", "-n", "5", "--", MainPath(Title));
+
+        // One transcript, and the sub-agent file lands under it rather than beside the abandoned name.
+        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+            .Should().Equal(MainPath(Title), AgentPath(Title, "a1", "alpha"));
     }
 
     // ---------------------------------------------------------------- AC 19

--- a/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
@@ -46,6 +46,17 @@ public sealed class ConversationTranscriptWriterTests
         + "if [ -s \"$3\" ] && [ -n \"$(tail -c1 \"$3\")\" ]; then printf '\\n' >> \"$3\" || exit 1; fi\n"
         + "cat \"$2\" >> \"$3\" && rm -f \"$2\"\n";
 
+    /// <summary>
+    /// The cold-start watermark probe, duplicated for the same reason. Its text is a contract twice over:
+    /// the <c>[ -e ]</c> test is what makes "there is no transcript" an answer the script GIVES rather than
+    /// one the caller infers from a generic <c>tail</c> failure, and exit <c>42</c> is the private code that
+    /// carries that answer back — a value neither <c>tail</c> (0/1) nor <c>sh</c> (126/127, 128+signal)
+    /// produces, so it cannot be minted by an accident.
+    /// </summary>
+    private const string ExpectedProbeScript =
+        "[ -e \"$1\" ] || exit 42\n"
+        + "exec tail -n \"$2\" -- \"$1\"\n";
+
     private static readonly string ShortThreadId = WorkspaceTranscriptLine.ShortId(ThreadId);
 
     private static readonly string TempPath =
@@ -206,6 +217,23 @@ public sealed class ConversationTranscriptWriterTests
     private static SandboxCommandResult Fail(string stderr = "boom") =>
         new() { ExitCode = 1, StandardOutput = "", StandardError = stderr, OperationId = "op" };
 
+    /// <summary>
+    /// What the watermark probe reports when the destination is DEFINITELY not there. The literal 42 is
+    /// duplicated here on purpose, exactly like <see cref="ExpectedProbeScript"/>: that one code is the
+    /// whole discrimination between "no transcript yet" and "could not tell", and a test that read it back
+    /// off the production constant could not notice it drifting onto a value <c>tail</c> or <c>sh</c> also
+    /// produces.
+    /// </summary>
+    private static SandboxCommandResult Missing() =>
+        new() { ExitCode = 42, StandardOutput = "", StandardError = "", OperationId = "op" };
+
+    /// <summary>
+    /// Selects the watermark probe out of a flush's commands. The splice is the call carrying the staged
+    /// temp file; every other shell call in a flush is the probe.
+    /// </summary>
+    private static bool IsSplice(SandboxCommand command) =>
+        command.Arguments.Contains(TempPath, StringComparer.Ordinal);
+
     // ---------------------------------------------------------------- AC 1, 6
 
     /// <summary>
@@ -238,7 +266,8 @@ public sealed class ConversationTranscriptWriterTests
             .NotContain(p => p.EndsWith(ConversationTranscriptWriter.TranscriptExtension, StringComparison.Ordinal));
 
         _ = browser.Commands.Should().HaveCount(2);
-        _ = browser.Commands[0].Arguments.Should().Equal("tail", "-n", "5", "--", MainPath(Title));
+        _ = browser.Commands[0].Arguments.Should()
+            .Equal("sh", "-c", ExpectedProbeScript, "sh", MainPath(Title), "5");
         _ = browser.Commands[1].Arguments.Should()
             .Equal("sh", "-c", ExpectedSpliceScript, "sh", ".conversations", TempPath, MainPath(Title));
         _ = browser.LastPersistedWorkspaceId.Should().Be(WorkspaceId);
@@ -271,8 +300,9 @@ public sealed class ConversationTranscriptWriterTests
         _ = Written(browser, 0).Should().Be(ExpectedAppend(first));
         _ = Written(browser, 1).Should().Be(ExpectedAppend(all, skip: 2));
 
-        // No second tail: the watermark survived in process, keyed by thread.
-        _ = browser.Commands.Select(c => c.Arguments[0]).Should().Equal("tail", "sh", "sh");
+        // No second probe: the watermark survived in process, keyed by thread.
+        _ = browser.Commands.Select(c => c.Arguments[2]).Should()
+            .Equal(ExpectedProbeScript, ExpectedSpliceScript, ExpectedSpliceScript);
 
         var file = Written(browser, 0) + Written(browser, 1);
         var uids = UidsIn(file);
@@ -305,14 +335,107 @@ public sealed class ConversationTranscriptWriterTests
 
         var browser = new FakeFileBrowser
         {
-            ExecuteHandler = command => command.Arguments[0] == "tail" ? Ok(intact + torn) : Ok(),
+            ExecuteHandler = command => IsSplice(command) ? Ok() : Ok(intact + torn),
         };
 
         _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
 
-        _ = browser.Commands[0].Arguments.Should().Equal("tail", "-n", "5", "--", MainPath(Title));
+        _ = browser.Commands[0].Arguments.Should()
+            .Equal("sh", "-c", ExpectedProbeScript, "sh", MainPath(Title), "5");
         _ = Written(browser, 0).Should().Be(ExpectedAppend(messages, skip: 2));
         _ = browser.ReadCalls.Should().Be(0);
+    }
+
+    /// <summary>
+    /// The same discrimination the adoption path already makes, one step later. A probe that THREW says
+    /// nothing whatsoever about the destination, yet reading it as "there is no transcript" sends the start
+    /// index to zero and re-appends the ENTIRE persisted history onto a file that already holds it — a
+    /// conversation with ten thousand rows duplicates all ten thousand, once per cold writer, so a host
+    /// that restarts in a loop while the gateway is unwell multiplies the transcript indefinitely. A probe
+    /// that did not settle defers: nothing staged, nothing spliced, and the next flush asks again.
+    /// </summary>
+    [Fact]
+    public async Task ColdStart_DefersWhenTheWatermarkProbeThrows_InsteadOfReAppendingTheWholeHistory()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        PersistedMessage[] messages = [Msg("m1", 1, "User"), Msg("m2", 2)];
+        await store.AppendMessagesAsync(ThreadId, messages);
+
+        var browser = new FakeFileBrowser
+        {
+            ExecuteHandler = _ => throw new SandboxException(SandboxErrorKind.Protocol, "gateway said no"),
+        };
+        var writer = CreateWriter(store, browser);
+
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+
+        // Nothing was staged and the splice was never even attempted: the flush stopped at the probe.
+        _ = browser.Writes.Where(w => w.Path == TempPath).Should().BeEmpty();
+        _ = browser.Commands.Should().ContainSingle();
+        _ = browser.Commands.Where(IsSplice).Should().BeEmpty();
+
+        // And once the gateway answers, the SAME writer appends the history exactly once.
+        browser.ExecuteHandler = command => IsSplice(command) ? Ok() : Missing();
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+        _ = browser.Writes.Where(w => w.Path == TempPath).Should().ContainSingle();
+        _ = Written(browser, 0).Should().Be(ExpectedAppend(messages));
+    }
+
+    /// <summary>
+    /// The exit code half of the same defect, and the reason the probe cannot be a bare <c>tail</c>. GNU
+    /// <c>tail</c> answers a missing file, an unreadable one and an I/O error with the SAME status 1, so
+    /// "no such file" is not something its exit code can tell you — and every wrong guess costs a full
+    /// duplicate of the transcript. Here the destination is present and complete, and the probe fails for a
+    /// reason that is not absence; the flush must add nothing at all rather than start again from row one.
+    /// </summary>
+    [Fact]
+    public async Task ColdStart_DefersWhenTheWatermarkProbeFails_InsteadOfDuplicatingTheWholeTranscript()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        PersistedMessage[] messages = [Msg("m1", 1, "User"), Msg("m2", 2)];
+        await store.AppendMessagesAsync(ThreadId, messages);
+
+        // The workspace already holds every one of these rows.
+        var existing = ExpectedAppend(messages);
+        var browser = new FakeFileBrowser
+        {
+            ExecuteHandler = command => IsSplice(command) ? Ok() : Fail("tail: cannot open: Permission denied"),
+        };
+        var writer = CreateWriter(store, browser);
+
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = browser.Writes.Where(w => w.Path == TempPath).Should().BeEmpty();
+
+        // Once the probe can read the file it finds the watermark on its last line, and there is nothing
+        // left to append — which is exactly what the duplicating path would have destroyed.
+        browser.ExecuteHandler = command => IsSplice(command) ? Ok() : Ok(existing);
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.UpToDate);
+        _ = browser.Writes.Where(w => w.Path == TempPath).Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The other side of that discrimination, and the reason it has to be narrow. A workspace that has
+    /// never held a transcript makes the probe report a DEFINITE absence, and that is the ordinary first
+    /// flush rather than a fault: the start index is zero and the whole history goes down. Deferring on it
+    /// would leave every brand-new conversation spinning its retry budget and never writing a first line.
+    /// </summary>
+    [Fact]
+    public async Task ColdStart_TreatsADefinitelyMissingTranscriptAsAFirstFlush_AndAppendsTheWholeHistory()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        PersistedMessage[] messages = [Msg("m1", 1, "User"), Msg("m2", 2)];
+        await store.AppendMessagesAsync(ThreadId, messages);
+
+        var browser = new FakeFileBrowser
+        {
+            ExecuteHandler = command => IsSplice(command) ? Ok() : Missing(),
+        };
+
+        _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+        _ = Written(browser, 0).Should().Be(ExpectedAppend(messages));
     }
 
     // ---------------------------------------------------------------- AC 5
@@ -330,12 +453,18 @@ public sealed class ConversationTranscriptWriterTests
         PersistedMessage[] messages = [Msg("m1", 1, "User"), Msg("m2", 2), Msg("m3", 3)];
         await store.AppendMessagesAsync(ThreadId, messages);
 
-        var browser = new FakeFileBrowser { ExecResult = Fail("no space left on device") };
+        // Only the splice fails: a failing PROBE is a different story (the destination could not be
+        // inspected at all), and it now defers before anything is staged, which would hide this case.
+        var browser = new FakeFileBrowser
+        {
+            ExecuteHandler = command => IsSplice(command) ? Fail("no space left on device") : Ok(),
+        };
         var writer = CreateWriter(store, browser);
 
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
         _ = browser.Writes.Where(w => w.Path == TempPath).Should().ContainSingle();
 
+        browser.ExecuteHandler = null;
         browser.ExecResult = Ok();
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
 
@@ -397,7 +526,7 @@ public sealed class ConversationTranscriptWriterTests
         var existing = ExpectedAppend(messages);
         var browser = new FakeFileBrowser
         {
-            ExecuteHandler = command => command.Arguments[0] == "tail" ? Ok(existing) : Ok(),
+            ExecuteHandler = command => IsSplice(command) ? Ok() : Ok(existing),
             WriteFailure = path =>
                 path == GitignorePath ? new SandboxException(SandboxErrorKind.Protocol, "gateway said no") : null,
         };
@@ -481,7 +610,7 @@ public sealed class ConversationTranscriptWriterTests
         _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
 
         var rootUid = WorkspaceTranscriptLine.DeriveUid("m2");
-        var splices = browser.Commands.Where(c => c.Arguments[0] == "sh").ToList();
+        var splices = browser.Commands.Where(c => IsSplice(c)).ToList();
         _ = splices.Select(c => c.Arguments[6]).Should().Equal(
             MainPath(Title),
             AgentPath(Title, "nameless", null),
@@ -527,14 +656,14 @@ public sealed class ConversationTranscriptWriterTests
         var browser = new FakeFileBrowser
         {
             ExecuteHandler = command =>
-                command.Arguments[0] == "sh" && command.Arguments[6] == MainPath(Title)
+                IsSplice(command) && command.Arguments[6] == MainPath(Title)
                     ? Fail("no space left on device")
                     : Ok(),
         };
         var writer = CreateWriter(store, browser);
 
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
-        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+        _ = browser.Commands.Where(c => IsSplice(c)).Select(c => c.Arguments[6])
             .Should().Equal(MainPath(Title));
 
         browser.ExecuteHandler = null;
@@ -542,7 +671,7 @@ public sealed class ConversationTranscriptWriterTests
 
         // The child's first line chains off the main file's real tail — a row that genuinely exists in the
         // main file — instead of off nothing.
-        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+        _ = browser.Commands.Where(c => IsSplice(c)).Select(c => c.Arguments[6])
             .Should().Equal(MainPath(Title), MainPath(Title), AgentPath(Title, "a1", "alpha"));
         _ = Written(browser, 2).Should()
             .Be(ExpectedAppend(child, agent: "alpha", rootParentUid: WorkspaceTranscriptLine.DeriveUid("m2")));
@@ -568,7 +697,7 @@ public sealed class ConversationTranscriptWriterTests
         var stagedWhenSpliced = new List<int>();
         browser.ExecuteHandler = command =>
         {
-            if (command.Arguments[0] == "sh")
+            if (IsSplice(command))
             {
                 // Counted over STAGED writes only: the containment .gitignore is PUT ahead of the first
                 // append and is not a staged payload, so counting every write would just measure it.
@@ -605,12 +734,12 @@ public sealed class ConversationTranscriptWriterTests
         var writer = CreateWriter(store, browser, maxSubAgentFilesPerFlush: 1);
 
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Progressing);
-        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+        _ = browser.Commands.Where(c => IsSplice(c)).Select(c => c.Arguments[6])
             .Should().Equal(MainPath(Title), AgentPath(Title, "a1", "alpha"));
 
         browser.Commands.Clear();
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
-        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+        _ = browser.Commands.Where(c => IsSplice(c)).Select(c => c.Arguments[6])
             .Should().Equal(AgentPath(Title, "b2", "beta"));
 
         // The sweep has now visited every descendant, so the writer stops asking. Reporting Deferred here
@@ -652,11 +781,11 @@ public sealed class ConversationTranscriptWriterTests
 
         browser.Commands.Clear();
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Progressing);
-        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Should().BeEmpty();
+        _ = browser.Commands.Where(c => IsSplice(c)).Should().BeEmpty();
 
         browser.Commands.Clear();
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
-        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+        _ = browser.Commands.Where(c => IsSplice(c)).Select(c => c.Arguments[6])
             .Should().Equal(AgentPath(Title, "b2", "beta"));
     }
 
@@ -712,13 +841,13 @@ public sealed class ConversationTranscriptWriterTests
 
         browser.Commands.Clear();
         _ = await writer.FlushAsync();
-        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+        _ = browser.Commands.Where(c => IsSplice(c)).Select(c => c.Arguments[6])
             .Should().Equal(MainPath(Title));
 
         writer.NoteSubAgentActivity();
         browser.Commands.Clear();
         _ = await writer.FlushAsync();
-        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+        _ = browser.Commands.Where(c => IsSplice(c)).Select(c => c.Arguments[6])
             .Should().Equal(AgentPath(Title, "late", "latecomer"));
     }
 
@@ -839,10 +968,11 @@ public sealed class ConversationTranscriptWriterTests
         _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(RetitledTo), MainPath(Title));
         _ = browser.Commands[1].Arguments.Should()
             .Equal("mv", "--", AgentsDirectory(RetitledTo), AgentsDirectory(Title));
-        _ = browser.Commands[2].Arguments.Should().Equal("tail", "-n", "5", "--", MainPath(Title));
+        _ = browser.Commands[2].Arguments.Should()
+            .Equal("sh", "-c", ExpectedProbeScript, "sh", MainPath(Title), "5");
 
         // One transcript, and the sub-agent file lands under it rather than beside the abandoned name.
-        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+        _ = browser.Commands.Where(IsSplice).Select(c => c.Arguments[6])
             .Should().Equal(MainPath(Title), AgentPath(Title, "a1", "alpha"));
     }
 
@@ -888,7 +1018,7 @@ public sealed class ConversationTranscriptWriterTests
         browser.ListThrows = null;
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
         _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(RetitledTo), MainPath(Title));
-        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+        _ = browser.Commands.Where(c => IsSplice(c)).Select(c => c.Arguments[6])
             .Should().Equal(MainPath(Title));
     }
 
@@ -915,7 +1045,7 @@ public sealed class ConversationTranscriptWriterTests
         };
 
         _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
-        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+        _ = browser.Commands.Where(c => IsSplice(c)).Select(c => c.Arguments[6])
             .Should().Equal(MainPath(Title));
     }
 
@@ -1121,10 +1251,11 @@ public sealed class ConversationTranscriptWriterTests
 
     /// <summary>
     /// The security invariant, stated as a test. <c>ExecuteWorkspaceCommandAsync</c> is a native argv
-    /// vector with NO implicit shell, so the one place a shell is invoked must carry a compile-time
-    /// constant script: the file leaf is derived from a user-authored title, and interpolating it into the
-    /// script text would make <c>$(…)</c> in a title executable. <c>--</c> on the pure-argv calls stops
-    /// option parsing, but it is the positional parameters that make the title inert.
+    /// vector with NO implicit shell, so every place a shell IS invoked — the splice that writes and the
+    /// watermark probe that reads — must carry a compile-time constant script: the file leaf is derived
+    /// from a user-authored title, and interpolating it into the script text would make <c>$(…)</c> in a
+    /// title executable. <c>--</c> on the pure-argv calls stops option parsing, but it is the positional
+    /// parameters that make the title inert.
     /// </summary>
     [Fact]
     public async Task EveryShellCall_UsesTheConstantScript_AndPassesTheTitleDerivedPathAsAPositionalParameter()
@@ -1143,19 +1274,37 @@ public sealed class ConversationTranscriptWriterTests
         _ = leaf.Should().Be($"touch-tmp-pwned-rm-rf-{ShortThreadId}");
 
         var shell = browser.Commands.Where(c => c.Arguments[0] == "sh").ToList();
-        _ = shell.Should().HaveCount(2);
+        var splices = shell.Where(IsSplice).ToList();
+        _ = splices.Should().HaveCount(2);
+        _ = shell.Should().HaveCountGreaterThan(
+            splices.Count,
+            "the watermark probe is the other shell call site and is covered by this invariant too"
+        );
+
         foreach (var command in shell)
         {
             _ = command.Arguments[1].Should().Be("-c");
-            _ = command.Arguments[2].Should().Be(ExpectedSpliceScript);
+            _ = command.Arguments[2].Should().BeOneOf(ExpectedProbeScript, ExpectedSpliceScript);
             _ = command.Arguments[3].Should().Be("sh");
-            _ = command.Arguments[6].Should().Contain(leaf);
+
+            // Whatever the call touches reaches `sh` as a positional parameter, never as script text.
+            _ = command.Arguments[2].Should().NotContain(leaf).And.NotContain(Hostile).And.NotContain("touch");
+            _ = command.Arguments.Skip(4).Should().NotBeEmpty();
         }
 
-        // The script never grows a dynamic fragment, and the pure-argv calls keep their `--`.
+        foreach (var splice in splices)
+        {
+            _ = splice.Arguments[6].Should().Contain(leaf);
+        }
+
+        // Neither script ever grows a dynamic fragment, and the pure-argv calls keep their `--`.
         _ = ExpectedSpliceScript.Should().NotContain(leaf).And.NotContain(Hostile).And.NotContain("touch");
-        _ = browser.Commands.Where(c => c.Arguments[0] is "tail" or "mv")
-            .Should().OnlyContain(c => c.Arguments.Contains("--"));
+        _ = ExpectedProbeScript.Should().NotContain(leaf).And.NotContain(Hostile).And.NotContain("touch");
+        // Every shell call is covered by the loop above; what is left is the pure-argv calls, and none of
+        // them may omit `--`. (Stated as "no call omits it" so the invariant does not change meaning when
+        // a flow happens not to move anything.)
+        _ = browser.Commands.Where(c => c.Arguments[0] != "sh")
+            .Should().NotContain(c => !c.Arguments.Contains("--"));
     }
 
     // ---------------------------------------------------------------- doubles

--- a/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
@@ -1,0 +1,893 @@
+using System.Collections.Immutable;
+using System.Text;
+using AchieveAi.LmDotnetTools.LmCore.Utils;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.Sandbox;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Tests.TestDoubles;
+using Microsoft.Extensions.Logging;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="ConversationTranscriptWriter"/> — the workspace transcript mirror (#251), driven
+/// entirely against <see cref="FakeFileBrowser"/> so there is no gateway and no container in the loop.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These assert the <b>exact bytes appended</b> and the <b>exact argv of every command</b>, not a
+/// paraphrase of either. The mirror's whole value is that a reader can dedupe on <c>uid</c> and chain on
+/// <c>parent_uid</c>; both properties are byte-level, so an assertion that only counts calls would pass
+/// while the file on disk was wrong.
+/// </para>
+/// <para>
+/// Every failure mode is forced rather than assumed: a non-zero splice, a non-zero <c>mv</c>, a resolve
+/// that throws, a credential conflict, and rows that never settle. The invariant each of those locks is
+/// the same one — <b>duplicate on retry, never silent loss</b>.
+/// </para>
+/// </remarks>
+public sealed class ConversationTranscriptWriterTests
+{
+    private const string ThreadId = "conv-1";
+    private const string WorkspaceId = "ws-1";
+    private const string Title = "Design Review";
+    private const string RetitledTo = "Shipping Plan";
+    private const string GitignorePath = ".conversations/.gitignore";
+
+    /// <summary>
+    /// The splice script, duplicated here ON PURPOSE. It is the feature's only shell call site, so its
+    /// text is a contract: the middle line is the newline weld that stops a torn tail from fusing two
+    /// records, and the <c>$1</c>/<c>$2</c>/<c>$3</c> parameters are what keep a user-authored title
+    /// inert. A test that read the constant back out of the production type could not notice either one
+    /// being edited away.
+    /// </summary>
+    private const string ExpectedSpliceScript =
+        "mkdir -p \"$1\" || exit 1\n"
+        + "if [ -s \"$3\" ] && [ -n \"$(tail -c1 \"$3\")\" ]; then printf '\\n' >> \"$3\" || exit 1; fi\n"
+        + "cat \"$2\" >> \"$3\" && rm -f \"$2\"\n";
+
+    private static readonly string ShortThreadId = WorkspaceTranscriptLine.ShortId(ThreadId);
+
+    private static readonly string TempPath =
+        $"{ConversationTranscriptWriter.TempDirectory}/{ShortThreadId}{ConversationTranscriptWriter.TempExtension}";
+
+    // ---------------------------------------------------------------- helpers
+
+    private static string MainPath(string? title) =>
+        $"{ConversationTranscriptWriter.TranscriptDirectory}/"
+        + $"{WorkspaceTranscriptLine.MainFileLeaf(title, ShortThreadId)}{ConversationTranscriptWriter.TranscriptExtension}";
+
+    private static string AgentsDirectory(string? title) =>
+        $"{ConversationTranscriptWriter.TranscriptDirectory}/"
+        + $"{WorkspaceTranscriptLine.MainFileLeaf(title, ShortThreadId)}{ConversationTranscriptWriter.AgentsDirectorySuffix}";
+
+    private static string AgentPath(string? title, string agentId, string? agentName) =>
+        $"{AgentsDirectory(title)}/"
+        + $"{WorkspaceTranscriptLine.AgentFileLeaf(agentName, WorkspaceTranscriptLine.ShortId(agentId))}"
+        + ConversationTranscriptWriter.TranscriptExtension;
+
+    private static ConversationTranscriptWriter CreateWriter(
+        IConversationStore store,
+        FakeFileBrowser browser,
+        ILogger<ConversationTranscriptWriter>? logger = null,
+        int maxSubAgentFilesPerFlush = ConversationTranscriptWriter.DefaultMaxSubAgentFilesPerFlush) =>
+        new(
+            ThreadId,
+            store,
+            browser,
+            new ConversationDescendantScanner(store, NullLogger<ConversationDescendantScanner>.Instance),
+            logger ?? NullLogger<ConversationTranscriptWriter>.Instance,
+            // Zero, so the stability probe's second read happens immediately: the tests drive settling
+            // through the store double, never through elapsed time.
+            TimeSpan.Zero,
+            maxSubAgentFilesPerFlush
+        );
+
+    private static Task SeedConversationAsync(
+        IConversationStore store,
+        string? title = Title,
+        string? workspaceId = WorkspaceId)
+    {
+        var properties = ImmutableDictionary.CreateBuilder<string, object>(StringComparer.Ordinal);
+        if (workspaceId is not null)
+        {
+            properties[MultiTurnAgentPool.WorkspacePropertyKey] = workspaceId;
+        }
+
+        if (title is not null)
+        {
+            properties["title"] = title;
+        }
+
+        return store.SaveMetadataAsync(
+            ThreadId,
+            new ThreadMetadata
+            {
+                ThreadId = ThreadId,
+                LastUpdated = 0,
+                Properties = properties.ToImmutable(),
+            }
+        );
+    }
+
+    /// <summary>Seeds one persisted sub-agent thread stamped as this conversation's child.</summary>
+    private static async Task SeedSubAgentAsync(
+        IConversationStore store,
+        string agentId,
+        string? name,
+        params PersistedMessage[] messages)
+    {
+        var childThreadId = SubAgentProvenance.ThreadIdPrefix + agentId;
+        await store.SaveMetadataAsync(
+            childThreadId,
+            new ThreadMetadata
+            {
+                ThreadId = childThreadId,
+                LastUpdated = 0,
+                Properties = SubAgentProvenance.Build(
+                    ThreadId,
+                    new SubAgentSnapshot(
+                        agentId,
+                        Name: name,
+                        TemplateName: "worker",
+                        Task: "do the thing",
+                        Status: SubAgentStatus.Completed,
+                        ThreadId: childThreadId,
+                        LastActivityUtc: DateTimeOffset.UnixEpoch,
+                        TerminalAtUtc: DateTimeOffset.UnixEpoch
+                    )
+                ),
+            }
+        );
+
+        await store.AppendMessagesAsync(childThreadId, messages);
+    }
+
+    private static PersistedMessage Msg(
+        string id,
+        long timestamp,
+        string role = "Assistant",
+        string threadId = ThreadId,
+        string runId = "run-1",
+        string messageType = "TextMessage",
+        string? messageJson = null) =>
+        new()
+        {
+            Id = id,
+            ThreadId = threadId,
+            RunId = runId,
+            GenerationId = runId,
+            Timestamp = timestamp,
+            MessageType = messageType,
+            Role = role,
+            // Deliberately not a shape TranscriptProjection can deserialize: Normalize passes an
+            // unreadable row through VERBATIM, so the expected bytes stay legible in the assertions.
+            MessageJson = messageJson ?? $"\"opaque-{id}\"",
+        };
+
+    /// <summary>
+    /// The bytes the writer is expected to append: the same projection it runs, serialized the same way,
+    /// minus the <paramref name="skip"/> lines a watermark already covers.
+    /// </summary>
+    private static string ExpectedAppend(
+        IReadOnlyList<PersistedMessage> all,
+        int skip = 0,
+        string? agent = null,
+        string? rootParentUid = null)
+    {
+        var lines = WorkspaceTranscriptLine.ChainMessages(
+            TranscriptProjection.Normalize(all, excludeReasoning: false),
+            agent,
+            rootParentUid
+        );
+
+        return string.Concat(lines.Skip(skip).Select(l => WorkspaceTranscriptLine.Serialize(l) + "\n"));
+    }
+
+    private static string Written(FakeFileBrowser browser, int index) =>
+        Encoding.UTF8.GetString(browser.Writes[index].Bytes);
+
+    private static IReadOnlyList<string> UidsIn(string payload) =>
+        [
+            .. payload
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .Select(line => JsonSerializer.Deserialize<JsonElement>(line).GetProperty("uid").GetString()!),
+        ];
+
+    private static SandboxCommandResult Ok(string stdout = "") =>
+        new() { ExitCode = 0, StandardOutput = stdout, StandardError = "", OperationId = "op" };
+
+    private static SandboxCommandResult Fail(string stderr = "boom") =>
+        new() { ExitCode = 1, StandardOutput = "", StandardError = stderr, OperationId = "op" };
+
+    // ---------------------------------------------------------------- AC 1, 6
+
+    /// <summary>
+    /// AC 1 / AC 6. The first flush writes one line per persisted message, in store order, staged through
+    /// <c>.conversations/.tmp/{shortThreadId}.part</c> and spliced with the single shell call site. The
+    /// staging path is asserted because a leaked temp file (the <c>rm -f</c> never ran) must be a name no
+    /// <c>**/*.jsonl</c> scan can match.
+    /// </summary>
+    [Fact]
+    public async Task FirstFlush_WritesOneLinePerMessageInStoreOrder_ThroughTheTempPathAndOneShellCall()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        PersistedMessage[] messages = [Msg("m1", 1, "User"), Msg("m2", 2), Msg("m3", 3)];
+        await store.AppendMessagesAsync(ThreadId, messages);
+
+        var browser = new FakeFileBrowser();
+        var outcome = await CreateWriter(store, browser).FlushAsync();
+
+        _ = outcome.Should().Be(TranscriptFlushOutcome.Written);
+
+        var payload = ExpectedAppend(messages);
+        _ = payload.Split('\n', StringSplitOptions.RemoveEmptyEntries).Should().HaveCount(3);
+
+        _ = browser.Writes[0].Path.Should().Be(TempPath);
+        _ = Written(browser, 0).Should().Be(payload);
+        _ = browser.Writes
+            .Select(w => w.Path)
+            .Should()
+            .NotContain(p => p.EndsWith(ConversationTranscriptWriter.TranscriptExtension, StringComparison.Ordinal));
+
+        _ = browser.Commands.Should().HaveCount(2);
+        _ = browser.Commands[0].Arguments.Should().Equal("tail", "-n", "5", "--", MainPath(Title));
+        _ = browser.Commands[1].Arguments.Should()
+            .Equal("sh", "-c", ExpectedSpliceScript, "sh", ".conversations", TempPath, MainPath(Title));
+        _ = browser.LastPersistedWorkspaceId.Should().Be(WorkspaceId);
+    }
+
+    // ---------------------------------------------------------------- AC 2, 3
+
+    /// <summary>
+    /// AC 2 / AC 3. A second flush appends ONLY the second run's bytes — the watermark is the last
+    /// appended <c>uid</c>, not a byte offset — and across both flushes the distinct <c>uid</c> count
+    /// equals the line count, which is the property a reader's dedupe relies on.
+    /// </summary>
+    [Fact]
+    public async Task SecondFlush_AppendsOnlyTheNewRun_AndEveryLineKeepsADistinctUid()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        PersistedMessage[] first = [Msg("m1", 1, "User"), Msg("m2", 2)];
+        await store.AppendMessagesAsync(ThreadId, first);
+
+        var browser = new FakeFileBrowser();
+        var writer = CreateWriter(store, browser);
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+
+        PersistedMessage[] second = [Msg("m3", 3, "User", runId: "run-2"), Msg("m4", 4, runId: "run-2")];
+        await store.AppendMessagesAsync(ThreadId, second);
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+
+        PersistedMessage[] all = [.. first, .. second];
+        _ = Written(browser, 0).Should().Be(ExpectedAppend(first));
+        _ = Written(browser, 2).Should().Be(ExpectedAppend(all, skip: 2));
+
+        // No second tail: the watermark survived in process, keyed by thread.
+        _ = browser.Commands.Select(c => c.Arguments[0]).Should().Equal("tail", "sh", "sh");
+
+        var file = Written(browser, 0) + Written(browser, 2);
+        var uids = UidsIn(file);
+        _ = uids.Should().HaveCount(4);
+        _ = uids.Distinct(StringComparer.Ordinal).Should().HaveCount(4);
+    }
+
+    // ---------------------------------------------------------------- AC 4
+
+    /// <summary>
+    /// AC 4. A cold start (crash resume) recovers its watermark from <c>tail -n 5</c> and appends only the
+    /// suffix. The window is five lines, not one, precisely so a run killed mid-splice — whose last line
+    /// is torn — still resolves to the last INTACT record instead of re-appending the whole history.
+    /// A GET is never issued: these files reach tens of megabytes.
+    /// </summary>
+    [Fact]
+    public async Task ColdStart_RecoversTheWatermarkFromTheTailWindow_EvenWithATornLastLine()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        PersistedMessage[] messages = [Msg("m1", 1, "User"), Msg("m2", 2), Msg("m3", 3)];
+        await store.AppendMessagesAsync(ThreadId, messages);
+
+        // What a previous process left on disk: m1, m2, then a half-written m3.
+        var onDisk = ExpectedAppend(messages, skip: 0);
+        var intact = string.Concat(onDisk.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Take(2)
+            .Select(l => l + "\n"));
+        var torn = onDisk.Split('\n', StringSplitOptions.RemoveEmptyEntries)[2][..20];
+
+        var browser = new FakeFileBrowser
+        {
+            ExecuteHandler = command => command.Arguments[0] == "tail" ? Ok(intact + torn) : Ok(),
+        };
+
+        _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+
+        _ = browser.Commands[0].Arguments.Should().Equal("tail", "-n", "5", "--", MainPath(Title));
+        _ = Written(browser, 0).Should().Be(ExpectedAppend(messages, skip: 2));
+        _ = browser.ReadCalls.Should().Be(0);
+    }
+
+    // ---------------------------------------------------------------- AC 5
+
+    /// <summary>
+    /// AC 5. A non-zero splice leaves the watermark unadvanced, so the next flush re-appends the same
+    /// suffix. The failure direction is duplicate-on-retry: an advanced watermark would have dropped
+    /// those rows permanently.
+    /// </summary>
+    [Fact]
+    public async Task FailedSplice_LeavesTheWatermarkUnadvanced_SoTheNextFlushDuplicatesRatherThanTruncates()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        PersistedMessage[] messages = [Msg("m1", 1, "User"), Msg("m2", 2), Msg("m3", 3)];
+        await store.AppendMessagesAsync(ThreadId, messages);
+
+        var browser = new FakeFileBrowser { ExecResult = Fail("no space left on device") };
+        var writer = CreateWriter(store, browser);
+
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = browser.Writes.Should().HaveCount(1);
+
+        browser.ExecResult = Ok();
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+
+        var payload = ExpectedAppend(messages);
+        _ = Written(browser, 0).Should().Be(payload);
+        _ = Written(browser, 1).Should().Be(payload);
+        _ = browser.Writes[2].Path.Should().Be(GitignorePath);
+    }
+
+    // ---------------------------------------------------------------- AC 8
+
+    /// <summary>
+    /// AC 8. <c>.conversations/.gitignore</c> is written exactly once, on the FIRST SUCCESSFUL flush — not
+    /// on every flush, and not before anything succeeded (a conversation that never produced a transcript
+    /// leaves no directory behind). A workspace is frequently a git checkout and an agent frequently runs
+    /// <c>git add -A</c>.
+    /// </summary>
+    [Fact]
+    public async Task Gitignore_IsWrittenOnceOnTheFirstSuccessfulFlush()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+
+        var browser = new FakeFileBrowser();
+        var writer = CreateWriter(store, browser);
+        _ = await writer.FlushAsync();
+
+        await store.AppendMessagesAsync(ThreadId, [Msg("m2", 2)]);
+        _ = await writer.FlushAsync();
+
+        var gitignores = browser.Writes.Where(w => w.Path == GitignorePath).ToList();
+        _ = gitignores.Should().HaveCount(1);
+        _ = Encoding.UTF8.GetString(gitignores[0].Bytes).Should().Be("*\n");
+    }
+
+    // ---------------------------------------------------------------- AC 7, 12
+
+    /// <summary>
+    /// AC 7 / AC 12. The fan-out writes one file per sub-agent: a null display name pins
+    /// <c>agent-{shortAgentId}</c>, and two sub-agents sharing a display name still land in DISTINCT files
+    /// because the short id comes from the agent id. Each file's first line hangs off the main file's
+    /// watermark, so a reader that concatenates the whole set still resolves one chain and still sees each
+    /// message exactly once.
+    /// </summary>
+    [Fact]
+    public async Task SubAgentFanOut_NamesFilesDistinctly_AndRootsEachFileInTheMainFile()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        PersistedMessage[] main = [Msg("m1", 1, "User"), Msg("m2", 2)];
+        await store.AppendMessagesAsync(ThreadId, main);
+
+        PersistedMessage[] nameless = [Msg("n1", 10, threadId: "subagent-nameless")];
+        PersistedMessage[] firstReviewer = [Msg("r1a", 20, threadId: "subagent-r1")];
+        PersistedMessage[] secondReviewer = [Msg("r2a", 30, threadId: "subagent-r2")];
+        await SeedSubAgentAsync(store, "nameless", null, nameless);
+        await SeedSubAgentAsync(store, "r1", "reviewer", firstReviewer);
+        await SeedSubAgentAsync(store, "r2", "reviewer", secondReviewer);
+
+        var browser = new FakeFileBrowser();
+        _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+
+        var rootUid = WorkspaceTranscriptLine.DeriveUid("m2");
+        var splices = browser.Commands.Where(c => c.Arguments[0] == "sh").ToList();
+        _ = splices.Select(c => c.Arguments[6]).Should().Equal(
+            MainPath(Title),
+            AgentPath(Title, "nameless", null),
+            AgentPath(Title, "r1", "reviewer"),
+            AgentPath(Title, "r2", "reviewer")
+        );
+        _ = AgentPath(Title, "nameless", null).Should()
+            .EndWith($"/agent-{WorkspaceTranscriptLine.ShortId("nameless")}.jsonl");
+        _ = AgentPath(Title, "r1", "reviewer").Should().NotBe(AgentPath(Title, "r2", "reviewer"));
+
+        _ = Written(browser, 0).Should().Be(ExpectedAppend(main));
+        _ = Written(browser, 1).Should().Be(ExpectedAppend(nameless, rootParentUid: rootUid));
+        _ = Written(browser, 2).Should().Be(ExpectedAppend(firstReviewer, agent: "reviewer", rootParentUid: rootUid));
+        _ = Written(browser, 3).Should().Be(ExpectedAppend(secondReviewer, agent: "reviewer", rootParentUid: rootUid));
+
+        // AC 12: two (here four) files present, and every uid still occurs exactly once across them.
+        var uids = UidsIn(string.Concat(Enumerable.Range(0, 4).Select(i => Written(browser, i))));
+        _ = uids.Should().HaveCount(5);
+        _ = uids.Distinct(StringComparer.Ordinal).Should().HaveCount(5);
+    }
+
+    /// <summary>
+    /// The fan-out is STRICTLY SEQUENTIAL, and this is a hard requirement rather than a style preference:
+    /// every file in a conversation is staged through ONE temp path, so two overlapping writes would PUT
+    /// over each other's bytes and <c>cat</c> the survivor into both destinations. Each splice is asserted
+    /// to observe exactly its own staged write and no other file's — an interleaved (or
+    /// <c>Task.WhenAll</c>-ed) fan-out could not produce this sequence.
+    /// </summary>
+    [Fact]
+    public async Task SubAgentFanOut_StagesAndSplicesOneFileAtATime()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+        await SeedSubAgentAsync(store, "a1", "alpha", Msg("a1a", 10, threadId: "subagent-a1"));
+        await SeedSubAgentAsync(store, "b2", "beta", Msg("b2a", 20, threadId: "subagent-b2"));
+
+        var browser = new FakeFileBrowser();
+        var stagedWhenSpliced = new List<int>();
+        browser.ExecuteHandler = command =>
+        {
+            if (command.Arguments[0] == "sh")
+            {
+                stagedWhenSpliced.Add(browser.Writes.Count);
+            }
+
+            return Ok();
+        };
+
+        _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+
+        // 1, 2, 3 — each splice sees its own PUT and nothing further. Any overlap shows up as a splice
+        // observing a later file's staged bytes already sitting in the shared slot.
+        _ = stagedWhenSpliced.Should().Equal(1, 2, 3);
+        _ = browser.Writes.Take(3).Select(w => w.Path).Should().AllBe(TempPath);
+    }
+
+    /// <summary>
+    /// The fan-out is bounded per flush and advances round-robin, so a conversation with many descendants
+    /// is covered across successive flushes instead of holding the store's process-wide read semaphore for
+    /// every descendant at one turn boundary. A truncated pass reports <c>Deferred</c> so another flush
+    /// follows.
+    /// </summary>
+    [Fact]
+    public async Task SubAgentFanOut_IsBoundedPerFlush_AndCoversTheRestOnTheNextOne()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+        await SeedSubAgentAsync(store, "a1", "alpha", Msg("a1a", 10, threadId: "subagent-a1"));
+        await SeedSubAgentAsync(store, "b2", "beta", Msg("b2a", 20, threadId: "subagent-b2"));
+
+        var browser = new FakeFileBrowser();
+        var writer = CreateWriter(store, browser, maxSubAgentFilesPerFlush: 1);
+
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+            .Should().Equal(MainPath(Title), AgentPath(Title, "a1", "alpha"));
+
+        browser.Commands.Clear();
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+            .Should().Equal(AgentPath(Title, "b2", "beta"));
+
+        // And it TERMINATES. Deferred is gated on a pass having mirrored something, so the first capped
+        // pass that finds its slice already current stops asking for another flush — a caller that
+        // re-schedules on Deferred would otherwise spin forever on any conversation above the cap.
+        browser.Commands.Clear();
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.UpToDate);
+        _ = browser.Commands.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A sub-agent that finishes AFTER its parent's turn ended never publishes the conversation's
+    /// <c>RunCompletedMessage</c>, so a mirror listening only for run completion would never write its
+    /// file. <see cref="ConversationTranscriptWriter.NoteSubAgentActivity"/> is that second trigger — and
+    /// it is also the only safe caller of the descendant cache's refresh, which costs a full store scan.
+    /// </summary>
+    [Fact]
+    public async Task NoteSubAgentActivity_IsWhatMakesALaterSpawnVisibleToTheFanOut()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+
+        var browser = new FakeFileBrowser();
+        var writer = CreateWriter(store, browser);
+        _ = await writer.FlushAsync();
+
+        await SeedSubAgentAsync(store, "late", "latecomer", Msg("l1", 10, threadId: "subagent-late"));
+        await store.AppendMessagesAsync(ThreadId, [Msg("m2", 2)]);
+
+        browser.Commands.Clear();
+        _ = await writer.FlushAsync();
+        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+            .Should().Equal(MainPath(Title));
+
+        writer.NoteSubAgentActivity();
+        browser.Commands.Clear();
+        _ = await writer.FlushAsync();
+        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+            .Should().Equal(AgentPath(Title, "late", "latecomer"));
+    }
+
+    // ---------------------------------------------------------------- AC 10, 11
+
+    /// <summary>
+    /// AC 10. A retitle reaches the mirror only through <c>ThreadMetadata</c> — the UI's
+    /// <c>PUT {threadId}/metadata</c> never touches the message stream — so the leaf is recomputed at the
+    /// top of every flush and the rename is issued BEFORE anything is appended. Without that ordering the
+    /// first flush after a retitle creates a second file and re-appends the entire history.
+    /// </summary>
+    [Fact]
+    public async Task Retitle_MovesTheFileAndTheAgentsDirectory_BeforeAppendingIntoTheMovedFile()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+        await SeedSubAgentAsync(store, "a1", "alpha", Msg("a1a", 10, threadId: "subagent-a1"));
+
+        var browser = new FakeFileBrowser();
+        var writer = CreateWriter(store, browser);
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+
+        await SeedConversationAsync(store, RetitledTo);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m2", 2)]);
+
+        browser.Commands.Clear();
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+
+        _ = browser.Commands.Should().HaveCount(3);
+        _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(Title), MainPath(RetitledTo));
+        _ = browser.Commands[1].Arguments.Should()
+            .Equal("mv", "--", AgentsDirectory(Title), AgentsDirectory(RetitledTo));
+        _ = browser.Commands[2].Arguments.Should()
+            .Equal("sh", "-c", ExpectedSpliceScript, "sh", ".conversations", TempPath, MainPath(RetitledTo));
+    }
+
+    /// <summary>
+    /// AC 11. A failed <c>mv</c> is not fatal: the old path is still complete and readable, so this flush
+    /// keeps writing to it and the rename is retried next time. The watermark is keyed by THREAD, never by
+    /// path, so nothing is re-appended when the move finally lands.
+    /// </summary>
+    [Fact]
+    public async Task FailedRename_KeepsWritingToTheOldPath_AndRetriesOnTheNextFlush()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+
+        var browser = new FakeFileBrowser();
+        var writer = CreateWriter(store, browser);
+        _ = await writer.FlushAsync();
+
+        browser.ExecuteHandler = command => command.Arguments[0] == "mv" ? Fail("device busy") : Ok();
+        await SeedConversationAsync(store, RetitledTo);
+        PersistedMessage[] all = [Msg("m1", 1, "User"), Msg("m2", 2)];
+        await store.AppendMessagesAsync(ThreadId, [all[1]]);
+
+        browser.Commands.Clear();
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+        _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(Title), MainPath(RetitledTo));
+        _ = browser.Commands[1].Arguments[6].Should().Be(MainPath(Title));
+        _ = Written(browser, 2).Should().Be(ExpectedAppend(all, skip: 1));
+
+        browser.ExecuteHandler = null;
+        PersistedMessage[] everything = [.. all, Msg("m3", 3)];
+        await store.AppendMessagesAsync(ThreadId, [everything[2]]);
+
+        browser.Commands.Clear();
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+        _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(Title), MainPath(RetitledTo));
+        _ = browser.Commands[1].Arguments[6].Should().Be(MainPath(RetitledTo));
+        _ = Written(browser, 3).Should().Be(ExpectedAppend(everything, skip: 2));
+    }
+
+    // ---------------------------------------------------------------- AC 19
+
+    /// <summary>
+    /// AC 19. The workspace mirror carries FULL fidelity, reasoning included. It is the one transcript
+    /// read that is not cross-agent — the rows go into the conversation's own workspace — so the
+    /// reasoning filter every other reader gets is deliberately not applied here.
+    /// </summary>
+    [Fact]
+    public async Task Flush_KeepsReasoningRowsInFull()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            WriteIndented = false,
+            Converters = { new IMessageJsonConverter() },
+        };
+        var reasoning = new ReasoningMessage { Reasoning = "weigh option A against option B", Role = Role.Assistant };
+
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        PersistedMessage[] messages =
+        [
+            Msg("m1", 1, "User"),
+            Msg(
+                "m2",
+                2,
+                messageType: nameof(ReasoningMessage),
+                messageJson: JsonSerializer.Serialize<IMessage>(reasoning, options)
+            ),
+        ];
+        await store.AppendMessagesAsync(ThreadId, messages);
+
+        var browser = new FakeFileBrowser();
+        _ = await CreateWriter(store, browser).FlushAsync();
+
+        var lines = Written(browser, 0).Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        _ = lines.Should().HaveCount(2);
+
+        var line = JsonSerializer.Deserialize<JsonElement>(lines[1]);
+        _ = line.GetProperty("message_type").GetString().Should().Be(nameof(ReasoningMessage));
+
+        var round = JsonSerializer.Deserialize<IMessage>(line.GetProperty("message_json").GetString()!, options);
+        _ = round.Should().BeOfType<ReasoningMessage>()
+            .Which.Reasoning.Should().Be("weigh option A against option B");
+    }
+
+    // ---------------------------------------------------------------- AC 23, 24
+
+    /// <summary>
+    /// AC 23. No sandbox session is the ordinary state of a non-sandbox conversation, not a fault: the
+    /// flush returns quietly with one debug line, writes nothing, and issues no command.
+    /// </summary>
+    [Fact]
+    public async Task NoSession_WritesNothingAndReportsNoError()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+
+        var browser = new FakeFileBrowser
+        {
+            Resolution = new SandboxSessionResolution(SandboxSessionResolutionOutcome.NoSession, null, null, null),
+        };
+        var logger = new CapturingLogger<ConversationTranscriptWriter>();
+
+        _ = (await CreateWriter(store, browser, logger).FlushAsync()).Should().Be(TranscriptFlushOutcome.Unavailable);
+
+        _ = browser.Writes.Should().BeEmpty();
+        _ = browser.Commands.Should().BeEmpty();
+        _ = logger.Entries.Should().ContainSingle().Which.Level.Should().Be(LogLevel.Debug);
+    }
+
+    /// <summary>
+    /// A conversation with no workspace bound never even reaches the gateway — the metadata read alone
+    /// settles it. Same quiet debug outcome.
+    /// </summary>
+    [Fact]
+    public async Task NoWorkspaceBound_NeverResolvesASession()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store, workspaceId: null);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+
+        var browser = new FakeFileBrowser();
+        var logger = new CapturingLogger<ConversationTranscriptWriter>();
+
+        _ = (await CreateWriter(store, browser, logger).FlushAsync()).Should().Be(TranscriptFlushOutcome.Unavailable);
+
+        _ = browser.LastPersistedWorkspaceId.Should().BeNull();
+        _ = browser.Writes.Should().BeEmpty();
+        _ = logger.Entries.Should().ContainSingle().Which.Level.Should().Be(LogLevel.Debug);
+    }
+
+    /// <summary>
+    /// AC 24. A resolve that throws, and a session owned by another identity, each report exactly ONE
+    /// warning and leave the run untouched — the mirror never propagates. Once the binding is usable
+    /// again the next flush writes the full history it had deferred.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task UnusableSession_WarnsOnce_ThenWritesAfterRebind(bool resolveThrows)
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        PersistedMessage[] messages = [Msg("m1", 1, "User"), Msg("m2", 2)];
+        await store.AppendMessagesAsync(ThreadId, messages);
+
+        var browser = new FakeFileBrowser();
+        if (resolveThrows)
+        {
+            browser.ResolveThrows = new SandboxException(SandboxErrorKind.Protocol, "gateway said no");
+        }
+        else
+        {
+            browser.Resolution = new SandboxSessionResolution(
+                SandboxSessionResolutionOutcome.CredentialConflict,
+                null,
+                "other-app",
+                "app"
+            );
+        }
+
+        var logger = new CapturingLogger<ConversationTranscriptWriter>();
+        var writer = CreateWriter(store, browser, logger);
+
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Unavailable);
+        _ = browser.Writes.Should().BeEmpty();
+        _ = logger.Entries.Where(e => e.Level == LogLevel.Warning).Should().ContainSingle();
+
+        browser.ResolveThrows = null;
+        browser.Resolution = new SandboxSessionResolution(
+            SandboxSessionResolutionOutcome.Resolved,
+            FakeFileBrowser.LiveSession,
+            "app",
+            null
+        );
+
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+        _ = Written(browser, 0).Should().Be(ExpectedAppend(messages));
+    }
+
+    // ---------------------------------------------------------------- read until stable
+
+    /// <summary>
+    /// The blocker this pipeline exists around. <c>MultiTurnAgentBase.AddToHistory</c> persists on a
+    /// discarded, unawaited task and <c>CompleteRunAsync</c> publishes run completion without joining
+    /// those tasks, so at trigger time a turn's final assistant and reasoning rows are commonly still in
+    /// flight. Rows that never settle mean the flush is SKIPPED with its watermark unadvanced — appending
+    /// the truncated list would also land the late row at the file tail next flush, giving it a
+    /// <c>parent_uid</c> pointing at a row it did not follow.
+    /// </summary>
+    [Fact]
+    public async Task RowsThatNeverSettle_DeferTheFlushWithoutWritingAnything()
+    {
+        var inner = new InMemoryConversationStore();
+        await SeedConversationAsync(inner);
+        await inner.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+
+        var late = 0;
+        var store = new ScriptedLoadStore(inner)
+        {
+            // One more row lands between every pair of reads — the pathological form of the real race.
+            BeforeLoad = (threadId, _) => inner.AppendMessagesAsync(threadId, [Msg($"late-{++late}", 100 + late)]),
+        };
+
+        var browser = new FakeFileBrowser();
+        _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+
+        _ = browser.Writes.Should().BeEmpty();
+        _ = browser.Commands.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The other half of the same guard: rows that settle on a RE-read are written in full. A probe that
+    /// gave up after one disagreement would truncate the turn it was triggered by.
+    /// </summary>
+    [Fact]
+    public async Task RowsThatSettleOnARetry_AreWrittenInFull()
+    {
+        var inner = new InMemoryConversationStore();
+        await SeedConversationAsync(inner);
+        PersistedMessage[] committed = [Msg("m1", 1, "User"), Msg("m2", 2)];
+        await inner.AppendMessagesAsync(ThreadId, [committed[0]]);
+
+        var store = new ScriptedLoadStore(inner)
+        {
+            // The in-flight assistant row lands during the first read and then stops changing.
+            BeforeLoad = (threadId, call) => call == 1
+                ? inner.AppendMessagesAsync(threadId, [committed[1]])
+                : Task.CompletedTask,
+        };
+
+        var browser = new FakeFileBrowser();
+        _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+        _ = Written(browser, 0).Should().Be(ExpectedAppend(committed));
+    }
+
+    // ---------------------------------------------------------------- shell safety
+
+    /// <summary>
+    /// The security invariant, stated as a test. <c>ExecuteWorkspaceCommandAsync</c> is a native argv
+    /// vector with NO implicit shell, so the one place a shell is invoked must carry a compile-time
+    /// constant script: the file leaf is derived from a user-authored title, and interpolating it into the
+    /// script text would make <c>$(…)</c> in a title executable. <c>--</c> on the pure-argv calls stops
+    /// option parsing, but it is the positional parameters that make the title inert.
+    /// </summary>
+    [Fact]
+    public async Task EveryShellCall_UsesTheConstantScript_AndPassesTheTitleDerivedPathAsAPositionalParameter()
+    {
+        const string Hostile = "$(touch /tmp/pwned); rm -rf ~";
+
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store, Hostile);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+        await SeedSubAgentAsync(store, "a1", "alpha", Msg("a1a", 10, threadId: "subagent-a1"));
+
+        var browser = new FakeFileBrowser();
+        _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+
+        var leaf = WorkspaceTranscriptLine.MainFileLeaf(Hostile, ShortThreadId);
+        _ = leaf.Should().Be($"touch-tmp-pwned-rm-rf-{ShortThreadId}");
+
+        var shell = browser.Commands.Where(c => c.Arguments[0] == "sh").ToList();
+        _ = shell.Should().HaveCount(2);
+        foreach (var command in shell)
+        {
+            _ = command.Arguments[1].Should().Be("-c");
+            _ = command.Arguments[2].Should().Be(ExpectedSpliceScript);
+            _ = command.Arguments[3].Should().Be("sh");
+            _ = command.Arguments[6].Should().Contain(leaf);
+        }
+
+        // The script never grows a dynamic fragment, and the pure-argv calls keep their `--`.
+        _ = ExpectedSpliceScript.Should().NotContain(leaf).And.NotContain(Hostile).And.NotContain("touch");
+        _ = browser.Commands.Where(c => c.Arguments[0] is "tail" or "mv")
+            .Should().OnlyContain(c => c.Arguments.Contains("--"));
+    }
+
+    // ---------------------------------------------------------------- doubles
+
+    /// <summary>
+    /// <see cref="IConversationStore"/> decorator that lets a test mutate the store BETWEEN the stability
+    /// probe's reads. That race is otherwise timing-dependent, and the writer is constructed with a zero
+    /// settle delay, so this is what keeps the read-until-stable tests deterministic instead of sleeping.
+    /// </summary>
+    private sealed class ScriptedLoadStore(IConversationStore inner) : IConversationStore
+    {
+        private readonly Dictionary<string, int> _loads = new(StringComparer.Ordinal);
+
+        /// <summary>Runs before each load, with the thread and that thread's 1-based read count.</summary>
+        public Func<string, int, Task>? BeforeLoad { get; init; }
+
+        public async Task<IReadOnlyList<PersistedMessage>> LoadMessagesAsync(
+            string threadId,
+            CancellationToken ct = default)
+        {
+            _ = _loads.TryGetValue(threadId, out var count);
+            _loads[threadId] = ++count;
+
+            if (BeforeLoad is not null)
+            {
+                await BeforeLoad(threadId, count);
+            }
+
+            return await inner.LoadMessagesAsync(threadId, ct);
+        }
+
+        public Task AppendMessagesAsync(
+            string threadId,
+            IReadOnlyList<PersistedMessage> messages,
+            CancellationToken ct = default) => inner.AppendMessagesAsync(threadId, messages, ct);
+
+        public Task ReplaceMessageAsync(
+            string threadId,
+            PersistedMessage replacement,
+            CancellationToken ct = default) => inner.ReplaceMessageAsync(threadId, replacement, ct);
+
+        public Task SaveMetadataAsync(
+            string threadId,
+            ThreadMetadata metadata,
+            CancellationToken ct = default) => inner.SaveMetadataAsync(threadId, metadata, ct);
+
+        public Task<ThreadMetadata?> LoadMetadataAsync(string threadId, CancellationToken ct = default) =>
+            inner.LoadMetadataAsync(threadId, ct);
+
+        public Task UpdateMetadataAsync(
+            string threadId,
+            Func<ThreadMetadata?, ThreadMetadata> update,
+            CancellationToken ct = default) => inner.UpdateMetadataAsync(threadId, update, ct);
+
+        public Task DeleteThreadAsync(string threadId, CancellationToken ct = default) =>
+            inner.DeleteThreadAsync(threadId, ct);
+
+        public Task<IReadOnlyList<ThreadMetadata>> ListThreadsAsync(
+            int limit = 50,
+            int offset = 0,
+            CancellationToken ct = default) => inner.ListThreadsAsync(limit, offset, ct);
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
@@ -36,31 +36,60 @@ public sealed class ConversationTranscriptWriterTests
     private const string GitignorePath = ".conversations/.gitignore";
 
     /// <summary>
-    /// The splice script, duplicated here ON PURPOSE. It is the feature's only shell call site, so its
-    /// text is a contract: the middle line is the newline weld that stops a torn tail from fusing two
-    /// records, and the <c>$1</c>/<c>$2</c>/<c>$3</c> parameters are what keep a user-authored title
-    /// inert. A test that read the constant back out of the production type could not notice either one
-    /// being edited away.
+    /// The <c>guard</c> preamble every script opens with, duplicated here ON PURPOSE alongside the scripts
+    /// that use it. Its text is a contract: <c>[ -L ]</c> is the only test that does not follow a link, the
+    /// ANCESTOR walk is what catches a redirected <c>.conversations</c> whose leaf does not exist yet, and
+    /// <c>return</c> rather than <c>exit</c> is what lets the caller attach exit <c>44</c> to the failure —
+    /// an <c>exit</c> inside a function would end the script with the function's own status. The trailing
+    /// <c>return 0</c> is equally load-bearing: without it a safe path reports the failed <c>[ -L ]</c>.
+    /// </summary>
+    private const string ExpectedGuardPreamble =
+        "guard() { p=\"$1\"; while [ -n \"$p\" ] && [ \"$p\" != \".\" ] && [ \"$p\" != \"/\" ]; do "
+        + "if [ -L \"$p\" ]; then return 1; fi; p=$(dirname \"$p\"); done; return 0; }\n";
+
+    /// <summary>
+    /// The splice script, duplicated here ON PURPOSE. It is the feature's only shell call site that writes,
+    /// so its text is a contract: the middle line is the newline weld that stops a torn tail from fusing two
+    /// records, the <c>$1</c>/<c>$2</c>/<c>$3</c> parameters are what keep a user-authored title
+    /// inert, and ALL THREE are guarded before anything runs — the destination because <c>&gt;&gt;</c>
+    /// follows links, the directory because <c>mkdir -p</c> silently accepts a symlinked one, and the
+    /// staged file because <c>cat</c> would read through a link into some other file. A test that read the
+    /// constant back out of the production type could not notice any of them being edited away.
     /// </summary>
     private const string ExpectedSpliceScript =
-        "mkdir -p \"$1\" || exit 1\n"
+        ExpectedGuardPreamble
+        + "guard \"$1\" || exit 44\n"
+        + "guard \"$2\" || exit 44\n"
+        + "guard \"$3\" || exit 44\n"
+        + "mkdir -p \"$1\" || exit 1\n"
         + "if [ -s \"$3\" ] && [ -n \"$(tail -c1 \"$3\")\" ]; then printf '\\n' >> \"$3\" || exit 1; fi\n"
         + "cat \"$2\" >> \"$3\" && rm -f \"$2\"\n";
 
     /// <summary>
-    /// The cold-start watermark probe, duplicated for the same reason. Its text is a contract three times
-    /// over: the <c>[ -e ]</c> test is what makes "there is no transcript" an answer the script GIVES rather
-    /// than one the caller infers from a generic <c>tail</c> failure; exit <c>42</c> is the private code that
+    /// The cold-start watermark probe, duplicated for the same reason. Its text is a contract four times
+    /// over: the guard runs FIRST because <c>[ -e ]</c> and <c>tail</c> both report on a link's target, so
+    /// a redirected destination would otherwise be probed as though it were the transcript; the <c>[ -e ]</c>
+    /// test is what makes "there is no transcript" an answer the script GIVES rather than one the caller
+    /// infers from a generic <c>tail</c> failure; exit <c>42</c> is the private code that
     /// carries that answer back — a value neither <c>tail</c> (0/1) nor <c>sh</c> (126/127, 128+signal)
     /// produces, so it cannot be minted by an accident; and <c>cut -c "1-$3"</c> is what bounds the output,
     /// without which a single multi-megabyte row makes the probe itself unanswerable. Exit <c>43</c> carries
     /// the one fact truncation destroys — whether the file ends mid-record.
     /// </summary>
     private const string ExpectedProbeScript =
-        "[ -e \"$1\" ] || exit 42\n"
+        ExpectedGuardPreamble
+        + "guard \"$1\" || exit 44\n"
+        + "[ -e \"$1\" ] || exit 42\n"
         + "tail -n \"$2\" -- \"$1\" | cut -c \"1-$3\" || exit 1\n"
         + "end=$(tail -c1 -- \"$1\") || exit 1\n"
         + "[ -z \"$end\" ] || exit 43\n";
+
+    /// <summary>
+    /// The standalone guard, for the two writes that reach the workspace without a shell — the staged
+    /// payload and the containment file, both PUT directly by the gateway. Duplicated for the same reason:
+    /// nothing else would notice if these writes stopped being checked.
+    /// </summary>
+    private const string ExpectedGuardScript = ExpectedGuardPreamble + "guard \"$1\" || exit 44\n";
 
     private static readonly string ShortThreadId = WorkspaceTranscriptLine.ShortId(ThreadId);
 
@@ -281,11 +310,21 @@ public sealed class ConversationTranscriptWriterTests
         Msg(id, timestamp, messageJson: "\"" + new string('x', megabytes * 1024 * 1024) + "\"");
 
     /// <summary>
-    /// Selects the watermark probe out of a flush's commands. The splice is the call carrying the staged
-    /// temp file; every other shell call in a flush is the probe.
+    /// Classifies a flush's shell calls BY SCRIPT rather than by the arguments that follow it. The earlier
+    /// "does the argv mention the temp path" test stopped being a classifier the moment the temp path got
+    /// a guard call of its own — the guard mentions it too, with a different arity, so the old predicate
+    /// answered true and the assertion behind it read a parameter that was not there.
     /// </summary>
-    private static bool IsSplice(SandboxCommand command) =>
-        command.Arguments.Contains(TempPath, StringComparer.Ordinal);
+    private static bool IsSplice(SandboxCommand command) => RunsScript(command, ExpectedSpliceScript);
+
+    /// <inheritdoc cref="IsSplice"/>
+    private static bool IsProbe(SandboxCommand command) => RunsScript(command, ExpectedProbeScript);
+
+    /// <inheritdoc cref="IsSplice"/>
+    private static bool IsGuard(SandboxCommand command) => RunsScript(command, ExpectedGuardScript);
+
+    private static bool RunsScript(SandboxCommand command, string script) =>
+        command.Arguments.Count > 2 && string.Equals(command.Arguments[2], script, StringComparison.Ordinal);
 
     // ---------------------------------------------------------------- AC 1, 6
 
@@ -318,10 +357,15 @@ public sealed class ConversationTranscriptWriterTests
             .Should()
             .NotContain(p => p.EndsWith(ConversationTranscriptWriter.TranscriptExtension, StringComparison.Ordinal));
 
-        _ = browser.Commands.Should().HaveCount(2);
-        _ = browser.Commands[0].Arguments.Should()
-            .Equal("sh", "-c", ExpectedProbeScript, "sh", MainPath(Title), "5", "256");
+        // Four calls, in this order and no other: check the ignore file's own path is not redirected,
+        // probe the destination, check the staging path is not redirected, splice. Each guard sits ahead
+        // of a write the gateway PUTs, which no script can check because no script has run yet.
+        _ = browser.Commands.Should().HaveCount(4);
+        _ = browser.Commands[0].Arguments.Should().Equal("sh", "-c", ExpectedGuardScript, "sh", GitignorePath);
         _ = browser.Commands[1].Arguments.Should()
+            .Equal("sh", "-c", ExpectedProbeScript, "sh", MainPath(Title), "5", "256");
+        _ = browser.Commands[2].Arguments.Should().Equal("sh", "-c", ExpectedGuardScript, "sh", TempPath);
+        _ = browser.Commands[3].Arguments.Should()
             .Equal("sh", "-c", ExpectedSpliceScript, "sh", ".conversations", TempPath, MainPath(Title));
         _ = browser.LastPersistedWorkspaceId.Should().Be(WorkspaceId);
     }
@@ -353,9 +397,18 @@ public sealed class ConversationTranscriptWriterTests
         _ = Written(browser, 0).Should().Be(ExpectedAppend(first));
         _ = Written(browser, 1).Should().Be(ExpectedAppend(all, skip: 2));
 
-        // No second probe: the watermark survived in process, keyed by thread.
+        // No second probe: the watermark survived in process, keyed by thread. Nor a second containment
+        // guard: the ignore file is written once per writer. The staging guard DOES run again — it is per
+        // flush, not per writer, because a symlink can be planted between two flushes.
         _ = browser.Commands.Select(c => c.Arguments[2]).Should()
-            .Equal(ExpectedProbeScript, ExpectedSpliceScript, ExpectedSpliceScript);
+            .Equal(
+                ExpectedGuardScript,
+                ExpectedProbeScript,
+                ExpectedGuardScript,
+                ExpectedSpliceScript,
+                ExpectedGuardScript,
+                ExpectedSpliceScript
+            );
 
         var file = Written(browser, 0) + Written(browser, 1);
         var uids = UidsIn(file);
@@ -388,12 +441,12 @@ public sealed class ConversationTranscriptWriterTests
 
         var browser = new FakeFileBrowser
         {
-            ExecuteHandler = command => IsSplice(command) ? Ok() : Partial(intact + torn),
+            ExecuteHandler = command => IsProbe(command) ? Partial(intact + torn) : Ok(),
         };
 
         _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
 
-        _ = browser.Commands[0].Arguments.Should()
+        _ = browser.Commands[1].Arguments.Should()
             .Equal("sh", "-c", ExpectedProbeScript, "sh", MainPath(Title), "5", "256");
         _ = Written(browser, 0).Should().Be(ExpectedAppend(messages, skip: 2));
         _ = browser.ReadCalls.Should().Be(0);
@@ -428,7 +481,7 @@ public sealed class ConversationTranscriptWriterTests
         {
             ExecuteHandler = command =>
             {
-                if (IsSplice(command))
+                if (!IsProbe(command))
                 {
                     return Ok();
                 }
@@ -485,7 +538,7 @@ public sealed class ConversationTranscriptWriterTests
 
         var browser = new FakeFileBrowser
         {
-            ExecuteHandler = command => IsSplice(command) ? Ok() : Ok(truncated),
+            ExecuteHandler = command => IsProbe(command) ? Ok(truncated) : Ok(),
         };
 
         _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
@@ -515,7 +568,7 @@ public sealed class ConversationTranscriptWriterTests
 
         var browser = new FakeFileBrowser
         {
-            ExecuteHandler = command => IsSplice(command) ? Ok() : SimulateProbe(command, onDisk),
+            ExecuteHandler = command => IsProbe(command) ? SimulateProbe(command, onDisk) : Ok(),
         };
 
         _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
@@ -555,7 +608,7 @@ public sealed class ConversationTranscriptWriterTests
         _ = browser.Commands.Where(IsSplice).Should().BeEmpty();
 
         // And once the gateway answers, the SAME writer appends the history exactly once.
-        browser.ExecuteHandler = command => IsSplice(command) ? Ok() : Missing();
+        browser.ExecuteHandler = command => IsProbe(command) ? Missing() : Ok();
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
         _ = browser.Writes.Where(w => w.Path == TempPath).Should().ContainSingle();
         _ = Written(browser, 0).Should().Be(ExpectedAppend(messages));
@@ -580,7 +633,7 @@ public sealed class ConversationTranscriptWriterTests
         var existing = ExpectedAppend(messages);
         var browser = new FakeFileBrowser
         {
-            ExecuteHandler = command => IsSplice(command) ? Ok() : Fail("tail: cannot open: Permission denied"),
+            ExecuteHandler = command => IsProbe(command) ? Fail("tail: cannot open: Permission denied") : Ok(),
         };
         var writer = CreateWriter(store, browser);
 
@@ -589,7 +642,7 @@ public sealed class ConversationTranscriptWriterTests
 
         // Once the probe can read the file it finds the watermark on its last line, and there is nothing
         // left to append — which is exactly what the duplicating path would have destroyed.
-        browser.ExecuteHandler = command => IsSplice(command) ? Ok() : Ok(existing);
+        browser.ExecuteHandler = command => IsProbe(command) ? Ok(existing) : Ok();
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.UpToDate);
         _ = browser.Writes.Where(w => w.Path == TempPath).Should().BeEmpty();
     }
@@ -610,7 +663,7 @@ public sealed class ConversationTranscriptWriterTests
 
         var browser = new FakeFileBrowser
         {
-            ExecuteHandler = command => IsSplice(command) ? Ok() : Missing(),
+            ExecuteHandler = command => IsProbe(command) ? Missing() : Ok(),
         };
 
         _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
@@ -705,7 +758,7 @@ public sealed class ConversationTranscriptWriterTests
         var existing = ExpectedAppend(messages);
         var browser = new FakeFileBrowser
         {
-            ExecuteHandler = command => IsSplice(command) ? Ok() : Ok(existing),
+            ExecuteHandler = command => IsProbe(command) ? Ok(existing) : Ok(),
             WriteFailure = path =>
                 path == GitignorePath ? new SandboxException(SandboxErrorKind.Protocol, "gateway said no") : null,
         };
@@ -745,19 +798,56 @@ public sealed class ConversationTranscriptWriterTests
         var writer = CreateWriter(store, browser);
 
         // Nothing staged, nothing spliced: the rows stay in the store, where they are already contained.
+        // The only shell call that runs is the guard ahead of the ignore file's own write, which reads
+        // nothing and writes nothing — it is not a transcript byte, and it is why this is not BeEmpty.
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
         _ = browser.Writes.Should().BeEmpty();
-        _ = browser.Commands.Should().BeEmpty();
+        _ = browser.Commands.Should().OnlyContain(c => IsGuard(c));
 
         // And a failure that is never followed by a successful flush still leaves nothing exposed — this is
         // the resting state of a conversation whose last turn has already happened.
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
         _ = browser.Writes.Should().BeEmpty();
-        _ = browser.Commands.Should().BeEmpty();
+        _ = browser.Commands.Should().OnlyContain(c => IsGuard(c));
 
         browser.WriteFailure = null;
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
         _ = browser.Writes[0].Path.Should().Be(GitignorePath);
+        _ = browser.Writes[1].Path.Should().Be(TempPath);
+    }
+
+    /// <summary>
+    /// The same guarantee for the flush that reaches the workspace WITHOUT the main conversation putting a
+    /// single byte there. A root with no stable rows and no known transcript answers "no" to both halves of
+    /// the flush-level containment condition, so that check is skipped; its own append then returns
+    /// <c>UpToDate</c> rather than <c>Failed</c>, so the guard that skips the fan-out on a failed main
+    /// append does not fire either. Both of the flush's brakes are keyed to the MAIN conversation, and the
+    /// bytes at stake belong to a DESCENDANT — which is why containment is enforced inside the one append
+    /// path every transcript byte passes through, main file and sub-agent file alike, instead of at a call
+    /// site that has to remember. A sub-agent's reasoning is no less publishable than the root's.
+    /// </summary>
+    [Fact]
+    public async Task Gitignore_IsWrittenBeforeAnyTranscriptByte_WhenOnlyADescendantHasRows()
+    {
+        var store = new InMemoryConversationStore();
+        // Deliberately no rows on the root: this conversation's own history is empty (or entirely
+        // unsettled) while a child it spawned has already finished and persisted its own.
+        await SeedConversationAsync(store);
+        PersistedMessage[] child = [Msg("a1a", 10, threadId: "subagent-a1")];
+        await SeedSubAgentAsync(store, "a1", "alpha", child);
+
+        var browser = new FakeFileBrowser();
+        _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+
+        // The descendant's transcript really did reach the workspace, so the ordering assertion below is
+        // about a flush that wrote something rather than one that happened to do nothing.
+        _ = browser.Commands.Where(c => IsSplice(c)).Select(c => c.Arguments[6])
+            .Should().Equal(AgentPath(Title, "a1", "alpha"));
+
+        _ = browser.Writes[0].Path.Should().Be(
+            GitignorePath,
+            "a descendant's transcript is as exposed as the root's — containment must precede the first "
+                + "byte of EITHER, and the root contributed none of them here");
         _ = browser.Writes[1].Path.Should().Be(TempPath);
     }
 
@@ -1141,11 +1231,12 @@ public sealed class ConversationTranscriptWriterTests
         browser.Commands.Clear();
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
 
-        _ = browser.Commands.Should().HaveCount(3);
+        _ = browser.Commands.Should().HaveCount(4);
         _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(Title), MainPath(RetitledTo));
         _ = browser.Commands[1].Arguments.Should()
             .Equal("mv", "--", AgentsDirectory(Title), AgentsDirectory(RetitledTo));
-        _ = browser.Commands[2].Arguments.Should()
+        _ = browser.Commands[2].Arguments.Should().Equal("sh", "-c", ExpectedGuardScript, "sh", TempPath);
+        _ = browser.Commands[3].Arguments.Should()
             .Equal("sh", "-c", ExpectedSpliceScript, "sh", ".conversations", TempPath, MainPath(RetitledTo));
     }
 
@@ -1173,7 +1264,7 @@ public sealed class ConversationTranscriptWriterTests
         browser.Commands.Clear();
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
         _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(Title), MainPath(RetitledTo));
-        _ = browser.Commands[1].Arguments[6].Should().Be(MainPath(Title));
+        _ = browser.Commands.Single(IsSplice).Arguments[6].Should().Be(MainPath(Title));
         _ = Written(browser, 1).Should().Be(ExpectedAppend(all, skip: 1));
 
         browser.ExecuteHandler = null;
@@ -1183,7 +1274,7 @@ public sealed class ConversationTranscriptWriterTests
         browser.Commands.Clear();
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
         _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(Title), MainPath(RetitledTo));
-        _ = browser.Commands[1].Arguments[6].Should().Be(MainPath(RetitledTo));
+        _ = browser.Commands.Single(IsSplice).Arguments[6].Should().Be(MainPath(RetitledTo));
         _ = Written(browser, 2).Should().Be(ExpectedAppend(everything, skip: 2));
     }
 
@@ -1228,11 +1319,13 @@ public sealed class ConversationTranscriptWriterTests
         _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
 
         // Adopted by the same move the warm path uses, and BEFORE the tail that recovers the watermark —
-        // otherwise the watermark is read from a file this flush is about to stop writing to.
+        // otherwise the watermark is read from a file this flush is about to stop writing to. The call
+        // between them is the guard ahead of the ignore file's write, which reads and writes nothing.
         _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(RetitledTo), MainPath(Title));
         _ = browser.Commands[1].Arguments.Should()
             .Equal("mv", "--", AgentsDirectory(RetitledTo), AgentsDirectory(Title));
-        _ = browser.Commands[2].Arguments.Should()
+        _ = browser.Commands[2].Arguments.Should().Equal("sh", "-c", ExpectedGuardScript, "sh", GitignorePath);
+        _ = browser.Commands[3].Arguments.Should()
             .Equal("sh", "-c", ExpectedProbeScript, "sh", MainPath(Title), "5", "256");
 
         // One transcript, and the sub-agent file lands under it rather than beside the abandoned name.
@@ -1515,11 +1608,11 @@ public sealed class ConversationTranscriptWriterTests
 
     /// <summary>
     /// The security invariant, stated as a test. <c>ExecuteWorkspaceCommandAsync</c> is a native argv
-    /// vector with NO implicit shell, so every place a shell IS invoked — the splice that writes and the
-    /// watermark probe that reads — must carry a compile-time constant script: the file leaf is derived
-    /// from a user-authored title, and interpolating it into the script text would make <c>$(…)</c> in a
-    /// title executable. <c>--</c> on the pure-argv calls stops option parsing, but it is the positional
-    /// parameters that make the title inert.
+    /// vector with NO implicit shell, so every place a shell IS invoked — the splice that writes, the
+    /// watermark probe that reads, and the path guard that does neither — must carry a compile-time
+    /// constant script: the file leaf is derived from a user-authored title, and interpolating it into the
+    /// script text would make <c>$(…)</c> in a title executable. <c>--</c> on the pure-argv calls stops
+    /// option parsing, but it is the positional parameters that make the title inert.
     /// </summary>
     [Fact]
     public async Task EveryShellCall_UsesTheConstantScript_AndPassesTheTitleDerivedPathAsAPositionalParameter()
@@ -1542,13 +1635,15 @@ public sealed class ConversationTranscriptWriterTests
         _ = splices.Should().HaveCount(2);
         _ = shell.Should().HaveCountGreaterThan(
             splices.Count,
-            "the watermark probe is the other shell call site and is covered by this invariant too"
+            "the watermark probe and the path guard are the other shell call sites and are covered by this "
+                + "invariant too"
         );
 
         foreach (var command in shell)
         {
             _ = command.Arguments[1].Should().Be("-c");
-            _ = command.Arguments[2].Should().BeOneOf(ExpectedProbeScript, ExpectedSpliceScript);
+            _ = command.Arguments[2].Should()
+                .BeOneOf(ExpectedProbeScript, ExpectedSpliceScript, ExpectedGuardScript);
             _ = command.Arguments[3].Should().Be("sh");
 
             // Whatever the call touches reaches `sh` as a positional parameter, never as script text.
@@ -1561,9 +1656,10 @@ public sealed class ConversationTranscriptWriterTests
             _ = splice.Arguments[6].Should().Contain(leaf);
         }
 
-        // Neither script ever grows a dynamic fragment, and the pure-argv calls keep their `--`.
+        // No script ever grows a dynamic fragment, and the pure-argv calls keep their `--`.
         _ = ExpectedSpliceScript.Should().NotContain(leaf).And.NotContain(Hostile).And.NotContain("touch");
         _ = ExpectedProbeScript.Should().NotContain(leaf).And.NotContain(Hostile).And.NotContain("touch");
+        _ = ExpectedGuardScript.Should().NotContain(leaf).And.NotContain(Hostile).And.NotContain("touch");
         // Every shell call is covered by the loop above; what is left is the pure-argv calls, and none of
         // them may omit `--`. (Stated as "no call omits it" so the invariant does not change meaning when
         // a flow happens not to move anything.)

--- a/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Text;
 using AchieveAi.LmDotnetTools.LmCore.Utils;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
@@ -47,15 +48,19 @@ public sealed class ConversationTranscriptWriterTests
         + "cat \"$2\" >> \"$3\" && rm -f \"$2\"\n";
 
     /// <summary>
-    /// The cold-start watermark probe, duplicated for the same reason. Its text is a contract twice over:
-    /// the <c>[ -e ]</c> test is what makes "there is no transcript" an answer the script GIVES rather than
-    /// one the caller infers from a generic <c>tail</c> failure, and exit <c>42</c> is the private code that
+    /// The cold-start watermark probe, duplicated for the same reason. Its text is a contract three times
+    /// over: the <c>[ -e ]</c> test is what makes "there is no transcript" an answer the script GIVES rather
+    /// than one the caller infers from a generic <c>tail</c> failure; exit <c>42</c> is the private code that
     /// carries that answer back — a value neither <c>tail</c> (0/1) nor <c>sh</c> (126/127, 128+signal)
-    /// produces, so it cannot be minted by an accident.
+    /// produces, so it cannot be minted by an accident; and <c>cut -c "1-$3"</c> is what bounds the output,
+    /// without which a single multi-megabyte row makes the probe itself unanswerable. Exit <c>43</c> carries
+    /// the one fact truncation destroys — whether the file ends mid-record.
     /// </summary>
     private const string ExpectedProbeScript =
         "[ -e \"$1\" ] || exit 42\n"
-        + "exec tail -n \"$2\" -- \"$1\"\n";
+        + "tail -n \"$2\" -- \"$1\" | cut -c \"1-$3\" || exit 1\n"
+        + "end=$(tail -c1 -- \"$1\") || exit 1\n"
+        + "[ -z \"$end\" ] || exit 43\n";
 
     private static readonly string ShortThreadId = WorkspaceTranscriptLine.ShortId(ThreadId);
 
@@ -228,6 +233,54 @@ public sealed class ConversationTranscriptWriterTests
         new() { ExitCode = 42, StandardOutput = "", StandardError = "", OperationId = "op" };
 
     /// <summary>
+    /// What the probe reports when the window was read but the destination's last byte is NOT a newline —
+    /// it ends mid-record, so the window's last line is the torn half of a row. The literal 43 is
+    /// duplicated for the same reason as 42: truncation makes every returned line LOOK torn, so this one
+    /// code is the only thing left that can tell a torn tail from an intact one.
+    /// </summary>
+    private static SandboxCommandResult Partial(string stdout) =>
+        new()
+        {
+            ExitCode = 43,
+            StandardOutput = stdout,
+            StandardError = "",
+            OperationId = "op",
+        };
+
+    /// <summary>
+    /// Runs the probe's SHELL semantics over a simulated <paramref name="onDisk"/> file, so the writer is
+    /// tested against what the script would really hand back rather than against a hand-written window.
+    /// </summary>
+    /// <remarks>
+    /// The per-line cut is applied only if the caller ASKED for it. That is the whole point: a shell told
+    /// no character cap returns the tail in full, so a transcript holding one multi-megabyte row hands back
+    /// megabytes — which is the wedge, and which a test that hard-codes a pre-truncated window cannot see.
+    /// </remarks>
+    private static SandboxCommandResult SimulateProbe(SandboxCommand command, string onDisk)
+    {
+        var tailLines = int.Parse(command.Arguments[5], CultureInfo.InvariantCulture);
+        var records = onDisk.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var window = records.Skip(Math.Max(0, records.Length - tailLines));
+
+        if (command.Arguments.Count > 6)
+        {
+            var maxChars = int.Parse(command.Arguments[6], CultureInfo.InvariantCulture);
+            window = window.Select(line => line.Length <= maxChars ? line : line[..maxChars]);
+        }
+
+        var stdout = string.Concat(window.Select(line => line + "\n"));
+        return onDisk.EndsWith('\n') ? Ok(stdout) : Partial(stdout);
+    }
+
+    /// <summary>A transcript row whose <c>message_json</c> alone is <paramref name="megabytes"/> long.</summary>
+    /// <remarks>
+    /// Not an exaggerated fixture: on this revision a tool result is stored inline on the row, so a single
+    /// file listing or a build log lands as one line of exactly this shape.
+    /// </remarks>
+    private static PersistedMessage HugeMsg(string id, long timestamp, int megabytes = 3) =>
+        Msg(id, timestamp, messageJson: "\"" + new string('x', megabytes * 1024 * 1024) + "\"");
+
+    /// <summary>
     /// Selects the watermark probe out of a flush's commands. The splice is the call carrying the staged
     /// temp file; every other shell call in a flush is the probe.
     /// </summary>
@@ -267,7 +320,7 @@ public sealed class ConversationTranscriptWriterTests
 
         _ = browser.Commands.Should().HaveCount(2);
         _ = browser.Commands[0].Arguments.Should()
-            .Equal("sh", "-c", ExpectedProbeScript, "sh", MainPath(Title), "5");
+            .Equal("sh", "-c", ExpectedProbeScript, "sh", MainPath(Title), "5", "256");
         _ = browser.Commands[1].Arguments.Should()
             .Equal("sh", "-c", ExpectedSpliceScript, "sh", ".conversations", TempPath, MainPath(Title));
         _ = browser.LastPersistedWorkspaceId.Should().Be(WorkspaceId);
@@ -335,15 +388,141 @@ public sealed class ConversationTranscriptWriterTests
 
         var browser = new FakeFileBrowser
         {
-            ExecuteHandler = command => IsSplice(command) ? Ok() : Ok(intact + torn),
+            ExecuteHandler = command => IsSplice(command) ? Ok() : Partial(intact + torn),
         };
 
         _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
 
         _ = browser.Commands[0].Arguments.Should()
-            .Equal("sh", "-c", ExpectedProbeScript, "sh", MainPath(Title), "5");
+            .Equal("sh", "-c", ExpectedProbeScript, "sh", MainPath(Title), "5", "256");
         _ = Written(browser, 0).Should().Be(ExpectedAppend(messages, skip: 2));
         _ = browser.ReadCalls.Should().Be(0);
+    }
+
+    /// <summary>
+    /// The probe's output must be a small CONSTANT, whatever the file holds. A transcript row carries a
+    /// whole message and on this revision a tool result is stored inline, so ONE line reaches megabytes;
+    /// five of those exceed the gateway's command-output cap, the SDK throws, and the writer reads the
+    /// transport fault as an indeterminate probe and defers. A cold start re-probes every time, so it
+    /// defers again until the retry budget is spent and the transcript is never mirrored at all. The fix
+    /// has to bound the probe without reading the file (a GET downloads tens of megabytes) and without
+    /// giving up the ability to find a uid, so the bound is per LINE rather than over the window: a byte
+    /// budget spent on one huge first line would leave nothing to read.
+    /// </summary>
+    [Fact]
+    public async Task ColdStart_CapsTheProbeOutputPerLine_SoOneMultiMegabyteRowCannotWedgeTheProbe()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        PersistedMessage[] messages = [Msg("m1", 1, "User"), HugeMsg("m2", 2), Msg("m3", 3)];
+        await store.AppendMessagesAsync(ThreadId, messages);
+
+        // What a previous process left on disk: m1 and the multi-megabyte m2, written whole.
+        var onDisk = string.Concat(
+            ExpectedAppend(messages).Split('\n', StringSplitOptions.RemoveEmptyEntries).Take(2).Select(l => l + "\n")
+        );
+        _ = onDisk.Length.Should().BeGreaterThan(3 * 1024 * 1024);
+
+        var probeOutput = "";
+        var browser = new FakeFileBrowser
+        {
+            ExecuteHandler = command =>
+            {
+                if (IsSplice(command))
+                {
+                    return Ok();
+                }
+
+                var result = SimulateProbe(command, onDisk);
+                probeOutput = result.StandardOutput;
+                return result;
+            },
+        };
+
+        var outcome = await CreateWriter(store, browser).FlushAsync();
+
+        // The bound itself, in bytes the gateway would have had to carry.
+        _ = probeOutput.Length.Should()
+            .BeLessThan(
+                4096,
+                "the probe's output has to be bounded by a constant, not by the size of the rows it reads"
+            );
+
+        // And the bound cost nothing: the watermark is still found and only the new row goes down.
+        _ = outcome.Should().Be(TranscriptFlushOutcome.Written);
+        _ = Written(browser, 0).Should().Be(ExpectedAppend(messages, skip: 2));
+        _ = browser.ReadCalls.Should().Be(0);
+    }
+
+    /// <summary>
+    /// The other half of that bound: a TRUNCATED line still has to yield its watermark. It does because the
+    /// serializer pins the key order — <c>schema_version</c>, <c>type</c>, then <c>uid</c> — so the uid
+    /// survives inside the first few dozen characters of any row. Reading the window with a whole-document
+    /// parse throws that away: every truncated line fails to parse, the probe reports "no intact record",
+    /// and the writer starts from row one and re-appends the ENTIRE history onto a file that already holds
+    /// it — the exact duplication the probe exists to prevent.
+    /// </summary>
+    [Fact]
+    public async Task ColdStart_ReadsTheWatermarkOutOfATruncatedLine_InsteadOfReAppendingTheWholeHistory()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        PersistedMessage[] messages = [Msg("m1", 1, "User"), HugeMsg("m2", 2), Msg("m3", 3)];
+        await store.AppendMessagesAsync(ThreadId, messages);
+
+        // The window exactly as `tail -n 5 | cut -c 1-256` returns it: every line cut to its prefix, so the
+        // last one — the watermark — is a fragment rather than a document.
+        var onDisk = string.Concat(
+            ExpectedAppend(messages).Split('\n', StringSplitOptions.RemoveEmptyEntries).Take(2).Select(l => l + "\n")
+        );
+        var truncated = string.Concat(
+            onDisk
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .Select(line => (line.Length <= 256 ? line : line[..256]) + "\n")
+        );
+        _ = truncated.Split('\n', StringSplitOptions.RemoveEmptyEntries)[1].Should()
+            .HaveLength(256, "the row the watermark sits on is the one that got cut");
+
+        var browser = new FakeFileBrowser
+        {
+            ExecuteHandler = command => IsSplice(command) ? Ok() : Ok(truncated),
+        };
+
+        _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+        _ = Written(browser, 0).Should().Be(ExpectedAppend(messages, skip: 2));
+    }
+
+    /// <summary>
+    /// Truncating every line costs the ability to tell a torn last line from an intact one by parsing it,
+    /// so the shell reports that separately through exit 43 — and the writer must act on it. Here the file
+    /// ends mid-record: the window's last line reads as a perfectly good row (its uid is inside the prefix
+    /// that survived) but the row it belongs to was never fully written. Adopting its uid as the watermark
+    /// would skip that row for good, which is a LOSS rather than the duplicate every other failure mode
+    /// degrades to.
+    /// </summary>
+    [Fact]
+    public async Task ColdStart_DropsATornFinalRecord_RatherThanAdoptingAWatermarkForARowThatWasNeverWritten()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        PersistedMessage[] messages = [Msg("m1", 1, "User"), Msg("m2", 2), HugeMsg("m3", 3)];
+        await store.AppendMessagesAsync(ThreadId, messages);
+
+        // m1 and m2 landed; m3 is a multi-megabyte row whose splice was killed part way through, so the
+        // file ends with no trailing newline.
+        var lines = ExpectedAppend(messages).Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var onDisk = lines[0] + "\n" + lines[1] + "\n" + lines[2][..(1024 * 1024)];
+
+        var browser = new FakeFileBrowser
+        {
+            ExecuteHandler = command => IsSplice(command) ? Ok() : SimulateProbe(command, onDisk),
+        };
+
+        _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+
+        // m3 goes down again in full. The alternative — treating the torn prefix as m3's watermark — would
+        // have appended nothing and left the transcript permanently missing that row.
+        _ = Written(browser, 0).Should().Be(ExpectedAppend(messages, skip: 2));
     }
 
     /// <summary>
@@ -820,6 +999,91 @@ public sealed class ConversationTranscriptWriterTests
     }
 
     /// <summary>
+    /// A descendant whose splice FAILED has not been covered, and marking it covered anyway loses it
+    /// permanently. With a roster larger than the cap the loss is silent and complete: slice 1 fails on one
+    /// descendant and reports <c>Deferred</c>, the caller's retry runs slice 2, slice 2 succeeds — and
+    /// because the failed descendant was marked the moment it was PICKED rather than when it was written,
+    /// the sweep is now complete, the chain stops, and that descendant's transcript never exists. Nothing
+    /// reports an error: the flush that failed did say <c>Deferred</c>, and the retry it asked for did run.
+    /// </summary>
+    /// <remarks>
+    /// The failure here is transient and hits exactly ONE descendant ONCE, which is the realistic shape —
+    /// a single gateway hiccup — and it is also what makes the assertion unambiguous: every descendant is
+    /// writable by the time the sweep ends, so a missing file can only be a descendant the sweep decided it
+    /// had already handled.
+    /// </remarks>
+    [Fact]
+    public async Task SubAgentFanOut_RetriesADescendantWhoseSpliceFailed_EvenWhenALaterSliceSucceeds()
+    {
+        const int roster = 16;
+        const int cap = 8;
+
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+        for (var i = 0; i < roster; i++)
+        {
+            var id = $"a{i:00}";
+            await SeedSubAgentAsync(store, id, $"agent-{i:00}", Msg($"{id}m", 10 + i, threadId: $"subagent-{id}"));
+        }
+
+        var browser = new FakeFileBrowser();
+        string? firstAgentPath = null;
+        var burned = false;
+        var spliced = new List<string>();
+        browser.ExecuteHandler = command =>
+        {
+            if (!IsSplice(command))
+            {
+                return Ok();
+            }
+
+            var destination = command.Arguments[6];
+            if (!destination.StartsWith(AgentsDirectory(Title), StringComparison.Ordinal))
+            {
+                spliced.Add(destination);
+                return Ok();
+            }
+
+            firstAgentPath ??= destination;
+
+            // The very first descendant the very first slice touches, and only that one, and only once.
+            if (!burned && string.Equals(destination, firstAgentPath, StringComparison.Ordinal))
+            {
+                burned = true;
+                return Fail();
+            }
+
+            spliced.Add(destination);
+            return Ok();
+        };
+
+        var writer = CreateWriter(store, browser, maxSubAgentFilesPerFlush: cap);
+
+        // Stands in for the mirror's drain: keep flushing while the writer asks for another pass. The bound
+        // is the termination claim — (MaxDeferredRetries + 2) x ceil(roster / cap) is 10 here — so a
+        // writer that never stops asking fails this as a hang-detector rather than looping forever.
+        var passes = 0;
+        while (passes++ < 10)
+        {
+            var outcome = await writer.FlushAsync();
+            if (outcome is not (TranscriptFlushOutcome.Deferred or TranscriptFlushOutcome.Progressing))
+            {
+                break;
+            }
+        }
+
+        _ = burned.Should().BeTrue("the scenario is only meaningful if a descendant's splice actually failed");
+        _ = spliced.Should().Contain(
+            firstAgentPath,
+            "the descendant whose splice failed in the first slice was never retried, so its transcript does not exist"
+        );
+
+        var expected = Enumerable.Range(0, roster).Select(i => AgentPath(Title, $"a{i:00}", $"agent-{i:00}"));
+        _ = spliced.Should().Contain(expected);
+    }
+
+    /// <summary>
     /// A sub-agent that finishes AFTER its parent's turn ended never publishes the conversation's
     /// <c>RunCompletedMessage</c>, so a mirror listening only for run completion would never write its
     /// file. <see cref="ConversationTranscriptWriter.NoteSubAgentActivity"/> is that second trigger — and
@@ -969,7 +1233,7 @@ public sealed class ConversationTranscriptWriterTests
         _ = browser.Commands[1].Arguments.Should()
             .Equal("mv", "--", AgentsDirectory(RetitledTo), AgentsDirectory(Title));
         _ = browser.Commands[2].Arguments.Should()
-            .Equal("sh", "-c", ExpectedProbeScript, "sh", MainPath(Title), "5");
+            .Equal("sh", "-c", ExpectedProbeScript, "sh", MainPath(Title), "5", "256");
 
         // One transcript, and the sub-agent file lands under it rather than beside the abandoned name.
         _ = browser.Commands.Where(IsSplice).Select(c => c.Arguments[6])

--- a/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
@@ -1454,10 +1454,12 @@ public sealed class ConversationTranscriptWriterTests
     /// directory out with it.
     /// </para>
     /// <para>
-    /// Every OTHER consumer of this listing compares a name for EQUALITY against one it already holds
-    /// (<c>FileBrowserController</c>, four call sites), so a traversing name there simply never matches.
-    /// This is the only consumer that adopts a name it did not compute — which is why the gap exists here
-    /// and only here.
+    /// <c>FileBrowserController</c> lists the same way at five call sites. Four of them compare a name for
+    /// EQUALITY against one they already hold, so a traversing name there simply never matches. The fifth
+    /// projects every entry into a DTO for display and compares nothing — a rendered name rather than an
+    /// addressed one, which is a different risk class and not what this test covers. This remains the only
+    /// consumer that ADDRESSES the filesystem with a name it did not compute, which is why the gap exists
+    /// here and only here.
     /// </para>
     /// </remarks>
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
@@ -184,8 +184,14 @@ public sealed class ConversationTranscriptWriterTests
         return string.Concat(lines.Skip(skip).Select(l => WorkspaceTranscriptLine.Serialize(l) + "\n"));
     }
 
+    /// <summary>
+    /// The bytes of the i-th STAGED transcript payload. Selected by path rather than by absolute position
+    /// in <see cref="FakeFileBrowser.Writes"/> because the writer also PUTs the containment
+    /// <c>.gitignore</c>, ahead of the first append — a positional index would then be counting two
+    /// different kinds of write and would shift the moment containment moved.
+    /// </summary>
     private static string Written(FakeFileBrowser browser, int index) =>
-        Encoding.UTF8.GetString(browser.Writes[index].Bytes);
+        Encoding.UTF8.GetString(browser.Writes.Where(w => w.Path == TempPath).ElementAt(index).Bytes);
 
     private static IReadOnlyList<string> UidsIn(string payload) =>
         [
@@ -224,7 +230,7 @@ public sealed class ConversationTranscriptWriterTests
         var payload = ExpectedAppend(messages);
         _ = payload.Split('\n', StringSplitOptions.RemoveEmptyEntries).Should().HaveCount(3);
 
-        _ = browser.Writes[0].Path.Should().Be(TempPath);
+        _ = browser.Writes.Select(w => w.Path).Should().Equal(GitignorePath, TempPath);
         _ = Written(browser, 0).Should().Be(payload);
         _ = browser.Writes
             .Select(w => w.Path)
@@ -263,12 +269,12 @@ public sealed class ConversationTranscriptWriterTests
 
         PersistedMessage[] all = [.. first, .. second];
         _ = Written(browser, 0).Should().Be(ExpectedAppend(first));
-        _ = Written(browser, 2).Should().Be(ExpectedAppend(all, skip: 2));
+        _ = Written(browser, 1).Should().Be(ExpectedAppend(all, skip: 2));
 
         // No second tail: the watermark survived in process, keyed by thread.
         _ = browser.Commands.Select(c => c.Arguments[0]).Should().Equal("tail", "sh", "sh");
 
-        var file = Written(browser, 0) + Written(browser, 2);
+        var file = Written(browser, 0) + Written(browser, 1);
         var uids = UidsIn(file);
         _ = uids.Should().HaveCount(4);
         _ = uids.Distinct(StringComparer.Ordinal).Should().HaveCount(4);
@@ -328,7 +334,7 @@ public sealed class ConversationTranscriptWriterTests
         var writer = CreateWriter(store, browser);
 
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
-        _ = browser.Writes.Should().HaveCount(1);
+        _ = browser.Writes.Where(w => w.Path == TempPath).Should().ContainSingle();
 
         browser.ExecResult = Ok();
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
@@ -336,7 +342,10 @@ public sealed class ConversationTranscriptWriterTests
         var payload = ExpectedAppend(messages);
         _ = Written(browser, 0).Should().Be(payload);
         _ = Written(browser, 1).Should().Be(payload);
-        _ = browser.Writes[2].Path.Should().Be(GitignorePath);
+
+        // Containment came first and was not repeated: the failure was the splice, not the ignore file.
+        _ = browser.Writes[0].Path.Should().Be(GitignorePath);
+        _ = browser.Writes.Where(w => w.Path == GitignorePath).Should().ContainSingle();
     }
 
     // ---------------------------------------------------------------- AC 8
@@ -370,21 +379,56 @@ public sealed class ConversationTranscriptWriterTests
     /// The containment file is the entire opt-out for the feature, so "we tried once and it did not work"
     /// is not an acceptable resting state: the transcript is on disk, unignored, and the next
     /// <c>git add -A</c> an agent runs in that workspace publishes the conversation's unredacted reasoning
-    /// off-machine. Two things have to be true for the retry to exist at all — the flush that failed must
-    /// report work still pending, and a later flush must attempt the write even though it appends NOTHING.
-    /// Tying the attempt to "this flush wrote rows" fails the second: for a conversation whose only
-    /// appending flush already happened, the trigger never comes again.
+    /// off-machine. Ordering containment ahead of the append covers everything this process writes — but
+    /// not a transcript an EARLIER process left behind, which is on disk before this writer exists and may
+    /// have nothing further to append. So the attempt must also be made on a flush that appends NOTHING;
+    /// tying it to "this flush wrote rows" leaves that file uncovered forever.
     /// </summary>
     [Fact]
-    public async Task Gitignore_IsRetriedOnAFlushThatAppendsNothing_AfterItsFirstWriteFails()
+    public async Task Gitignore_IsWrittenOnAFlushThatAppendsNothing_ForATranscriptAnEarlierProcessLeft()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        PersistedMessage[] messages = [Msg("m1", 1, "User"), Msg("m2", 2)];
+        await store.AppendMessagesAsync(ThreadId, messages);
+
+        // Cold writer over a workspace whose transcript is already complete: the tail already ends at the
+        // last row, so no flush this writer ever runs has anything to append.
+        var existing = ExpectedAppend(messages);
+        var browser = new FakeFileBrowser
+        {
+            ExecuteHandler = command => command.Arguments[0] == "tail" ? Ok(existing) : Ok(),
+            WriteFailure = path =>
+                path == GitignorePath ? new SandboxException(SandboxErrorKind.Protocol, "gateway said no") : null,
+        };
+        var writer = CreateWriter(store, browser);
+
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = browser.Writes.Should().BeEmpty();
+
+        browser.WriteFailure = null;
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.UpToDate);
+        _ = browser.Writes.Should().ContainSingle(w => w.Path == GitignorePath);
+
+        // And nothing was appended on either pass — the rows were already there.
+        _ = browser.Writes.Where(w => w.Path == TempPath).Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Retrying containment is not enough on its own, because a retry budget can run out and a finished
+    /// conversation produces no further trigger. The ordering is what makes the guarantee unconditional:
+    /// containment is established BEFORE the first transcript byte reaches the workspace, so "reasoning on
+    /// disk with nothing covering it" is not a state the writer can be left in — not by a failed write, not
+    /// by an exhausted budget, not by a process that exits between the two calls. A conversation that never
+    /// gets its <c>.gitignore</c> written simply never gets a transcript either, which is the safe side.
+    /// </summary>
+    [Fact]
+    public async Task Gitignore_IsWrittenBeforeAnyTranscriptByte_SoAFailedContainmentLeavesNothingExposed()
     {
         var store = new InMemoryConversationStore();
         await SeedConversationAsync(store);
         await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
 
-        // ONLY the containment file fails. The rows themselves land — which is exactly the combination
-        // that makes the gap invisible: a complete transcript sitting in a git checkout with nothing
-        // covering it.
         var browser = new FakeFileBrowser
         {
             WriteFailure = path =>
@@ -392,17 +436,21 @@ public sealed class ConversationTranscriptWriterTests
         };
         var writer = CreateWriter(store, browser);
 
+        // Nothing staged, nothing spliced: the rows stay in the store, where they are already contained.
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
-        _ = browser.Writes.Select(w => w.Path).Should().NotContain(GitignorePath);
+        _ = browser.Writes.Should().BeEmpty();
+        _ = browser.Commands.Should().BeEmpty();
 
-        // The next flush has nothing whatsoever to append — and must still write the file.
+        // And a failure that is never followed by a successful flush still leaves nothing exposed — this is
+        // the resting state of a conversation whose last turn has already happened.
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = browser.Writes.Should().BeEmpty();
+        _ = browser.Commands.Should().BeEmpty();
+
         browser.WriteFailure = null;
-        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.UpToDate);
-        _ = browser.Writes.Should().ContainSingle(w => w.Path == GitignorePath);
-
-        // Deferring for containment must not re-appear as duplicated rows: the watermark advanced with the
-        // successful splice, so exactly one staged payload was ever written.
-        _ = browser.Writes.Where(w => w.Path == TempPath).Should().ContainSingle();
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+        _ = browser.Writes[0].Path.Should().Be(GitignorePath);
+        _ = browser.Writes[1].Path.Should().Be(TempPath);
     }
 
     // ---------------------------------------------------------------- AC 7, 12
@@ -522,7 +570,9 @@ public sealed class ConversationTranscriptWriterTests
         {
             if (command.Arguments[0] == "sh")
             {
-                stagedWhenSpliced.Add(browser.Writes.Count);
+                // Counted over STAGED writes only: the containment .gitignore is PUT ahead of the first
+                // append and is not a staged payload, so counting every write would just measure it.
+                stagedWhenSpliced.Add(browser.Writes.Count(w => w.Path == TempPath));
             }
 
             return Ok();
@@ -533,14 +583,14 @@ public sealed class ConversationTranscriptWriterTests
         // 1, 2, 3 — each splice sees its own PUT and nothing further. Any overlap shows up as a splice
         // observing a later file's staged bytes already sitting in the shared slot.
         _ = stagedWhenSpliced.Should().Equal(1, 2, 3);
-        _ = browser.Writes.Take(3).Select(w => w.Path).Should().AllBe(TempPath);
+        _ = browser.Writes.Skip(1).Take(3).Select(w => w.Path).Should().AllBe(TempPath);
     }
 
     /// <summary>
     /// The fan-out is bounded per flush and advances round-robin, so a conversation with many descendants
     /// is covered across successive flushes instead of holding the store's process-wide read semaphore for
-    /// every descendant at one turn boundary. A truncated pass reports <c>Deferred</c> so another flush
-    /// follows.
+    /// every descendant at one turn boundary. A truncated pass reports <c>Progressing</c> so another flush
+    /// follows — and once the sweep has covered everything, it stops asking.
     /// </summary>
     [Fact]
     public async Task SubAgentFanOut_IsBoundedPerFlush_AndCoversTheRestOnTheNextOne()
@@ -554,31 +604,29 @@ public sealed class ConversationTranscriptWriterTests
         var browser = new FakeFileBrowser();
         var writer = CreateWriter(store, browser, maxSubAgentFilesPerFlush: 1);
 
-        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Progressing);
         _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
             .Should().Equal(MainPath(Title), AgentPath(Title, "a1", "alpha"));
 
         browser.Commands.Clear();
-        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
         _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
             .Should().Equal(AgentPath(Title, "b2", "beta"));
 
-        // A capped pass keeps asking, whether or not its own slice had anything to write: "this slice is
-        // current" says nothing about the descendants outside it. What terminates the chain is the caller's
-        // bounded retry budget (WorkspaceTranscriptMirror.MaxDeferredRetries), reset at each turn boundary
-        // — so a large fan-out is paced a slice per attempt instead of either spinning or stopping one step
-        // short of the descendant that actually changed.
+        // The sweep has now visited every descendant, so the writer stops asking. Reporting Deferred here
+        // instead — as a capped pass once did — would spend the caller's FAILURE budget on a conversation
+        // where nothing failed, capping how far any single trigger can ever reach into a large roster.
         browser.Commands.Clear();
-        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.UpToDate);
         _ = browser.Commands.Should().BeEmpty();
     }
 
     /// <summary>
-    /// The consequence of the rule above, at the only scale where it is visible: the descendant that
-    /// changed is OUTSIDE the current slice. Ending the chain on the first capped pass whose own slice was
-    /// already current stops exactly one step short of it — the pass that would have covered it never runs,
-    /// and the sub-agent's rows sit unmirrored until some unrelated later trigger happens along. There is
-    /// no ordering that avoids this: the cursor cannot know which descendant moved without reading it.
+    /// The reason a capped pass keeps asking at all: the descendant that changed is OUTSIDE the current
+    /// slice, and "this slice is current" says nothing about the ones beyond it. Stopping on the first
+    /// capped pass whose own slice was already current ends one step short — the pass that would have
+    /// covered the changed descendant never runs. There is no ordering that avoids this: the cursor cannot
+    /// know which descendant moved without reading it.
     /// </summary>
     [Fact]
     public async Task SubAgentFanOut_KeepsAskingWhileCapped_SoAChangeBeyondTheSliceIsStillMirrored()
@@ -596,17 +644,50 @@ public sealed class ConversationTranscriptWriterTests
         _ = await writer.FlushAsync();
         _ = await writer.FlushAsync();
 
-        // Only the descendant the NEXT slice will not look at moves.
+        // Only the descendant the NEXT slice will not look at moves. In production that change IS an
+        // external trigger — the mirror observes the child's completion notification — and the trigger is
+        // what starts the fresh sweep this scenario depends on.
         await store.AppendMessagesAsync("subagent-b2", [Msg("b2b", 21, threadId: "subagent-b2")]);
+        writer.NoteExternalTrigger();
 
         browser.Commands.Clear();
-        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Progressing);
         _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Should().BeEmpty();
 
         browser.Commands.Clear();
-        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
         _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
             .Should().Equal(AgentPath(Title, "b2", "beta"));
+    }
+
+    /// <summary>
+    /// The chain has to END. "Keep asking while capped" with no notion of coverage asks forever — every
+    /// pass over a roster larger than the cap is a capped pass, so the writer requests a follow-up on a
+    /// conversation that is completely mirrored and quiet, and the only thing that stops it is the caller
+    /// burning a failure budget that exists for failures. Once a sweep has visited every descendant the
+    /// writer is done asking, and it does not start over until an external trigger says something moved.
+    /// </summary>
+    [Fact]
+    public async Task SubAgentFanOut_StopsAskingOnceEveryDescendantHasBeenCovered()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+        await SeedSubAgentAsync(store, "a1", "alpha", Msg("a1a", 10, threadId: "subagent-a1"));
+        await SeedSubAgentAsync(store, "b2", "beta", Msg("b2a", 20, threadId: "subagent-b2"));
+        await SeedSubAgentAsync(store, "c3", "gamma", Msg("c3a", 30, threadId: "subagent-c3"));
+
+        var browser = new FakeFileBrowser();
+        var writer = CreateWriter(store, browser, maxSubAgentFilesPerFlush: 1);
+
+        // While descendants remain unvisited the pass is still making progress and asks for a follow-up.
+        _ = (await writer.FlushAsync()).Should().NotBe(TranscriptFlushOutcome.UpToDate);
+        _ = (await writer.FlushAsync()).Should().NotBe(TranscriptFlushOutcome.UpToDate);
+
+        // The third pass completes the sweep, and the fourth has nothing left to ask about. Neither may
+        // report Deferred: nothing failed, and Deferred is what spends the caller's failure budget.
+        _ = (await writer.FlushAsync()).Should().NotBe(TranscriptFlushOutcome.Deferred);
+        _ = (await writer.FlushAsync()).Should().NotBe(TranscriptFlushOutcome.Deferred);
     }
 
     /// <summary>
@@ -700,7 +781,7 @@ public sealed class ConversationTranscriptWriterTests
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
         _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(Title), MainPath(RetitledTo));
         _ = browser.Commands[1].Arguments[6].Should().Be(MainPath(Title));
-        _ = Written(browser, 2).Should().Be(ExpectedAppend(all, skip: 1));
+        _ = Written(browser, 1).Should().Be(ExpectedAppend(all, skip: 1));
 
         browser.ExecuteHandler = null;
         PersistedMessage[] everything = [.. all, Msg("m3", 3)];
@@ -710,7 +791,7 @@ public sealed class ConversationTranscriptWriterTests
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
         _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(Title), MainPath(RetitledTo));
         _ = browser.Commands[1].Arguments[6].Should().Be(MainPath(RetitledTo));
-        _ = Written(browser, 3).Should().Be(ExpectedAppend(everything, skip: 2));
+        _ = Written(browser, 2).Should().Be(ExpectedAppend(everything, skip: 2));
     }
 
     /// <summary>
@@ -763,6 +844,79 @@ public sealed class ConversationTranscriptWriterTests
         // One transcript, and the sub-agent file lands under it rather than beside the abandoned name.
         _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
             .Should().Equal(MainPath(Title), AgentPath(Title, "a1", "alpha"));
+    }
+
+    /// <summary>
+    /// The listing is the cold writer's ONLY route to the file it already owns, so a listing that FAILS and
+    /// a directory that is genuinely empty cannot be answered the same way. Treating a transport or
+    /// protocol failure as "nothing to adopt" recreates the split transcript above — the old file frozen
+    /// under its old slug, a second one restarting the history from zero — except now it is triggered by a
+    /// momentary gateway fault rather than by a real absence, and the adoption path never runs again
+    /// because the second file IS the computed leaf from then on. A failure defers instead: nothing is
+    /// appended, nothing is renamed, and the next flush asks again.
+    /// </summary>
+    [Fact]
+    public async Task ColdStart_DefersWhenTheDirectoryListingFails_InsteadOfAdoptingASecondTranscript()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+
+        // The conversation's transcript IS in the workspace, under the slug in force when it was written.
+        var stale = WorkspaceTranscriptLine.MainFileLeaf(RetitledTo, ShortThreadId);
+        var browser = new FakeFileBrowser
+        {
+            ListThrows = new SandboxException(SandboxErrorKind.Protocol, "gateway said no"),
+        };
+        browser.Listings[ConversationTranscriptWriter.TranscriptDirectory] =
+        [
+            new SandboxDirectoryEntry(
+                $"{stale}{ConversationTranscriptWriter.TranscriptExtension}",
+                SandboxEntryType.File,
+                128,
+                NameLossy: false
+            ),
+        ];
+
+        var writer = CreateWriter(store, browser);
+
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = browser.Writes.Should().BeEmpty();
+        _ = browser.Commands.Should().BeEmpty();
+
+        // And once the gateway answers, the SAME writer adopts the file that was there all along.
+        browser.ListThrows = null;
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+        _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(RetitledTo), MainPath(Title));
+        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+            .Should().Equal(MainPath(Title));
+    }
+
+    /// <summary>
+    /// The other side of that discrimination, and the reason it has to be narrow: a workspace that has
+    /// never held a transcript answers the listing with a DEFINITE miss, and that is the ordinary
+    /// first-flush case rather than a fault. Deferring on it would leave every brand-new conversation
+    /// spinning its retry budget and never writing a first line.
+    /// </summary>
+    [Fact]
+    public async Task ColdStart_TreatsADefinitelyMissingDirectoryAsNothingToAdopt()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        PersistedMessage[] messages = [Msg("m1", 1, "User")];
+        await store.AppendMessagesAsync(ThreadId, messages);
+
+        var browser = new FakeFileBrowser
+        {
+            ListThrows = new SandboxException(SandboxErrorKind.NotFound, "no such path")
+            {
+                ErrorCode = "path_not_found",
+            },
+        };
+
+        _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+        _ = browser.Commands.Where(c => c.Arguments[0] == "sh").Select(c => c.Arguments[6])
+            .Should().Equal(MainPath(Title));
     }
 
     // ---------------------------------------------------------------- AC 19

--- a/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
@@ -91,6 +91,27 @@ public sealed class ConversationTranscriptWriterTests
     /// </summary>
     private const string ExpectedGuardScript = ExpectedGuardPreamble + "guard \"$1\" || exit 44\n";
 
+    /// <summary>
+    /// The rename script, duplicated for the same reason and carrying the same weight. Its text is a
+    /// contract three times over. The <c>target()</c> check is not belt-and-braces: <c>mv A B</c> moves A
+    /// INSIDE B whenever B resolves to a directory, symlinked or not, so an unguarded rename relocates the
+    /// whole transcript out of <c>.conversations</c> and out from under the <c>.gitignore</c> — a rename
+    /// does NOT merely "replace the destination path", which was the belief that left this call site
+    /// unguarded for several rounds. <c>-T</c> closes the window outright by making the destination a NAME,
+    /// and is tried first; it is a GNU extension, so the plain form has to remain behind it for a BSD
+    /// <c>mv</c>. And that fallback is only safe because <c>target</c> is re-run before it: <c>mv -T</c>
+    /// also fails on a real non-empty directory, which is exactly the <c>_agents</c> case, and a bare
+    /// fallback would then nest.
+    /// </summary>
+    private const string ExpectedMoveScript =
+        ExpectedGuardPreamble
+        + "target() { guard \"$1\" || exit 44; [ ! -d \"$1\" ] || exit 45; }\n"
+        + "guard \"$1\" || exit 44\n"
+        + "target \"$2\"\n"
+        + "mv -T -- \"$1\" \"$2\" 2>/dev/null && exit 0\n"
+        + "target \"$2\"\n"
+        + "mv -- \"$1\" \"$2\"\n";
+
     private static readonly string ShortThreadId = WorkspaceTranscriptLine.ShortId(ThreadId);
 
     private static readonly string TempPath =
@@ -323,6 +344,9 @@ public sealed class ConversationTranscriptWriterTests
     /// <inheritdoc cref="IsSplice"/>
     private static bool IsGuard(SandboxCommand command) => RunsScript(command, ExpectedGuardScript);
 
+    /// <inheritdoc cref="IsSplice"/>
+    private static bool IsMove(SandboxCommand command) => RunsScript(command, ExpectedMoveScript);
+
     private static bool RunsScript(SandboxCommand command, string script) =>
         command.Arguments.Count > 2 && string.Equals(command.Arguments[2], script, StringComparison.Ordinal);
 
@@ -398,8 +422,8 @@ public sealed class ConversationTranscriptWriterTests
         _ = Written(browser, 1).Should().Be(ExpectedAppend(all, skip: 2));
 
         // No second probe: the watermark survived in process, keyed by thread. Nor a second containment
-        // guard: the ignore file is written once per writer. The staging guard DOES run again — it is per
-        // flush, not per writer, because a symlink can be planted between two flushes.
+        // guard: the ignore file is written once per writer. The staging guard DOES run again — it runs
+        // before EVERY staging PUT, because a symlink can be planted between any two of them.
         _ = browser.Commands.Select(c => c.Arguments[2]).Should()
             .Equal(
                 ExpectedGuardScript,
@@ -1232,9 +1256,10 @@ public sealed class ConversationTranscriptWriterTests
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
 
         _ = browser.Commands.Should().HaveCount(4);
-        _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(Title), MainPath(RetitledTo));
+        _ = browser.Commands[0].Arguments.Should()
+            .Equal("sh", "-c", ExpectedMoveScript, "sh", MainPath(Title), MainPath(RetitledTo));
         _ = browser.Commands[1].Arguments.Should()
-            .Equal("mv", "--", AgentsDirectory(Title), AgentsDirectory(RetitledTo));
+            .Equal("sh", "-c", ExpectedMoveScript, "sh", AgentsDirectory(Title), AgentsDirectory(RetitledTo));
         _ = browser.Commands[2].Arguments.Should().Equal("sh", "-c", ExpectedGuardScript, "sh", TempPath);
         _ = browser.Commands[3].Arguments.Should()
             .Equal("sh", "-c", ExpectedSpliceScript, "sh", ".conversations", TempPath, MainPath(RetitledTo));
@@ -1256,14 +1281,15 @@ public sealed class ConversationTranscriptWriterTests
         var writer = CreateWriter(store, browser);
         _ = await writer.FlushAsync();
 
-        browser.ExecuteHandler = command => command.Arguments[0] == "mv" ? Fail("device busy") : Ok();
+        browser.ExecuteHandler = command => IsMove(command) ? Fail("device busy") : Ok();
         await SeedConversationAsync(store, RetitledTo);
         PersistedMessage[] all = [Msg("m1", 1, "User"), Msg("m2", 2)];
         await store.AppendMessagesAsync(ThreadId, [all[1]]);
 
         browser.Commands.Clear();
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
-        _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(Title), MainPath(RetitledTo));
+        _ = browser.Commands[0].Arguments.Should()
+            .Equal("sh", "-c", ExpectedMoveScript, "sh", MainPath(Title), MainPath(RetitledTo));
         _ = browser.Commands.Single(IsSplice).Arguments[6].Should().Be(MainPath(Title));
         _ = Written(browser, 1).Should().Be(ExpectedAppend(all, skip: 1));
 
@@ -1273,7 +1299,8 @@ public sealed class ConversationTranscriptWriterTests
 
         browser.Commands.Clear();
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
-        _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(Title), MainPath(RetitledTo));
+        _ = browser.Commands[0].Arguments.Should()
+            .Equal("sh", "-c", ExpectedMoveScript, "sh", MainPath(Title), MainPath(RetitledTo));
         _ = browser.Commands.Single(IsSplice).Arguments[6].Should().Be(MainPath(RetitledTo));
         _ = Written(browser, 2).Should().Be(ExpectedAppend(everything, skip: 2));
     }
@@ -1321,9 +1348,10 @@ public sealed class ConversationTranscriptWriterTests
         // Adopted by the same move the warm path uses, and BEFORE the tail that recovers the watermark —
         // otherwise the watermark is read from a file this flush is about to stop writing to. The call
         // between them is the guard ahead of the ignore file's write, which reads and writes nothing.
-        _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(RetitledTo), MainPath(Title));
+        _ = browser.Commands[0].Arguments.Should()
+            .Equal("sh", "-c", ExpectedMoveScript, "sh", MainPath(RetitledTo), MainPath(Title));
         _ = browser.Commands[1].Arguments.Should()
-            .Equal("mv", "--", AgentsDirectory(RetitledTo), AgentsDirectory(Title));
+            .Equal("sh", "-c", ExpectedMoveScript, "sh", AgentsDirectory(RetitledTo), AgentsDirectory(Title));
         _ = browser.Commands[2].Arguments.Should().Equal("sh", "-c", ExpectedGuardScript, "sh", GitignorePath);
         _ = browser.Commands[3].Arguments.Should()
             .Equal("sh", "-c", ExpectedProbeScript, "sh", MainPath(Title), "5", "256");
@@ -1374,7 +1402,8 @@ public sealed class ConversationTranscriptWriterTests
         // And once the gateway answers, the SAME writer adopts the file that was there all along.
         browser.ListThrows = null;
         _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
-        _ = browser.Commands[0].Arguments.Should().Equal("mv", "--", MainPath(RetitledTo), MainPath(Title));
+        _ = browser.Commands[0].Arguments.Should()
+            .Equal("sh", "-c", ExpectedMoveScript, "sh", MainPath(RetitledTo), MainPath(Title));
         _ = browser.Commands.Where(c => IsSplice(c)).Select(c => c.Arguments[6])
             .Should().Equal(MainPath(Title));
     }
@@ -1609,10 +1638,10 @@ public sealed class ConversationTranscriptWriterTests
     /// <summary>
     /// The security invariant, stated as a test. <c>ExecuteWorkspaceCommandAsync</c> is a native argv
     /// vector with NO implicit shell, so every place a shell IS invoked — the splice that writes, the
-    /// watermark probe that reads, and the path guard that does neither — must carry a compile-time
-    /// constant script: the file leaf is derived from a user-authored title, and interpolating it into the
-    /// script text would make <c>$(…)</c> in a title executable. <c>--</c> on the pure-argv calls stops
-    /// option parsing, but it is the positional parameters that make the title inert.
+    /// watermark probe that reads, the rename that moves and the path guard that does none of those — must
+    /// carry a compile-time constant script: the file leaf is derived from a user-authored title, and
+    /// interpolating it into the script text would make <c>$(…)</c> in a title executable. The positional
+    /// parameters are what make the title inert.
     /// </summary>
     [Fact]
     public async Task EveryShellCall_UsesTheConstantScript_AndPassesTheTitleDerivedPathAsAPositionalParameter()
@@ -1643,7 +1672,7 @@ public sealed class ConversationTranscriptWriterTests
         {
             _ = command.Arguments[1].Should().Be("-c");
             _ = command.Arguments[2].Should()
-                .BeOneOf(ExpectedProbeScript, ExpectedSpliceScript, ExpectedGuardScript);
+                .BeOneOf(ExpectedProbeScript, ExpectedSpliceScript, ExpectedGuardScript, ExpectedMoveScript);
             _ = command.Arguments[3].Should().Be("sh");
 
             // Whatever the call touches reaches `sh` as a positional parameter, never as script text.
@@ -1656,15 +1685,17 @@ public sealed class ConversationTranscriptWriterTests
             _ = splice.Arguments[6].Should().Contain(leaf);
         }
 
-        // No script ever grows a dynamic fragment, and the pure-argv calls keep their `--`.
+        // No script ever grows a dynamic fragment.
         _ = ExpectedSpliceScript.Should().NotContain(leaf).And.NotContain(Hostile).And.NotContain("touch");
         _ = ExpectedProbeScript.Should().NotContain(leaf).And.NotContain(Hostile).And.NotContain("touch");
         _ = ExpectedGuardScript.Should().NotContain(leaf).And.NotContain(Hostile).And.NotContain("touch");
-        // Every shell call is covered by the loop above; what is left is the pure-argv calls, and none of
-        // them may omit `--`. (Stated as "no call omits it" so the invariant does not change meaning when
-        // a flow happens not to move anything.)
-        _ = browser.Commands.Where(c => c.Arguments[0] != "sh")
-            .Should().NotContain(c => !c.Arguments.Contains("--"));
+        _ = ExpectedMoveScript.Should().NotContain(leaf).And.NotContain(Hostile).And.NotContain("touch");
+
+        // And there is nothing left OUTSIDE the loop above. The rename was the last workspace call issued
+        // as a bare argv, which also made it the one workspace mutation with no path guard in scope; now
+        // every command the writer emits is a shell call running one of the four constant scripts, so the
+        // loop's coverage is total rather than partial.
+        _ = browser.Commands.Should().OnlyContain(c => c.Arguments[0] == "sh");
     }
 
     // ---------------------------------------------------------------- doubles

--- a/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
@@ -1435,6 +1435,65 @@ public sealed class ConversationTranscriptWriterTests
             .Should().Equal(MainPath(Title));
     }
 
+    /// <summary>
+    /// The adopted leaf is the one path component in this type the writer does NOT compute. It arrives as
+    /// a <c>name</c> field in the gateway's JSON listing and the writer builds a filesystem path out of it.
+    /// <see cref="SandboxDirectoryEntry.Name"/> documents itself as a non-recursive name "excluding
+    /// <c>.</c> and <c>..</c>" — but nothing enforces that: <c>SandboxClient.ListDirectoryEntriesAsync</c>
+    /// checks only that a name is present, and says in terms that per-entry validation is "left to each
+    /// caller's projection". This is that projection, so the check belongs here.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A name carrying <c>/</c> defeats every guard in the type, and not narrowly. The ancestor walk tests
+    /// each component with <c>[ -L ]</c>, and <c>..</c> is a real directory rather than a symlink, so the
+    /// walk passes; the path then reaches <c>cat &gt;&gt; "$3"</c> inside the container, which no gateway
+    /// path validation mediates because it is argv to a shell rather than a file API call. The unredacted
+    /// transcript lands outside <c>.conversations</c> — outside the <c>.gitignore</c> that is the entire
+    /// containment mechanism — at exit code 0, and the sub-agent fan-out takes the <c>_agents</c>
+    /// directory out with it.
+    /// </para>
+    /// <para>
+    /// Every OTHER consumer of this listing compares a name for EQUALITY against one it already holds
+    /// (<c>FileBrowserController</c>, four call sites), so a traversing name there simply never matches.
+    /// This is the only consumer that adopts a name it did not compute — which is why the gap exists here
+    /// and only here.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task ColdStart_RefusesAListedNameThatIsNotASinglePathComponent()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1, "User")]);
+        await SeedSubAgentAsync(store, "a1", "alpha", Msg("a1a", 10, threadId: "subagent-a1"));
+
+        // Shaped to pass every filter the projection applies: typed File, not lossy, .jsonl suffix, and a
+        // stem ending in this conversation's short id. Only its SHAPE disqualifies it.
+        var browser = new FakeFileBrowser();
+        browser.Listings[ConversationTranscriptWriter.TranscriptDirectory] =
+        [
+            new SandboxDirectoryEntry(
+                $"../../../escape-{ShortThreadId}{ConversationTranscriptWriter.TranscriptExtension}",
+                SandboxEntryType.File,
+                128,
+                NameLossy: false
+            ),
+        ];
+
+        _ = (await CreateWriter(store, browser).FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+
+        // Nothing the writer hands the container may leave the transcript directory, by any route.
+        _ = browser.Commands.SelectMany(c => c.Arguments).Concat(browser.Writes.Select(w => w.Path))
+            .Should().NotContain(argument => argument.Contains("..", StringComparison.Ordinal));
+
+        // The traversing name is ignored rather than renamed onto: adopting it and then MOVING it would
+        // read the file from outside the workspace just as surely as writing to it would.
+        _ = browser.Commands.Should().NotContain(command => IsMove(command));
+        _ = browser.Commands.Where(IsSplice).Select(c => c.Arguments[6])
+            .Should().Equal(MainPath(Title), AgentPath(Title, "a1", "alpha"));
+    }
+
     // ---------------------------------------------------------------- AC 19
 
     /// <summary>

--- a/tests/LmStreaming.Sample.Tests/Services/TranscriptFlushSchedulerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/TranscriptFlushSchedulerTests.cs
@@ -1,0 +1,374 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using LmStreaming.Sample.Services;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// Concurrency contract of <see cref="TranscriptFlushScheduler"/> (#251). The scheduler is a deliberate
+/// copy of <c>UsagePersistenceWriter</c>'s Schedule/Drain shape — that type is internal to LmMultiTurn and
+/// visible only to test assemblies, not to the sample's production assembly — so it carries its own tests.
+/// The two copy-specific behaviours are pinned here: pending work is a SET of keys (one conversation's
+/// pending flush is never dropped by another's), and a failing key is caught PER KEY so it cannot strand
+/// every other conversation.
+/// <para>
+/// Synchronisation is by <see cref="TaskCompletionSource"/> / <see cref="SemaphoreSlim"/> throughout. The
+/// only timeouts are failure bounds (a hang fails the test) and two deliberately-bounded negative windows,
+/// noted where they appear — neither can produce a false failure.
+/// </para>
+/// </summary>
+public sealed class TranscriptFlushSchedulerTests
+{
+    private static readonly TimeSpan FailureTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Long enough to observe a flush that should not happen; short enough to keep tests fast.</summary>
+    private static readonly TimeSpan NegativeWindow = TimeSpan.FromMilliseconds(300);
+
+    private static TaskCompletionSource Signal() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>Records which keys were flushed, and lets a test await the Nth flush of a given key.</summary>
+    private sealed class FlushRecorder
+    {
+        private readonly ConcurrentDictionary<string, SemaphoreSlim> _signals = new(StringComparer.Ordinal);
+        private readonly ConcurrentQueue<string> _flushed = new();
+
+        public IReadOnlyCollection<string> Flushed => _flushed;
+
+        public SemaphoreSlim SignalFor(string key) =>
+            _signals.GetOrAdd(key, static _ => new SemaphoreSlim(0));
+
+        public void Record(string key)
+        {
+            _flushed.Enqueue(key);
+            _ = SignalFor(key).Release();
+        }
+
+        /// <summary>Awaits one more flush of <paramref name="key"/>; fails the test rather than hanging.</summary>
+        public async Task WaitForFlushAsync(string key)
+        {
+            var observed = await SignalFor(key).WaitAsync(FailureTimeout);
+            observed.Should().BeTrue($"'{key}' should have been flushed within {FailureTimeout}");
+        }
+    }
+
+    /// <summary>
+    /// AC 8. <c>Schedule()</c> must not put I/O on the caller's thread. Proven two ways at once, both
+    /// deterministic: the flush callback never completes until the test releases it (so a <c>Schedule</c>
+    /// that awaited it would deadlock and fail on the xunit timeout rather than pass by luck), and the
+    /// callback provably runs on a different thread than the one that called <c>Schedule</c> — which is what
+    /// the <c>await Task.Yield()</c> at the top of the drain buys, since <c>Schedule</c> starts the drain
+    /// while holding its lock.
+    /// </summary>
+    [Fact]
+    public async Task Schedule_ReturnsWithoutRunningTheFlushOnTheCallersThread()
+    {
+        var entered = Signal();
+        var release = Signal();
+        var flushThreadId = 0;
+        using var scheduler = new TranscriptFlushScheduler(
+            (_, _) =>
+            {
+                flushThreadId = Environment.CurrentManagedThreadId;
+                entered.SetResult();
+                return release.Task;
+            }
+        );
+        var callerThreadId = Environment.CurrentManagedThreadId;
+
+        scheduler.Schedule("a");
+
+        await entered.Task.WaitAsync(FailureTimeout);
+        flushThreadId
+            .Should()
+            .NotBe(
+                callerThreadId,
+                "the drain yields before touching the flush, so no I/O can run on the subscriber's thread"
+            );
+        release.SetResult();
+    }
+
+    [Fact]
+    public async Task TwoDistinctKeys_AreBothFlushed()
+    {
+        var recorder = new FlushRecorder();
+        using var scheduler = new TranscriptFlushScheduler(
+            (key, _) =>
+            {
+                recorder.Record(key);
+                return Task.CompletedTask;
+            }
+        );
+
+        scheduler.Schedule("a");
+        scheduler.Schedule("b");
+
+        await recorder.WaitForFlushAsync("a");
+        await recorder.WaitForFlushAsync("b");
+    }
+
+    /// <summary>
+    /// The reason pending work is a SET and not one <c>bool</c> slot: with a single slot, scheduling
+    /// conversation B while conversation A's flush is in flight silently consumes A's re-arm, so A's newest
+    /// turn never reaches disk.
+    /// </summary>
+    [Fact]
+    public async Task KeyScheduledWhileAnotherKeyIsInFlight_IsNotDropped()
+    {
+        var recorder = new FlushRecorder();
+        var entered = Signal();
+        var release = Signal();
+        using var scheduler = new TranscriptFlushScheduler(
+            (key, _) =>
+            {
+                if (key == "a" && entered.TrySetResult())
+                {
+                    return release.Task;
+                }
+
+                recorder.Record(key);
+                return Task.CompletedTask;
+            }
+        );
+
+        scheduler.Schedule("a");
+        await entered.Task.WaitAsync(FailureTimeout);
+        scheduler.Schedule("a");
+        scheduler.Schedule("b");
+        release.SetResult();
+
+        await recorder.WaitForFlushAsync("a");
+        await recorder.WaitForFlushAsync("b");
+    }
+
+    /// <summary>
+    /// THE regression test for this copy. <c>UsagePersistenceWriter</c>'s catch re-arms the pending flag and
+    /// returns, aborting the drain — so with N keys one permanently-broken conversation strands every other
+    /// one, and the re-armed failing key is picked first by the restarted drain and aborts it again. Here the
+    /// catch is per key, so a healthy key keeps flushing across cycle after cycle beside a key that always
+    /// throws.
+    /// </summary>
+    [Fact]
+    public async Task PermanentlyFailingKey_DoesNotStrandAHealthyKey()
+    {
+        const int cycles = 5;
+        var recorder = new FlushRecorder();
+        var errors = new ConcurrentQueue<(string Key, Exception Error)>();
+        using var scheduler = new TranscriptFlushScheduler(
+            (key, _) =>
+            {
+                if (key == "broken")
+                {
+                    throw new InvalidOperationException("this conversation's flush is permanently broken");
+                }
+
+                recorder.Record(key);
+                return Task.CompletedTask;
+            },
+            (key, error) => errors.Enqueue((key, error))
+        );
+
+        for (var cycle = 0; cycle < cycles; cycle++)
+        {
+            scheduler.Schedule("broken");
+            scheduler.Schedule("healthy");
+            await recorder.WaitForFlushAsync("healthy");
+        }
+
+        recorder
+            .Flushed.Count(key => key == "healthy")
+            .Should()
+            .BeGreaterThanOrEqualTo(cycles, "a broken conversation must never block a healthy one");
+        errors.Should().NotBeEmpty();
+        errors
+            .Select(entry => entry.Key)
+            .Should()
+            .AllBe("broken", "the failure is reported against the key that failed");
+        errors.Select(entry => entry.Error).Should().AllBeOfType<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// Re-scheduling a key whose flush is already in flight must earn exactly one more flush: the key left
+    /// the pending set before the flush began, so re-adding it is neither lost (the new lines would never be
+    /// written) nor duplicated per call (a burst of turn boundaries would multiply gateway calls).
+    /// </summary>
+    [Fact]
+    public async Task ReschedulingAKeyMidFlight_CoalescesIntoExactlyOneMoreFlush()
+    {
+        var recorder = new FlushRecorder();
+        var entered = Signal();
+        var release = Signal();
+        var calls = 0;
+        var scheduler = new TranscriptFlushScheduler(
+            (key, _) =>
+            {
+                if (Interlocked.Increment(ref calls) == 1)
+                {
+                    entered.SetResult();
+                    return release.Task;
+                }
+
+                recorder.Record(key);
+                return Task.CompletedTask;
+            }
+        );
+
+        scheduler.Schedule("a");
+        await entered.Task.WaitAsync(FailureTimeout);
+        scheduler.Schedule("a");
+        scheduler.Schedule("a");
+        scheduler.Schedule("a");
+        release.SetResult();
+        await recorder.WaitForFlushAsync("a");
+
+        // Dispose waits on the drain, so once it returns the call count can no longer move.
+        scheduler.Dispose();
+        calls.Should().Be(2, "three re-schedules of an in-flight key collapse into one follow-up flush");
+    }
+
+    [Fact]
+    public void Dispose_WhenIdle_DoesNotThrowAndIsIdempotent()
+    {
+        var scheduler = new TranscriptFlushScheduler((_, _) => Task.CompletedTask);
+
+        var dispose = scheduler.Dispose;
+
+        dispose.Should().NotThrow();
+        dispose.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// Disposal waits BOUNDED on the in-flight flush. The callback here ignores the cancellation token, so
+    /// this proves the bound itself rather than cooperative cancellation — host teardown must not hang on a
+    /// gateway call that never returns.
+    /// </summary>
+    [Fact]
+    public async Task Dispose_WithAFlushThatNeverCompletes_ReturnsPromptly()
+    {
+        var entered = Signal();
+        var release = Signal();
+        var scheduler = new TranscriptFlushScheduler(
+            (_, _) =>
+            {
+                entered.SetResult();
+                return release.Task;
+            },
+            shutdownDrainTimeout: TimeSpan.FromMilliseconds(150)
+        );
+        scheduler.Schedule("a");
+        await entered.Task.WaitAsync(FailureTimeout);
+
+        var elapsed = Stopwatch.StartNew();
+        scheduler.Dispose();
+        elapsed.Stop();
+
+        elapsed.Elapsed.Should().BeLessThan(FailureTimeout, "the wait on an in-flight drain is bounded");
+        release.SetResult();
+    }
+
+    /// <summary>
+    /// Proves the CUT: there is no disposal-time flush. A key pending when <c>Dispose</c> is called is
+    /// dropped, not written — an awaited shutdown flush loses a race with the sandbox session registry's
+    /// disposal guard and is swallowed anyway, so the gap is accepted and documented rather than papered over.
+    /// The negative window can only weaken this assertion, never make it fail spuriously.
+    /// </summary>
+    [Fact]
+    public async Task Dispose_DoesNotFlushKeysThatWereStillPending()
+    {
+        var recorder = new FlushRecorder();
+        var entered = Signal();
+        var release = Signal();
+        var scheduler = new TranscriptFlushScheduler(
+            (key, _) =>
+            {
+                if (key == "a")
+                {
+                    entered.SetResult();
+                    return release.Task;
+                }
+
+                recorder.Record(key);
+                return Task.CompletedTask;
+            },
+            shutdownDrainTimeout: TimeSpan.FromMilliseconds(150)
+        );
+
+        scheduler.Schedule("a");
+        await entered.Task.WaitAsync(FailureTimeout);
+        scheduler.Schedule("b");
+        scheduler.Dispose();
+        release.SetResult();
+
+        var flushedB = await recorder.SignalFor("b").WaitAsync(NegativeWindow);
+        flushedB.Should().BeFalse("disposal drops pending work; it deliberately does not flush it");
+        recorder.Flushed.Should().NotContain("b");
+    }
+
+    [Fact]
+    public async Task Schedule_AfterDispose_IsANoOp()
+    {
+        var recorder = new FlushRecorder();
+        var scheduler = new TranscriptFlushScheduler(
+            (key, _) =>
+            {
+                recorder.Record(key);
+                return Task.CompletedTask;
+            }
+        );
+        scheduler.Dispose();
+
+        var schedule = () => scheduler.Schedule("a");
+
+        schedule.Should().NotThrow("a best-effort mirror must not throw into the subscriber loop");
+        (await recorder.SignalFor("a").WaitAsync(NegativeWindow))
+            .Should()
+            .BeFalse("nothing scheduled after disposal is flushed");
+    }
+
+    /// <summary>
+    /// The error channel must not be able to stop the loop: a throwing <c>onError</c> would otherwise fault
+    /// the drain task and leave the fault unobserved.
+    /// </summary>
+    [Fact]
+    public async Task ThrowingErrorCallback_DoesNotStopTheDrain()
+    {
+        var recorder = new FlushRecorder();
+        using var scheduler = new TranscriptFlushScheduler(
+            (key, _) =>
+            {
+                if (key == "broken")
+                {
+                    throw new InvalidOperationException("flush failed");
+                }
+
+                recorder.Record(key);
+                return Task.CompletedTask;
+            },
+            (_, _) => throw new InvalidOperationException("and so did the logger")
+        );
+
+        scheduler.Schedule("broken");
+        scheduler.Schedule("healthy");
+
+        await recorder.WaitForFlushAsync("healthy");
+    }
+
+    [Fact]
+    public void Constructor_RejectsANullFlushCallback()
+    {
+        var construct = () => new TranscriptFlushScheduler(null!);
+
+        construct.Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Schedule_RejectsAMissingKey(string? key)
+    {
+        using var scheduler = new TranscriptFlushScheduler((_, _) => Task.CompletedTask);
+
+        var schedule = () => scheduler.Schedule(key!);
+
+        schedule.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/TranscriptFlushSchedulerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/TranscriptFlushSchedulerTests.cs
@@ -107,6 +107,67 @@ public sealed class TranscriptFlushSchedulerTests
     }
 
     /// <summary>
+    /// The lost wakeup. The drain decides to stop from INSIDE the lock, but the <see cref="Task"/> it
+    /// returns only transitions to completed once that lock is released and the state machine unwinds. A
+    /// <c>Schedule</c> landing in that window adds its key, infers "a drain is already running" from an
+    /// incomplete task, and starts nothing — while the loop it trusted has already stopped looking at the
+    /// pending set. The key then waits for an unrelated future <c>Schedule</c>, which for a conversation
+    /// whose last turn just ended never comes: the transcript silently ends one turn early.
+    /// </summary>
+    /// <remarks>
+    /// The window is nanoseconds wide, so it is CONTENDED FOR rather than waited on. The test thread spins
+    /// on the flush counter — it never sleeps and never awaits, so it is not at the mercy of a thread-pool
+    /// wake-up — and issues the next <c>Schedule</c> the instant a flush is recorded, which is the same
+    /// instant the drain starts heading for its exit check. Each round is an independent attempt and one
+    /// lost key is enough to fail, so the loop stops at the first key that misses the bound. Nothing here
+    /// can fail spuriously: with the wakeup published under the lock, EVERY scheduled key is flushed.
+    /// </remarks>
+    [Fact]
+    public void KeyScheduledAsTheDrainIsExiting_IsNotLost()
+    {
+        const int Rounds = 2000;
+        string[] keys = [.. Enumerable.Range(0, Rounds).Select(i => $"k{i}")];
+
+        var flushes = 0;
+        using var scheduler = new TranscriptFlushScheduler(
+            (_, _) =>
+            {
+                _ = Interlocked.Increment(ref flushes);
+                return Task.CompletedTask;
+            }
+        );
+
+        var lost = -1;
+        var elapsed = new Stopwatch();
+        for (var round = 0; round < Rounds && lost < 0; round++)
+        {
+            scheduler.Schedule(keys[round]);
+
+            // SpinWait spins outright before it starts yielding: tight enough to reach the gate inside the
+            // window, and still safe on a single-core agent because it does eventually yield.
+            var spin = new SpinWait();
+            elapsed.Restart();
+            while (Volatile.Read(ref flushes) <= round)
+            {
+                if (elapsed.Elapsed > FailureTimeout)
+                {
+                    lost = round;
+                    break;
+                }
+
+                spin.SpinOnce();
+            }
+        }
+
+        lost.Should()
+            .Be(
+                -1,
+                "a key scheduled while the drain was exiting must still be flushed — the drain's decision to "
+                    + "stop and the publication of that decision have to be one atomic step"
+            );
+    }
+
+    /// <summary>
     /// The reason pending work is a SET and not one <c>bool</c> slot: with a single slot, scheduling
     /// conversation B while conversation A's flush is in flight silently consumes A's re-arm, so A's newest
     /// turn never reaches disk.

--- a/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptLineTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptLineTests.cs
@@ -448,6 +448,37 @@ public sealed class WorkspaceTranscriptLineTests
         later.Uid.Should().NotBe(first.Uid);
     }
 
+    /// <summary>
+    /// A cleared value and an absent one are DIFFERENT lines — one serialises <c>"value": ""</c>, the other
+    /// <c>"value": null</c> — so they cannot share a uid. Both the watermark and every reader's dedupe key
+    /// off uid alone, so a collision here means the second of the two is treated as already written: the
+    /// state change is silently dropped and never appears in the mirror at all. Joining fields with a
+    /// separator does not save it, because null and empty both contribute nothing between the separators.
+    /// </summary>
+    [Fact]
+    public void StateLine_TellsAClearedValueApartFromAnAbsentOne()
+    {
+        var absent = WorkspaceTranscriptLine.ForState(ThreadId, "title", null, DateTimeOffset.UnixEpoch);
+        var cleared = WorkspaceTranscriptLine.ForState(ThreadId, "title", "", DateTimeOffset.UnixEpoch);
+
+        cleared.Uid.Should().NotBe(absent.Uid);
+    }
+
+    /// <summary>
+    /// The field encoding has to survive its own delimiter appearing inside a value. A conversation title
+    /// is user-authored and reaches this method verbatim, so "no caller would ever pass U+001F" is an
+    /// assumption about input the type does not control — and if it is wrong, two genuinely different state
+    /// changes fuse into one uid and one of them is dropped.
+    /// </summary>
+    [Fact]
+    public void StateLine_TellsValuesApartWhenOneContainsTheFieldDelimiter()
+    {
+        var split = WorkspaceTranscriptLine.ForState(ThreadId, "title", "a\u001fb", DateTimeOffset.UnixEpoch);
+        var shifted = WorkspaceTranscriptLine.ForState(ThreadId, "title\u001fa", "b", DateTimeOffset.UnixEpoch);
+
+        shifted.Uid.Should().NotBe(split.Uid);
+    }
+
     // ---- AC 16: parent_uid chains over a sequence -------------------------------------------------
 
     [Fact]

--- a/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptLineTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptLineTests.cs
@@ -379,6 +379,25 @@ public sealed class WorkspaceTranscriptLineTests
         shortId.Should().NotBe(WorkspaceTranscriptLine.ShortId(SubAgentProvenance.ThreadIdPrefix + "child-2"));
     }
 
+    /// <summary>
+    /// A short id is an IDENTITY, so it has to be sized against the birthday bound rather than for looks.
+    /// Conversations whose titles slug the same — "Untitled", "Code review", any title that slugs to
+    /// nothing — differ only by this suffix, so a collision does not produce two similar file names: it
+    /// produces ONE file that both conversations append to, interleaved, each one's watermark rewinding
+    /// the other's, with no way for a reader to separate them again. Twenty thousand ids is well inside
+    /// what a long-lived agent workspace accumulates, and the corpus is fixed, so this is a deterministic
+    /// statement about the current width and not a sampled one.
+    /// </summary>
+    [Fact]
+    public void ShortId_DoesNotCollide_AcrossAWorkspacesWorthOfConversations()
+    {
+        string[] ids = [.. Enumerable.Range(0, 20_000).Select(i => $"conv-{i}")];
+
+        var shortIds = ids.Select(WorkspaceTranscriptLine.ShortId).ToList();
+
+        shortIds.Distinct(StringComparer.Ordinal).Should().HaveCount(ids.Length);
+    }
+
     // ---- AC 22: state lines are constructible and distinguishable by type ------------------------
 
     [Theory]

--- a/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptLineTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptLineTests.cs
@@ -1,0 +1,514 @@
+using System.Collections.Immutable;
+using LmStreaming.Sample.Services;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+///     Pure unit coverage for <see cref="WorkspaceTranscriptLine"/> — the workspace-transcript line
+///     envelope, its <c>uid</c> derivation, the ASCII file-leaf slug, and the exact bytes a line
+///     serializes to (#251, phase 1 step B). Nothing here touches a store, a sandbox or a clock: every
+///     assertion is over a pure function, which is the point — <c>uid</c> is only usable as an append
+///     watermark because it is deterministic.
+/// </summary>
+public sealed class WorkspaceTranscriptLineTests
+{
+    private const string ThreadId = "thread-alpha";
+    private const string RunId = "run-1";
+
+    /// <summary>
+    ///     A provider message id of the shape that lands in <see cref="PersistedMessage.FromAgent"/> —
+    ///     the value <c>agent</c> must NEVER be sourced from.
+    /// </summary>
+    private const string ProviderMessageId = "msg_01AbCdEfGhIjKlMnOpQrStUv";
+
+    private static PersistedMessage Persisted(
+        string id,
+        string messageType = "TextMessage",
+        string role = "Assistant",
+        string? messageJson = null,
+        string? generationId = "gen-1",
+        int? messageOrderIdx = 0,
+        string? parentRunId = null,
+        string? fromAgent = ProviderMessageId) =>
+        new()
+        {
+            Id = id,
+            ThreadId = ThreadId,
+            RunId = RunId,
+            ParentRunId = parentRunId,
+            GenerationId = generationId,
+            MessageOrderIdx = messageOrderIdx,
+            Timestamp = 1_700_000_000_000,
+            MessageType = messageType,
+            Role = role,
+            FromAgent = fromAgent,
+            MessageJson = messageJson ?? """{"role":"assistant","text":"hi"}""",
+        };
+
+    /// <summary>The five message kinds the transcript has to carry with one uniform key set.</summary>
+    private static IReadOnlyList<PersistedMessage> FiveMessageKinds() =>
+    [
+        Persisted("id-text", "TextMessage", "Assistant"),
+        Persisted("id-tool-call", "ToolCallMessage", "Assistant", """{"role":"assistant","tool_calls":[]}"""),
+        // A tool result carries no generation/order in some stores, and a reasoning row may arrive
+        // without a parent run — the key set still has to come out identical.
+        Persisted(
+            "id-tool-result",
+            "ToolCallResultMessage",
+            "Tool",
+            """{"role":"tool","result":"ok"}""",
+            generationId: null,
+            messageOrderIdx: null),
+        Persisted("id-reasoning", "ReasoningMessage", "Assistant", """{"role":"assistant","reasoning":"…"}"""),
+        Persisted("id-usage", "UsageMessage", "None", """{"role":"none","usage":{"total_tokens":7}}"""),
+    ];
+
+    private static JsonElement Parse(WorkspaceTranscriptLine line) =>
+        JsonDocument.Parse(WorkspaceTranscriptLine.Serialize(line)).RootElement;
+
+    private static IReadOnlyList<string> KeysOf(JsonElement element) =>
+        [.. element.EnumerateObject().Select(p => p.Name)];
+
+    // ---- AC 13: every emitted line has a non-empty uid -------------------------------------------
+
+    [Fact]
+    public void EveryEmittedLine_HasNonEmptyUid()
+    {
+        var lines = WorkspaceTranscriptLine
+            .ChainMessages(FiveMessageKinds())
+            .Append(WorkspaceTranscriptLine.ForState(ThreadId, "title", "Fix the login bug", DateTimeOffset.UnixEpoch))
+            .ToList();
+
+        lines.Should().HaveCount(6);
+        foreach (var line in lines)
+        {
+            line.Uid.Should().NotBeNullOrWhiteSpace();
+            line.Uid.Should().HaveLength(WorkspaceTranscriptLine.UidLength);
+            line.Uid.Should().MatchRegex("^[a-z2-7]+$", "uid is base32 lowercase, RFC 4648 alphabet");
+            Parse(line).GetProperty("uid").GetString().Should().Be(line.Uid);
+        }
+    }
+
+    [Fact]
+    public void Uid_IsUnique_AcrossDistinctMessages()
+    {
+        var lines = WorkspaceTranscriptLine.ChainMessages(FiveMessageKinds());
+
+        lines.Select(l => l.Uid).Distinct(StringComparer.Ordinal).Should().HaveCount(lines.Count);
+    }
+
+    // ---- AC 14: the same message yields an identical uid every time ------------------------------
+
+    [Fact]
+    public void Uid_IsIdentical_AcrossThreeSeparateDerivations()
+    {
+        // Stands in for flushes N, N+1, N+2: the derivation is over PersistedMessage.Id alone, so a
+        // re-read of the same stored row must land on the same uid or the append watermark is useless.
+        var message = Persisted("id-text");
+
+        var first = WorkspaceTranscriptLine.ForMessage(message).Uid;
+        var second = WorkspaceTranscriptLine.ForMessage(message with { }, parentUid: "somethingelse").Uid;
+        var third = WorkspaceTranscriptLine.ForMessage(Persisted("id-text"), agent: "reviewer").Uid;
+
+        second.Should().Be(first);
+        third.Should().Be(first);
+        WorkspaceTranscriptLine.DeriveUid("id-text").Should().Be(first);
+    }
+
+    [Fact]
+    public void DeriveUid_IsSensitiveToTheWholeSeed()
+    {
+        WorkspaceTranscriptLine.DeriveUid("id-text").Should().NotBe(WorkspaceTranscriptLine.DeriveUid("id-texu"));
+    }
+
+    // ---- AC 15: role classifies all five Role members, including None ----------------------------
+
+    [Theory]
+    [InlineData(Role.None)]
+    [InlineData(Role.User)]
+    [InlineData(Role.Assistant)]
+    [InlineData(Role.System)]
+    [InlineData(Role.Tool)]
+    public void Role_ClassifiesEveryRoleMember_IncludingNone(Role role)
+    {
+        // The envelope's role is PascalCase; the same role inside message_json is lowercase. Both
+        // casings must land on the same canonical member — None included, since it is a real member
+        // and not an error code.
+        var pascal = WorkspaceTranscriptLine.ForMessage(Persisted("id", role: role.ToString()));
+        var lower = WorkspaceTranscriptLine.ForMessage(Persisted("id", role: role.ToString().ToLowerInvariant()));
+
+        pascal.Role.Should().Be(role.ToString());
+        lower.Role.Should().Be(role.ToString());
+        Parse(pascal).GetProperty("role").GetString().Should().Be(role.ToString());
+    }
+
+    [Fact]
+    public void Role_FallsBackToNone_ForAnUnrecognizedOrAbsentValue()
+    {
+        WorkspaceTranscriptLine.NormalizeRole(null).Should().Be(nameof(Role.None));
+        WorkspaceTranscriptLine.NormalizeRole("").Should().Be(nameof(Role.None));
+        WorkspaceTranscriptLine.NormalizeRole("developer").Should().Be(nameof(Role.None));
+    }
+
+    [Fact]
+    public void Role_CoversEveryDeclaredRoleMember()
+    {
+        // Guard: if a sixth Role member is ever added, this fails and forces the classification above
+        // to be extended rather than silently collapsing the new member to None.
+        Enum.GetValues<Role>().Should().HaveCount(5);
+    }
+
+    // ---- AC 18: uniform key set across five message kinds ----------------------------------------
+
+    [Fact]
+    public void MessageLines_ShareOneUniformKeySet_AcrossFiveMessageKinds()
+    {
+        var lines = WorkspaceTranscriptLine.ChainMessages(FiveMessageKinds());
+        var expected = new[]
+        {
+            "schema_version",
+            "type",
+            "uid",
+            "parent_uid",
+            "agent",
+            "thread_id",
+            "run_id",
+            "parent_run_id",
+            "generation_id",
+            "message_order_idx",
+            "timestamp",
+            "message_type",
+            "role",
+            "id",
+            "message_json",
+        };
+
+        foreach (var line in lines)
+        {
+            // Key ORDER as well as key SET: absent values are written as JSON null, never omitted, so a
+            // columnar reader sees one stable schema no matter which message kind a line carries.
+            KeysOf(Parse(line)).Should().Equal(expected, $"kind {line.MessageType} must not change the key set");
+        }
+    }
+
+    [Fact]
+    public void AbsentMessageFields_AreWrittenAsExplicitNulls_NotOmitted()
+    {
+        var line = WorkspaceTranscriptLine.ForMessage(
+            Persisted("id-tool-result", generationId: null, messageOrderIdx: null));
+        var json = Parse(line);
+
+        json.GetProperty("parent_uid").ValueKind.Should().Be(JsonValueKind.Null);
+        json.GetProperty("agent").ValueKind.Should().Be(JsonValueKind.Null);
+        json.GetProperty("parent_run_id").ValueKind.Should().Be(JsonValueKind.Null);
+        json.GetProperty("generation_id").ValueKind.Should().Be(JsonValueKind.Null);
+        json.GetProperty("message_order_idx").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public void SchemaVersion_IsStampedOnEveryLine()
+    {
+        Parse(WorkspaceTranscriptLine.ForMessage(Persisted("id")))
+            .GetProperty("schema_version").GetInt32().Should().Be(WorkspaceTranscriptLine.CurrentSchemaVersion);
+        Parse(WorkspaceTranscriptLine.ForState(ThreadId, "mode", "chat", DateTimeOffset.UnixEpoch))
+            .GetProperty("schema_version").GetInt32().Should().Be(WorkspaceTranscriptLine.CurrentSchemaVersion);
+    }
+
+    // ---- AC 20: message_json is an opaque STRING, and stays recoverable --------------------------
+
+    [Fact]
+    public void MessageJson_IsSerializedAsAString_NotAnInlinedObject()
+    {
+        const string Payload =
+            """{"role":"assistant","message_id":"m-42","in_response_to":"m-41","text":"answer"}""";
+
+        var json = Parse(WorkspaceTranscriptLine.ForMessage(Persisted("id-text", messageJson: Payload)));
+        var messageJson = json.GetProperty("message_json");
+
+        messageJson.ValueKind.Should().Be(
+            JsonValueKind.String,
+            "message_json is opaque — an object-or-string union is exactly what a tolerant JSONL reader drops");
+        messageJson.GetString().Should().Be(Payload);
+
+        // AC 20 proper: message_id / in_response_to remain recoverable by parsing that string.
+        var inner = JsonDocument.Parse(messageJson.GetString()!).RootElement;
+        inner.GetProperty("message_id").GetString().Should().Be("m-42");
+        inner.GetProperty("in_response_to").GetString().Should().Be("m-41");
+    }
+
+    [Fact]
+    public void SerializedLine_IsExactlyOneLine_EvenWhenMessageJsonContainsNewlines()
+    {
+        var payload = "{\"role\":\"assistant\",\"text\":\"line one\nline two\"}";
+
+        var serialized = WorkspaceTranscriptLine.Serialize(
+            WorkspaceTranscriptLine.ForMessage(Persisted("id-text", messageJson: payload)));
+
+        serialized.Should().NotContain("\n", "a JSONL record must occupy exactly one physical line");
+        JsonDocument.Parse(serialized).RootElement.GetProperty("message_json").GetString().Should().Be(payload);
+    }
+
+    // ---- AC 21: agent is the display name, never a provider message id ---------------------------
+
+    [Fact]
+    public void Agent_IsTheProvenanceDisplayName_NeverTheProviderMessageId()
+    {
+        // The display name is read off SubAgentProvenance.NameKey — the only place a human-authored
+        // sub-agent name is durably stamped. PersistedMessage.FromAgent holds a provider message id.
+        var metadata = new ThreadMetadata
+        {
+            ThreadId = SubAgentProvenance.ThreadIdPrefix + "child-1",
+            LastUpdated = 1_700_000_000_000,
+            Properties = ImmutableDictionary<string, object>
+                .Empty.Add(SubAgentProvenance.ParentThreadIdKey, ThreadId)
+                .Add(SubAgentProvenance.NameKey, "reviewer"),
+        };
+        var displayName = SubAgentProvenance.TryProject(metadata)!.Name;
+        displayName.Should().Be("reviewer");
+
+        var line = WorkspaceTranscriptLine.ForMessage(Persisted("id-text"), agent: displayName);
+
+        line.Agent.Should().Be("reviewer");
+        WorkspaceTranscriptLine.Serialize(line).Should().NotContain(
+            ProviderMessageId,
+            "FromAgent carries a provider message id and must never reach the transcript envelope");
+    }
+
+    [Fact]
+    public void Agent_IsNull_OnAMainFileLine()
+    {
+        WorkspaceTranscriptLine.ForMessage(Persisted("id-text")).Agent.Should().BeNull();
+    }
+
+    // ---- AC 9: the ASCII slug and the file leaves -------------------------------------------------
+
+    [Theory]
+    [InlineData("Fix the login bug", "fix-the-login-bug")]
+    [InlineData("a/b/c", "a-b-c")]
+    [InlineData("a\\b\\c", "a-b-c")]
+    [InlineData("../../etc/passwd", "etc-passwd")]
+    [InlineData("/leading/slash", "leading-slash")]
+    [InlineData("..", "")]
+    [InlineData("/", "")]
+    [InlineData("  ", "")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    // Unicode is DROPPED, not passed through — this is the whole reason none of the repo's six
+    // char.IsLetterOrDigit-based slug helpers could be reused here.
+    [InlineData("修复登录错误", "")]
+    [InlineData("café résumé", "caf-r-sum")]
+    [InlineData("Ünïcödé", "n-c-d")]
+    [InlineData("Trailing---hyphens---", "trailing-hyphens")]
+    [InlineData("multi   space", "multi-space")]
+    public void Slug_ProducesAsciiOnlyFlatSegments(string? title, string expected)
+    {
+        var slug = WorkspaceTranscriptLine.Slug(title);
+
+        slug.Should().Be(expected);
+        slug.Should().MatchRegex("^[a-z0-9-]*$");
+        slug.Should().NotStartWith("-").And.NotEndWith("-");
+    }
+
+    [Theory]
+    [InlineData("a/b/c")]
+    [InlineData("a\\b\\c")]
+    [InlineData("../../etc/passwd")]
+    [InlineData("/leading/slash")]
+    [InlineData("..")]
+    [InlineData("修复登录错误")]
+    [InlineData("café")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void MainFileLeaf_IsAlwaysAFlatLegalNonEmptyAsciiName(string? title)
+    {
+        var leaf = WorkspaceTranscriptLine.MainFileLeaf(title, WorkspaceTranscriptLine.ShortId(ThreadId));
+
+        leaf.Should().NotBeNullOrEmpty();
+        leaf.Should().MatchRegex("^[a-z0-9-]+$");
+        leaf.Should().NotContain("/").And.NotContain("\\").And.NotContain("..");
+    }
+
+    [Fact]
+    public void MainFileLeaf_FallsBackToTheShortThreadId_WhenTheTitleSlugsToNothing()
+    {
+        var shortId = WorkspaceTranscriptLine.ShortId(ThreadId);
+
+        WorkspaceTranscriptLine.MainFileLeaf("修复登录错误", shortId).Should().Be(shortId);
+        WorkspaceTranscriptLine.MainFileLeaf("Fix the login bug", shortId).Should().Be($"fix-the-login-bug-{shortId}");
+    }
+
+    [Fact]
+    public void MainFileLeaf_TruncatesAnUnboundedTitle()
+    {
+        var leaf = WorkspaceTranscriptLine.MainFileLeaf(new string('x', 500), "abcd");
+
+        leaf.Length.Should().BeLessThan(120, "a path component has to stay under the filesystem's 255-byte cap");
+    }
+
+    [Fact]
+    public void AgentFileLeaf_PinsToAgentPrefix_WhenTheNameIsNullOrSlugsToNothing()
+    {
+        var shortAgentId = WorkspaceTranscriptLine.ShortId("agent-7");
+
+        WorkspaceTranscriptLine.AgentFileLeaf(null, shortAgentId)
+            .Should().Be($"{WorkspaceTranscriptLine.UnnamedAgentLeafPrefix}-{shortAgentId}");
+        WorkspaceTranscriptLine.AgentFileLeaf("修复", shortAgentId)
+            .Should().Be($"{WorkspaceTranscriptLine.UnnamedAgentLeafPrefix}-{shortAgentId}");
+        WorkspaceTranscriptLine.AgentFileLeaf("Reviewer", shortAgentId).Should().Be($"reviewer-{shortAgentId}");
+    }
+
+    [Fact]
+    public void AgentFileLeaf_KeepsTwoAgentsWithTheSameDisplayNameApart()
+    {
+        var first = WorkspaceTranscriptLine.AgentFileLeaf("reviewer", WorkspaceTranscriptLine.ShortId("agent-a"));
+        var second = WorkspaceTranscriptLine.AgentFileLeaf("reviewer", WorkspaceTranscriptLine.ShortId("agent-b"));
+
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void ShortId_IsDeterministicAndAsciiLegal()
+    {
+        var shortId = WorkspaceTranscriptLine.ShortId(SubAgentProvenance.ThreadIdPrefix + "child-1");
+
+        shortId.Should().HaveLength(WorkspaceTranscriptLine.ShortIdLength);
+        shortId.Should().MatchRegex("^[a-z2-7]+$");
+        shortId.Should().Be(WorkspaceTranscriptLine.ShortId(SubAgentProvenance.ThreadIdPrefix + "child-1"));
+        // Ids in this sample share the "subagent-" prefix, so a prefix slice would collide where a
+        // hash does not.
+        shortId.Should().NotBe(WorkspaceTranscriptLine.ShortId(SubAgentProvenance.ThreadIdPrefix + "child-2"));
+    }
+
+    // ---- AC 22: state lines are constructible and distinguishable by type ------------------------
+
+    [Theory]
+    [InlineData("title", "Fix the login bug")]
+    [InlineData("mode", "chat")]
+    [InlineData("provider", "claude-opus-5")]
+    public void StateLine_IsConstructible_AndDistinguishableFromAMessageLineByType(string key, string value)
+    {
+        var at = DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000);
+
+        var state = WorkspaceTranscriptLine.ForState(ThreadId, key, value, at, parentUid: "aaaaaaaa");
+        var json = Parse(state);
+
+        state.Type.Should().Be(WorkspaceTranscriptLine.StateLineType);
+        json.GetProperty("type").GetString().Should().Be("state");
+        json.GetProperty("key").GetString().Should().Be(key);
+        json.GetProperty("value").GetString().Should().Be(value);
+        json.GetProperty("parent_uid").GetString().Should().Be("aaaaaaaa");
+        json.GetProperty("thread_id").GetString().Should().Be(ThreadId);
+
+        // A state line carries none of PersistedMessage's seven required members — that is exactly why
+        // the message-specific envelope fields are nullable.
+        KeysOf(json).Should().Equal("schema_version", "type", "uid", "parent_uid", "thread_id", "timestamp", "key", "value");
+    }
+
+    [Fact]
+    public void StateAndMessageLines_AreTellableApartByTypeAlone()
+    {
+        var lines = new[]
+        {
+            WorkspaceTranscriptLine.ForMessage(Persisted("id-text")),
+            WorkspaceTranscriptLine.ForState(ThreadId, "title", "t", DateTimeOffset.UnixEpoch),
+        };
+
+        lines.Count(l => l.Type == WorkspaceTranscriptLine.MessageLineType).Should().Be(1);
+        lines.Count(l => l.Type == WorkspaceTranscriptLine.StateLineType).Should().Be(1);
+    }
+
+    [Fact]
+    public void StateLine_ForTheSameKeyAtADifferentInstant_GetsADistinctUid()
+    {
+        var first = WorkspaceTranscriptLine.ForState(ThreadId, "title", "one", DateTimeOffset.UnixEpoch);
+        var again = WorkspaceTranscriptLine.ForState(ThreadId, "title", "one", DateTimeOffset.UnixEpoch);
+        var later = WorkspaceTranscriptLine.ForState(
+            ThreadId, "title", "one", DateTimeOffset.UnixEpoch.AddSeconds(1));
+
+        again.Uid.Should().Be(first.Uid, "the derivation is pure");
+        later.Uid.Should().NotBe(first.Uid);
+    }
+
+    // ---- AC 16: parent_uid chains over a sequence -------------------------------------------------
+
+    [Fact]
+    public void ChainMessages_ChainsEachLineToItsPredecessorInStoreOrder()
+    {
+        var lines = WorkspaceTranscriptLine.ChainMessages(FiveMessageKinds());
+
+        lines[0].ParentUid.Should().BeNull("the first line of the main file has no predecessor");
+        for (var i = 1; i < lines.Count; i++)
+        {
+            lines[i].ParentUid.Should().Be(lines[i - 1].Uid);
+        }
+
+        // The chain has to resolve: walking parent_uid backwards from the tail visits every line once.
+        var byUid = lines.ToDictionary(l => l.Uid, StringComparer.Ordinal);
+        var walked = 0;
+        var cursor = lines[^1];
+        while (true)
+        {
+            walked++;
+            if (cursor.ParentUid is null)
+            {
+                break;
+            }
+
+            byUid.Should().ContainKey(cursor.ParentUid);
+            cursor = byUid[cursor.ParentUid];
+        }
+
+        walked.Should().Be(lines.Count);
+    }
+
+    [Fact]
+    public void ChainMessages_AnchorsASubAgentFileToTheMainFile()
+    {
+        var main = WorkspaceTranscriptLine.ChainMessages(FiveMessageKinds());
+        var anchor = main[2].Uid;
+
+        var agentLines = WorkspaceTranscriptLine.ChainMessages(
+            [Persisted("sub-1"), Persisted("sub-2")],
+            agent: "reviewer",
+            rootParentUid: anchor);
+
+        // AC 16 as reworded: the chain resolves within the conversation's FILE SET — an _agents/ root
+        // line points into the main file, not into its own file.
+        agentLines[0].ParentUid.Should().Be(anchor);
+        agentLines[1].ParentUid.Should().Be(agentLines[0].Uid);
+        agentLines.Should().OnlyContain(l => l.Agent == "reviewer");
+    }
+
+    [Fact]
+    public void ChainMessages_OnAnEmptySequence_ReturnsNoLines()
+    {
+        WorkspaceTranscriptLine.ChainMessages([]).Should().BeEmpty();
+    }
+
+    // ---- envelope field mapping -------------------------------------------------------------------
+
+    [Fact]
+    public void MessageLine_CarriesTheStoreFieldsVerbatim()
+    {
+        var message = Persisted("id-text", parentRunId: "run-0", messageOrderIdx: 3);
+
+        var json = Parse(WorkspaceTranscriptLine.ForMessage(message, parentUid: "bbbbbbbb", agent: "reviewer"));
+
+        json.GetProperty("type").GetString().Should().Be("message");
+        json.GetProperty("agent").GetString().Should().Be("reviewer");
+        json.GetProperty("thread_id").GetString().Should().Be(ThreadId);
+        json.GetProperty("run_id").GetString().Should().Be(RunId);
+        json.GetProperty("parent_run_id").GetString().Should().Be("run-0");
+        json.GetProperty("generation_id").GetString().Should().Be("gen-1");
+        json.GetProperty("message_order_idx").GetInt32().Should().Be(3);
+        json.GetProperty("message_type").GetString().Should().Be("TextMessage");
+        json.GetProperty("id").GetString().Should().Be("id-text");
+        json.GetProperty("timestamp").GetString().Should().Be("2023-11-14T22:13:20.0000000Z");
+    }
+
+    [Fact]
+    public void FormatTimestamp_IsIso8601Utc()
+    {
+        WorkspaceTranscriptLine.FormatTimestamp(0).Should().Be("1970-01-01T00:00:00.0000000Z");
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptLiveFileTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptLiveFileTests.cs
@@ -1,0 +1,327 @@
+using System.Collections.Immutable;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Tests.TestDoubles;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// The end-to-end read-back for #251: drive the mirror over a REAL filesystem and a REAL shell, then open
+/// the file it produced and prove it is what every downstream reader is promised — one JSON object per
+/// line, each line carrying a <c>uid</c>, each <c>parent_uid</c> naming the line before it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every other test in this area asserts an INTENTION: the argv the writer issued, the bytes it staged.
+/// None of them opens a file, because none of them produces one. That leaves the most consequential claim
+/// of the feature — "the workspace ends up holding a readable transcript" — resting on the assumption that
+/// the recorded argv, run for real, does what it reads like. This test removes that assumption; it is the
+/// only place a quoting slip, a missing directory or a mis-welded newline can surface.
+/// </para>
+/// <para>
+/// The transcript is deliberately left on disk under <see cref="LiveDirectoryName"/> in the temp folder
+/// (a few KB, wiped and rewritten on every run) so the produced artifact can also be read with an external
+/// JSONL reader — DuckDB's <c>read_ndjson_objects</c> — rather than only through this assembly's own idea
+/// of what it wrote.
+/// </para>
+/// </remarks>
+public sealed class WorkspaceTranscriptLiveFileTests
+{
+    /// <summary>Folder under the temp directory that the produced transcript is left in.</summary>
+    private const string LiveDirectoryName = "lm-transcript-live";
+
+    private const string ThreadId = "conv-live-9f2c";
+    private const string WorkspaceId = "ws-live";
+    private const string Title = "Live Read Proof";
+    private const string AgentId = "agent-live-1";
+    private const string AgentName = "researcher";
+
+    private static readonly TimeSpan Deadline = TimeSpan.FromSeconds(30);
+
+    [SkippableFact]
+    public async Task Mirror_ProducesARealJsonlFile_ThatParsesAndChainsByUid()
+    {
+        var shell = LocalShellWorkspaceBrowser.FindPosixShell();
+        Skip.If(
+            shell is null,
+            "No POSIX shell (sh) on this machine, so the writer's real append script cannot be run.");
+
+        var root = Path.Combine(Path.GetTempPath(), LiveDirectoryName);
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+
+        _ = Directory.CreateDirectory(root);
+
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, FirstTurn());
+        await SeedSubAgentAsync(store);
+
+        var browser = new LocalShellWorkspaceBrowser(root, shell!);
+        await using var agent = new PublishingAgent(ThreadId);
+        using var mirror = new WorkspaceTranscriptMirror(
+            _ => agent,
+            store,
+            browser,
+            new ConversationDescendantScanner(store, NullLogger<ConversationDescendantScanner>.Instance),
+            NullLoggerFactory.Instance,
+            TimeSpan.Zero,
+            TimeSpan.Zero);
+
+        var leaf = WorkspaceTranscriptLine.MainFileLeaf(Title, WorkspaceTranscriptLine.ShortId(ThreadId));
+        var mainFile = Path.Combine(
+            root,
+            ConversationTranscriptWriter.TranscriptDirectory,
+            leaf + ConversationTranscriptWriter.TranscriptExtension);
+        var agentFile = Path.Combine(
+            root,
+            ConversationTranscriptWriter.TranscriptDirectory,
+            leaf + ConversationTranscriptWriter.AgentsDirectorySuffix,
+            WorkspaceTranscriptLine.AgentFileLeaf(AgentName, WorkspaceTranscriptLine.ShortId(AgentId))
+                + ConversationTranscriptWriter.TranscriptExtension);
+
+        mirror.Attach(agent);
+        await PublishUntilAsync(agent, () => LineCount(mainFile) >= 4, "the first turn never reached the file");
+
+        // A second turn, so the file is APPENDED to rather than written once — the incremental path is
+        // where a torn tail or a re-welded newline would corrupt the chain.
+        await store.AppendMessagesAsync(ThreadId, SecondTurn());
+        await PublishUntilAsync(agent, () => LineCount(mainFile) >= 6, "the second turn never reached the file");
+
+        await PublishUntilAsync(agent, () => LineCount(agentFile) >= 1, "the sub-agent transcript was never written");
+
+        // ---- the read-back ----
+        var mainUids = await VerifyChainAsync(mainFile, anchors: null);
+
+        // A sub-agent file's FIRST line is not a root: it anchors to the line the parent conversation was
+        // at when the child appeared, which is what makes the two files one lineage rather than two piles.
+        _ = await VerifyChainAsync(agentFile, mainUids);
+
+        // The newest turn is present, not just the first flush's rows.
+        _ = string
+            .Join('\n', ReadRecords(mainFile))
+            .Should()
+            .Contain("the-answer", "the second turn's content must be in the file");
+
+        // And the opt-out the feature ships with is on disk beside the transcript.
+        _ = File
+            .Exists(
+                Path.Combine(
+                    root,
+                    ConversationTranscriptWriter.TranscriptDirectory,
+                    "." + ConversationTranscriptWriter.GitignoreName))
+            .Should()
+            .BeTrue();
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    /// <summary>
+    /// Opens a produced file, proves every record is one JSON object with a unique <c>uid</c>, and walks
+    /// the <c>parent_uid</c> chain. The first record either roots the file (<c>parent_uid: null</c>) or,
+    /// when <paramref name="anchors"/> is supplied, points at a line of the file this one descends from.
+    /// </summary>
+    /// <returns>The file's uids, in order.</returns>
+    private static async Task<IReadOnlyList<string>> VerifyChainAsync(
+        string file,
+        IReadOnlyCollection<string>? anchors)
+    {
+        var lines = await ReadSettledRecordsAsync(file);
+        _ = lines.Should().NotBeEmpty($"{file} should hold at least one record");
+
+        var uids = new List<string>(lines.Count);
+        string? previousUid = null;
+        foreach (var (line, index) in lines.Select((line, index) => (line, index)))
+        {
+            using var document = JsonDocument.Parse(line);
+            _ = document
+                .RootElement.ValueKind.Should()
+                .Be(JsonValueKind.Object, $"line {index + 1} of {file} must be one JSON object");
+
+            var uid = document.RootElement.GetProperty("uid").GetString();
+            _ = uid.Should().NotBeNullOrEmpty();
+            _ = uids.Should().NotContain(uid!, $"uid {uid} is repeated in {file}");
+
+            var parentUid = document.RootElement.GetProperty("parent_uid");
+            if (previousUid is not null)
+            {
+                _ = parentUid
+                    .GetString()
+                    .Should()
+                    .Be(previousUid, $"line {index + 1} of {file} must chain onto the line before it");
+            }
+            else if (anchors is null)
+            {
+                _ = parentUid.ValueKind.Should().Be(JsonValueKind.Null, $"{file} is a root file");
+            }
+            else
+            {
+                _ = anchors.Should().Contain(parentUid.GetString()!, $"{file} must anchor to its parent");
+            }
+
+            uids.Add(uid!);
+            previousUid = uid;
+        }
+
+        return uids;
+    }
+
+    private static int LineCount(string file) => ReadRecords(file).Count;
+
+    /// <summary>
+    /// Reads the file's non-blank records with SHARED access. The writer's splice is a real
+    /// <c>cat &gt;&gt;</c> in another process, and on Windows an exclusive open races it into a sharing
+    /// violation — an artifact of watching the file, not a defect in it.
+    /// </summary>
+    private static IReadOnlyList<string> ReadRecords(string file)
+    {
+        if (!File.Exists(file))
+        {
+            return [];
+        }
+
+        try
+        {
+            using var stream = new FileStream(
+                file,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete);
+            using var reader = new StreamReader(stream);
+
+            var records = new List<string>();
+            while (reader.ReadLine() is { } line)
+            {
+                if (!string.IsNullOrWhiteSpace(line))
+                {
+                    records.Add(line);
+                }
+            }
+
+            return records;
+        }
+        catch (IOException)
+        {
+            return [];
+        }
+    }
+
+    /// <summary>Waits until the file stops growing, so the read-back cannot observe a half-written record.</summary>
+    private static async Task<IReadOnlyList<string>> ReadSettledRecordsAsync(string file)
+    {
+        var deadline = DateTime.UtcNow + Deadline;
+        while (true)
+        {
+            var before = ReadRecords(file);
+            await Task.Delay(250);
+            var after = ReadRecords(file);
+            if (after.Count == before.Count && after.Count > 0)
+            {
+                return after;
+            }
+
+            if (DateTime.UtcNow > deadline)
+            {
+                throw new TimeoutException($"{file} never stopped growing.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Republishes a turn boundary until <paramref name="done"/> holds. The mirror starts its pump on a
+    /// worker, so a single publish can legitimately land before the subscription exists; a flush is
+    /// idempotent, so an extra boundary costs a no-op flush and nothing else.
+    /// </summary>
+    private static async Task PublishUntilAsync(PublishingAgent agent, Func<bool> done, string because)
+    {
+        var deadline = DateTime.UtcNow + Deadline;
+        while (!done())
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                throw new TimeoutException($"Timed out: {because}.");
+            }
+
+            await agent.PublishAsync(new RunCompletedMessage { CompletedRunId = "run-1" });
+            await Task.Delay(25);
+        }
+    }
+
+    private static Task SeedConversationAsync(IConversationStore store) =>
+        store.SaveMetadataAsync(
+            ThreadId,
+            new ThreadMetadata
+            {
+                ThreadId = ThreadId,
+                LastUpdated = 0,
+                Properties = ImmutableDictionary<string, object>
+                    .Empty.Add(MultiTurnAgentPool.WorkspacePropertyKey, WorkspaceId)
+                    .Add("title", Title),
+            });
+
+    private static async Task SeedSubAgentAsync(IConversationStore store)
+    {
+        var childThreadId = SubAgentProvenance.ThreadIdPrefix + AgentId;
+        await store.SaveMetadataAsync(
+            childThreadId,
+            new ThreadMetadata
+            {
+                ThreadId = childThreadId,
+                LastUpdated = 0,
+                Properties = SubAgentProvenance.Build(
+                    ThreadId,
+                    new SubAgentSnapshot(
+                        AgentId,
+                        Name: AgentName,
+                        TemplateName: "worker",
+                        Task: "look it up",
+                        Status: SubAgentStatus.Completed,
+                        ThreadId: childThreadId,
+                        LastActivityUtc: DateTimeOffset.UnixEpoch,
+                        TerminalAtUtc: DateTimeOffset.UnixEpoch)),
+            });
+
+        await store.AppendMessagesAsync(
+            childThreadId,
+            [
+                Msg("s1", 1, "TextMessage", "User", "\"look it up\"", childThreadId),
+                Msg("s2", 2, "TextMessage", "Assistant", "\"found it\"", childThreadId),
+            ]);
+    }
+
+    /// <summary>A full first turn: question, reasoning, a tool call and its result.</summary>
+    private static PersistedMessage[] FirstTurn() =>
+        [
+            Msg("m1", 1, "TextMessage", "User", "\"what is it?\""),
+            Msg("m2", 2, "ReasoningMessage", "Assistant", "\"weighing the options\\nline two\""),
+            Msg("m3", 3, "ToolsCallMessage", "Assistant", "{\"tool\":\"search\",\"args\":\"{}\"}"),
+            Msg("m4", 4, "ToolsCallResultMessage", "Tool", "\"result rows\""),
+        ];
+
+    private static PersistedMessage[] SecondTurn() =>
+        [
+            Msg("m5", 5, "TextMessage", "Assistant", "\"the-answer\""),
+            Msg("m6", 6, "TextMessage", "User", "\"thanks\""),
+        ];
+
+    private static PersistedMessage Msg(
+        string id,
+        long timestamp,
+        string messageType,
+        string role,
+        string messageJson,
+        string threadId = ThreadId) =>
+        new()
+        {
+            Id = id,
+            ThreadId = threadId,
+            RunId = "run-1",
+            GenerationId = "run-1",
+            Timestamp = timestamp,
+            MessageType = messageType,
+            Role = role,
+            MessageJson = messageJson,
+        };
+}

--- a/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptMirrorTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptMirrorTests.cs
@@ -1,0 +1,586 @@
+using System.Collections.Immutable;
+using System.Text;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Tests.TestDoubles;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="WorkspaceTranscriptMirror"/> — the piece that ties the writer, the flush
+/// scheduler and a live agent subscription together (#251).
+/// </summary>
+/// <remarks>
+/// <para>
+/// These drive a <b>real <see cref="MultiTurnAgentBase"/></b> rather than a stub subscriber. The behaviour
+/// under test that matters most — a subscription the agent silently DROPS when its bounded output channel
+/// fills — exists only in that base class, and a hand-written fake that ends its enumeration on command
+/// would prove the test's own fake works, not that the mirror survives the real drop.
+/// </para>
+/// <para>
+/// Background work is awaited by polling a bounded deadline, never by sleeping for a guessed duration: the
+/// mirror's whole point is that the subscriber hot path does no I/O, so every effect it produces is
+/// asynchronous by design. The one place a fixed delay appears is the <i>quiescence</i> helper, where the
+/// claim being made is "nothing further happened" — which has no edge to wait on.
+/// </para>
+/// </remarks>
+public sealed class WorkspaceTranscriptMirrorTests
+{
+    private const string ThreadId = "conv-mirror";
+    private const string WorkspaceId = "ws-1";
+    private const string Title = "Mirror Test";
+    private const string OtherThreadId = "conv-other";
+
+    private static readonly TimeSpan Deadline = TimeSpan.FromSeconds(20);
+
+    /// <summary>How long "nothing else happened" is observed for before it is believed.</summary>
+    private static readonly TimeSpan QuietWindow = TimeSpan.FromMilliseconds(250);
+
+    private static readonly string ShortThreadId = WorkspaceTranscriptLine.ShortId(ThreadId);
+
+    private static readonly string Leaf = WorkspaceTranscriptLine.MainFileLeaf(Title, ShortThreadId);
+
+    private static readonly string MainPath =
+        $"{ConversationTranscriptWriter.TranscriptDirectory}/{Leaf}{ConversationTranscriptWriter.TranscriptExtension}";
+
+    private static readonly string AgentsDirectory =
+        $"{ConversationTranscriptWriter.TranscriptDirectory}/{Leaf}{ConversationTranscriptWriter.AgentsDirectorySuffix}";
+
+    private static readonly string TempPath =
+        $"{ConversationTranscriptWriter.TempDirectory}/{ShortThreadId}{ConversationTranscriptWriter.TempExtension}";
+
+    // ---------------------------------------------------------------- fixtures
+
+    /// <summary>
+    /// Forwarding store that counts flushes. The writer reads the conversation's metadata exactly once per
+    /// flush attempt, before it has decided anything, so that call is the only signal that counts every
+    /// attempt including the ones that write nothing.
+    /// </summary>
+    private sealed class FlushCountingStore(IConversationStore inner) : IConversationStore
+    {
+        private int _flushes;
+
+        public int FlushCount => Volatile.Read(ref _flushes);
+
+        public Task<ThreadMetadata?> LoadMetadataAsync(string threadId, CancellationToken ct = default)
+        {
+            if (string.Equals(threadId, ThreadId, StringComparison.Ordinal))
+            {
+                _ = Interlocked.Increment(ref _flushes);
+            }
+
+            return inner.LoadMetadataAsync(threadId, ct);
+        }
+
+        public Task AppendMessagesAsync(
+            string threadId,
+            IReadOnlyList<PersistedMessage> messages,
+            CancellationToken ct = default) => inner.AppendMessagesAsync(threadId, messages, ct);
+
+        public Task<IReadOnlyList<PersistedMessage>> LoadMessagesAsync(
+            string threadId,
+            CancellationToken ct = default) => inner.LoadMessagesAsync(threadId, ct);
+
+        public Task ReplaceMessageAsync(
+            string threadId,
+            PersistedMessage replacement,
+            CancellationToken ct = default) => inner.ReplaceMessageAsync(threadId, replacement, ct);
+
+        public Task SaveMetadataAsync(
+            string threadId,
+            ThreadMetadata metadata,
+            CancellationToken ct = default) => inner.SaveMetadataAsync(threadId, metadata, ct);
+
+        public Task UpdateMetadataAsync(
+            string threadId,
+            Func<ThreadMetadata?, ThreadMetadata> update,
+            CancellationToken ct = default) => inner.UpdateMetadataAsync(threadId, update, ct);
+
+        public Task DeleteThreadAsync(string threadId, CancellationToken ct = default) =>
+            inner.DeleteThreadAsync(threadId, ct);
+
+        public Task<IReadOnlyList<ThreadMetadata>> ListThreadsAsync(
+            int limit = 50,
+            int offset = 0,
+            CancellationToken ct = default) => inner.ListThreadsAsync(limit, offset, ct);
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static WorkspaceTranscriptMirror CreateMirror(
+        IConversationStore store,
+        FakeFileBrowser browser,
+        Func<string, IMultiTurnAgent?> agentLookup) =>
+        new(
+            agentLookup,
+            store,
+            browser,
+            new ConversationDescendantScanner(store, NullLogger<ConversationDescendantScanner>.Instance),
+            NullLoggerFactory.Instance,
+            // Zero: the drop test re-subscribes in a loop and the delay is only there to rate-limit a
+            // saturated production conversation, never to sequence anything.
+            TimeSpan.Zero,
+            // Zero: the writer's stability probe re-reads immediately; these tests drive settling through
+            // the store, never through elapsed time.
+            TimeSpan.Zero);
+
+    private static Task SeedConversationAsync(IConversationStore store) =>
+        store.SaveMetadataAsync(
+            ThreadId,
+            new ThreadMetadata
+            {
+                ThreadId = ThreadId,
+                LastUpdated = 0,
+                Properties = ImmutableDictionary<string, object>
+                    .Empty.Add(MultiTurnAgentPool.WorkspacePropertyKey, WorkspaceId)
+                    .Add("title", Title),
+            });
+
+    private static async Task SeedSubAgentAsync(IConversationStore store, string agentId, string name)
+    {
+        var childThreadId = SubAgentProvenance.ThreadIdPrefix + agentId;
+        await store.SaveMetadataAsync(
+            childThreadId,
+            new ThreadMetadata
+            {
+                ThreadId = childThreadId,
+                LastUpdated = 0,
+                Properties = SubAgentProvenance.Build(
+                    ThreadId,
+                    new SubAgentSnapshot(
+                        agentId,
+                        Name: name,
+                        TemplateName: "worker",
+                        Task: "do the thing",
+                        Status: SubAgentStatus.Completed,
+                        ThreadId: childThreadId,
+                        LastActivityUtc: DateTimeOffset.UnixEpoch,
+                        TerminalAtUtc: DateTimeOffset.UnixEpoch)),
+            });
+
+        await store.AppendMessagesAsync(childThreadId, [Msg("c1", 1, threadId: childThreadId)]);
+    }
+
+    private static PersistedMessage Msg(string id, long timestamp, string threadId = ThreadId) =>
+        new()
+        {
+            Id = id,
+            ThreadId = threadId,
+            RunId = "run-1",
+            GenerationId = "run-1",
+            Timestamp = timestamp,
+            MessageType = "TextMessage",
+            Role = "Assistant",
+            MessageJson = $"\"opaque-{id}\"",
+        };
+
+    private static string ExpectedAppend(IReadOnlyList<PersistedMessage> all, int skip = 0)
+    {
+        var lines = WorkspaceTranscriptLine.ChainMessages(
+            TranscriptProjection.Normalize(all, excludeReasoning: false));
+
+        return string.Concat(lines.Skip(skip).Select(l => WorkspaceTranscriptLine.Serialize(l) + "\n"));
+    }
+
+    private static RunCompletedMessage RunCompleted() => new() { CompletedRunId = "run-1" };
+
+    private static ToolsCallMessage SpawnCall() =>
+        new()
+        {
+            ToolCalls =
+            [
+                new ToolCall
+                {
+                    FunctionName = SubAgentToolProvider.SpawnToolName,
+                    FunctionArgs = "{}",
+                    ToolCallId = "call-1",
+                },
+            ],
+        };
+
+    private static async Task WaitForAsync(Func<bool> condition, string because)
+    {
+        var deadline = DateTime.UtcNow + Deadline;
+        while (!condition())
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                throw new TimeoutException(because);
+            }
+
+            await Task.Delay(10);
+        }
+    }
+
+    /// <summary>
+    /// Publishes run-completions until the mirror has flushed at least <paramref name="flushes"/> times.
+    /// Republishing is what makes attachment deterministic: <see cref="WorkspaceTranscriptMirror.Attach"/>
+    /// starts its pump on a worker, so the first publish can legitimately land before the subscription
+    /// exists — and a flush is idempotent, so an extra one changes nothing but the count.
+    /// </summary>
+    private static async Task PublishUntilFlushedAsync(PublishingAgent agent, FlushCountingStore store, int flushes)
+    {
+        var deadline = DateTime.UtcNow + Deadline;
+        while (store.FlushCount < flushes)
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                throw new TimeoutException($"The mirror never reached {flushes} flush(es).");
+            }
+
+            await agent.PublishAsync(RunCompleted());
+            await Task.Delay(10);
+        }
+    }
+
+    /// <summary>Waits until no flush has started for a quiet window, and returns the settled count.</summary>
+    private static async Task<int> SettleAsync(FlushCountingStore store)
+    {
+        var deadline = DateTime.UtcNow + Deadline;
+        while (true)
+        {
+            var before = store.FlushCount;
+            await Task.Delay(QuietWindow);
+            if (store.FlushCount == before)
+            {
+                return before;
+            }
+
+            if (DateTime.UtcNow > deadline)
+            {
+                throw new TimeoutException("The mirror never went quiet.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// The bytes of the most recent STAGED append. Selected by path rather than by position because the
+    /// writer also writes the <c>.gitignore</c>, after the first successful append.
+    /// </summary>
+    private static string? LastPayload(FakeFileBrowser browser)
+    {
+        for (var i = browser.Writes.Count - 1; i >= 0; i--)
+        {
+            if (string.Equals(browser.Writes[i].Path, TempPath, StringComparison.Ordinal))
+            {
+                return Encoding.UTF8.GetString(browser.Writes[i].Bytes);
+            }
+        }
+
+        return null;
+    }
+
+    private static bool SplicedInto(FakeFileBrowser browser, string path) =>
+        browser.Commands.Any(c => c.Arguments.Count == 7 && string.Equals(c.Arguments[6], path, StringComparison.Ordinal));
+
+    // ---------------------------------------------------------------- tests
+
+    /// <summary>
+    /// The whole composition, end to end: an attached agent's run completion drives a flush that appends
+    /// this conversation's persisted rows into its workspace, and a LATER completion appends only what is
+    /// new. Asserting the exact bytes (not a call count) is what makes the <c>uid</c>/<c>parent_uid</c>
+    /// chain — the property every reader depends on — actually covered.
+    /// </summary>
+    [Fact]
+    public async Task Attach_MirrorsTheThread_AtEachTurnBoundary()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        PersistedMessage[] first = [Msg("m1", 1), Msg("m2", 2)];
+        await store.AppendMessagesAsync(ThreadId, first);
+
+        var browser = new FakeFileBrowser();
+        await using var agent = new PublishingAgent(ThreadId);
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        mirror.Attach(agent);
+        await PublishUntilFlushedAsync(agent, store, 1);
+        await WaitForAsync(
+            () => SplicedInto(browser, MainPath),
+            "The first run completion never produced an append into the main transcript.");
+
+        // Staged through the writer's temp file and spliced from there — the payload is picked by that
+        // path because the writer also drops a .gitignore after its first successful append.
+        _ = LastPayload(browser).Should().Be(ExpectedAppend(first));
+
+        // A second turn: only the new row is appended, because the watermark advanced on the first splice.
+        PersistedMessage[] all = [.. first, Msg("m3", 3)];
+        await store.AppendMessagesAsync(ThreadId, [all[2]]);
+        await agent.PublishAsync(RunCompleted());
+
+        await WaitForAsync(
+            () => LastPayload(browser) == ExpectedAppend(all, skip: 2),
+            "The second run completion never appended ONLY the new row.");
+    }
+
+    /// <summary>
+    /// The flush trigger is the turn BOUNDARY, not message traffic. A turn that streams a hundred deltas
+    /// must cost exactly one flush — otherwise every conversation pays a gateway round trip per delta, and
+    /// the coalescing scheduler is doing nothing but hiding the cost.
+    /// </summary>
+    [Fact]
+    public async Task Attach_SchedulesNoFlush_ForMessagesInsideATurn()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1)]);
+
+        var browser = new FakeFileBrowser();
+        await using var agent = new PublishingAgent(ThreadId);
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        mirror.Attach(agent);
+        await PublishUntilFlushedAsync(agent, store, 1);
+        var baseline = await SettleAsync(store);
+
+        for (var i = 0; i < 64; i++)
+        {
+            await agent.PublishAsync(new TextMessage { Text = "delta", Role = Role.Assistant });
+        }
+
+        await agent.PublishAsync(RunCompleted());
+        await WaitForAsync(
+            () => store.FlushCount > baseline,
+            "The run completion after the burst never produced a flush.");
+
+        // The burst is fully consumed by now — the pump is strictly ordered, so observing the completion's
+        // flush proves every delta ahead of it was observed too.
+        _ = (await SettleAsync(store)).Should().Be(baseline + 1);
+    }
+
+    /// <summary>
+    /// A sub-agent spawned mid-conversation must appear in the transcript. The descendant graph is cached
+    /// (an empty result included), so the ONLY thing that makes a later spawn visible is the mirror
+    /// noticing the spawn call and telling the writer — without that, this conversation's first, empty
+    /// scan would be served forever and the child's file would never be written.
+    /// </summary>
+    [Fact]
+    public async Task Attach_RefreshesTheDescendantGraph_WhenASpawnCallIsObserved()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1)]);
+
+        var browser = new FakeFileBrowser();
+        await using var agent = new PublishingAgent(ThreadId);
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        mirror.Attach(agent);
+
+        // Two flushes, so the FIRST one has certainly completed its (empty) descendant scan before the
+        // sub-agent is seeded. Seeding into the window of that scan would let it be found by luck.
+        await PublishUntilFlushedAsync(agent, store, 2);
+        _ = await SettleAsync(store);
+        await SeedSubAgentAsync(store, "agent-1", "researcher");
+
+        await agent.PublishAsync(SpawnCall());
+        await agent.PublishAsync(RunCompleted());
+
+        // Named by the sub-agent's OWN id, not by its prefixed thread id.
+        var expected = $"{AgentsDirectory}/{WorkspaceTranscriptLine.AgentFileLeaf("researcher", WorkspaceTranscriptLine.ShortId("agent-1"))}{ConversationTranscriptWriter.TranscriptExtension}";
+        await WaitForAsync(
+            () => SplicedInto(browser, expected),
+            "The sub-agent transcript was never written, so the spawn call did not refresh the graph.");
+    }
+
+    /// <summary>
+    /// The other half of the cache-invalidation contract: a BACKGROUND sub-agent that finishes after its
+    /// parent's turn already ended is never announced by a spawn call in this process's message stream —
+    /// the only evidence is the completion notification it pushes back. Matching solely on the spawn call
+    /// would leave that child with no file at all, behind a fully green suite.
+    /// </summary>
+    [Fact]
+    public async Task Attach_RefreshesTheDescendantGraph_WhenACompletionNotificationIsObserved()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1)]);
+
+        var browser = new FakeFileBrowser();
+        await using var agent = new PublishingAgent(ThreadId);
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        mirror.Attach(agent);
+
+        // As above: two flushes, so the empty scan is certainly cached before the child exists.
+        await PublishUntilFlushedAsync(agent, store, 2);
+        _ = await SettleAsync(store);
+        await SeedSubAgentAsync(store, "agent-2", "reviewer");
+
+        // No spawn call — this process only ever sees the notification.
+        await agent.PublishAsync(new NotifyMessage { NotifyKind = NotifyKinds.SubAgentCompletion });
+        await agent.PublishAsync(RunCompleted());
+
+        var expected = $"{AgentsDirectory}/{WorkspaceTranscriptLine.AgentFileLeaf("reviewer", WorkspaceTranscriptLine.ShortId("agent-2"))}{ConversationTranscriptWriter.TranscriptExtension}";
+        await WaitForAsync(
+            () => SplicedInto(browser, expected),
+            "The sub-agent transcript was never written, so the completion notification did not refresh the graph.");
+    }
+
+    /// <summary>
+    /// A subscriber that cannot keep up is REMOVED from the agent's fan-out and its channel completed, so
+    /// its enumeration ends normally with no exception — indistinguishable, to a naive <c>await foreach</c>,
+    /// from the conversation having finished. Every later turn of a still-live conversation would then go
+    /// unmirrored, silently. The drop here is the real one: a capacity-1 output channel and a burst that
+    /// outruns the pump, driven through the shipping <c>PublishToSubscriber</c>.
+    /// </summary>
+    [Fact]
+    public async Task Attach_ReSubscribes_WhenTheAgentSilentlyDropsTheSubscription()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1)]);
+
+        var browser = new FakeFileBrowser();
+        await using var agent = new PublishingAgent(ThreadId, outputChannelCapacity: 1);
+
+        // The pool still holds THIS instance, which is what tells the mirror the conversation is live and
+        // the enumeration ended because it was dropped rather than torn down.
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        mirror.Attach(agent);
+        await PublishUntilFlushedAsync(agent, store, 1);
+
+        var deadline = DateTime.UtcNow + Deadline;
+        while (mirror.ResubscribeCount == 0)
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                throw new TimeoutException("A burst into a capacity-1 channel never forced a drop.");
+            }
+
+            for (var i = 0; i < 64; i++)
+            {
+                await agent.PublishAsync(new TextMessage { Text = "delta", Role = Role.Assistant });
+            }
+        }
+
+        _ = mirror.ResubscribeCount.Should().BeGreaterThan(0);
+
+        // Recovery is the point, not the counter: a turn boundary published AFTER the drop must still
+        // reach the mirror.
+        var before = store.FlushCount;
+        await PublishUntilFlushedAsync(agent, store, before + 1);
+    }
+
+    /// <summary>
+    /// A mode switch builds a REPLACEMENT agent for the same threadId. The subscription must move to it,
+    /// and the writer must NOT be rebuilt — a fresh writer has no watermark, so it would re-append the
+    /// conversation's entire history under the same uids.
+    /// </summary>
+    [Fact]
+    public async Task Attach_MovesTheSubscription_AndKeepsTheWriter_WhenTheAgentIsReplaced()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        PersistedMessage[] first = [Msg("m1", 1)];
+        await store.AppendMessagesAsync(ThreadId, first);
+
+        var browser = new FakeFileBrowser();
+        await using var original = new PublishingAgent(ThreadId);
+        await using var replacement = new PublishingAgent(ThreadId);
+        IMultiTurnAgent current = original;
+        using var mirror = CreateMirror(store, browser, _ => current);
+
+        mirror.Attach(original);
+        await PublishUntilFlushedAsync(original, store, 1);
+        await WaitForAsync(
+            () => SplicedInto(browser, MainPath),
+            "The original agent's run completion never produced an append.");
+
+        current = replacement;
+        mirror.Attach(replacement);
+        var settled = await SettleAsync(store);
+
+        PersistedMessage[] all = [.. first, Msg("m2", 2)];
+        await store.AppendMessagesAsync(ThreadId, [all[1]]);
+        await PublishUntilFlushedAsync(replacement, store, settled + 1);
+        await WaitForAsync(
+            () => LastPayload(browser) == ExpectedAppend(all, skip: 1),
+            "The replacement agent's turn did not append ONLY the new row — the writer was rebuilt.");
+
+        // And the original is no longer listened to: its publishes are inert.
+        var afterSwitch = await SettleAsync(store);
+        await original.PublishAsync(RunCompleted());
+        _ = (await SettleAsync(store)).Should().Be(afterSwitch);
+    }
+
+    /// <summary>
+    /// Eviction stops the mirror and RETAINS the transcript. Deleting it would defeat the feature: a record
+    /// written into the workspace is meant to outlive the conversation that produced it, which is exactly
+    /// the moment the pool raises <c>ThreadRemoved</c>.
+    /// </summary>
+    [Fact]
+    public async Task Evict_StopsMirroring_AndNeverDeletesTheTranscript()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1)]);
+
+        var browser = new FakeFileBrowser();
+        await using var agent = new PublishingAgent(ThreadId);
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        mirror.Attach(agent);
+        await PublishUntilFlushedAsync(agent, store, 1);
+        _ = await SettleAsync(store);
+
+        mirror.Evict(ThreadId);
+        var afterEvict = await SettleAsync(store);
+
+        await agent.PublishAsync(RunCompleted());
+        _ = (await SettleAsync(store)).Should().Be(afterEvict);
+        _ = browser
+            .Commands.Should()
+            .NotContain(c => c.Arguments.Contains("rm") || c.Arguments.Contains("rm -rf"));
+        _ = SplicedInto(browser, MainPath).Should().BeTrue();
+
+        // Evicting an unknown thread is a no-op, not a fault: ThreadRemoved fires for conversations this
+        // process may never have attached (a restart, an S2S-only thread).
+        var evictUnknown = () => mirror.Evict(OtherThreadId);
+        _ = evictUnknown.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// The mirror must be disposable by a SYNCHRONOUS <c>ServiceProvider.Dispose()</c>. A container-tracked
+    /// <c>IAsyncDisposable</c>-only singleton makes that call throw <i>"only implements IAsyncDisposable"</i>,
+    /// which is how a mirror bug turns into every E2E test failing at host teardown for a reason that looks
+    /// unrelated to transcripts. This test fails at COMPILE time if the interface is ever narrowed, and at
+    /// run time if disposal starts throwing.
+    /// </summary>
+    [Fact]
+    public async Task Dispose_TearsDownTheHostSynchronously_WithLiveSubscriptions()
+    {
+        var store = new InMemoryConversationStore();
+        await SeedConversationAsync(store);
+
+        var services = new ServiceCollection();
+        _ = services.AddSingleton<IConversationStore>(store);
+        _ = services.AddSingleton<IWorkspaceFileBrowser>(new FakeFileBrowser());
+        _ = services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        _ = services.AddSingleton(sp => new ConversationDescendantScanner(
+            sp.GetRequiredService<IConversationStore>(),
+            NullLogger<ConversationDescendantScanner>.Instance));
+        _ = services.AddSingleton(sp => new WorkspaceTranscriptMirror(
+            _ => null,
+            sp.GetRequiredService<IConversationStore>(),
+            sp.GetRequiredService<IWorkspaceFileBrowser>(),
+            sp.GetRequiredService<ConversationDescendantScanner>(),
+            sp.GetRequiredService<ILoggerFactory>()));
+
+        var provider = services.BuildServiceProvider();
+        await using var agent = new PublishingAgent(ThreadId);
+        var mirror = provider.GetRequiredService<WorkspaceTranscriptMirror>();
+        mirror.Attach(agent);
+        await agent.PublishAsync(RunCompleted());
+
+        var dispose = provider.Dispose;
+        _ = dispose.Should().NotThrow();
+
+        // Idempotent, because host teardown and an explicit dispose can both reach it.
+        var again = mirror.Dispose;
+        _ = again.Should().NotThrow();
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptMirrorTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptMirrorTests.cs
@@ -671,6 +671,82 @@ public sealed class WorkspaceTranscriptMirrorTests
     }
 
     /// <summary>
+    /// The budget is per TRIGGER, and a run completion is not the only trigger. A background sub-agent that
+    /// finishes after its parent's last turn arrives as a notification and nothing else — if that path
+    /// leaves an exhausted budget in place, the child gets one single attempt at a workspace that was
+    /// failing a moment ago, and its transcript is then abandoned with no further trigger coming. Every
+    /// independent external trigger starts a fresh generation of retries.
+    /// </summary>
+    [Fact]
+    public async Task Attach_ResetsTheRetryBudget_WhenASubAgentNotificationArrivesAfterItWasSpent()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1)]);
+
+        var browser = new FakeFileBrowser
+        {
+            ExecResult = new SandboxCommandResult
+            {
+                ExitCode = 1,
+                StandardOutput = "",
+                StandardError = "no space left on device",
+                OperationId = "op",
+            },
+        };
+        await using var agent = new PublishingAgent(ThreadId);
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        mirror.Attach(agent);
+        await agent.PublishAsync(RunCompleted());
+
+        var expected = 1 + WorkspaceTranscriptMirror.MaxDeferredRetries;
+        _ = (await SettleAsync(store)).Should().Be(expected);
+
+        // A different trigger entirely — and it is owed the same budget the run completion got.
+        await agent.PublishAsync(new NotifyMessage { NotifyKind = NotifyKinds.SubAgentCompletion });
+        _ = (await SettleAsync(store)).Should().Be(2 * expected);
+    }
+
+    /// <summary>
+    /// The fan-out is capped per flush, and a capped pass is PROGRESS rather than failure. Counting it
+    /// against the bounded retry budget puts a hard ceiling on how many descendants one trigger can ever
+    /// reach — <c>MaxDeferredRetries</c> plus one passes times the per-flush cap — and a conversation whose
+    /// roster is larger than that ceiling leaves its tail unmirrored, with no error anywhere and no further
+    /// trigger coming once the run has completed.
+    /// </summary>
+    [Fact]
+    public async Task Attach_MirrorsEveryDescendant_WhenTheRosterOutrunsTheRetryBudget()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1)]);
+
+        // One more than (1 + MaxDeferredRetries) passes of the default cap can reach.
+        var roster = ((1 + WorkspaceTranscriptMirror.MaxDeferredRetries)
+            * ConversationTranscriptWriter.DefaultMaxSubAgentFilesPerFlush) + 1;
+        for (var i = 0; i < roster; i++)
+        {
+            await SeedSubAgentAsync(store, $"agent-{i:D2}", $"worker{i:D2}");
+        }
+
+        var browser = new FakeFileBrowser();
+        await using var agent = new PublishingAgent(ThreadId);
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        mirror.Attach(agent);
+        await agent.PublishAsync(RunCompleted());
+
+        var expectedPaths = Enumerable.Range(0, roster).Select(i =>
+            $"{AgentsDirectory}/{WorkspaceTranscriptLine.AgentFileLeaf($"worker{i:D2}", WorkspaceTranscriptLine.ShortId($"agent-{i:D2}"))}{ConversationTranscriptWriter.TranscriptExtension}")
+            .ToList();
+
+        await WaitForAsync(
+            () => expectedPaths.All(p => SplicedInto(browser, p)),
+            "The tail of the descendant roster was never mirrored: the capped fan-out spent the retry budget before it got there.");
+    }
+
+    /// <summary>
     /// A mode switch builds a REPLACEMENT agent for the same threadId. The subscription must move to it,
     /// and the writer must NOT be rebuilt — a fresh writer has no watermark, so it would re-append the
     /// conversation's entire history under the same uids.

--- a/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptMirrorTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptMirrorTests.cs
@@ -166,8 +166,92 @@ public sealed class WorkspaceTranscriptMirrorTests
         public ValueTask DisposeAsync() => inner.DisposeAsync();
     }
 
-    // ---------------------------------------------------------------- helpers
+    /// <summary>
+    /// Fails the FIRST subscription setup and forwards every later one to a real
+    /// <see cref="PublishingAgent"/>, so a test can drive a transient failure and then a genuine recovery
+    /// through the same agent INSTANCE — which is the identity the mirror's idempotent re-attach turns on.
+    /// </summary>
+    /// <param name="inner">The real agent every surviving attempt subscribes to.</param>
+    /// <param name="failOnFirstMoveNext">
+    /// <c>false</c> throws out of <c>SubscribeAsync</c> itself, before any enumerator exists; <c>true</c>
+    /// hands back an enumerable whose first <c>MoveNextAsync</c> throws, which is the case that leaves an
+    /// enumerator — and with it a live channel registration — behind for the mirror to clean up.
+    /// </param>
+    private sealed class FlakySubscriptionAgent(PublishingAgent inner, bool failOnFirstMoveNext)
+        : IMultiTurnAgent
+    {
+        private int _attempts;
+        private int _abandonedDisposals;
 
+        /// <summary>How many times anything asked this agent for its message stream.</summary>
+        public int SubscribeAttempts => Volatile.Read(ref _attempts);
+
+        /// <summary>How many enumerators of the FAILING enumerable were disposed.</summary>
+        public int AbandonedEnumeratorDisposals => Volatile.Read(ref _abandonedDisposals);
+
+        public string? CurrentRunId => inner.CurrentRunId;
+
+        public string ThreadId => inner.ThreadId;
+
+        public bool IsRunning => inner.IsRunning;
+
+        public IAsyncEnumerable<IMessage> SubscribeAsync(CancellationToken ct = default)
+        {
+            if (Interlocked.Increment(ref _attempts) > 1)
+            {
+                return inner.SubscribeAsync(ct);
+            }
+
+            return failOnFirstMoveNext
+                ? new ThrowingEnumerable(() => Interlocked.Increment(ref _abandonedDisposals))
+                : throw new InvalidOperationException("the fan-out refused the subscriber");
+        }
+
+        public ValueTask<SendReceipt> SendAsync(
+            List<IMessage> messages,
+            string? inputId = null,
+            string? parentRunId = null,
+            CancellationToken ct = default) => inner.SendAsync(messages, inputId, parentRunId, ct);
+
+        public ValueTask<SendReceipt?> TrySendAsync(
+            List<IMessage> messages,
+            string? inputId = null,
+            string? parentRunId = null,
+            CancellationToken ct = default) => inner.TrySendAsync(messages, inputId, parentRunId, ct);
+
+        public IAsyncEnumerable<IMessage> ExecuteRunAsync(UserInput userInput, CancellationToken ct = default) =>
+            inner.ExecuteRunAsync(userInput, ct);
+
+        public Task RunAsync(CancellationToken ct = default) => inner.RunAsync(ct);
+
+        public Task StopAsync(TimeSpan? timeout = null) => inner.StopAsync(timeout);
+
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+
+        /// <summary>An enumerable whose first <c>MoveNextAsync</c> throws, reporting whether the enumerator
+        /// the caller had already created was disposed.</summary>
+        private sealed class ThrowingEnumerable(Action onDispose) : IAsyncEnumerable<IMessage>
+        {
+            public IAsyncEnumerator<IMessage> GetAsyncEnumerator(CancellationToken ct = default) =>
+                new Enumerator(onDispose);
+
+            private sealed class Enumerator(Action onDispose) : IAsyncEnumerator<IMessage>
+            {
+                public IMessage Current => throw new NotSupportedException();
+
+                public ValueTask<bool> MoveNextAsync() =>
+                    throw new InvalidOperationException("the fan-out refused the subscriber");
+
+                public ValueTask DisposeAsync()
+                {
+                    onDispose();
+                    return ValueTask.CompletedTask;
+                }
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------- helpers
 
     private static WorkspaceTranscriptMirror CreateMirror(
         IConversationStore store,
@@ -393,6 +477,83 @@ public sealed class WorkspaceTranscriptMirrorTests
         await WaitForAsync(
             () => SplicedInto(browser, MainPath),
             "A single run completion published after Attach returned never reached the mirror.");
+        _ = LastPayload(browser).Should().Be(ExpectedAppend(only));
+    }
+
+    /// <summary>
+    /// A subscription whose SETUP failed must leave nothing behind. The registration is recorded before the
+    /// pump starts — deliberately, so nothing can be published into the window between them — and
+    /// <c>Attach</c> treats an existing registration for the same agent instance as an idempotent no-op, so
+    /// a failure that leaves that registration in place converts one transient error into a conversation
+    /// that can never be mirrored again: the pool hands the same instance back, <c>Attach</c> returns
+    /// without subscribing, and no later turn of that conversation reaches a transcript.
+    /// </summary>
+    [Fact]
+    public async Task Attach_ReSubscribes_WhenAnEarlierSubscriptionSetupFailed()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        PersistedMessage[] only = [Msg("m1", 1)];
+        await store.AppendMessagesAsync(ThreadId, only);
+
+        var browser = new FakeFileBrowser();
+        await using var inner = new PublishingAgent(ThreadId);
+        var agent = new FlakySubscriptionAgent(inner, failOnFirstMoveNext: false);
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        // The failure must not escape into the pool's agent factory, which is what calls this.
+        var attach = () => mirror.Attach(agent);
+        _ = attach.Should().NotThrow();
+        _ = agent.SubscribeAttempts.Should().Be(1);
+
+        // The pool hands the SAME instance back on a later request. This is the re-attach the idempotent
+        // early return swallows while the failed registration is still resident.
+        mirror.Attach(agent);
+        _ = agent.SubscribeAttempts.Should().Be(
+            2,
+            "a registration whose pump never started must not make a re-attach of that agent a no-op");
+
+        await inner.PublishAsync(RunCompleted());
+        await WaitForAsync(
+            () => SplicedInto(browser, MainPath),
+            "The conversation stayed unmirrored after a transient subscription failure and a re-attach.");
+        _ = LastPayload(browser).Should().Be(ExpectedAppend(only));
+    }
+
+    /// <summary>
+    /// The other half of the same failure: when <c>MoveNextAsync</c> is what threw, an enumerator already
+    /// exists — and it is the enumerator, not the call that produced it, that holds this subscriber's slot
+    /// in the agent's fan-out and its channel. Abandoning it retains both for the life of the agent, and
+    /// the re-subscription then publishes alongside a registration nobody is draining.
+    /// </summary>
+    [Fact]
+    public async Task Attach_DisposesTheEnumerator_WhenTheFirstMoveNextFails()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        PersistedMessage[] only = [Msg("m1", 1)];
+        await store.AppendMessagesAsync(ThreadId, only);
+
+        var browser = new FakeFileBrowser();
+        await using var inner = new PublishingAgent(ThreadId);
+        var agent = new FlakySubscriptionAgent(inner, failOnFirstMoveNext: true);
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        var attach = () => mirror.Attach(agent);
+        _ = attach.Should().NotThrow();
+
+        // Disposal is deliberately off the caller's thread — Attach may neither block nor throw inside the
+        // pool's factory — so it is awaited rather than asserted inline.
+        await WaitForAsync(
+            () => agent.AbandonedEnumeratorDisposals == 1,
+            "The enumerator whose first MoveNextAsync threw was never disposed, so its subscriber registration and channel leak.");
+
+        // And the recovery still works, exactly as in the throw-before-the-enumerator case.
+        mirror.Attach(agent);
+        await inner.PublishAsync(RunCompleted());
+        await WaitForAsync(
+            () => SplicedInto(browser, MainPath),
+            "The conversation stayed unmirrored after a failed first MoveNextAsync and a re-attach.");
         _ = LastPayload(browser).Should().Be(ExpectedAppend(only));
     }
 

--- a/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptMirrorTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptMirrorTests.cs
@@ -1,6 +1,8 @@
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using System.Text;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.Sandbox;
 using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Tests.TestDoubles;
 using Microsoft.Extensions.DependencyInjection;
@@ -107,7 +109,65 @@ public sealed class WorkspaceTranscriptMirrorTests
             CancellationToken ct = default) => inner.ListThreadsAsync(limit, offset, ct);
     }
 
+    /// <summary>
+    /// Forwards everything to a real <see cref="PublishingAgent"/> and records the managed thread that
+    /// pulls the FIRST <c>MoveNextAsync</c> of the output enumeration.
+    /// </summary>
+    /// <remarks>
+    /// That pull is the moment <c>MultiTurnAgentBase.SubscribeAsync</c> registers the subscriber under
+    /// its replay lock — the iterator's prologue runs synchronously, on whichever thread pulls it — so
+    /// the recorded id answers "was the subscription live before <c>Attach</c> returned?" without
+    /// depending on any timing. A subclass could not observe this: <see cref="PublishingAgent"/> is
+    /// sealed and <c>SubscribeAsync</c> is not virtual, so the probe has to be a decorator.
+    /// </remarks>
+    private sealed class SubscriptionProbeAgent(PublishingAgent inner) : IMultiTurnAgent
+    {
+        private int _subscribeThreadId;
+
+        /// <summary>Zero until something has started enumerating.</summary>
+        public int SubscribeThreadId => Volatile.Read(ref _subscribeThreadId);
+
+        public string? CurrentRunId => inner.CurrentRunId;
+
+        public string ThreadId => inner.ThreadId;
+
+        public bool IsRunning => inner.IsRunning;
+
+        public async IAsyncEnumerable<IMessage> SubscribeAsync(
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            Volatile.Write(ref _subscribeThreadId, Environment.CurrentManagedThreadId);
+
+            await foreach (var message in inner.SubscribeAsync(ct).ConfigureAwait(false))
+            {
+                yield return message;
+            }
+        }
+
+        public ValueTask<SendReceipt> SendAsync(
+            List<IMessage> messages,
+            string? inputId = null,
+            string? parentRunId = null,
+            CancellationToken ct = default) => inner.SendAsync(messages, inputId, parentRunId, ct);
+
+        public ValueTask<SendReceipt?> TrySendAsync(
+            List<IMessage> messages,
+            string? inputId = null,
+            string? parentRunId = null,
+            CancellationToken ct = default) => inner.TrySendAsync(messages, inputId, parentRunId, ct);
+
+        public IAsyncEnumerable<IMessage> ExecuteRunAsync(UserInput userInput, CancellationToken ct = default) =>
+            inner.ExecuteRunAsync(userInput, ct);
+
+        public Task RunAsync(CancellationToken ct = default) => inner.RunAsync(ct);
+
+        public Task StopAsync(TimeSpan? timeout = null) => inner.StopAsync(timeout);
+
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+    }
+
     // ---------------------------------------------------------------- helpers
+
 
     private static WorkspaceTranscriptMirror CreateMirror(
         IConversationStore store,
@@ -216,9 +276,12 @@ public sealed class WorkspaceTranscriptMirrorTests
 
     /// <summary>
     /// Publishes run-completions until the mirror has flushed at least <paramref name="flushes"/> times.
-    /// Republishing is what makes attachment deterministic: <see cref="WorkspaceTranscriptMirror.Attach"/>
-    /// starts its pump on a worker, so the first publish can legitimately land before the subscription
-    /// exists — and a flush is idempotent, so an extra one changes nothing but the count.
+    /// A flush is idempotent, so an extra one changes nothing but the count — which is what lets a test
+    /// ask for "at least N flushes have happened" as a barrier without knowing how many publishes that
+    /// takes. It is NOT a workaround for a racy attachment: since
+    /// <see cref="WorkspaceTranscriptMirror.Attach"/> registers the subscription before it returns, one
+    /// publish is enough, and
+    /// <see cref="Attach_RegistersTheSubscription_BeforeItReturns"/> is the test that holds it to that.
     /// </summary>
     private static async Task PublishUntilFlushedAsync(PublishingAgent agent, FlushCountingStore store, int flushes)
     {
@@ -276,6 +339,48 @@ public sealed class WorkspaceTranscriptMirrorTests
         browser.Commands.Any(c => c.Arguments.Count == 7 && string.Equals(c.Arguments[6], path, StringComparison.Ordinal));
 
     // ---------------------------------------------------------------- tests
+
+    /// <summary>
+    /// <b>Attachment must be complete when <c>Attach</c> returns</b>, not merely requested. The
+    /// subscription is registered by the first <c>MoveNextAsync</c> of the agent's output enumeration,
+    /// and <c>MultiTurnAgentBase</c> runs that prologue synchronously under its replay lock — so pulling
+    /// it on the caller's thread is what closes the window. Handing the whole pump to a worker instead
+    /// lets <c>Attach</c> return first, and a completion published in that window is lost outright: the
+    /// agent's replay buffer is OPENED by a run assignment and CLOSED by the run completion, so a
+    /// completion that arrives before the subscriber exists is neither delivered live nor replayed. For a
+    /// conversation that runs once and stops — the common shape of a one-shot task — the transcript is
+    /// then never written at all.
+    /// </summary>
+    [Fact]
+    public async Task Attach_RegistersTheSubscription_BeforeItReturns()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        PersistedMessage[] only = [Msg("m1", 1)];
+        await store.AppendMessagesAsync(ThreadId, only);
+
+        var browser = new FakeFileBrowser();
+        await using var inner = new PublishingAgent(ThreadId);
+        var agent = new SubscriptionProbeAgent(inner);
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        var caller = Environment.CurrentManagedThreadId;
+        mirror.Attach(agent);
+
+        // Zero would mean nothing has enumerated yet; a pool thread's id would mean the registration was
+        // merely queued. Task.Run never inlines onto the caller, so only pulling it directly can match.
+        _ = agent.SubscribeThreadId.Should().Be(
+            caller,
+            "Attach must pull the first MoveNextAsync itself, so the subscription exists before it returns");
+
+        // The consequence, end to end: ONE completion — published exactly once, never in a retry loop —
+        // is enough to get this conversation's rows into its workspace.
+        await inner.PublishAsync(RunCompleted());
+        await WaitForAsync(
+            () => SplicedInto(browser, MainPath),
+            "A single run completion published after Attach returned never reached the mirror.");
+        _ = LastPayload(browser).Should().Be(ExpectedAppend(only));
+    }
 
     /// <summary>
     /// The whole composition, end to end: an attached agent's run completion drives a flush that appends
@@ -391,6 +496,13 @@ public sealed class WorkspaceTranscriptMirrorTests
     /// the only evidence is the completion notification it pushes back. Matching solely on the spawn call
     /// would leave that child with no file at all, behind a fully green suite.
     /// </summary>
+    /// <remarks>
+    /// <b>This test used to publish a run completion after the notification and therefore proved
+    /// nothing.</b> Noticing a notification and SCHEDULING A FLUSH for it are two different steps, and
+    /// only the second one writes a file; the trailing completion supplied that second step itself, so the
+    /// test passed while the notification path was inert. There is deliberately no completion here — a
+    /// background child finishing after its parent's last turn is exactly the case where none is coming.
+    /// </remarks>
     [Fact]
     public async Task Attach_RefreshesTheDescendantGraph_WhenACompletionNotificationIsObserved()
     {
@@ -409,14 +521,13 @@ public sealed class WorkspaceTranscriptMirrorTests
         _ = await SettleAsync(store);
         await SeedSubAgentAsync(store, "agent-2", "reviewer");
 
-        // No spawn call — this process only ever sees the notification.
+        // No spawn call and NO run completion — the notification has to carry this on its own.
         await agent.PublishAsync(new NotifyMessage { NotifyKind = NotifyKinds.SubAgentCompletion });
-        await agent.PublishAsync(RunCompleted());
 
         var expected = $"{AgentsDirectory}/{WorkspaceTranscriptLine.AgentFileLeaf("reviewer", WorkspaceTranscriptLine.ShortId("agent-2"))}{ConversationTranscriptWriter.TranscriptExtension}";
         await WaitForAsync(
             () => SplicedInto(browser, expected),
-            "The sub-agent transcript was never written, so the completion notification did not refresh the graph.");
+            "The sub-agent transcript was never written, so the completion notification did not schedule a flush.");
     }
 
     /// <summary>
@@ -463,6 +574,100 @@ public sealed class WorkspaceTranscriptMirrorTests
         // reach the mirror.
         var before = store.FlushCount;
         await PublishUntilFlushedAsync(agent, store, before + 1);
+    }
+
+    /// <summary>
+    /// Recovering the subscription is only half of recovery. Everything published during the gap was
+    /// DROPPED — including, in general, the run completion that would have triggered a flush — so a
+    /// re-subscribe that does not also schedule one leaves the conversation stalled until some unrelated
+    /// later turn happens to arrive. For the common case (the drop happens on the burst of the final
+    /// turn) no later turn ever comes and the transcript silently ends one turn early.
+    /// </summary>
+    /// <remarks>
+    /// Nothing published here after the baseline can schedule a flush on its own — deltas are
+    /// deliberately not a trigger (see
+    /// <see cref="Attach_SchedulesNoFlush_ForMessagesInsideATurn"/>) — so the counter moving at all is
+    /// attributable to the recovery path and to nothing else.
+    /// </remarks>
+    [Fact]
+    public async Task Attach_SchedulesAFlush_AfterRecoveringADroppedSubscription()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1)]);
+
+        var browser = new FakeFileBrowser();
+        await using var agent = new PublishingAgent(ThreadId, outputChannelCapacity: 1);
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        mirror.Attach(agent);
+        await PublishUntilFlushedAsync(agent, store, 1);
+        var baseline = await SettleAsync(store);
+
+        var deadline = DateTime.UtcNow + Deadline;
+        while (mirror.ResubscribeCount == 0)
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                throw new TimeoutException("A burst into a capacity-1 channel never forced a drop.");
+            }
+
+            for (var i = 0; i < 64; i++)
+            {
+                await agent.PublishAsync(new TextMessage { Text = "delta", Role = Role.Assistant });
+            }
+        }
+
+        await WaitForAsync(
+            () => store.FlushCount > baseline,
+            "Re-subscribing after a drop never scheduled a flush, so whatever was published during the gap stays unmirrored.");
+    }
+
+    /// <summary>
+    /// A <c>Deferred</c> flush asks to be rescheduled, and that request must be BOUNDED. A workspace whose
+    /// writes are failing defers every time, so an unconditional re-schedule is a self-feeding loop: the
+    /// drain is a SINGLE loop shared by every conversation, so one permanently-broken conversation spins
+    /// it at full speed and every other conversation's flush queues behind it. The bound is what makes the
+    /// retry terminate.
+    /// </summary>
+    /// <remarks>
+    /// The bound is a COUNT, with no delay attached, and that is deliberate: a backoff delay inside the
+    /// flush would run on that same shared drain loop and stall every other conversation, and a detached
+    /// timer is exactly the background machinery this feature is not meant to grow. The budget is per
+    /// turn, not per conversation — the second half of this test — so a transient outage cannot silence a
+    /// conversation permanently.
+    /// </remarks>
+    [Fact]
+    public async Task Attach_StopsReschedulingADeferredFlush_AfterABoundedNumberOfAttempts()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1)]);
+
+        // Every splice fails, so every flush defers with its watermark unadvanced and asks for another.
+        var browser = new FakeFileBrowser
+        {
+            ExecResult = new SandboxCommandResult
+            {
+                ExitCode = 1,
+                StandardOutput = "",
+                StandardError = "no space left on device",
+                OperationId = "op",
+            },
+        };
+        await using var agent = new PublishingAgent(ThreadId);
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        mirror.Attach(agent);
+        await agent.PublishAsync(RunCompleted());
+
+        // The turn's own flush, then exactly MaxDeferredRetries more. Unbounded, the mirror never goes
+        // quiet at all and this settles into a timeout instead of a count.
+        var expected = 1 + WorkspaceTranscriptMirror.MaxDeferredRetries;
+        _ = (await SettleAsync(store)).Should().Be(expected);
+
+        await agent.PublishAsync(RunCompleted());
+        _ = (await SettleAsync(store)).Should().Be(2 * expected);
     }
 
     /// <summary>

--- a/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptMirrorTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptMirrorTests.cs
@@ -335,8 +335,22 @@ public sealed class WorkspaceTranscriptMirrorTests
         return null;
     }
 
+    /// <summary>
+    /// Whether the flush spliced into <paramref name="path"/>. The splice is selected by the STAGED temp
+    /// file it consumes, not by argument count: the watermark probe now takes a per-line character cap as
+    /// a third positional, so it has the same arity as the splice and an arity test alone no longer tells
+    /// them apart.
+    /// </summary>
     private static bool SplicedInto(FakeFileBrowser browser, string path) =>
-        browser.Commands.Any(c => c.Arguments.Count == 7 && string.Equals(c.Arguments[6], path, StringComparison.Ordinal));
+        browser.Commands.Any(c =>
+            c.Arguments.Contains(TempPath, StringComparer.Ordinal)
+            && string.Equals(c.Arguments[^1], path, StringComparison.Ordinal));
+
+    private static SandboxCommandResult Ok() =>
+        new() { ExitCode = 0, StandardOutput = "", StandardError = "", OperationId = "op" };
+
+    private static SandboxCommandResult Fail() =>
+        new() { ExitCode = 1, StandardOutput = "", StandardError = "no space left on device", OperationId = "op" };
 
     // ---------------------------------------------------------------- tests
 
@@ -744,6 +758,193 @@ public sealed class WorkspaceTranscriptMirrorTests
         await WaitForAsync(
             () => expectedPaths.All(p => SplicedInto(browser, p)),
             "The tail of the descendant roster was never mirrored: the capped fan-out spent the retry budget before it got there.");
+    }
+
+    /// <summary>
+    /// A descendant whose splice keeps failing must be RETRIED across passes — and the retrying must still
+    /// END. These two are one test on purpose: the cheap way to guarantee termination is to mark every
+    /// descendant the sweep merely LOOKED at, which loses the failing one silently, and the cheap way to
+    /// guarantee the retry is to keep asking while anything is uncovered, which spins forever on a
+    /// descendant that can never be written. Only a version that does both passes here.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Termination.</b> A pass that failed reports <c>Deferred</c> and is charged to
+    /// <see cref="WorkspaceTranscriptMirror.MaxDeferredRetries"/>; a pass that failed on nothing covers its
+    /// whole window, and successive windows tile the roster, so at most ceil(roster / cap) consecutive
+    /// passes can be failure-free before either everything is covered or the doomed descendant is picked
+    /// again and the budget is charged. Hence the bound asserted below. <see cref="SettleAsync"/> is the
+    /// real check: a chain that does not terminate never goes quiet, and this fails as a timeout.
+    /// </para>
+    /// <para>
+    /// The doomed descendant is whichever one the first slice reaches first, chosen that way rather than
+    /// by name so the test does not encode the scanner's ordering.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task Attach_KeepsRetryingADescendantThatFails_AndStillStops()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1)]);
+
+        const int slices = 2;
+        var cap = ConversationTranscriptWriter.DefaultMaxSubAgentFilesPerFlush;
+        var roster = slices * cap;
+        for (var i = 0; i < roster; i++)
+        {
+            await SeedSubAgentAsync(store, $"agent-{i:D2}", $"worker{i:D2}");
+        }
+
+        var browser = new FakeFileBrowser();
+        string? doomed = null;
+        var attempts = 0;
+        browser.ExecuteHandler = command =>
+        {
+            var destination = command.Arguments[^1];
+            if (!command.Arguments.Contains(TempPath, StringComparer.Ordinal)
+                || !destination.StartsWith(AgentsDirectory, StringComparison.Ordinal))
+            {
+                return Ok();
+            }
+
+            doomed ??= destination;
+            if (!string.Equals(destination, doomed, StringComparison.Ordinal))
+            {
+                return Ok();
+            }
+
+            attempts++;
+            return Fail();
+        };
+
+        await using var agent = new PublishingAgent(ThreadId);
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        mirror.Attach(agent);
+        await agent.PublishAsync(RunCompleted());
+
+        var settled = await SettleAsync(store);
+
+        _ = attempts.Should().BeGreaterThan(
+            1,
+            "a descendant whose splice failed was never retried — the sweep marked it covered the moment it picked it, so the later slice's success ended the chain with that transcript missing"
+        );
+        _ = settled.Should().BeLessThanOrEqualTo(
+            (WorkspaceTranscriptMirror.MaxDeferredRetries + 2) * slices,
+            "the retry has to be bounded by the failure budget, not by the roster"
+        );
+    }
+
+    /// <summary>
+    /// Recovering a dropped subscription restarts coverage and the retry budget, but the descendant ROSTER
+    /// it restarts over is cached — and the cache is only ever invalidated by an announcement the mirror
+    /// OBSERVED. Everything published during the gap was dropped, which is precisely the case where the
+    /// announcement of a new sub-agent is the thing that went missing. So a child persisted while the
+    /// channel was down, and never mentioned again afterwards, is mirrored only if the recovery path forces
+    /// a rescan itself.
+    /// </summary>
+    /// <remarks>
+    /// Only the drop-recovery site forces it. The other two triggers fire because a message ARRIVED: a
+    /// sub-agent notification already arms a rescan through <c>NoteSubAgentActivity</c>, and a run
+    /// completion is not evidence about descendants at all — forcing a full store scan there would put one
+    /// on every turn boundary of every conversation, which is the cost the cache exists to avoid.
+    /// </remarks>
+    [Fact]
+    public async Task Attach_RescansTheDescendantRoster_AfterRecoveringADroppedSubscription()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1)]);
+
+        var browser = new FakeFileBrowser();
+        await using var agent = new PublishingAgent(ThreadId, outputChannelCapacity: 1);
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        mirror.Attach(agent);
+
+        // Two flushes, so the EMPTY descendant scan is certainly cached before the child exists.
+        await PublishUntilFlushedAsync(agent, store, 2);
+        _ = await SettleAsync(store);
+
+        // The child appears while the channel is about to go down, and NOTHING announces it afterwards.
+        await SeedSubAgentAsync(store, "agent-2", "reviewer");
+
+        var deadline = DateTime.UtcNow + Deadline;
+        while (mirror.ResubscribeCount == 0)
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                throw new TimeoutException("A burst into a capacity-1 channel never forced a drop.");
+            }
+
+            for (var i = 0; i < 64; i++)
+            {
+                await agent.PublishAsync(new TextMessage { Text = "delta", Role = Role.Assistant });
+            }
+        }
+
+        var expected = $"{AgentsDirectory}/{WorkspaceTranscriptLine.AgentFileLeaf("reviewer", WorkspaceTranscriptLine.ShortId("agent-2"))}{ConversationTranscriptWriter.TranscriptExtension}";
+        await WaitForAsync(
+            () => SplicedInto(browser, expected),
+            "The sub-agent that appeared during the gap was never mirrored: recovery reused the roster cached before it existed."
+        );
+    }
+
+    /// <summary>
+    /// A fresh trigger clears the retry budget from the SUBSCRIBER thread, while a flush from the previous
+    /// generation can still be sitting inside a gateway call on the drain. If that older flush's
+    /// <c>Deferred</c> is counted when it finally returns, it lands in the new generation's budget and the
+    /// new trigger starts one attempt down — a workspace recovering from an outage then gets fewer retries
+    /// exactly when it needs them, and nothing anywhere reports that the budget was spent on a result the
+    /// caller had already given up on.
+    /// </summary>
+    [Fact]
+    public async Task Attach_IgnoresTheOutcomeOfASupersededFlush_SoItCannotSpendTheNewBudget()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m1", 1)]);
+
+        // Every gateway call fails, so every flush defers and the budget is the only thing that stops it.
+        var browser = new FakeFileBrowser();
+        using var reached = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+        var gated = 0;
+        browser.ExecuteHandler = command =>
+        {
+            if (Interlocked.Exchange(ref gated, 1) == 0)
+            {
+                reached.Set();
+                _ = release.Wait(Deadline);
+            }
+
+            return Fail();
+        };
+
+        await using var agent = new PublishingAgent(ThreadId);
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        mirror.Attach(agent);
+        await agent.PublishAsync(RunCompleted());
+
+        _ = reached.Wait(Deadline).Should().BeTrue("the first flush never reached the gateway, so nothing is in flight to supersede");
+
+        // A brand-new trigger, published while that first flush is still blocked in the sandbox call.
+        await agent.PublishAsync(RunCompleted());
+
+        // The subscriber hot path does no I/O — handling this is a lock and a set-add — so the same quiet
+        // window the settling helper trusts is far more than it needs. That the drain really is still
+        // parked is asserted, not assumed: nothing can have flushed a second time.
+        await Task.Delay(QuietWindow);
+        _ = store.FlushCount.Should().Be(1, "the gate did not hold, so there was no in-flight flush to supersede");
+
+        release.Set();
+
+        // The superseded flush, then the new generation's own full budget. Counting the superseded
+        // Deferred instead costs the new generation its first attempt and settles one lower.
+        var expected = 1 + 1 + WorkspaceTranscriptMirror.MaxDeferredRetries;
+        _ = (await SettleAsync(store)).Should().Be(expected);
     }
 
     /// <summary>

--- a/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptMirrorTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptMirrorTests.cs
@@ -166,20 +166,38 @@ public sealed class WorkspaceTranscriptMirrorTests
         public ValueTask DisposeAsync() => inner.DisposeAsync();
     }
 
+    /// <summary>Where a failing subscription throws from — the three shapes are NOT interchangeable, see
+    /// <see cref="FlakySubscriptionAgent"/>.</summary>
+    private enum SubscriptionFailure
+    {
+        /// <summary>Out of the <c>SubscribeAsync</c> call itself, before any enumerator exists.</summary>
+        BeforeTheEnumerator,
+
+        /// <summary>Out of the first <c>MoveNextAsync</c>, leaving an enumerator someone must dispose.</summary>
+        OnFirstMoveNext,
+
+        /// <summary>
+        ///     From inside a genuine async iterator, before its first yield — the shape the production
+        ///     agent has. The compiler-generated state machine captures the throw into a FAULTED
+        ///     <c>ValueTask</c> returned by the first <c>MoveNextAsync</c>; nothing is thrown out of the
+        ///     subscribe call or out of <c>MoveNextAsync</c>, so no synchronous <c>try</c> around either
+        ///     can see it.
+        /// </summary>
+        InsideTheIterator,
+    }
+
     /// <summary>
     /// Fails the FIRST subscription setup and forwards every later one to a real
     /// <see cref="PublishingAgent"/>, so a test can drive a transient failure and then a genuine recovery
     /// through the same agent INSTANCE — which is the identity the mirror's idempotent re-attach turns on.
     /// </summary>
     /// <param name="inner">The real agent every surviving attempt subscribes to.</param>
-    /// <param name="failOnFirstMoveNext">
-    /// <c>false</c> throws out of <c>SubscribeAsync</c> itself, before any enumerator exists; <c>true</c>
-    /// hands back an enumerable whose first <c>MoveNextAsync</c> throws, which is the case that leaves an
-    /// enumerator — and with it a live channel registration — behind for the mirror to clean up.
-    /// </param>
-    private sealed class FlakySubscriptionAgent(PublishingAgent inner, bool failOnFirstMoveNext)
+    /// <param name="failure">Where that first attempt throws from — see <see cref="SubscriptionFailure"/>.</param>
+    private sealed class FlakySubscriptionAgent(PublishingAgent inner, SubscriptionFailure failure)
         : IMultiTurnAgent
     {
+        private const string FailureMessage = "the fan-out refused the subscriber";
+
         private int _attempts;
         private int _abandonedDisposals;
 
@@ -197,14 +215,43 @@ public sealed class WorkspaceTranscriptMirrorTests
 
         public IAsyncEnumerable<IMessage> SubscribeAsync(CancellationToken ct = default)
         {
+            if (failure == SubscriptionFailure.InsideTheIterator)
+            {
+                // Counted inside the iterator instead of here, because that is where an async iterator's
+                // body actually runs — including its first statement. Nothing about this method call
+                // executes it.
+                return IteratorAsync(ct);
+            }
+
             if (Interlocked.Increment(ref _attempts) > 1)
             {
                 return inner.SubscribeAsync(ct);
             }
 
-            return failOnFirstMoveNext
+            return failure == SubscriptionFailure.OnFirstMoveNext
                 ? new ThrowingEnumerable(() => Interlocked.Increment(ref _abandonedDisposals))
-                : throw new InvalidOperationException("the fan-out refused the subscriber");
+                : throw new InvalidOperationException(FailureMessage);
+        }
+
+        /// <summary>
+        ///     A real <c>async IAsyncEnumerable</c>, shaped like <c>MultiTurnAgentBase.SubscribeAsync</c>:
+        ///     a prologue that can fail, then a forwarded stream. The failure therefore reaches the caller
+        ///     the way the production one does — as a faulted <c>ValueTask</c> from the first
+        ///     <c>MoveNextAsync</c>, on whatever thread awaits it — and not as a throw the subscriber's own
+        ///     stack frame could catch.
+        /// </summary>
+        private async IAsyncEnumerable<IMessage> IteratorAsync(
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            if (Interlocked.Increment(ref _attempts) == 1)
+            {
+                throw new InvalidOperationException(FailureMessage);
+            }
+
+            await foreach (var message in inner.SubscribeAsync(ct))
+            {
+                yield return message;
+            }
         }
 
         public ValueTask<SendReceipt> SendAsync(
@@ -240,7 +287,7 @@ public sealed class WorkspaceTranscriptMirrorTests
                 public IMessage Current => throw new NotSupportedException();
 
                 public ValueTask<bool> MoveNextAsync() =>
-                    throw new InvalidOperationException("the fan-out refused the subscriber");
+                    throw new InvalidOperationException(FailureMessage);
 
                 public ValueTask DisposeAsync()
                 {
@@ -498,7 +545,7 @@ public sealed class WorkspaceTranscriptMirrorTests
 
         var browser = new FakeFileBrowser();
         await using var inner = new PublishingAgent(ThreadId);
-        var agent = new FlakySubscriptionAgent(inner, failOnFirstMoveNext: false);
+        var agent = new FlakySubscriptionAgent(inner, SubscriptionFailure.BeforeTheEnumerator);
         using var mirror = CreateMirror(store, browser, _ => agent);
 
         // The failure must not escape into the pool's agent factory, which is what calls this.
@@ -536,7 +583,7 @@ public sealed class WorkspaceTranscriptMirrorTests
 
         var browser = new FakeFileBrowser();
         await using var inner = new PublishingAgent(ThreadId);
-        var agent = new FlakySubscriptionAgent(inner, failOnFirstMoveNext: true);
+        var agent = new FlakySubscriptionAgent(inner, SubscriptionFailure.OnFirstMoveNext);
         using var mirror = CreateMirror(store, browser, _ => agent);
 
         var attach = () => mirror.Attach(agent);
@@ -554,6 +601,58 @@ public sealed class WorkspaceTranscriptMirrorTests
         await WaitForAsync(
             () => SplicedInto(browser, MainPath),
             "The conversation stayed unmirrored after a failed first MoveNextAsync and a re-attach.");
+        _ = LastPayload(browser).Should().Be(ExpectedAppend(only));
+    }
+
+    /// <summary>
+    /// The same defect through the door the real code uses. <c>MultiTurnAgentBase.SubscribeAsync</c> is an
+    /// async iterator, so a throw in its prologue — creating the bounded channel, joining the fan-out under
+    /// the replay lock — never reaches the subscriber synchronously: the state machine captures it into a
+    /// faulted <c>ValueTask</c> returned by the first <c>MoveNextAsync</c>. So the mirror's synchronous
+    /// try/catch around subscription setup cannot fire, the fault surfaces on the pump instead, and it is
+    /// the PUMP that must not leave a registration behind — otherwise <c>Attach</c>'s idempotent early
+    /// return makes every later re-attach of that same agent instance a no-op and the conversation is
+    /// unmirrorable for the rest of its life. The two tests above cover synchronous throws, which are a
+    /// real but narrower shape that no production subscribe path actually produces.
+    /// </summary>
+    [Fact]
+    public async Task Attach_ReSubscribes_WhenAnEarlierSubscriptionFaultedAsynchronously()
+    {
+        var store = new FlushCountingStore(new InMemoryConversationStore());
+        await SeedConversationAsync(store);
+        PersistedMessage[] only = [Msg("m1", 1)];
+        await store.AppendMessagesAsync(ThreadId, only);
+
+        var browser = new FakeFileBrowser();
+        await using var inner = new PublishingAgent(ThreadId);
+        var agent = new FlakySubscriptionAgent(inner, SubscriptionFailure.InsideTheIterator);
+        using var mirror = CreateMirror(store, browser, _ => agent);
+
+        var attach = () => mirror.Attach(agent);
+        _ = attach.Should().NotThrow();
+
+        // Already 1 even though nothing threw here: the iterator's body — the counter included — runs on
+        // the first MoveNextAsync, which Attach performs on this thread before returning.
+        _ = agent.SubscribeAttempts.Should().Be(1);
+
+        // Unlike a synchronous failure, this one is only observed once the pump awaits it, on another
+        // thread and after Attach has returned. So the recovering re-attach is POLLED rather than issued
+        // once: while the dead registration is still resident Attach is a documented no-op, which makes
+        // repeating it harmless, and repeating it is precisely what the pool does when it hands the same
+        // pooled instance back on a later request.
+        await WaitForAsync(
+            () =>
+            {
+                mirror.Attach(agent);
+                return agent.SubscribeAttempts >= 2;
+            },
+            "A subscription that faulted asynchronously kept its registration, so re-attaching the same "
+                + "agent stayed a no-op and the conversation could never be mirrored again.");
+
+        await inner.PublishAsync(RunCompleted());
+        await WaitForAsync(
+            () => SplicedInto(browser, MainPath),
+            "The conversation stayed unmirrored after an asynchronously faulted subscription and a re-attach.");
         _ = LastPayload(browser).Should().Be(ExpectedAppend(only));
     }
 

--- a/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptSymlinkTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptSymlinkTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using AchieveAi.LmDotnetTools.Sandbox;
 using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Tests.TestDoubles;
 
@@ -35,14 +36,22 @@ public sealed class WorkspaceTranscriptSymlinkTests
     private const string ThreadId = "conv-link-7a3b";
     private const string WorkspaceId = "ws-link";
     private const string Title = "Link Proof";
-    private const string AgentId = "agent-link-1";
-    private const string AgentName = "researcher";
+    private const string RetitledTo = "Renamed Proof";
+
+    /// <summary>Sub-agent ids and display names, paired by index and consumed in seeding order.</summary>
+    private static readonly string[] AgentIds = ["agent-link-1", "agent-link-2"];
+
+    private static readonly string[] AgentNames = ["researcher", "reviewer"];
 
     /// <summary>Content of the file each symlink points at. No flush may ever change it.</summary>
     private const string TrackedContent = "tracked source file, not a transcript\n";
 
-    private static readonly string Leaf =
-        WorkspaceTranscriptLine.MainFileLeaf(Title, WorkspaceTranscriptLine.ShortId(ThreadId));
+    private static readonly string ShortThreadId = WorkspaceTranscriptLine.ShortId(ThreadId);
+
+    private static readonly string Leaf = WorkspaceTranscriptLine.MainFileLeaf(Title, ShortThreadId);
+
+    private static readonly string RetitledLeaf =
+        WorkspaceTranscriptLine.MainFileLeaf(RetitledTo, ShortThreadId);
 
     /// <summary>
     /// The destination transcript file is a symlink to a tracked file. <c>cat &gt;&gt;</c> follows it, so the
@@ -52,9 +61,9 @@ public sealed class WorkspaceTranscriptSymlinkTests
     [SkippableFact]
     public async Task Flush_RefusesToAppendThroughASymlinkedDestinationFile()
     {
-        var (root, writer) = await SetupAsync(nameof(Flush_RefusesToAppendThroughASymlinkedDestinationFile));
+        var (root, writer, _, _) = await SetupAsync(nameof(Flush_RefusesToAppendThroughASymlinkedDestinationFile));
         var tracked = WriteTrackedFile(root, "tracked.txt");
-        var destination = Path.Combine(root, ConversationTranscriptWriter.TranscriptDirectory, Leaf + ".jsonl");
+        var destination = TranscriptPath(root, Leaf);
         _ = Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
         LinkToFile(destination, tracked);
 
@@ -74,8 +83,8 @@ public sealed class WorkspaceTranscriptSymlinkTests
     [SkippableFact]
     public async Task Flush_RefusesToWriteThroughASymlinkedTranscriptDirectory()
     {
-        var (root, writer) = await SetupAsync(nameof(Flush_RefusesToWriteThroughASymlinkedTranscriptDirectory));
-        var elsewhere = Directory.CreateDirectory(Path.Combine(root, "elsewhere")).FullName;
+        var (root, writer, _, _) = await SetupAsync(nameof(Flush_RefusesToWriteThroughASymlinkedTranscriptDirectory));
+        var elsewhere = ElsewhereIn(root);
         var transcriptDirectory = Path.Combine(root, ConversationTranscriptWriter.TranscriptDirectory);
         LinkToDirectory(transcriptDirectory, elsewhere);
 
@@ -95,14 +104,11 @@ public sealed class WorkspaceTranscriptSymlinkTests
     [SkippableFact]
     public async Task Flush_RefusesToWriteADescendantThroughASymlinkedAgentsDirectory()
     {
-        var (root, writer) = await SetupAsync(
+        var (root, writer, _, _) = await SetupAsync(
             nameof(Flush_RefusesToWriteADescendantThroughASymlinkedAgentsDirectory),
-            withSubAgent: true);
-        var elsewhere = Directory.CreateDirectory(Path.Combine(root, "elsewhere")).FullName;
-        var agentsDirectory = Path.Combine(
-            root,
-            ConversationTranscriptWriter.TranscriptDirectory,
-            Leaf + ConversationTranscriptWriter.AgentsDirectorySuffix);
+            subAgents: 1);
+        var elsewhere = ElsewhereIn(root);
+        var agentsDirectory = AgentsDirectoryPath(root, Leaf);
         _ = Directory.CreateDirectory(Path.GetDirectoryName(agentsDirectory)!);
         LinkToDirectory(agentsDirectory, elsewhere);
 
@@ -115,8 +121,7 @@ public sealed class WorkspaceTranscriptSymlinkTests
 
         // The main transcript DID get written: the refusal is scoped to the redirected path, and this flush
         // was doing real work rather than failing before it started.
-        _ = File.Exists(Path.Combine(root, ConversationTranscriptWriter.TranscriptDirectory, Leaf + ".jsonl"))
-            .Should().BeTrue();
+        _ = File.Exists(TranscriptPath(root, Leaf)).Should().BeTrue();
     }
 
     /// <summary>
@@ -128,12 +133,9 @@ public sealed class WorkspaceTranscriptSymlinkTests
     [SkippableFact]
     public async Task Flush_RefusesToStageThroughASymlinkedTempPath()
     {
-        var (root, writer) = await SetupAsync(nameof(Flush_RefusesToStageThroughASymlinkedTempPath));
+        var (root, writer, _, _) = await SetupAsync(nameof(Flush_RefusesToStageThroughASymlinkedTempPath));
         var tracked = WriteTrackedFile(root, "tracked-staging.txt");
-        var tempPath = Path.Combine(
-            root,
-            ConversationTranscriptWriter.TempDirectory,
-            WorkspaceTranscriptLine.ShortId(ThreadId) + ConversationTranscriptWriter.TempExtension);
+        var tempPath = TempPath(root);
         _ = Directory.CreateDirectory(Path.GetDirectoryName(tempPath)!);
         LinkToFile(tempPath, tracked);
 
@@ -152,7 +154,7 @@ public sealed class WorkspaceTranscriptSymlinkTests
     [SkippableFact]
     public async Task Flush_RefusesToWriteContainmentThroughASymlink()
     {
-        var (root, writer) = await SetupAsync(nameof(Flush_RefusesToWriteContainmentThroughASymlink));
+        var (root, writer, _, _) = await SetupAsync(nameof(Flush_RefusesToWriteContainmentThroughASymlink));
         var tracked = WriteTrackedFile(root, "tracked-config.txt");
         var gitignore = Path.Combine(
             root,
@@ -172,15 +174,147 @@ public sealed class WorkspaceTranscriptSymlinkTests
             .BeEmpty("containment could not be established, so no transcript may exist either");
     }
 
+    /// <summary>
+    /// The staging path becomes a symlink PART-WAY THROUGH a flush — after one descendant has been spliced
+    /// and before the next is staged. One temp path serves the whole flush, and between two consecutive
+    /// PUTs sits a full shell execution, so a guard that answers once per flush leaves every append after
+    /// the first writing through whatever was planted in that window.
+    /// </summary>
+    /// <remarks>
+    /// Planting the link before the flush starts is a different and far weaker claim — it is already
+    /// covered by <see cref="Flush_RefusesToStageThroughASymlinkedTempPath"/>, and it passes against a
+    /// once-per-flush guard, so it says nothing about this. The discriminating assertion is the tracked
+    /// file's CONTENT: the flush defers either way (the append script guards its own destination), but only
+    /// a per-append staging guard keeps the second descendant's rows out of the link's target.
+    /// </remarks>
+    [SkippableFact]
+    public async Task Flush_RefusesToStageThroughATempPathSymlinkedBetweenTwoDescendants()
+    {
+        var (root, writer, _, browser) = await SetupAsync(
+            nameof(Flush_RefusesToStageThroughATempPathSymlinkedBetweenTwoDescendants),
+            subAgents: 2);
+        var tracked = WriteTrackedFile(root, "tracked-interleaved.txt");
+        var tempPath = TempPath(root);
+
+        // Fire on the first splice INTO the sub-agent directory: descendant one is on disk by then, and
+        // descendant two has not been staged yet. The append script's own `rm -f` has just removed the temp
+        // file, so the link goes down on a clear path — which is also why planting it after the PUT instead
+        // would not survive to be followed.
+        var planted = false;
+        browser.AfterCommand = command =>
+        {
+            if (planted || !IsDescendantSplice(command))
+            {
+                return;
+            }
+
+            planted = true;
+            _ = Directory.CreateDirectory(Path.GetDirectoryName(tempPath)!);
+            File.Delete(tempPath);
+            LinkToFile(tempPath, tracked);
+        };
+
+        var outcome = await writer.FlushAsync();
+
+        _ = planted.Should().BeTrue("the plant has to land mid-flush or the case is not being exercised");
+        AssertUntouched(tracked);
+        AssertStillALink(tempPath);
+        _ = outcome.Should().Be(TranscriptFlushOutcome.Deferred);
+
+        // The first descendant DID get written, so the flush was mid-fan-out rather than stopped early.
+        _ = Directory.GetFiles(AgentsDirectoryPath(root, Leaf)).Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// A retitle whose destination leaf is a symlink resolving to a DIRECTORY. <c>mv</c> then moves the
+    /// transcript INSIDE that directory instead of renaming it, carrying the whole unredacted file out of
+    /// <c>.conversations</c> and out from under the <c>.gitignore</c> beside it.
+    /// </summary>
+    /// <remarks>
+    /// An earlier round of this work left the rename unguarded on the rationale that "<c>mv A B</c>
+    /// replaces the destination PATH rather than writing through a link at B". That rationale is wrong for
+    /// the case that matters. It holds only when the link resolves to a FILE — <c>rename(2)</c> then
+    /// replaces the link itself and leaves its target alone — and a link to a directory inverts it
+    /// completely.
+    /// </remarks>
+    [SkippableFact]
+    public async Task Retitle_RefusesToMoveTheTranscriptThroughASymlinkedDestination()
+    {
+        var (root, writer, store, _) = await SetupAsync(
+            nameof(Retitle_RefusesToMoveTheTranscriptThroughASymlinkedDestination));
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+
+        var original = TranscriptPath(root, Leaf);
+        var before = await File.ReadAllTextAsync(original);
+        var elsewhere = ElsewhereIn(root);
+        var destination = TranscriptPath(root, RetitledLeaf);
+        LinkToDirectory(destination, elsewhere);
+
+        await SaveTitleAsync(store, RetitledTo);
+        await store.AppendMessagesAsync(ThreadId, [Msg("m3", 3, "User", "\"and now?\"", ThreadId)]);
+        _ = await writer.FlushAsync();
+
+        _ = Directory.GetFileSystemEntries(elsewhere).Should().BeEmpty(
+            "mv moves its source INSIDE a destination that resolves to a directory, which would carry the "
+                + "whole unredacted transcript out of the ignored directory");
+        AssertDirectoryStillALink(destination);
+
+        // Refusing the rename must not cost the conversation its mirror: the transcript keeps the old name
+        // and keeps growing there.
+        _ = File.Exists(original).Should().BeTrue();
+        _ = (await File.ReadAllTextAsync(original)).Should().StartWith(before);
+    }
+
+    /// <summary>
+    /// The <c>_agents</c> half of the same rename, which carries every descendant transcript and has
+    /// exactly the same exposure. Its destination is a symlink to a directory, so an unguarded <c>mv</c>
+    /// relocates the whole directory rather than renaming it.
+    /// </summary>
+    [SkippableFact]
+    public async Task Retitle_RefusesToMoveTheAgentsDirectoryThroughASymlinkedDestination()
+    {
+        var (root, writer, store, _) = await SetupAsync(
+            nameof(Retitle_RefusesToMoveTheAgentsDirectoryThroughASymlinkedDestination),
+            subAgents: 1);
+        _ = (await writer.FlushAsync()).Should().Be(TranscriptFlushOutcome.Written);
+
+        var agentsDirectory = AgentsDirectoryPath(root, Leaf);
+        _ = Directory.GetFiles(agentsDirectory).Should().ContainSingle();
+
+        var elsewhere = ElsewhereIn(root);
+        var destination = AgentsDirectoryPath(root, RetitledLeaf);
+        LinkToDirectory(destination, elsewhere);
+
+        await SaveTitleAsync(store, RetitledTo);
+        _ = await writer.FlushAsync();
+
+        _ = Directory.GetFileSystemEntries(elsewhere).Should().BeEmpty(
+            "a descendant's reasoning leaves through a redirected rename exactly as the root's does");
+        AssertDirectoryStillALink(destination);
+        _ = Directory.GetFiles(agentsDirectory).Should().ContainSingle(
+            "the sub-agent transcripts stay where they were rather than travelling through the link");
+    }
+
     // ---------------------------------------------------------------- helpers
+
+    /// <summary>
+    /// Whether an argv is the append script splicing a SUB-AGENT file — i.e. a descendant has just landed.
+    /// The append script's directory argument is what distinguishes it from the main transcript's splice.
+    /// </summary>
+    private static bool IsDescendantSplice(SandboxCommand command) =>
+        command.Arguments.Count == 7
+        && command.Arguments[4].EndsWith(ConversationTranscriptWriter.AgentsDirectorySuffix, StringComparison.Ordinal);
 
     /// <summary>
     /// A clean workspace root and a writer pointed at it through a real shell. Skips when the machine has
     /// no POSIX shell — the same condition <see cref="WorkspaceTranscriptLiveFileTests"/> skips on.
     /// </summary>
-    private static async Task<(string Root, ConversationTranscriptWriter Writer)> SetupAsync(
-        string caseName,
-        bool withSubAgent = false)
+    /// <param name="caseName">Names the workspace root, so cases cannot see each other's files.</param>
+    /// <param name="subAgents">
+    /// How many descendant threads to seed. Two of them is what makes a mid-flush plant expressible: the
+    /// fan-out stages each descendant through the SAME temp path, one after the other.
+    /// </param>
+    private static async Task<Fixture> SetupAsync(string caseName, int subAgents = 0)
     {
         var shell = LocalShellWorkspaceBrowser.FindPosixShell();
         Skip.If(
@@ -196,16 +330,7 @@ public sealed class WorkspaceTranscriptSymlinkTests
         _ = Directory.CreateDirectory(root);
 
         var store = new InMemoryConversationStore();
-        await store.SaveMetadataAsync(
-            ThreadId,
-            new ThreadMetadata
-            {
-                ThreadId = ThreadId,
-                LastUpdated = 0,
-                Properties = ImmutableDictionary<string, object>
-                    .Empty.Add(MultiTurnAgentPool.WorkspacePropertyKey, WorkspaceId)
-                    .Add("title", Title),
-            });
+        await SaveTitleAsync(store, Title);
         await store.AppendMessagesAsync(
             ThreadId,
             [
@@ -213,9 +338,10 @@ public sealed class WorkspaceTranscriptSymlinkTests
                 Msg("m2", 2, "Assistant", "\"a secret\"", ThreadId),
             ]);
 
-        if (withSubAgent)
+        for (var i = 0; i < subAgents; i++)
         {
-            var childThreadId = SubAgentProvenance.ThreadIdPrefix + AgentId;
+            var agentId = AgentIds[i];
+            var childThreadId = SubAgentProvenance.ThreadIdPrefix + agentId;
             await store.SaveMetadataAsync(
                 childThreadId,
                 new ThreadMetadata
@@ -225,8 +351,8 @@ public sealed class WorkspaceTranscriptSymlinkTests
                     Properties = SubAgentProvenance.Build(
                         ThreadId,
                         new SubAgentSnapshot(
-                            AgentId,
-                            Name: AgentName,
+                            agentId,
+                            Name: AgentNames[i],
                             TemplateName: "worker",
                             Task: "look it up",
                             Status: SubAgentStatus.Completed,
@@ -236,20 +362,61 @@ public sealed class WorkspaceTranscriptSymlinkTests
                 });
             await store.AppendMessagesAsync(
                 childThreadId,
-                [Msg("s1", 1, "Assistant", "\"found it\"", childThreadId)]);
+                [Msg($"s{i}", 1, "Assistant", "\"found it\"", childThreadId)]);
         }
 
+        var browser = new LocalShellWorkspaceBrowser(root, shell);
         var writer = new ConversationTranscriptWriter(
             ThreadId,
             store,
-            new LocalShellWorkspaceBrowser(root, shell),
+            browser,
             new ConversationDescendantScanner(store, NullLogger<ConversationDescendantScanner>.Instance),
             NullLogger<ConversationTranscriptWriter>.Instance,
             TimeSpan.Zero,
             ConversationTranscriptWriter.DefaultMaxSubAgentFilesPerFlush);
 
-        return (root, writer);
+        return new Fixture(root, writer, store, browser);
     }
+
+    /// <summary>Everything a case needs to reach past the writer and change the world mid-flush.</summary>
+    private sealed record Fixture(
+        string Root,
+        ConversationTranscriptWriter Writer,
+        InMemoryConversationStore Store,
+        LocalShellWorkspaceBrowser Browser);
+
+    private static Task SaveTitleAsync(InMemoryConversationStore store, string title) =>
+        store.SaveMetadataAsync(
+            ThreadId,
+            new ThreadMetadata
+            {
+                ThreadId = ThreadId,
+                LastUpdated = 0,
+                Properties = ImmutableDictionary<string, object>
+                    .Empty.Add(MultiTurnAgentPool.WorkspacePropertyKey, WorkspaceId)
+                    .Add("title", title),
+            });
+
+    private static string TranscriptPath(string root, string leaf) =>
+        Path.Combine(
+            root,
+            ConversationTranscriptWriter.TranscriptDirectory,
+            leaf + ConversationTranscriptWriter.TranscriptExtension);
+
+    private static string AgentsDirectoryPath(string root, string leaf) =>
+        Path.Combine(
+            root,
+            ConversationTranscriptWriter.TranscriptDirectory,
+            leaf + ConversationTranscriptWriter.AgentsDirectorySuffix);
+
+    private static string TempPath(string root) =>
+        Path.Combine(
+            root,
+            ConversationTranscriptWriter.TempDirectory,
+            ShortThreadId + ConversationTranscriptWriter.TempExtension);
+
+    private static string ElsewhereIn(string root) =>
+        Directory.CreateDirectory(Path.Combine(root, "elsewhere")).FullName;
 
     private static string WriteTrackedFile(string root, string name)
     {

--- a/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptSymlinkTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptSymlinkTests.cs
@@ -1,0 +1,327 @@
+using System.Collections.Immutable;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Tests.TestDoubles;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// The transcript mirror against a workspace that is not cooperating: every path it is about to write
+/// through has been replaced with a SYMLINK first. Driven over a REAL filesystem and a REAL POSIX shell,
+/// because the whole defect is a property of the operating system rather than of any C# call — <c>&gt;&gt;</c>,
+/// <c>mkdir -p</c>, <c>[ -e ]</c>, <c>tail</c> and a gateway PUT all follow symlinks silently, and a fake
+/// that hands back a regular file where production meets a link cannot fail.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The threat is ordinary rather than exotic. A workspace is shared with the agents working in it, and the
+/// transcript leaf is derived from the conversation TITLE, so its name is guessable well before it exists.
+/// An agent that drops a symlink there redirects the conversation's unredacted reasoning to wherever the
+/// link points — typically a tracked file, which is precisely the destination the <c>.gitignore</c> beside
+/// the transcript exists to keep it out of.
+/// </para>
+/// <para>
+/// Every case asserts the same two things: the transcript did NOT travel through the link, and the link
+/// itself is STILL THERE afterwards. The second is not incidental. An indeterminate destination must be
+/// refused, never repaired: unlinking it and writing a fresh file would destroy whatever the link pointed
+/// at, which is the very file being protected. Deferring costs a repeated flush; there is nothing to
+/// recover from having overwritten someone's source file.
+/// </para>
+/// </remarks>
+public sealed class WorkspaceTranscriptSymlinkTests
+{
+    private const string RootDirectoryName = "lm-transcript-symlink";
+
+    private const string ThreadId = "conv-link-7a3b";
+    private const string WorkspaceId = "ws-link";
+    private const string Title = "Link Proof";
+    private const string AgentId = "agent-link-1";
+    private const string AgentName = "researcher";
+
+    /// <summary>Content of the file each symlink points at. No flush may ever change it.</summary>
+    private const string TrackedContent = "tracked source file, not a transcript\n";
+
+    private static readonly string Leaf =
+        WorkspaceTranscriptLine.MainFileLeaf(Title, WorkspaceTranscriptLine.ShortId(ThreadId));
+
+    /// <summary>
+    /// The destination transcript file is a symlink to a tracked file. <c>cat &gt;&gt;</c> follows it, so the
+    /// entire conversation would be appended into that file — outside the ignored directory, and staged for
+    /// the next <c>git add -A</c>.
+    /// </summary>
+    [SkippableFact]
+    public async Task Flush_RefusesToAppendThroughASymlinkedDestinationFile()
+    {
+        var (root, writer) = await SetupAsync(nameof(Flush_RefusesToAppendThroughASymlinkedDestinationFile));
+        var tracked = WriteTrackedFile(root, "tracked.txt");
+        var destination = Path.Combine(root, ConversationTranscriptWriter.TranscriptDirectory, Leaf + ".jsonl");
+        _ = Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+        LinkToFile(destination, tracked);
+
+        var outcome = await writer.FlushAsync();
+
+        _ = outcome.Should().Be(TranscriptFlushOutcome.Deferred);
+        AssertUntouched(tracked);
+        AssertStillALink(destination);
+    }
+
+    /// <summary>
+    /// The transcript DIRECTORY is a symlink. <c>mkdir -p</c> on it succeeds silently — there is nothing to
+    /// create — and every file beneath it then lands in the link's target, including the <c>.gitignore</c>
+    /// that is supposed to be covering them. Worse than a leak: that PUT writes <c>*</c> over whatever file
+    /// the ignore path resolves to.
+    /// </summary>
+    [SkippableFact]
+    public async Task Flush_RefusesToWriteThroughASymlinkedTranscriptDirectory()
+    {
+        var (root, writer) = await SetupAsync(nameof(Flush_RefusesToWriteThroughASymlinkedTranscriptDirectory));
+        var elsewhere = Directory.CreateDirectory(Path.Combine(root, "elsewhere")).FullName;
+        var transcriptDirectory = Path.Combine(root, ConversationTranscriptWriter.TranscriptDirectory);
+        LinkToDirectory(transcriptDirectory, elsewhere);
+
+        var outcome = await writer.FlushAsync();
+
+        _ = outcome.Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = Directory.GetFileSystemEntries(elsewhere).Should().BeEmpty(
+            "not one byte — transcript or .gitignore — may be written through a redirected directory");
+        AssertDirectoryStillALink(transcriptDirectory);
+    }
+
+    /// <summary>
+    /// The sub-agent directory is a symlink. The main file's own path is untouched, so the flush gets past
+    /// every check that only looks at the root conversation and reaches the fan-out — the descendant
+    /// transcripts are what leave through the link.
+    /// </summary>
+    [SkippableFact]
+    public async Task Flush_RefusesToWriteADescendantThroughASymlinkedAgentsDirectory()
+    {
+        var (root, writer) = await SetupAsync(
+            nameof(Flush_RefusesToWriteADescendantThroughASymlinkedAgentsDirectory),
+            withSubAgent: true);
+        var elsewhere = Directory.CreateDirectory(Path.Combine(root, "elsewhere")).FullName;
+        var agentsDirectory = Path.Combine(
+            root,
+            ConversationTranscriptWriter.TranscriptDirectory,
+            Leaf + ConversationTranscriptWriter.AgentsDirectorySuffix);
+        _ = Directory.CreateDirectory(Path.GetDirectoryName(agentsDirectory)!);
+        LinkToDirectory(agentsDirectory, elsewhere);
+
+        var outcome = await writer.FlushAsync();
+
+        _ = outcome.Should().Be(TranscriptFlushOutcome.Deferred);
+        _ = Directory.GetFileSystemEntries(elsewhere).Should().BeEmpty(
+            "a sub-agent's reasoning is as exposed as the root conversation's");
+        AssertDirectoryStillALink(agentsDirectory);
+
+        // The main transcript DID get written: the refusal is scoped to the redirected path, and this flush
+        // was doing real work rather than failing before it started.
+        _ = File.Exists(Path.Combine(root, ConversationTranscriptWriter.TranscriptDirectory, Leaf + ".jsonl"))
+            .Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The STAGING path is a symlink. Nothing in the shell scripts can defend this one — the payload is put
+    /// there by the gateway before any script runs — and the bytes it carries are the same unredacted rows
+    /// the destination would have received. Its name is as guessable as the transcript's: a compile-time
+    /// directory plus a short hash of the thread id.
+    /// </summary>
+    [SkippableFact]
+    public async Task Flush_RefusesToStageThroughASymlinkedTempPath()
+    {
+        var (root, writer) = await SetupAsync(nameof(Flush_RefusesToStageThroughASymlinkedTempPath));
+        var tracked = WriteTrackedFile(root, "tracked-staging.txt");
+        var tempPath = Path.Combine(
+            root,
+            ConversationTranscriptWriter.TempDirectory,
+            WorkspaceTranscriptLine.ShortId(ThreadId) + ConversationTranscriptWriter.TempExtension);
+        _ = Directory.CreateDirectory(Path.GetDirectoryName(tempPath)!);
+        LinkToFile(tempPath, tracked);
+
+        var outcome = await writer.FlushAsync();
+
+        _ = outcome.Should().Be(TranscriptFlushOutcome.Deferred);
+        AssertUntouched(tracked);
+        AssertStillALink(tempPath);
+    }
+
+    /// <summary>
+    /// The containment file itself is a symlink. This one destroys rather than leaks: the PUT writes
+    /// <c>*</c> over the link's target, so a tracked file becomes a one-character ignore file. Refusing is
+    /// the only safe answer, and refusing containment stops the flush outright.
+    /// </summary>
+    [SkippableFact]
+    public async Task Flush_RefusesToWriteContainmentThroughASymlink()
+    {
+        var (root, writer) = await SetupAsync(nameof(Flush_RefusesToWriteContainmentThroughASymlink));
+        var tracked = WriteTrackedFile(root, "tracked-config.txt");
+        var gitignore = Path.Combine(
+            root,
+            ConversationTranscriptWriter.TranscriptDirectory,
+            "." + ConversationTranscriptWriter.GitignoreName);
+        _ = Directory.CreateDirectory(Path.GetDirectoryName(gitignore)!);
+        LinkToFile(gitignore, tracked);
+
+        var outcome = await writer.FlushAsync();
+
+        _ = outcome.Should().Be(TranscriptFlushOutcome.Deferred);
+        AssertUntouched(tracked);
+        AssertStillALink(gitignore);
+        _ = Directory
+            .GetFiles(Path.Combine(root, ConversationTranscriptWriter.TranscriptDirectory), "*.jsonl")
+            .Should()
+            .BeEmpty("containment could not be established, so no transcript may exist either");
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    /// <summary>
+    /// A clean workspace root and a writer pointed at it through a real shell. Skips when the machine has
+    /// no POSIX shell — the same condition <see cref="WorkspaceTranscriptLiveFileTests"/> skips on.
+    /// </summary>
+    private static async Task<(string Root, ConversationTranscriptWriter Writer)> SetupAsync(
+        string caseName,
+        bool withSubAgent = false)
+    {
+        var shell = LocalShellWorkspaceBrowser.FindPosixShell();
+        Skip.If(
+            shell is null,
+            "No POSIX shell (sh) on this machine, so the writer's real scripts cannot be run.");
+
+        var root = Path.Combine(Path.GetTempPath(), RootDirectoryName, caseName);
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+
+        _ = Directory.CreateDirectory(root);
+
+        var store = new InMemoryConversationStore();
+        await store.SaveMetadataAsync(
+            ThreadId,
+            new ThreadMetadata
+            {
+                ThreadId = ThreadId,
+                LastUpdated = 0,
+                Properties = ImmutableDictionary<string, object>
+                    .Empty.Add(MultiTurnAgentPool.WorkspacePropertyKey, WorkspaceId)
+                    .Add("title", Title),
+            });
+        await store.AppendMessagesAsync(
+            ThreadId,
+            [
+                Msg("m1", 1, "User", "\"what is it?\"", ThreadId),
+                Msg("m2", 2, "Assistant", "\"a secret\"", ThreadId),
+            ]);
+
+        if (withSubAgent)
+        {
+            var childThreadId = SubAgentProvenance.ThreadIdPrefix + AgentId;
+            await store.SaveMetadataAsync(
+                childThreadId,
+                new ThreadMetadata
+                {
+                    ThreadId = childThreadId,
+                    LastUpdated = 0,
+                    Properties = SubAgentProvenance.Build(
+                        ThreadId,
+                        new SubAgentSnapshot(
+                            AgentId,
+                            Name: AgentName,
+                            TemplateName: "worker",
+                            Task: "look it up",
+                            Status: SubAgentStatus.Completed,
+                            ThreadId: childThreadId,
+                            LastActivityUtc: DateTimeOffset.UnixEpoch,
+                            TerminalAtUtc: DateTimeOffset.UnixEpoch)),
+                });
+            await store.AppendMessagesAsync(
+                childThreadId,
+                [Msg("s1", 1, "Assistant", "\"found it\"", childThreadId)]);
+        }
+
+        var writer = new ConversationTranscriptWriter(
+            ThreadId,
+            store,
+            new LocalShellWorkspaceBrowser(root, shell),
+            new ConversationDescendantScanner(store, NullLogger<ConversationDescendantScanner>.Instance),
+            NullLogger<ConversationTranscriptWriter>.Instance,
+            TimeSpan.Zero,
+            ConversationTranscriptWriter.DefaultMaxSubAgentFilesPerFlush);
+
+        return (root, writer);
+    }
+
+    private static string WriteTrackedFile(string root, string name)
+    {
+        var path = Path.Combine(root, name);
+        File.WriteAllText(path, TrackedContent);
+        return path;
+    }
+
+    /// <summary>
+    /// Plants a real symlink, or skips. Windows only permits this with Developer Mode or elevation, and a
+    /// test that quietly substituted a regular file would assert nothing at all — following a link is the
+    /// entire behaviour under test.
+    /// </summary>
+    private static void LinkToFile(string link, string target) =>
+        Plant(() => File.CreateSymbolicLink(link, target));
+
+    private static void LinkToDirectory(string link, string target) =>
+        Plant(() => Directory.CreateSymbolicLink(link, target));
+
+    private static void Plant(Action create)
+    {
+        try
+        {
+            create();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Skip.If(true, $"This machine does not permit creating symlinks ({ex.GetType().Name}: {ex.Message}).");
+        }
+    }
+
+    private static void AssertUntouched(string trackedFile)
+    {
+        _ = File.ReadAllText(trackedFile)
+            .Should()
+            .Be(TrackedContent, "the file the link pointed at must be exactly as it was");
+    }
+
+    /// <summary>
+    /// The link survived. An indeterminate destination is REFUSED, not repaired — removing the link to
+    /// write a clean file would destroy the target, which is the file the refusal exists to protect.
+    /// </summary>
+    private static void AssertStillALink(string path)
+    {
+        _ = new FileInfo(path)
+            .LinkTarget.Should()
+            .NotBeNull($"{path} must still be the symlink it was, untouched");
+    }
+
+    /// <inheritdoc cref="AssertStillALink"/>
+    private static void AssertDirectoryStillALink(string path)
+    {
+        _ = new DirectoryInfo(path)
+            .LinkTarget.Should()
+            .NotBeNull($"{path} must still be the symlink it was, untouched");
+    }
+
+    private static PersistedMessage Msg(
+        string id,
+        long timestamp,
+        string role,
+        string messageJson,
+        string threadId) =>
+        new()
+        {
+            Id = id,
+            ThreadId = threadId,
+            RunId = "run-1",
+            GenerationId = "run-1",
+            Timestamp = timestamp,
+            MessageType = "TextMessage",
+            Role = role,
+            MessageJson = messageJson,
+        };
+}

--- a/tests/LmStreaming.Sample.Tests/TestDoubles/FakeFileBrowser.cs
+++ b/tests/LmStreaming.Sample.Tests/TestDoubles/FakeFileBrowser.cs
@@ -1,0 +1,88 @@
+using AchieveAi.LmDotnetTools.Sandbox;
+
+namespace LmStreaming.Sample.Tests.TestDoubles;
+
+/// <summary>
+/// In-memory <see cref="IWorkspaceFileBrowser"/> stand-in for everything that talks to a sandbox
+/// workspace without a gateway or a container: the file-browser HTTP routes (WI #195) and the workspace
+/// transcript mirror (#251). It records every write and every command verbatim, so a test asserts the
+/// exact bytes and the exact argv rather than a paraphrase of them.
+/// </summary>
+/// <remarks>
+/// Shared rather than duplicated per suite: the two consumers must agree about the seam they are written
+/// against, and a second copy is how they stop agreeing. <see cref="ExecuteHandler"/> is the one addition
+/// the mirror needed — it issues several DIFFERENT commands in one flush (<c>tail</c>, <c>mv</c>, the
+/// splice), and a single settable <see cref="ExecResult"/> cannot fail one of them while the others
+/// succeed.
+/// </remarks>
+internal sealed class FakeFileBrowser : IWorkspaceFileBrowser
+{
+    /// <summary>The session a resolved outcome hands out.</summary>
+    public static SandboxSession LiveSession => new("default", "sess-1", "/workspace", "/host/ws");
+
+    public SandboxSessionResolution Resolution { get; set; } =
+        new(SandboxSessionResolutionOutcome.Resolved, LiveSession, "app", null);
+
+    public Exception? ResolveThrows { get; set; }
+
+    /// <summary>The <c>persistedWorkspaceId</c> the caller passed to the last resolve call (the value
+    /// <c>ReadWorkspaceId</c> extracted from metadata) — asserted by the JsonElement regression tests.</summary>
+    public string? LastPersistedWorkspaceId { get; private set; }
+
+    public Dictionary<string, IReadOnlyList<SandboxDirectoryEntry>> Listings { get; } = new(StringComparer.Ordinal);
+    public byte[] FileBytes { get; set; } = [];
+    public Exception? ReadThrows { get; set; }
+    public Exception? WriteThrows { get; set; }
+    public SandboxCommandResult ExecResult { get; set; } = new() { ExitCode = 0, StandardOutput = "", StandardError = "", OperationId = "op" };
+
+    /// <summary>
+    /// Per-command result selector. When set it wins over <see cref="ExecResult"/>; it may also throw, to
+    /// exercise a caller's <see cref="SandboxException"/> handling.
+    /// </summary>
+    public Func<SandboxCommand, SandboxCommandResult>? ExecuteHandler { get; set; }
+
+    public List<(string Path, byte[] Bytes)> Writes { get; } = [];
+    public List<SandboxCommand> Commands { get; } = [];
+    public int ReadCalls { get; private set; }
+
+    public Task<SandboxSessionResolution> ResolveThreadWorkspaceSessionAsync(string threadId, string persistedWorkspaceId, SandboxCredential? requestCredential, CancellationToken ct = default)
+    {
+        LastPersistedWorkspaceId = persistedWorkspaceId;
+        return ResolveThrows is not null ? Task.FromException<SandboxSessionResolution>(ResolveThrows) : Task.FromResult(Resolution);
+    }
+
+    public Task<IReadOnlyList<SandboxDirectoryEntry>> ListWorkspaceDirectoryAsync(string sessionId, string relativePath, CancellationToken ct = default) =>
+        Listings.TryGetValue(relativePath, out var entries)
+            ? Task.FromResult(entries)
+            : Task.FromResult<IReadOnlyList<SandboxDirectoryEntry>>([]);
+
+    public Task<byte[]> ReadWorkspaceFileBytesAsync(string sessionId, string relativePath, long? maxBytes, CancellationToken ct = default)
+    {
+        ReadCalls++;
+        return ReadThrows is not null ? Task.FromException<byte[]>(ReadThrows) : Task.FromResult(FileBytes);
+    }
+
+    public Task WriteWorkspaceFileBytesAsync(string sessionId, string relativePath, byte[] bytes, CancellationToken ct = default)
+    {
+        if (WriteThrows is not null)
+        {
+            return Task.FromException(WriteThrows);
+        }
+
+        Writes.Add((relativePath, bytes));
+        return Task.CompletedTask;
+    }
+
+    public Task<SandboxCommandResult> ExecuteWorkspaceCommandAsync(string sessionId, SandboxCommand command, CancellationToken ct = default)
+    {
+        Commands.Add(command);
+        try
+        {
+            return Task.FromResult(ExecuteHandler is null ? ExecResult : ExecuteHandler(command));
+        }
+        catch (SandboxException ex)
+        {
+            return Task.FromException<SandboxCommandResult>(ex);
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/TestDoubles/FakeFileBrowser.cs
+++ b/tests/LmStreaming.Sample.Tests/TestDoubles/FakeFileBrowser.cs
@@ -33,6 +33,14 @@ internal sealed class FakeFileBrowser : IWorkspaceFileBrowser
     public byte[] FileBytes { get; set; } = [];
     public Exception? ReadThrows { get; set; }
     public Exception? WriteThrows { get; set; }
+
+    /// <summary>
+    /// Per-path write failure selector: returns the exception the write to that relative path should
+    /// fail with, or null to let it through. <see cref="WriteThrows"/> fails EVERY path, which cannot
+    /// express the case the containment tests need — the transcript itself is written and only
+    /// <c>.conversations/.gitignore</c> fails.
+    /// </summary>
+    public Func<string, Exception?>? WriteFailure { get; set; }
     public SandboxCommandResult ExecResult { get; set; } = new() { ExitCode = 0, StandardOutput = "", StandardError = "", OperationId = "op" };
 
     /// <summary>
@@ -67,6 +75,11 @@ internal sealed class FakeFileBrowser : IWorkspaceFileBrowser
         if (WriteThrows is not null)
         {
             return Task.FromException(WriteThrows);
+        }
+
+        if (WriteFailure?.Invoke(relativePath) is { } failure)
+        {
+            return Task.FromException(failure);
         }
 
         Writes.Add((relativePath, bytes));

--- a/tests/LmStreaming.Sample.Tests/TestDoubles/FakeFileBrowser.cs
+++ b/tests/LmStreaming.Sample.Tests/TestDoubles/FakeFileBrowser.cs
@@ -32,6 +32,14 @@ internal sealed class FakeFileBrowser : IWorkspaceFileBrowser
     public Dictionary<string, IReadOnlyList<SandboxDirectoryEntry>> Listings { get; } = new(StringComparer.Ordinal);
     public byte[] FileBytes { get; set; } = [];
     public Exception? ReadThrows { get; set; }
+
+    /// <summary>
+    /// Makes every directory listing fail. A listing that fails is NOT the same as one that comes back
+    /// empty — an empty <see cref="Listings"/> entry says "the directory holds nothing", whereas this says
+    /// "the gateway could not tell you" — and the transcript writer's adoption path has to answer the two
+    /// differently, so the double has to be able to express both.
+    /// </summary>
+    public Exception? ListThrows { get; set; }
     public Exception? WriteThrows { get; set; }
 
     /// <summary>
@@ -59,10 +67,17 @@ internal sealed class FakeFileBrowser : IWorkspaceFileBrowser
         return ResolveThrows is not null ? Task.FromException<SandboxSessionResolution>(ResolveThrows) : Task.FromResult(Resolution);
     }
 
-    public Task<IReadOnlyList<SandboxDirectoryEntry>> ListWorkspaceDirectoryAsync(string sessionId, string relativePath, CancellationToken ct = default) =>
-        Listings.TryGetValue(relativePath, out var entries)
+    public Task<IReadOnlyList<SandboxDirectoryEntry>> ListWorkspaceDirectoryAsync(string sessionId, string relativePath, CancellationToken ct = default)
+    {
+        if (ListThrows is not null)
+        {
+            return Task.FromException<IReadOnlyList<SandboxDirectoryEntry>>(ListThrows);
+        }
+
+        return Listings.TryGetValue(relativePath, out var entries)
             ? Task.FromResult(entries)
             : Task.FromResult<IReadOnlyList<SandboxDirectoryEntry>>([]);
+    }
 
     public Task<byte[]> ReadWorkspaceFileBytesAsync(string sessionId, string relativePath, long? maxBytes, CancellationToken ct = default)
     {

--- a/tests/LmStreaming.Sample.Tests/TestDoubles/LocalShellWorkspaceBrowser.cs
+++ b/tests/LmStreaming.Sample.Tests/TestDoubles/LocalShellWorkspaceBrowser.cs
@@ -27,6 +27,15 @@ namespace LmStreaming.Sample.Tests.TestDoubles;
 /// <param name="shell">Absolute path to a POSIX <c>sh</c>.</param>
 internal sealed class LocalShellWorkspaceBrowser(string root, string shell) : IWorkspaceFileBrowser
 {
+    /// <summary>
+    /// Runs after each command completes, with the argv that was executed. It exists so a test can change
+    /// the filesystem BETWEEN two of the writer's workspace operations — planting a symlink after one
+    /// descendant has been spliced and before the next is staged, say. Nothing else can express that: a
+    /// flush is one <c>await</c>, and a link planted before it starts is a different scenario entirely,
+    /// answered by a guard that only ever runs once.
+    /// </summary>
+    public Action<SandboxCommand>? AfterCommand { get; set; }
+
     /// <summary>Resolves an <c>sh</c> on this machine, or null when there is none to run.</summary>
     /// <remarks>
     /// On Windows the shell ships with Git but is frequently absent from a non-Bash <c>PATH</c>, so the
@@ -132,6 +141,8 @@ internal sealed class LocalShellWorkspaceBrowser(string root, string shell) : IW
         var stdout = await process.StandardOutput.ReadToEndAsync(ct).ConfigureAwait(false);
         var stderr = await process.StandardError.ReadToEndAsync(ct).ConfigureAwait(false);
         await process.WaitForExitAsync(ct).ConfigureAwait(false);
+
+        AfterCommand?.Invoke(command);
 
         return new SandboxCommandResult
         {

--- a/tests/LmStreaming.Sample.Tests/TestDoubles/LocalShellWorkspaceBrowser.cs
+++ b/tests/LmStreaming.Sample.Tests/TestDoubles/LocalShellWorkspaceBrowser.cs
@@ -1,0 +1,147 @@
+using System.Diagnostics;
+using AchieveAi.LmDotnetTools.Sandbox;
+
+namespace LmStreaming.Sample.Tests.TestDoubles;
+
+/// <summary>
+/// An <see cref="IWorkspaceFileBrowser"/> backed by a REAL directory and a REAL POSIX shell, instead of
+/// by recorded calls. It exists for exactly one claim the recording fake cannot make: that the bytes the
+/// transcript writer stages and the shell script it splices them with actually produce a parseable
+/// <c>.jsonl</c> file on a filesystem.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Everything else about the writer is asserted against <see cref="FakeFileBrowser"/>, which records argv
+/// verbatim — the right tool for "what did it ask for". This one answers "and what did that DO", which is
+/// where a quoting bug, a missing <c>mkdir</c> or a newline weld that welds the wrong way actually shows
+/// up. The gateway runs the same argv against <c>/bin/sh</c> in a container; here it runs against the
+/// host's, in a temp directory.
+/// </para>
+/// <para>
+/// Argv is passed through, never re-interpreted: an <c>sh</c> command is handed to the shell as-is, and any
+/// other command is executed through <c>sh -c 'exec "$@"' sh …</c> so the vector reaches the program
+/// unsplit. Reimplementing <c>tail</c>/<c>mv</c>/the append script in C# would test the reimplementation.
+/// </para>
+/// </remarks>
+/// <param name="root">Workspace root; every relative path resolves under it.</param>
+/// <param name="shell">Absolute path to a POSIX <c>sh</c>.</param>
+internal sealed class LocalShellWorkspaceBrowser(string root, string shell) : IWorkspaceFileBrowser
+{
+    /// <summary>Resolves an <c>sh</c> on this machine, or null when there is none to run.</summary>
+    /// <remarks>
+    /// On Windows the shell ships with Git but is frequently absent from a non-Bash <c>PATH</c>, so the
+    /// well-known install locations are probed too — the alternative is a test that silently skips on
+    /// every developer machine.
+    /// </remarks>
+    public static string? FindPosixShell()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return File.Exists("/bin/sh") ? "/bin/sh" : null;
+        }
+
+        var candidates = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(dir => Path.Combine(dir, "sh.exe"))
+            .Concat(
+                new[]
+                {
+                    Environment.GetEnvironmentVariable("ProgramFiles"),
+                    Environment.GetEnvironmentVariable("ProgramFiles(x86)"),
+                    Environment.GetEnvironmentVariable("ProgramW6432"),
+                }
+                    .Where(programFiles => !string.IsNullOrWhiteSpace(programFiles))
+                    .Select(programFiles => Path.Combine(programFiles!, "Git", "usr", "bin", "sh.exe")));
+
+        return candidates.FirstOrDefault(File.Exists);
+    }
+
+    public Task<SandboxSessionResolution> ResolveThreadWorkspaceSessionAsync(
+        string threadId,
+        string persistedWorkspaceId,
+        SandboxCredential? requestCredential,
+        CancellationToken ct = default) =>
+        Task.FromResult(
+            new SandboxSessionResolution(
+                SandboxSessionResolutionOutcome.Resolved,
+                new SandboxSession(persistedWorkspaceId, "sess-local", "/workspace", root),
+                "app",
+                null));
+
+    public Task<IReadOnlyList<SandboxDirectoryEntry>> ListWorkspaceDirectoryAsync(
+        string sessionId,
+        string relativePath,
+        CancellationToken ct = default) => Task.FromResult<IReadOnlyList<SandboxDirectoryEntry>>([]);
+
+    public Task<byte[]> ReadWorkspaceFileBytesAsync(
+        string sessionId,
+        string relativePath,
+        long? maxBytes,
+        CancellationToken ct = default)
+    {
+        var full = Resolve(relativePath);
+        return Task.FromResult(File.Exists(full) ? File.ReadAllBytes(full) : []);
+    }
+
+    public async Task WriteWorkspaceFileBytesAsync(
+        string sessionId,
+        string relativePath,
+        byte[] bytes,
+        CancellationToken ct = default)
+    {
+        var full = Resolve(relativePath);
+        _ = Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        await File.WriteAllBytesAsync(full, bytes, ct).ConfigureAwait(false);
+    }
+
+    public async Task<SandboxCommandResult> ExecuteWorkspaceCommandAsync(
+        string sessionId,
+        SandboxCommand command,
+        CancellationToken ct = default)
+    {
+        var startInfo = new ProcessStartInfo(shell)
+        {
+            WorkingDirectory = root,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        if (string.Equals(command.Arguments[0], "sh", StringComparison.Ordinal))
+        {
+            foreach (var argument in command.Arguments.Skip(1))
+            {
+                startInfo.ArgumentList.Add(argument);
+            }
+        }
+        else
+        {
+            startInfo.ArgumentList.Add("-c");
+            startInfo.ArgumentList.Add("exec \"$@\"");
+            startInfo.ArgumentList.Add("sh");
+            foreach (var argument in command.Arguments)
+            {
+                startInfo.ArgumentList.Add(argument);
+            }
+        }
+
+        using var process =
+            Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Could not start '{shell}'.");
+
+        var stdout = await process.StandardOutput.ReadToEndAsync(ct).ConfigureAwait(false);
+        var stderr = await process.StandardError.ReadToEndAsync(ct).ConfigureAwait(false);
+        await process.WaitForExitAsync(ct).ConfigureAwait(false);
+
+        return new SandboxCommandResult
+        {
+            ExitCode = process.ExitCode,
+            StandardOutput = stdout,
+            StandardError = stderr,
+            OperationId = "local",
+        };
+    }
+
+    private string Resolve(string relativePath) =>
+        Path.GetFullPath(Path.Combine(root, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+}

--- a/tests/LmStreaming.Sample.Tests/TestDoubles/PublishingAgent.cs
+++ b/tests/LmStreaming.Sample.Tests/TestDoubles/PublishingAgent.cs
@@ -1,0 +1,20 @@
+namespace LmStreaming.Sample.Tests.TestDoubles;
+
+/// <summary>
+/// A REAL agent with a publish hook, for tests that need something to subscribe to.
+/// </summary>
+/// <remarks>
+/// It inherits the production fan-out, so <see cref="MultiTurnAgentBase.SubscribeAsync"/>, the bounded
+/// per-subscriber channel and the drop-the-slow-subscriber path are all the shipping implementations. A
+/// hand-written fake that ended its enumeration on command would prove the fake works, not that a
+/// subscriber survives the real drop.
+/// </remarks>
+/// <param name="threadId">The conversation the agent belongs to.</param>
+/// <param name="outputChannelCapacity">Per-subscriber channel capacity; lower it to force a drop.</param>
+internal sealed class PublishingAgent(string threadId, int outputChannelCapacity = 1000)
+    : MultiTurnAgentBase(threadId, outputChannelCapacity: outputChannelCapacity)
+{
+    public ValueTask PublishAsync(IMessage message) => PublishToAllAsync(message, CancellationToken.None);
+
+    protected override Task RunLoopAsync(CancellationToken ct) => Task.CompletedTask;
+}

--- a/tests/LmStreaming.Sample.Tests/TestDoubles/TouchingConversationStore.cs
+++ b/tests/LmStreaming.Sample.Tests/TestDoubles/TouchingConversationStore.cs
@@ -1,0 +1,80 @@
+namespace LmStreaming.Sample.Tests.TestDoubles;
+
+/// <summary>
+/// A forwarding <see cref="IConversationStore"/> view that models the one thing a persisted-thread scan
+/// cannot assume away: the store keeps changing while the scan reads it. After every
+/// <see cref="ListThreadsAsync"/> call it bumps one thread's <c>LastUpdated</c>, which — because
+/// <see cref="IConversationStore.ListThreadsAsync"/> is contractually "ordered by last updated
+/// descending" — moves that thread to the front of the ordering the next call will see.
+/// </summary>
+/// <remarks>
+///     The bump happens AFTER the page has been read, so it can never corrupt the call that triggered it.
+///     That is deliberate: a scan that reads the store exactly once is unaffected by this double no matter
+///     how much the store churns, while an offset-paged scan loses the touched thread — it slid forward
+///     past an offset the scan has already stepped over. The double therefore isolates the paging, not the
+///     mutation.
+/// </remarks>
+/// <param name="inner">The real store every call is forwarded to.</param>
+/// <param name="threadIdToTouch">The thread whose <c>LastUpdated</c> is bumped after each listing.</param>
+internal sealed class TouchingConversationStore(IConversationStore inner, string threadIdToTouch)
+    : IConversationStore
+{
+    private long _stamp = long.MaxValue / 2;
+
+    /// <inheritdoc />
+    public Task AppendMessagesAsync(
+        string threadId,
+        IReadOnlyList<PersistedMessage> messages,
+        CancellationToken ct = default) => inner.AppendMessagesAsync(threadId, messages, ct);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<PersistedMessage>> LoadMessagesAsync(
+        string threadId,
+        CancellationToken ct = default) => inner.LoadMessagesAsync(threadId, ct);
+
+    /// <inheritdoc />
+    public Task ReplaceMessageAsync(
+        string threadId,
+        PersistedMessage replacement,
+        CancellationToken ct = default) => inner.ReplaceMessageAsync(threadId, replacement, ct);
+
+    /// <inheritdoc />
+    public Task SaveMetadataAsync(
+        string threadId,
+        ThreadMetadata metadata,
+        CancellationToken ct = default) => inner.SaveMetadataAsync(threadId, metadata, ct);
+
+    /// <inheritdoc />
+    public Task<ThreadMetadata?> LoadMetadataAsync(string threadId, CancellationToken ct = default) =>
+        inner.LoadMetadataAsync(threadId, ct);
+
+    /// <inheritdoc />
+    public Task UpdateMetadataAsync(
+        string threadId,
+        Func<ThreadMetadata?, ThreadMetadata> update,
+        CancellationToken ct = default) => inner.UpdateMetadataAsync(threadId, update, ct);
+
+    /// <inheritdoc />
+    public Task DeleteThreadAsync(string threadId, CancellationToken ct = default) =>
+        inner.DeleteThreadAsync(threadId, ct);
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ThreadMetadata>> ListThreadsAsync(
+        int limit = 50,
+        int offset = 0,
+        CancellationToken ct = default)
+    {
+        var page = await inner.ListThreadsAsync(limit, offset, ct);
+
+        var current = await inner.LoadMetadataAsync(threadIdToTouch, ct);
+        if (current is not null)
+        {
+            await inner.SaveMetadataAsync(
+                threadIdToTouch,
+                current with { LastUpdated = Interlocked.Increment(ref _stamp) },
+                ct);
+        }
+
+        return page;
+    }
+}


### PR DESCRIPTION
Fixes #251

Every conversation that has a sandbox workspace now writes its own message history into `.conversations/` inside that workspace, as append-only JSONL an agent can read with the tools it already has — `Read`, `Grep`, `Bash`, DuckDB, whatever it likes.

```
.conversations/
├── .gitignore                                  # "*" — never committed by an agent working in the repo
├── refactor-the-parser-7kzf.jsonl              # {slug(title)}-{shortThreadId}.jsonl
└── refactor-the-parser-7kzf_agents/
    └── researcher-sq7p.jsonl                   # {agentName}-{shortAgentId}.jsonl
```

Each line is one JSON object: `uid`, `parent_uid`, `ts`, `role`, `message_type`, `agent_name`, `message_json`. Flushed at each turn boundary.

## Key decisions

**Full fidelity, reasoning included.** Every other transcript reader in the sample strips reasoning, because every other reader is *cross-agent*. This one is not — it is the conversation reading its own record inside its own workspace. `TranscriptProjection`'s remarks now name this fourth caller explicitly so the next person doesn't "fix" it back.

**Ordering is by parent pointers, not an ordinal.** `uid` / `parent_uid`, so a line's position is a property of the line rather than of the flush that wrote it. `uid` is a truncated SHA-256 of the persisted message id — derived, so the same message always gets the same uid, and a re-flush produces byte-identical lines.

**`message_json` is an opaque string.** The reader owns the schema. The mirror never parses or reinterprets a provider payload, so a provider adding a field can't break the writer.

**Appends are genuine appends.** Stage a temp file, `cat` it onto the destination, remove the temp — one `sh -c` with positional parameters, and no data is ever interpolated into the script. Retitling a conversation is `mv`. Nothing is ever read-modify-rewritten, so the file never briefly ceases to exist and a reader never sees a truncated file.

**Every failure path leaves the watermark unadvanced.** The watermark advances *only* on exit code 0, so a failed append means the next flush recomputes the same suffix and writes it again. The worst outcome is a duplicated tail on retry — never silent loss. That is the deliberate shape for "works in 95% of cases without extreme durability."

**The store lags the stream.** History is persisted on an unawaited task that `CompleteRunAsync` never joins, so `RunCompletedMessage` can arrive before the last message is on disk. A flush reads twice and compares message-**id sequences** — not counts, which would miss a reorder — bounded at three attempts, then defers whole.

**A dropped subscriber is detected and resubscribed.** When the bounded output channel is full the subscriber is removed and its channel *completed*, so the enumeration ends normally with no exception — a naive `await foreach` would exit as if the conversation had finished and silently stop mirroring. The detector asks the pool for the current agent and compares by reference: on ordinary teardown the pool holds a different instance or nothing, so only a genuine drop looks like a drop. Recovery needs no replay — the watermark is cumulative.

**Always on, no feature flag.** A reviewer recommended one; the owner overruled it. The kill switch is the `.gitignore`.

**Zero `src/` changes.** Ships entirely in `samples/LmStreaming.Sample`. The agent pool is reached through a lookup delegate rather than injected, because the pool's own registration resolves this singleton and a direct dependency would close a DI construction cycle.

**Transcripts are retained on conversation delete**, and excluded from agent file listing/preview unless a read targets `.conversations/` directly.

## Known gaps (deliberate, follow-ups to file)

- **S2S-initiated conversations are not mirrored in v1** — UI-only, an explicit no-op rather than an accident.
- **Tool results are inlined** rather than externalized to sidecar files.

## Verification

| Gate | Result |
|---|---|
| `dotnet build LmDotnetTools.sln --no-incremental` | 0 warnings, 0 errors |
| `tests/LmStreaming.Sample.Tests` | 1317 passed / 1 skipped / 0 failed |
| `tests/LmStreaming.Sample.E2E.Tests` | 90 passed / 0 failed |
| `tests/LmStreaming.Sample.Browser.E2E.Tests` | 56 passed / 5 skipped / 0 failed |
| `dotnet format whitespace --verify-no-changes` | clean |

`--no-incremental` matters: `TreatWarningsAsErrors` plus `EnforceCodeStyleInBuild` make one clean full build the complete analyzer sweep. An incremental build skips analyzers on up-to-date projects and can look clean when it isn't.

The 1 unit skip and the 5 browser skips are pre-existing and environment-gated (case-sensitive-filesystem check; sandbox git-clone; Codex and Claude mock providers).

**+110 tests**, including a live-file test that runs the real writer against a real temp directory and a real POSIX `sh`, then reads the result back **externally with DuckDB**:

```
live-read-proof-7kzf.jsonl                        zig7fsk2  NULL      TextMessage             User
live-read-proof-7kzf.jsonl                        fha3fcph  zig7fsk2  ReasoningMessage        Assistant
live-read-proof-7kzf.jsonl                        cu4bfls7  fha3fcph  ToolsCallMessage        Assistant
live-read-proof-7kzf.jsonl                        eolkcjlk  cu4bfls7  ToolsCallResultMessage  Tool
live-read-proof-7kzf.jsonl                        wxzaghvw  eolkcjlk  TextMessage             Assistant
live-read-proof-7kzf.jsonl                        4na7zrei  wxzaghvw  TextMessage             User
live-read-proof-7kzf_agents/researcher-sq7p.jsonl 5c6bmpec  eolkcjlk  TextMessage             User
live-read-proof-7kzf_agents/researcher-sq7p.jsonl vuziqrvk  5c6bmpec  TextMessage             Assistant
```

Every line parses, every `uid` is unique, every `parent_uid` names the line before it, reasoning is present at full fidelity, and the sub-agent file's first line anchors to `eolkcjlk` — a line in the *parent* file. That anchor is what makes the two files one lineage.

The drop-detection test uses a `PublishingAgent` derived from the production `MultiTurnAgentBase` with `outputChannelCapacity: 1`, so the shipping fan-out and the shipping drop path actually run — a fake that ended its enumeration on command would only have proved the fake works.

## Design record

[ADR 0011 — Mirror each conversation's transcript into its own workspace](docs/adrs/0011-workspace-transcript-files.md)
