### PR TITLE
feat(sample): professional markdown rendering in the chat client

### DIFF
--- a/samples/LmStreaming.Sample/ClientApp/package-lock.json
+++ b/samples/LmStreaming.Sample/ClientApp/package-lock.json
@@ -8,7 +8,9 @@
       "name": "lmstreaming-chat-client",
       "version": "1.0.0",
       "dependencies": {
+        "highlight.js": "^11.11.1",
         "marked": "^17.0.1",
+        "marked-highlight": "^2.2.4",
         "vue": "^3.5.13"
       },
       "devDependencies": {
@@ -1626,6 +1628,15 @@
         "he": "bin/he"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
@@ -1724,6 +1735,15 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/marked-highlight": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.2.4.tgz",
+      "integrity": "sha512-PZxisNMJDduSjc0q6uvjsnqqHCXc9s0eyzxDO9sB1eNGJnd/H1/Fu+z6g/liC1dfJdFW4SftMwMlLvsBhUPrqQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "marked": ">=4 <19"
       }
     },
     "node_modules/minimatch": {

--- a/samples/LmStreaming.Sample/ClientApp/package.json
+++ b/samples/LmStreaming.Sample/ClientApp/package.json
@@ -12,7 +12,9 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "highlight.js": "^11.11.1",
     "marked": "^17.0.1",
+    "marked-highlight": "^2.2.4",
     "vue": "^3.5.13"
   },
   "devDependencies": {

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/MessageList.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/MessageList.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import MessageList from '../../components/MessageList.vue';
+import TextMessage from '../../components/TextMessage.vue';
 import { nextTick } from 'vue';
 
 import { MessageType } from '@/types';
@@ -97,8 +98,94 @@ describe('MessageList', () => {
     expect(requestAnimationFrameMock).toHaveBeenCalled();
   });
 
-  describe('Layout containment (overflow regression)', () => {
-    const componentSource = (() => {
+  describe('Streaming highlight opt-out wiring', () => {
+    // hljs TOKEN classes only; the block's own `hljs language-csharp` class is present either way.
+    const tokenSpans = (html: string) => (html.match(/class="hljs-/g) || []).length;
+    const FENCE = ['```csharp', 'var s = "a & b";', 'if (x is null) { }', '```'].join('\n');
+
+    const userItem = (id: string) => ({
+      id,
+      type: 'user-message' as const,
+      content: { $type: MessageType.Text, role: 'user' as const, text: 'Show me code', isThinking: false },
+      status: 'active' as const,
+      timestamp: Date.now(),
+    });
+    const assistantItem = (id: string, text = FENCE) => ({
+      id,
+      type: 'assistant-message' as const,
+      content: { $type: MessageType.Text, role: 'assistant' as const, text, isThinking: false },
+    });
+
+    const isCompleteById = (wrapper: any) =>
+      Object.fromEntries(
+        wrapper
+          .findAllComponents(TextMessage)
+          .map((c: any) => [c.props('message').text.slice(0, 12), c.props('isComplete')])
+      );
+
+    const mountList = (displayItems: any[], isLoading: boolean) =>
+      mount(MessageList, { props: { displayItems, isLoading } });
+
+    it('marks only the LAST assistant bubble of the active group incomplete while loading', () => {
+      const wrapper = mountList(
+        [userItem('u-1'), assistantItem('a-1', 'first block'), assistantItem('a-2', 'second block')],
+        true
+      );
+
+      // Two bubbles in the same active group: the earlier one is finished and must stay
+      // highlighted, or already-rendered code goes monochrome mid-run.
+      expect(isCompleteById(wrapper)).toMatchObject({
+        'Show me code': true,
+        'first block': true,
+        'second block': false,
+      });
+    });
+
+    it('marks every bubble complete once the run ends', async () => {
+      const items = [userItem('u-1'), assistantItem('a-1', 'first block'), assistantItem('a-2', 'second block')];
+      const wrapper = mountList(items, true);
+
+      await wrapper.setProps({ isLoading: false });
+
+      expect(isCompleteById(wrapper)).toMatchObject({ 'first block': true, 'second block': true });
+    });
+
+    it('keeps HISTORY bubbles complete while a later turn streams', () => {
+      const wrapper = mountList(
+        [
+          userItem('u-1'),
+          assistantItem('a-1', 'history block'),
+          userItem('u-2'),
+          assistantItem('a-2', 'live block'),
+        ],
+        true
+      );
+
+      expect(isCompleteById(wrapper)).toMatchObject({
+        'history bloc': true,
+        'live block': false,
+      });
+    });
+
+    it('renders the streaming bubble UNHIGHLIGHTED and highlights it when the run ends', async () => {
+      const wrapper = mountList([userItem('u-1'), assistantItem('a-1')], true);
+
+      // End-to-end through MessageList -> TextMessage -> parseMarkdown, not just the prop.
+      expect(tokenSpans(wrapper.html())).toBe(0);
+      expect(wrapper.html()).toContain('hljs language-csharp');
+
+      await wrapper.setProps({ isLoading: false });
+
+      expect(tokenSpans(wrapper.html())).toBeGreaterThan(0);
+    });
+
+    it('highlights everything when not loading at all', () => {
+      const wrapper = mountList([userItem('u-1'), assistantItem('a-1')], false);
+      expect(tokenSpans(wrapper.html())).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Layout containment (overflow regression)', () => {    const componentSource = (() => {
       const fs = require('fs');
       const path = require('path');
       return fs.readFileSync(

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/TextMessage.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/components/TextMessage.test.ts
@@ -95,4 +95,50 @@ describe('TextMessage.vue', () => {
 
     expect(wrapper.find('.markdown-content').text()).toContain(longText);
   });
+
+  describe('isComplete (streaming highlight opt-out)', () => {
+    const FENCE = ['```csharp', 'var s = "a & b";', 'if (x is null) { }', '```'].join('\n');
+    // hljs TOKEN classes only -- the block's own `hljs language-csharp` class must survive both ways.
+    const tokenSpans = (html: string) => (html.match(/class="hljs-/g) || []).length;
+
+    it('skips syntax highlighting while the message is incomplete', () => {
+      const wrapper = mount(TextMessage, {
+        props: { message: createMessage({ text: FENCE }), isComplete: false },
+      });
+
+      expect(tokenSpans(wrapper.html())).toBe(0);
+      expect(wrapper.html()).toContain('hljs language-csharp');
+      expect(wrapper.html()).toContain('a &amp; b');
+    });
+
+    it('highlights when isComplete is true', () => {
+      const wrapper = mount(TextMessage, {
+        props: { message: createMessage({ text: FENCE }), isComplete: true },
+      });
+
+      expect(tokenSpans(wrapper.html())).toBeGreaterThan(0);
+    });
+
+    it('highlights when isComplete is absent (defaults to complete)', () => {
+      const wrapper = mount(TextMessage, {
+        props: { message: createMessage({ text: FENCE }) },
+      });
+
+      expect(tokenSpans(wrapper.html())).toBeGreaterThan(0);
+    });
+
+    it('highlights once isComplete flips true, without touching the cursor', async () => {
+      const wrapper = mount(TextMessage, {
+        props: { message: createMessage({ text: FENCE }), isComplete: false },
+      });
+      expect(tokenSpans(wrapper.html())).toBe(0);
+
+      await wrapper.setProps({ isComplete: true });
+
+      expect(tokenSpans(wrapper.html())).toBeGreaterThan(0);
+      // isComplete must not drag the blinking cursor along with it -- that is `isStreaming`'s job,
+      // and a stray '|' would land in [data-testid="assistant-text"] textContent.
+      expect(wrapper.find('.cursor').exists()).toBe(false);
+    });
+  });
 });

--- a/samples/LmStreaming.Sample/ClientApp/src/__tests__/utils/markdown.test.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/__tests__/utils/markdown.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { parseMarkdown } from '@/utils/markdown';
+
+/**
+ * `parseMarkdown` re-runs for a streaming message on EVERY delta, and highlighting a fence is
+ * O(fence length) -- so a growing code block gets highlighted from scratch per chunk. The
+ * `highlight: false` opt-out is what keeps that off the main thread while a message is live;
+ * these tests pin both halves of the contract: no token spans, but still ESCAPED (the output
+ * goes straight into `v-html`) and with an unchanged class list so finalizing does not restyle.
+ */
+describe('parseMarkdown', () => {
+  const FENCE = [
+    '# Heading',
+    '',
+    '```csharp',
+    'var s = "a & b";',
+    'if (msg.RunId is null) { }',
+    '```',
+  ].join('\n');
+
+  // Counts highlight.js TOKEN classes (`hljs-keyword`, ...) without matching the block's own
+  // `hljs language-csharp` class, which both paths must keep.
+  const tokenSpans = (html: string) => (html.match(/class="hljs-/g) || []).length;
+
+  it('highlights fenced code by default', () => {
+    const html = parseMarkdown(FENCE);
+    expect(tokenSpans(html)).toBeGreaterThan(0);
+    expect(html).toContain('class="hljs language-csharp"');
+  });
+
+  it('highlights fenced code when highlight is explicitly true', () => {
+    expect(tokenSpans(parseMarkdown(FENCE, { highlight: true }))).toBeGreaterThan(0);
+  });
+
+  it('emits ZERO token spans when highlight is false', () => {
+    const html = parseMarkdown(FENCE, { highlight: false });
+    expect(tokenSpans(html)).toBe(0);
+    expect(html).toContain('var s = &quot;a &amp; b&quot;;');
+  });
+
+  it('keeps the code block class list identical across both paths', () => {
+    const classOf = (html: string) => (html.match(/<code class="([^"]*)"/) || [])[1];
+    expect(classOf(parseMarkdown(FENCE, { highlight: false }))).toBe('hljs language-csharp');
+    expect(classOf(parseMarkdown(FENCE, { highlight: false }))).toBe(classOf(parseMarkdown(FENCE)));
+  });
+
+  it('escapes HTML inside an un-highlighted fence', () => {
+    const md = ['```html', '<script>alert("x")</script>', '```'].join('\n');
+    const html = parseMarkdown(md, { highlight: false });
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&quot;x&quot;');
+  });
+
+  it('escapes HTML in a fence with no language, both paths', () => {
+    const md = ['```', '<img src=x onerror=alert(1)>', '```'].join('\n');
+    for (const html of [parseMarkdown(md, { highlight: false }), parseMarkdown(md)]) {
+      expect(html).not.toContain('<img src=x');
+      expect(html).toContain('&lt;img src=x');
+    }
+  });
+
+  it('renders the surrounding markdown identically apart from token spans', () => {
+    const strip = (html: string) => html.replace(/<span class="hljs-[^"]*">/g, '').replace(/<\/span>/g, '');
+    expect(strip(parseMarkdown(FENCE))).toBe(parseMarkdown(FENCE, { highlight: false }));
+  });
+
+  it('returns an empty string for empty input on both paths', () => {
+    expect(parseMarkdown('')).toBe('');
+    expect(parseMarkdown('', { highlight: false })).toBe('');
+  });
+
+  it('degrades an unknown fence language to escaped plain text', () => {
+    const md = ['```mermaid', 'graph TD; A-->B;', '```'].join('\n');
+    expect(parseMarkdown(md)).toContain('A--&gt;B');
+    expect(parseMarkdown(md, { highlight: false })).toContain('A--&gt;B');
+  });
+});

--- a/samples/LmStreaming.Sample/ClientApp/src/assets/markdown.css
+++ b/samples/LmStreaming.Sample/ClientApp/src/assets/markdown.css
@@ -1,0 +1,339 @@
+/*
+ * Rendering rules for markdown produced by `marked` and injected via `v-html`.
+ *
+ * Global on purpose: TextMessage and PendingMessage both render into `.markdown-content`,
+ * and Vue's scoped `:deep()` would force every rule below to be duplicated per component
+ * (which is exactly how the two surfaces drifted apart before).
+ *
+ * The app's universal reset in styles.css strips margin/padding from *every* element, so
+ * each construct has to restore its own spacing explicitly -- without these rules headings,
+ * lists, tables, blockquotes and rules all collapse into an undifferentiated wall of text.
+ *
+ * Spacing is expressed in `em` throughout so the whole document scales with whatever font
+ * size the surrounding bubble sets (16px in the answer bubble, 14px in the pending bubble).
+ */
+
+.markdown-content {
+  --md-border: #dfe2e5;
+  --md-border-soft: #ececf0;
+  --md-surface: #f6f8fa;
+  --md-accent: #007bff;
+  --md-muted: #6a737d;
+  /* Vertical rhythm: one "block gap" between sibling blocks. */
+  --md-gap: 0.9em;
+
+  overflow-wrap: break-word;
+  line-height: 1.65;
+  /* inherit, so the italic/grey "thinking" treatment on the parent still applies */
+  color: inherit;
+}
+
+/* No dead space at the top or bottom of a bubble. */
+.markdown-content > :first-child {
+  margin-top: 0;
+}
+
+.markdown-content > :last-child {
+  margin-bottom: 0;
+}
+
+/* ---------- Paragraphs ---------- */
+
+.markdown-content p {
+  margin: 0 0 var(--md-gap);
+  /* avoids one-word last lines; no-op in engines that don't support it */
+  text-wrap: pretty;
+}
+
+/* ---------- Headings ---------- */
+
+/*
+ * Type scale is roughly 1.125 per step, deliberately shallow: these are section headings
+ * inside a chat bubble, not a landing page. Negative tracking on the two largest sizes is
+ * what keeps a big heading from reading as "shouty" next to 16px body text.
+ */
+.markdown-content h1,
+.markdown-content h2,
+.markdown-content h3,
+.markdown-content h4,
+.markdown-content h5,
+.markdown-content h6 {
+  margin: 1.6em 0 0.65em;
+  line-height: 1.3;
+  font-weight: 600;
+  color: inherit;
+  text-wrap: balance;
+}
+
+/* A heading straight after another heading is a subtitle, not a new section. */
+.markdown-content :is(h1, h2, h3, h4, h5, h6) + :is(h1, h2, h3, h4, h5, h6) {
+  margin-top: 0.9em;
+}
+
+.markdown-content h1 {
+  font-size: 1.6em;
+  letter-spacing: -0.015em;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--md-border);
+}
+
+.markdown-content h2 {
+  font-size: 1.3em;
+  letter-spacing: -0.01em;
+  padding-bottom: 0.25em;
+  border-bottom: 1px solid var(--md-border-soft);
+}
+
+.markdown-content h3 {
+  font-size: 1.125em;
+}
+
+.markdown-content h4 {
+  font-size: 1em;
+}
+
+/* h5/h6 are rare and shouldn't compete with body text, so they change *case*, not size. */
+.markdown-content h5,
+.markdown-content h6 {
+  font-size: 0.82em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--md-muted);
+}
+
+/* ---------- Lists ---------- */
+
+.markdown-content ul,
+.markdown-content ol {
+  margin: 0 0 var(--md-gap);
+  padding-left: 1.5em;
+}
+
+.markdown-content ul {
+  list-style: disc;
+}
+
+.markdown-content ul ul {
+  list-style: circle;
+}
+
+.markdown-content ul ul ul {
+  list-style: square;
+}
+
+.markdown-content ol {
+  list-style: decimal;
+}
+
+.markdown-content li {
+  margin: 0.3em 0;
+  padding-left: 0.15em;
+}
+
+.markdown-content li::marker {
+  color: var(--md-muted);
+}
+
+.markdown-content li > ul,
+.markdown-content li > ol {
+  margin: 0.3em 0 0;
+}
+
+.markdown-content li > p {
+  margin-bottom: 0.4em;
+}
+
+/* GFM task lists: drop the bullet so the checkbox is the only marker. */
+.markdown-content li:has(> input[type='checkbox']) {
+  list-style: none;
+  margin-left: -1.4em;
+}
+
+.markdown-content input[type='checkbox'] {
+  margin-right: 0.5em;
+  vertical-align: middle;
+  accent-color: var(--md-accent);
+}
+
+/* ---------- Blockquotes ---------- */
+
+.markdown-content blockquote {
+  margin: 0 0 var(--md-gap);
+  padding: 0.7em 1em;
+  border-left: 3px solid var(--md-accent);
+  border-radius: 0 6px 6px 0;
+  background: #f7f9fc;
+  color: var(--md-muted);
+}
+
+.markdown-content blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+/* ---------- Tables ---------- */
+
+/*
+ * `display: block` + `width: max-content` lets a wide table scroll inside the bubble instead
+ * of forcing the whole message column wider; `overflow: auto` also makes the radius clip.
+ *
+ * `border-collapse`/`border-spacing` are *inherited* properties, so setting them here reaches
+ * the anonymous inner table that `display: block` creates. `separate` (not `collapse`) is what
+ * lets the outer border keep its rounded corners -- with `collapse` the cell borders win and
+ * the corners square off. Cells therefore draw dividers only, never a full box.
+ */
+.markdown-content table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow: auto;
+  border-collapse: separate;
+  border-spacing: 0;
+  border: 1px solid var(--md-border);
+  border-radius: 8px;
+  margin: 0 0 1.15em;
+  font-size: 0.94em;
+  /* digits share one advance width, so numeric columns line up down the column */
+  font-variant-numeric: tabular-nums;
+}
+
+.markdown-content th,
+.markdown-content td {
+  padding: 8px 14px;
+  border: 0;
+  border-bottom: 1px solid var(--md-border-soft);
+}
+
+.markdown-content th + th,
+.markdown-content td + td {
+  border-left: 1px solid var(--md-border-soft);
+}
+
+/* The table's own border supplies the bottom edge. */
+.markdown-content tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.markdown-content th {
+  text-align: left;
+}
+
+/*
+ * GFM column alignment (`| ---: |`) arrives from `marked` as the legacy `align` *attribute*, and a
+ * presentational attribute loses to any CSS rule -- so a blanket `text-align` on th/td silently
+ * flattens every aligned column. These have to opt back in explicitly.
+ */
+.markdown-content th[align='left'],
+.markdown-content td[align='left'] {
+  text-align: left;
+}
+
+.markdown-content th[align='center'],
+.markdown-content td[align='center'] {
+  text-align: center;
+}
+
+.markdown-content th[align='right'],
+.markdown-content td[align='right'] {
+  text-align: right;
+}
+
+.markdown-content thead th {
+  background: #f5f7f9;
+  font-weight: 600;
+  white-space: nowrap;
+  border-bottom: 1px solid var(--md-border);
+}
+
+.markdown-content tbody tr:nth-child(2n) {
+  background: #fafbfc;
+}
+
+/* ---------- Code ---------- */
+
+/*
+ * The chip treatment is for *inline* code only. Without the `:not(pre code)` guard it
+ * leaks into fenced blocks and renders a chip inside a box.
+ */
+.markdown-content code:not(pre code) {
+  background: rgba(27, 31, 35, 0.06);
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.9em;
+  white-space: break-spaces;
+}
+
+.markdown-content pre {
+  margin: 0 0 1.15em;
+  padding: 12px 14px;
+  background: var(--md-surface);
+  border: 1px solid #e4e8ed;
+  border-radius: 8px;
+  overflow-x: auto;
+  font-size: 0.875em;
+  line-height: 1.55;
+  tab-size: 4;
+}
+
+/*
+ * highlight.js emits `class="hljs language-x"` on the inner <code>, and its theme paints a
+ * background + padding there. That would draw a second box inside our panel, so the panel
+ * keeps the chrome and the theme keeps only the token colours.
+ *
+ * `display: block` is load-bearing, not cosmetic: as an *inline* box the <code> does not
+ * contribute its intrinsic width to the <pre>'s scroll area, so a long line reports
+ * `scrollWidth === clientWidth`, no scrollbar appears, and the line is silently CLIPPED
+ * rather than scrolled. `width: fit-content` + `min-width: 100%` restores the real width
+ * while keeping selection/background spanning the full panel on short lines.
+ */
+.markdown-content pre code,
+.markdown-content pre code.hljs {
+  display: block;
+  width: fit-content;
+  min-width: 100%;
+  background: none;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  font-size: inherit;
+  white-space: pre;
+}
+
+/* ---------- Rules, links, media, inline emphasis ---------- */
+
+.markdown-content hr {
+  height: 1px;
+  border: 0;
+  background: var(--md-border);
+  margin: 1.6em 0;
+}
+
+.markdown-content a {
+  color: var(--md-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: rgba(0, 123, 255, 0.4);
+}
+
+.markdown-content a:hover {
+  text-decoration-color: var(--md-accent);
+}
+
+.markdown-content img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 0.5em 0;
+  border-radius: 6px;
+}
+
+.markdown-content strong {
+  font-weight: 600;
+}
+
+.markdown-content em {
+  font-style: italic;
+}
+
+.markdown-content del {
+  opacity: 0.7;
+}

--- a/samples/LmStreaming.Sample/ClientApp/src/assets/styles.css
+++ b/samples/LmStreaming.Sample/ClientApp/src/assets/styles.css
@@ -22,8 +22,12 @@ body {
 }
 
 /* Scrollbar styling */
+/* `height` is not optional here: once ::-webkit-scrollbar is styled at all, an unset height
+   collapses the HORIZONTAL scrollbar, so overflowing code blocks and wide tables scroll with
+   no affordance and read as silently truncated. */
 ::-webkit-scrollbar {
   width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track {
@@ -52,9 +56,13 @@ body {
 }
 
 /* Code styling */
+/* `ui-monospace`/`SF Mono`/`Menlo` first so macOS and modern browsers get the system code
+   face; Courier New is kept only as a last resort -- it was previously third in line, which
+   meant most Linux users read code in a 1980s typewriter face. */
 pre,
 code {
-  font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
 }
 
 /* Button base reset */

--- a/samples/LmStreaming.Sample/ClientApp/src/components/MessageList.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/MessageList.vue
@@ -115,6 +115,25 @@ const splitGroups = computed(() => {
   };
 });
 
+/**
+ * The one assistant bubble that is still growing: the last assistant text item of the active
+ * (current) group while a run is in flight. Its markdown is re-parsed on EVERY streamed delta,
+ * so it renders without syntax highlighting and gets highlighted once the run ends -- see
+ * `parseMarkdown`'s `highlight` option. Scoped to a single item on purpose: disabling it for
+ * the whole active group would turn already-finished code blocks monochrome mid-run.
+ */
+const streamingItemId = computed<string | null>(() => {
+  if (!props.isLoading) return null;
+  const groups = splitGroups.value.current;
+  for (let g = groups.length - 1; g >= 0; g--) {
+    const items = groups[g].items;
+    for (let i = items.length - 1; i >= 0; i--) {
+      if (items[i].type === 'assistant-message') return items[i].id;
+    }
+  }
+  return null;
+});
+
 // Track the last user message to scroll to it when it is added (pending or active)
 const lastScrolledMessageId = ref<string | null>(null);
 
@@ -282,7 +301,11 @@ watch(
 
                 <!-- Assistant text message -->
                 <div v-else-if="item.type === 'assistant-message'" class="text-bubble" data-testid="assistant-text">
-                  <TextMessage :message="item.content" :is-streaming="false" />
+                  <TextMessage
+                    :message="item.content"
+                    :is-streaming="false"
+                    :is-complete="item.id !== streamingItemId"
+                  />
                 </div>
               </template>
             </div>

--- a/samples/LmStreaming.Sample/ClientApp/src/components/PendingMessage.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/PendingMessage.vue
@@ -13,7 +13,7 @@ const parsedText = computed(() => parseMarkdown(props.content.text));
 <template>
   <div class="pending-message">
     <div class="pending-content">
-      <div class="markdown-body" v-html="parsedText"></div>
+      <div class="markdown-content" v-html="parsedText"></div>
       <div class="waiting-indicator">
         <span class="dot"></span>
         <span class="dot"></span>
@@ -40,22 +40,10 @@ const parsedText = computed(() => parseMarkdown(props.content.text));
   align-items: center;
   gap: 12px;
   opacity: 0.7;
-}
-
-.markdown-body {
   font-size: 14px;
-  line-height: 1.5;
-  word-break: break-word;
 }
 
-/* Deep selector for markdown content styles */
-.markdown-body :deep(p) {
-  margin: 0 0 0.5em 0;
-}
-
-.markdown-body :deep(p:last-child) {
-  margin-bottom: 0;
-}
+/* Markdown element styling lives in assets/markdown.css (shared with TextMessage). */
 
 .waiting-indicator {
   display: flex;

--- a/samples/LmStreaming.Sample/ClientApp/src/components/TextMessage.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/TextMessage.vue
@@ -3,12 +3,23 @@ import { computed } from 'vue';
 import type { TextMessage } from '@/types';
 import { parseMarkdown } from '@/utils/markdown';
 
-const props = defineProps<{
-  message: TextMessage;
-  isStreaming?: boolean;
-}>();
+const props = withDefaults(
+  defineProps<{
+    message: TextMessage;
+    isStreaming?: boolean;
+    /**
+     * `false` while this message is still being streamed into. Syntax highlighting is skipped
+     * for the growing text (it re-parses on every delta) and applied once the run completes.
+     * Distinct from `isStreaming`, which only controls the blinking cursor.
+     */
+    isComplete?: boolean;
+  }>(),
+  { isComplete: true }
+);
 
-const parsedText = computed(() => parseMarkdown(props.message.text));
+const parsedText = computed(() =>
+  parseMarkdown(props.message.text, { highlight: props.isComplete !== false })
+);
 </script>
 
 <template>

--- a/samples/LmStreaming.Sample/ClientApp/src/components/TextMessage.vue
+++ b/samples/LmStreaming.Sample/ClientApp/src/components/TextMessage.vue
@@ -24,32 +24,7 @@ const parsedText = computed(() => parseMarkdown(props.message.text));
   position: relative;
 }
 
-.markdown-content {
-  overflow-wrap: break-word;
-}
-
-/* Deep selector for markdown content styles */
-.markdown-content :deep(p) {
-  margin: 0 0 1em 0;
-}
-
-.markdown-content :deep(p:last-child) {
-  margin-bottom: 0;
-}
-
-.markdown-content :deep(pre) {
-  background: #f4f4f4;
-  padding: 10px;
-  border-radius: 4px;
-  overflow-x: auto;
-}
-
-.markdown-content :deep(code) {
-  font-family: monospace;
-  background: rgba(0, 0, 0, 0.05);
-  padding: 2px 4px;
-  border-radius: 3px;
-}
+/* Markdown element styling lives in assets/markdown.css (shared with PendingMessage). */
 
 .text-message.thinking {
   font-style: italic;

--- a/samples/LmStreaming.Sample/ClientApp/src/main.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/main.ts
@@ -1,6 +1,10 @@
 import { createApp } from 'vue';
 import App from './App.vue';
 import './assets/styles.css';
+// highlight.js token colours first, so markdown.css can override the theme's own
+// block background/padding and keep code blocks inside our panel treatment.
+import 'highlight.js/styles/github.css';
+import './assets/markdown.css';
 import { logger } from './utils';
 
 const log = logger.forComponent('App');

--- a/samples/LmStreaming.Sample/ClientApp/src/utils/markdown.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/utils/markdown.ts
@@ -1,4 +1,4 @@
-import { marked } from 'marked';
+import { Marked } from 'marked';
 import { markedHighlight } from 'marked-highlight';
 import hljs from 'highlight.js/lib/core';
 
@@ -54,33 +54,70 @@ for (const [name, definition] of Object.entries(LANGUAGES)) {
   hljs.registerLanguage(name, definition);
 }
 
-marked.use({
+const MARKED_OPTIONS = {
   breaks: true, // Enable GFM line breaks
   gfm: true     // Enable GFM
-});
+};
+
+const ESCAPE_REPLACEMENTS: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+/*
+ * marked-highlight treats whatever the highlight callback returns as HTML, so the
+ * no-highlight path has to escape the fence body itself -- returning raw code here would
+ * put attacker-controlled markup straight into the `v-html` binding.
+ */
+function escapeHtml(code: string): string {
+  return code.replace(/[&<>"']/g, (ch) => ESCAPE_REPLACEMENTS[ch]);
+}
 
 /*
  * marked dropped its built-in `highlight` option; `marked-highlight` is the supported
  * replacement. The `hljs ` prefix on the class is what the highlight.js theme selects on --
  * without it the emitted token spans are styled but the block itself is not.
+ *
+ * TWO instances rather than one instance with a mutable flag: highlighting is skipped while a
+ * message is still streaming (see below), and a module-level flag toggled around `parse()` is
+ * hidden state that any concurrent parse would read. Both instances share MARKED_OPTIONS and
+ * the same `hljs language-x` class list, so finalizing a message only paints token colours in
+ * -- the block keeps its panel styling throughout and nothing shifts.
  */
-marked.use(
-  markedHighlight({
-    langPrefix: 'hljs language-',
-    emptyLangClass: 'hljs',
-    highlight(code: string, lang: string): string {
-      // An unknown or absent language must degrade to escaped plain text, never throw:
-      // a model can label a fence with anything at all (```mermaid, ```text, ```).
-      const language = lang && hljs.getLanguage(lang) ? lang : 'plaintext';
-      return hljs.highlight(code, { language, ignoreIllegals: true }).value;
-    },
-  })
-);
+function createMarked(highlightCode: (code: string, lang: string) => string): Marked {
+  return new Marked(
+    MARKED_OPTIONS,
+    markedHighlight({
+      langPrefix: 'hljs language-',
+      emptyLangClass: 'hljs',
+      highlight: highlightCode,
+    })
+  );
+}
+
+const markedHighlighted = createMarked((code, lang) => {
+  // An unknown or absent language must degrade to escaped plain text, never throw:
+  // a model can label a fence with anything at all (```mermaid, ```text, ```).
+  const language = lang && hljs.getLanguage(lang) ? lang : 'plaintext';
+  return hljs.highlight(code, { language, ignoreIllegals: true }).value;
+});
+
+const markedPlain = createMarked((code) => escapeHtml(code));
 
 /**
- * Parse markdown text to HTML
+ * Parse markdown text to HTML.
+ *
+ * `highlight: false` skips syntax highlighting. Highlighting a fence is O(fence length), and a
+ * streaming message re-parses its whole accumulated text on every delta, so highlighting a
+ * growing fence per chunk is quadratic on the main thread (measured: 500 incremental parses of
+ * a 10 KB JS fence took 2.02 s highlighted vs 8.5 ms plain). Callers rendering a message that
+ * is still streaming should pass `false` and re-render highlighted once it completes.
  */
-export function parseMarkdown(text: string): string {
+export function parseMarkdown(text: string, options?: { highlight?: boolean }): string {
   if (!text) return '';
-  return marked.parse(text) as string;
+  const instance = options?.highlight === false ? markedPlain : markedHighlighted;
+  return instance.parse(text) as string;
 }

--- a/samples/LmStreaming.Sample/ClientApp/src/utils/markdown.ts
+++ b/samples/LmStreaming.Sample/ClientApp/src/utils/markdown.ts
@@ -1,10 +1,81 @@
 import { marked } from 'marked';
+import { markedHighlight } from 'marked-highlight';
+import hljs from 'highlight.js/lib/core';
 
-// Configure marked options
+import bash from 'highlight.js/lib/languages/bash';
+import csharp from 'highlight.js/lib/languages/csharp';
+import css from 'highlight.js/lib/languages/css';
+import diff from 'highlight.js/lib/languages/diff';
+import go from 'highlight.js/lib/languages/go';
+import ini from 'highlight.js/lib/languages/ini';
+import java from 'highlight.js/lib/languages/java';
+import javascript from 'highlight.js/lib/languages/javascript';
+import json from 'highlight.js/lib/languages/json';
+import markdown from 'highlight.js/lib/languages/markdown';
+import plaintext from 'highlight.js/lib/languages/plaintext';
+import powershell from 'highlight.js/lib/languages/powershell';
+import python from 'highlight.js/lib/languages/python';
+import rust from 'highlight.js/lib/languages/rust';
+import sql from 'highlight.js/lib/languages/sql';
+import typescript from 'highlight.js/lib/languages/typescript';
+import xml from 'highlight.js/lib/languages/xml';
+import yaml from 'highlight.js/lib/languages/yaml';
+
+/*
+ * highlight.js is registered from `lib/core` with an explicit language list rather than the
+ * default bundle: the full bundle pulls in ~190 grammars (~1 MB) for the handful an assistant
+ * actually emits here. Adding a language is one import + one registerLanguage line.
+ *
+ * `registerLanguage` also registers each grammar's own aliases, so ```cs, ```ts, ```sh, ```yml
+ * and ```html all resolve without being listed.
+ */
+const LANGUAGES = {
+  bash,
+  csharp,
+  css,
+  diff,
+  go,
+  ini,
+  java,
+  javascript,
+  json,
+  markdown,
+  plaintext,
+  powershell,
+  python,
+  rust,
+  sql,
+  typescript,
+  xml,
+  yaml,
+};
+
+for (const [name, definition] of Object.entries(LANGUAGES)) {
+  hljs.registerLanguage(name, definition);
+}
+
 marked.use({
   breaks: true, // Enable GFM line breaks
   gfm: true     // Enable GFM
 });
+
+/*
+ * marked dropped its built-in `highlight` option; `marked-highlight` is the supported
+ * replacement. The `hljs ` prefix on the class is what the highlight.js theme selects on --
+ * without it the emitted token spans are styled but the block itself is not.
+ */
+marked.use(
+  markedHighlight({
+    langPrefix: 'hljs language-',
+    emptyLangClass: 'hljs',
+    highlight(code: string, lang: string): string {
+      // An unknown or absent language must degrade to escaped plain text, never throw:
+      // a model can label a fence with anything at all (```mermaid, ```text, ```).
+      const language = lang && hljs.getLanguage(lang) ? lang : 'plaintext';
+      return hljs.highlight(code, { language, ignoreIllegals: true }).value;
+    },
+  })
+);
 
 /**
  * Parse markdown text to HTML

--- a/samples/LmStreaming.Sample/PromptExamples.md
+++ b/samples/LmStreaming.Sample/PromptExamples.md
@@ -83,6 +83,28 @@ Long text response (200 words):
 Multi-turn: tool call then long text summary (300 words):
 <|instruction_start|>{"instruction_chain":[{"id":"long-turn1","id_message":"Gathering data","messages":[{"tool_call":[{"name":"get_weather","args":{"location":"Tokyo"}}]}]},{"id":"long-turn2","id_message":"Long summary","messages":[{"text_message":{"length":300}}]}]}<|instruction_end|>
 
+### Markdown Rendering Showcase
+
+`text_message: {"length": N}` emits lorem ipsum, so it never exercises the markdown renderer.
+`{"text": "..."}` pins literal assistant text instead (see `InstructionChainParser.cs`), which
+makes it possible to drive every GFM construct through the mock deterministically.
+
+This prompt renders headings h1-h3, bold/italic, inline code, a blockquote, an ordered list with
+nested bullets, an aligned GFM table, two fenced code blocks, a task list, a horizontal rule and a
+link — i.e. everything `assets/markdown.css` is responsible for styling. Use it to eyeball the
+chat's markdown after any change to `markdown.ts` or the markdown stylesheet.
+
+<|instruction_start|>{"instruction_chain":[{"id":"md-showcase","id_message":"Markdown showcase","messages":[{"text":"# Streaming Architecture Review\n\nThe pipeline is **healthy** overall, with _two_ follow-ups worth tracking. Latency is measured at the `MessageTransformationMiddleware` boundary.\n\n## Findings\n\n### 1. Merge keys collide across turns\n\nTurn 2+ reuses the run-scoped `generationId`, so `(generationId, messageOrderIdx)` is not unique.\n\n> Any fix that changes message identity must ship a multi-turn end-to-end test.\n> Single-turn green is not evidence.\n\n### 2. Tool pills duplicate on resume\n\nSteps to reproduce:\n\n1. Start a tool-heavy run\n2. Switch to another conversation mid-run\n3. Switch back before the run completes\n   - the pill count freezes\n   - a full page reload \"fixes\" it\n\n## Latency by stage\n\n| Stage | p50 (ms) | p99 (ms) | Budget |\n| --- | ---: | ---: | :---: |\n| Provider stream | 42 | 180 | ok |\n| Transform | 3 | 11 | ok |\n| WebSocket fan-out | 8 | 260 | over |\n\n## Suggested patch\n\n```csharp\nif (msg.RunId is null && currentRunId is not null)\n{\n    msg = msg with { RunId = currentRunId };\n}\n```\n\nAnd on the client:\n\n```ts\nconst key = [kind, runId, generationId, orderIdx].join('-');\n```\n\n## Checklist\n\n- [x] Reproduce with 12 tool calls\n- [ ] Add `useChatResume` coverage\n- [ ] Backfill persisted conversations\n\n---\n\nSee the [pipeline notes](https://example.com/pipeline) for the full trace. Terms: HTTP/2, SSE."}]}]}<|instruction_end|>
+
+Regenerate the line above (rather than hand-editing the escaped JSON) with:
+
+```bash
+node playwright-scripts/gen-md-showcase-prompt.mjs
+```
+
+`playwright-scripts/markdown-render-audit.mjs` sends this same prompt and asserts on the computed
+styles of every rendered construct.
+
 ### Weather Emoji Conditions
 
 The mock SampleTools.GetWeather returns random conditions from:

--- a/samples/LmStreaming.Sample/playwright-scripts/gen-md-showcase-prompt.mjs
+++ b/samples/LmStreaming.Sample/playwright-scripts/gen-md-showcase-prompt.mjs
@@ -1,0 +1,81 @@
+// gen-md-showcase-prompt.mjs — regenerates the "Markdown Rendering Showcase" prompt for
+// PromptExamples.md from the markdown source below, so the escaped one-line JSON in the docs
+// can never drift out of sync by hand-editing.
+//
+//   node playwright-scripts/gen-md-showcase-prompt.mjs
+//
+// Keep MARKDOWN identical to the copy in markdown-render-audit.mjs.
+import { writeFileSync } from 'node:fs';
+
+export const MARKDOWN = [
+  '# Streaming Architecture Review',
+  '',
+  'The pipeline is **healthy** overall, with _two_ follow-ups worth tracking. Latency is measured at the `MessageTransformationMiddleware` boundary.',
+  '',
+  '## Findings',
+  '',
+  '### 1. Merge keys collide across turns',
+  '',
+  'Turn 2+ reuses the run-scoped `generationId`, so `(generationId, messageOrderIdx)` is not unique.',
+  '',
+  '> Any fix that changes message identity must ship a multi-turn end-to-end test.',
+  '> Single-turn green is not evidence.',
+  '',
+  '### 2. Tool pills duplicate on resume',
+  '',
+  'Steps to reproduce:',
+  '',
+  '1. Start a tool-heavy run',
+  '2. Switch to another conversation mid-run',
+  '3. Switch back before the run completes',
+  '   - the pill count freezes',
+  '   - a full page reload "fixes" it',
+  '',
+  '## Latency by stage',
+  '',
+  '| Stage | p50 (ms) | p99 (ms) | Budget |',
+  '| --- | ---: | ---: | :---: |',
+  '| Provider stream | 42 | 180 | ok |',
+  '| Transform | 3 | 11 | ok |',
+  '| WebSocket fan-out | 8 | 260 | over |',
+  '',
+  '## Suggested patch',
+  '',
+  '```csharp',
+  'if (msg.RunId is null && currentRunId is not null)',
+  '{',
+  '    msg = msg with { RunId = currentRunId };',
+  '}',
+  '```',
+  '',
+  'And on the client:',
+  '',
+  '```ts',
+  "const key = [kind, runId, generationId, orderIdx].join('-');",
+  '```',
+  '',
+  '## Checklist',
+  '',
+  '- [x] Reproduce with 12 tool calls',
+  '- [ ] Add `useChatResume` coverage',
+  '- [ ] Backfill persisted conversations',
+  '',
+  '---',
+  '',
+  'See the [pipeline notes](https://example.com/pipeline) for the full trace. Terms: HTTP/2, SSE.',
+].join('\n');
+
+export const PROMPT =
+  '<|instruction_start|>' +
+  JSON.stringify({
+    instruction_chain: [
+      { id: 'md-showcase', id_message: 'Markdown showcase', messages: [{ text: MARKDOWN }] },
+    ],
+  }) +
+  '<|instruction_end|>';
+
+if (process.argv[2]) {
+  writeFileSync(process.argv[2], PROMPT);
+} else {
+  process.stdout.write(PROMPT + '\n');
+}

--- a/samples/LmStreaming.Sample/playwright-scripts/markdown-render-audit.mjs
+++ b/samples/LmStreaming.Sample/playwright-scripts/markdown-render-audit.mjs
@@ -15,7 +15,16 @@
 async (page) => {
   const BASE = 'http://127.0.0.1:5000';
   const PROVIDER_ID = 'test-anthropic';
-  const OUT_DIR = 'B:/sources/LmDotnetTools/.worktrees/WT1/.logs';
+  // Output dir must follow the checkout that RUNS the script, never a hardcoded clone.
+  //
+  // Observed in the Playwright MCP runner: `process` is NOT defined there (no `process`, no
+  // `Buffer`, no `require`), so `process.cwd()` / `process.env` would throw a ReferenceError --
+  // hence the `typeof` guard. What DOES work, and is the route this script relies on, is a
+  // relative path: Playwright resolves `path` against the server process's cwd, which is the
+  // repo/worktree root (verified: '.logs/_probe/rel.png' landed in this worktree's .logs).
+  // The env override is for other runners that do expose `process`.
+  const OUT_DIR =
+    (typeof process !== 'undefined' && process.env && process.env.LMSTREAMING_OUT_DIR) || '.logs';
 
   // Professional markdown showcase — every construct the chat client is expected to render.
   const MARKDOWN = [
@@ -348,9 +357,17 @@ async (page) => {
     // Deliberately NOT pass/fail: needs an npm dependency and is held pending a decision.
     notes.htmlSanitizer = 'none (marked output goes straight into v-html)';
 
-    await page.screenshot({ path: `${OUT_DIR}/markdown-after-viewport.png` });
-    await tid('assistant-text').last().screenshot({ path: `${OUT_DIR}/markdown-after-bubble.png` }).catch(() => {});
-    record('screenshots-captured', true, [`${OUT_DIR}/markdown-after-viewport.png`, `${OUT_DIR}/markdown-after-bubble.png`]);
+    // Screenshots are supporting evidence here, not the deliverable -- the 23 DOM assertions
+    // above are. An unwritable output dir must therefore NOT fail the audit: before this was
+    // isolated, a throwing screenshot escaped to the outer catch and reported every check as
+    // failed. Recorded as a note instead.
+    try {
+      await page.screenshot({ path: `${OUT_DIR}/markdown-after-viewport.png` });
+      await tid('assistant-text').last().screenshot({ path: `${OUT_DIR}/markdown-after-bubble.png` }).catch(() => {});
+      notes.screenshots = [`${OUT_DIR}/markdown-after-viewport.png`, `${OUT_DIR}/markdown-after-bubble.png`];
+    } catch (shotErr) {
+      notes.screenshots = `NOT captured (non-fatal): ${String((shotErr && shotErr.message) || shotErr)}`;
+    }
   } catch (e) {
     record('exception', false, String((e && e.stack) || e));
   }

--- a/samples/LmStreaming.Sample/playwright-scripts/markdown-render-audit.mjs
+++ b/samples/LmStreaming.Sample/playwright-scripts/markdown-render-audit.mjs
@@ -1,0 +1,360 @@
+// markdown-render-audit.mjs — drives ONE markdown-rich assistant reply through the `test-anthropic`
+// mock and reports, for every GFM construct, whether it rendered and what CSS it actually got.
+//
+// Purpose: evidence for "is the chat's markdown rendering presentable?" — headings, lists, tables,
+// blockquotes, links, code blocks, task lists, hr, images, nested lists. The mock's
+// `{"text": "..."}` explicit-text instruction (InstructionChainParser.cs) lets us pin the exact
+// markdown source, so the audit is deterministic and needs no real LLM.
+//
+// Run with:
+//   browser_run_code_unsafe({ filename: "samples/LmStreaming.Sample/playwright-scripts/markdown-render-audit.mjs" })
+//
+// Prompt source: PromptExamples.md -> "Markdown Rendering Showcase". MARKDOWN below must stay
+// identical to the copy in gen-md-showcase-prompt.mjs (this file has to be a single self-contained
+// function expression, so it cannot import it).
+async (page) => {
+  const BASE = 'http://127.0.0.1:5000';
+  const PROVIDER_ID = 'test-anthropic';
+  const OUT_DIR = 'B:/sources/LmDotnetTools/.worktrees/WT1/.logs';
+
+  // Professional markdown showcase — every construct the chat client is expected to render.
+  const MARKDOWN = [
+    '# Streaming Architecture Review',
+    '',
+    'The pipeline is **healthy** overall, with _two_ follow-ups worth tracking. Latency is measured at the `MessageTransformationMiddleware` boundary.',
+    '',
+    '## Findings',
+    '',
+    '### 1. Merge keys collide across turns',
+    '',
+    'Turn 2+ reuses the run-scoped `generationId`, so `(generationId, messageOrderIdx)` is not unique.',
+    '',
+    '> Any fix that changes message identity must ship a multi-turn end-to-end test.',
+    '> Single-turn green is not evidence.',
+    '',
+    '### 2. Tool pills duplicate on resume',
+    '',
+    'Steps to reproduce:',
+    '',
+    '1. Start a tool-heavy run',
+    '2. Switch to another conversation mid-run',
+    '3. Switch back before the run completes',
+    '   - the pill count freezes',
+    '   - a full page reload "fixes" it',
+    '',
+    '## Latency by stage',
+    '',
+    '| Stage | p50 (ms) | p99 (ms) | Budget |',
+    '| --- | ---: | ---: | :---: |',
+    '| Provider stream | 42 | 180 | ok |',
+    '| Transform | 3 | 11 | ok |',
+    '| WebSocket fan-out | 8 | 260 | over |',
+    '',
+    '## Suggested patch',
+    '',
+    '```csharp',
+    'if (msg.RunId is null && currentRunId is not null)',
+    '{',
+    '    msg = msg with { RunId = currentRunId };',
+    '}',
+    '```',
+    '',
+    'And on the client:',
+    '',
+    '```ts',
+    "const key = [kind, runId, generationId, orderIdx].join('-');",
+    '```',
+    '',
+    '## Checklist',
+    '',
+    '- [x] Reproduce with 12 tool calls',
+    '- [ ] Add `useChatResume` coverage',
+    '- [ ] Backfill persisted conversations',
+    '',
+    '---',
+    '',
+    'See the [pipeline notes](https://example.com/pipeline) for the full trace. Terms: HTTP/2, SSE.',
+  ].join('\n');
+
+  const PROMPT =
+    '<|instruction_start|>' +
+    JSON.stringify({
+      instruction_chain: [
+        { id: 'md-showcase', id_message: 'Markdown showcase', messages: [{ text: MARKDOWN }] },
+      ],
+    }) +
+    '<|instruction_end|>';
+
+  const steps = [];
+  const notes = {};
+  const record = (name, pass, detail) => steps.push({ name, pass, detail });
+  const tid = (id) => page.locator(`[data-testid="${id}"]`);
+  const px = (v) => parseFloat(v || '0') || 0;
+  // A colour is "transparent" when fully alpha-zero.
+  const isTransparent = (c) => !c || c === 'transparent' || /rgba\(\s*0,\s*0,\s*0,\s*0\s*\)/.test(c);
+
+  async function waitForLabelMatch(getLabel, regex, timeoutMs = 8000, intervalMs = 200) {
+    const deadline = Date.now() + timeoutMs;
+    let last = null;
+    while (Date.now() < deadline) {
+      last = await getLabel();
+      if (regex.test(last ?? '')) return last;
+      await page.waitForTimeout(intervalMs);
+    }
+    return last;
+  }
+
+  try {
+    await page.goto(BASE);
+    await tid('chat-input-textarea').waitFor({ timeout: 20000 });
+
+    // Provider must be chosen BEFORE the first send — the thread locks to the active provider.
+    // Gate on the *rendered* label: reading it straight after the click races Vue's re-render and
+    // the send then goes out against whichever provider was previously selected.
+    await tid('provider-selector-button').click();
+    await tid(`provider-option-${PROVIDER_ID}`).click({ timeout: 10000 });
+    const providerLabel = await waitForLabelMatch(
+      () => tid('provider-selector-button').textContent(),
+      /Test \(Anthropic\)/i
+    );
+    record('provider-selected', /Test \(Anthropic\)/i.test(providerLabel ?? ''), (providerLabel || '').trim());
+
+    await tid('chat-input-textarea').fill(PROMPT);
+    await tid('send-button').click();
+
+    // Gate on stream idle.
+    await tid('stop-button').waitFor({ state: 'hidden', timeout: 90000 }).catch(() => {});
+    await tid('send-button').waitFor({ state: 'visible', timeout: 90000 }).catch(() => {});
+
+    const bubbleCount = await tid('assistant-text').count();
+    record('assistant-bubble-rendered', bubbleCount > 0, { bubbleCount });
+
+    // Single bulk extraction: which constructs rendered + the CSS they actually got.
+    const audit = await page.evaluate(() => {
+      const root = [...document.querySelectorAll('[data-testid="assistant-text"]')].pop();
+      if (!root) return { error: 'no assistant-text element' };
+
+      const cs = (el, props) => {
+        const s = getComputedStyle(el);
+        const out = {};
+        for (const p of props) out[p] = s.getPropertyValue(p);
+        return out;
+      };
+      const first = (sel) => root.querySelector(sel);
+      const count = (sel) => root.querySelectorAll(sel).length;
+
+      const box = ['margin-top', 'margin-bottom', 'padding-left', 'font-size', 'font-weight', 'line-height'];
+
+      const present = {
+        h1: count('h1'), h2: count('h2'), h3: count('h3'),
+        p: count('p'), ul: count('ul'), ol: count('ol'), li: count('li'),
+        table: count('table'), th: count('th'), td: count('td'),
+        blockquote: count('blockquote'), pre: count('pre'),
+        codeInline: count('code:not(pre code)'), codeBlock: count('pre code'),
+        a: count('a'), hr: count('hr'),
+        taskCheckbox: count('input[type="checkbox"]'),
+        strong: count('strong'), em: count('em'),
+      };
+
+      const styles = {};
+      const probe = (name, sel, props) => {
+        const el = first(sel);
+        styles[name] = el ? cs(el, props) : null;
+      };
+      probe('h1', 'h1', [...box, 'border-bottom-width']);
+      probe('h2', 'h2', [...box, 'border-bottom-width']);
+      probe('h3', 'h3', box);
+      probe('ul', 'ul', box);
+      probe('ol', 'ol', box);
+      probe('li', 'li', box);
+      probe('table', 'table', ['border-collapse', 'width', 'font-size', 'margin-bottom', 'overflow-x']);
+      probe('th', 'th', ['border-bottom-width', 'border-bottom-style', 'padding-top', 'padding-left', 'text-align', 'background-color', 'font-weight']);
+      probe('td', 'td', ['border-bottom-width', 'border-bottom-style', 'padding-top', 'padding-left', 'text-align']);
+      probe('blockquote', 'blockquote', ['border-left-width', 'border-left-style', 'border-left-color', 'padding-left', 'margin-left', 'background-color', 'color']);
+      probe('pre', 'pre', ['background-color', 'padding-top', 'padding-left', 'border-radius', 'border-top-width', 'font-size', 'overflow-x']);
+      probe('preCode', 'pre code', ['background-color', 'padding-top', 'font-family', 'color']);
+      probe('inlineCode', 'code:not(pre code)', ['background-color', 'padding-top', 'padding-left', 'border-radius', 'font-family', 'font-size']);
+      probe('a', 'a', ['color', 'text-decoration-line']);
+      probe('hr', 'hr', ['border-top-width', 'background-color', 'margin-top', 'height']);
+      probe('taskLi', 'li:has(> input[type="checkbox"])', ['list-style-type', 'margin-left']);
+
+      // Are code blocks syntax-highlighted? Presence of spans is not enough -- a theme that
+      // failed to load still leaves the spans, just all one colour. Measure DISTINCT colours.
+      const preCode = first('pre code');
+      const highlightSpans = preCode ? preCode.querySelectorAll('span').length : 0;
+      const highlightColors = preCode
+        ? [...new Set([...preCode.querySelectorAll('span')].map((el) => getComputedStyle(el).color))]
+        : [];
+      const codeHasHljsClass = preCode ? preCode.className : null;
+
+      // Table chrome: an outer rounded border, with cells drawing dividers rather than full boxes.
+      const tableEl = first('table');
+      const tdEl = first('td');
+      const tdNextEl = root.querySelector('td + td');
+      const tableChrome = tableEl
+        ? cs(tableEl, ['border-top-width', 'border-top-left-radius', 'border-collapse', 'font-variant-numeric'])
+        : null;
+      const tdBorders = tdEl
+        ? (() => {
+            const s = getComputedStyle(tdEl);
+            return ['top', 'right', 'bottom', 'left'].map((side) => s.getPropertyValue(`border-${side}-width`));
+          })()
+        : null;
+      const tdDividerLeft = tdNextEl ? getComputedStyle(tdNextEl).borderLeftWidth : null;
+
+      // GFM column alignment arrives as an inline style and must survive the stylesheet.
+      const alignments = [...root.querySelectorAll('thead th')].map((el) => getComputedStyle(el).textAlign);
+
+      // Does anything overflow the bubble horizontally?
+      const overflowing = [...root.querySelectorAll('*')]
+        .filter((el) => el.scrollWidth > el.clientWidth + 1 && getComputedStyle(el).overflowX === 'visible')
+        .map((el) => el.tagName.toLowerCase());
+
+      // Scrollable panels must actually SCROLL, and their content must be REACHABLE.
+      //
+      // The bug this guards is a silent clip, and it is subtle to detect: with an *inline* inner
+      // <code>, the <code> contributes no intrinsic width to the <pre>'s scroll area, so the
+      // browser reports scrollWidth === clientWidth -- no overflow, no scrollbar -- while the long
+      // line is cut off. So "if it overflows it must scroll" passes VACUOUSLY against the very bug
+      // it is meant to catch.
+      //
+      // The anchor is therefore the content's own rendered width. An inline box's
+      // getBoundingClientRect() is the union of its line boxes, so `contentWidth` is the widest
+      // rendered line whether <code> is inline or block -- it stays honest under the bug, and the
+      // panel's scroll area has to cover it.
+      const scrollProbe = (el) => {
+        const s = getComputedStyle(el);
+        const chrome = parseFloat(s.borderTopWidth) + parseFloat(s.borderBottomWidth);
+        const inner = el.querySelector('code');
+        const needed = inner
+          ? Math.round(inner.getBoundingClientRect().width + parseFloat(s.paddingLeft) + parseFloat(s.paddingRight))
+          : 0;
+        const restore = el.scrollLeft;
+        el.scrollLeft = 10000;
+        const maxScrollLeft = el.scrollLeft;
+        el.scrollLeft = restore;
+        return {
+          tag: el.tagName.toLowerCase(),
+          scrollWidth: el.scrollWidth,
+          clientWidth: el.clientWidth,
+          needed,
+          contentReachable: el.scrollWidth + 1 >= needed,
+          overflows: el.scrollWidth > el.clientWidth + 1,
+          maxScrollLeft,
+          scrollbarPx: Math.round(el.offsetHeight - el.clientHeight - chrome),
+        };
+      };
+      const scrollPanels = [...root.querySelectorAll('pre, table')].map(scrollProbe);
+
+      return {
+        present,
+        styles,
+        highlightSpans,
+        highlightColors,
+        codeHasHljsClass,
+        tableChrome,
+        tdBorders,
+        tdDividerLeft,
+        alignments,
+        overflowing,
+        scrollPanels,
+        bodyFontSize: getComputedStyle(root).fontSize,
+        textLen: root.textContent.trim().length,
+      };
+    });
+
+    record('markdown-audit-collected', !audit.error, audit);
+
+    if (!audit.error) {
+      const s = audit.styles;
+
+      // --- every construct still parses ---
+      record('table-rendered', audit.present.table > 0 && audit.present.th === 4 && audit.present.td === 12,
+        { table: audit.present.table, th: audit.present.th, td: audit.present.td });
+      record('task-checkboxes-rendered', audit.present.taskCheckbox === 3, { taskCheckbox: audit.present.taskCheckbox });
+
+      // --- the styling gaps this change is meant to close ---
+      record('headings-have-vertical-rhythm',
+        !!(s.h2 && px(s.h2['margin-top']) > 0 && px(s.h2['margin-bottom']) > 0), s.h2);
+      record('h1-h2-have-underline-rule',
+        !!(s.h1 && s.h2 && px(s.h1['border-bottom-width']) > 0 && px(s.h2['border-bottom-width']) > 0),
+        { h1: s.h1 && s.h1['border-bottom-width'], h2: s.h2 && s.h2['border-bottom-width'] });
+      record('lists-are-indented',
+        !!(s.ul && s.ol && px(s.ul['padding-left']) > 0 && px(s.ol['padding-left']) > 0),
+        { ul: s.ul && s.ul['padding-left'], ol: s.ol && s.ol['padding-left'] });
+      record('task-list-marker-suppressed',
+        !!(s.taskLi && s.taskLi['list-style-type'] === 'none'), s.taskLi);
+      record('table-has-cell-dividers',
+        !!(audit.tdBorders && px(audit.tdBorders[2]) > 0 && px(audit.tdDividerLeft) > 0),
+        { tdBorders: audit.tdBorders, tdDividerLeft: audit.tdDividerLeft });
+      record('table-has-rounded-outer-border',
+        !!(audit.tableChrome && px(audit.tableChrome['border-top-width']) > 0
+           && px(audit.tableChrome['border-top-left-radius']) > 0),
+        audit.tableChrome);
+      record('table-uses-tabular-numerals',
+        !!(audit.tableChrome && /tabular-nums/.test(audit.tableChrome['font-variant-numeric'])),
+        audit.tableChrome && audit.tableChrome['font-variant-numeric']);
+      record('table-header-is-distinct',
+        !!(s.th && !isTransparent(s.th['background-color']) && px(s.th['padding-left']) > 0), s.th);
+      record('table-column-alignment-preserved',
+        JSON.stringify(audit.alignments) === JSON.stringify(['left', 'right', 'right', 'center']),
+        audit.alignments);
+      record('blockquote-has-left-rule',
+        !!(s.blockquote && px(s.blockquote['border-left-width']) > 0 && px(s.blockquote['padding-left']) > 0),
+        s.blockquote);
+      record('inline-code-is-chipped',
+        !!(s.inlineCode && !isTransparent(s.inlineCode['background-color']) && px(s.inlineCode['padding-left']) > 0),
+        s.inlineCode);
+      record('code-block-has-no-chip-leak',
+        !!(s.preCode && isTransparent(s.preCode['background-color']) && px(s.preCode['padding-top']) === 0),
+        s.preCode);
+      record('code-block-is-a-panel',
+        !!(s.pre && !isTransparent(s.pre['background-color']) && px(s.pre['border-top-width']) > 0 && s.pre['overflow-x'] === 'auto'),
+        s.pre);
+      // Spans alone prove nothing -- an unloaded theme leaves the markup and paints it all one
+      // colour. Distinct computed colours are the only evidence highlighting actually landed.
+      record('code-block-is-syntax-highlighted',
+        audit.highlightSpans >= 3 && audit.highlightColors.length >= 2,
+        { spans: audit.highlightSpans, distinctColors: audit.highlightColors, class: audit.codeHasHljsClass });
+      record('code-uses-a-monospace-face',
+        !!(s.preCode && /mono|consolas|menlo|courier/i.test(s.preCode['font-family'])),
+        s.preCode && s.preCode['font-family']);
+      // A heading that isn't bigger than the text under it isn't a heading.
+      record('heading-scale-descends',
+        !!(s.h1 && s.h2 && s.h3
+           && px(s.h1['font-size']) > px(s.h2['font-size'])
+           && px(s.h2['font-size']) > px(s.h3['font-size'])
+           && px(s.h3['font-size']) > px(audit.bodyFontSize)),
+        { h1: s.h1 && s.h1['font-size'], h2: s.h2 && s.h2['font-size'], h3: s.h3 && s.h3['font-size'], body: audit.bodyFontSize });
+      record('hr-visible', !!(s.hr && (px(s.hr['height']) > 0 || px(s.hr['border-top-width']) > 0)), s.hr);
+      record('links-are-underlined',
+        !!(s.a && /underline/.test(s.a['text-decoration-line'])), s.a);
+      record('nothing-overflows-the-bubble', audit.overflowing.length === 0, audit.overflowing);
+
+      // Verified RED/GREEN against the defect: forcing `pre code { display: inline }` back in-page
+      // drops both panels to unreachable (402 < 413 and 476 < 490) and fails this check.
+      const unreachable = audit.scrollPanels.filter((p) => !p.contentReachable);
+      record('code-panel-content-is-reachable-not-clipped', unreachable.length === 0,
+        { unreachable, panels: audit.scrollPanels });
+
+      // And a panel that does overflow has to offer the affordance: real scroll range + a bar.
+      const noAffordance = audit.scrollPanels
+        .filter((p) => p.overflows)
+        .filter((p) => !(p.maxScrollLeft > 0) || p.scrollbarPx <= 0);
+      record('overflowing-panels-offer-a-scroll-affordance', noAffordance.length === 0,
+        { noAffordance, panels: audit.scrollPanels });
+    }
+
+    // Deliberately NOT pass/fail: needs an npm dependency and is held pending a decision.
+    notes.htmlSanitizer = 'none (marked output goes straight into v-html)';
+
+    await page.screenshot({ path: `${OUT_DIR}/markdown-after-viewport.png` });
+    await tid('assistant-text').last().screenshot({ path: `${OUT_DIR}/markdown-after-bubble.png` }).catch(() => {});
+    record('screenshots-captured', true, [`${OUT_DIR}/markdown-after-viewport.png`, `${OUT_DIR}/markdown-after-bubble.png`]);
+  } catch (e) {
+    record('exception', false, String((e && e.stack) || e));
+  }
+
+  const failures = steps.filter((s) => !s.pass).map((s) => s.name);
+  return { pass: failures.length === 0, failures, notes, steps };
+}

--- a/samples/LmStreaming.Sample/playwright-scripts/markdown-showcase-screenshots.mjs
+++ b/samples/LmStreaming.Sample/playwright-scripts/markdown-showcase-screenshots.mjs
@@ -12,7 +12,17 @@
 async (page) => {
   const BASE = 'http://127.0.0.1:5000';
   const PROVIDER_ID = 'test-anthropic';
-  const OUT_DIR = 'B:/sources/LmDotnetTools/.worktrees/WT1/.logs/markdown-shots';
+  // Output dir must follow the checkout that RUNS the script, never a hardcoded clone.
+  //
+  // Observed in the Playwright MCP runner: `process` is NOT defined there (no `process`, no
+  // `Buffer`, no `require`), so `process.cwd()` / `process.env` would throw a ReferenceError --
+  // hence the `typeof` guard. What DOES work, and is the route this script relies on, is a
+  // relative path: Playwright resolves `path` against the server process's cwd, which is the
+  // repo/worktree root (verified: '.logs/_probe/rel.png' landed in this worktree's .logs).
+  // The env override is for other runners that do expose `process`.
+  const OUT_DIR =
+    ((typeof process !== 'undefined' && process.env && process.env.LMSTREAMING_OUT_DIR) || '.logs') +
+    '/markdown-shots';
 
   // The MCP browser context runs at deviceScaleFactor 1, so `page.screenshot()` writes CSS pixels:
   // a 1600x1000 viewport yields a 1600x1000 PNG that looks small on a high-DPI display and gains

--- a/samples/LmStreaming.Sample/playwright-scripts/markdown-showcase-screenshots.mjs
+++ b/samples/LmStreaming.Sample/playwright-scripts/markdown-showcase-screenshots.mjs
@@ -1,0 +1,222 @@
+// markdown-showcase-screenshots.mjs — renders the markdown showcase through the `test-anthropic`
+// mock and captures screenshots of the RUNNING APP (full window: sidebar, header, composer and the
+// conversation), so the shots show markdown as a user actually sees it rather than a cropped
+// element. Companion to markdown-render-audit.mjs, which asserts; this one just shows.
+//
+// Run with:
+//   browser_run_code_unsafe({ filename: "samples/LmStreaming.Sample/playwright-scripts/markdown-showcase-screenshots.mjs" })
+//
+// The MARKDOWN block must stay identical to the copies in markdown-render-audit.mjs and
+// gen-md-showcase-prompt.mjs (each script has to be a single self-contained function expression,
+// so they cannot share an import).
+async (page) => {
+  const BASE = 'http://127.0.0.1:5000';
+  const PROVIDER_ID = 'test-anthropic';
+  const OUT_DIR = 'B:/sources/LmDotnetTools/.worktrees/WT1/.logs/markdown-shots';
+
+  // The MCP browser context runs at deviceScaleFactor 1, so `page.screenshot()` writes CSS pixels:
+  // a 1600x1000 viewport yields a 1600x1000 PNG that looks small on a high-DPI display and gains
+  // nothing from maximising the image viewer.
+  //
+  // `deviceScaleFactor` is a CONTEXT option and cannot be changed on a live context. Overriding it
+  // per-page over CDP does NOT work either -- Playwright re-applies the context's own device
+  // metrics while taking the screenshot, silently discarding the override (observed: every PNG came
+  // out at the stale 900x1000 viewport). So capture in a DEDICATED high-DPI context instead, and
+  // close it afterwards so the shared MCP page is left exactly as it was found.
+  const DPR = 2;
+
+  const MARKDOWN = [
+    '# Streaming Architecture Review',
+    '',
+    'The pipeline is **healthy** overall, with _two_ follow-ups worth tracking. Latency is measured at the `MessageTransformationMiddleware` boundary.',
+    '',
+    '## Findings',
+    '',
+    '### 1. Merge keys collide across turns',
+    '',
+    'Turn 2+ reuses the run-scoped `generationId`, so `(generationId, messageOrderIdx)` is not unique.',
+    '',
+    '> Any fix that changes message identity must ship a multi-turn end-to-end test.',
+    '> Single-turn green is not evidence.',
+    '',
+    '### 2. Tool pills duplicate on resume',
+    '',
+    'Steps to reproduce:',
+    '',
+    '1. Start a tool-heavy run',
+    '2. Switch to another conversation mid-run',
+    '3. Switch back before the run completes',
+    '   - the pill count freezes',
+    '   - a full page reload "fixes" it',
+    '',
+    '## Latency by stage',
+    '',
+    '| Stage | p50 (ms) | p99 (ms) | Budget |',
+    '| --- | ---: | ---: | :---: |',
+    '| Provider stream | 42 | 180 | ok |',
+    '| Transform | 3 | 11 | ok |',
+    '| WebSocket fan-out | 8 | 260 | over |',
+    '',
+    '## Suggested patch',
+    '',
+    '```csharp',
+    'if (msg.RunId is null && currentRunId is not null)',
+    '{',
+    '    msg = msg with { RunId = currentRunId };',
+    '}',
+    '```',
+    '',
+    'And on the client:',
+    '',
+    '```ts',
+    "const key = [kind, runId, generationId, orderIdx].join('-');",
+    '```',
+    '',
+    '## Checklist',
+    '',
+    '- [x] Reproduce with 12 tool calls',
+    '- [ ] Add `useChatResume` coverage',
+    '- [ ] Backfill persisted conversations',
+    '',
+    '---',
+    '',
+    'See the [pipeline notes](https://example.com/pipeline) for the full trace. Terms: HTTP/2, SSE.',
+  ].join('\n');
+
+  const PROMPT =
+    '<|instruction_start|>' +
+    JSON.stringify({
+      instruction_chain: [
+        { id: 'md-showcase', id_message: 'Markdown showcase', messages: [{ text: MARKDOWN }] },
+      ],
+    }) +
+    '<|instruction_end|>';
+
+  const shots = [];
+  let hiDpiContext = null;
+  let pg = page;
+
+  try {
+    const browser = page.context().browser();
+    if (browser) {
+      hiDpiContext = await browser.newContext({
+        viewport: { width: 1800, height: 1150 },
+        deviceScaleFactor: DPR,
+      });
+      pg = await hiDpiContext.newPage();
+    }
+
+    const tid = (id) => pg.locator(`[data-testid="${id}"]`);
+
+    async function waitForLabelMatch(getLabel, regex, timeoutMs = 8000, intervalMs = 200) {
+      const deadline = Date.now() + timeoutMs;
+      let last = null;
+      while (Date.now() < deadline) {
+        last = await getLabel();
+        if (regex.test(last ?? '')) return last;
+        await pg.waitForTimeout(intervalMs);
+      }
+      return last;
+    }
+
+    // Whole-window shot. `pg.screenshot()` (not a locator screenshot) is the point: the app chrome
+    // -- sidebar, provider header, composer -- is part of what we are showing. The PNG's real pixel
+    // size is read back out of the IHDR header (bytes 16..24) so the run PROVES it captured at DPR
+    // rather than trusting a setting that may have been silently discarded.
+    async function shot(name, note) {
+      const file = `${OUT_DIR}/${name}.png`;
+      const buf = await pg.screenshot({ path: file });
+      shots.push({
+        name,
+        file,
+        css: pg.viewportSize(),
+        png: { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) },
+        note,
+      });
+    }
+
+    // The conversation lives in an inner scroll container, so `fullPage` would not reach the parts
+    // below the fold -- scroll the container itself and shoot the window again.
+    const scrollFeed = (top) =>
+      pg.evaluate((y) => {
+        const list = document.querySelector('[data-testid="message-list"]');
+        const el = list && list.scrollHeight > list.clientHeight ? list : document.scrollingElement;
+        el.scrollTop = y === 'end' ? el.scrollHeight : y;
+        return {
+          scrollTop: el.scrollTop,
+          scrollHeight: el.scrollHeight,
+          clientHeight: el.clientHeight,
+        };
+      }, top);
+
+    await pg.setViewportSize({ width: 1800, height: 1150 });
+    await pg.goto(BASE);
+    await tid('chat-input-textarea').waitFor({ timeout: 20000 });
+
+    // Start a FRESH thread. The app restores the last conversation on load, so without this the
+    // showcase is appended to whatever was there before and the screenshots show old traffic.
+    // `.new-chat-btn` is the documented selector (PlaywrightTestingGuide.md) -- it has no testid.
+    await pg.locator('.new-chat-btn').click();
+    await pg.waitForFunction(
+      () => document.querySelectorAll('[data-testid="assistant-text"]').length === 0,
+      null,
+      { timeout: 10000 }
+    );
+
+    // Provider must be chosen BEFORE the first send -- the thread locks to the active provider.
+    await tid('provider-selector-button').click();
+    await tid(`provider-option-${PROVIDER_ID}`).click({ timeout: 10000 });
+    await waitForLabelMatch(
+      () => tid('provider-selector-button').textContent(),
+      /Test \(Anthropic\)/i
+    );
+
+    await tid('chat-input-textarea').fill(PROMPT);
+    await tid('send-button').click();
+
+    await tid('stop-button').waitFor({ state: 'hidden', timeout: 90000 }).catch(() => {});
+    await tid('send-button').waitFor({ state: 'visible', timeout: 90000 }).catch(() => {});
+    await tid('assistant-text').last().waitFor({ timeout: 20000 });
+
+    // 1-3: the app at a wide desktop size, scrolled through the reply.
+    const geom = await scrollFeed(0);
+    await shot('1-app-top', 'desktop 1800x1150 at 2x, top of the conversation');
+    await scrollFeed(Math.round(geom.clientHeight * 0.8));
+    await shot('2-app-middle', 'scrolled to the table');
+    await scrollFeed('end');
+    await shot('3-app-bottom', 'scrolled to the code blocks and checklist');
+
+    // 4: one tall window so the entire reply is visible in app chrome at once.
+    await pg.setViewportSize({ width: 1800, height: 1700 });
+    await scrollFeed('end');
+    await shot('4-app-whole-reply', 'tall window, entire reply in one frame');
+
+    // 5-6: narrow window -- this is where the long `ts` line used to be SILENTLY CLIPPED rather
+    // than scrolled. Shot before and after scrolling the code panel to its end.
+    await pg.setViewportSize({ width: 1000, height: 1100 });
+    const tsPre = tid('assistant-text').last().locator('pre').nth(1);
+    await tsPre.scrollIntoViewIfNeeded();
+    await shot('5-app-narrow-code-start', 'narrow window, code panel at scrollLeft 0');
+    await tsPre.evaluate((el) => {
+      el.scrollLeft = 10000;
+    });
+    await shot(
+      '6-app-narrow-code-scrolled',
+      'same panel scrolled to its end -- tail reachable, scrollbar painted'
+    );
+
+    const scroll = await tsPre.evaluate((el) => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+      scrolledTo: el.scrollLeft,
+    }));
+
+    // Every shot must be DPR-scaled, or the run silently reproduces the small-image problem.
+    const scaled = shots.every((s) => s.css && s.png.width === s.css.width * DPR);
+    return { pass: shots.length === 6 && scaled, hiDpiContext: hiDpiContext !== null, shots, scroll };
+  } catch (err) {
+    return { pass: false, error: String(err && err.stack ? err.stack : err), shots };
+  } finally {
+    if (hiDpiContext) await hiDpiContext.close().catch(() => {});
+  }
+}


### PR DESCRIPTION
## What

Markdown in the LmStreaming.Sample chat client rendered as an undifferentiated wall of text. This makes an assistant reply read like a document.

**The parser was never the problem** — all 18 GFM construct types rendered correctly from the start (h1, h2, h3, ul, ol, table, blockquote, pre, inline code, links, hr, task lists, strong, em…). The failure was purely styling.

`assets/styles.css` opens with a universal reset:

```css
*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
```

Only `p`, `pre` and `code` had their spacing restored (in `TextMessage.vue`'s scoped `:deep()` rules). Everything else — headings, lists, tables, blockquotes, `hr` — was left flattened. Compounding it, `TextMessage.vue` used `.markdown-content` while `PendingMessage.vue` used `.markdown-body`, each with its own partial duplicate of the rules, which is how the two surfaces drifted apart.

## Changes

- **New shared `ClientApp/src/assets/markdown.css`**, imported from `main.ts`. Both components now render into `.markdown-content`; their scoped blocks keep only bubble chrome. Scoped `:deep()` is what *forced* the duplication in the first place.
- **Syntax highlighting** — `marked-highlight` + `highlight.js/lib/core` with 18 explicitly registered grammars. marked v17 dropped its built-in `highlight` option, so `marked-highlight` is the supported route; the core build avoids pulling ~190 unused grammars. Unknown fences fall back to `plaintext` with `ignoreIllegals`, because a model can label a fence with anything.
- **Tables** — outer border + radius, header fill, column dividers, zebra rows, `tabular-nums`.
- **Typography** — heading scale with rules under h1/h2, list indents, blockquote bar, task-list checkboxes without a stray bullet, `ui-monospace` font stack for code.

### Measured before → after

| Element | Before | After |
|---|---|---|
| heading scale | all three at body size, `margin: 0` | h1 25.6 / h2 20.8 / h3 18 / body 16px, rules under h1+h2 |
| `ul`/`ol` | `padding-left: 0px` | `24px` |
| table | no cell borders, no header fill | outer border + 8px radius, dividers, zebra, `tabular-nums` |
| column alignment | n/a | `["left","right","right","center"]` |
| syntax highlighting | 0 token spans (monochrome) | `hljs language-csharp`, 7 spans, distinct colours |
| blockquote | `border-left: 0` — rendered as a plain paragraph | 3px bar, padding, tinted background |
| `pre code` | chip background + padding (a chip inside a box) | transparent, `ui-monospace` |
| long code lines | **silently clipped** — 409/409, no scrollbar | 413/402 and 490/402, scrollbar 8px, scrolls |

## Two rendering bugs fixed along the way

**1. GFM column alignment was silently flattened.** My first pass shipped a blanket `text-align: left` on `th, td`. marked emits the *legacy presentational attribute* `<th align="right">` for `| ---: |`, not an inline style — and a presentational attribute has effectively zero specificity, so it loses to any CSS rule. One blanket `text-align` overrode every aligned column in the app. Aligned cells now opt back in via `[align='right'|'center'|'left']` selectors.

Generalisable: **if you style a construct the renderer expresses via HTML attributes, a blanket CSS rule on that element is a silent override, not a default.**

**2. Long code lines were silently CLIPPED, not scrolled.** `pre code` was `display: inline`. An inline box contributes no intrinsic width to its scroll container, so `pre` never grew its scroll area to the long line — the browser reported `scrollWidth === clientWidth`, painted no scrollbar, and cut the line off. Separately, `::-webkit-scrollbar` had a `width` but no `height`, which collapses the *horizontal* bar once that pseudo-element is styled at all. Both were live; fixing either alone leaves the symptom.

## Verification

- `playwright-scripts/markdown-render-audit.mjs` — **23 assertions green** against the running app. Everything is measured (computed styles, DOM state), not asserted from reading source.
- Client unit tests **840/840** (66 files).
- `npm run build` + `dotnet build` — 0 warnings, 0 errors. Asset hashes changed, confirming the CSS actually shipped (a stale `dist/` served through Static Web Assets is the classic false-green here).

The clipping assertion is worth calling out. Its first formulation — *"at least one panel overflows, and no overflowing panel is clipped"* — **stayed green when I injected the defect back in-page**. The bug's whole signature is that it makes `overflows` false, so the predicate skipped exactly the panels it existed to test. Re-anchored on a quantity the bug cannot suppress (the content's own rendered width, since an inline box's client rect is the union of its line boxes), it re-proved RED and then caught a *second* clipped panel the first formulation never touched.

## Not done

**HTML sanitization.** `marked` output still goes straight into `v-html`; there is no DOMPurify. This is a real exposure the moment a model or tool result echoes HTML. It adds a dependency and was out of scope here, so the audit reports it in `notes` rather than faking a passing assertion — a dependency-gated gap should be visible, not silently green.

## Also included

- `playwright-scripts/gen-md-showcase-prompt.mjs` — generates the escaped mock instruction-chain prompt now documented in `PromptExamples.md`. Generated rather than hand-edited because hand-inlining it ate a TS template literal.
- `playwright-scripts/markdown-showcase-screenshots.mjs` — captures the running app at 2× device scale.
- `PromptExamples.md` gains a "Markdown Rendering Showcase" entry. Note the determinism lever: `text_message: {"length": N}` only emits lorem ipsum; only `{"text": "..."}` pins exact literal output, which is what makes a rendering test possible at all.
