### PR TITLE
fix(transcript): attach the mirror on every agent branch, drain flushes FIFO, refuse aliased paths — with a real browser E2E

### DIFF
--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -717,8 +717,67 @@ try
                 .LogWarning("Web tools disabled (invalid configuration): {Errors}", string.Join("; ", webToolsErrors));
         }
 
-        var pool = new MultiTurnAgentPool(
+        // Best-effort disposal of an agent's owned resources (MCP clients) on a construction failure.
+        // Shared by the branch that builds them and by the mirror-attach wrapper below, so both failure
+        // paths dispose identically instead of one of them quietly leaking.
+        static void DisposeOwnedResources(IReadOnlyList<IAsyncDisposable>? ownedResources)
+        {
+            if (ownedResources == null)
+            {
+                return;
+            }
+
+            foreach (var resource in ownedResources)
+            {
+                try
+                {
+                    resource.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                }
+                catch
+                { /* ignore cleanup errors */
+                }
+            }
+        }
+
+        // Start mirroring every conversation's messages into its workspace (#251).
+        //
+        // THIS WRAPPER IS THE ATTACH POINT, and it is a wrapper rather than a call inside the factory
+        // on purpose. The factory below has seven construction branches, each ending in its own
+        // `return`; an attach placed in one of them is invisible to the other six. That is exactly how
+        // the CLI-backed providers (codex, claude, copilot and their three mocks) shipped unmirrored —
+        // they return before reaching the attach, so their workspace conversations produced neither a
+        // root transcript nor descendant files even though those loops all support SubscribeAsync.
+        // Wrapping makes it structural: there is now exactly one place a result can leave this factory,
+        // so an eighth provider cannot repeat the bug.
+        //
+        // Attaching here still happens after construction and before the agent is handed to the pool,
+        // so no turn boundary can be missed. A mode switch builds a replacement agent for the same
+        // threadId and re-attaches through this same path; the mirror swaps the subscription and keeps
+        // the writer.
+        Func<MultiTurnAgentPool.AgentCreationContext, MultiTurnAgentPool.AgentCreationResult> AttachingToMirror(
+            Func<MultiTurnAgentPool.AgentCreationContext, MultiTurnAgentPool.AgentCreationResult> build
+        ) =>
             context =>
+            {
+                var result = build(context);
+                try
+                {
+                    transcriptMirror.Attach(result.Agent);
+                }
+                catch
+                {
+                    // The construction branches dispose what they own when they throw; once one has
+                    // returned, this wrapper is the only thing standing between a failed attach and a
+                    // leaked MCP client, so it takes over that duty.
+                    DisposeOwnedResources(result.OwnedResources);
+                    throw;
+                }
+
+                return result;
+            };
+
+        var pool = new MultiTurnAgentPool(
+            AttachingToMirror(context =>
             {
                 var threadId = context.ThreadId;
                 var mode = context.Mode;
@@ -1791,34 +1850,16 @@ subAgentFactory,
                         collaboration: rootCollaboration
                     );
 
-                    // Start mirroring this conversation's messages into its workspace (#251). Attached
-                    // after construction and before the agent is handed to the pool, so no turn boundary
-                    // can be missed. A mode switch builds a replacement agent for the same threadId and
-                    // re-attaches here; the mirror swaps the subscription and keeps the writer.
-                    transcriptMirror.Attach(agent);
-
                     return new MultiTurnAgentPool.AgentCreationResult(agent, ownedResources) { StagedBinding = stagedBinding };
                 }
                 catch
                 {
                     // Dispose owned resources (MCP clients) if agent construction fails
-                    if (ownedResources != null)
-                    {
-                        foreach (var resource in ownedResources)
-                        {
-                            try
-                            {
-                                resource.DisposeAsync().AsTask().GetAwaiter().GetResult();
-                            }
-                            catch
-                            { /* ignore cleanup errors */
-                            }
-                        }
-                    }
+                    DisposeOwnedResources(ownedResources);
 
                     throw;
                 }
-            },
+            }),
             providerRegistry: providerRegistry,
             conversationStore: conversationStore,
             logger: loggerFactory.CreateLogger<MultiTurnAgentPool>(),

