### PR TITLE
docs: identify ADRs by slug, and record the missing signature-derived principal

### DIFF
--- a/docs/adrs/0010-adr-identity-is-the-slug.md
+++ b/docs/adrs/0010-adr-identity-is-the-slug.md
@@ -1,0 +1,80 @@
+# ADR 0010: An ADR's identity is its slug, and colliding numbers are left standing
+
+* Status: Accepted
+* Date: 2026-08-03
+* Related issues, PRs, or commits: [#227](https://github.com/achieveai/LmDotnetTools/issues/227),
+  [#231](https://github.com/achieveai/LmDotnetTools/pull/231); corrects the index for
+  [0002 — workflow controller transparency](0002-workflow-controller-transparency.md),
+  [0003 — per-conversation usage collector](0003-per-conversation-usage-collector.md),
+  [0002 — lifecycle event wire contract](0002-lifecycle-event-wire-contract.md),
+  [0003 — fail-closed tool approval](0003-fail-closed-tool-approval.md)
+
+## Context
+
+This directory contains two ADRs numbered 0002 and two numbered 0003.
+
+The cause is ordinary and will recur. Two work streams were in flight across the same
+week. The workflow-transparency and usage-collector records were written on 2026-07-23;
+the #227 lifecycle, approval, and delivery set was written on 2026-07-27. Each was drafted
+against the state of `docs/adrs/` visible from its own branch, where the highest merged
+number was 0001, and each therefore took 0002 and 0003 as the next free numbers. Nothing
+detected the collision at merge, because a duplicate number is a duplicate *filename
+prefix*, not a duplicate filename — git merges both without conflict.
+
+The damage is confined to one place, which is worth stating precisely before choosing a
+remedy. In-file cross references already link by filename — `[ADR 0002](0002-lifecycle-event-wire-contract.md)`
+in ADR 0005, `[Fail-closed tool approval](adrs/0003-fail-closed-tool-approval.md)` in the
+field matrix — so every link in the repository resolves to exactly one record today. What
+is ambiguous is the *bare number* in prose, and the README index, which lists all four
+entries and so reads as though 0002 and 0003 each decided two unrelated things.
+
+The obvious remedy is to renumber the newer set to 0010 and up. It is not available.
+This directory's own rule is that ADRs are append-only and that a later decision supersedes
+an earlier one rather than editing it, and a record's number is part of the record — it is
+in the filename, in the `# ADR NNNN` heading, and in every link and citation already made
+to it. Renumbering would rewrite four accepted records to fix a defect in a fifth file that
+is not a record at all. It would also break references that live outside this repository's
+control, in issue #227 and PR #231.
+
+## Decision
+
+**An ADR is identified by its slug, not by its number.** The canonical reference is the
+full filename — `0002-lifecycle-event-wire-contract` — and every cross reference, in prose
+or in code comments, links or names that slug. A number is allocation order within the
+branch that authored the record. It is a sort key and a filename prefix. It is not, and
+never was, a guaranteed-unique identifier.
+
+**The existing collisions stand.** 0002 and 0003 each name two records permanently. Bare
+"ADR 0002" and "ADR 0003" in already-merged prose are left as they are, because
+disambiguating them means editing accepted records to serve a convenience, which is the
+precise trade this directory has already refused.
+
+**A number is claimed at merge, not at drafting.** A branch drafts against whatever number
+looks free; whoever merges second checks `docs/adrs/` as it stands on the target branch and
+renames the file before merging if the number has since been taken. Renaming a draft is not
+an edit to a record — a draft is not yet a record — so this is the one moment at which the
+correction is free, and it is the only moment at which it is available.
+
+**The README index is corrected, because it is not a record.** It is a navigation aid
+describing the directory's current contents, and a navigation aid that misdescribes them is
+simply wrong rather than historically interesting. Colliding entries are listed with their
+slugs so the index distinguishes what the numbers cannot.
+
+## Consequences
+
+Two numbers in this directory are ambiguous forever, and a reader who cites one without a
+slug will be misunderstood roughly half the time. That is the accepted cost of the
+append-only rule, and it is cheaper than the alternative: a directory where numbers are
+authoritative is a directory where numbers get rewritten, and a record whose identity can
+be rewritten is not immutable in any sense that matters.
+
+Prevention is procedural rather than enforced. It relies on whoever merges an ADR looking
+at the directory first, which is one `ls` and is exactly the check that was skipped both
+times. A future collision is therefore possible; it is also harmless under this decision,
+because the slug still resolves it. If collisions become frequent enough to be irritating
+rather than rare enough to be tolerable, the answer is a merge check that fails on a
+duplicate prefix — not a renumbering pass.
+
+Finally, this ADR supersedes nothing. The four colliding records remain accepted, correct,
+and in force exactly as written. What changes is only how they are referred to and how the
+index presents them.

--- a/docs/adrs/0010-adr-identity-is-the-slug.md
+++ b/docs/adrs/0010-adr-identity-is-the-slug.md
@@ -33,8 +33,8 @@ This directory's own rule is that ADRs are append-only and that a later decision
 an earlier one rather than editing it, and a record's number is part of the record — it is
 in the filename, in the `# ADR NNNN` heading, and in every link and citation already made
 to it. Renumbering would rewrite four accepted records to fix a defect in a fifth file that
-is not a record at all. It would also break references that live outside this repository's
-control, in issue #227 and PR #231.
+is not a record at all. It would also break a reference that lives outside this repository's
+control, in PR #231, which indexes the set as "ADRs 0002–0008".
 
 ## Decision
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -33,24 +33,43 @@ The architectural choice that was made.
 What improved, what became more complex, and what future work this implies.
 ```
 
+## Referring to an ADR
+
+Refer to an ADR by its **slug** — `0002-lifecycle-event-wire-contract` — never by its number
+alone. Numbers are allocation order within the branch that authored the record, not unique
+identifiers: `0002` and `0003` each name two different records here. See
+[ADR 0010](0010-adr-identity-is-the-slug.md) for why the collision was left standing rather
+than renumbered away.
+
 ## Creating future ADRs
 
 1. Copy [templates/adr-template.md](templates/adr-template.md) into this directory.
 2. Name it with the next four-digit number and a short kebab-case title, e.g.
-   `0002-use-example-backend.md`.
+   `0011-use-example-backend.md`.
 3. Open it as `Proposed`, and move it to `Accepted` once the decision is made.
+4. **Before merging, re-check this directory on the target branch.** A number that was free
+   when you drafted may have been taken by another branch since. Rename the file then —
+   while it is still a draft, and therefore still changeable — because once merged the
+   number is part of an immutable record.
 
 ## Index
 
+Two numbers below are shared by two records each, for the reason given in
+[ADR 0010](0010-adr-identity-is-the-slug.md). Both entries of a colliding pair are listed
+together with their slugs.
+
 * [0001 — Route all programmatic sandbox gateway access through the typed SDK](0001-route-gateway-access-through-sandbox-sdk.md)
-* [0002 — WorkflowAgent controller transparency and sub-agent tool inheritance](0002-workflow-controller-transparency.md)
-* [0003 — Per-conversation usage/cost collector shared by every agent](0003-per-conversation-usage-collector.md)
-* [0002 — Publish lifecycle events through a dependency-neutral versioned wire contract](0002-lifecycle-event-wire-contract.md)
-* [0003 — Gate host-executed tool calls behind a fail-closed approval decision](0003-fail-closed-tool-approval.md)
+* 0002 — **two records share this number:**
+  * [WorkflowAgent controller transparency and sub-agent tool inheritance](0002-workflow-controller-transparency.md) (`0002-workflow-controller-transparency`, 2026-07-23)
+  * [Publish lifecycle events through a dependency-neutral versioned wire contract](0002-lifecycle-event-wire-contract.md) (`0002-lifecycle-event-wire-contract`, 2026-07-27)
+* 0003 — **two records share this number:**
+  * [Per-conversation usage/cost collector shared by every agent](0003-per-conversation-usage-collector.md) (`0003-per-conversation-usage-collector`, 2026-07-23)
+  * [Gate host-executed tool calls behind a fail-closed approval decision](0003-fail-closed-tool-approval.md) (`0003-fail-closed-tool-approval`, 2026-07-27)
 * [0004 — Resolve delayed tool results as serialized child runs caused by the real tool result](0004-delayed-tool-results-as-child-runs.md)
 * [0005 — Scope service-to-service lifecycle delivery to a host-resolved owner key](0005-service-to-service-lifecycle-delivery.md)
 * [0006 — Order a workflow transition against the run observer with a publish-order watermark](0006-workflow-transition-observation-barrier.md)
 * [0007 — Observe turns and context at the seam where the fact settles](0007-observe-at-the-settling-seam.md)
 * [0008 — Dispatch provider tool requests off the stdio read loop, bounded and refusing](0008-asynchronous-provider-tool-dispatch.md)
 * [0009 — Scope agent collaboration to a root-owned directory, and leave delivery with the owner](0009-hierarchy-wide-agent-collaboration.md)
+* [0010 — An ADR's identity is its slug, and colliding numbers are left standing](0010-adr-identity-is-the-slug.md)
 * [0011 — Mirror each conversation's transcript into its own workspace, readable by anyone who can reach the workspace](0011-workspace-transcript-files.md)

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -45,7 +45,7 @@ than renumbered away.
 
 1. Copy [templates/adr-template.md](templates/adr-template.md) into this directory.
 2. Name it with the next four-digit number and a short kebab-case title, e.g.
-   `0011-use-example-backend.md`.
+   `NNNN-use-example-backend.md`.
 3. Open it as `Proposed`, and move it to `Accepted` once the decision is made.
 4. **Before merging, re-check this directory on the target branch.** A number that was free
    when you drafted may have been taken by another branch since. Rename the file then —

--- a/src/LmAgentInfra/Lifecycle/LifecycleApprovalController.cs
+++ b/src/LmAgentInfra/Lifecycle/LifecycleApprovalController.cs
@@ -54,20 +54,33 @@ public sealed record ToolApprovalDecisionResponse
 /// misconfiguration rather than routine traffic.
 /// </para>
 /// <para>
-/// <b>Known gap, accepted for now: there is no supported way to turn a verified signature into a
-/// principal.</b> A subscriber already proves who it is on every delivery it answers — it holds a
-/// host-minted signing secret bound to one subscription and one owner — and yet that proof cannot be
-/// spent here, so an integrator who wants nothing more than "the holder of subscription X may decide
-/// X's approvals" must stand up a separate authentication scheme to express it. The refusal is
-/// correct (see the paragraph above: a controller cannot tell a verified header from a typed one, so
-/// trusting one would be trusting every deployment to have wired verification), but the burden it
-/// creates is larger than the problem it solves for the common case. The intended fix is a
-/// first-party <c>AuthenticationHandler</c> shipped alongside
-/// <see cref="Webhooks.WebhookRequestVerifier"/> that verifies the signature and, on success, emits a
-/// principal carrying the subscription id and its resolved owner — so the guarantee comes from a
-/// component the library owns and tests, rather than from each host's wiring. Until that exists, the
-/// host-supplied scheme documented above is the only supported path, and this endpoint stays
-/// fail-closed without it.
+/// <b>Known gap, accepted for now: an integrator who wants nothing more than "the holder of
+/// subscription X may decide X's approvals" must stand up a whole separate authentication scheme to
+/// say it.</b> The refusal above is correct — a controller cannot tell a verified header from a
+/// merely typed one, so trusting one would be trusting every deployment to have wired verification —
+/// but the burden it creates is larger than the problem it solves for the common case. There is a
+/// latent capability here: a subscriber does hold a host-minted secret bound to one subscription and
+/// one owner. It is only a capability. Today that secret is used in one direction — the host signs
+/// outbound deliveries with it (<see cref="HttpLifecycleDeliverySender"/>), the subscriber verifies
+/// them — and no subscriber-to-host signing convention exists, so nothing a caller sends to this
+/// endpoint carries a signature for anyone to check.
+/// </para>
+/// <para>
+/// Closing the gap therefore means defining that inbound protocol first, not merely adding an
+/// <c>AuthenticationHandler</c>. Three prerequisites, none of them satisfied today, and all of them
+/// changes to contracts this type does not own:
+/// <list type="number">
+/// <item>a subscriber-to-host signing convention, which does not exist;</item>
+/// <item>a way to resolve a subscription id to its secret and owner <em>before</em> a principal
+/// exists, which <see cref="ILifecycleSubscriptionRegistry"/> deliberately forbids — every lookup on
+/// it is owner-scoped precisely so that a caller cannot reach another tenant's subscription by id;</item>
+/// <item>a signed payload that names its own direction and route domain. The current HMAC binds only
+/// <c>{timestamp}.{deliveryId}.{body}</c>, so reusing it unchanged for caller authentication would let
+/// a captured outbound delivery signature be replayed as an inbound credential.</item>
+/// </list>
+/// That is a design decision spanning the registry and the wire format, so it belongs in a superseding
+/// ADR rather than in this comment. Until it is made, the host-supplied scheme documented above is the
+/// only supported path, and this endpoint stays fail-closed without it.
 /// </para>
 /// <para>
 /// The capability check is repeated here rather than trusted from registration time, because

--- a/src/LmAgentInfra/Lifecycle/LifecycleApprovalController.cs
+++ b/src/LmAgentInfra/Lifecycle/LifecycleApprovalController.cs
@@ -54,6 +54,22 @@ public sealed record ToolApprovalDecisionResponse
 /// misconfiguration rather than routine traffic.
 /// </para>
 /// <para>
+/// <b>Known gap, accepted for now: there is no supported way to turn a verified signature into a
+/// principal.</b> A subscriber already proves who it is on every delivery it answers — it holds a
+/// host-minted signing secret bound to one subscription and one owner — and yet that proof cannot be
+/// spent here, so an integrator who wants nothing more than "the holder of subscription X may decide
+/// X's approvals" must stand up a separate authentication scheme to express it. The refusal is
+/// correct (see the paragraph above: a controller cannot tell a verified header from a typed one, so
+/// trusting one would be trusting every deployment to have wired verification), but the burden it
+/// creates is larger than the problem it solves for the common case. The intended fix is a
+/// first-party <c>AuthenticationHandler</c> shipped alongside
+/// <see cref="Webhooks.WebhookRequestVerifier"/> that verifies the signature and, on success, emits a
+/// principal carrying the subscription id and its resolved owner — so the guarantee comes from a
+/// component the library owns and tests, rather than from each host's wiring. Until that exists, the
+/// host-supplied scheme documented above is the only supported path, and this endpoint stays
+/// fail-closed without it.
+/// </para>
+/// <para>
 /// The capability check is repeated here rather than trusted from registration time, because
 /// <see cref="LifecycleCapabilities.ToolApprovalDecide"/> can be revoked while an approval is
 /// pending, and the moment that matters is the moment the decision lands. It is checked against the

--- a/src/LmAgentInfra/Lifecycle/LifecycleSubscriptionsController.cs
+++ b/src/LmAgentInfra/Lifecycle/LifecycleSubscriptionsController.cs
@@ -92,7 +92,9 @@ public sealed record LifecycleSubscriptionResponse
 /// <see cref="HttpContext.User"/> — established by whatever authentication the host wired in front of
 /// it — and resolves an owner from that alone. No route, header, or body field names an owner, so a
 /// caller cannot register into, rotate, or revoke another tenant's subscriptions. A host that wires no
-/// authentication scheme gets an endpoint that refuses everything, which is the safe direction.
+/// authentication scheme gets an endpoint that refuses everything, which is the safe direction — and,
+/// as the known gap recorded on <see cref="LifecycleApprovalController"/> notes, a heavier burden on
+/// the integrator than it should be until a signature-derived principal is shipped.
 /// </para>
 /// <para>
 /// <b>There is no listing route, and no route that reads a subscription back.</b> ADR 0005 leaves the

--- a/src/LmAgentInfra/Lifecycle/LifecycleSubscriptionsController.cs
+++ b/src/LmAgentInfra/Lifecycle/LifecycleSubscriptionsController.cs
@@ -94,7 +94,10 @@ public sealed record LifecycleSubscriptionResponse
 /// caller cannot register into, rotate, or revoke another tenant's subscriptions. A host that wires no
 /// authentication scheme gets an endpoint that refuses everything, which is the safe direction — and,
 /// as the known gap recorded on <see cref="LifecycleApprovalController"/> notes, a heavier burden on
-/// the integrator than it should be until a signature-derived principal is shipped.
+/// the integrator than it should be. Note that registration is excluded from that gap on principle:
+/// it is the operation that <em>mints</em> the subscription secret, so a caller cannot present that
+/// secret as proof of identity beforehand. Host authentication stays mandatory here no matter what
+/// the existing-subscription routes (rotate, revoke, unregister) may later gain.
 /// </para>
 /// <para>
 /// <b>There is no listing route, and no route that reads a subscription back.</b> ADR 0005 leaves the


### PR DESCRIPTION
Follow-up documentation from the **#227 / #231** lifecycle-and-approval work. Docs and XML comments only — no behaviour change. `LmAgentInfra` builds clean, **0 warnings, 0 errors**.

> **Revised after review.** An earlier version of this description claimed a subscriber "already proves who it is on every delivery it answers." That is false and has been corrected in both the code comment and this text — see [§3](#3-correction).

## 1. ADR 0010 — an ADR's identity is its slug

This directory contains **two ADRs numbered 0002 and two numbered 0003**. Both of the newer pair came from #231:

| Number | Records sharing it |
|---|---|
| `0002` | `0002-workflow-controller-transparency` (2026-07-23) · `0002-lifecycle-event-wire-contract` (2026-07-27) |
| `0003` | `0003-per-conversation-usage-collector` (2026-07-23) · `0003-fail-closed-tool-approval` (2026-07-27) |

Two work streams were in flight the same week, each drafting against the state of `docs/adrs/` visible from its own branch, where the highest merged number was `0001`. Nothing caught it at merge, because **a duplicate number is a duplicate filename *prefix*, not a duplicate filename** — git merges both without conflict.

**The damage is narrower than it looks.** Every in-file cross reference already links by filename, so every link in the repo resolves to exactly one record today. What is ambiguous is the *bare number in prose*, and the README index — which listed all four entries flat, reading as though 0002 and 0003 each decided two unrelated things.

### The decision

- **An ADR is identified by its slug.** A number is allocation order within the authoring branch — a sort key and a filename prefix, never a guaranteed-unique identifier.
- **The existing collisions stand.** Renumbering would rewrite four *accepted* records to fix a defect in a fifth file that is not a record at all, and would break PR #231's "ADRs 0002–0008" index.
- **The README index is corrected**, because it is a navigation aid describing current contents, not an immutable record.
- **A number is claimed at merge, not at drafting.** Whoever merges second checks the target branch and renames the file — a draft is not yet a record, so this is the one moment the correction is free.

### Why this needs to be committed

These files are not a speculative draft. They deliver decisions already taken on 2026-08-03 during the lifecycle-hooks survey — *"fix the collisions, but preserve ADR immutability"* and *"note the auth gap in a code comment, fix later."* That survey lives under `scratchPad/`, which is **gitignored** (`.gitignore:61`), so it never leaves one machine. Without this PR the decisions have no durable form anywhere in the repository, and the next person to hit the collision re-litigates it from scratch.

## 2. A known gap in the approval endpoint

`LifecycleApprovalController` refuses any request without a host-wired authentication scheme. That refusal is **correct** — a controller cannot tell a verified header from a merely typed one. But the burden is larger than the problem it solves for the common case: an integrator who wants only *"the holder of subscription X may decide X's approvals"* must stand up an entire separate scheme to say it.

The comment now records this as a **latent capability with three unmet prerequisites**, not as a settled fix:

1. **No subscriber-to-host signing convention exists.** The secret travels one way today.
2. **`ILifecycleSubscriptionRegistry` deliberately forbids resolving a subscription by id alone** — every lookup is owner-scoped, which *is* the authorization model.
3. **The HMAC binds only `{timestamp}.{deliveryId}.{body}`** — no direction, no route domain — so reusing it for caller authentication would let a captured outbound signature be replayed inbound.

That spans the registry and the wire format, so it is flagged as belonging in a **superseding ADR**. Registration is excluded on principle: it is the operation that *mints* the secret, so host authentication stays mandatory there regardless.

**No issue is filed for the handler** — related to #237 (*P1: Identity, principals and authorization*), but narrower.

## 3. Correction

The original commit asserted that a subscriber "already proves who it is on every delivery it answers." Verified false in review:

- `WebhookRequestSigner` has exactly one caller — `HttpLifecycleDeliverySender:105`, the **host**, signing **outbound**.
- `WebhookRequestVerifier`'s only consumer is `WebhookVerificationMiddleware`.
- **No subscriber signs anything, and no lifecycle route verifies a subscriber-produced signature.**

The underlying fact — the secret is host-minted and bound to one subscription and one owner — is true, but identity-proof does not follow from it. Direction was never checked. Corrected in `c774ec24`, along with four other review findings (all five valid, all confirmed against the code).

## Verification

| Claim | Result |
|---|---|
| The 0002/0003 collision is real and still present | both pairs on disk **and** on `origin/main` |
| Secret is host-minted, bound to one subscription + owner | `InMemoryLifecycleSubscriptionRegistry:143` → `LifecycleSubscription` carrying `SubscriptionId` + `Owner` |
| Subscriber does **not** sign inbound | `WebhookRequestSigner` single call site is host-outbound |
| Registry forbids id-alone lookup | every method owner-scoped; `ILifecycleSubscriptionRegistry:45` |
| README example filename is not a real number | `NNNN-`, after `0011` was found already taken |
| #227 carries no ADR reference | grep of body + comments returns nothing; citation dropped |
| Comments compile | `dotnet build` — 0 warnings, 0 errors |

Refs #227, #231.
