### PR TITLE
Add LmStreaming output-token policy and Copilot web search

### DIFF
--- a/docs/superpowers/plans/2026-07-30-copilot-jina-web-tools.md
+++ b/docs/superpowers/plans/2026-07-30-copilot-jina-web-tools.md
@@ -1,0 +1,573 @@
+# Copilot and Jina Web Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose Copilot's hosted `web_search` through its readonly MCP endpoint for every Copilot provider path, retain Jina `WebFetch`, and fall back to Jina `WebSearch` when hosted search is unavailable.
+
+**Architecture:** Keep the existing transparent `/mcp` proxy unchanged. Add one narrow sample service that creates an authenticated Streamable-HTTP MCP client with `X-MCP-Tools: web_search`, imports its sole contract into a supplied `FunctionRegistry`, and returns the client for conversation-lifetime disposal. Both dynamically discovered Copilot models and the plain `copilot` CLI path use this service; existing `WebToolRegistrationPolicy` continues to add Jina tools, with one flag suppressing Jina search after hosted search succeeds.
+
+**Tech Stack:** .NET 9, C#, ModelContextProtocol.Client 1.3.0, existing `McpMiddleware`, `GithubCopilotProvider`, xUnit, FluentAssertions.
+
+## Global Constraints
+
+- Reuse existing files and abstractions; do not create versioned or enhanced variants.
+- Do not rewrite the existing `/mcp` or `/mcp/readonly` proxy.
+- Select only `web_search` with `X-MCP-Tools: web_search`; do not import the full hosted catalog.
+- Copilot MCP failures degrade gracefully and never prevent provider creation.
+- Never read, log, copy, or commit the user's `JINA_API_KEY` or Copilot credentials.
+- Preserve mode-level `EnabledTools` filtering and the existing provider capability policy.
+- Do not commit changes unless the user explicitly requests it.
+
+## File Structure
+
+- Create `samples/LmStreaming.Sample/Services/CopilotWebSearchRegistration.cs` — owns the narrow authenticated MCP connection/import operation and its result type.
+- Create `tests/LmStreaming.Sample.Tests/Services/CopilotWebSearchRegistrationTests.cs` — deterministic fake-upstream coverage for discovery, invocation, filtering, failure, and disposal handoff.
+- Modify `samples/LmStreaming.Sample/Services/WebToolRegistrationPolicy.cs` — add a `suppressWebSearch` input while leaving `WebFetch` and all existing gates intact.
+- Modify `tests/LmStreaming.Sample.Tests/Services/WebToolRegistrationPolicyTests.cs` — prove hosted-search success suppresses only Jina search.
+- Modify `samples/LmStreaming.Sample/Program.cs` — wire the helper into dynamically discovered and plain Copilot paths and append clients to owned resources.
+- Modify `tests/CopilotAnthropicProxy.Tests/McpProxyTests.cs` — make the MCP control-header proof use the actual `web_search` selector.
+- Create `tests/CopilotLive.Tests/CopilotMcpLiveTests.cs` — opt-in proof that the real readonly endpoint exposes exactly `web_search`.
+- Modify `samples/CopilotAnthropicProxy.Sample/README.md` — document the verified selector and clarify that no hosted `web_fetch` exists.
+
+---
+
+### Task 1: Narrow Copilot Hosted Search Registration
+
+**Files:**
+- Create: `samples/LmStreaming.Sample/Services/CopilotWebSearchRegistration.cs`
+- Create: `tests/LmStreaming.Sample.Tests/Services/CopilotWebSearchRegistrationTests.cs`
+
+**Interfaces:**
+- Consumes: `FunctionRegistry`, `ICopilotTokenProvider`, `CopilotSessionContext`, `CopilotOptions`, `ILoggerFactory`, `McpClientFunctionProvider`, `HttpClientTransport`.
+- Produces:
+
+```csharp
+internal sealed record CopilotWebSearchRegistrationResult(
+    bool Registered,
+    McpClient? Client,
+    string Status
+);
+
+internal static class CopilotWebSearchRegistration
+{
+    internal const string ToolName = "web_search";
+
+    public static CopilotWebSearchRegistrationResult TryRegister(
+        FunctionRegistry registry,
+        IReadOnlyList<string>? enabledTools,
+        ICopilotTokenProvider tokenProvider,
+        CopilotSessionContext session,
+        CopilotOptions options,
+        ILoggerFactory loggerFactory,
+        HttpMessageHandler? innerHandler = null
+    );
+}
+```
+
+`innerHandler` is a test seam only. Production passes `null`, allowing `CopilotHttpClientFactory` to use its normal transport.
+
+- [ ] **Step 1: Write failing mode-gate and successful-discovery tests**
+
+Create a fake Streamable-HTTP MCP handler that:
+
+1. records request headers;
+2. returns an `initialize` SSE response with `Mcp-Session-Id`;
+3. accepts `notifications/initialized`;
+4. returns one `tools/list` entry named `web_search` with required `query`;
+5. returns a citation-bearing result for `tools/call`.
+
+Add tests equivalent to:
+
+```csharp
+[Fact]
+public void TryRegister_WhenModeEnablesWebSearch_ImportsBareHostedTool()
+{
+    var registry = new FunctionRegistry();
+    using var upstream = new FakeCopilotMcpHandler();
+
+    var result = CopilotWebSearchRegistration.TryRegister(
+        registry,
+        enabledTools: ["web_search"],
+        new StaticTokenProvider("test-token"),
+        new CopilotSessionContext(),
+        new CopilotOptions(),
+        NullLoggerFactory.Instance,
+        upstream
+    );
+
+    result.Registered.Should().BeTrue();
+    result.Client.Should().NotBeNull();
+    registry.Build().Contracts.Select(x => x.Name).Should().ContainSingle().Which.Should().Be("web_search");
+    upstream.RequestHeaders.SelectMany(x => x).Should().Contain(x =>
+        x.Key.Equals("X-MCP-Tools", StringComparison.OrdinalIgnoreCase)
+        && x.Value.Contains("web_search")
+    );
+}
+
+[Theory]
+[InlineData(null, true)]
+[InlineData("web_search", true)]
+[InlineData("WebSearch", false)]
+[InlineData("WebFetch", false)]
+public void TryRegister_RespectsExactModeToolName(string? enabledTool, bool expected)
+{
+    IReadOnlyList<string>? enabled = enabledTool is null ? null : [enabledTool];
+    // Arrange the same fake MCP handler, invoke TryRegister, and assert Registered == expected.
+}
+```
+
+For the `null` case, pass `enabledTools: null`; an empty list must also receive a dedicated assertion returning `Registered == false` without contacting the upstream.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test tests/LmStreaming.Sample.Tests/LmStreaming.Sample.Tests.csproj --filter FullyQualifiedName~CopilotWebSearchRegistrationTests
+```
+
+Expected: FAIL because `CopilotWebSearchRegistration` does not exist.
+
+- [ ] **Step 3: Implement the minimal authenticated MCP import**
+
+Implement `TryRegister` with this flow:
+
+```csharp
+if (enabledTools is not null && !enabledTools.Contains(ToolName))
+{
+    return new(false, null, "Copilot web_search disabled by mode");
+}
+
+McpClient? client = null;
+try
+{
+    var httpClient = CopilotHttpClientFactory.Create(
+        options.BaseUrl,
+        tokenProvider,
+        session,
+        options,
+        innerHandler: innerHandler
+    );
+    var transport = new HttpClientTransport(
+        new HttpClientTransportOptions
+        {
+            Name = "copilot-web-search",
+            Endpoint = new Uri(new Uri(options.BaseUrl), "/mcp/readonly"),
+            TransportMode = HttpTransportMode.StreamableHttp,
+            AdditionalHeaders = new Dictionary<string, string>
+            {
+                ["X-MCP-Tools"] = ToolName,
+            },
+        },
+        httpClient,
+        loggerFactory,
+        ownsHttpClient: true
+    );
+
+    client = McpClient.CreateAsync(transport).GetAwaiter().GetResult();
+    var provider = McpClientFunctionProvider.CreateAsync(
+        client,
+        "copilot-web-search",
+        "CopilotWebSearch",
+        loggerFactory.CreateLogger<McpClientFunctionProvider>(),
+        omitServerPrefix: true
+    ).GetAwaiter().GetResult();
+
+    var functions = provider.GetFunctions().ToList();
+    if (functions.Count != 1 || !string.Equals(functions[0].Contract.Name, ToolName, StringComparison.Ordinal))
+    {
+        client.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        return new(false, null, "Copilot web_search unavailable");
+    }
+
+    _ = registry.AddProvider(provider);
+    return new(true, client, "Copilot web_search registered");
+}
+catch (Exception ex)
+{
+    if (client is not null)
+    {
+        client.DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+    logger.LogWarning(ex, "Copilot hosted web_search is unavailable; using configured fallback");
+    return new(false, null, "Copilot web_search unavailable");
+}
+```
+
+Match the installed MCP package's exact overload names at compile time. Keep the method synchronous because the surrounding agent factory is synchronous and existing MCP connection helpers use the same bounded sync-over-async pattern.
+
+- [ ] **Step 4: Add failure and invocation tests**
+
+Add deterministic tests asserting:
+
+- an upstream initialization exception returns `Registered == false`, `Client == null`, and leaves the registry empty;
+- a catalog with zero or more than one tool is rejected and disposed;
+- invoking the registered handler with `{"query":"current .NET release"}` sends `tools/call` for `web_search` and returns the fake citation text;
+- no captured log or status contains the static bearer token.
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+Run the Task 1 test command again.
+
+Expected: PASS.
+
+- [ ] **Step 6: Run formatter on touched C# files**
+
+Run:
+
+```powershell
+dotnet csharpier format samples/LmStreaming.Sample/Services/CopilotWebSearchRegistration.cs tests/LmStreaming.Sample.Tests/Services/CopilotWebSearchRegistrationTests.cs
+```
+
+Expected: formatter exits successfully.
+
+---
+
+### Task 2: Jina Fallback Precedence
+
+**Files:**
+- Modify: `samples/LmStreaming.Sample/Services/WebToolRegistrationPolicy.cs:28-143`
+- Modify: `tests/LmStreaming.Sample.Tests/Services/WebToolRegistrationPolicyTests.cs:21-307`
+
+**Interfaces:**
+- Consumes: Task 1's `CopilotWebSearchRegistrationResult.Registered`.
+- Produces: updated `WebToolRegistrationPolicy.Apply(..., bool suppressWebSearch = false)`.
+
+- [ ] **Step 1: Write failing fallback-precedence tests**
+
+Add:
+
+```csharp
+[Fact]
+public void Apply_WhenHostedSearchRegistered_StillRegistersJinaFetchButSuppressesJinaSearch()
+{
+    var registry = new FunctionRegistry();
+    var (provider, options) = Backend(ApiKey);
+
+    _ = WebToolRegistrationPolicy.Apply(
+        registry,
+        "claude-sonnet-5",
+        enabledTools: ["web_search", "WebFetch", "WebSearch"],
+        provider,
+        options,
+        NullLoggerFactory.Instance,
+        isCopilotBackedModel: true,
+        suppressWebSearch: true
+    );
+
+    RegisteredNames(registry).Should().Contain("WebFetch").And.NotContain("WebSearch");
+}
+
+[Fact]
+public void Apply_WhenHostedSearchUnavailable_RegistersJinaSearchAndFetch()
+{
+    // Same arrangement with suppressWebSearch: false; assert both Jina tools exist.
+}
+```
+
+- [ ] **Step 2: Run the focused policy tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test tests/LmStreaming.Sample.Tests/LmStreaming.Sample.Tests.csproj --filter FullyQualifiedName~WebToolRegistrationPolicyTests
+```
+
+Expected: compile failure because `suppressWebSearch` is absent.
+
+- [ ] **Step 3: Add the single suppression gate**
+
+Extend `Apply` with `bool suppressWebSearch = false`. Change only the search branch:
+
+```csharp
+if (suppressWebSearch)
+{
+    statuses.Add("WebSearch skipped: Copilot web_search registered");
+}
+else if (string.IsNullOrWhiteSpace(options.JinaApiKey))
+{
+    // existing missing-key branch
+}
+else if (ModeEnables(WebSearchTool.ToolName))
+{
+    // existing registration branch
+}
+```
+
+Do not alter Jina `WebFetch`, provider eligibility, collision handling, or mode matching.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run the Task 2 test command again.
+
+Expected: PASS, including all pre-existing provider/mode/collision cases.
+
+- [ ] **Step 5: Format the two touched files**
+
+Run:
+
+```powershell
+dotnet csharpier format samples/LmStreaming.Sample/Services/WebToolRegistrationPolicy.cs tests/LmStreaming.Sample.Tests/Services/WebToolRegistrationPolicyTests.cs
+```
+
+Expected: success.
+
+---
+
+### Task 3: Wire Every Copilot Provider Path and Resource Lifetime
+
+**Files:**
+- Modify: `samples/LmStreaming.Sample/Program.cs:985-1019,1024-1250,3045-3147`
+- Test: `tests/LmStreaming.Sample.Tests/Services/CopilotWebSearchRegistrationTests.cs`
+- Test: existing `tests/LmStreaming.Sample.Tests/Agents/MultiTurnAgentPoolTests.cs` only if an end-to-end disposal assertion needs the pool boundary.
+
+**Interfaces:**
+- Consumes: `CopilotWebSearchRegistration.TryRegister` and `WebToolRegistrationPolicy.Apply(... suppressWebSearch)`.
+- Produces: hosted search plus Jina fallback for dynamically discovered Copilot models and plain `copilot` CLI conversations.
+
+- [ ] **Step 1: Add a helper-level composition test before changing Program**
+
+Add a test that creates one registry, registers hosted search successfully, then applies Jina policy with `suppressWebSearch: result.Registered`. Assert exact names:
+
+```csharp
+names.Should().BeEquivalentTo("web_search", "WebFetch");
+```
+
+Repeat with failed hosted MCP and assert:
+
+```csharp
+names.Should().BeEquivalentTo("WebSearch", "WebFetch");
+```
+
+This is the deterministic RED/GREEN proof of the intended composition without booting the full sample.
+
+- [ ] **Step 2: Run the composition tests**
+
+Run:
+
+```powershell
+dotnet test tests/LmStreaming.Sample.Tests/LmStreaming.Sample.Tests.csproj --filter "FullyQualifiedName~CopilotWebSearchRegistrationTests|FullyQualifiedName~WebToolRegistrationPolicyTests"
+```
+
+Expected before wiring: helper-level tests PASS. Program behavior remains unimplemented.
+
+- [ ] **Step 3: Wire dynamically discovered Copilot models**
+
+In the middleware-provider path:
+
+1. initialize `ownedResources` as an empty `List<IAsyncDisposable>` instead of nullable;
+2. change existing MCP branches from assignment to `ownedResources.AddRange(...)`;
+3. after `isCopilotBackedModel` is resolved and before Jina policy runs, call `TryRegister` when true;
+4. append `result.Client` when non-null;
+5. pass `suppressWebSearch: result.Registered` to `WebToolRegistrationPolicy.Apply`;
+6. pass `ownedResources.Count == 0 ? null : ownedResources` into `AgentCreationResult` at the existing return site.
+
+Do not connect Copilot MCP for non-Copilot providers.
+
+- [ ] **Step 4: Wire the plain `copilot` CLI path through its dynamic function bridge**
+
+Before the early return at `Program.cs:985`:
+
+1. clone `functionRegistry` into a conversation-local registry so the singleton is never mutated;
+2. call `TryRegister` against the clone using the selected mode;
+3. call `WebToolRegistrationPolicy.Apply` with `providerId: "copilot"`, `isCopilotBackedModel: true`, and `suppressWebSearch: hostedResult.Registered` so Jina `WebFetch` and fallback `WebSearch` are available;
+4. pass the clone to `CreateCopilotAgentLoop`;
+5. return `new AgentCreationResult(loop, hostedResult.Client is null ? null : [hostedResult.Client])`.
+
+Do not add the same hosted endpoint through `extraMcpServers`: the CLI config would require embedding a bearer token that cannot refresh. The dynamic bridge reuses the authenticated in-process MCP client and existing `CopilotToolPolicyEngine`.
+
+- [ ] **Step 5: Preserve exact mode behavior**
+
+Ensure Research Assistant's existing `enabledTools` entries continue to enable:
+
+- hosted `web_search`;
+- Jina `WebFetch`;
+- Jina `WebSearch` fallback.
+
+Do not add tools to modes whose `EnabledTools` is empty. Keep `Prompts.yaml` unchanged unless a failing test proves the current entries insufficient.
+
+- [ ] **Step 6: Compile and run focused sample tests**
+
+Run:
+
+```powershell
+dotnet build samples/LmStreaming.Sample/LmStreaming.Sample.csproj
+dotnet test tests/LmStreaming.Sample.Tests/LmStreaming.Sample.Tests.csproj --filter "FullyQualifiedName~CopilotWebSearchRegistrationTests|FullyQualifiedName~WebToolRegistrationPolicyTests|FullyQualifiedName~MultiTurnAgentPool"
+```
+
+Expected: build succeeds with zero new warnings; focused tests pass.
+
+- [ ] **Step 7: Format Program and rerun compile**
+
+Run:
+
+```powershell
+dotnet csharpier format samples/LmStreaming.Sample/Program.cs
+dotnet build samples/LmStreaming.Sample/LmStreaming.Sample.csproj
+```
+
+Expected: success.
+
+---
+
+### Task 4: Proxy Contract and Opt-In Live Proof
+
+**Files:**
+- Modify: `tests/CopilotAnthropicProxy.Tests/McpProxyTests.cs:84-113`
+- Create: `tests/CopilotLive.Tests/CopilotMcpLiveTests.cs`
+- Modify: `samples/CopilotAnthropicProxy.Sample/README.md:228-253,290-338`
+
+**Interfaces:**
+- Consumes: real Copilot `/mcp/readonly`, `CopilotLiveFixture`, existing proxy header forwarding.
+- Produces: regression proof and operator documentation; no production proxy change.
+
+- [ ] **Step 1: Tighten the deterministic proxy header test**
+
+Change the representative selector in `X_mcp_control_headers_are_forwarded` from:
+
+```csharp
+"get_file_contents,search_code"
+```
+
+to:
+
+```csharp
+"web_search"
+```
+
+Keep assertions for `X-MCP-Readonly` and `X-MCP-Host`. This confirms the exact production selector is transparently forwarded by both existing proxy routes without changing proxy code.
+
+- [ ] **Step 2: Run proxy tests**
+
+Run:
+
+```powershell
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --filter FullyQualifiedName~McpProxyTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Add the opt-in live catalog test**
+
+Create `CopilotMcpLiveTests` using `IClassFixture<CopilotLiveFixture>`. The test must:
+
+1. skip when `_fixture.Available` is false;
+2. create `HttpClient` with `CopilotHttpClientFactory`;
+3. POST MCP `initialize` to `/mcp/readonly` with `X-MCP-Tools: web_search`, `Accept: application/json, text/event-stream`, and protocol `2025-06-18`;
+4. capture `Mcp-Session-Id` without printing it;
+5. POST `notifications/initialized` and `tools/list` with the same session/header set;
+6. parse the SSE `data:` JSON;
+7. assert exactly one tool named `web_search`, whose schema requires `query`;
+8. never emit authorization headers, token values, or session IDs to test output.
+
+Use a 30-second cancellation timeout and `Skip.If` for missing credentials only; protocol or catalog drift must fail visibly.
+
+- [ ] **Step 4: Run the opt-in live proof**
+
+Run:
+
+```powershell
+dotnet test tests/CopilotLive.Tests/CopilotLive.Tests.csproj --filter FullyQualifiedName~CopilotMcpLiveTests
+```
+
+Expected with valid local Copilot auth: PASS. Without auth: SKIP with the fixture's existing message.
+
+- [ ] **Step 5: Update proxy documentation**
+
+In the README's MCP section, add:
+
+- `X-MCP-Tools: web_search` exposes exactly Copilot's hosted general web-search tool on `/mcp/readonly`;
+- its contract takes required `query` and returns citation-bearing output;
+- no hosted `web_fetch` appeared in the verified catalog as of 2026-07-30;
+- `LmStreaming.Sample` therefore uses Jina for `WebFetch` and as search fallback.
+
+Replace the old “planned, not scheduled” paragraph that says MCP-backed web search is unimplemented; after this change, that statement would be stale for `LmStreaming.Sample`. Keep the proxy's hosted-tool stripping explanation intact because translating `/responses` hosted tools remains out of scope.
+
+- [ ] **Step 6: Format and run the affected tests**
+
+Run:
+
+```powershell
+dotnet csharpier format tests/CopilotAnthropicProxy.Tests/McpProxyTests.cs tests/CopilotLive.Tests/CopilotMcpLiveTests.cs
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --filter FullyQualifiedName~McpProxyTests
+```
+
+Expected: PASS.
+
+---
+
+### Task 5: Full Verification
+
+**Files:**
+- Verify all files listed above.
+- Do not modify `.env` or any credential store.
+
+**Interfaces:**
+- Consumes: completed Tasks 1-4.
+- Produces: build/test evidence suitable for completion reporting.
+
+- [ ] **Step 1: Verify secret files remain untouched**
+
+Run:
+
+```powershell
+git status --short
+git diff -- .env samples/LmStreaming.Sample/.env
+```
+
+Expected: no `.env` diff; only intended source/test/doc/spec/plan files plus the pre-existing `.claude/scratchpad/` entry.
+
+- [ ] **Step 2: Run all directly affected test projects**
+
+Run:
+
+```powershell
+dotnet test tests/LmStreaming.Sample.Tests/LmStreaming.Sample.Tests.csproj --logger "trx;LogFileName=copilot-jina-web-tools.trx" --results-directory .logs/test-results
+dotnet test tests/CopilotAnthropicProxy.Tests/CopilotAnthropicProxy.Tests.csproj --logger "trx;LogFileName=copilot-mcp-proxy.trx" --results-directory .logs/test-results
+```
+
+Expected: both projects PASS with no skipped deterministic tests.
+
+- [ ] **Step 3: Run solution build**
+
+Run:
+
+```powershell
+dotnet build LmDotnetTools.sln -bl:.logs/build.binlog
+```
+
+Expected: success with no new warnings.
+
+- [ ] **Step 4: Run the opt-in live MCP proof once more**
+
+Run:
+
+```powershell
+dotnet test tests/CopilotLive.Tests/CopilotLive.Tests.csproj --filter FullyQualifiedName~CopilotMcpLiveTests --logger "trx;LogFileName=copilot-mcp-live.trx" --results-directory .logs/test-results
+```
+
+Expected on this authorized development machine: PASS and exactly one discovered `web_search` contract.
+
+- [ ] **Step 5: Review the final diff**
+
+Run:
+
+```powershell
+git diff --check
+git diff --stat
+git status --short
+```
+
+Expected: no whitespace errors, no generated binaries/logs/secrets, and no unrelated project changes.
+
+- [ ] **Step 6: Report completion without committing**
+
+Report:
+
+- proxy behavior verified rather than rewritten;
+- hosted `web_search` registration paths covered;
+- Jina `WebFetch` and fallback behavior covered;
+- deterministic and live test outcomes;
+- any skipped live test or failure verbatim.
+
+Do not create a commit unless the user explicitly asks.

--- a/docs/superpowers/plans/2026-07-31-lmstreaming-output-token-policy.md
+++ b/docs/superpowers/plans/2026-07-31-lmstreaming-output-token-policy.md
@@ -1,0 +1,435 @@
+# LmStreaming.Sample Output-Token Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Configure `LmStreaming.Sample` to use 24,576 output tokens for primary conversations and 16,384 for sample-created delegated agents while preserving explicit budgets and the global library's existing 8,192 fallback.
+
+**Architecture:** Add a focused options type in the sample and bind it through standard .NET configuration with startup validation. Add a small sample-local policy helper that applies primary and delegated defaults without clamping explicit values, then call it from the existing root-agent, ordinary-subagent, and workflow-controller construction paths. Workflow delegates continue using the existing parent-budget inheritance path.
+
+**Tech Stack:** .NET 9, ASP.NET Core options/configuration, C#, xUnit, FluentAssertions, CSharpier.
+
+## Global Constraints
+
+- `AgentOutputTokens:Primary` defaults to exactly `24576`.
+- `AgentOutputTokens:Delegated` defaults to exactly `16384`.
+- Configuration must reject non-positive values and `Primary < Delegated` at startup.
+- Explicit `GenerateReplyOptions.MaxToken` values remain authoritative; do not clamp or rewrite them.
+- Keep `MultiTurnAgentBase.DefaultMaxTokenFloor` at `8192` for non-sample consumers.
+- Keep the change scoped to `LmStreaming.Sample`; do not introduce model-capability discovery or per-model maps.
+- Preserve all unrelated working-tree changes.
+- Do not create a git commit unless the user explicitly asks.
+
+---
+
+## File Structure
+
+- Create `samples/LmStreaming.Sample/Configuration/AgentOutputTokenOptions.cs` — owns configuration keys, defaults, and validation.
+- Create `samples/LmStreaming.Sample/Services/AgentOutputTokenPolicy.cs` — applies the validated sample policy to root options and subagent templates while preserving explicit values.
+- Modify `samples/LmStreaming.Sample/appsettings.json` — records the deployment defaults.
+- Modify `samples/LmStreaming.Sample/Program.cs` — registers options, resolves the policy, and uses it in the three construction paths.
+- Create `tests/LmStreaming.Sample.Tests/Configuration/AgentOutputTokenOptionsTests.cs` — tests defaults and validation.
+- Create `tests/LmStreaming.Sample.Tests/Services/AgentOutputTokenPolicyTests.cs` — tests primary/delegated application and explicit-value preservation.
+- Modify `tests/LmMultiTurn.Tests/MultiTurnAgentBudgetTests.cs` only if necessary to pin the unchanged library fallback at `8192`; otherwise leave it untouched and run it as a regression test.
+
+---
+
+### Task 1: Add and Validate Sample Token Configuration
+
+**Files:**
+- Create: `samples/LmStreaming.Sample/Configuration/AgentOutputTokenOptions.cs`
+- Modify: `samples/LmStreaming.Sample/appsettings.json`
+- Create: `tests/LmStreaming.Sample.Tests/Configuration/AgentOutputTokenOptionsTests.cs`
+
+**Interfaces:**
+- Produces: `AgentOutputTokenOptions.SectionName`, `Primary`, `Delegated`, and `Validate()`.
+- Consumes: standard `Microsoft.Extensions.Options.ValidateOptionsResult`.
+
+- [ ] **Step 1: Write failing default and validation tests**
+
+Create tests equivalent to:
+
+```csharp
+using LmStreaming.Sample.Configuration;
+
+namespace LmStreaming.Sample.Tests.Configuration;
+
+public sealed class AgentOutputTokenOptionsTests
+{
+    [Fact]
+    public void Defaults_ArePrimary24K_AndDelegated16K()
+    {
+        var options = new AgentOutputTokenOptions();
+
+        options.Primary.Should().Be(24_576);
+        options.Delegated.Should().Be(16_384);
+        options.Validate().Succeeded.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0, 16_384)]
+    [InlineData(24_576, 0)]
+    [InlineData(-1, 16_384)]
+    public void Validate_RejectsNonPositiveValues(int primary, int delegated)
+    {
+        new AgentOutputTokenOptions { Primary = primary, Delegated = delegated }
+            .Validate().Failed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_RejectsPrimaryBelowDelegated()
+    {
+        new AgentOutputTokenOptions { Primary = 16_383, Delegated = 16_384 }
+            .Validate().Failed.Should().BeTrue();
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test tests/LmStreaming.Sample.Tests/LmStreaming.Sample.Tests.csproj --filter FullyQualifiedName~AgentOutputTokenOptionsTests
+```
+
+Expected: compilation fails because `AgentOutputTokenOptions` does not exist.
+
+- [ ] **Step 3: Implement the options type**
+
+Create a sealed options type with this contract:
+
+```csharp
+namespace LmStreaming.Sample.Configuration;
+
+public sealed class AgentOutputTokenOptions
+{
+    public const string SectionName = "AgentOutputTokens";
+
+    public int Primary { get; init; } = 24_576;
+
+    public int Delegated { get; init; } = 16_384;
+
+    public ValidateOptionsResult Validate()
+    {
+        if (Primary <= 0)
+        {
+            return ValidateOptionsResult.Fail("AgentOutputTokens:Primary must be greater than zero.");
+        }
+
+        if (Delegated <= 0)
+        {
+            return ValidateOptionsResult.Fail("AgentOutputTokens:Delegated must be greater than zero.");
+        }
+
+        return Primary < Delegated
+            ? ValidateOptionsResult.Fail("AgentOutputTokens:Primary must be greater than or equal to Delegated.")
+            : ValidateOptionsResult.Success;
+    }
+}
+```
+
+Add the required `Microsoft.Extensions.Options` using. Keep validation in this type so tests do not require booting the whole web host.
+
+- [ ] **Step 4: Add checked-in defaults to appsettings**
+
+Add this top-level section to `samples/LmStreaming.Sample/appsettings.json`:
+
+```json
+"AgentOutputTokens": {
+  "Primary": 24576,
+  "Delegated": 16384
+}
+```
+
+Do not add a duplicate section to `appsettings.Development.json`; normal configuration layering and `AgentOutputTokens__*` environment variables already provide overrides.
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+Run the same filtered `dotnet test` command.
+
+Expected: all `AgentOutputTokenOptionsTests` pass.
+
+---
+
+### Task 2: Add the Sample-Local Application Policy
+
+**Files:**
+- Create: `samples/LmStreaming.Sample/Services/AgentOutputTokenPolicy.cs`
+- Create: `tests/LmStreaming.Sample.Tests/Services/AgentOutputTokenPolicyTests.cs`
+
+**Interfaces:**
+- Consumes: `AgentOutputTokenOptions`, `GenerateReplyOptions`, `SubAgentOptions`, `SubAgentTemplate`.
+- Produces:
+  - `GenerateReplyOptions ApplyPrimary(GenerateReplyOptions options)`
+  - `GenerateReplyOptions ApplyDelegated(GenerateReplyOptions? options)`
+  - `SubAgentOptions ApplyDelegated(SubAgentOptions options)`
+
+- [ ] **Step 1: Write failing policy tests**
+
+Cover these exact cases:
+
+```csharp
+[Fact]
+public void ApplyPrimary_UsesConfiguredPrimaryWhenUnset()
+{
+    var policy = Policy(primary: 30_000, delegated: 18_000);
+
+    policy.ApplyPrimary(new GenerateReplyOptions()).MaxToken.Should().Be(30_000);
+}
+
+[Fact]
+public void ApplyPrimary_PreservesExplicitValue()
+{
+    var policy = Policy(primary: 30_000, delegated: 18_000);
+
+    policy.ApplyPrimary(new GenerateReplyOptions { MaxToken = 4_096 })
+        .MaxToken.Should().Be(4_096);
+}
+
+[Fact]
+public void ApplyDelegatedOptions_UsesConfiguredDelegatedWhenUnset()
+{
+    Policy().ApplyDelegated((GenerateReplyOptions?)null).MaxToken.Should().Be(16_384);
+}
+
+[Fact]
+public void ApplyDelegatedTemplates_FillsOnlyMissingBudgets()
+{
+    var options = new SubAgentOptions
+    {
+        Templates = new Dictionary<string, SubAgentTemplate>
+        {
+            ["unset"] = Template(defaultOptions: null),
+            ["explicit"] = Template(defaultOptions: new GenerateReplyOptions { MaxToken = 7_000 }),
+        },
+    };
+
+    var result = Policy().ApplyDelegated(options);
+
+    result.Templates["unset"].DefaultOptions!.MaxToken.Should().Be(16_384);
+    result.Templates["explicit"].DefaultOptions!.MaxToken.Should().Be(7_000);
+}
+```
+
+Also assert that all non-token template fields and non-template `SubAgentOptions` fields remain equivalent.
+
+- [ ] **Step 2: Run the focused policy tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test tests/LmStreaming.Sample.Tests/LmStreaming.Sample.Tests.csproj --filter FullyQualifiedName~AgentOutputTokenPolicyTests
+```
+
+Expected: compilation fails because `AgentOutputTokenPolicy` does not exist.
+
+- [ ] **Step 3: Implement the minimal policy**
+
+Implement a sealed class that accepts validated `AgentOutputTokenOptions` and uses record `with` expressions:
+
+```csharp
+public GenerateReplyOptions ApplyPrimary(GenerateReplyOptions options) =>
+    options.MaxToken is null ? options with { MaxToken = _options.Primary } : options;
+
+public GenerateReplyOptions ApplyDelegated(GenerateReplyOptions? options)
+{
+    var effective = options ?? new GenerateReplyOptions();
+    return effective.MaxToken is null
+        ? effective with { MaxToken = _options.Delegated }
+        : effective;
+}
+
+public SubAgentOptions ApplyDelegated(SubAgentOptions options) =>
+    options with
+    {
+        Templates = options.Templates.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value with { DefaultOptions = ApplyDelegated(pair.Value.DefaultOptions) },
+            StringComparer.Ordinal),
+    };
+```
+
+Use a new dictionary rather than mutating discovery/shared template sources. Preserve keys and every template field except a missing `DefaultOptions.MaxToken`.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run the same filtered policy-test command.
+
+Expected: all policy tests pass.
+
+---
+
+### Task 3: Wire the Policy Through LmStreaming.Sample
+
+**Files:**
+- Modify: `samples/LmStreaming.Sample/Program.cs:130-150`
+- Modify: `samples/LmStreaming.Sample/Program.cs:1393-1426`
+- Modify: `samples/LmStreaming.Sample/Program.cs:1525-1596`
+- Modify: `samples/LmStreaming.Sample/Program.cs:1616-1628`
+- Modify: `samples/LmStreaming.Sample/Program.cs:1720-1738`
+- Modify or extend: `tests/LmStreaming.Sample.Tests/ProgramSubAgentCompositionTests.cs`
+- Modify or extend: `tests/LmStreaming.Sample.Tests/WorkspaceWorkflowWiringTests.cs`
+
+**Interfaces:**
+- Consumes: `AgentOutputTokenPolicy` from Task 2 and `IOptions<AgentOutputTokenOptions>` from Task 1.
+- Produces: root `GenerateReplyOptions.MaxToken = Primary`; sample templates/controller defaults use `Delegated` when unset.
+
+- [ ] **Step 1: Add failing composition tests for Program-facing helpers**
+
+Expose narrow `internal static` wrappers on `Program` only if direct closure testing is impractical:
+
+```csharp
+internal static SubAgentOptions ApplyDelegatedOutputTokens(
+    SubAgentOptions options,
+    AgentOutputTokenPolicy policy) => policy.ApplyDelegated(options);
+
+internal static GenerateReplyOptions ApplyPrimaryOutputTokens(
+    GenerateReplyOptions options,
+    AgentOutputTokenPolicy policy) => policy.ApplyPrimary(options);
+```
+
+Write tests proving the wrappers preserve explicit values and apply configured defaults. For workflow wiring, construct `WorkflowManager` with controller defaults returned by `policy.ApplyDelegated(new GenerateReplyOptions { ModelId = "controller" })`, then use the existing observable/controller construction seams to assert the effective controller `MaxToken` is delegated. If `WorkflowManager` does not expose that value, keep the assertion at the policy helper boundary rather than adding production observability solely for a test.
+
+- [ ] **Step 2: Run composition tests and verify RED**
+
+Run:
+
+```powershell
+dotnet test tests/LmStreaming.Sample.Tests/LmStreaming.Sample.Tests.csproj --filter "FullyQualifiedName~ProgramSubAgentCompositionTests|FullyQualifiedName~WorkspaceWorkflowWiringTests"
+```
+
+Expected: new assertions fail or compilation fails because policy wiring helpers are absent.
+
+- [ ] **Step 3: Register and validate options at startup**
+
+Immediately after `AddLmStreaming`, register:
+
+```csharp
+_ = builder.Services
+    .AddOptions<AgentOutputTokenOptions>()
+    .Bind(builder.Configuration.GetSection(AgentOutputTokenOptions.SectionName))
+    .Validate(options => options.Validate().Succeeded, "Invalid AgentOutputTokens configuration.")
+    .ValidateOnStart();
+_ = builder.Services.AddSingleton<AgentOutputTokenPolicy>();
+```
+
+If preserving the detailed validation message requires `IValidateOptions<AgentOutputTokenOptions>`, register the options type as that validator instead of collapsing messages into the predicate. Prefer detailed startup messages if this can be done without adding another type.
+
+- [ ] **Step 4: Resolve the policy once in the conversation factory**
+
+Near the existing provider/subagent setup, resolve:
+
+```csharp
+var outputTokenPolicy = sp.GetRequiredService<AgentOutputTokenPolicy>();
+```
+
+Do not read configuration directly inside the closure.
+
+- [ ] **Step 5: Apply delegated defaults to ordinary subagents**
+
+After `BuildSubAgentOptionsAsync` returns non-null and before catalog binding/inheritance, call:
+
+```csharp
+subAgentOptions = outputTokenPolicy.ApplyDelegated(subAgentOptions);
+```
+
+Apply this before creating/reusing the shared template source so dynamically shared templates start with the host default. For templates discovered later, identify the registration seam; if late registrations bypass this normalization, wrap the source registration or apply the policy at the final spawn/template resolution boundary available in the sample. Do not modify `SubAgentManager` globally.
+
+- [ ] **Step 6: Apply delegated defaults to workflow controller templates and controller options**
+
+In `BuildControllerOptions`, normalize the returned `SubAgentOptions` through `outputTokenPolicy.ApplyDelegated` before applying the conversation store.
+
+Set controller defaults using:
+
+```csharp
+controllerDefaultOptions: outputTokenPolicy.ApplyDelegated(
+    new GenerateReplyOptions
+    {
+        ModelId = controllerModelId,
+        ExtraProperties = BuildControllerReasoningExtraProperties(...),
+    })
+```
+
+The existing workflow delegate inheritance then carries 16K from controller to unset delegate templates. Explicit delegate-template `MaxToken` values continue to win.
+
+- [ ] **Step 7: Replace the root hardcode with primary policy application**
+
+Build the existing root options without `MaxToken = 8192`, then wrap them:
+
+```csharp
+defaultOptions: outputTokenPolicy.ApplyPrimary(
+    new GenerateReplyOptions
+    {
+        ModelId = modelId,
+        BuiltInTools = filteredBuiltInTools,
+        RequestResponseDumpFileName = requestResponseDumpFileName,
+        PromptCaching = PromptCachingMode.Auto,
+        ExtraProperties = extraProperties,
+    })
+```
+
+Delete the obsolete comment about a fixed 2,048-token thinking budget and replace it with a short comment pointing to `AgentOutputTokens` configuration only if the code is not self-explanatory.
+
+- [ ] **Step 8: Run composition tests and verify GREEN**
+
+Run the filtered composition command from Step 2.
+
+Expected: all tests pass.
+
+---
+
+### Task 4: Prove the Policy End to End and Protect Global Compatibility
+
+**Files:**
+- Test: `tests/LmStreaming.Sample.Tests/LmStreaming.Sample.Tests.csproj`
+- Test: `tests/LmMultiTurn.Tests/LmMultiTurn.Tests.csproj`
+- Format: all modified `.cs` files
+
+**Interfaces:**
+- Consumes all prior tasks.
+- Produces verified sample-local behavior with unchanged global fallback.
+
+- [ ] **Step 1: Run the full sample unit-test project**
+
+```powershell
+dotnet test tests/LmStreaming.Sample.Tests/LmStreaming.Sample.Tests.csproj --logger "trx;LogFileName=lmstreaming-output-policy.trx" --results-directory .logs/test-results
+```
+
+Expected: PASS with zero failed tests.
+
+- [ ] **Step 2: Run the global multi-turn budget regression tests**
+
+```powershell
+dotnet test tests/LmMultiTurn.Tests/LmMultiTurn.Tests.csproj --filter FullyQualifiedName~MultiTurnAgentBudgetTests --logger "trx;LogFileName=multiturn-budget.trx" --results-directory .logs/test-results
+```
+
+Expected: PASS. Confirm `src/LmMultiTurn/MultiTurnAgentBase.cs` remains unchanged and its `DefaultMaxTokenFloor` is still `8192`.
+
+- [ ] **Step 3: Format only changed C# files**
+
+Run CSharpier against the exact changed files, for example:
+
+```powershell
+dotnet csharpier format samples/LmStreaming.Sample/Configuration/AgentOutputTokenOptions.cs samples/LmStreaming.Sample/Services/AgentOutputTokenPolicy.cs samples/LmStreaming.Sample/Program.cs tests/LmStreaming.Sample.Tests/Configuration/AgentOutputTokenOptionsTests.cs tests/LmStreaming.Sample.Tests/Services/AgentOutputTokenPolicyTests.cs tests/LmStreaming.Sample.Tests/ProgramSubAgentCompositionTests.cs tests/LmStreaming.Sample.Tests/WorkspaceWorkflowWiringTests.cs
+```
+
+Do not format unrelated modified files.
+
+- [ ] **Step 4: Re-run both test commands after formatting**
+
+Expected: both test runs pass.
+
+- [ ] **Step 5: Inspect the final diff for scope and unrelated changes**
+
+```powershell
+git diff -- samples/LmStreaming.Sample/Configuration/AgentOutputTokenOptions.cs samples/LmStreaming.Sample/Services/AgentOutputTokenPolicy.cs samples/LmStreaming.Sample/appsettings.json samples/LmStreaming.Sample/Program.cs tests/LmStreaming.Sample.Tests
+```
+
+Verify:
+
+- Primary default is 24,576.
+- Delegated default is 16,384.
+- Explicit `MaxToken` values are preserved.
+- No global library constant changed.
+- No unrelated user edits were overwritten.
+- No commit was created.

--- a/docs/superpowers/specs/2026-07-30-copilot-jina-web-tools-design.md
+++ b/docs/superpowers/specs/2026-07-30-copilot-jina-web-tools-design.md
@@ -1,0 +1,126 @@
+# Copilot and Jina Web Tools Design
+
+**Date:** 2026-07-30
+
+## Goal
+
+Expose general web search to Copilot providers through GitHub Copilot's hosted readonly MCP endpoint, while retaining Jina as the URL-fetch implementation and as the web-search fallback. Keep the change narrow and reuse the existing MCP and web-tool infrastructure.
+
+## Confirmed upstream behavior
+
+Live probing through the existing local `CopilotAnthropicProxy.Sample` established that:
+
+- `POST /mcp/readonly` supports MCP protocol `2025-06-18` and returns a session ID.
+- The request header `X-MCP-Tools: web_search` makes `tools/list` expose exactly one tool named `web_search`.
+- `web_search` accepts one required string parameter, `query`, and returns an AI-generated web answer with citations and sources.
+- The hosted catalog does not expose a `web_fetch` tool.
+- The existing `/mcp` and `/mcp/readonly` proxy routes already relay request bodies, response bodies, streaming responses, MCP session/protocol headers, and `X-MCP-*` headers. They do not require reimplementation.
+
+## Scope
+
+### In scope
+
+1. Verify and retain transparent proxying of `/mcp` and `/mcp/readonly` to GitHub Copilot.
+2. For all Copilot provider paths, expose Copilot's hosted `web_search` selected with `X-MCP-Tools: web_search`.
+3. Configure Jina `WebFetch` from `JINA_API_KEY` loaded from the sample's `.env` file.
+4. Use Jina `WebSearch` as the fallback when Copilot hosted MCP search cannot be initialized.
+5. Preserve chat-mode `EnabledTools` filtering.
+6. Degrade gracefully when Copilot MCP is unavailable.
+
+### Out of scope
+
+- Importing GitHub's code, issue, pull-request, repository, commit, or user search tools.
+- Importing the complete Copilot readonly MCP catalog.
+- Translating arbitrary Anthropic/OpenAI hosted-tool types into MCP calls.
+- Adding an MCP protocol parser to the proxy.
+- Adding a new dotenv library or logging API keys.
+
+## Architecture
+
+### Existing proxy
+
+Keep `CopilotAnthropicProxy.Sample`'s `/mcp` and `/mcp/readonly` mappings unchanged. Extend tests only where needed to prove that `X-MCP-Tools: web_search` is forwarded verbatim alongside raw JSON-RPC bodies and MCP session headers.
+
+### Copilot hosted web search
+
+Add a small sample-level registration helper adjacent to `WebToolRegistrationPolicy`. It will:
+
+1. Run only for Copilot-backed providers.
+2. Build an authenticated Copilot `HttpClient` through `CopilotHttpClientFactory`, preserving per-request token refresh and required Copilot headers.
+3. Create an MCP Streamable-HTTP client targeting `{CopilotBaseUrl}/mcp/readonly`.
+4. Set `X-MCP-Tools: web_search`, so discovery returns only the desired hosted tool.
+5. Import the discovered tool through the existing `McpClientFunctionProvider`/`FunctionRegistry` path.
+6. Return the MCP client as an owned asynchronous resource for conversation-lifetime disposal.
+7. Return a success indicator and diagnostic status so the caller can choose the Jina fallback.
+
+The helper remains sample-specific. It does not become a new general provider abstraction.
+
+### Provider coverage
+
+- Dynamically discovered Copilot-backed Anthropic and OpenAI models receive the hosted MCP function in their per-conversation registry.
+- The plain `copilot` CLI path receives the same capability through the smallest existing compatible path: prefer its MCP-server configuration when the CLI can carry Copilot authentication and the required header; otherwise expose the imported function through the existing dynamic-tool bridge. The implementation plan must verify this path before choosing it.
+- Non-Copilot providers retain current behavior.
+
+### Jina WebSearch and WebFetch
+
+`LmStreaming.Sample` already calls `EnvironmentHelper.LoadEnvIfNeeded(FindEnvFile())` before `WebToolsOptions.FromEnvironment()`. A sample-local `.env` is therefore a supported source for `JINA_API_KEY`; no secret-loading code change is required unless a regression test proves otherwise.
+
+Retain `WebToolRegistrationPolicy` and its provider/mode filtering:
+
+- `WebFetch` is registered through Jina for eligible providers whenever enabled by the selected mode and `JINA_API_KEY` is present.
+- For Copilot paths, Jina `WebSearch` is registered only when hosted MCP `web_search` registration failed or was unavailable.
+- Existing name-collision checks remain authoritative.
+- Direct providers with native web capability retain the current capability policy.
+
+## Data flow
+
+1. The sample loads `.env` without logging secret values.
+2. It creates `WebToolsOptions` and a process-level `JinaWebProvider` when `JINA_API_KEY` is available.
+3. During Copilot conversation creation, the hosted-search registration helper connects to `/mcp/readonly` with `X-MCP-Tools: web_search`.
+4. On success, the sole MCP contract is added to the active function registry and the MCP client is added to conversation-owned resources.
+5. `WebToolRegistrationPolicy` adds Jina `WebFetch`; it skips Jina `WebSearch` because hosted search succeeded.
+6. On MCP failure, the helper logs a structured warning and returns failure. Conversation creation continues, and `WebToolRegistrationPolicy` adds Jina `WebSearch` and `WebFetch` when enabled and configured.
+7. Tool calls execute through the existing middleware and MCP/Jina handlers.
+
+## Error handling
+
+- MCP initialization, discovery, or call failures must not make a Copilot provider unavailable.
+- Initialization/discovery failure produces one structured warning without credentials, authorization headers, session IDs, or response bodies that may contain sensitive data.
+- A failed MCP client is disposed immediately.
+- Successfully created MCP clients are disposed with the conversation agent.
+- Missing `JINA_API_KEY` leaves Jina tools disabled using the existing status reporting.
+- When both Copilot MCP and Jina are unavailable, the provider remains usable without web tools.
+
+## Testing
+
+### Deterministic tests
+
+1. Proxy tests prove `/mcp` and `/mcp/readonly` forward:
+   - raw JSON-RPC bodies;
+   - `Mcp-Session-Id` and `Mcp-Protocol-Version`;
+   - `X-MCP-Tools: web_search`;
+   - streamed responses and statuses.
+2. Hosted-search registration tests use a fake MCP upstream to prove:
+   - only `web_search` is imported;
+   - non-Copilot providers do not connect;
+   - mode filtering can suppress the tool;
+   - failure returns control for Jina fallback;
+   - created clients are disposed.
+3. Web-tool policy tests prove:
+   - Copilot MCP success yields hosted `web_search` plus Jina `WebFetch`, without duplicate Jina `WebSearch`;
+   - MCP failure yields Jina `WebSearch` and `WebFetch` when configured;
+   - missing Jina configuration remains non-fatal;
+   - non-Copilot behavior is unchanged.
+4. Environment-loading coverage proves the sample resolves its local `.env` before constructing web-tool options without reading or printing the key.
+
+### Opt-in live test
+
+Add or extend `tests/CopilotLive.Tests` to initialize the real readonly MCP endpoint with `X-MCP-Tools: web_search` and assert that `tools/list` returns exactly that contract. It remains outside the solution/CI and skips when Copilot credentials are unavailable.
+
+## Success criteria
+
+- Existing proxy routes continue to pass MCP traffic transparently.
+- Copilot-backed models can call hosted `web_search` without importing unrelated GitHub tools.
+- Jina performs URL fetches and provides search fallback using `JINA_API_KEY` from the sample's `.env`.
+- Web-tool availability still respects the selected chat mode.
+- Copilot and conversations remain usable when either hosted MCP or Jina is unavailable.

--- a/docs/superpowers/specs/2026-07-31-lmstreaming-output-token-policy-design.md
+++ b/docs/superpowers/specs/2026-07-31-lmstreaming-output-token-policy-design.md
@@ -1,0 +1,86 @@
+# LmStreaming.Sample Output-Token Policy Design
+
+## Status
+
+Approved for implementation on 2026-07-31.
+
+## Problem
+
+`LmStreaming.Sample` hardcodes `MaxToken = 8192` for primary conversations. The value was originally chosen around a fixed 2,048-token thinking budget and is no longer appropriate for current adaptive-thinking, tool-heavy models. In a real Claude Opus 5 conversation, two turns exhausted all 8,192 output tokens and truncated `Write` tool arguments before the file content was emitted.
+
+The generic `LmMultiTurn` library also has an 8,192 unset-value floor. Other library consumers may rely on that behavior, so this change must not alter the global default.
+
+## Policy
+
+Within `LmStreaming.Sample`:
+
+- Primary conversation loops default to 24,576 output tokens.
+- Sample-created delegated loops default to 16,384 output tokens.
+- An explicit template or caller `MaxToken` remains authoritative.
+- Other `LmMultiTurn` consumers retain the existing 8,192 library fallback.
+
+## Configuration
+
+Add typed sample configuration bound from:
+
+```json
+{
+  "AgentOutputTokens": {
+    "Primary": 24576,
+    "Delegated": 16384
+  }
+}
+```
+
+The options type validates both values as positive integers and requires `Primary >= Delegated`. Invalid startup configuration fails clearly rather than silently restoring an unsafe ceiling.
+
+Environment-specific configuration can override the normal .NET configuration keys, including `AgentOutputTokens__Primary` and `AgentOutputTokens__Delegated`.
+
+## Data Flow
+
+### Primary conversation
+
+The conversation factory reads the validated options and supplies `Primary` to the root `MultiTurnAgentLoop` through `GenerateReplyOptions.MaxToken`.
+
+### Ordinary subagents
+
+The sample normalizes its subagent templates before passing them to `SubAgentManager`: when a template has no explicit `DefaultOptions.MaxToken`, it receives `Delegated`; explicit values are unchanged. This makes the host policy independent of the global library fallback.
+
+### Workflow controllers
+
+`WorkflowManager.ControllerDefaultOptions.MaxToken` receives `Delegated`. A per-run model/provider override changes only the model and reasoning transport metadata, preserving the configured token budget.
+
+### Workflow delegates
+
+Workflow delegates inherit the workflow controller's effective `MaxToken` through the existing `SubAgentManager.ResolveSubAgentOptions` path. A delegate template with an explicit `MaxToken` continues to win.
+
+## Compatibility
+
+- No public `LmCore` or `LmMultiTurn` API changes are required.
+- `MultiTurnAgentBase.DefaultMaxTokenFloor` remains 8,192.
+- Direct callers that explicitly set smaller budgets remain unchanged.
+- Provider request conversion remains unchanged; it receives the larger host-selected value through existing `GenerateReplyOptions`.
+- All requests are already streamed, so 24K does not introduce a non-streaming timeout concern.
+
+## Testing
+
+Add focused tests that prove:
+
+1. Default configuration binds to 24,576 primary and 16,384 delegated tokens.
+2. Invalid non-positive values fail validation.
+3. `Primary < Delegated` fails validation.
+4. The root conversation construction path uses the configured primary value.
+5. Sample template normalization fills only missing delegated budgets.
+6. Explicit template budgets are preserved.
+7. Workflow controller defaults use the configured delegated value.
+8. Existing `LmMultiTurn` budget tests remain unchanged, proving the global library default was not modified.
+
+Where direct construction of the large `Program.cs` closure is impractical, extract a small internal sample policy/helper that applies the options to `GenerateReplyOptions` and templates; test that helper directly. The helper must remain narrowly scoped to token-policy application rather than becoming a general options builder.
+
+## Non-goals
+
+- Dynamic model-capability discovery.
+- Raising or clamping explicit caller budgets.
+- Changing defaults for other samples or library consumers.
+- Introducing per-model token mappings.
+- Changing thinking or effort configuration.

--- a/samples/CopilotAnthropicProxy.Sample/README.md
+++ b/samples/CopilotAnthropicProxy.Sample/README.md
@@ -251,6 +251,12 @@ remain raw pass-through and do not gain local fallback tools. `DELETE` and an up
 clear the corresponding local routing snapshot. `/mcp` and `/mcp/readonly` keep independent snapshots.
 Point MCP Streamable-HTTP clients at `http://127.0.0.1:8787/mcp` or `/mcp/readonly` as before.
 
+Live verification on 2026-07-30 established that sending `X-MCP-Tools: web_search` to
+`/mcp/readonly` exposes exactly Copilot's hosted general `web_search` tool. Its input schema requires
+a single `query` string and its output includes inline citations and sources. The verified hosted
+catalog did not expose a `web_fetch` tool; `LmStreaming.Sample` therefore uses Jina for `WebFetch`
+and as the `WebSearch` fallback when hosted MCP search is unavailable.
+
 **Header policy**: every inbound header is forwarded verbatim **except** `Authorization` (the
 proxy attaches its own Copilot bearer token instead, via the same `CopilotHeadersHandler` used for
 `/v1/messages`) and a handful of hop-by-hop/framing headers .NET's `HttpClient` must own
@@ -349,10 +355,11 @@ Copilot's backend rejects three things its clients routinely send. All are strip
   tools are forwarded byte-for-byte.
 
   Dropping those two is a decision rather than an oversight, and so is the fact that the allowlist
-  does not widen on its own — it is meant to be curated by hand. The planned direction for web
-  search (agreed, not scheduled) is to stop treating it as a server tool at all: the proxy would
-  expose it as a client tool it implements itself and service the call against Copilot's MCP server,
-  which turns it into an ordinary `function` and removes the exemption instead of widening the list.
+  does not widen on its own — it is meant to be curated by hand. `LmStreaming.Sample` now exposes
+  hosted search as an ordinary client function by importing Copilot's `/mcp/readonly` `web_search`
+  tool with `X-MCP-Tools: web_search`; it does not widen this hosted-tool allowlist or translate
+  `/responses` server-tool definitions. The proxy sample itself remains a transparent MCP endpoint
+  rather than an MCP client or tool executor.
 
 The translated route avoids the first two by construction: it builds a new Responses body from an
 explicit allowlist rather than patching the inbound one, so `betas`, `cache_control`, `metadata` and

--- a/samples/LmStreaming.Sample/Configuration/AgentOutputTokenOptions.cs
+++ b/samples/LmStreaming.Sample/Configuration/AgentOutputTokenOptions.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Options;
+
+namespace LmStreaming.Sample.Configuration;
+
+public sealed class AgentOutputTokenOptions
+{
+    public const string SectionName = "AgentOutputTokens";
+
+    public int Primary { get; init; } = 24_576;
+
+    public int Delegated { get; init; } = 16_384;
+
+    public ValidateOptionsResult Validate()
+    {
+        if (Primary <= 0)
+        {
+            return ValidateOptionsResult.Fail("AgentOutputTokens:Primary must be greater than zero.");
+        }
+
+        if (Delegated <= 0)
+        {
+            return ValidateOptionsResult.Fail("AgentOutputTokens:Delegated must be greater than zero.");
+        }
+
+        return Primary < Delegated
+            ? ValidateOptionsResult.Fail("AgentOutputTokens:Primary must be greater than or equal to Delegated.")
+            : ValidateOptionsResult.Success;
+    }
+}

--- a/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
+++ b/samples/LmStreaming.Sample/Controllers/ContextDiscoveryController.cs
@@ -3,6 +3,7 @@ using AchieveAi.LmDotnetTools.LmAgentInfra.Auth;
 using AchieveAi.LmDotnetTools.LmAgentInfra.Context;
 using AchieveAi.LmDotnetTools.LmAgentInfra.Sandbox;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Services.Discovery;
 using Microsoft.AspNetCore.Mvc;
 
@@ -41,6 +42,7 @@ public sealed class ContextDiscoveryController(
     WorkspaceSubAgentLoader subAgentLoader,
     ContextDiscoveryInjector contextInjector,
     ContextDiscoveryDiagnostics diagnostics,
+    AgentOutputTokenPolicy outputTokenPolicy,
     ILogger<ContextDiscoveryController> logger) : ControllerBase
 {
     /// <summary>
@@ -315,11 +317,13 @@ public sealed class ContextDiscoveryController(
             // (with the first conversation's factory), but each conversation must spawn the
             // discovered sub-agent with its OWN provider — otherwise a sub-agent fanned into
             // conversation B would run on conversation A's provider.
-            var conversationTemplate = template with
-            {
-                AgentFactory = binding.AgentFactory,
-                CharacteristicsAgentFactory = binding.CharacteristicsAgentFactory,
-            };
+            var conversationTemplate = outputTokenPolicy.ApplyDelegated(
+                template with
+                {
+                    AgentFactory = binding.AgentFactory,
+                    CharacteristicsAgentFactory = binding.CharacteristicsAgentFactory,
+                }
+            );
 
             if (binding.Source.TryRegister(registrationKey, conversationTemplate))
             {

--- a/samples/LmStreaming.Sample/Program.cs
+++ b/samples/LmStreaming.Sample/Program.cs
@@ -135,6 +135,13 @@ try
         options.WebSocketPath = "/ws";
         options.WriteIndentedJson = builder.Environment.IsDevelopment();
     });
+    _ = builder.Services
+        .AddOptions<AgentOutputTokenOptions>()
+        .Bind(builder.Configuration.GetSection(AgentOutputTokenOptions.SectionName))
+        .Validate(options => options.Validate().Succeeded, "Invalid AgentOutputTokens configuration.")
+        .ValidateOnStart();
+    _ = builder.Services.AddSingleton(sp =>
+        new AgentOutputTokenPolicy(sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<AgentOutputTokenOptions>>().Value));
 
     // Service-to-service lifecycle observation and remote tool approval (ADR 0003 + ADR 0005). Both
     // are off unless the matching `Lifecycle:*:Enabled` flag is set, and this file carries no default
@@ -1097,39 +1104,95 @@ try
 
                 if (string.Equals(normalizedProviderId, "copilot", StringComparison.Ordinal))
                 {
-                    // Sandbox MCP header dict: X-Session-ID plus the app's sandbox auth headers.
-                    // The caller's credential (S2S) wins over the process default so an S2S
-                    // caller's /mcp tool calls carry its own identity; the interactive UI (null)
-                    // falls back to the default (issue #153 M1/M2). Connect-time-frozen for the
-                    // pooled agent by design — not re-evaluated per turn.
-                    Dictionary<string, string>? sandboxMcpHeaders = null;
-                    if (isWorkspaceMode)
+                    // Keep hosted/Jina web tools conversation-local; the shared registry is a process
+                    // singleton and must never retain an MCP client owned by one pooled agent.
+                    var copilotRegistry = new FunctionRegistry();
+                    var (copilotSharedContracts, copilotSharedHandlers) = functionRegistry.Build();
+                    foreach (var contract in copilotSharedContracts)
                     {
-                        sandboxMcpHeaders = new Dictionary<string, string>
+                        if (copilotSharedHandlers.TryGetValue(contract.Name, out var handler))
                         {
-                            ["X-Session-ID"] = sandboxSession!.SessionId,
-                        };
-                        AddSandboxAuthHeaders(
-                            sandboxMcpHeaders,
-                            callerCredential ?? sandboxCredential
-                        );
+                            _ = copilotRegistry.AddFunction(contract, handler, "SampleTools");
+                        }
                     }
 
-                    return new MultiTurnAgentPool.AgentCreationResult(
-                        CreateCopilotAgentLoop(
-                            threadId,
-                            effectiveMode,
-                            functionRegistry,
-                            requestResponseDumpFileName,
-                            conversationStore,
-                            loggerFactory,
-                            extraMcpServers: isWorkspaceMode
-                                ? BuildHttpMcpServer("sandbox", $"{sandboxLifetime.GatewayBaseUrl}/mcp", sandboxMcpHeaders!)
-                                : null,
-                            workingDirectoryOverride: isWorkspaceMode ? sandboxSession!.HostPath : null,
-                            lifecycleServices: lifecycleServices
-                        )
+                    var cliHostedSearch = CopilotWebSearchRegistration.TryRegister(
+                        copilotRegistry,
+                        WebToolRegistrationPolicy.ResolveEnabledTools(
+                            mode.EnabledTools,
+                            mode.EnabledBuiltInTools
+                        ),
+                        s_copilotTokenProvider.Value,
+                        s_copilotSession.Value,
+                        new CopilotOptions(),
+                        loggerFactory
                     );
+                    try
+                    {
+                        _ = WebToolRegistrationPolicy.Apply(
+                            copilotRegistry,
+                            normalizedProviderId,
+                            WebToolRegistrationPolicy.ResolveEnabledTools(
+                                mode.EnabledTools,
+                                mode.EnabledBuiltInTools
+                            ),
+                            jinaWebProvider,
+                            webToolsOptions,
+                            loggerFactory,
+                            isCopilotBackedModel: true,
+                            suppressWebSearch: cliHostedSearch.Registered
+                        );
+
+                        // Sandbox MCP header dict: X-Session-ID plus the app's sandbox auth headers.
+                        // The caller's credential (S2S) wins over the process default so an S2S
+                        // caller's /mcp tool calls carry its own identity; the interactive UI (null)
+                        // falls back to the default (issue #153 M1/M2). Connect-time-frozen for the
+                        // pooled agent by design — not re-evaluated per turn.
+                        Dictionary<string, string>? sandboxMcpHeaders = null;
+                        if (isWorkspaceMode)
+                        {
+                            sandboxMcpHeaders = new Dictionary<string, string>
+                            {
+                                ["X-Session-ID"] = sandboxSession!.SessionId,
+                            };
+                            AddSandboxAuthHeaders(
+                                sandboxMcpHeaders,
+                                callerCredential ?? sandboxCredential
+                            );
+                        }
+
+                        return new MultiTurnAgentPool.AgentCreationResult(
+                            CreateCopilotAgentLoop(
+                                threadId,
+                                effectiveMode,
+                                copilotRegistry,
+                                requestResponseDumpFileName,
+                                conversationStore,
+                                loggerFactory,
+                                extraMcpServers: isWorkspaceMode
+                                    ? BuildHttpMcpServer("sandbox", $"{sandboxLifetime.GatewayBaseUrl}/mcp", sandboxMcpHeaders!)
+                                    : null,
+                                workingDirectoryOverride: isWorkspaceMode ? sandboxSession!.HostPath : null,
+                                lifecycleServices: lifecycleServices
+                            ),
+                            cliHostedSearch.Resource is null ? null : [cliHostedSearch.Resource]
+                        );
+                    }
+                    catch
+                    {
+                        if (cliHostedSearch.Resource is not null)
+                        {
+                            try
+                            {
+                                cliHostedSearch.Resource.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                            }
+                            catch
+                            { /* ignore cleanup errors so the construction failure remains primary */
+                            }
+                        }
+
+                        throw;
+                    }
                 }
 
                 var providerAgent = agentFactory(normalizedProviderId);
@@ -1168,7 +1231,7 @@ try
 
                 // Add LlmQuery book search MCP tools — only for medical knowledge mode
                 // Track MCP clients for proper disposal alongside the agent
-                List<IAsyncDisposable>? ownedResources = null;
+                var ownedResources = new List<IAsyncDisposable>();
                 var workspaceWorkflowEnabled = false;
                 if (!string.IsNullOrEmpty(mcpBaseUrl))
                 {
@@ -1181,7 +1244,7 @@ try
                     );
                     if (mcpClients.Count > 0)
                     {
-                        ownedResources = [.. mcpClients.Cast<IAsyncDisposable>()];
+                        ownedResources.AddRange(mcpClients.Cast<IAsyncDisposable>());
                     }
                 }
                 else if (isWorkspaceMode)
@@ -1239,7 +1302,7 @@ try
                     );
                     if (sandboxClients.Count > 0)
                     {
-                        ownedResources = [.. sandboxClients.Cast<IAsyncDisposable>()];
+                        ownedResources.AddRange(sandboxClients.Cast<IAsyncDisposable>());
                     }
                     else
                     {
@@ -1304,7 +1367,7 @@ try
                     );
                     if (workflowAuthorSandboxClients.Count > 0)
                     {
-                        ownedResources = [.. workflowAuthorSandboxClients.Cast<IAsyncDisposable>()];
+                        ownedResources.AddRange(workflowAuthorSandboxClients.Cast<IAsyncDisposable>());
                     }
                     else
                     {
@@ -1343,27 +1406,47 @@ try
                 // DeepSeek); its raw model id drives the model-id and web-tool wiring below.
                 var isAnthropicCompatModel = providerRegistry.TryGetAnthropicCompatModel(normalizedProviderId, out var anthropicCompatModelInfo);
 
-                var webToolStatuses = WebToolRegistrationPolicy.Apply(
-                    filteredRegistry,
-                    normalizedProviderId,
+                var enabledWebTools = WebToolRegistrationPolicy.ResolveEnabledTools(
                     mode.EnabledTools,
-                    jinaWebProvider,
-                    webToolsOptions,
-                    loggerFactory,
-                    isCopilotBackedModel,
-                    isAnthropicCompatModel
+                    mode.EnabledBuiltInTools
                 );
-                if (webToolStatuses.Count > 0)
+                var hostedSearch = isCopilotBackedModel
+                    ? CopilotWebSearchRegistration.TryRegister(
+                        filteredRegistry,
+                        enabledWebTools,
+                        s_copilotTokenProvider.Value,
+                        s_copilotSession.Value,
+                        new CopilotOptions(),
+                        loggerFactory
+                    )
+                    : new CopilotWebSearchRegistrationResult(false, null, string.Empty);
+                if (hostedSearch.Resource is not null)
                 {
-                    var webToolsLogger = loggerFactory.CreateLogger<Program>();
-                    foreach (var status in webToolStatuses)
-                    {
-                        webToolsLogger.LogInformation("WebTools: {Status}", status);
-                    }
+                    ownedResources.Add(hostedSearch.Resource);
                 }
 
                 try
                 {
+                    var webToolStatuses = WebToolRegistrationPolicy.Apply(
+                        filteredRegistry,
+                        normalizedProviderId,
+                        enabledWebTools,
+                        jinaWebProvider,
+                        webToolsOptions,
+                        loggerFactory,
+                        isCopilotBackedModel,
+                        isAnthropicCompatModel,
+                        suppressWebSearch: hostedSearch.Registered
+                    );
+                    if (webToolStatuses.Count > 0)
+                    {
+                        var webToolsLogger = loggerFactory.CreateLogger<Program>();
+                        foreach (var status in webToolStatuses)
+                        {
+                            webToolsLogger.LogInformation("WebTools: {Status}", status);
+                        }
+                    }
+
                     // Discovered Copilot models use their raw model id verbatim; discovered
                     // Anthropic-compatible models likewise use their configured model name verbatim;
                     // fixed providers keep the curated per-provider id map.
@@ -1442,11 +1525,12 @@ try
                         // reasoning (e.g. a classic Thinking budget) to an inherited-model sub-agent.
                         parentReasoningExtraProperties: extraProperties)
                         .Create;
+                    var outputTokenPolicy = sp.GetRequiredService<AgentOutputTokenPolicy>();
                     var subAgentOptions = BuildSubAgentOptionsAsync(
                             isTestMode,
                             sp.GetRequiredService<ITestAgentBuilder>(),
                             loggerFactory,
-subAgentFactory,
+                            subAgentFactory,
                             characteristicsAgentFactory,
                             sandboxSession,
                             sp.GetRequiredService<WorkspaceSubAgentLoader>(),
@@ -1455,6 +1539,11 @@ subAgentFactory,
                             loggerFactory.CreateLogger("LmStreaming.Sample.SubAgentCatalog"))
                         .GetAwaiter()
                         .GetResult();
+
+                    if (subAgentOptions is not null)
+                    {
+                        subAgentOptions = outputTokenPolicy.ApplyDelegated(subAgentOptions);
+                    }
 
                     // Route a spawn's modelIntelligence tier (the Agent tool's argument, or a workflow task's
                     // tier) to a concrete model via the host's tier ladder, climbing to the nearest higher
@@ -1642,7 +1731,10 @@ subAgentFactory,
 
                             // Persist nested delegate transcripts (subagent-{agentId}) to the shared store so a
                             // nested workflow tab survives a page reload (live streaming works regardless).
-                            return ApplyDefaultSubAgentStore(opts, conversationStore);
+                            return ApplyDefaultSubAgentStore(
+                                outputTokenPolicy.ApplyDelegated(opts),
+                                conversationStore
+                            );
                         }
 
                         var controllerSubAgentOptions = BuildControllerOptions(normalizedProviderId);
@@ -1665,19 +1757,21 @@ subAgentFactory,
                             },
                             maxConcurrentWorkflows: maxConcurrentWorkflows,
 
-                            controllerDefaultOptions: new GenerateReplyOptions
-                            {
-                                ModelId = controllerModelId,
-                                // The controller loop inherits the parent's reasoning (Option A: fixed High
-                                // floor), shaped for its OWN model so the orchestrator thinks instead of
-                                // running un-nudged. A per-run preferred-model override reshapes this in
-                                // WorkflowManager.StartAsync via the profile's ControllerReasoningExtraProperties.
-                                ExtraProperties = BuildControllerReasoningExtraProperties(
-                                    providerRegistry,
-                                    controllerModelId,
-                                    normalizedProviderId
-                                ),
-                            },
+                            controllerDefaultOptions: outputTokenPolicy.ApplyDelegated(
+                                new GenerateReplyOptions
+                                {
+                                    ModelId = controllerModelId,
+                                    // The controller loop inherits the parent's reasoning (Option A: fixed High
+                                    // floor), shaped for its OWN model so the orchestrator thinks instead of
+                                    // running un-nudged. A per-run preferred-model override reshapes this in
+                                    // WorkflowManager.StartAsync via the profile's ControllerReasoningExtraProperties.
+                                    ExtraProperties = BuildControllerReasoningExtraProperties(
+                                        providerRegistry,
+                                        controllerModelId,
+                                        normalizedProviderId
+                                    ),
+                                }
+                            ),
                             logger: loggerFactory.CreateLogger<WorkflowManager>(),
                             // Fold a StartWorkflowAgent run's controller + task usage into THIS conversation's
                             // total. Late-bound because the WorkflowManager is created before the root `agent`
@@ -1714,7 +1808,9 @@ subAgentFactory,
                                 // Provider switch must also replace the launching provider's default model.
                                 // For discovered Copilot providers the provider id is the raw model id; for
                                 // family providers this is the same id the host's agent factory accepts.
-                                new GenerateReplyOptions { ModelId = providerId }
+                                outputTokenPolicy.ApplyDelegated(
+                                    new GenerateReplyOptions { ModelId = providerId }
+                                )
                             ),
                             // Scope the controller's persistence thread to THIS conversation so a human-chosen
                             // (non-unique) workflowId can never map two different conversations onto the same
@@ -1738,7 +1834,7 @@ subAgentFactory,
                             // launch inputs above; the handle itself is already built.
                             callerCollaboration: () => rootCollaboration
                         ));