--- a/samples/LmStreaming.Sample/PromptExamples.md
+++ b/samples/LmStreaming.Sample/PromptExamples.md
@@ -267,6 +267,33 @@ tab holds a substantial transcript (a MetadataPill with a thinking row + two too
 The browser-observable slice of the two-tab scenario is locked in CI by
 `tests/LmStreaming.Sample.Browser.E2E.Tests/Scenarios/SubAgentTabsTests.cs`.
 
+### Two named background sub-agents, text-only (transcript-mirror fixture)
+
+Same shape as "Two sub-agents → two distinct colored tabs", but the nested chains use **only `text`**
+— no `calculate` / `get_weather`. That matters because this fixture runs in **Workspace Agent mode**,
+where the mock's demo tools are not registered; the only tool the parent needs to exist is `Agent`.
+The parent turn also asks for `reasoning`, so the transcript carries raw reasoning content to assert
+on — the mirror stores full RAW fidelity, so reasoning must survive the round trip.
+
+Used by `playwright-scripts/transcript-mirror.mjs` (workspace transcript mirror, #251 / PR #252) to
+force a `{leaf}_agents/` directory holding two **named** child transcripts, `mirror-alpha.jsonl` and
+`mirror-beta.jsonl`. The names are load-bearing: the fixture asserts the sub-agent filename is
+`{agentName}-{shortAgentId}.jsonl`, which an unnamed sub-agent could not prove.
+
+Substitute your own run stamp for `<STAMP>` (the script uses a timestamp) so a re-run cannot pass on
+a previous run's transcript. Build the nested chains with `JSON.stringify` rather than hand-escaping.
+
+<|instruction_start|>{"instruction_chain":[{"id":"spawn-mirror-pair","id_message":"Spawn two named background sub-agents","reasoning":{"length":30},"messages":[{"tool_call":[{"name":"Agent","args":{"subagent_type":"researcher","name":"mirror-alpha","run_in_background":true,"prompt":"<|instruction_start|>{\"instruction_chain\":[{\"id\":\"ma1\",\"messages\":[{\"text\":\"mirror-alpha reporting MIRROR-TURN1-<STAMP>\"}]}]}<|instruction_end|>"}},{"name":"Agent","args":{"subagent_type":"general-purpose","name":"mirror-beta","run_in_background":true,"prompt":"<|instruction_start|>{\"instruction_chain\":[{\"id\":\"mb1\",\"messages\":[{\"text\":\"mirror-beta reporting MIRROR-TURN1-<STAMP>\"}]}]}<|instruction_end|>"}}]}]},{"id":"parent-done","messages":[{"text":"Spawned mirror-alpha and mirror-beta. MIRROR-TURN1-<STAMP>"}]}]}<|instruction_end|>
+
+Expected: two background `Agent` pills return immediately, a `mirror-alpha` and a `mirror-beta` tab
+appear within ~3s (the sub-agent poll), and the parent finishes with the "Spawned…" text.
+
+Reading the resulting transcripts back through the app: use the file browser's **`download`**
+endpoint, not `preview`. `preview` refuses any dot-directory outright
+(`FileBrowserController.cs` — the sole `FilePreviewPolicy.IsUnderDotDirectory` call site), by design,
+so a transcript fetched through `preview` returns `{"previewable":false,"reason":"excluded"}` — which
+is indistinguishable from a transcript that was never written, and reads as a false regression.
+
 ---
 
 ## Wait / Trigger (Park-and-Wake)

--- a/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
+++ b/samples/LmStreaming.Sample/Services/ConversationTranscriptWriter.cs
@@ -105,33 +105,55 @@ public enum TranscriptFlushOutcome
 ///         </item>
 ///         <item>
 ///             <description><see cref="AppendAsync"/> — PUTs the staged payload. Guarded by
-///             <see cref="IsPathSafeAsync"/> per append, uncached.</description>
+///             <see cref="IsPathSafeAsync"/> per append, uncached; that guard is also where the staging
+///             path's link count is checked, because this PUT is the write an in-script check would be
+///             too late for.</description>
 ///         </item>
 ///         <item>
 ///             <description><see cref="AppendAsync"/> — runs <see cref="AppendScript"/>. Guards its three
-///             path parameters in-script.</description>
+///             path parameters in-script, and additionally requires its two FILE operands to be
+///             unaliased.</description>
 ///         </item>
 ///         <item>
 ///             <description><see cref="RecoverWatermarkAsync"/> — runs <see cref="WatermarkProbeScript"/>.
-///             Guards in-script; its output is bounded per line and is never logged.</description>
+///             Guards in-script and refuses an aliased destination before reading it; its output is bounded
+///             per line and is never logged.</description>
 ///         </item>
 ///         <item>
 ///             <description><see cref="EnsureGitignoreAsync"/> — PUTs the <c>.gitignore</c>. Guarded by
-///             <see cref="IsPathSafeAsync"/>. This is the write that DESTROYS rather than leaks.</description>
+///             <see cref="IsPathSafeAsync"/>, link count included. This is the write that DESTROYS rather
+///             than leaks.</description>
 ///         </item>
 ///         <item>
 ///             <description><see cref="TryMoveAsync"/> — runs <see cref="MoveScript"/>. Guards both operands
-///             in-script and additionally refuses a destination that resolves to a directory.</description>
+///             in-script and additionally refuses a destination that resolves to a directory. It needs no
+///             link-count check, and that is a measured exclusion rather than an omission: see
+///             <see cref="AliasedPathExitCode"/>.</description>
 ///         </item>
 ///     </list>
 ///     </para>
 ///     <para>
-///     <b>What none of the six can cover.</b> <c>[ -L ]</c> does not see a HARD link, and no shell test
-///     does; a hard link planted at a transcript's name is written through with every guard reporting
-///     clean. That is left uncovered deliberately rather than overlooked — closing it needs
-///     <c>O_NOFOLLOW</c>/<c>st_nlink</c> checks the gateway does not expose, and Linux's
-///     <c>fs.protected_hardlinks</c> already blocks the interesting targets, which are files the sandboxed
-///     user neither owns nor may write.
+///     <b>What none of the six can cover — and a retracted claim about what they could not.</b> An earlier
+///     revision of this paragraph asserted that a HARD link at a transcript's name was undetectable here,
+///     because <c>[ -L ]</c> cannot see one and "the gateway does not expose <c>st_nlink</c>". The first
+///     half is true and the second was never checked. A hard link is indeed not a distinguishable KIND of
+///     file — but its LINK COUNT is an ordinary stat field, and the boundary these scripts run against is a
+///     shell, which can read it with a POSIX <c>ls -l</c> listing and no extension at all. The same
+///     paragraph offered
+///     <c>fs.protected_hardlinks</c> as the mitigation, which is wrong in the same direction: that sysctl
+///     only refuses links to files the user neither owns nor may write, and the targets that matter here —
+///     the tracked sources in the agent's own workspace — are owned by exactly that user. Nothing was
+///     stopping it. See <see cref="AliasedPathExitCode"/> for the check that now does.
+///     </para>
+///     <para>
+///     What genuinely remains is smaller and of a different kind. <b>The TOCTOU residue:</b> every check
+///     here happens before its write rather than atomically with it, so a link planted in the window is
+///     still followed; closing that needs <c>O_NOFOLLOW</c>/<c>O_EXCL</c>, which neither a shell redirection
+///     nor the gateway's file PUT exposes. <b>An unreliable <c>st_nlink</c>:</b> a filesystem that reports
+///     every file as having one link — some network and FUSE mounts do — makes the alias check pass and
+///     protect nothing, silently, with no shell-visible way to tell that apart from a genuinely unaliased
+///     file. Both are narrowings rather than closures, and both are stated so the next reader does not have
+///     to rediscover them by assuming the opposite.
 ///     </para>
 ///     <para>
 ///     <b>Concurrency:</b> <see cref="FlushAsync"/> is not re-entrant and must not be called concurrently
@@ -232,6 +254,61 @@ public sealed class ConversationTranscriptWriter
     public const int MoveTargetDirectoryExitCode = 45;
 
     /// <summary>
+    ///     Exit code every script reports when a leaf it is about to write — or read as its own staged
+    ///     payload — is not a regular file with EXACTLY ONE name. Chosen on the same grounds as
+    ///     <see cref="WatermarkMissingExitCode"/>: outside every code the scripts' own commands can mint
+    ///     (POSIX <c>find</c> answers 0 or &gt;0).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <b>A hard link is the same attack as a symlink with none of the tells.</b> The transcript's name
+    ///     is derived from the conversation title, so it is guessable long before the file exists; an agent
+    ///     that runs <c>ln tracked-file .conversations/&lt;leaf&gt;.jsonl</c> gives a tracked source file a
+    ///     second name inside the mirror's directory. Every check in
+    ///     <see cref="PathGuardPreamble"/> then passes — the entry is not a symlink, no ancestor is, and it
+    ///     is a perfectly ordinary regular file — and <c>cat "$2" &gt;&gt; "$3"</c> appends the unredacted
+    ///     transcript into the shared inode, which is to say into the tracked file, outside the reach of the
+    ///     <c>.gitignore</c> that never covered it. Directly observed rather than inferred: with
+    ///     <c>ln tracked.txt aliased.jsonl</c>, <c>[ -L aliased.jsonl ]</c> is false and
+    ///     <c>printf 'SECRET\n' &gt;&gt; aliased.jsonl</c> puts SECRET in <c>tracked.txt</c>.
+    ///     </para>
+    ///     <para>
+    ///     <b>The link count is the whole of the check, because there is nothing else to look at.</b> A hard
+    ///     link is not a kind of file and has no target; both names are equally the file, and the
+    ///     filesystem does not record which came first. So "is this OUR transcript that someone aliased, or
+    ///     THEIR file we were pointed at?" is not a question that can be answered here, in principle rather
+    ///     than for want of a syscall — which is exactly why the answer is to refuse either way rather than
+    ///     to repair, on the same reasoning as <see cref="UnsafePathExitCode"/>. Unlinking the extra name
+    ///     would be indistinguishable from deleting a file the workspace owner meant to keep.
+    ///     </para>
+    ///     <para>
+    ///     <b>The availability consequence is real and is the accepted cost.</b> Once a transcript exists,
+    ///     anyone with write access to the workspace can <c>ln</c> to IT and drive the count to two, after
+    ///     which every append is refused, the flush defers, the caller's retry budget is spent and that
+    ///     conversation's mirror simply stops. A backup or checkout tool that hard-links (<c>cp -l</c>,
+    ///     <c>rsync --link-dest</c>) does the same by accident. This is the correct direction to fail — a
+    ///     stalled transcript is recoverable by removing the extra link, an unredacted transcript welded
+    ///     into a tracked file is not — but it is a behaviour change rather than a pure hardening, and a
+    ///     transcript that has silently stopped is something an operator will otherwise debug from the
+    ///     wrong end. Hence a code of its own rather than sharing
+    ///     <see cref="UnsafePathExitCode"/>, and a log line that names the cause.
+    ///     </para>
+    ///     <para>
+    ///     <b>Which surfaces need it, and which measurably do not.</b> The two gateway PUTs need it MOST and
+    ///     could not get it from a script guard at all: the payload and the <c>.gitignore</c> are written
+    ///     before any script for that write runs, so by the time <see cref="AppendScript"/> could inspect
+    ///     the staging path the PUT has already gone through it — a <c>.gitignore</c> PUT through an aliased
+    ///     path replaces a tracked file's whole content with <c>*</c>. They are covered in
+    ///     <see cref="IsPathSafeAsync"/>, which runs immediately before each PUT.
+    ///     <see cref="MoveScript"/> is the exclusion: <c>rename(2)</c> unlinks the destination NAME and does
+    ///     not write through it, so an aliased destination loses only its extra name and the file itself is
+    ///     untouched. Verified rather than assumed — <c>ln tracked.txt new.jsonl</c> followed by
+    ///     <c>mv -T old.jsonl new.jsonl</c> leaves <c>tracked.txt</c> byte-identical, at link count one.
+    ///     </para>
+    /// </remarks>
+    public const int AliasedPathExitCode = 46;
+
+    /// <summary>
     ///     How many leading characters of each windowed line the probe returns. This is what bounds the
     ///     probe's output, and bounding it is not an optimisation.
     /// </summary>
@@ -279,8 +356,9 @@ public sealed class ConversationTranscriptWriter
     private const string TitlePropertyKey = "title";
 
     /// <summary>
-    ///     Defines the <c>guard</c> shell function every script opens with: it walks a path and each of its
-    ///     ancestor directories and fails if ANY of them is a symlink. Prepended, never interpolated into.
+    ///     Defines the two shell functions every script opens with. <c>guard</c> walks a path and each of
+    ///     its ancestor directories and fails if ANY of them is a symlink; <c>solo</c> answers whether an
+    ///     EXISTING path is a regular file bearing exactly one name. Prepended, never interpolated into.
     /// </summary>
     /// <remarks>
     ///     <para>
@@ -297,16 +375,49 @@ public sealed class ConversationTranscriptWriter
     ///     <c>[ -L ]</c> it ran, which is 1 for every safe path.
     ///     </para>
     ///     <para>
+    ///     <b><c>solo</c> exists because <c>guard</c> cannot see a hard link at all</b> — see
+    ///     <see cref="AliasedPathExitCode"/> for what that costs. A MISSING path passes: these paths are
+    ///     routinely written before they exist, and the check is about the file that is there, not about
+    ///     the name. <c>[ -f ]</c> ahead of the count is doing real work rather than tidying — it rejects a
+    ///     destination that has become a directory, whose link count is at least two by construction and
+    ///     would otherwise be reported as an alias, which is true but for the wrong reason and would read
+    ///     as one in the log.
+    ///     </para>
+    ///     <para>
+    ///     <b>The link count comes from <c>ls</c>, and the two more obvious primitives were both tried and
+    ///     rejected on evidence.</b> <c>stat</c> is out because the format string is not portable —
+    ///     <c>%h</c> is GNU and <c>%l</c> is BSD — and these scripts are compile-time constants shared by
+    ///     two very different executions: the sandbox container in production, and whatever <c>sh</c> the
+    ///     developer's machine offers under test. POSIX <c>find … -links 1</c> looked like the portable
+    ///     answer and is worse: on a Windows host the shell resolves <c>find</c> to
+    ///     <c>C:\WINDOWS\system32\find.exe</c>, an unrelated text-search tool that prints
+    ///     "FIND: Parameter format not correct" and no path — indistinguishable from a legitimate refusal,
+    ///     so every append on such a host is declined. Directly observed, which is the only reason it was
+    ///     not shipped. <c>ls -dn</c> has no such collision, and the second field of a <c>-l</c> listing is
+    ///     the link count by POSIX definition (<c>-n</c> turns on <c>-l</c>), so the format is specified
+    ///     rather than incidental.
+    ///     </para>
+    ///     <para>
+    ///     <c>solo</c> is fail-closed by construction rather than by an added check. A failing <c>ls</c>
+    ///     returns 1 outright, and any output that is not a long listing leaves field two something other
+    ///     than <c>1</c> — so every way the test can go wrong, including <c>ls</c> being absent, comes out
+    ///     as a refusal. The one direction it can be wrong in silently is a filesystem that reports an
+    ///     unreliable <c>st_nlink</c> (some network and FUSE mounts pin it to 1), where an aliased file
+    ///     would pass; nothing readable from a shell distinguishes that case.
+    ///     </para>
+    ///     <para>
     ///     This narrows the window rather than closing it: a link planted between the guard and the write
     ///     is still followed. Closing it needs <c>O_NOFOLLOW</c>, which neither the gateway's file PUT nor
     ///     a POSIX shell redirection exposes. The residue is a race an attacker must win against a
-    ///     millisecond; what it replaces is a symlink that could be planted at leisure, days ahead, and
+    ///     millisecond; what it replaces is a link that could be planted at leisure, days ahead, and
     ///     would be followed with certainty.
     ///     </para>
     /// </remarks>
     private const string PathGuardPreamble =
         "guard() { p=\"$1\"; while [ -n \"$p\" ] && [ \"$p\" != \".\" ] && [ \"$p\" != \"/\" ]; do "
-        + "if [ -L \"$p\" ]; then return 1; fi; p=$(dirname \"$p\"); done; return 0; }\n";
+        + "if [ -L \"$p\" ]; then return 1; fi; p=$(dirname \"$p\"); done; return 0; }\n"
+        + "solo() { [ -e \"$1\" ] || return 0; [ -f \"$1\" ] || return 1; "
+        + "sl=$(ls -dn \"$1\") || return 1; set -- $sl; [ \"$2\" = \"1\" ]; }\n";
 
     /// <summary>
     ///     One guard invocation for the given positional parameter, reporting
@@ -321,11 +432,33 @@ public sealed class ConversationTranscriptWriter
         + "\n";
 
     /// <summary>
-    ///     The guard on its own, for the two writes that reach the workspace WITHOUT a shell — the staged
-    ///     payload and the <c>.gitignore</c>, both of which the gateway PUTs directly. <c>$1</c> is the
-    ///     path. Reads nothing, writes nothing. See <see cref="IsPathSafeAsync"/>.
+    ///     One <c>solo</c> invocation for the given positional parameter, reporting
+    ///     <see cref="AliasedPathExitCode"/>. Paired with <see cref="GuardLine"/> for the same
+    ///     no-drift reason, and always written AFTER it: a symlinked ancestor makes the link count of the
+    ///     leaf a fact about somebody else's file, so "not redirected" has to be settled first.
     /// </summary>
-    private static readonly string PathGuardScript = PathGuardPreamble + GuardLine("$1");
+    private static string SoloLine(string parameter) =>
+        "solo \""
+        + parameter
+        + "\" || exit "
+        + AliasedPathExitCode.ToString(CultureInfo.InvariantCulture)
+        + "\n";
+
+    /// <summary>
+    ///     The guards on their own, for the two writes that reach the workspace WITHOUT a shell — the
+    ///     staged payload and the <c>.gitignore</c>, both of which the gateway PUTs directly. <c>$1</c> is
+    ///     the path. Reads nothing, writes nothing. See <see cref="IsPathSafeAsync"/>.
+    /// </summary>
+    /// <remarks>
+    ///     This is the ONLY place the alias check can defend those two writes, and it is why
+    ///     <see cref="AliasedPathExitCode"/> belongs here rather than only on the append: a PUT carries no
+    ///     shell, so by the time <see cref="AppendScript"/> could look at the staging path the bytes are
+    ///     already through it. The <c>.gitignore</c> is the sharper of the two — it is PUT with the whole
+    ///     file's content, so an aliased path does not append to a tracked file, it REPLACES one with
+    ///     <c>*</c>.
+    /// </remarks>
+    private static readonly string PathGuardScript =
+        PathGuardPreamble + GuardLine("$1") + SoloLine("$1");
 
     /// <summary>
     ///     THE one shell call site that writes. Built from concatenated literals rather than a raw string
@@ -353,12 +486,22 @@ public sealed class ConversationTranscriptWriter
     ///     a link too, and a staged payload that is really a pointer at some other file would splice that
     ///     file's contents into the transcript. See <see cref="UnsafePathExitCode"/>.
     ///     </para>
+    ///     <para>
+    ///     <c>solo</c> covers the same two FILE parameters and deliberately not <c>$1</c>: a directory's
+    ///     link count is at least two by construction (itself and <c>.</c>), so applying it there would
+    ///     refuse every append that has ever worked. <c>$3</c> is the destination the hard-link attack aims
+    ///     at; <c>$2</c> is symmetric with its symlink guard, and closes the narrower window in which the
+    ///     staged payload is aliased AFTER the PUT that <see cref="IsPathSafeAsync"/> cleared. See
+    ///     <see cref="AliasedPathExitCode"/>.
+    ///     </para>
     /// </remarks>
     private static readonly string AppendScript =
         PathGuardPreamble
         + GuardLine("$1")
         + GuardLine("$2")
         + GuardLine("$3")
+        + SoloLine("$2")
+        + SoloLine("$3")
         + "mkdir -p \"$1\" || exit 1\n"
         + "if [ -s \"$3\" ] && [ -n \"$(tail -c1 \"$3\")\" ]; then printf '\\n' >> \"$3\" || exit 1; fi\n"
         + "cat \"$2\" >> \"$3\" && rm -f \"$2\"\n";
@@ -412,10 +555,19 @@ public sealed class ConversationTranscriptWriter
     ///     it. Reporting <see cref="UnsafePathExitCode"/> lands in the same "indeterminate" branch as any
     ///     other unexpected status, which is the correct reading: nothing about that path is known.
     ///     </para>
+    ///     <para>
+    ///     <c>solo</c> is here for a reason of COST rather than of confidentiality — this probe reads, and
+    ///     an aliased destination is going to be refused at the append regardless. But the watermark is
+    ///     only recorded after a SUCCESSFUL append, so while the destination stays aliased the probe re-runs
+    ///     from cold on every flush, and each of those doomed attempts stages the entire unredacted history
+    ///     into <c>.conversations/.tmp/</c> through a gateway PUT before the append declines it. Refusing at
+    ///     the probe collapses that to one cheap shell call. See <see cref="AliasedPathExitCode"/>.
+    ///     </para>
     /// </remarks>
     private static readonly string WatermarkProbeScript =
         PathGuardPreamble
         + GuardLine("$1")
+        + SoloLine("$1")
         + "[ -e \"$1\" ] || exit "
         + WatermarkMissingExitCode.ToString(CultureInfo.InvariantCulture)
         + "\n"
@@ -446,6 +598,15 @@ public sealed class ConversationTranscriptWriter
     ///     A symlink to a FILE is a different matter and never was the hazard: <c>rename(2)</c> replaces
     ///     the link itself, so the link's target is not written through. Resolving to a directory is the
     ///     whole of it, which is why <c>[ ! -d ]</c> is an exact test rather than a conservative one.
+    ///     </para>
+    ///     <para>
+    ///     <b>The hard-link check the other three scripts carry is deliberately absent here, on the same
+    ///     reasoning and with the same kind of evidence.</b> A rename unlinks the destination NAME; it does
+    ///     not open the file behind it, so an aliased destination loses one of its names and nothing is
+    ///     written into the shared inode. Observed rather than assumed: with <c>new.jsonl</c> a hard link to
+    ///     a tracked file, <c>mv -T -- old.jsonl new.jsonl</c> exits 0, leaves the tracked file
+    ///     byte-identical, and drops its link count back to one. Adding <c>solo</c> here would buy nothing
+    ///     and would hand every retitle a new way to fail. See <see cref="AliasedPathExitCode"/>.
     ///     </para>
     ///     <para>
     ///     <c>mv -T</c> (<c>--no-target-directory</c>) is tried FIRST because it treats the destination as
@@ -1400,6 +1561,14 @@ public sealed class ConversationTranscriptWriter
         {
             // Step 7: the watermark advances ONLY on exit code 0, so the next flush recomputes the same
             // suffix and appends it again. Duplicate-on-retry, never silent loss.
+            if (spliced is { ExitCode: AliasedPathExitCode })
+            {
+                // Reached when the alias appears in the window between IsPathSafeAsync and this splice, or
+                // on the destination, which no earlier check in this method looks at.
+                LogAliasedRefusal(path);
+                return AppendResult.Failed;
+            }
+
             _logger.LogWarning(
                 "Transcript splice into {Path} failed with exit {ExitCode}: {Error}",
                 path,
@@ -1512,6 +1681,15 @@ public sealed class ConversationTranscriptWriter
 
         if (tailed.ExitCode is not (0 or WatermarkPartialExitCode))
         {
+            if (tailed.ExitCode == AliasedPathExitCode)
+            {
+                // Unsettled, like every other refusal here: an aliased destination is one this writer will
+                // not touch, and reporting Absent would send the caller off to append the whole history
+                // into it.
+                LogAliasedRefusal(path);
+                return WatermarkProbe.Unsettled;
+            }
+
             _logger.LogWarning(
                 "Transcript watermark probe of {Path} failed with exit {ExitCode}: {Error}",
                 path,
@@ -1716,6 +1894,12 @@ public sealed class ConversationTranscriptWriter
             return false;
         }
 
+        if (guarded is { ExitCode: AliasedPathExitCode })
+        {
+            LogAliasedRefusal(path);
+            return false;
+        }
+
         _logger.LogWarning(
             "Transcript path guard for {Path} failed with exit {ExitCode}: {Error}",
             path,
@@ -1723,6 +1907,26 @@ public sealed class ConversationTranscriptWriter
             guarded?.StandardError ?? "(no result)"
         );
         return false;
+    }
+
+    /// <summary>
+    ///     The one message for every alias refusal, wherever it is detected. Shared rather than repeated
+    ///     because this is the failure an operator will be reading BACKWARDS from a transcript that quietly
+    ///     stopped growing, and the fix — remove the extra name — is not one anybody guesses from
+    ///     "exit 46". See <see cref="AliasedPathExitCode"/>.
+    /// </summary>
+    private void LogAliasedRefusal(string path)
+    {
+        _logger.LogWarning(
+            "Transcript path {Path} for thread {ThreadId} is not a regular file with exactly one name — "
+                + "either something else in the workspace is hard-linked to it, or it is a directory. "
+                + "Refusing to use it: appending would write the unredacted transcript into whatever else "
+                + "shares that inode, which the .conversations/.gitignore does not cover. Nothing is "
+                + "unlinked, because a hard link is symmetric and this cannot tell our file from theirs. "
+                + "This conversation's mirror stays stopped until the extra link is removed.",
+            path,
+            ThreadId
+        );
     }
 
     private async Task<bool> TryMoveAsync(string sessionId, string from, string to, CancellationToken ct)

--- a/samples/LmStreaming.Sample/Services/TranscriptFlushScheduler.cs
+++ b/samples/LmStreaming.Sample/Services/TranscriptFlushScheduler.cs
@@ -21,8 +21,9 @@ namespace LmStreaming.Sample.Services;
 ///     </para>
 ///     <list type="number">
 ///         <item>
-///             A <see cref="HashSet{T}" /> of pending keys rather than one <c>bool _pending</c> slot. A single
-///             slot silently drops conversation A's pending flush the moment conversation B schedules.
+///             A <b>set of pending keys plus a FIFO queue</b> rather than one <c>bool _pending</c> slot. A
+///             single slot silently drops conversation A's pending flush the moment conversation B
+///             schedules. See <see cref="_order" /> for why the set alone is not enough.
 ///         </item>
 ///         <item>
 ///             <b>Failures are caught per key and the loop continues.</b> The original's catch re-arms the
@@ -66,7 +67,30 @@ public sealed class TranscriptFlushScheduler : IDisposable
     private readonly TimeSpan _shutdownDrainTimeout;
     private readonly CancellationTokenSource _shutdown = new();
     private readonly object _gate = new();
+
+    /// <summary>
+    ///     Membership of the pending set, used purely to COALESCE: a key already waiting earns no second
+    ///     queue slot. Drain order is <see cref="_order" />'s, never this set's.
+    /// </summary>
     private readonly HashSet<string> _pending = new(StringComparer.Ordinal);
+
+    /// <summary>
+    ///     The drain order, oldest first. A re-scheduled key goes to the TAIL.
+    /// </summary>
+    /// <remarks>
+    ///     <b>This queue is a starvation fix, not a tidier spelling of the set.</b> Draining with
+    ///     <c>_pending.First()</c> takes whichever key occupies the lowest <see cref="HashSet{T}" /> slot, and
+    ///     that is not the oldest key — it is an artifact of the set's free list. A key is REMOVED from the
+    ///     set while its flush runs, and <see cref="HashSet{T}" /> hands the slot that frees up to the next
+    ///     insertion; a flush that re-schedules its own key (the mirror does exactly this, on both
+    ///     <c>Progressing</c> and <c>Deferred</c>) therefore lands back in the slot it just vacated and is
+    ///     picked again ahead of a key that has been waiting in a higher slot the whole time. It is
+    ///     deterministic, not a race: with A and B both pending, A wins every round. One conversation's large
+    ///     descendant sweep then delays every other conversation for as many gateway calls as it takes, and a
+    ///     continuously-deferring conversation delays them without end.
+    /// </remarks>
+    private readonly Queue<string> _order = new();
+
     private Task _drain = Task.CompletedTask;
 
     /// <summary>
@@ -118,7 +142,8 @@ public sealed class TranscriptFlushScheduler : IDisposable
     ///     Requests a flush of <paramref name="key" />. <b>Strictly non-blocking</b> and fire-and-forget: it
     ///     takes a short lock and returns, doing no I/O on the caller's thread. Repeat calls for the same key
     ///     coalesce — while a key's flush is in flight the key is already out of the pending set, so a
-    ///     re-schedule re-adds it and earns exactly one more flush rather than being lost or duplicated.
+    ///     re-schedule re-adds it (at the BACK of the queue) and earns exactly one more flush rather than
+    ///     being lost or duplicated.
     ///     A no-op after <see cref="Dispose" /> (the mirror is best-effort; shutdown must not throw into a
     ///     message-subscriber loop).
     /// </summary>
@@ -133,7 +158,13 @@ public sealed class TranscriptFlushScheduler : IDisposable
                 return;
             }
 
-            _ = _pending.Add(key);
+            // Add is the coalescing gate: only a key that was NOT already pending is queued, so the two
+            // structures cannot drift apart and one key never occupies two queue slots.
+            if (_pending.Add(key))
+            {
+                _order.Enqueue(key);
+            }
+
             if (!_draining)
             {
                 _draining = true;
@@ -159,7 +190,7 @@ public sealed class TranscriptFlushScheduler : IDisposable
             string key;
             lock (_gate)
             {
-                if (_disposed || _pending.Count == 0)
+                if (_disposed || _order.Count == 0)
                 {
                     // Cleared HERE, under the same lock that made the decision — see _draining. Any
                     // Schedule that reaches the gate after this point starts a fresh loop.
@@ -167,7 +198,7 @@ public sealed class TranscriptFlushScheduler : IDisposable
                     return;
                 }
 
-                key = _pending.First();
+                key = _order.Dequeue();
                 _ = _pending.Remove(key);
             }
 
@@ -224,6 +255,7 @@ public sealed class TranscriptFlushScheduler : IDisposable
 
             _disposed = true;
             _pending.Clear();
+            _order.Clear();
             drain = _drain;
         }
 

--- a/samples/LmStreaming.Sample/Services/WorkspaceTranscriptMirror.cs
+++ b/samples/LmStreaming.Sample/Services/WorkspaceTranscriptMirror.cs
@@ -181,6 +181,26 @@ public sealed class WorkspaceTranscriptMirror : IDisposable
     public int ResubscribeCount => Volatile.Read(ref _resubscribeCount);
 
     /// <summary>
+    ///     Whether <paramref name="threadId"/> currently has a live subscription.
+    /// </summary>
+    /// <remarks>
+    ///     A test seam, and specifically the one that makes "this provider was never attached" assertable.
+    ///     Every other symptom of a missed <see cref="Attach"/> is an <i>absence</i> — no root transcript,
+    ///     no descendant files — which only shows up long after the agent was built and looks identical to
+    ///     a conversation that simply had nothing to write yet. Six of the sample's provider branches
+    ///     shipped unattached precisely because nothing could ask this question.
+    /// </remarks>
+    internal bool IsMirroring(string threadId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(threadId);
+
+        lock (_gate)
+        {
+            return _subscriptions.ContainsKey(threadId);
+        }
+    }
+
+    /// <summary>
     ///     Starts mirroring <paramref name="agent"/>'s conversation. Called from the sample's agent
     ///     factory for every agent the pool creates, including the replacement built by a mode switch —
     ///     that case cancels the previous subscription and keeps the existing writer.

--- a/samples/LmStreaming.Sample/playwright-scripts/transcript-mirror.mjs
+++ b/samples/LmStreaming.Sample/playwright-scripts/transcript-mirror.mjs
@@ -1,0 +1,698 @@
+// transcript-mirror.mjs — single-call Playwright E2E driver AND verifier for the WORKSPACE
+// CONVERSATION TRANSCRIPT MIRROR (#251 / PR #252) and its two follow-up fixes on
+// `wt3-transcript-followup`.
+//
+//   browser_run_code_unsafe({ filename: "<path>/transcript-mirror.mjs" })
+//
+// WHAT THIS PROVES
+//   (a) a provider that ALWAYS attached           → `test-anthropic` + workspace-agent mode, turn 1
+//   (c) a named background sub-agent              → turn 1 spawns `mirror-alpha` / `mirror-beta`
+//   (b) a CLI/mock provider that DID NOT attach   → same thread switched to `codex-mock`, turn 2
+//       ^^^ THIS IS THE P1 PROOF (458dbca1). Before P1 the CLI provider branches in Program.cs
+//       returned before the single Attach call, so those agents mirrored nothing. Because turn 1
+//       already created the file, the bug's signature is: file exists, contains MARKER1, and MARKER2
+//       is ABSENT — a silent hole in the middle of a live transcript.
+//   P2 (57bf4200, FIFO flush drain) is checked best-effort: no duplicate `uid`s, and MARKER1's row
+//       precedes MARKER2's row. A drain that re-ordered or replayed a queued flush shows up here.
+//
+// HOW IT VERIFIES — read this before changing the assertions.
+// The mirror writes into the SANDBOX WORKSPACE through the gateway, so the bytes are NOT on the
+// browser side. Earlier drafts therefore punted the verdict to a host-filesystem PowerShell script.
+// That is WRONG on this deployment: `samples/LmStreaming.Sample/.env` pins
+// `SandboxGateway__BaseUrl=http://192.168.11.139:3000` with `AutoSpawn=false`, and 192.168.11.139 is
+// a DIFFERENT machine (this host is 192.168.11.20; the route to .139 leaves via the Tailscale
+// interface, and the two gateways report different `active_sessions`). The transcript lands on
+// whichever machine the configured gateway runs on, so a host-path check on the wrong machine reads
+// as "no file" — a FALSE P1 REGRESSED.
+//
+// So this script reads the transcript back through the app's own file browser
+// (`FileBrowserController`, `[Route("api/conversations/{threadId}/files")]`), which goes through the
+// SAME gateway the writer used and is therefore correct whether that gateway is local or remote.
+// `disk-checks.ps1` remains useful only as a second opinion when the gateway is the local one.
+//   • `files?path=…`          → listing (200 + `{state:"no_session_yet"}` before a sandbox exists)
+//   • `files/download?path=…` → raw bytes. Use THIS, not `preview`: `FilePreviewPolicy` excludes
+//     anything under a dot-directory outright, so `preview` returns `{previewable:false,
+//     reason:"excluded"}` for `.conversations/*.jsonl` BY DESIGN. Not a bug — do not "fix" it.
+//   • `[InboundS2SAuth]` is marker-gated (it enforces only when `X-S2S-Auth` / `X-Sbx-App-Id` is
+//     present), so plain same-origin `fetch` from the page is allowed. All API calls run in-page.
+//
+// KNOWN INCONCLUSIVE PATH: the controller resolves a path one component at a time against the
+// gateway's listing, so reaching `.conversations` needs the ROOT listing to include dot entries. The
+// UI can navigate there (that is why the preview exclusion exists), but this script does not assume
+// it — step `workspace root listing` records every root entry name, and if `.conversations` never
+// resolves the verdict is INCONCLUSIVE_NOT_LISTABLE, never REGRESSED. Fall back to disk-checks.ps1.
+//
+// HARD PREREQUISITE: a LIVE SANDBOX GATEWAY. With no workspace binding every flush returns
+// TranscriptFlushOutcome.Unavailable and writes nothing, silently — indistinguishable from the bug.
+// The script fails fast at `workspace bound before send` rather than producing a false negative.
+//
+// Prompt: PromptExamples.md → "Sub-Agent Tabs (center-pane, colored)" → "Two named background
+// sub-agents, text-only (transcript-mirror fixture)". Nested chains are built with JSON.stringify so
+// the escaping is correct by construction — never hand-escape these.
+async (page) => {
+  // PORTS — there is NO launchSettings.json in samples/LmStreaming.Sample, so nothing overrides the
+  // binding except `samples/LmStreaming.Sample/.env`, which Program.cs:66 loads via FindEnvFile.
+  // FindEnvFile walks up from **AppContext.BaseDirectory** (the bin dir), NOT the shell cwd, so the
+  // launch directory cannot change which .env wins. That file sets
+  // ASPNETCORE_URLS=http://0.0.0.0:5055. `:5000` is the bare framework default you only get without
+  // it; `:5050`/`:5098`/`:5273` are isolated instances. Probe rather than pin — put your origin
+  // first to skip the probe.
+  const CANDIDATES = [
+    'http://localhost:5055',
+    'http://localhost:5050',
+    'http://localhost:5000',
+    'http://localhost:5098',
+    'http://localhost:5273',
+    'http://localhost:5173',
+  ];
+  const WORKSPACE_NAME = 'transcript-e2e';
+  const WORKSPACE_DIR = 'transcript-e2e'; // single segment — separators are stripped by the sanitizer
+  const BOUND_PROVIDER = 'test-anthropic'; // the one mock Workspace Agent mode permits
+  const CLI_PROVIDER = 'codex-mock'; // the only CLI-family provider needing no binary on PATH
+  const TRANSCRIPT_DIR = '.conversations'; // ConversationTranscriptWriter.TranscriptDirectory
+  const AGENTS_SUFFIX = '_agents'; // ConversationTranscriptWriter.AgentsDirectorySuffix
+  const STAMP = String(Date.now());
+  const TITLE = `Transcript Mirror E2E ${STAMP}`; // slugs to `transcript-mirror-e2e-<stamp>`
+  // Every `.jsonl` under `.conversations/` is NOT this run's transcript — the directory accumulates
+  // one per conversation, so on the SECOND run "the first .jsonl in the listing" is a previous run's
+  // file, whose MARKER1 carries a previous stamp. That reads as FAILED_TURN1_NOT_MIRRORED against a
+  // perfectly healthy mirror. Match this run's file by its own slug prefix instead.
+  const EXPECTED_PREFIX = `transcript-mirror-e2e-${STAMP}-`;
+  const isOurTranscript = (name) =>
+    String(name).startsWith(EXPECTED_PREFIX) && String(name).endsWith('.jsonl');
+  const MARKER1 = `MIRROR-TURN1-${STAMP}`;
+  const MARKER2 = `MIRROR-TURN2-CLI-${STAMP}`;
+  const ALPHA_TEXT = `mirror-alpha reporting ${MARKER1}`;
+  const BETA_TEXT = `mirror-beta reporting ${MARKER1}`;
+  // The flush is scheduled/debounced (TranscriptFlushScheduler), so the bytes trail the UI going
+  // idle. These are generous ceilings on a poll, not sleeps — every wait exits on first success.
+  const APPEAR_TIMEOUT_MS = 120000;
+  const POLL_MS = 2000;
+
+  const steps = [];
+  const record = (name, pass, detail) => {
+    steps.push({ name, pass, detail });
+    return pass;
+  };
+  const tid = (id) => page.locator(`[data-testid="${id}"]`);
+  const waitIdle = async () => {
+    await tid('stop-button').waitFor({ state: 'hidden', timeout: 120000 });
+    await tid('send-button').waitFor({ state: 'visible', timeout: 120000 });
+  };
+  const send = async (text) => {
+    await tid('chat-input-textarea').fill(text);
+    await tid('send-button').click();
+  };
+  const errorBanner = async () => {
+    const n = await tid('error-banner').count();
+    return n === 0 ? null : (await tid('error-banner').first().innerText().catch(() => '<unreadable>'));
+  };
+
+  let BASE = null;
+
+  // Same-origin, in-page fetch — the interactive path [InboundS2SAuth] deliberately lets through.
+  const api = (method, path, body) =>
+    page.evaluate(
+      async ({ method, path, body }) => {
+        const init = { method, headers: { 'content-type': 'application/json' } };
+        if (body !== undefined) init.body = JSON.stringify(body);
+        const res = await fetch(`${location.origin}${path}`, init);
+        const text = await res.text();
+        let json = null;
+        try {
+          json = text ? JSON.parse(text) : null;
+        } catch {
+          /* non-JSON body — the raw text is kept for the failure detail */
+        }
+        return { status: res.status, ok: res.ok, json, text: text.slice(0, 600) };
+      },
+      { method, path, body }
+    );
+
+  // Raw workspace bytes (transcripts are JSONL; `preview` refuses dot-directories by design).
+  const downloadWorkspaceFile = (threadId, wsPath) =>
+    page.evaluate(
+      async ({ threadId, wsPath }) => {
+        const url = `${location.origin}/api/conversations/${encodeURIComponent(threadId)}/files/download?path=${encodeURIComponent(wsPath)}`;
+        const res = await fetch(url);
+        return { status: res.status, ok: res.ok, text: res.ok ? await res.text() : null };
+      },
+      { threadId, wsPath }
+    );
+
+  // Classifies a listing into the four states that mean different things here. `no_session_yet` is
+  // NOT "empty": it means no sandbox has been established, so nothing could have been written.
+  const listWorkspaceDir = async (threadId, wsPath) => {
+    const res = await api('GET', `/api/conversations/${encodeURIComponent(threadId)}/files?path=${encodeURIComponent(wsPath)}`);
+    if (res.status === 404) return { state: 'not-found', entries: [] };
+    if (!res.ok) return { state: 'error', entries: [], status: res.status, body: res.text };
+    if (res.json && res.json.state === 'no_session_yet') return { state: 'no-session', entries: [] };
+    const entries = (res.json && res.json.entries) || [];
+    return { state: 'listed', entries, moreCount: (res.json && res.json.moreCount) || 0 };
+  };
+
+  const pollUntil = async (fn, timeoutMs) => {
+    const deadline = Date.now() + timeoutMs;
+    let last = null;
+    for (;;) {
+      last = await fn();
+      if (last && last.done) return last;
+      if (Date.now() >= deadline) return last;
+      await page.waitForTimeout(POLL_MS);
+    }
+  };
+
+  // UI-idle is NOT run-idle. When a turn spawns BACKGROUND sub-agents, the parent's stop-button
+  // hides as soon as the PARENT's own stream ends, but `agentPool.GetRunStateInfo(threadId)` stays
+  // IsInProgress until the whole run drains. The mode/provider switch guards
+  // (ConversationsController.cs:1263, :1380) read exactly that state, so switching on UI-idle earns
+  // a 409 `mode_switch_while_streaming` — observed as AgentIsRunning=True, RunTaskCompleted=False,
+  // IsStale=False, i.e. a genuinely live run, not a stale-state bug. Gate on the same signal the
+  // guard reads rather than on a proxy for it.
+  const waitRunIdle = (threadId, timeoutMs) =>
+    pollUntil(async () => {
+      const rs = await api('GET', `/api/conversations/${encodeURIComponent(threadId)}/run-state`);
+      return { done: !(rs.json && rs.json.isInProgress), runState: rs.json };
+    }, timeoutMs);
+
+  const result = {
+    pass: false,
+    verdict: 'NOT_REACHED',
+    failures: [],
+    steps,
+    base: null,
+    workspace: null,
+    conversation: null,
+    transcript: null,
+    markers: { turn1: MARKER1, turn2: MARKER2, alpha: ALPHA_TEXT, beta: BETA_TEXT },
+    subAgents: [],
+    diskChecks: null,
+  };
+
+  try {
+    // ---- 0. Find the running instance -------------------------------------------------------
+    for (const candidate of CANDIDATES) {
+      const res = await page.request
+        .get(`${candidate}/api/providers`, { timeout: 4000 })
+        .catch(() => null);
+      if (res && res.ok()) {
+        BASE = candidate;
+        break;
+      }
+    }
+    if (!record('backend reachable', BASE !== null, { tried: CANDIDATES, base: BASE })) {
+      result.failures.push('backend reachable');
+      result.verdict = 'INCONCLUSIVE_NO_BACKEND';
+      return result;
+    }
+    result.base = BASE;
+    await page.goto(BASE);
+    await tid('chat-input-textarea').waitFor({ timeout: 30000 });
+
+    // ---- 1. Providers actually available on this host -------------------------------------
+    // `/api/providers` returns an ENVELOPE `{providers:[…], default:"…"}`, not a bare array. Calling
+    // .filter on the envelope throws, and the throw is swallowed by the outer catch as
+    // INCONCLUSIVE_SCRIPT_ERROR — a script bug wearing the costume of an environment problem.
+    const providers = await api('GET', '/api/providers');
+    const providerList = Array.isArray(providers.json)
+      ? providers.json
+      : (providers.json && providers.json.providers) || [];
+    const availableIds = providerList
+      .filter((p) => p.isAvailable !== false && p.available !== false)
+      .map((p) => p.id);
+    const boundOk = availableIds.includes(BOUND_PROVIDER);
+    const cliOk = availableIds.includes(CLI_PROVIDER);
+    record('required providers available', boundOk && cliOk, {
+      needs: [BOUND_PROVIDER, CLI_PROVIDER],
+      boundOk,
+      cliOk,
+      availableIds,
+      hint: cliOk ? undefined : 'codex-mock also requires MockProviderHostLifetime.IsRunning',
+    });
+    if (!boundOk) {
+      result.failures.push('required providers available');
+      result.verdict = 'INCONCLUSIVE_NO_PROVIDER';
+      return result;
+    }
+
+    // ---- 2. Resolve-or-create the workspace BY NAME (a hardcoded id goes stale across data dirs)
+    const list = await api('GET', '/api/workspaces');
+    const workspaces = Array.isArray(list.json) ? list.json : (list.json && list.json.workspaces) || [];
+    let workspace = workspaces.find(
+      (w) => w.name === WORKSPACE_NAME || w.directoryRelPath === WORKSPACE_DIR
+    );
+    if (!workspace) {
+      const created = await api('POST', '/api/workspaces', {
+        name: WORKSPACE_NAME,
+        directoryRelPath: WORKSPACE_DIR,
+        marketplaces: [],
+      });
+      workspace = created.json;
+      if (!record('workspace created', created.ok && !!(workspace && workspace.id), {
+        status: created.status,
+        body: created.text,
+      })) {
+        result.failures.push('workspace created');
+        result.verdict = 'INCONCLUSIVE_NO_WORKSPACE';
+        return result;
+      }
+    } else {
+      record('workspace resolved (pre-existing)', true, {
+        id: workspace.id,
+        name: workspace.name,
+        directoryRelPath: workspace.directoryRelPath,
+      });
+    }
+    result.workspace = {
+      id: workspace.id,
+      name: workspace.name,
+      // Report this: it names the directory the transcript will appear under, and it is the only
+      // way the caller can tell WHICH workspace on WHICH gateway host was actually used.
+      directoryRelPath: workspace.directoryRelPath ?? WORKSPACE_DIR,
+      known: workspaces.map((w) => ({ id: w.id, name: w.name, dir: w.directoryRelPath })),
+    };
+
+    // ---- 3. Modes: find workspace-agent and a non-workspace fallback -----------------------
+    // The route is `/api/chat-modes` (see ClientApp/src/api/chatModesApi.ts). `/api/modes` does NOT
+    // 404 — it falls through to the SPA fallback and returns index.html, so JSON.parse fails, json is
+    // null, and modeIds silently becomes []. A wrong route here reads as "this host has no modes".
+    const modes = await api('GET', '/api/chat-modes');
+    const modeList = Array.isArray(modes.json) ? modes.json : (modes.json && modes.json.modes) || [];
+    const modeIds = modeList.map((m) => m.id);
+    const wsMode = modeIds.includes('workspace-agent') ? 'workspace-agent' : null;
+    const plainMode = modeIds.includes('default')
+      ? 'default'
+      : modeIds.find((m) => m !== 'workspace-agent' && m !== 'workflow-author');
+    if (!record('modes resolved', !!wsMode && !!plainMode, { wsMode, plainMode, modeIds })) {
+      result.failures.push('modes resolved');
+      result.verdict = 'INCONCLUSIVE_NO_MODE';
+      return result;
+    }
+
+    // ---- 4. Provision the workspace-bound conversation (race-free; no UI clicking) ---------
+    const prov = await api('POST', '/api/conversations', {
+      workspaceId: result.workspace.id,
+      providerId: BOUND_PROVIDER,
+      modeId: wsMode,
+    });
+    const threadId = prov.json && prov.json.threadId;
+    if (!record('conversation provisioned (workspace-agent)', prov.ok && !!threadId, {
+      status: prov.status,
+      body: prov.text,
+      hint: prov.status === 503 ? 'provider_unavailable — check the mock host / gateway' : undefined,
+    })) {
+      result.failures.push('conversation provisioned (workspace-agent)');
+      result.verdict = 'INCONCLUSIVE_NO_THREAD';
+      return result;
+    }
+    await api('PUT', `/api/conversations/${threadId}/metadata`, { title: TITLE });
+    result.conversation = { threadId, title: TITLE, providerAtTurn1: BOUND_PROVIDER, modeAtTurn1: wsMode };
+
+    // ---- 5. The workspace really is bound BEFORE we send anything --------------------------
+    // A missing workspace property means every flush returns Unavailable and NOTHING is written —
+    // which looks exactly like the P1 bug. Refuse to continue rather than emit a false negative.
+    const convs = await api('GET', '/api/conversations');
+    const summary = (convs.json || []).find((c) => c.threadId === threadId);
+    if (!record('workspace bound before send', !!(summary && summary.workspace), {
+      workspace: summary && summary.workspace,
+      provider: summary && summary.provider,
+      mode: summary && summary.mode,
+      why: 'no workspace ⇒ TranscriptFlushOutcome.Unavailable ⇒ no file, silently',
+    })) {
+      result.failures.push('workspace bound before send');
+      result.verdict = 'INCONCLUSIVE_UNBOUND';
+      return result;
+    }
+
+    // ---- 5b. BASELINE, recorded through the same reader that will later prove the bytes -----
+    // Taking the baseline through the gateway (rather than a host path) is what makes the later
+    // "the file appeared" claim mean something: same reader, same session, same machine.
+    const baseRoot = await listWorkspaceDir(threadId, '');
+    record('baseline: workspace root listing', true, {
+      state: baseRoot.state,
+      entries: baseRoot.entries.map((e) => `${e.name}${e.type === 'directory' ? '/' : ''}`),
+      dotEntriesVisible: baseRoot.entries.some((e) => String(e.name).startsWith('.')),
+      why: 'if dot entries never appear at root, `.conversations` cannot be resolved by this API',
+    });
+    const baseTranscriptDir = await listWorkspaceDir(threadId, TRANSCRIPT_DIR);
+    const baselineClean =
+      baseTranscriptDir.state === 'not-found' ||
+      baseTranscriptDir.state === 'no-session' ||
+      (baseTranscriptDir.state === 'listed' &&
+        !baseTranscriptDir.entries.some((e) => isOurTranscript(e.name)));
+    record(`baseline: no ${TRANSCRIPT_DIR} transcript yet`, baselineClean, {
+      state: baseTranscriptDir.state,
+      entries: baseTranscriptDir.entries.map((e) => e.name),
+      meaning:
+        baseTranscriptDir.state === 'no-session'
+          ? 'no sandbox established yet — nothing could have been written; the cleanest baseline'
+          : baseTranscriptDir.state === 'not-found'
+            ? 'directory does not exist'
+            : 'directory exists but holds no transcript',
+    });
+
+    // ---- 6. Turn 1 on the attaching provider, spawning two NAMED background sub-agents -----
+    const inner = (id, text) =>
+      `<|instruction_start|>${JSON.stringify({ instruction_chain: [{ id, messages: [{ text }] }] })}<|instruction_end|>`;
+    const parent = {
+      instruction_chain: [
+        {
+          id: 'spawn-mirror-pair',
+          id_message: 'Spawn two named background sub-agents',
+          reasoning: { length: 30 }, // reasoning must appear RAW in the transcript — checked below
+          messages: [
+            {
+              tool_call: [
+                {
+                  name: 'Agent',
+                  args: {
+                    subagent_type: 'researcher',
+                    name: 'mirror-alpha',
+                    run_in_background: true,
+                    prompt: inner('ma1', ALPHA_TEXT),
+                  },
+                },
+                {
+                  name: 'Agent',
+                  args: {
+                    subagent_type: 'general-purpose',
+                    name: 'mirror-beta',
+                    run_in_background: true,
+                    prompt: inner('mb1', BETA_TEXT),
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'parent-done',
+          messages: [{ text: `Spawned mirror-alpha and mirror-beta. ${MARKER1}` }],
+        },
+      ],
+    };
+    const PROMPT1 = `${MARKER1}\n<|instruction_start|>${JSON.stringify(parent)}<|instruction_end|>`;
+
+    await page.goto(`${BASE}/?threadId=${threadId}`);
+    await tid('chat-input-textarea').waitFor({ timeout: 30000 });
+    const notFound = await tid('conversation-not-found').count();
+    if (!record('deep link opened the provisioned thread', notFound === 0, { threadId, notFound })) {
+      result.failures.push('deep link opened the provisioned thread');
+      result.verdict = 'INCONCLUSIVE_DEAD_THREAD';
+      return result;
+    }
+
+    await send(PROMPT1);
+    await waitIdle();
+    const err1 = await errorBanner();
+    record(`turn 1 ran on ${BOUND_PROVIDER} without error`, err1 === null, {
+      errorBanner: err1,
+      why: 'an error here usually means the sandbox gateway is down — the read-back would be meaningless',
+    });
+    if (err1 !== null) {
+      result.failures.push(`turn 1 ran on ${BOUND_PROVIDER} without error`);
+      result.verdict = 'INCONCLUSIVE_TURN1_ERROR';
+      return result;
+    }
+
+    // ---- 7. The two named sub-agents exist (⇒ an `_agents/` child file is expected) ---------
+    let rows = [];
+    for (let i = 0; i < 20; i++) {
+      const sub = await api('GET', `/api/conversations/${threadId}/subagents`);
+      rows = Array.isArray(sub.json) ? sub.json : [];
+      if (rows.length >= 2) break;
+      await page.waitForTimeout(1500);
+    }
+    result.subAgents = rows.map((r) => ({
+      name: r.name ?? r.agentName ?? null,
+      agentId: r.agentId ?? r.id ?? null,
+      threadId: r.threadId ?? null,
+      status: r.status ?? null,
+    }));
+    record('two named background sub-agents spawned', rows.length >= 2, {
+      count: rows.length,
+      subAgents: result.subAgents,
+      expectedNames: ['mirror-alpha', 'mirror-beta'],
+    });
+
+    // ---- 7b. THE POSITIVE ASSERTION: real bytes, read back through the gateway --------------
+    // Absence of errors is not evidence. This is: the file exists and contains MARKER1.
+    const appeared = await pollUntil(async () => {
+      const listing = await listWorkspaceDir(threadId, TRANSCRIPT_DIR);
+      const file = listing.entries.find((e) => isOurTranscript(e.name));
+      return { done: !!file, listing, file };
+    }, APPEAR_TIMEOUT_MS);
+
+    if (!appeared || !appeared.file) {
+      const listable = appeared && appeared.listing.state !== 'error';
+      record(`transcript file created under ${TRANSCRIPT_DIR}`, false, {
+        state: appeared && appeared.listing.state,
+        entries: appeared ? appeared.listing.entries.map((e) => e.name) : [],
+        expectedPrefix: EXPECTED_PREFIX,
+        note: listable
+          ? `directory readable but nothing matching ${EXPECTED_PREFIX} — the mirror wrote nothing on the ATTACHING provider`
+          : 'directory not readable through this API — fall back to disk-checks.ps1',
+      });
+      result.failures.push(`transcript file created under ${TRANSCRIPT_DIR}`);
+      result.verdict = listable ? 'FAILED_NO_TRANSCRIPT_AT_ALL' : 'INCONCLUSIVE_NOT_LISTABLE';
+      return result;
+    }
+
+    const fileName = appeared.file.name;
+    const leaf = fileName.replace(/\.jsonl$/, '');
+    const mainPath = `${TRANSCRIPT_DIR}/${fileName}`;
+    record(`transcript file created under ${TRANSCRIPT_DIR}`, true, {
+      fileName,
+      size: appeared.file.size,
+      expectedShape: `slug(title)-shortId(threadId).jsonl  (slug ⇒ transcript-mirror-e2e-${STAMP})`,
+    });
+    result.transcript = { dir: TRANSCRIPT_DIR, fileName, leaf, path: mainPath };
+
+    const turn1Bytes = await pollUntil(async () => {
+      const dl = await downloadWorkspaceFile(threadId, mainPath);
+      return { done: !!(dl.ok && dl.text && dl.text.includes(MARKER1)), dl };
+    }, APPEAR_TIMEOUT_MS);
+    const turn1Text = (turn1Bytes && turn1Bytes.dl.text) || '';
+    if (!record('turn 1 bytes are in the transcript (MARKER1)', turn1Text.includes(MARKER1), {
+      status: turn1Bytes && turn1Bytes.dl.status,
+      bytes: turn1Text.length,
+      lines: turn1Text ? turn1Text.split('\n').filter((l) => l.trim()).length : 0,
+      // NO reasoning check here. It was tried and it lies twice over: this snapshot is taken before
+      // reasoning has flushed, and a /"reasoning"/ scan matches the User message's own message_json,
+      // which echoes the prompt's `"reasoning":{"length":30}` back verbatim. RAW fidelity is asserted
+      // against the FINAL transcript off the message_type discriminator instead — see step 12.
+    })) {
+      result.failures.push('turn 1 bytes are in the transcript (MARKER1)');
+      result.verdict = 'FAILED_TURN1_NOT_MIRRORED';
+      return result;
+    }
+
+    // Sub-agent fan-out — case (c). Recorded, not fatal: P1 is about the parent attach.
+    const agentsDir = `${TRANSCRIPT_DIR}/${leaf}${AGENTS_SUFFIX}`;
+    // POLL for BOTH children. Each sub-agent flushes on its own schedule, so a single-shot listing
+    // taken right after the parent's flush reliably catches only the first — a script race that
+    // reads as "the second sub-agent was never mirrored". Observed exactly once: alpha present /
+    // beta absent at list time, beta on disk (2431 bytes) moments later. This directory is
+    // per-conversation, so a bare `.jsonl` filter is safe here (unlike `.conversations/` itself).
+    const agentsPoll = await pollUntil(async () => {
+      const listing = await listWorkspaceDir(threadId, agentsDir);
+      const files = listing.entries.filter((e) => String(e.name).endsWith('.jsonl'));
+      return { done: files.length >= 2, listing, files };
+    }, APPEAR_TIMEOUT_MS);
+    const agentsListing = agentsPoll.listing;
+    const agentFiles = agentsPoll.files;
+    const agentTexts = {};
+    let agentsBlob = '';
+    for (const f of agentFiles) {
+      const dl = await downloadWorkspaceFile(threadId, `${agentsDir}/${f.name}`);
+      const text = (dl.ok && dl.text) || '';
+      agentTexts[f.name] = text.length;
+      agentsBlob += `${text}\n`;
+    }
+    record('sub-agent transcripts mirrored', agentFiles.length >= 2, {
+      dir: agentsDir,
+      state: agentsListing.state,
+      files: agentFiles.map((f) => f.name),
+      byteCounts: agentTexts,
+      alphaPresent: agentsBlob.includes(ALPHA_TEXT),
+      betaPresent: agentsBlob.includes(BETA_TEXT),
+      expectedLeafShape: 'slug(agentName)-shortId(agentId).jsonl ⇒ mirror-alpha-… / mirror-beta-…',
+    });
+
+    // ---- 8. THE P1 SETUP: leave workspace mode, switch to the CLI-family provider -----------
+    // Order matters: workspace-agent mode REJECTS codex-mock (Program.cs:822-856), so the mode must
+    // drop first. The established sandbox binding survives both switches — PublishBindingIfStaged
+    // only ever publishes, and ClearEstablishedBinding fires only on agent REMOVAL — so the
+    // codex-mock agent's flush WOULD write, iff P1 attached the mirror to it.
+    if (!cliOk) {
+      record(`SKIPPED: switch to ${CLI_PROVIDER}`, false, {
+        why: `${CLI_PROVIDER} is not available on this host — the P1 case cannot be driven`,
+        availableIds,
+      });
+      result.failures.push(`SKIPPED: switch to ${CLI_PROVIDER}`);
+      result.verdict = 'INCONCLUSIVE_NO_CLI_PROVIDER';
+      return result;
+    }
+    const runIdle = await waitRunIdle(threadId, APPEAR_TIMEOUT_MS);
+    if (!record('run drained server-side before switching', !!(runIdle && runIdle.done), {
+      runState: runIdle && runIdle.runState,
+      why: 'the switch guards read agentPool.GetRunStateInfo; UI-idle is not run-idle when the turn spawned background sub-agents',
+    })) {
+      result.failures.push('run drained server-side before switching');
+      result.verdict = 'INCONCLUSIVE_RUN_NEVER_DRAINED';
+      return result;
+    }
+    const modeSwitch = await api('POST', `/api/conversations/${threadId}/mode`, { modeId: plainMode });
+    record('mode switched out of workspace-agent', modeSwitch.ok, {
+      to: plainMode,
+      status: modeSwitch.status,
+      body: modeSwitch.text,
+    });
+    const provSwitch = await api('POST', `/api/conversations/${threadId}/provider`, {
+      providerId: CLI_PROVIDER,
+    });
+    if (!record(`provider switched to ${CLI_PROVIDER}`, provSwitch.ok, {
+      status: provSwitch.status,
+      body: provSwitch.text,
+    })) {
+      result.failures.push(`provider switched to ${CLI_PROVIDER}`);
+      result.verdict = 'INCONCLUSIVE_NO_SWITCH';
+      return result;
+    }
+
+    // Workspace metadata must be untouched by the two switches, or turn 2 proves nothing.
+    const convs2 = await api('GET', '/api/conversations');
+    const summary2 = (convs2.json || []).find((c) => c.threadId === threadId);
+    if (!record('workspace binding survived the switches', !!(summary2 && summary2.workspace), {
+      workspace: summary2 && summary2.workspace,
+      provider: summary2 && summary2.provider,
+      mode: summary2 && summary2.mode,
+    })) {
+      result.failures.push('workspace binding survived the switches');
+      result.verdict = 'INCONCLUSIVE_BINDING_LOST';
+      return result;
+    }
+    result.conversation.providerAtTurn2 = CLI_PROVIDER;
+    result.conversation.modeAtTurn2 = plainMode;
+
+    // ---- 9. Turn 2 on the CLI-family provider — the byte that P1 is about ------------------
+    // Plain text: codex-mock does not interpret the instruction-chain format, and the assertion
+    // rides on the USER message (which the mirror records) rather than any scripted reply.
+    await page.reload();
+    await tid('chat-input-textarea').waitFor({ timeout: 30000 });
+    const beforeUser = await tid('user-message-group').count();
+    await send(`${MARKER2} — please acknowledge.`);
+    await waitIdle();
+    // Drain server-side too: the mirror flushes at a TURN BOUNDARY, so reading the transcript while
+    // the run is still in progress can miss MARKER2 for reasons that have nothing to do with P1.
+    await waitRunIdle(threadId, APPEAR_TIMEOUT_MS);
+    const afterUser = await tid('user-message-group').count();
+    const afterAssistant = await tid('assistant-message-group').count();
+    const err2 = await errorBanner();
+    record(`turn 2 ran on ${CLI_PROVIDER}`, err2 === null && afterUser > beforeUser, {
+      errorBanner: err2,
+      userGroups: { before: beforeUser, after: afterUser },
+      assistantGroups: afterAssistant,
+      note: 'CLI mocks may complete silently — the user turn landing is what matters',
+    });
+    if (err2 !== null || afterUser <= beforeUser) {
+      result.failures.push(`turn 2 ran on ${CLI_PROVIDER}`);
+      result.verdict = 'INCONCLUSIVE_TURN2_DID_NOT_RUN';
+      return result;
+    }
+
+    // ---- 10. THE P1 VERDICT: MARKER2 must join MARKER1 in the SAME file --------------------
+    const turn2Bytes = await pollUntil(async () => {
+      const dl = await downloadWorkspaceFile(threadId, mainPath);
+      return { done: !!(dl.ok && dl.text && dl.text.includes(MARKER2)), dl };
+    }, APPEAR_TIMEOUT_MS);
+    const finalText = (turn2Bytes && turn2Bytes.dl.text) || '';
+    const hasM1 = finalText.includes(MARKER1);
+    const hasM2 = finalText.includes(MARKER2);
+    const p1 = record('P1 (458dbca1): the CLI-provider turn was mirrored too (MARKER2)', hasM2, {
+      marker1Present: hasM1,
+      marker2Present: hasM2,
+      bytes: finalText.length,
+      bytesAfterTurn1: turn1Text.length,
+      signature: hasM1 && !hasM2 ? 'MARKER1 without MARKER2 = the exact P1 bug: a silent hole mid-transcript' : undefined,
+    });
+    if (!p1) result.failures.push('P1 (458dbca1): the CLI-provider turn was mirrored too (MARKER2)');
+
+    // ---- 11. P2 (57bf4200) best-effort: the FIFO drain neither duplicated nor re-ordered ----
+    const lines = finalText.split('\n').filter((l) => l.trim());
+    const parsed = [];
+    let unparsable = 0;
+    for (const line of lines) {
+      try {
+        parsed.push(JSON.parse(line));
+      } catch {
+        unparsable++;
+      }
+    }
+    const uids = parsed.map((r) => r && r.uid).filter(Boolean);
+    const dupUids = uids.filter((u, i) => uids.indexOf(u) !== i);
+    const idx1 = lines.findIndex((l) => l.includes(MARKER1));
+    const idx2 = lines.findIndex((l) => l.includes(MARKER2));
+    record('P2 (57bf4200): drain kept the transcript append-only and in order', dupUids.length === 0 && unparsable === 0 && (idx2 === -1 || idx1 < idx2), {
+      lines: lines.length,
+      parsed: parsed.length,
+      unparsableLines: unparsable,
+      duplicateUids: dupUids.slice(0, 5),
+      marker1LineIndex: idx1,
+      marker2LineIndex: idx2,
+      why: 'a mis-drained queue shows up as a repeated uid, a torn line, or turn 2 landing before turn 1',
+    });
+
+    // ---- 12. RAW fidelity: reasoning survived the mirror --------------------------------------
+    // The locked decision is FULL/RAW content fidelity INCLUDING reasoning, so a transcript that
+    // silently dropped thinking would satisfy every check above and still be wrong.
+    // Count `message_type`, NOT a substring. A /"reasoning"/ scan over the raw text reports ~49 hits
+    // on a healthy run and would report them on a BROKEN one too, because the User row's
+    // `message_json` quotes the prompt's own `"reasoning":{"length":30}`. The discriminator is the
+    // only field the mock cannot forge from prompt text.
+    const byType = {};
+    for (const r of parsed) {
+      const t = (r && r.message_type) || '(none)';
+      byType[t] = (byType[t] || 0) + 1;
+    }
+    const reasoningRows = Object.entries(byType)
+      .filter(([t]) => t.startsWith('Reasoning'))
+      .reduce((n, [, c]) => n + c, 0);
+    record('RAW fidelity: reasoning rows survived the mirror', reasoningRows > 0, {
+      reasoningRows,
+      messageTypes: byType,
+      why: 'reasoning is part of the locked full-fidelity contract; counted by message_type because the prompt echoes the word "reasoning" into its own message_json',
+    });
+    if (reasoningRows === 0) result.failures.push('RAW fidelity: reasoning rows survived the mirror');
+
+    result.verdict = hasM2 ? 'P1_HOLDS' : hasM1 ? 'P1_REGRESSED' : 'FAILED_NOTHING_MIRRORED';
+
+    // ---- 13. Optional second opinion (LOCAL gateway only) ----------------------------------
+    result.diskChecks = {
+      how: 'run disk-checks.ps1 with -ThreadId / -Title / -Marker1 / -Marker2 / -WorkspaceDir',
+      onlyValidWhen:
+        'SandboxGateway:BaseUrl points at a gateway on THIS host. The .env pins http://192.168.11.139:3000 ' +
+        '(a different machine, reached over Tailscale), in which case the bytes are on THAT host and this ' +
+        'script\'s in-band read-back above is the authoritative check.',
+      overrideForALocalRun:
+        'dotnet run --project samples/LmStreaming.Sample -- --SandboxGateway:BaseUrl=http://127.0.0.1:3000 ' +
+        '--SandboxGateway:WorkspaceBasePath=B:\\sandbox-workspaces\\workspaces   ' +
+        '(command-line args outrank the .env; shell env vars do NOT — dotenv.net overwrites existing vars)',
+      threadId,
+      title: TITLE,
+      workspaceDir: result.workspace.directoryRelPath,
+      mainFile: mainPath,
+      agentsDir,
+    };
+  } catch (e) {
+    record('unexpected error', false, { message: String(e && e.message ? e.message : e) });
+    result.failures.push('unexpected error');
+    if (result.verdict === 'NOT_REACHED') result.verdict = 'INCONCLUSIVE_SCRIPT_ERROR';
+  }
+
+  for (const s of steps) {
+    if (!s.pass && !result.failures.includes(s.name)) result.failures.push(s.name);
+  }
+  result.pass = result.failures.length === 0;
+  return result
+}

--- a/samples/LmStreaming.Sample/playwright-scripts/transcript-mirror.mjs
+++ b/samples/LmStreaming.Sample/playwright-scripts/transcript-mirror.mjs
@@ -111,33 +111,72 @@ async (page) => {
   let BASE = null;
 
   // Same-origin, in-page fetch — the interactive path [InboundS2SAuth] deliberately lets through.
-  const api = (method, path, body) =>
+  // EVERY call is time-boxed. `page.evaluate` does not impose one, and a hung request inside the page
+  // blocks the whole script with no diagnostic: the run dies on the harness's own ceiling, after the
+  // steps array has stopped growing, so the report names a step that had already passed. A timeout
+  // surfaced as `{ok:false, status:0, timedOut:true}` flows through the same failure paths as any
+  // other bad response — and since `waitRunIdle` now demands an OK response, a timed-out poll retries
+  // instead of being mistaken for an idle run.
+  const API_TIMEOUT_MS = 20000;
+  const api = (method, path, body, timeoutMs) =>
     page.evaluate(
-      async ({ method, path, body }) => {
+      async ({ method, path, body, timeoutMs }) => {
         const init = { method, headers: { 'content-type': 'application/json' } };
         if (body !== undefined) init.body = JSON.stringify(body);
-        const res = await fetch(`${location.origin}${path}`, init);
-        const text = await res.text();
-        let json = null;
+        const ctrl = new AbortController();
+        const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+        init.signal = ctrl.signal;
         try {
-          json = text ? JSON.parse(text) : null;
-        } catch {
-          /* non-JSON body — the raw text is kept for the failure detail */
+          const res = await fetch(`${location.origin}${path}`, init);
+          const text = await res.text();
+          let json = null;
+          try {
+            json = text ? JSON.parse(text) : null;
+          } catch {
+            /* non-JSON body — the raw text is kept for the failure detail */
+          }
+          return { status: res.status, ok: res.ok, json, text: text.slice(0, 600) };
+        } catch (e) {
+          const aborted = ctrl.signal.aborted;
+          return {
+            status: 0,
+            ok: false,
+            json: null,
+            timedOut: aborted,
+            text: aborted ? `request aborted after ${timeoutMs}ms` : `fetch failed: ${String(e && e.message ? e.message : e)}`,
+          };
+        } finally {
+          clearTimeout(timer);
         }
-        return { status: res.status, ok: res.ok, json, text: text.slice(0, 600) };
       },
-      { method, path, body }
+      { method, path, body, timeoutMs: timeoutMs ?? API_TIMEOUT_MS }
     );
 
   // Raw workspace bytes (transcripts are JSONL; `preview` refuses dot-directories by design).
+  // Longer ceiling than `api`: this reads a whole transcript, not a small JSON envelope.
+  const DOWNLOAD_TIMEOUT_MS = 60000;
   const downloadWorkspaceFile = (threadId, wsPath) =>
     page.evaluate(
-      async ({ threadId, wsPath }) => {
+      async ({ threadId, wsPath, timeoutMs }) => {
         const url = `${location.origin}/api/conversations/${encodeURIComponent(threadId)}/files/download?path=${encodeURIComponent(wsPath)}`;
-        const res = await fetch(url);
-        return { status: res.status, ok: res.ok, text: res.ok ? await res.text() : null };
+        const ctrl = new AbortController();
+        const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+        try {
+          const res = await fetch(url, { signal: ctrl.signal });
+          return { status: res.status, ok: res.ok, text: res.ok ? await res.text() : null };
+        } catch (e) {
+          return {
+            status: 0,
+            ok: false,
+            text: null,
+            timedOut: ctrl.signal.aborted,
+            error: String(e && e.message ? e.message : e),
+          };
+        } finally {
+          clearTimeout(timer);
+        }
       },
-      { threadId, wsPath }
+      { threadId, wsPath, timeoutMs: DOWNLOAD_TIMEOUT_MS }
     );
 
   // Classifies a listing into the four states that mean different things here. `no_session_yet` is
@@ -169,10 +208,24 @@ async (page) => {
   // a 409 `mode_switch_while_streaming` — observed as AgentIsRunning=True, RunTaskCompleted=False,
   // IsStale=False, i.e. a genuinely live run, not a stale-state bug. Gate on the same signal the
   // guard reads rather than on a proxy for it.
+  //
+  // A FAILED request is NOT an idle run. `!(rs.json && rs.json.isInProgress)` is true for a 500, a
+  // dropped connection, and — most likely of all — a 404 that falls through to the SPA fallback and
+  // returns index.html, so `json` parses to null. Any of those would silently skip this gate and hand
+  // the 409 back at the switch: the exact failure the gate exists to prevent, wearing a green tick.
+  // Require an OK response that EXPLICITLY says `isInProgress === false`; anything else keeps polling
+  // and, if it never resolves, says which of the two it was.
   const waitRunIdle = (threadId, timeoutMs) =>
     pollUntil(async () => {
       const rs = await api('GET', `/api/conversations/${encodeURIComponent(threadId)}/run-state`);
-      return { done: !(rs.json && rs.json.isInProgress), runState: rs.json };
+      const readable = !!(rs.ok && rs.json && typeof rs.json.isInProgress === 'boolean');
+      return {
+        done: readable && rs.json.isInProgress === false,
+        readable,
+        status: rs.status,
+        body: readable ? undefined : rs.text,
+        runState: rs.json,
+      };
     }, timeoutMs);
 
   const result = {
@@ -229,9 +282,14 @@ async (page) => {
       availableIds,
       hint: cliOk ? undefined : 'codex-mock also requires MockProviderHostLifetime.IsRunning',
     });
-    if (!boundOk) {
+    // BOTH prerequisites gate here, before anything expensive. `cliOk` used to be checked only at the
+    // provider switch — after turn 1 had already provisioned a workspace, run a full agent turn and
+    // spawned two sub-agents, all of which is then discarded for an INCONCLUSIVE verdict. A missing
+    // prerequisite is knowable in the first second; paying minutes to rediscover it is pure waste,
+    // and it leaves a half-finished conversation behind in the workspace every time.
+    if (!boundOk || !cliOk) {
       result.failures.push('required providers available');
-      result.verdict = 'INCONCLUSIVE_NO_PROVIDER';
+      result.verdict = !boundOk ? 'INCONCLUSIVE_NO_PROVIDER' : 'INCONCLUSIVE_NO_CLI_PROVIDER';
       return result;
     }
 
@@ -416,11 +474,16 @@ async (page) => {
     }
 
     // ---- 7. The two named sub-agents exist (⇒ an `_agents/` child file is expected) ---------
+    const EXPECTED_AGENTS = ['mirror-alpha', 'mirror-beta'];
+    const nameOf = (r) => String((r && (r.name ?? r.agentName)) ?? '');
     let rows = [];
     for (let i = 0; i < 20; i++) {
       const sub = await api('GET', `/api/conversations/${threadId}/subagents`);
       rows = Array.isArray(sub.json) ? sub.json : [];
-      if (rows.length >= 2) break;
+      // Wait for the two we ASKED for, not for any two. Breaking on `rows.length >= 2` settles as
+      // soon as a pair exists, which on a partial spawn can be the wrong pair — and then the name
+      // assertion below fails against a listing that was never given time to complete.
+      if (EXPECTED_AGENTS.every((n) => rows.some((r) => nameOf(r) === n))) break;
       await page.waitForTimeout(1500);
     }
     result.subAgents = rows.map((r) => ({
@@ -429,10 +492,18 @@ async (page) => {
       threadId: r.threadId ?? null,
       status: r.status ?? null,
     }));
-    record('two named background sub-agents spawned', rows.length >= 2, {
+    // Identify them BY NAME, not by count. `rows.length >= 2` passes if the mock spawned two agents
+    // called something else entirely, or spawned one twice — and the whole point of this fixture is
+    // that the two NAMED agents are what the `_agents/` leaves are derived from. A count is satisfied
+    // by the wrong pair.
+    const spawnedNames = result.subAgents.map((a) => String(a.name ?? ''));
+    const missingAgents = EXPECTED_AGENTS.filter((n) => !spawnedNames.includes(n));
+    record('two named background sub-agents spawned', missingAgents.length === 0, {
       count: rows.length,
       subAgents: result.subAgents,
-      expectedNames: ['mirror-alpha', 'mirror-beta'],
+      expectedNames: EXPECTED_AGENTS,
+      spawnedNames,
+      missing: missingAgents,
     });
 
     // ---- 7b. THE POSITIVE ASSERTION: real bytes, read back through the gateway --------------
@@ -445,16 +516,31 @@ async (page) => {
 
     if (!appeared || !appeared.file) {
       const listable = appeared && appeared.listing.state !== 'error';
+      // The listing is CAPPED (FileBrowserController.cs:78 — `entries.Take(MaxListingRows)`, 500) and
+      // the overflow comes back as a count, not an error. `.conversations/` accumulates one file per
+      // conversation forever, so a long-lived workspace eventually pushes this run's file outside the
+      // window — and "not in the first 500 entries" would then read as FAILED_NO_TRANSCRIPT_AT_ALL
+      // against a mirror that wrote perfectly. moreCount is the only signal that the window was
+      // partial; without checking it, this step gets less trustworthy the longer the workspace lives.
+      const truncated = !!(appeared && appeared.listing.moreCount > 0);
       record(`transcript file created under ${TRANSCRIPT_DIR}`, false, {
         state: appeared && appeared.listing.state,
         entries: appeared ? appeared.listing.entries.map((e) => e.name) : [],
+        moreCount: appeared && appeared.listing.moreCount,
+        listingTruncated: truncated,
         expectedPrefix: EXPECTED_PREFIX,
-        note: listable
-          ? `directory readable but nothing matching ${EXPECTED_PREFIX} — the mirror wrote nothing on the ATTACHING provider`
-          : 'directory not readable through this API — fall back to disk-checks.ps1',
+        note: !listable
+          ? 'directory not readable through this API — fall back to disk-checks.ps1'
+          : truncated
+            ? `listing was CAPPED at ${appeared.listing.entries.length} of ${appeared.listing.entries.length + appeared.listing.moreCount} entries — this run's file may simply be past the cap. Prune ${TRANSCRIPT_DIR}/ or check disk-checks.ps1; this is NOT evidence of a mirror failure`
+            : `directory readable in full but nothing matching ${EXPECTED_PREFIX} — the mirror wrote nothing on the ATTACHING provider`,
       });
       result.failures.push(`transcript file created under ${TRANSCRIPT_DIR}`);
-      result.verdict = listable ? 'FAILED_NO_TRANSCRIPT_AT_ALL' : 'INCONCLUSIVE_NOT_LISTABLE';
+      result.verdict = !listable
+        ? 'INCONCLUSIVE_NOT_LISTABLE'
+        : truncated
+          ? 'INCONCLUSIVE_LISTING_TRUNCATED'
+          : 'FAILED_NO_TRANSCRIPT_AT_ALL';
       return result;
     }
 
@@ -494,52 +580,73 @@ async (page) => {
     // reads as "the second sub-agent was never mirrored". Observed exactly once: alpha present /
     // beta absent at list time, beta on disk (2431 bytes) moments later. This directory is
     // per-conversation, so a bare `.jsonl` filter is safe here (unlike `.conversations/` itself).
+    // Match each child by the leaf its NAME derives (`{slug(agentName)}-{shortAgentId}.jsonl`), not by
+    // counting `.jsonl`s. Two files is not evidence of the two agents: one agent mirrored twice, or an
+    // unrelated pair, satisfies a count identically. The filename contract is the thing under test.
+    const leafFor = (agentName) => (f) => String(f.name).startsWith(`${agentName}-`);
     const agentsPoll = await pollUntil(async () => {
       const listing = await listWorkspaceDir(threadId, agentsDir);
       const files = listing.entries.filter((e) => String(e.name).endsWith('.jsonl'));
-      return { done: files.length >= 2, listing, files };
+      return { done: EXPECTED_AGENTS.every((n) => files.some(leafFor(n))), listing, files };
     }, APPEAR_TIMEOUT_MS);
     const agentsListing = agentsPoll.listing;
     const agentFiles = agentsPoll.files;
     const agentTexts = {};
+    const agentDownloadFailures = [];
     let agentsBlob = '';
     for (const f of agentFiles) {
       const dl = await downloadWorkspaceFile(threadId, `${agentsDir}/${f.name}`);
       const text = (dl.ok && dl.text) || '';
       agentTexts[f.name] = text.length;
+      // A failed download yields '' and would quietly drag the marker checks below to false, blaming
+      // the mirror for a reader problem. Name it instead.
+      if (!dl.ok) agentDownloadFailures.push({ file: f.name, status: dl.status });
       agentsBlob += `${text}\n`;
     }
-    record('sub-agent transcripts mirrored', agentFiles.length >= 2, {
-      dir: agentsDir,
-      state: agentsListing.state,
-      files: agentFiles.map((f) => f.name),
-      byteCounts: agentTexts,
-      alphaPresent: agentsBlob.includes(ALPHA_TEXT),
-      betaPresent: agentsBlob.includes(BETA_TEXT),
-      expectedLeafShape: 'slug(agentName)-shortId(agentId).jsonl ⇒ mirror-alpha-… / mirror-beta-…',
-    });
+    const missingLeaves = EXPECTED_AGENTS.filter((n) => !agentFiles.some(leafFor(n)));
+    const alphaPresent = agentsBlob.includes(ALPHA_TEXT);
+    const betaPresent = agentsBlob.includes(BETA_TEXT);
+    // Assert the content markers too. They were already being COLLECTED here and reported in the
+    // detail while the pass/fail rode on the file count alone — so a pair of empty or wrong-agent
+    // files scored green with the disproof sitting in its own evidence block.
+    record(
+      'sub-agent transcripts mirrored',
+      missingLeaves.length === 0 && alphaPresent && betaPresent && agentDownloadFailures.length === 0,
+      {
+        dir: agentsDir,
+        state: agentsListing.state,
+        files: agentFiles.map((f) => f.name),
+        byteCounts: agentTexts,
+        missingLeaves,
+        alphaPresent,
+        betaPresent,
+        downloadFailures: agentDownloadFailures,
+        expectedLeafShape: 'slug(agentName)-shortId(agentId).jsonl ⇒ mirror-alpha-… / mirror-beta-…',
+      }
+    );
 
     // ---- 8. THE P1 SETUP: leave workspace mode, switch to the CLI-family provider -----------
     // Order matters: workspace-agent mode REJECTS codex-mock (Program.cs:822-856), so the mode must
     // drop first. The established sandbox binding survives both switches — PublishBindingIfStaged
     // only ever publishes, and ClearEstablishedBinding fires only on agent REMOVAL — so the
     // codex-mock agent's flush WOULD write, iff P1 attached the mirror to it.
-    if (!cliOk) {
-      record(`SKIPPED: switch to ${CLI_PROVIDER}`, false, {
-        why: `${CLI_PROVIDER} is not available on this host — the P1 case cannot be driven`,
-        availableIds,
-      });
-      result.failures.push(`SKIPPED: switch to ${CLI_PROVIDER}`);
-      result.verdict = 'INCONCLUSIVE_NO_CLI_PROVIDER';
-      return result;
-    }
+    // (`cliOk` was already required at step `required providers available` — reaching here without it
+    // is impossible, so there is no late SKIP branch to fall into after turn 1 has been paid for.)
     const runIdle = await waitRunIdle(threadId, APPEAR_TIMEOUT_MS);
     if (!record('run drained server-side before switching', !!(runIdle && runIdle.done), {
       runState: runIdle && runIdle.runState,
+      runStateReadable: !!(runIdle && runIdle.readable),
+      status: runIdle && runIdle.status,
+      body: runIdle && runIdle.body,
       why: 'the switch guards read agentPool.GetRunStateInfo; UI-idle is not run-idle when the turn spawned background sub-agents',
     })) {
       result.failures.push('run drained server-side before switching');
-      result.verdict = 'INCONCLUSIVE_RUN_NEVER_DRAINED';
+      // Two different problems wearing one symptom: the run genuinely never finished, versus the
+      // endpoint never answered. Naming the second one is the difference between "investigate the
+      // app" and "investigate the route".
+      result.verdict = runIdle && runIdle.readable
+        ? 'INCONCLUSIVE_RUN_NEVER_DRAINED'
+        : 'INCONCLUSIVE_RUN_STATE_UNREADABLE';
       return result;
     }
     const modeSwitch = await api('POST', `/api/conversations/${threadId}/mode`, { modeId: plainMode });
@@ -585,7 +692,18 @@ async (page) => {
     await waitIdle();
     // Drain server-side too: the mirror flushes at a TURN BOUNDARY, so reading the transcript while
     // the run is still in progress can miss MARKER2 for reasons that have nothing to do with P1.
-    await waitRunIdle(threadId, APPEAR_TIMEOUT_MS);
+    // RECORD the outcome — discarding it means a turn-2 run that never drained turns into a MARKER2
+    // read taken mid-flight, and the resulting `P1_REGRESSED` blames the mirror for a timing problem
+    // in this script. Not fatal on its own (the byte poll below still has APPEAR_TIMEOUT_MS to catch
+    // up) but it must appear in the report, because it changes how a subsequent failure reads.
+    const runIdle2 = await waitRunIdle(threadId, APPEAR_TIMEOUT_MS);
+    record('turn 2 run drained server-side before reading bytes', !!(runIdle2 && runIdle2.done), {
+      runState: runIdle2 && runIdle2.runState,
+      runStateReadable: !!(runIdle2 && runIdle2.readable),
+      status: runIdle2 && runIdle2.status,
+      body: runIdle2 && runIdle2.body,
+      why: 'if this failed, a MARKER2 miss below is inconclusive rather than a P1 regression',
+    });
     const afterUser = await tid('user-message-group').count();
     const afterAssistant = await tid('assistant-message-group').count();
     const err2 = await errorBanner();
@@ -609,14 +727,24 @@ async (page) => {
     const finalText = (turn2Bytes && turn2Bytes.dl.text) || '';
     const hasM1 = finalText.includes(MARKER1);
     const hasM2 = finalText.includes(MARKER2);
-    const p1 = record('P1 (458dbca1): the CLI-provider turn was mirrored too (MARKER2)', hasM2, {
+    const drained2 = !!(runIdle2 && runIdle2.done);
+    // BOTH markers, not just MARKER2. MARKER1 was already PROVEN present in this same file at step
+    // `turn 1 bytes are in the transcript` — and the transcript is append-only — so if it is missing
+    // now, previously-verified content was DESTROYED. That is strictly worse than the P1 hole this
+    // step is named for, and asserting `hasM2` alone reports it as a clean pass.
+    const p1 = record('P1 (458dbca1): the CLI-provider turn joined turn 1 in the same file', hasM1 && hasM2, {
       marker1Present: hasM1,
       marker2Present: hasM2,
       bytes: finalText.length,
       bytesAfterTurn1: turn1Text.length,
-      signature: hasM1 && !hasM2 ? 'MARKER1 without MARKER2 = the exact P1 bug: a silent hole mid-transcript' : undefined,
+      turn2Drained: drained2,
+      signature: hasM1 && !hasM2
+        ? 'MARKER1 without MARKER2 = the exact P1 bug: a silent hole mid-transcript'
+        : hasM2 && !hasM1
+          ? 'MARKER2 WITHOUT MARKER1 = turn 1 lines vanished from an append-only file after being verified present — a LOSS bug, not P1'
+          : undefined,
     });
-    if (!p1) result.failures.push('P1 (458dbca1): the CLI-provider turn was mirrored too (MARKER2)');
+    if (!p1) result.failures.push('P1 (458dbca1): the CLI-provider turn joined turn 1 in the same file');
 
     // ---- 11. P2 (57bf4200) best-effort: the FIFO drain neither duplicated nor re-ordered ----
     const lines = finalText.split('\n').filter((l) => l.trim());
@@ -655,17 +783,46 @@ async (page) => {
       const t = (r && r.message_type) || '(none)';
       byType[t] = (byType[t] || 0) + 1;
     }
-    const reasoningRows = Object.entries(byType)
-      .filter(([t]) => t.startsWith('Reasoning'))
-      .reduce((n, [, c]) => n + c, 0);
-    record('RAW fidelity: reasoning rows survived the mirror', reasoningRows > 0, {
+    const reasoningLines = parsed.filter((r) => r && String(r.message_type || '').startsWith('Reasoning'));
+    // …and then check the PAYLOAD, because the discriminator alone only proves a reasoning-shaped row
+    // EXISTS. A mirror that wrote the envelope and dropped its content — the precise failure "RAW
+    // fidelity" names — keeps `message_type` intact and scores green on a count.
+    // `reasoning:{length:30}` makes the mock emit the first 30 LOREM words
+    // (AnthropicSseStreamHttpContent.cs:630), so "lorem ipsum" is text that exists only if the actual
+    // thinking content made it through. It cannot leak in from the prompt the way the word
+    // "reasoning" does — the prompt carries the request, never the generated lorem.
+    const REASONING_SENTINEL = 'lorem ipsum';
+    const withPayload = reasoningLines.filter((r) =>
+      String(r.message_json || '').toLowerCase().includes(REASONING_SENTINEL)
+    );
+    const reasoningRows = reasoningLines.length;
+    const rawFidelity = reasoningRows > 0 && withPayload.length > 0;
+    record('RAW fidelity: reasoning rows survived the mirror WITH their content', rawFidelity, {
       reasoningRows,
+      reasoningRowsCarryingContent: withPayload.length,
+      sentinel: REASONING_SENTINEL,
+      payloadLengths: reasoningLines.map((r) => String(r.message_json || '').length),
       messageTypes: byType,
-      why: 'reasoning is part of the locked full-fidelity contract; counted by message_type because the prompt echoes the word "reasoning" into its own message_json',
+      why: 'counted by message_type because the prompt echoes the word "reasoning" into its own message_json; content proven by the generated lorem text, which the prompt never contains',
+      diagnosis:
+        reasoningRows === 0
+          ? 'no reasoning row at all — the mirror dropped thinking entirely'
+          : withPayload.length === 0
+            ? 'reasoning ENVELOPES present but empty of generated content — the exact failure a discriminator-only check misses'
+            : undefined,
     });
-    if (reasoningRows === 0) result.failures.push('RAW fidelity: reasoning rows survived the mirror');
+    if (!rawFidelity) result.failures.push('RAW fidelity: reasoning rows survived the mirror WITH their content');
 
-    result.verdict = hasM2 ? 'P1_HOLDS' : hasM1 ? 'P1_REGRESSED' : 'FAILED_NOTHING_MIRRORED';
+    // A MARKER2 miss only means "P1 regressed" if the run actually finished. If turn 2 never drained,
+    // the mirror was never given its turn boundary and the miss says nothing about the attach path.
+    result.verdict =
+      hasM1 && hasM2
+        ? 'P1_HOLDS'
+        : hasM2 && !hasM1
+          ? 'FAILED_TURN1_LINES_DISAPPEARED'
+          : hasM1
+            ? (drained2 ? 'P1_REGRESSED' : 'INCONCLUSIVE_TURN2_NEVER_DRAINED')
+            : 'FAILED_NOTHING_MIRRORED';
 
     // ---- 13. Optional second opinion (LOCAL gateway only) ----------------------------------
     result.diskChecks = {

--- a/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ConversationTranscriptWriterTests.cs
@@ -36,16 +36,32 @@ public sealed class ConversationTranscriptWriterTests
     private const string GitignorePath = ".conversations/.gitignore";
 
     /// <summary>
-    /// The <c>guard</c> preamble every script opens with, duplicated here ON PURPOSE alongside the scripts
-    /// that use it. Its text is a contract: <c>[ -L ]</c> is the only test that does not follow a link, the
-    /// ANCESTOR walk is what catches a redirected <c>.conversations</c> whose leaf does not exist yet, and
-    /// <c>return</c> rather than <c>exit</c> is what lets the caller attach exit <c>44</c> to the failure —
-    /// an <c>exit</c> inside a function would end the script with the function's own status. The trailing
-    /// <c>return 0</c> is equally load-bearing: without it a safe path reports the failed <c>[ -L ]</c>.
+    /// The preamble every script opens with, duplicated here ON PURPOSE alongside the scripts that use it.
+    /// Its text is a contract. For <c>guard</c>: <c>[ -L ]</c> is the only test that does not follow a link,
+    /// the ANCESTOR walk is what catches a redirected <c>.conversations</c> whose leaf does not exist yet,
+    /// and <c>return</c> rather than <c>exit</c> is what lets the caller attach exit <c>44</c> to the
+    /// failure — an <c>exit</c> inside a function would end the script with the function's own status. The
+    /// trailing <c>return 0</c> is equally load-bearing: without it a safe path reports the failed
+    /// <c>[ -L ]</c>.
     /// </summary>
+    /// <remarks>
+    /// <c>solo</c> is the half <c>guard</c> structurally cannot do: a hard link is not a KIND of file, so
+    /// <c>[ -L ]</c> is blind to it, and <c>ln tracked-file .conversations/&lt;leaf&gt;.jsonl</c> gets the
+    /// unredacted transcript appended into a tracked file at exit 0. Three pieces of this text are each
+    /// load-bearing and each easy to "simplify" away. <c>[ -e "$1" ] || return 0</c> — these paths are
+    /// routinely written before they exist, so a missing path MUST pass or the feature never writes
+    /// anything. <c>ls -dn</c> rather than <c>stat</c> or <c>find</c> — <c>stat</c>'s format string is
+    /// GNU/BSD-specific (<c>%h</c> vs <c>%l</c>), and <c>find</c>, which looks like the portable answer,
+    /// resolves on a Windows host to <c>system32\find.exe</c> and silently declines every append; the
+    /// second field of a POSIX <c>-l</c> listing is the link count by definition. And the failure
+    /// direction: a failed <c>ls</c> returns 1 and any non-listing output leaves field two something other
+    /// than <c>1</c>, so every way this can go wrong is a refusal.
+    /// </remarks>
     private const string ExpectedGuardPreamble =
         "guard() { p=\"$1\"; while [ -n \"$p\" ] && [ \"$p\" != \".\" ] && [ \"$p\" != \"/\" ]; do "
-        + "if [ -L \"$p\" ]; then return 1; fi; p=$(dirname \"$p\"); done; return 0; }\n";
+        + "if [ -L \"$p\" ]; then return 1; fi; p=$(dirname \"$p\"); done; return 0; }\n"
+        + "solo() { [ -e \"$1\" ] || return 0; [ -f \"$1\" ] || return 1; "
+        + "sl=$(ls -dn \"$1\") || return 1; set -- $sl; [ \"$2\" = \"1\" ]; }\n";
 
     /// <summary>
     /// The splice script, duplicated here ON PURPOSE. It is the feature's only shell call site that writes,
@@ -56,11 +72,19 @@ public sealed class ConversationTranscriptWriterTests
     /// staged file because <c>cat</c> would read through a link into some other file. A test that read the
     /// constant back out of the production type could not notice any of them being edited away.
     /// </summary>
+    /// <remarks>
+    /// The <c>solo</c> lines cover the two FILE operands and pointedly NOT <c>$1</c>: a directory's link
+    /// count is at least two by construction, so a <c>solo "$1"</c> that looks like a consistency
+    /// improvement would refuse every append that has ever worked. That asymmetry is the reason this
+    /// constant spells the lines out one by one rather than looping.
+    /// </remarks>
     private const string ExpectedSpliceScript =
         ExpectedGuardPreamble
         + "guard \"$1\" || exit 44\n"
         + "guard \"$2\" || exit 44\n"
         + "guard \"$3\" || exit 44\n"
+        + "solo \"$2\" || exit 46\n"
+        + "solo \"$3\" || exit 46\n"
         + "mkdir -p \"$1\" || exit 1\n"
         + "if [ -s \"$3\" ] && [ -n \"$(tail -c1 \"$3\")\" ]; then printf '\\n' >> \"$3\" || exit 1; fi\n"
         + "cat \"$2\" >> \"$3\" && rm -f \"$2\"\n";
@@ -76,9 +100,16 @@ public sealed class ConversationTranscriptWriterTests
     /// without which a single multi-megabyte row makes the probe itself unanswerable. Exit <c>43</c> carries
     /// the one fact truncation destroys — whether the file ends mid-record.
     /// </summary>
+    /// <remarks>
+    /// The <c>solo</c> line here is about COST, not confidentiality — this script only reads. The watermark
+    /// is stored only after a SUCCESSFUL append, so an aliased destination keeps the probe cold on every
+    /// flush, and each doomed attempt PUTs the whole unredacted history into <c>.conversations/.tmp/</c>
+    /// before the splice declines it. Deleting this one line trades a shell call for that.
+    /// </remarks>
     private const string ExpectedProbeScript =
         ExpectedGuardPreamble
         + "guard \"$1\" || exit 44\n"
+        + "solo \"$1\" || exit 46\n"
         + "[ -e \"$1\" ] || exit 42\n"
         + "tail -n \"$2\" -- \"$1\" | cut -c \"1-$3\" || exit 1\n"
         + "end=$(tail -c1 -- \"$1\") || exit 1\n"
@@ -89,7 +120,13 @@ public sealed class ConversationTranscriptWriterTests
     /// payload and the containment file, both PUT directly by the gateway. Duplicated for the same reason:
     /// nothing else would notice if these writes stopped being checked.
     /// </summary>
-    private const string ExpectedGuardScript = ExpectedGuardPreamble + "guard \"$1\" || exit 44\n";
+    /// <remarks>
+    /// This is the ONLY place the alias check can defend those two writes: a PUT carries no shell, so an
+    /// in-script check would run after the bytes were already through. The containment file is the sharper
+    /// of the two — it is PUT whole, so an aliased path does not append to a tracked file, it REPLACES one.
+    /// </remarks>
+    private const string ExpectedGuardScript =
+        ExpectedGuardPreamble + "guard \"$1\" || exit 44\n" + "solo \"$1\" || exit 46\n";
 
     /// <summary>
     /// The rename script, duplicated for the same reason and carrying the same weight. Its text is a
@@ -103,6 +140,12 @@ public sealed class ConversationTranscriptWriterTests
     /// also fails on a real non-empty directory, which is exactly the <c>_agents</c> case, and a bare
     /// fallback would then nest.
     /// </summary>
+    /// <remarks>
+    /// The ABSENCE of a <c>solo</c> line is part of the contract here, not an oversight in it.
+    /// <c>rename(2)</c> unlinks the destination NAME and never opens the file behind it, so an aliased
+    /// destination loses one name and the shared file is not written to. Adding <c>solo "$2"</c> for
+    /// symmetry with the splice would buy nothing and would give every retitle a new way to fail.
+    /// </remarks>
     private const string ExpectedMoveScript =
         ExpectedGuardPreamble
         + "target() { guard \"$1\" || exit 44; [ ! -d \"$1\" ] || exit 45; }\n"

--- a/tests/LmStreaming.Sample.Tests/Services/TranscriptFlushSchedulerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/TranscriptFlushSchedulerTests.cs
@@ -413,6 +413,79 @@ public sealed class TranscriptFlushSchedulerTests
         await recorder.WaitForFlushAsync("healthy");
     }
 
+    /// <summary>
+    /// PR #252 review round 8 (P1): a key that re-schedules ITSELF must not starve a key that has been
+    /// waiting longer. The mirror re-schedules from inside the flush on both <c>Progressing</c> (a capped
+    /// descendant sweep continuing) and <c>Deferred</c> (a failed attempt retrying), so this is the
+    /// scheduler's normal traffic, not an exotic case.
+    /// <para>
+    /// <b>Why the warm-up key is load-bearing.</b> The claim under test is about the order two keys that are
+    /// pending SIMULTANEOUSLY are drained in, so both have to be in the pending set before the loop picks
+    /// either. Flushing <c>warm-up</c> first parks the drain inside a callback that will not return until
+    /// this test says so, which is the only point at which <c>Schedule</c> is provably not racing the loop.
+    /// It also empties the set, so <c>a</c> and <c>b</c> land in slot order.
+    /// </para>
+    /// <para>
+    /// <b>What this catches.</b> Draining with <c>_pending.First()</c> takes the lowest-numbered
+    /// <see cref="HashSet{T}"/> slot. Removing <c>a</c> to flush it frees slot 0 onto the set's free list,
+    /// and <c>a</c>'s own re-schedule takes that slot straight back, so the next pick is <c>a</c> again
+    /// while <c>b</c> sits in slot 1 untouched — every round, deterministically. Against that
+    /// implementation the observed order is <c>a a a a a a b</c> and the assertion below fails on the very
+    /// first comparison; only a FIFO drain order produces <c>a b a …</c>.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task Drain_FlushesAKeyThatHasBeenWaitingBeforeReflushingOneThatReschedulesItself()
+    {
+        const int reschedules = 5;
+        var recorder = new FlushRecorder();
+        var warmUpEntered = Signal();
+        var releaseWarmUp = Signal();
+        var remainingReschedules = reschedules;
+        TranscriptFlushScheduler? scheduler = null;
+
+        using var owned = scheduler = new TranscriptFlushScheduler(
+            async (key, _) =>
+            {
+                if (key == "warm-up")
+                {
+                    warmUpEntered.SetResult();
+                    await releaseWarmUp.Task;
+                    return;
+                }
+
+                recorder.Record(key);
+
+                // 'a' asks for itself again, exactly as the mirror does for a Progressing/Deferred flush.
+                // Bounded so the drain terminates whichever order it picks — an unbounded chain would hang
+                // the fixed implementation instead of failing it. Flushes are serialised on the one drain
+                // loop, so the plain decrement needs no interlock.
+                if (key == "a" && remainingReschedules-- > 0)
+                {
+                    scheduler!.Schedule("a");
+                }
+            }
+        );
+
+        owned.Schedule("warm-up");
+        await warmUpEntered.Task.WaitAsync(FailureTimeout);
+
+        // The drain is parked inside the warm-up flush, so both of these are pending before it picks again.
+        owned.Schedule("a");
+        owned.Schedule("b");
+        releaseWarmUp.SetResult();
+
+        await recorder.WaitForFlushAsync("b");
+
+        var order = recorder.Flushed.ToList();
+        order.Should().HaveCountGreaterThanOrEqualTo(2);
+        order[0].Should().Be("a", "'a' was scheduled first, so it is drained first");
+        order[1].Should().Be(
+            "b",
+            "'b' had been waiting since before 'a' was flushed, so 'a' re-scheduling itself must put it "
+                + "BEHIND 'b', not back at the front");
+    }
+
     [Fact]
     public void Constructor_RejectsANullFlushCallback()
     {

--- a/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptMirrorAttachCompositionTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptMirrorAttachCompositionTests.cs
@@ -1,0 +1,155 @@
+using LmStreaming.Sample.Services;
+using LmStreaming.Sample.Tests.TestDoubles;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+/// <summary>
+/// PR #252 review round 8 (P1): every agent <c>Program.cs</c>'s pool factory builds must be registered
+/// with the <see cref="WorkspaceTranscriptMirror"/>, whichever provider branch built it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The factory has seven construction branches and each ends in its own <c>return</c>. The mirror attach
+/// used to live in only one of them — the branch that builds the API-backed providers — so the six
+/// CLI-backed branches (<c>codex</c>, <c>claude</c>, <c>copilot</c> and their three <c>*-mock</c>
+/// siblings) returned before ever reaching it. Those loops all support <c>SubscribeAsync</c>, so nothing
+/// about them prevents mirroring; they were simply never registered, and a workspace conversation on any
+/// of them produced neither a root transcript nor descendant files.
+/// </para>
+/// <para>
+/// <b>Why this has to be a composition-root test.</b> The bug is not in the mirror and not in any agent
+/// loop — both halves are individually correct and individually covered. It is in the wiring between
+/// them, and it is an <i>omission</i>: nothing throws, nothing logs, and the only symptom is a file that
+/// never appears. A test built against <see cref="WorkspaceTranscriptMirror"/> directly has to call
+/// <c>Attach</c> to do anything at all, which is precisely the call under dispute. So the host has to be
+/// booted for real and the agent has to be requested through the real pool.
+/// </para>
+/// <para>
+/// <b>Why the CLI mock providers.</b> They are the cheapest branches to reach that were actually broken:
+/// availability is gated only on a CLI being on PATH (faked here) plus the in-process mock provider host,
+/// which the host itself starts. Their loops are constructed, not started — <c>RunLoopAsync</c> blocks on
+/// its input channel before touching a CLI — so no child process is spawned. <c>codex</c>/<c>codex-mock</c>
+/// are deliberately excluded because their branch calls <c>EnsureStartedAsync</c> on the codex MCP server,
+/// which is real process startup and does not belong in a wiring test.
+/// </para>
+/// </remarks>
+public sealed class WorkspaceTranscriptMirrorAttachCompositionTests
+{
+    private static readonly AgentProfile Mode = SystemChatModes.GetById(SystemChatModes.DefaultModeId)!;
+
+    /// <summary>
+    /// Boots the real <c>Program</c> host with both CLI gates forced open, so the <c>claude-mock</c> and
+    /// <c>copilot-mock</c> providers are selectable without either CLI being installed on the machine
+    /// running the suite.
+    /// </summary>
+    private sealed class MirrorAttachWebAppFactory : WebApplicationFactory<Program>
+    {
+        private readonly string _conversationsPath;
+
+        public MirrorAttachWebAppFactory(string conversationsPath)
+        {
+            _conversationsPath = conversationsPath;
+
+            // 'test' mode keeps startup provider discovery side-effect-free (no real API key or network
+            // needed to boot) — same rationale as the other in-process host tests here.
+            Environment.SetEnvironmentVariable("LM_PROVIDER_MODE", "test");
+
+            // ProviderRegistry prefers an explicit CLI path over the PATH probe. Cleared so the faked
+            // probe below is what decides availability, rather than whatever the developer's machine has.
+            Environment.SetEnvironmentVariable("CLAUDE_CLI_PATH", null);
+            Environment.SetEnvironmentVariable("COPILOT_CLI_PATH", null);
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            // Avoids the Vite dev-server auto-spawn (matches every other in-process host test here).
+            builder.UseEnvironment("Production");
+
+            builder.ConfigureTestServices(services =>
+            {
+                // Forces the claude/copilot CLI availability gates open. ProviderRegistry is registered
+                // with a factory that resolves IFileSystemProbe, so replacing the probe here is enough —
+                // the registry singleton has not been built yet.
+                services.RemoveAll<IFileSystemProbe>();
+                services.AddSingleton<IFileSystemProbe>(
+                    new FakeFileSystemProbe(executablesOnPath: ["claude", "copilot"]));
+
+                // Isolates conversation storage to this test's temp dir.
+                services.RemoveAll<IConversationStore>();
+                services.AddSingleton<IConversationStore>(new FileConversationStore(_conversationsPath));
+            });
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+            {
+                Environment.SetEnvironmentVariable("LM_PROVIDER_MODE", null);
+            }
+        }
+    }
+
+    /// <summary>
+    /// <c>claude-mock</c> and <c>copilot-mock</c> are the two CLI-backed branches reachable without
+    /// starting a real subprocess or MCP server. Against the pre-fix factory both fail here: the agent is
+    /// created successfully and <c>IsMirroring</c> returns false, because their branch returned before the
+    /// single <c>transcriptMirror.Attach(agent)</c> call.
+    /// </summary>
+    [Theory]
+    [InlineData("claude-mock")]
+    [InlineData("copilot-mock")]
+    public async Task Host_AttachesTheMirrorToAgentsBuiltByCliBackedProviderBranches(string providerId)
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(), "lmstreaming-mirror-attach-composition-test", Guid.NewGuid().ToString("N"));
+        _ = Directory.CreateDirectory(root);
+        try
+        {
+            await using var host = new MirrorAttachWebAppFactory(Path.Combine(root, "conversations"));
+
+            var registry = host.Services.GetRequiredService<ProviderRegistry>();
+            registry.IsAvailable(providerId).Should().BeTrue(
+                "the faked CLI probe and the host's own in-process mock provider host must make "
+                    + "{0} selectable, otherwise this test would silently stop covering that branch",
+                providerId);
+
+            var mirror = host.Services.GetRequiredService<WorkspaceTranscriptMirror>();
+            var pool = host.Services.GetRequiredService<MultiTurnAgentPool>();
+
+            var threadId = $"mirror-attach-{providerId}-{Guid.NewGuid():N}";
+            var agent = pool.GetOrCreateAgent(threadId, Mode, providerId, requestResponseDumpFileName: null);
+
+            agent.Should().NotBeNull("the provider branch under test must actually build an agent");
+            mirror.IsMirroring(threadId).Should().BeTrue(
+                "every agent the pool factory returns must be registered with the transcript mirror; "
+                    + "{0} builds and returns from its own branch, so an attach that lives inside one "
+                    + "other branch never runs for it and the conversation is mirrored nowhere",
+                providerId);
+        }
+        finally
+        {
+            TryDeleteDir(root);
+        }
+    }
+
+    private static void TryDeleteDir(string root)
+    {
+        try
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup; a leftover temp dir must not fail the test.
+        }
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptPathAliasTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/WorkspaceTranscriptPathAliasTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using AchieveAi.LmDotnetTools.Sandbox;
 using LmStreaming.Sample.Services;
@@ -8,10 +9,11 @@ namespace LmStreaming.Sample.Tests.Services;
 
 /// <summary>
 /// The transcript mirror against a workspace that is not cooperating: every path it is about to write
-/// through has been replaced with a SYMLINK first. Driven over a REAL filesystem and a REAL POSIX shell,
-/// because the whole defect is a property of the operating system rather than of any C# call — <c>&gt;&gt;</c>,
-/// <c>mkdir -p</c>, <c>[ -e ]</c>, <c>tail</c> and a gateway PUT all follow symlinks silently, and a fake
-/// that hands back a regular file where production meets a link cannot fail.
+/// through has been ALIASED first — replaced with a symlink, or given a second name with <c>ln</c>. Driven
+/// over a REAL filesystem and a REAL POSIX shell, because the whole defect is a property of the operating
+/// system rather than of any C# call — <c>&gt;&gt;</c>, <c>mkdir -p</c>, <c>[ -e ]</c>, <c>tail</c> and a
+/// gateway PUT all follow an alias silently, and a fake that hands back a plain unaliased file where
+/// production meets one cannot fail.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -22,16 +24,26 @@ namespace LmStreaming.Sample.Tests.Services;
 /// the transcript exists to keep it out of.
 /// </para>
 /// <para>
-/// Every case asserts the same two things: the transcript did NOT travel through the link, and the link
+/// The HARD-link cases are the same attack with none of the tells, and they are here because the first
+/// round of this work concluded they could not be covered at all. A hard link is not a distinguishable KIND
+/// of file: <c>[ -L ]</c> is false, <c>-f</c> is true, and the entry is in every respect an ordinary regular
+/// file, so the symlink guard passes it. What gives it away is its LINK COUNT, which the second field of a
+/// POSIX <c>ls -l</c> listing reports with no <c>stat</c> format string and no GNU extension. Each
+/// hard-link case here is RED against a build that has only the symlink guard.
+/// </para>
+/// <para>
+/// Every case asserts the same two things: the transcript did NOT travel through the alias, and the alias
 /// itself is STILL THERE afterwards. The second is not incidental. An indeterminate destination must be
-/// refused, never repaired: unlinking it and writing a fresh file would destroy whatever the link pointed
-/// at, which is the very file being protected. Deferring costs a repeated flush; there is nothing to
-/// recover from having overwritten someone's source file.
+/// refused, never repaired: unlinking it and writing a fresh file would destroy whatever it named, which is
+/// the very file being protected. That is sharper still for a hard link, which is SYMMETRIC — nothing on
+/// the filesystem records which name came first, so "clean up our aliased transcript" and "delete the
+/// user's file" are the same operation. Deferring costs a repeated flush; there is nothing to recover from
+/// having overwritten someone's source file.
 /// </para>
 /// </remarks>
-public sealed class WorkspaceTranscriptSymlinkTests
+public sealed class WorkspaceTranscriptPathAliasTests
 {
-    private const string RootDirectoryName = "lm-transcript-symlink";
+    private const string RootDirectoryName = "lm-transcript-alias";
 
     private const string ThreadId = "conv-link-7a3b";
     private const string WorkspaceId = "ws-link";
@@ -43,7 +55,7 @@ public sealed class WorkspaceTranscriptSymlinkTests
 
     private static readonly string[] AgentNames = ["researcher", "reviewer"];
 
-    /// <summary>Content of the file each symlink points at. No flush may ever change it.</summary>
+    /// <summary>Content of the file each alias names. No flush may ever change it.</summary>
     private const string TrackedContent = "tracked source file, not a transcript\n";
 
     private static readonly string ShortThreadId = WorkspaceTranscriptLine.ShortId(ThreadId);
@@ -295,6 +307,88 @@ public sealed class WorkspaceTranscriptSymlinkTests
             "the sub-agent transcripts stay where they were rather than travelling through the link");
     }
 
+    // ------------------------------------------------------- hard links (a second NAME, not a pointer)
+
+    /// <summary>
+    /// The destination transcript file is a HARD link to a tracked file — one inode, two names. Every
+    /// symlink check passes it: <c>[ -L ]</c> is false for both names and no ancestor is a link either, so
+    /// the splice appends the whole unredacted conversation into the tracked file, outside the ignored
+    /// directory and staged for the next <c>git add -A</c>.
+    /// </summary>
+    /// <remarks>
+    /// This is the case an earlier round of this work declared uncoverable, on the reasoning that a hard
+    /// link is indistinguishable from a regular file. It is indistinguishable by TYPE and perfectly
+    /// distinguishable by link count, which is what makes this test possible at all.
+    /// </remarks>
+    [SkippableFact]
+    public async Task Flush_RefusesToAppendThroughAHardLinkedDestinationFile()
+    {
+        var (root, writer, _, _) = await SetupAsync(
+            nameof(Flush_RefusesToAppendThroughAHardLinkedDestinationFile));
+        var tracked = WriteTrackedFile(root, "tracked.txt");
+        var destination = TranscriptPath(root, Leaf);
+        _ = Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+        HardLinkToFile(root, destination, tracked);
+
+        var outcome = await writer.FlushAsync();
+
+        // The leak is asserted BEFORE the outcome in these three: an outcome assertion that fires first
+        // reports "Written, expected Deferred" and says nothing about whether anything actually escaped.
+        AssertUntouched(tracked);
+        _ = outcome.Should().Be(TranscriptFlushOutcome.Deferred);
+        AssertStillHardLinked(destination, tracked);
+    }
+
+    /// <summary>
+    /// The STAGING path is a hard link. This one DESTROYS rather than leaks, and does it before any script
+    /// runs: the gateway PUTs the payload with the whole file's bytes, so a tracked file is not appended to
+    /// but overwritten with the transcript. Its name is as guessable as the destination's — a compile-time
+    /// directory plus a short hash of the thread id.
+    /// </summary>
+    [SkippableFact]
+    public async Task Flush_RefusesToStageThroughAHardLinkedTempPath()
+    {
+        var (root, writer, _, _) = await SetupAsync(nameof(Flush_RefusesToStageThroughAHardLinkedTempPath));
+        var tracked = WriteTrackedFile(root, "tracked-staging.txt");
+        var tempPath = TempPath(root);
+        _ = Directory.CreateDirectory(Path.GetDirectoryName(tempPath)!);
+        HardLinkToFile(root, tempPath, tracked);
+
+        var outcome = await writer.FlushAsync();
+
+        AssertUntouched(tracked);
+        _ = outcome.Should().Be(TranscriptFlushOutcome.Deferred);
+        AssertStillHardLinked(tempPath, tracked);
+    }
+
+    /// <summary>
+    /// The containment file is a hard link. The <c>.gitignore</c> is PUT whole, so this replaces a tracked
+    /// file's entire content with a single <c>*</c> — the sharpest of the three, and the one where refusing
+    /// has to stop the flush outright rather than merely skip a write.
+    /// </summary>
+    [SkippableFact]
+    public async Task Flush_RefusesToWriteContainmentThroughAHardLink()
+    {
+        var (root, writer, _, _) = await SetupAsync(nameof(Flush_RefusesToWriteContainmentThroughAHardLink));
+        var tracked = WriteTrackedFile(root, "tracked-config.txt");
+        var gitignore = Path.Combine(
+            root,
+            ConversationTranscriptWriter.TranscriptDirectory,
+            "." + ConversationTranscriptWriter.GitignoreName);
+        _ = Directory.CreateDirectory(Path.GetDirectoryName(gitignore)!);
+        HardLinkToFile(root, gitignore, tracked);
+
+        var outcome = await writer.FlushAsync();
+
+        AssertUntouched(tracked);
+        _ = outcome.Should().Be(TranscriptFlushOutcome.Deferred);
+        AssertStillHardLinked(gitignore, tracked);
+        _ = Directory
+            .GetFiles(Path.Combine(root, ConversationTranscriptWriter.TranscriptDirectory), "*.jsonl")
+            .Should()
+            .BeEmpty("containment could not be established, so no transcript may exist either");
+    }
+
     // ---------------------------------------------------------------- helpers
 
     /// <summary>
@@ -448,6 +542,54 @@ public sealed class WorkspaceTranscriptSymlinkTests
         }
     }
 
+    /// <summary>
+    /// Plants a real HARD link — a second directory entry for the same inode — with the same <c>sh</c> the
+    /// writer's own scripts run through, or skips when the filesystem refuses one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Shelling out to <c>ln</c> is not a shortcut around a .NET API; there is no hard-link API in .NET at
+    /// all (<see cref="File.CreateSymbolicLink"/> has no counterpart), and faking one would defeat the
+    /// test — the property under examination is that two names share ONE inode, which nothing but the
+    /// filesystem can produce.
+    /// </para>
+    /// <para>
+    /// Both operands are made relative to the shell's working directory rather than passed absolute. The
+    /// <c>ln</c> that runs here is the shell's own coreutils, which on Windows reaches it through a path
+    /// translation layer that a drive letter and a backslash separator each confuse; a relative path under
+    /// the working directory needs no translation and behaves identically on every host.
+    /// </para>
+    /// </remarks>
+    private static void HardLinkToFile(string root, string link, string target)
+    {
+        var shell = LocalShellWorkspaceBrowser.FindPosixShell();
+        Skip.If(shell is null, "No POSIX shell (sh) on this machine, so a hard link cannot be planted.");
+
+        var startInfo = new ProcessStartInfo(shell)
+        {
+            WorkingDirectory = root,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("-c");
+        startInfo.ArgumentList.Add("ln \"$1\" \"$2\"");
+        startInfo.ArgumentList.Add("sh");
+        startInfo.ArgumentList.Add(RelativeToRoot(root, target));
+        startInfo.ArgumentList.Add(RelativeToRoot(root, link));
+
+        using var process =
+            Process.Start(startInfo) ?? throw new InvalidOperationException($"Could not start '{shell}'.");
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Skip.If(
+            process.ExitCode != 0,
+            $"This filesystem does not permit hard links (ln exited {process.ExitCode}: {stderr.Trim()}).");
+    }
+
+    private static string RelativeToRoot(string root, string path) =>
+        Path.GetRelativePath(root, path).Replace(Path.DirectorySeparatorChar, '/');
+
     private static void AssertUntouched(string trackedFile)
     {
         _ = File.ReadAllText(trackedFile)
@@ -472,6 +614,25 @@ public sealed class WorkspaceTranscriptSymlinkTests
         _ = new DirectoryInfo(path)
             .LinkTarget.Should()
             .NotBeNull($"{path} must still be the symlink it was, untouched");
+    }
+
+    /// <summary>
+    /// The hard link survived, asserted by IDENTITY rather than by existence. A file being present at the
+    /// aliased path proves nothing on its own: a "cleanup" that unlinked the extra name and wrote a fresh
+    /// transcript leaves one there too, having destroyed exactly what the refusal exists to protect.
+    /// Appending through the tracked name and reading it back through the transcript's is the only check
+    /// that tells those apart, because it can only pass while the two names are still one inode.
+    /// </summary>
+    private static void AssertStillHardLinked(string alias, string tracked)
+    {
+        const string Probe = "still one inode\n";
+        File.AppendAllText(tracked, Probe);
+        _ = File.ReadAllText(alias)
+            .Should()
+            .Be(
+                TrackedContent + Probe,
+                $"{alias} must still be a second name for {tracked} — a hard link is symmetric, so removing "
+                    + "it is indistinguishable from deleting the user's file");
     }
 
     private static PersistedMessage Msg(


### PR DESCRIPTION
Follow-up to #252 (issue #251). Three fixes found while babysitting that PR, plus a real end-to-end proof that the main one works.

## The fixes

| Commit | What it fixes |
|---|---|
| `57bf4200` | **P2** — the flush scheduler drained in `HashSet` slot order, not FIFO |
| `458dbca1` | **P1** — the mirror attached on one agent-construction branch, not all of them |
| `acc96e35` | a transcript path that acquires a *second name* (hard link) is now refused, not just a symlinked one |

### P1 (`458dbca1`) — what is and isn't proven

`MultiTurnAgentPool` builds agents down several branches, and only one of them reached the single
`Attach` call. Providers routed through the others mirrored **nothing**.

Being precise about the coverage claim, because it is easy to overstate:

- **Two branches are covered by test** — `WorkspaceTranscriptMirrorAttachCompositionTests` drives
  those directly.
- **Four more are covered by a structural argument**: attachment moved to the single point every
  branch funnels through, so they cannot individually regress without that point changing.

That is **not** six tested branches, and this PR does not claim it is. The structural half is only as
good as the funnel staying a funnel — which is exactly what the E2E below checks from the outside.

### The bug's real signature

Worth stating because it is not "no transcript appears". Turn 1 on an attaching provider already
created the file. Switching that same conversation to a non-attaching provider left the file in
place and simply **stopped adding to it** — a silent hole in the middle of a live transcript, with
no error anywhere. Any check that only asserts "a file exists" passes on the broken build.

## Availability traded for containment (`acc96e35`) — read this before merging

This one deliberately makes the feature **less available** to make it safer, and the tradeoff should
be a decision, not a surprise.

A transcript destination is refused if it is a symlink **or if it bears more than one name** (a hard
link). The consequence:

> **A conversation whose transcript leaf acquires a second name stops mirroring, and stays stopped
> until a human removes the link.** It does not recover on its own, and no amount of restarting
> helps.

That is not a limitation waiting to be polished away — it is forced by the filesystem. A hard link is
**symmetric**: the two names are equally real, and the filesystem **does not record which one came
first**. So on finding two names there is no way to tell the original from the intruder, which means
there is no safe automatic repair. Deleting "the other one" is a coin flip that can destroy the
user's file; following it writes the conversation's bytes to a location nobody chose.

Refusing is the only option that cannot lose data or leak it somewhere unintended. It is also why the
guard **detects but never repairs**, and why the check walks every **ancestor** directory rather than
just the leaf — a symlinked `.conversations` redirects every file beneath it, including the
`.gitignore` that is supposed to be covering them, while the leaf itself tests perfectly clean
because at that point it does not exist yet.

Detection cost, for the record: `[ -L ]` cannot see a hard link at all, so the link count comes from
`ls -dn` field 2 (POSIX-specified; `-n` implies `-l`). `stat` was rejected (the format string is not
portable — `%h` GNU vs `%l` BSD) and POSIX `find … -links 1` is worse: the guard is a compile-time
`const string` shared by **both** executors, and the test surface is a Windows host where `sh`
resolves `find` to `C:\WINDOWS\system32\find.exe`, which prints `FIND: Parameter format not correct`
and no path — indistinguishable from a legitimate refusal. That was not reasoned about, it was run:
it made the guard refuse four pre-existing symlink cases that require a successful write. `ls -dn` is
POSIX and has no Windows name collision. Both alternatives were tried; neither shipped.

### Verified on the production surface, not just the host

The guard text was run inside `llm-sandbox-agent:latest` — **six of six behaviours as specified**
(absent → allow, nlink 1 → allow, nlink 2 → refuse, other end of the same link → refuse, directory →
refuse, symlink → caught by the ancestor walk). Shell is `/usr/bin/dash`, not bash; coreutils is GNU
9.1 with no busybox.

Two readings sharpen the severity claim, and both **reduce** it:

- **`protected_hardlinks=1` and enforced**, proven with a valid control: uid 1000 linking a
  root-owned file it can read but not write fails `EPERM`, while linking a file it owns succeeds
  (`exit=0`, `-rw-r--r-- 2 1000 1000`).
- **The writer runs as the agent's own uid by construction, not by coincidence.** Both mutation paths
  in `SandboxSessionRegistry` (`:1638` file-PUT, `:1655` `ExecuteWorkspaceCommandAsync`) resolve the
  same `sessionId` → same credential → same container, and `SandboxCommand` has exactly three members
  — `Arguments`, `WorkingDirectory`, `OperationId`. There is **no user, uid, or privilege field on the
  type at all**, so no mechanism exists for the writer to run as anything else.

**So this is not a confused deputy.** The agent can only link files it already owns, which it can
already write directly. The guard's value is containment and hygiene — keeping the transcript from
landing inside a git-tracked file — not privilege escalation. It ships as defense-in-depth, and the
severity is stated that way rather than inflated.

The guard **fails closed** when `ls` succeeds but prints something unparseable. The obvious objection
— "a missing binary would then disable the feature forever" — was checked and does not apply: GNU
coreutils 9.1 is present, there is no busybox, and `ls` is the least removable external a POSIX shell
has. The axis it actually fails closed on is *"the link count could not be read"*, where proceeding
would mean writing while admitting you don't know what you're writing to.

Both PUT paths are guarded **before** the bytes land (`ConversationTranscriptWriter.cs:1541` ahead of
`:1549`, same shape at `:1830` for the `.gitignore`), because a script-side check alone would be
useless — the PUT completes before any script runs. The in-script `solo "$2"` is the second layer,
catching an alias planted in the window between the guard and the splice.

## The end-to-end proof (`42a3771d`)

The unit tests verify the seam. They cannot verify that the mirror survives a real provider switch on
a real conversation writing through a real gateway — which is the exact thing P1 broke. So this adds
`playwright-scripts/transcript-mirror.mjs`: one self-contained script that drives the whole flow and
returns a structured verdict.

It exercises all three attach paths **in a single conversation**:

1. a provider that always attached → turn 1, `test-anthropic`, workspace-agent mode
2. named background sub-agents → turn 1 spawns `mirror-alpha` / `mirror-beta`
3. a CLI provider that did **not** attach → same thread switched to `codex-mock`, turn 2

Because turn 1 creates the file, a P1 regression appears as **MARKER1 present, MARKER2 absent**. The
verdict distinguishes `P1_HOLDS` / `P1_REGRESSED` / `FAILED_NOTHING_MIRRORED` rather than collapsing
to pass/fail.

**Result: `P1_HOLDS`, 21/21 steps, zero failures — green on two consecutive independent runs**, the
second against a `.conversations/` directory that already held the first run's transcript.

| Claim | Evidence |
|---|---|
| P1 holds | MARKER1 **and** MARKER2 in the same file; 13319 → 21773 bytes across the provider switch |
| P2 holds | 19/19 lines parsed, 0 unparsable, 0 duplicate `uid`s, MARKER1 line 0 → MARKER2 line 15 |
| Sub-agent fan-out | `mirror-alpha-….jsonl` + `mirror-beta-….jsonl`, both markers present |
| Filename contract | `transcript-mirror-e2e-<stamp>-<shortThreadId>.jsonl` |
| Binding survived | workspace intact across mode→`default` and provider→`codex-mock` |
| RAW reasoning fidelity | `ReasoningMessage` rows present, counted by discriminator |

### Three things the script gets right only because the first run got them wrong

- **Gates the switch on `GET {id}/run-state`, not on the UI going idle.** UI-idle is not run-idle:
  when a turn spawns background sub-agents the stop button hides while `GetRunStateInfo` stays
  `IsInProgress`, and the switch guards read *exactly that state* — so switching on the UI proxy
  earns a 409. The poll now reads the same signal the guard reads, so it cannot disagree with it.
- **Polls for both sub-agent files.** Each child flushes on its own schedule, so a single-shot
  listing catches only the first and reads as "the second was never mirrored". Observed once,
  against a perfectly healthy mirror.
- **Matches this run's transcript by its own slug prefix.** `.conversations/` accumulates one file
  per conversation, so "the first `.jsonl` in the listing" silently becomes a *previous* run's file
  on any re-run, whose marker carries a stale stamp.

Reading the bytes back **through the app's own file-browser route** is load-bearing, not a
convenience: the mirror writes into the sandbox workspace through the gateway, and this deployment
pins that gateway to a different machine, so a host-filesystem check reads as "no file" and reports a
false regression. `files/download` is used rather than `preview` because `FilePreviewPolicy` excludes
dot-directories by design.

RAW reasoning fidelity is asserted off the `message_type` discriminator, **never a substring** — a
`/"reasoning"/` scan matches the User row's own `message_json`, which echoes the prompt's
`"reasoning":{"length":30}` back verbatim, and so reports hits on a broken mirror too.

## Known gap, not fixed here: state lines are dead code

The E2E surfaced this and it is worth a decision rather than silence. `WorkspaceTranscriptLine.ForState`
(title / mode / provider) is specified, serialized, and unit-tested — and has **zero production
callers**. A run that set the title, switched mode, *and* switched provider produced 43/43
`type:"message"` lines and **0** `type:"state"`.

It is not a one-line fix. `ResolveStartIndexAsync` re-derives the entire transcript on every flush and
locates a watermark `uid` inside that recomputed list, which requires every line to be **replayable**.
`ForState` seeds its uid with the wall clock, so a state line is not reproducible on the next flush →
the watermark goes missing → the whole history re-appends, every flush. Dropping the timestamp does
not rescue it either: at the head, state changes are never appended; at the tail, new messages are
never appended.

A correct fix needs a persisted, timestamped state-change history (`Properties["mode"]` keeps only the
current value), plus `RecoverWatermarkAsync` skipping state lines when reading the file tail. That
type lives in `src/`, and the locked decision for this feature is **zero `src/` changes** — so it is
filed rather than smuggled in here.

Closes nothing on its own; follow-up to #251.