-                        ownedResources = [.. ownedResources ?? [], workflowManager];
+                        ownedResources.Add(workflowManager);
 
                         // Publish this conversation's WorkflowManager so /subagents + the sub-agent WebSocket
                         // can surface its runs as tabs. Safe to leave a stale entry: WorkflowManager.DisposeAsync
@@ -1807,20 +1903,17 @@ subAgentFactory,
                         filteredRegistry,
                         threadId,
                         systemPrompt: effectiveMode.SystemPrompt,
-                        defaultOptions: new GenerateReplyOptions
-                        {
-                            ModelId = modelId,
-                            // Output-token ceiling. The provider default is 4096; with extended thinking
-                            // enabled (2048-token budget, set above) that left only ~2K for the answer, so
-                            // a large structured reply could exhaust the budget while still thinking and
-                            // emit no text at all (stop_reason=max_tokens). 8192 leaves ~6K for the answer
-                            // after the 2K thinking budget.
-                            MaxToken = 8192,
-                            BuiltInTools = filteredBuiltInTools,
-                            RequestResponseDumpFileName = requestResponseDumpFileName,
-                            PromptCaching = PromptCachingMode.Auto,
-                            ExtraProperties = extraProperties,
-                        },
+                        defaultOptions: outputTokenPolicy.ApplyPrimary(
+                            new GenerateReplyOptions
+                            {
+                                ModelId = modelId,
+                                BuiltInTools = filteredBuiltInTools,
+                                RequestResponseDumpFileName = requestResponseDumpFileName,
+                                PromptCaching = PromptCachingMode.Auto,
+                                ExtraProperties = extraProperties,
+                            },
+                            useDelegatedFallback: normalizedProviderId is "openai"
+                        ),
                         // LmStreaming.Sample allows longer agentic runs than the library's 50-turn
                         // default: workspace/tool-heavy conversations routinely need more turns before
                         // the run hits its cap.
@@ -1850,7 +1943,13 @@ subAgentFactory,
                         collaboration: rootCollaboration
                     );
 
-                    return new MultiTurnAgentPool.AgentCreationResult(agent, ownedResources) { StagedBinding = stagedBinding };
+                    return new MultiTurnAgentPool.AgentCreationResult(
+                        agent,
+                        ownedResources.Count == 0 ? null : ownedResources
+                    )
+                    {
+                        StagedBinding = stagedBinding,
+                    };
                 }
                 catch
                 {
@@ -2751,6 +2850,22 @@ public partial class Program
         };
     }
 
+    internal static GenerateReplyOptions ApplyPrimaryOutputTokens(
+        GenerateReplyOptions options,
+        AgentOutputTokenPolicy policy,
+        bool useDelegatedFallback = false
+    ) => policy.ApplyPrimary(options, useDelegatedFallback);
+
+    internal static GenerateReplyOptions ApplyDelegatedOutputTokens(
+        GenerateReplyOptions? options,
+        AgentOutputTokenPolicy policy
+    ) => policy.ApplyDelegated(options);
+
+    internal static SubAgentOptions ApplyDelegatedOutputTokens(
+        SubAgentOptions options,
+        AgentOutputTokenPolicy policy
+    ) => policy.ApplyDelegated(options);
+
     /// <summary>
     /// Attaches one conversation-scoped characteristics factory to every template while preserving
     /// template-specific agents for inherited model routing.
@@ -3325,6 +3440,14 @@ public partial class Program
             : string.IsNullOrWhiteSpace(workingDirectory) ? null
             : workingDirectory;
 
+        IReadOnlyList<string>? enabledTools = mode.EnabledTools;
+        if (mode.EnabledBuiltInTools is not null)
+        {
+            var combinedTools = new HashSet<string>(mode.EnabledTools ?? [], StringComparer.Ordinal);
+            combinedTools.UnionWith(mode.EnabledBuiltInTools);
+            enabledTools = [.. combinedTools];
+        }
+
         var copilotOptions = new CopilotSdkOptions
         {
             CopilotCliPath = copilotCliPath,
@@ -3347,7 +3470,7 @@ public partial class Program
         return new CopilotAgentLoop(
             copilotOptions,
             functionRegistry,
-            mode.EnabledTools,
+            enabledTools,
             threadId,
             systemPrompt: mode.SystemPrompt,
             defaultOptions: new GenerateReplyOptions

--- a/samples/LmStreaming.Sample/Services/AgentOutputTokenPolicy.cs
+++ b/samples/LmStreaming.Sample/Services/AgentOutputTokenPolicy.cs
@@ -1,0 +1,58 @@
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using LmStreaming.Sample.Configuration;
+
+namespace LmStreaming.Sample.Services;
+
+public sealed class AgentOutputTokenPolicy
+{
+    private readonly AgentOutputTokenOptions _options;
+
+    public AgentOutputTokenPolicy(AgentOutputTokenOptions options)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public GenerateReplyOptions ApplyPrimary(
+        GenerateReplyOptions options,
+        bool useDelegatedFallback = false
+    )
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.MaxToken is not null)
+        {
+            return options;
+        }
+
+        return options with
+        {
+            MaxToken = useDelegatedFallback ? _options.Delegated : _options.Primary,
+        };
+    }
+
+    public GenerateReplyOptions ApplyDelegated(GenerateReplyOptions? options)
+    {
+        var effective = options ?? new GenerateReplyOptions();
+        return effective.MaxToken is null
+            ? effective with { MaxToken = _options.Delegated }
+            : effective;
+    }
+
+    public SubAgentTemplate ApplyDelegated(SubAgentTemplate template)
+    {
+        ArgumentNullException.ThrowIfNull(template);
+        return template with { DefaultOptions = ApplyDelegated(template.DefaultOptions) };
+    }
+
+    public SubAgentOptions ApplyDelegated(SubAgentOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        return options with
+        {
+            Templates = options.Templates.ToDictionary(
+                pair => pair.Key,
+                pair => ApplyDelegated(pair.Value),
+                StringComparer.Ordinal),
+        };
+    }
+}

--- a/samples/LmStreaming.Sample/Services/CopilotWebSearchRegistration.cs
+++ b/samples/LmStreaming.Sample/Services/CopilotWebSearchRegistration.cs
@@ -1,0 +1,127 @@
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using AchieveAi.LmDotnetTools.McpMiddleware;
+using ModelContextProtocol.Client;
+
+namespace LmStreaming.Sample.Services;
+
+internal sealed record CopilotWebSearchRegistrationResult(
+    bool Registered,
+    IAsyncDisposable? Resource,
+    string Status
+);
+
+internal static class CopilotWebSearchRegistration
+{
+    internal const string ToolName = "web_search";
+    private const string ClientName = "copilot-web-search";
+    private static readonly TimeSpan InitializationTimeout = TimeSpan.FromSeconds(10);
+
+    public static CopilotWebSearchRegistrationResult TryRegister(
+        FunctionRegistry registry,
+        IReadOnlyList<string>? enabledTools,
+        ICopilotTokenProvider tokenProvider,
+        CopilotSessionContext session,
+        CopilotOptions options,
+        ILoggerFactory loggerFactory,
+        HttpMessageHandler? innerHandler = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(tokenProvider);
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
+        if (enabledTools is not null && !enabledTools.Contains(ToolName))
+        {
+            return new(false, null, "Copilot web_search disabled by mode");
+        }
+
+        var logger = loggerFactory.CreateLogger("LmStreaming.Sample.CopilotWebSearchRegistration");
+        HttpClientTransport? transport = null;
+        McpClient? client = null;
+        try
+        {
+            var httpClient = CopilotHttpClientFactory.Create(
+                options.BaseUrl,
+                tokenProvider,
+                session,
+                options,
+                innerHandler: innerHandler
+            );
+            transport = new HttpClientTransport(
+                new HttpClientTransportOptions
+                {
+                    Name = ClientName,
+                    Endpoint = new Uri(new Uri(options.BaseUrl), "/mcp/readonly"),
+                    TransportMode = HttpTransportMode.StreamableHttp,
+                    ConnectionTimeout = InitializationTimeout,
+                    AdditionalHeaders = new Dictionary<string, string> { ["X-MCP-Tools"] = ToolName },
+                },
+                httpClient,
+                loggerFactory,
+                ownsHttpClient: true
+            );
+
+            using var cts = new CancellationTokenSource(InitializationTimeout);
+            client = McpClient.CreateAsync(transport, cancellationToken: cts.Token).GetAwaiter().GetResult();
+            var provider = McpClientFunctionProvider
+                .CreateAsync(
+                    new Dictionary<string, McpClient> { [ClientName] = client },
+                    ClientName,
+                    loggerFactory.CreateLogger<McpClientFunctionProvider>(),
+                    cts.Token,
+                    omitServerPrefix: true
+                )
+                .GetAwaiter()
+                .GetResult();
+            var functions = provider.GetFunctions().ToList();
+            if (
+                functions.Count != 1
+                || !string.Equals(functions[0].Contract.Name, ToolName, StringComparison.Ordinal)
+            )
+            {
+                Dispose(client, transport);
+                return new(false, null, "Copilot web_search unavailable");
+            }
+
+            _ = registry.AddProvider(provider);
+            return new(true, new OwnedMcpResource(client, transport), "Copilot web_search registered");
+        }
+        catch (Exception ex)
+        {
+            Dispose(client, transport);
+            logger.LogWarning(ex, "Copilot hosted web_search is unavailable; using configured fallback");
+            return new(false, null, "Copilot web_search unavailable");
+        }
+    }
+
+    private static void Dispose(McpClient? client, HttpClientTransport? transport)
+    {
+        if (client is not null)
+        {
+            client.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+
+        if (transport is not null)
+        {
+            transport.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
+
+    private sealed class OwnedMcpResource(McpClient client, HttpClientTransport transport) : IAsyncDisposable
+    {
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await client.DisposeAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                await transport.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/samples/LmStreaming.Sample/Services/WebToolRegistrationPolicy.cs
+++ b/samples/LmStreaming.Sample/Services/WebToolRegistrationPolicy.cs
@@ -15,16 +15,41 @@ internal static class WebToolRegistrationPolicy
 {
     /// <summary>
     /// <see cref="ProviderRegistry" /> ids that have NO native web capability and therefore receive
-    /// the Jina fallback tools. Plain <c>copilot</c> is intentionally excluded: it returns early on
-    /// the <c>CopilotAgentLoop</c> (CLI) path before the per-conversation registry is built, so it
-    /// never reaches this seam. Dynamically discovered Copilot models (Anthropic/OpenAI) route through
-    /// the normal middleware agent loop and are included via the <c>isCopilotBackedModel</c> flag the
-    /// caller passes, not by literal id.
+    /// the Jina fallback tools. Plain <c>copilot</c> and dynamically discovered Copilot models are
+    /// included through the <c>isCopilotBackedModel</c> flag the caller passes, not by literal id.
+    /// Keeping them out of this static set ensures the caller explicitly establishes Copilot context
+    /// before enabling fallback tools.
     /// </summary>
     private static readonly HashSet<string> FallbackProviderIds = new(StringComparer.OrdinalIgnoreCase)
     {
         "openai",
+        // Deterministic mock providers exercise the same function-tool surface in manual/E2E validation.
+        "test",
+        "test-anthropic",
     };
+
+    /// <summary>
+    /// Resolves function-tool intent for web-capable modes. A dedicated built-in <c>web_search</c>
+    /// declaration also enables the function-shaped hosted/Jina search and Jina fetch equivalents.
+    /// </summary>
+    public static IReadOnlyList<string>? ResolveEnabledTools(
+        IReadOnlyList<string>? enabledTools,
+        IReadOnlyList<string>? enabledBuiltInTools
+    )
+    {
+        if (enabledBuiltInTools is null || !enabledBuiltInTools.Contains("web_search"))
+        {
+            return enabledTools;
+        }
+
+        var resolved = new HashSet<string>(enabledTools ?? [], StringComparer.Ordinal)
+        {
+            "web_search",
+            WebSearchTool.ToolName,
+            WebFetchTool.ToolName,
+        };
+        return [.. resolved];
+    }
 
     /// <summary>
     /// Registers the Jina <c>WebFetch</c>/<c>WebSearch</c> function tools into <paramref name="registry" />
@@ -50,6 +75,8 @@ internal static class WebToolRegistrationPolicy
     /// provider-family model (e.g. DeepSeek). Those models likewise lack a native web capability and so
     /// receive the Jina fallback tools, alongside <paramref name="isCopilotBackedModel" /> and the
     /// statically allow-listed ids in <see cref="FallbackProviderIds" />.</param>
+    /// <param name="suppressWebSearch"><c>true</c> when Copilot hosted <c>web_search</c> was registered;
+    /// Jina <c>WebSearch</c> is then skipped while Jina <c>WebFetch</c> remains eligible.</param>
     /// <returns>A small list of human-readable status strings describing what was registered, skipped,
     /// or disabled (for diagnostics/logging). Never contains secret values.</returns>
     public static IReadOnlyList<string> Apply(
@@ -60,7 +87,8 @@ internal static class WebToolRegistrationPolicy
         WebToolsOptions options,
         ILoggerFactory loggerFactory,
         bool isCopilotBackedModel = false,
-        bool isAnthropicCompatModel = false
+        bool isAnthropicCompatModel = false,
+        bool suppressWebSearch = false
     )
     {
         ArgumentNullException.ThrowIfNull(registry);
@@ -117,8 +145,13 @@ internal static class WebToolRegistrationPolicy
             }
         }
 
+        // Copilot's hosted web_search takes precedence; Jina remains the fallback.
+        if (suppressWebSearch)
+        {
+            statuses.Add("WebSearch skipped: Copilot web_search registered");
+        }
         // WebSearch requires the Jina API key; without it the tool is not advertised at all.
-        if (string.IsNullOrWhiteSpace(options.JinaApiKey))
+        else if (string.IsNullOrWhiteSpace(options.JinaApiKey))
         {
             logger.LogInformation("WebSearch disabled: JINA_API_KEY not set");
             statuses.Add("WebSearch disabled: JINA_API_KEY not set");

--- a/samples/LmStreaming.Sample/appsettings.json
+++ b/samples/LmStreaming.Sample/appsettings.json
@@ -33,6 +33,10 @@
       "WithExceptionDetails"
     ]
   },
+  "AgentOutputTokens": {
+    "Primary": 24576,
+    "Delegated": 16384
+  },
   "SandboxGateway": {
     "BaseUrl": "http://127.0.0.1:3000",
     "AutoSpawn": true

--- a/samples/LmStreaming.Sample/playwright-scripts/workspace-webtools-validation.mjs
+++ b/samples/LmStreaming.Sample/playwright-scripts/workspace-webtools-validation.mjs
@@ -1,0 +1,75 @@
+async (page) => {
+  const failures = [];
+  const steps = [];
+  const base = 'http://127.0.0.1:5050/dist/index.html';
+  const prompt = (chain) => `<|instruction_start|>${JSON.stringify({ instruction_chain: chain })}<|instruction_end|>`;
+
+  await page.goto(base);
+  await page.waitForSelector('[data-testid="send-button"]', { timeout: 30000 });
+
+  const choose = async (testId) => {
+    await page.getByTestId(testId.split('/')[0]).click();
+    await page.getByTestId(testId.split('/')[1]).click();
+  };
+  await choose('provider-selector-button/provider-option-test');
+  await choose('mode-selector-button/mode-option-workspace-agent');
+  steps.push('selected Workspace Agent + test mock provider');
+
+  const send = async (text) => {
+    const input = page.getByTestId('chat-input-textarea');
+    await input.fill(text);
+    await page.getByTestId('send-button').click();
+    await page.getByTestId('stop-button').waitFor({ state: 'hidden', timeout: 120000 });
+    await page.getByTestId('send-button').waitFor({ state: 'visible', timeout: 30000 });
+  };
+
+  await send(prompt([{ id: 'workspace-tools', id_message: 'List Workspace web tools', messages: [{ tools_list: {} }] }]));
+  const firstText = (await page.getByTestId('assistant-text').last().textContent()) || '';
+  for (const name of ['WebSearch', 'WebFetch']) {
+    if (!firstText.includes(name)) failures.push(`tools_list missing ${name}: ${firstText}`);
+  }
+  steps.push({ toolsList: firstText });
+
+  await send(prompt([{ id: 'workspace-search', id_message: 'Use Jina WebSearch', messages: [{ tool_call: [{ name: 'WebSearch', args: { query: 'LmDotnetTools GitHub repository', count: 2 } }] }] }]));
+  await send(prompt([{ id: 'workspace-fetch', id_message: 'Use Jina WebFetch', messages: [{ tool_call: [{ name: 'WebFetch', args: { url: 'https://example.com' } }] }] }]));
+
+  const pills = await page.getByTestId('tool-call-pill').evaluateAll((nodes) => nodes.map((n) => ({
+    name: n.getAttribute('data-tool-name'),
+    text: (n.textContent || '').trim(),
+  })));
+  for (const name of ['WebSearch', 'WebFetch']) {
+    const matches = pills.filter((p) => p.name === name);
+    if (!matches.length) failures.push(`no ${name} pill rendered`);
+    if (matches.some((p) => /unknown function/i.test(p.text))) failures.push(`${name} resolved as unknown function`);
+  }
+  steps.push({ toolPills: pills.filter((p) => ['WebSearch', 'WebFetch'].includes(p.name)) });
+
+  const threadId = await page.locator('[data-testid="conversation-item"]').first().getAttribute('data-thread-id');
+  const persisted = threadId ? await page.evaluate(async (id) => {
+    const r = await fetch(`/api/conversations/${id}/messages`);
+    return r.ok ? r.json() : { status: r.status };
+  }, threadId) : null;
+  const persistedText = JSON.stringify(persisted);
+  const messages = Array.isArray(persisted) ? persisted : [];
+  const toolResults = messages
+    .map((message) => {
+      try { return JSON.parse(message.messageJson || '{}'); } catch { return {}; }
+    })
+    .filter((message) => message.$type === 'tool_call_result' && ['WebSearch', 'WebFetch'].includes(message.tool_name));
+  const searchResult = toolResults.find((message) => message.tool_name === 'WebSearch');
+  const fetchResult = toolResults.find((message) => message.tool_name === 'WebFetch');
+  if (!searchResult || searchResult.is_error || !searchResult.result?.includes('github.com/achieveai/LmDotnetTools')) {
+    failures.push(`WebSearch did not return the expected live GitHub result: ${JSON.stringify(searchResult)}`);
+  }
+  if (!fetchResult || fetchResult.is_error || !fetchResult.result?.includes('# Example Domain')) {
+    failures.push(`WebFetch did not return the expected page content: ${JSON.stringify(fetchResult)}`);
+  }
+  if (/Unknown function: (WebSearch|WebFetch)/i.test(persistedText)) failures.push('persisted transcript contains unknown-function error');
+  steps.push({
+    threadId,
+    WebSearch: searchResult ? { isError: searchResult.is_error, preview: searchResult.result.slice(0, 500) } : null,
+    WebFetch: fetchResult ? { isError: fetchResult.is_error, preview: fetchResult.result.slice(0, 500) } : null,
+  });
+
+  return { pass: failures.length === 0, failures, steps };
+}

--- a/tests/CopilotAnthropicProxy.Tests/McpProxyTests.cs
+++ b/tests/CopilotAnthropicProxy.Tests/McpProxyTests.cs
@@ -96,7 +96,7 @@ public sealed class McpProxyTests
         using var client = factory.CreateClient();
 
         using var request = new HttpRequestMessage(HttpMethod.Post, "/mcp/readonly") { Content = JsonRpc("{}") };
-        request.Headers.TryAddWithoutValidation("X-MCP-Tools", "get_file_contents,search_code");
+        request.Headers.TryAddWithoutValidation("X-MCP-Tools", "web_search");
         request.Headers.TryAddWithoutValidation("X-MCP-Readonly", "true");
         request.Headers.TryAddWithoutValidation("X-MCP-Host", "copilot-cli");
 
@@ -108,7 +108,7 @@ public sealed class McpProxyTests
             .Should()
             .ContainSingle()
             .Which.Should()
-            .Be("get_file_contents,search_code");
+            .Be("web_search");
         forwarded.Headers.GetValues("X-MCP-Readonly").Should().ContainSingle().Which.Should().Be("true");
         forwarded.Headers.GetValues("X-MCP-Host").Should().ContainSingle().Which.Should().Be("copilot-cli");
     }

--- a/tests/CopilotLive.Tests/CopilotMcpLiveTests.cs
+++ b/tests/CopilotLive.Tests/CopilotMcpLiveTests.cs
@@ -1,0 +1,102 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
+using FluentAssertions;
+
+namespace AchieveAi.LmDotnetTools.CopilotLive.Tests;
+
+[Collection(CopilotLiveCollection.Name)]
+public sealed class CopilotMcpLiveTests(CopilotLiveFixture fixture)
+{
+    [SkippableFact]
+    public async Task Readonly_catalog_can_select_only_hosted_web_search()
+    {
+        Skip.IfNot(fixture.Available, fixture.SkipReason);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var http = CopilotHttpClientFactory.Create(
+            fixture.Options.BaseUrl,
+            fixture.TokenProvider,
+            fixture.Session,
+            fixture.Options,
+            timeout: TimeSpan.FromSeconds(30)
+        );
+        const string endpoint = "/mcp/readonly";
+
+        using var initializeResponse = await SendAsync(
+            http,
+            endpoint,
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-06-18\",\"capabilities\":{},\"clientInfo\":{\"name\":\"lmdotnettools-live-test\",\"version\":\"1\"}}}",
+            sessionId: null,
+            cts.Token
+        );
+        initializeResponse.EnsureSuccessStatusCode();
+        var sessionId = initializeResponse.Headers.GetValues("Mcp-Session-Id").Single();
+
+        using var initializedResponse = await SendAsync(
+            http,
+            endpoint,
+            "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}",
+            sessionId,
+            cts.Token
+        );
+        initializedResponse.IsSuccessStatusCode.Should().BeTrue();
+
+        using var listResponse = await SendAsync(
+            http,
+            endpoint,
+            "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}",
+            sessionId,
+            cts.Token
+        );
+        listResponse.EnsureSuccessStatusCode();
+        var body = await listResponse.Content.ReadAsStringAsync(cts.Token);
+        using var payload = JsonDocument.Parse(ReadSseData(body));
+        var tools = payload.RootElement.GetProperty("result").GetProperty("tools");
+
+        tools.GetArrayLength().Should().Be(1);
+        var tool = tools[0];
+        tool.GetProperty("name").GetString().Should().Be("web_search");
+        tool
+            .GetProperty("inputSchema")
+            .GetProperty("required")
+            .EnumerateArray()
+            .Select(item => item.GetString())
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be("query");
+    }
+
+    private static async Task<HttpResponseMessage> SendAsync(
+        HttpClient http,
+        string endpoint,
+        string body,
+        string? sessionId,
+        CancellationToken cancellationToken
+    )
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+        request.Headers.TryAddWithoutValidation("Mcp-Protocol-Version", "2025-06-18");
+        request.Headers.TryAddWithoutValidation("X-MCP-Tools", "web_search");
+        if (sessionId is not null)
+        {
+            request.Headers.TryAddWithoutValidation("Mcp-Session-Id", sessionId);
+        }
+
+        return await http.SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken);
+    }
+
+    private static string ReadSseData(string body)
+    {
+        return body
+                .Split('\n')
+                .First(line => line.StartsWith("data: ", StringComparison.Ordinal))
+                ["data: ".Length..];
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Configuration/AgentOutputTokenOptionsTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Configuration/AgentOutputTokenOptionsTests.cs
@@ -1,0 +1,33 @@
+using LmStreaming.Sample.Configuration;
+
+namespace LmStreaming.Sample.Tests.Configuration;
+
+public sealed class AgentOutputTokenOptionsTests
+{
+    [Fact]
+    public void Defaults_ArePrimary24K_AndDelegated16K()
+    {
+        var options = new AgentOutputTokenOptions();
+
+        options.Primary.Should().Be(24_576);
+        options.Delegated.Should().Be(16_384);
+        options.Validate().Succeeded.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0, 16_384)]
+    [InlineData(24_576, 0)]
+    [InlineData(-1, 16_384)]
+    public void Validate_RejectsNonPositiveValues(int primary, int delegated)
+    {
+        new AgentOutputTokenOptions { Primary = primary, Delegated = delegated }
+            .Validate().Failed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_RejectsPrimaryBelowDelegated()
+    {
+        new AgentOutputTokenOptions { Primary = 16_383, Delegated = 16_384 }
+            .Validate().Failed.Should().BeTrue();
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryControllerTests.cs
@@ -4,6 +4,8 @@ using System.Text;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using LmStreaming.Sample.Configuration;
+using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Services.Discovery;
 using LmStreaming.Sample.Tests.TestDoubles;
 using Microsoft.AspNetCore.Http;
@@ -56,6 +58,7 @@ public class ContextDiscoveryControllerTests
             loader,
             injector,
             diagnostics,
+            new AgentOutputTokenPolicy(new AgentOutputTokenOptions()),
             NullLogger<ContextDiscoveryController>.Instance);
 
         var httpContext = new DefaultHttpContext();

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryEndToEndTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryEndToEndTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
 using System.Net;
+using LmStreaming.Sample.Configuration;
+using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Services.Discovery;
 using LmStreaming.Sample.Tests.TestDoubles;
 using Microsoft.AspNetCore.Http;
@@ -247,6 +249,7 @@ public sealed class ContextDiscoveryEndToEndTests
                 Loader,
                 Injector,
                 Diagnostics,
+                new AgentOutputTokenPolicy(new AgentOutputTokenOptions()),
                 NullLogger<ContextDiscoveryController>.Instance);
 
             var httpContext = new DefaultHttpContext();

--- a/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryWebhookHttpTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Controllers/ContextDiscoveryWebhookHttpTests.cs
@@ -4,6 +4,8 @@ using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+using LmStreaming.Sample.Configuration;
+using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Services.Discovery;
 using LmStreaming.Sample.Tests.TestDoubles;
 using Microsoft.AspNetCore.Builder;
@@ -213,6 +215,9 @@ public sealed class ContextDiscoveryWebhookHttpTests
                     services.AddSingleton(new ContextDiscoveryOptions { RouteToOpeningSubAgent = true });
                     services.AddSingleton(diagnostics);
                     services.AddSingleton<ContextDiscoveryInjector>();
+                    services.AddSingleton(
+                        new AgentOutputTokenPolicy(new AgentOutputTokenOptions())
+                    );
                     services.AddSingleton<WorkspaceSubAgentLoader>();
                 });
                 webBuilder.Configure(appBuilder =>
@@ -329,6 +334,9 @@ public sealed class ContextDiscoveryWebhookHttpTests
                         services.AddSingleton<ContextDiscoveryFormatter>();
                         services.AddSingleton(new ContextDiscoveryOptions());
                         services.AddSingleton<ContextDiscoveryInjector>();
+                        services.AddSingleton(
+                            new AgentOutputTokenPolicy(new AgentOutputTokenOptions())
+                        );
                         services.AddSingleton<ContextDiscoveryDiagnostics>();
                         services.AddSingleton<WorkspaceSubAgentLoader>();
                     });

--- a/tests/LmStreaming.Sample.Tests/ProgramSubAgentCompositionTests.cs
+++ b/tests/LmStreaming.Sample.Tests/ProgramSubAgentCompositionTests.cs
@@ -6,6 +6,7 @@ using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using AchieveAi.LmDotnetTools.OpenAiResponsesProvider.Models;
+using LmStreaming.Sample.Configuration;
 using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Services.Discovery;
 using LmStreaming.Sample.Tests.TestDoubles;
@@ -14,6 +15,52 @@ namespace LmStreaming.Sample.Tests;
 
 public sealed class ProgramSubAgentCompositionTests
 {
+    [Fact]
+    public void OutputTokenPolicyHelpers_ApplyConfiguredDefaults_AndPreserveExplicitValues()
+    {
+        var policy = new AgentOutputTokenPolicy(
+            new AgentOutputTokenOptions { Primary = 24_576, Delegated = 16_384 }
+        );
+
+        global::Program.ApplyPrimaryOutputTokens(new GenerateReplyOptions(), policy)
+            .MaxToken.Should().Be(24_576);
+        global::Program.ApplyPrimaryOutputTokens(
+                new GenerateReplyOptions(),
+                policy,
+                useDelegatedFallback: true
+            )
+            .MaxToken.Should().Be(16_384);
+        global::Program.ApplyPrimaryOutputTokens(
+                new GenerateReplyOptions { MaxToken = 4_096 },
+                policy,
+                useDelegatedFallback: true
+            )
+            .MaxToken.Should().Be(4_096);
+        global::Program.ApplyDelegatedOutputTokens(
+                new GenerateReplyOptions { ModelId = "controller" },
+                policy
+            )
+            .MaxToken.Should().Be(16_384);
+
+        var subAgentOptions = global::Program.ApplyDelegatedOutputTokens(
+            new SubAgentOptions
+            {
+                Templates = new Dictionary<string, SubAgentTemplate>
+                {
+                    ["unset"] = Template("unset", () => Mock.Of<IStreamingAgent>()),
+                    ["explicit"] = Template("explicit", () => Mock.Of<IStreamingAgent>()) with
+                    {
+                        DefaultOptions = new GenerateReplyOptions { MaxToken = 7_000 },
+                    },
+                },
+            },
+            policy
+        );
+
+        subAgentOptions.Templates["unset"].DefaultOptions!.MaxToken.Should().Be(16_384);
+        subAgentOptions.Templates["explicit"].DefaultOptions!.MaxToken.Should().Be(7_000);
+    }
+
     [Fact]
     public void ApplyCharacteristicsAgentFactory_InheritedModelPreservesTemplateAgentAndRequestProperties()
     {

--- a/tests/LmStreaming.Sample.Tests/Services/AgentOutputTokenPolicyTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/AgentOutputTokenPolicyTests.cs
@@ -1,0 +1,128 @@
+using LmStreaming.Sample.Configuration;
+using LmStreaming.Sample.Services;
+using AchieveAi.LmDotnetTools.LmCore.Core;
+using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+public class AgentOutputTokenPolicyTests
+{
+    private static AgentOutputTokenPolicy Policy(int primary = 24_576, int delegated = 16_384)
+    {
+        var options = new AgentOutputTokenOptions { Primary = primary, Delegated = delegated };
+        options.Validate().Succeeded.Should().BeTrue();
+        return new AgentOutputTokenPolicy(options);
+    }
+
+    private static SubAgentTemplate Template(GenerateReplyOptions? defaultOptions)
+    {
+        return new SubAgentTemplate
+        {
+            SystemPrompt = "Test prompt",
+            AgentFactory = () => throw new NotImplementedException(),
+            DefaultOptions = defaultOptions,
+        };
+    }
+
+    [Fact]
+    public void ApplyPrimary_UsesConfiguredPrimaryWhenUnset()
+    {
+        var policy = Policy(primary: 30_000, delegated: 18_000);
+
+        policy.ApplyPrimary(new GenerateReplyOptions()).MaxToken.Should().Be(30_000);
+    }
+
+    [Fact]
+    public void ApplyPrimary_UsesDelegatedFallback_WhenRequested()
+    {
+        Policy().ApplyPrimary(new GenerateReplyOptions(), useDelegatedFallback: true)
+            .MaxToken.Should().Be(16_384);
+    }
+
+    [Fact]
+    public void ApplyPrimary_PreservesExplicitValue()
+    {
+        var policy = Policy(primary: 30_000, delegated: 18_000);
+
+        policy.ApplyPrimary(new GenerateReplyOptions { MaxToken = 4_096 })
+            .MaxToken.Should().Be(4_096);
+    }
+
+    [Fact]
+    public void ApplyDelegatedOptions_UsesConfiguredDelegatedWhenUnset()
+    {
+        Policy().ApplyDelegated((GenerateReplyOptions?)null).MaxToken.Should().Be(16_384);
+    }
+
+    [Fact]
+    public void ApplyDelegatedTemplate_FillsMissingBudget()
+    {
+        var template = Template(defaultOptions: null);
+
+        var result = Policy().ApplyDelegated(template);
+
+        result.DefaultOptions!.MaxToken.Should().Be(16_384);
+    }
+
+    [Fact]
+    public void ApplyDelegatedTemplates_FillsOnlyMissingBudgets()
+    {
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate>
+            {
+                ["unset"] = Template(defaultOptions: null),
+                ["explicit"] = Template(defaultOptions: new GenerateReplyOptions { MaxToken = 7_000 }),
+            },
+        };
+
+        var result = Policy().ApplyDelegated(options);
+
+        result.Templates["unset"].DefaultOptions!.MaxToken.Should().Be(16_384);
+        result.Templates["explicit"].DefaultOptions!.MaxToken.Should().Be(7_000);
+    }
+
+    [Fact]
+    public void ApplyDelegatedTemplates_PreservesAllOtherTemplateFields()
+    {
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate>
+            {
+                ["test"] = Template(defaultOptions: null) with
+                {
+                    Name = "TestName",
+                    Description = "Test description",
+                    WhenToUse = "When needed",
+                    MaxTurnsPerRun = 25,
+                },
+            },
+        };
+
+        var result = Policy().ApplyDelegated(options);
+
+        result.Templates["test"].Name.Should().Be("TestName");
+        result.Templates["test"].Description.Should().Be("Test description");
+        result.Templates["test"].WhenToUse.Should().Be("When needed");
+        result.Templates["test"].MaxTurnsPerRun.Should().Be(25);
+    }
+
+    [Fact]
+    public void ApplyDelegatedTemplates_PreservesAllOtherSubAgentOptionsFields()
+    {
+        var options = new SubAgentOptions
+        {
+            Templates = new Dictionary<string, SubAgentTemplate>
+            {
+                ["test"] = Template(defaultOptions: null),
+            },
+            MaxConcurrentSubAgents = 3,
+            MaxQueuedSubAgents = 50,
+        };
+
+        var result = Policy().ApplyDelegated(options);
+
+        result.MaxConcurrentSubAgents.Should().Be(3);
+        result.MaxQueuedSubAgents.Should().Be(50);
+    }
+}

--- a/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorRoutingTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/ContextDiscoveryInjectorRoutingTests.cs
@@ -2,6 +2,8 @@ using System.Collections.Concurrent;
 using System.Net;
 using AchieveAi.LmDotnetTools.LmCore.Agents;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using LmStreaming.Sample.Configuration;
+using LmStreaming.Sample.Services;
 using LmStreaming.Sample.Services.Discovery;
 using LmStreaming.Sample.Tests.TestDoubles;
 using Microsoft.AspNetCore.Http;
@@ -544,6 +546,7 @@ public sealed class ContextDiscoveryInjectorRoutingTests
                 loader,
                 Injector,
                 Diagnostics,
+                new AgentOutputTokenPolicy(new AgentOutputTokenOptions()),
                 NullLogger<ContextDiscoveryController>.Instance);
 
             var httpContext = new DefaultHttpContext();

--- a/tests/LmStreaming.Sample.Tests/Services/CopilotWebSearchRegistrationTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/CopilotWebSearchRegistrationTests.cs
@@ -1,0 +1,345 @@
+using System.Net;
+using System.Text;
+using AchieveAi.LmDotnetTools.GithubCopilotProvider.Auth;
+using AchieveAi.LmDotnetTools.LmCore.Middleware;
+using LmStreaming.Sample.Services;
+
+namespace LmStreaming.Sample.Tests.Services;
+
+public sealed class CopilotWebSearchRegistrationTests
+{
+    private const string Token = "test-copilot-token";
+
+    [Fact]
+    public void TryRegister_WhenModeEnablesWebSearch_ImportsOnlyBareHostedTool()
+    {
+        var registry = new FunctionRegistry();
+        var upstream = new FakeCopilotMcpHandler();
+
+        var result = CopilotWebSearchRegistration.TryRegister(
+            registry,
+            enabledTools: [CopilotWebSearchRegistration.ToolName],
+            new StaticTokenProvider(Token),
+            new CopilotSessionContext(),
+            new CopilotOptions { BaseUrl = "https://copilot.test" },
+            NullLoggerFactory.Instance,
+            upstream
+        );
+
+        result.Registered.Should().BeTrue();
+        result.Resource.Should().NotBeNull();
+        RegisteredNames(registry).Should().Equal(CopilotWebSearchRegistration.ToolName);
+        upstream.Requests.Should().NotBeEmpty();
+        upstream.Requests.Should().OnlyContain(request => request.WebSearchSelector == "web_search");
+        upstream.Requests.Should().OnlyContain(request => request.Authorization == $"Bearer {Token}");
+    }
+
+    [Fact]
+    public async Task TryRegister_SuccessResourceDisposesUnderlyingHttpHandler()
+    {
+        var upstream = new FakeCopilotMcpHandler();
+        var result = Register(enabledTools: null, upstream);
+
+        result.Resource.Should().NotBeNull();
+        upstream.Disposed.Should().BeFalse();
+
+        await result.Resource!.DisposeAsync();
+
+        upstream.Disposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryRegister_WhenEnabledToolsIsNull_RegistersHostedTool()
+    {
+        var result = Register(enabledTools: null, new FakeCopilotMcpHandler());
+
+        result.Registered.Should().BeTrue();
+        result.Resource.Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData("WebSearch")]
+    [InlineData("WebFetch")]
+    public void TryRegister_WhenModeDoesNotEnableExactHostedName_DoesNotConnect(string enabledTool)
+    {
+        var upstream = new FakeCopilotMcpHandler();
+
+        var result = Register([enabledTool], upstream);
+
+        result.Registered.Should().BeFalse();
+        result.Resource.Should().BeNull();
+        upstream.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TryRegister_WhenEnabledToolsIsEmpty_DoesNotConnect()
+    {
+        var upstream = new FakeCopilotMcpHandler();
+
+        var result = Register([], upstream);
+
+        result.Registered.Should().BeFalse();
+        result.Resource.Should().BeNull();
+        upstream.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task TryRegister_RegisteredHandlerCallsHostedWebSearch()
+    {
+        var registry = new FunctionRegistry();
+        var upstream = new FakeCopilotMcpHandler();
+        var result = CopilotWebSearchRegistration.TryRegister(
+            registry,
+            enabledTools: null,
+            new StaticTokenProvider(Token),
+            new CopilotSessionContext(),
+            new CopilotOptions { BaseUrl = "https://copilot.test" },
+            NullLoggerFactory.Instance,
+            upstream
+        );
+        var (_, handlers) = registry.Build();
+
+        var handlerResult = await handlers[CopilotWebSearchRegistration.ToolName](
+            "{\"query\":\"current .NET release\"}",
+            new ToolCallContext(),
+            CancellationToken.None
+        );
+
+        handlerResult
+            .Should()
+            .BeOfType<ToolHandlerResult.Resolved>()
+            .Which.Payload.Text.Should()
+            .Contain("https://example.test/source");
+        upstream.Requests.Should().Contain(request => request.Body.Contains("\"method\":\"tools/call\""));
+        upstream.Requests.Should().Contain(request => request.Body.Contains("\"name\":\"web_search\""));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(2)]
+    public void TryRegister_WhenCatalogDoesNotContainExactlyOneTool_RejectsAndDisposesClient(int toolCount)
+    {
+        var registry = new FunctionRegistry();
+        var upstream = new FakeCopilotMcpHandler(toolCount: toolCount);
+
+        var result = CopilotWebSearchRegistration.TryRegister(
+            registry,
+            enabledTools: null,
+            new StaticTokenProvider(Token),
+            new CopilotSessionContext(),
+            new CopilotOptions { BaseUrl = "https://copilot.test" },
+            NullLoggerFactory.Instance,
+            upstream
+        );
+
+        result.Registered.Should().BeFalse();
+        result.Resource.Should().BeNull();
+        RegisteredNames(registry).Should().BeEmpty();
+        upstream.Disposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HostedSearchSuccess_ComposesWithJinaFetchWithoutDuplicateSearch()
+    {
+        var registry = new FunctionRegistry();
+        var hosted = CopilotWebSearchRegistration.TryRegister(
+            registry,
+            enabledTools: ["web_search", "WebFetch", "WebSearch"],
+            new StaticTokenProvider(Token),
+            new CopilotSessionContext(),
+            new CopilotOptions { BaseUrl = "https://copilot.test" },
+            NullLoggerFactory.Instance,
+            new FakeCopilotMcpHandler()
+        );
+        var webOptions = new AchieveAi.LmDotnetTools.Misc.Configuration.WebToolsOptions
+        {
+            JinaApiKey = "test-jina-key",
+        };
+        var jinaProvider = new AchieveAi.LmDotnetTools.Misc.Web.Jina.JinaWebProvider(webOptions);
+
+        _ = WebToolRegistrationPolicy.Apply(
+            registry,
+            "claude-sonnet-5",
+            ["web_search", "WebFetch", "WebSearch"],
+            jinaProvider,
+            webOptions,
+            NullLoggerFactory.Instance,
+            isCopilotBackedModel: true,
+            suppressWebSearch: hosted.Registered
+        );
+
+        RegisteredNames(registry).Should().BeEquivalentTo("web_search", "WebFetch");
+    }
+
+    [Fact]
+    public void HostedSearchFailure_ComposesWithJinaSearchAndFetchFallback()
+    {
+        var registry = new FunctionRegistry();
+        var hosted = CopilotWebSearchRegistration.TryRegister(
+            registry,
+            enabledTools: ["web_search", "WebFetch", "WebSearch"],
+            new StaticTokenProvider(Token),
+            new CopilotSessionContext(),
+            new CopilotOptions { BaseUrl = "https://copilot.test" },
+            NullLoggerFactory.Instance,
+            new FakeCopilotMcpHandler(failInitialization: true)
+        );
+        var webOptions = new AchieveAi.LmDotnetTools.Misc.Configuration.WebToolsOptions
+        {
+            JinaApiKey = "test-jina-key",
+        };
+        var jinaProvider = new AchieveAi.LmDotnetTools.Misc.Web.Jina.JinaWebProvider(webOptions);
+
+        _ = WebToolRegistrationPolicy.Apply(
+            registry,
+            "claude-sonnet-5",
+            ["web_search", "WebFetch", "WebSearch"],
+            jinaProvider,
+            webOptions,
+            NullLoggerFactory.Instance,
+            isCopilotBackedModel: true,
+            suppressWebSearch: hosted.Registered
+        );
+
+        RegisteredNames(registry).Should().BeEquivalentTo("WebSearch", "WebFetch");
+    }
+
+    [Fact]
+    public void TryRegister_WhenInitializationFails_DegradesWithoutRegisteringTool()
+    {
+        var registry = new FunctionRegistry();
+        var upstream = new FakeCopilotMcpHandler(failInitialization: true);
+
+        var result = CopilotWebSearchRegistration.TryRegister(
+            registry,
+            enabledTools: null,
+            new StaticTokenProvider(Token),
+            new CopilotSessionContext(),
+            new CopilotOptions { BaseUrl = "https://copilot.test" },
+            NullLoggerFactory.Instance,
+            upstream
+        );
+
+        result.Registered.Should().BeFalse();
+        result.Resource.Should().BeNull();
+        RegisteredNames(registry).Should().BeEmpty();
+        result.Status.Should().NotContain(Token);
+    }
+
+    private static CopilotWebSearchRegistrationResult Register(
+        IReadOnlyList<string>? enabledTools,
+        FakeCopilotMcpHandler upstream
+    )
+    {
+        return CopilotWebSearchRegistration.TryRegister(
+            new FunctionRegistry(),
+            enabledTools,
+            new StaticTokenProvider(Token),
+            new CopilotSessionContext(),
+            new CopilotOptions { BaseUrl = "https://copilot.test" },
+            NullLoggerFactory.Instance,
+            upstream
+        );
+    }
+
+    private static IReadOnlyList<string> RegisteredNames(FunctionRegistry registry)
+    {
+        var (contracts, _) = registry.Build();
+        return [.. contracts.Select(contract => contract.Name)];
+    }
+
+    private sealed class StaticTokenProvider(string token) : ICopilotTokenProvider
+    {
+        public Task<string> GetTokenAsync(CancellationToken cancellationToken = default) => Task.FromResult(token);
+    }
+
+    private sealed class FakeCopilotMcpHandler(bool failInitialization = false, int toolCount = 1)
+        : HttpMessageHandler
+    {
+        private const string SessionId = "test-mcp-session";
+
+        public List<CapturedRequest> Requests { get; } = [];
+        public bool Disposed { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var body = request.Content is null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            Requests.Add(
+                new CapturedRequest(
+                    request.Headers.Authorization?.ToString(),
+                    request.Headers.TryGetValues("X-MCP-Tools", out var selectors)
+                        ? selectors.Single()
+                        : null,
+                    body
+                )
+            );
+
+            if (failInitialization)
+            {
+                return new HttpResponseMessage(HttpStatusCode.BadGateway)
+                {
+                    Content = new StringContent("upstream unavailable", Encoding.UTF8, "text/plain"),
+                };
+            }
+
+            var method = ReadMethod(body);
+            return method switch
+            {
+                "initialize" => Sse(
+                    "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"capabilities\":{\"tools\":{}},\"protocolVersion\":\"2025-06-18\",\"serverInfo\":{\"name\":\"copilot-test\",\"version\":\"1\"}}}",
+                    includeSession: true
+                ),
+                "notifications/initialized" => new HttpResponseMessage(HttpStatusCode.Accepted),
+                "tools/list" => Sse(ToolsListResponse(toolCount)),
+                "tools/call" => Sse(
+                    "{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"Current answer [1]\\n\\nSources: https://example.test/source\"}]}}"
+                ),
+                _ => new HttpResponseMessage(HttpStatusCode.Accepted),
+            };
+        }
+
+        private static string ToolsListResponse(int count)
+        {
+            const string tool = "{\"name\":\"web_search\",\"description\":\"Search the web with citations\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]}}";
+            return $"{{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{{\"tools\":[{string.Join(",", Enumerable.Repeat(tool, count))}]}}}}";
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Disposed = true;
+            base.Dispose(disposing);
+        }
+
+        private static string? ReadMethod(string body)
+        {
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                return null;
+            }
+
+            using var document = JsonDocument.Parse(body);
+            return document.RootElement.TryGetProperty("method", out var method) ? method.GetString() : null;
+        }
+
+        private static HttpResponseMessage Sse(string json, bool includeSession = false)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent($"event: message\ndata: {json}\n\n", Encoding.UTF8, "text/event-stream"),
+            };
+            if (includeSession)
+            {
+                response.Headers.TryAddWithoutValidation("Mcp-Session-Id", SessionId);
+            }
+
+            return response;
+        }
+    }
+
+    private sealed record CapturedRequest(string? Authorization, string? WebSearchSelector, string Body);
+}

--- a/tests/LmStreaming.Sample.Tests/Services/WebToolRegistrationPolicyTests.cs
+++ b/tests/LmStreaming.Sample.Tests/Services/WebToolRegistrationPolicyTests.cs
@@ -83,16 +83,34 @@ public class WebToolRegistrationPolicyTests
         RegisteredNames(registry).Should().Contain("WebFetch").And.Contain("WebSearch");
     }
 
-    // ---- Provider matrix: providers with native web (or mocks/test/unknown) receive nothing ----
+    [Theory]
+    [InlineData("test")]
+    [InlineData("test-anthropic")]
+    public void Apply_RegistersJinaTools_ForMockProviders_WhenKeyPresent(string providerId)
+    {
+        var registry = new FunctionRegistry();
+        var (provider, options) = Backend(ApiKey);
+
+        _ = WebToolRegistrationPolicy.Apply(
+            registry,
+            providerId,
+            enabledTools: ["WebSearch", "WebFetch"],
+            provider,
+            options,
+            NullLoggerFactory.Instance
+        );
+
+        RegisteredNames(registry).Should().Contain("WebFetch").And.Contain("WebSearch");
+    }
+
+    // ---- Provider matrix: providers with native web (or unsupported/unknown) receive nothing ----
 
     [Theory]
     [InlineData("anthropic")]
-    [InlineData("test-anthropic")]
     [InlineData("claude")]
     [InlineData("claude-mock")]
     [InlineData("codex")]
     [InlineData("codex-mock")]
-    [InlineData("test")]
     [InlineData("copilot")]
     [InlineData("copilot-mock")]
     [InlineData("unknown")]
@@ -159,6 +177,17 @@ public class WebToolRegistrationPolicyTests
         );
 
         RegisteredNames(registry).Should().Contain("WebFetch").And.Contain("WebSearch");
+    }
+
+    [Fact]
+    public void ResolveEnabledTools_WhenModeRequestsBuiltInWebSearch_EnablesJinaSearchAndFetch()
+    {
+        var enabled = WebToolRegistrationPolicy.ResolveEnabledTools(
+            enabledTools: [],
+            enabledBuiltInTools: ["web_search"]
+        );
+
+        enabled.Should().BeEquivalentTo("web_search", "WebSearch", "WebFetch");
     }
 
     // ---- EnabledTools gate (the function-tool allow-list: null = all) ----
@@ -242,6 +271,49 @@ public class WebToolRegistrationPolicyTests
         );
 
         RegisteredNames(registry).Should().NotContain("WebFetch").And.NotContain("WebSearch");
+    }
+
+    // ---- Hosted Copilot search takes precedence over Jina search, not Jina fetch ----
+
+    [Fact]
+    public void Apply_WhenHostedSearchRegistered_StillRegistersJinaFetchButSuppressesJinaSearch()
+    {
+        var registry = new FunctionRegistry();
+        var (provider, options) = Backend(ApiKey);
+
+        var statuses = WebToolRegistrationPolicy.Apply(
+            registry,
+            "claude-sonnet-5",
+            enabledTools: ["web_search", "WebFetch", "WebSearch"],
+            provider,
+            options,
+            NullLoggerFactory.Instance,
+            isCopilotBackedModel: true,
+            suppressWebSearch: true
+        );
+
+        RegisteredNames(registry).Should().Contain("WebFetch").And.NotContain("WebSearch");
+        statuses.Should().Contain("WebSearch skipped: Copilot web_search registered");
+    }
+
+    [Fact]
+    public void Apply_WhenHostedSearchUnavailable_RegistersJinaSearchAndFetch()
+    {
+        var registry = new FunctionRegistry();
+        var (provider, options) = Backend(ApiKey);
+
+        _ = WebToolRegistrationPolicy.Apply(
+            registry,
+            "claude-sonnet-5",
+            enabledTools: ["web_search", "WebFetch", "WebSearch"],
+            provider,
+            options,
+            NullLoggerFactory.Instance,
+            isCopilotBackedModel: true,
+            suppressWebSearch: false
+        );
+
+        RegisteredNames(registry).Should().Contain("WebFetch").And.Contain("WebSearch");
     }
 
     // ---- Missing key: WebFetch still registers, WebSearch does not (and reports a status) ----

--- a/tests/LmStreaming.Sample.Tests/WorkspaceWorkflowWiringTests.cs
+++ b/tests/LmStreaming.Sample.Tests/WorkspaceWorkflowWiringTests.cs
@@ -1,8 +1,10 @@
 using AchieveAi.LmDotnetTools.LmCore.Agents;
+using AchieveAi.LmDotnetTools.LmCore.Core;
 using AchieveAi.LmDotnetTools.LmCore.Middleware;
 using AchieveAi.LmDotnetTools.LmMultiTurn.SubAgents;
 using AchieveAi.LmDotnetTools.LmWorkflow;
 using AchieveAi.LmDotnetTools.LmWorkflow.Tools;
+using LmStreaming.Sample.Configuration;
 using LmStreaming.Sample.Services;
 
 namespace LmStreaming.Sample.Tests;
@@ -27,6 +29,25 @@ public sealed class WorkspaceWorkflowWiringTests
             Templates = BuiltInSubAgentTemplates.CreateWorkflowControllerTemplates(FakeAgent),
             NonInheritedToolNames = [.. WorkflowAndLaunchToolNames],
         };
+
+    [Fact]
+    public void WorkflowControllerDefaults_UseDelegatedBudget_AndPreserveExplicitValues()
+    {
+        var policy = new AgentOutputTokenPolicy(
+            new AgentOutputTokenOptions { Primary = 24_576, Delegated = 16_384 }
+        );
+
+        global::Program.ApplyDelegatedOutputTokens(
+                new GenerateReplyOptions { ModelId = "controller" },
+                policy
+            )
+            .MaxToken.Should().Be(16_384);
+        global::Program.ApplyDelegatedOutputTokens(
+                new GenerateReplyOptions { ModelId = "controller", MaxToken = 12_000 },
+                policy
+            )
+            .MaxToken.Should().Be(12_000);
+    }
 
     [Fact]
     public void ControllerTemplates_AreInheritAll_AndAcceptedByWorkflowManager_WithStructuralExclusion()


### PR DESCRIPTION
## Summary

- add configurable output-token defaults for primary and delegated LmStreaming agents
- import Copilot's hosted `web_search` MCP tool while preserving Jina fallback composition
- apply delegated token policy to discovered, workflow, workspace, and nested sub-agent paths
- retain transcript-mirror resource ownership and cleanup from current `main`

## Key behavior

- primary/default work uses 24,576 output tokens unless the caller supplied a value
- delegated/fallback work uses 16,384 output tokens unless the caller supplied a value
- Copilot-backed conversations can register the hosted `web_search` tool from `/mcp/readonly`
- web tool policy prevents duplicate hosted/fallback search registration
- context-discovered templates inherit the delegated output-token policy

## Verification

- clean solution build: no warnings or errors
- LmStreaming.Sample.Tests: 1,402 passed, 1 platform skip
- CopilotAnthropicProxy.Tests: 365/365 passed
- transcript mirror / descendant scanner regression: 40/40 passed
- CopilotMcpLiveTests: 1/1 passed
- formatting pre-commit hook: passed
- `git diff --check`: passed

## Notes

- `.claude/scratchpad/**` is intentionally excluded
- the branch is based on current `origin/main` (`f518182c`)